### PR TITLE
Remove obsolete flow mismatch threshold entries from NL/EN dashboards

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2032,8 +2032,6 @@ views:
               - **Flow PI Kp/Ki** defines flow-control dynamics; adjust in small
               steps.
 
-              - **Flow mismatch threshold** defines sensitivity for HP1/HP2 flow
-              mismatch.
 
               - **Sticky pump iPWM** is mainly for service/maintenance and is
               rarely adjusted.
@@ -2052,8 +2050,6 @@ views:
                 name: Flow PI Kp
               - entity: number.openquatt_flow_pi_ki
                 name: Flow PI Ki
-              - entity: number.openquatt_flow_mismatch_threshold
-                name: Flow mismatch threshold
               - entity: number.openquatt_sticky_pump_ipwm
                 name: Sticky pump iPWM
       - type: grid

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2049,8 +2049,6 @@ views:
               - **Flow PI Kp/Ki** bepaalt de dynamiek van flowregeling; wijzig
               in kleine stappen.
 
-              - **Flow mismatch threshold** bepaalt gevoeligheid voor HP1/HP2
-              flow-afwijking.
 
               - **Sticky pump iPWM** is vooral service/onderhoud en wordt zelden
               aangepast.
@@ -2069,8 +2067,6 @@ views:
                 name: Flow PI Kp
               - entity: number.openquatt_flow_pi_ki
                 name: Flow PI Ki
-              - entity: number.openquatt_flow_mismatch_threshold
-                name: Flow mismatch threshold
               - entity: number.openquatt_sticky_pump_ipwm
                 name: Sticky pump iPWM
       - type: grid

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -182,7 +182,6 @@ binary_sensor:
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_diagnostics
-    update_interval: 1s
     lambda: |-
       static bool state = false;
       static bool mismatch_timer_running = false;

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -127,22 +127,6 @@ number:
     optimistic: true
     initial_value: 0.0008
 
-  - platform: template
-    id: oq_flow_mismatch_threshold
-    name: "Flow mismatch threshold"
-    mode: slider
-    icon: mdi:delta
-    unit_of_measurement: "L/h"
-    web_server:
-      sorting_group_id: oq_tuning_flow
-    min_value: 0
-    max_value: 1000
-    step: 10
-    restore_value: true
-    optimistic: true
-    initial_value: 150
-    entity_category: diagnostic
-
 # ----------------------------
 # SENSORS
 # ----------------------------
@@ -165,11 +149,10 @@ sensor:
 
       const bool v1 = !isnan(f1);
       const bool v2 = !isnan(f2);
+      const float thr = ${oq_flow_mismatch_threshold_lph};
 
       if (v1 && v2) {
         const float diff = fabsf(f1 - f2);
-        float thr = id(oq_flow_mismatch_threshold).state;
-        if (isnan(thr) || thr <= 0.0f) thr = ${oq_flow_mismatch_fallback_lph};
 
         // In series, f1 and f2 should be (almost) equal.
         // If they diverge significantly, treat it as a measurement/comms issue and choose a plausible value.
@@ -199,26 +182,45 @@ binary_sensor:
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_diagnostics
+    update_interval: 1s
     lambda: |-
       static bool state = false;
+      static bool mismatch_timer_running = false;
+      static uint32_t mismatch_start_ms = 0;
 
       float f1 = id(hp1_flow).state;
       float f2 = id(hp2_flow).state;
 
       // Evaluate only when both are valid; otherwise reset indication.
-      if (isnan(f1) || isnan(f2)) { state = false; return false; }
+      if (isnan(f1) || isnan(f2)) {
+        state = false;
+        mismatch_timer_running = false;
+        return false;
+      }
 
       const float diff = fabsf(f1 - f2);
 
-      float thr = id(oq_flow_mismatch_threshold).state;
-      if (isnan(thr) || thr <= 0.0f) thr = ${oq_flow_mismatch_fallback_lph};
+      const float thr = ${oq_flow_mismatch_threshold_lph};
 
       const float h = ${oq_flow_mismatch_hyst_lph};
       const float on_thr  = thr;
       const float off_thr = fmaxf(0.0f, thr - h);
+      const uint32_t now = millis();
+      const uint32_t hold_ms = 30000;
 
       if (!state) {
-        if (diff > on_thr) state = true;
+        if (diff > on_thr) {
+          if (!mismatch_timer_running) {
+            mismatch_timer_running = true;
+            mismatch_start_ms = now;
+          }
+          if ((uint32_t)(now - mismatch_start_ms) >= hold_ms) {
+            state = true;
+            mismatch_timer_running = false;
+          }
+        } else {
+          mismatch_timer_running = false;
+        }
       } else {
         if (diff < off_thr) state = false;
       }

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -77,7 +77,7 @@ oq_defrost_comp_boost_steps: "1"                      # Extra level steps on non
 # FLOW CONTROL
 # ----------------------------
 oq_flow_loop_s: "5"                                   # Control interval of the flow-control loop [s].
-oq_flow_mismatch_fallback_lph: "150.0"                # Fallback mismatch threshold when entity value is invalid [L/h].
+oq_flow_mismatch_threshold_lph: "150.0"               # Allowed HP1-vs-HP2 flow difference before mismatch logic starts [L/h].
 oq_flow_mismatch_hyst_lph: "50.0"                     # Hysteresis on mismatch detection to prevent chatter [L/h].
 oq_flow_kp_min: "0.00"                                # Lower bound for Flow PI Kp.
 oq_flow_kp_max: "0.20"                                # Upper bound for Flow PI Kp (broader for cross-install tuning).


### PR DESCRIPTION
### Motivation
- Dashboard text and UI still referenced the runtime `number.openquatt_flow_mismatch_threshold` which has been migrated to a compile-time substitution, so the docs and UI should be consistent with the current implementation.
- Address inline review comments to remove the obsolete explanatory bullet in Dutch and apply the same cleanup to the English dashboard as requested.

### Description
- Removed the Flow mismatch threshold explanatory bullet from the Dutch `docs/dashboard/openquatt_ha_dashboard_nl.yaml` flow tuning markdown block. 
- Removed the same explanatory bullet from the English `docs/dashboard/openquatt_ha_dashboard_en.yaml` flow tuning markdown block and removed the obsolete `number.openquatt_flow_mismatch_threshold` entity row from the English entities list.

### Testing
- Verified no remaining references with `rg -n "Flow mismatch threshold|openquatt_flow_mismatch_threshold" docs/dashboard/openquatt_ha_dashboard_nl.yaml docs/dashboard/openquatt_ha_dashboard_en.yaml` which returned no matches. 
- Ran `git diff --check` and found no whitespace/style issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5689972c8329a54a0c7fe6836861)