### PR TITLE
Add internal diagnostics for runtime-based HP lead selection

### DIFF
--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -309,18 +309,6 @@ sensor:
     lambda: |-
       return (float) id(hp2_minutes);
 
-text_sensor:
-  - platform: template
-    id: oq_runtime_lead_hp_sensor
-    name: "Runtime lead HP (internal)"
-    icon: mdi:source-branch
-    update_interval: 10s
-    web_server:
-      sorting_group_id: oq_diagnostics
-    lambda: |-
-      const bool lead_is_hp1 = (id(hp1_minutes) <= id(hp2_minutes));
-      return std::string(lead_is_hp1 ? "HP1" : "HP2");
-
 # ----------------------------
 # Extra overview sensors for capacity deficit
 # ----------------------------
@@ -352,6 +340,18 @@ text_sensor:
       sorting_group_id: oq_overview
     lambda: |-
       return id(oq_P_deficit_w);
+
+text_sensor:
+  - platform: template
+    id: oq_runtime_lead_hp_sensor
+    name: "Runtime lead HP (internal)"
+    icon: mdi:source-branch
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      const bool lead_is_hp1 = (id(hp1_minutes) <= id(hp2_minutes));
+      return std::string(lead_is_hp1 ? "HP1" : "HP2");
 
 # ----------------------------
 # BUTTON

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -159,6 +159,12 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  # Diagnostic: last computed lead pump based on runtime minutes.
+  - id: oq_last_lead_hp
+    type: int
+    restore_value: false
+    initial_value: '0'
+
 # ----------------------------
 # SENSORS (energie + status)
 # ----------------------------
@@ -276,6 +282,44 @@ sensor:
       auto idx = id(hp2_compressor_level).active_index();
       if (!idx.has_value()) return NAN;
       return (float) idx.value();
+
+  - platform: template
+    id: oq_hp1_runtime_minutes_sensor
+    name: "HP1 runtime minutes (internal)"
+    icon: mdi:timer-outline
+    unit_of_measurement: "min"
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return (float) id(hp1_minutes);
+
+  - platform: template
+    id: oq_hp2_runtime_minutes_sensor
+    name: "HP2 runtime minutes (internal)"
+    icon: mdi:timer-outline
+    unit_of_measurement: "min"
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return (float) id(hp2_minutes);
+
+text_sensor:
+  - platform: template
+    id: oq_runtime_lead_hp_sensor
+    name: "Runtime lead HP (internal)"
+    icon: mdi:source-branch
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      const bool lead_is_hp1 = (id(hp1_minutes) <= id(hp2_minutes));
+      return std::string(lead_is_hp1 ? "HP1" : "HP2");
 
 # ----------------------------
 # Extra overview sensors for capacity deficit
@@ -436,6 +480,13 @@ interval:
 
           // Lead HP = fewest runtime minutes
           const bool lead_is_hp1 = (id(hp1_minutes) <= id(hp2_minutes));
+
+          const int lead_code = lead_is_hp1 ? 1 : 2;
+          if (id(oq_last_lead_hp) != lead_code) {
+            id(oq_last_lead_hp) = lead_code;
+            ESP_LOGI("quatt", "Runtime lead changed: %s (hp1_minutes=%d, hp2_minutes=%d)",
+                     lead_is_hp1 ? "HP1" : "HP2", id(hp1_minutes), id(hp2_minutes));
+          }
 
           int hp1_req = 0;
           int hp2_req = 0;


### PR DESCRIPTION
### Motivation
- Users reported HP2 consistently starting first despite runtime-balancing logic, so additional observability is required to determine whether the allocator decision or state/timing is the root cause.

### Description
- Added global `oq_last_lead_hp` to record the last computed runtime lead and emit a one-time `ESP_LOGI` when the lead changes.
- Added template sensors `oq_hp1_runtime_minutes_sensor` and `oq_hp2_runtime_minutes_sensor` to expose the internal `hp1_minutes` and `hp2_minutes` counters used by the allocator.
- Added text sensor `oq_runtime_lead_hp_sensor` that reports the allocator's current lead as `HP1` or `HP2` and integrated a lead-change log in the heat-control loop.

### Testing
- Attempted to validate the configuration with `esphome config openquatt.yaml`, but validation failed in this environment because `esphome` is not available.
- Verified the file-level diff and that `openquatt/oq_heat_control.yaml` contains the inserted diagnostics, but no runtime integration tests were performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c62b4d76c8329b61ccc585cd7fa51)