### PR TITLE
Power House stability + adaptive comfort bias + power input clamp

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,9 +59,9 @@ docs/
 - `getting-started.md`: hardware prerequisites, baseline runtime, build/flash flow, first validation.
 - `system-overview.md`: package architecture, control ownership, data pipeline, safety model.
 - `control-modes-and-flow.md`: CM behavior, Flow Mode semantics, Heating Strategy modes, and precedence.
-- `settings-reference.md`: compile-time vs runtime settings and tuning intent.
-- `tuning-and-troubleshooting.md`: practical workflows, symptom-driven diagnostics, safe iteration.
-- `home-assistant-dashboard.md`: how the dashboard is organized and how to use each tab.
+- `settings-reference.md`: compile-time vs runtime settings, including low-load and anti-flip controls.
+- `tuning-and-troubleshooting.md`: practical workflows, symptom-driven diagnostics, and low-load/zero-edge stability tuning.
+- `home-assistant-dashboard.md`: dashboard structure and how to use new low-load and shadow-arbiter debug cards.
 - `release-process.md`: GitHub Actions CI/release flow, tag strategy, and release execution steps.
 - `dashboard/README.md`: dashboard language variants and Home Assistant import instructions.
 - `specifications/functional-specification.md`: what the system must do.

--- a/docs/control-modes-and-flow.md
+++ b/docs/control-modes-and-flow.md
@@ -61,6 +61,14 @@ Promotion to CM3 is driven by `oq_P_deficit_w` and ON threshold + timer.
 Demotion back to CM2 is driven by OFF threshold + timer.
 Minimum dwell times avoid rapid toggling.
 
+Additional CM2 anti-flip behavior:
+
+- CM2 idle-exit is only allowed when both HP levels are 0 and both units are idle for `oq_cm2_idle_exit_s`.
+- A CM2 startup-grace window (`oq_cm2_min_run_s`) blocks idle-exit right after entering CM2.
+- In Power House mode, idle-exit is blocked when `P_req` is above low-load OFF threshold (high-load guard).
+- When idle-exit trips in Power House mode, a temporary CM2 re-entry block may hold return to CM2.
+- In heating-curve mode, CM1 postflow can resume directly to CM2 when demand recovered, avoiding unnecessary CM0 hops.
+
 ## 3. Supervisory Override
 
 Runtime entity: `select.openquatt_cm_override`
@@ -96,6 +104,9 @@ Runtime entity: `select.openquatt_heating_mode`
 - Applies room correction (`Trsp - Tr`) with deadband.
 - Applies ramp constraints.
 - Maps to demand `0..20`.
+- Adds low-load OFF/ON hysteresis on `P_req` through a heat-request latch.
+- Uses dynamic low-load thresholds (`pmin/off/on`) derived from performance map level 1, with bounded clamps and fallback values.
+- Exposes diagnostics: `Low-load dynamic thresholds`, `CM2 idle-exit reason`, `CM2 re-entry block active`, and `Heat-enable state (shadow)`.
 
 ### 5.2 Water Temperature Control (heating curve)
 
@@ -103,6 +114,8 @@ Runtime entity: `select.openquatt_heating_mode`
 - Runs PID on selected supply temperature.
 - Maps PID output to demand `0..20`.
 - Resets integral when SP/PV is invalid.
+- Adds near-zero anti-flip guards: `Curve Temp Deadband` and `Curve Demand Off Hold`.
+- Uses an overtemp latch to avoid direct demand hard-drop chatter around the supply-target crossover.
 
 ## 6. Flow Mode
 

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -1757,6 +1757,10 @@ views:
 
               - **Deadband** voorkomt onrust bij kleine afwijkingen.
 
+              - **Comfort below/above setpoint** defines an asymmetric comfort
+              zone around room setpoint where room correction stays neutral.
+              This lets users tune how much undershoot/overshoot is acceptable.
+
               - **Ramp up/down** limit rise/fall rate of requested heat.
 
               - **Heating strategy transition** defines how quickly the strategy
@@ -1778,6 +1782,10 @@ views:
                 name: Power House Kp (W/K)
               - entity: number.openquatt_power_house_deadband
                 name: Power House deadband
+              - entity: number.openquatt_power_house_comfort_below_setpoint
+                name: Power House comfort below setpoint
+              - entity: number.openquatt_power_house_comfort_above_setpoint
+                name: Power House comfort above setpoint
               - entity: number.openquatt_power_house_ramp_up
                 name: Power House ramp up
               - entity: number.openquatt_power_house_ramp_down

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2291,6 +2291,10 @@ views:
               - `Low-load dynamic thresholds` shows live `pmin/off/on` thresholds.
               - `Heat-enable state (shadow)` shows the shadow arbiter state
                 (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) for strategy validation.
+              - `CM2 idle-exit reason` explains why idle-exit is timing, blocked,
+                or tripped in the current cycle.
+              - `CM2 re-entry block active` indicates whether temporary CM2
+                restart blocking is currently active.
 
               If `P_req` or demand looks unexpectedly high/low: check outside source, room setpoint/temp, and ramp/deadband tuning.
 
@@ -2315,6 +2319,10 @@ views:
                 name: Low-load dynamic thresholds
               - entity: sensor.openquatt_heat_enable_state_shadow
                 name: Heat-enable state (shadow)
+              - entity: sensor.openquatt_cm2_idle_exit_reason
+                name: CM2 idle-exit reason
+              - entity: binary_sensor.openquatt_cm2_re_entry_block_active
+                name: CM2 re-entry block active
               - entity: number.openquatt_low_load_off_fallback
                 name: Low-load OFF fallback
               - entity: number.openquatt_low_load_on_fallback

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2200,6 +2200,8 @@ views:
               - First compare `Supply target` and `Supply actual` to see control error.
               - Then verify the chain: `Demand curve raw (PID)` -> `Demand raw` -> `Demand filtered`.
               - In curve mode, `P_req` is derived from demand and is used by deficit/CM3 logic.
+              - `Curve Temp Deadband` and `Curve Demand Off Hold` are the main
+                anti-flip stabilizers around the zero-demand edge.
 
               Note: if `Supply actual` is above target while demand stays high, check PID tuning (`Kp/Ki/Kd`) and time behavior.
 
@@ -2232,6 +2234,10 @@ views:
                 name: PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: PID Kd
+              - entity: number.openquatt_curve_temp_deadband
+                name: Curve Temp Deadband
+              - entity: number.openquatt_curve_demand_off_hold
+                name: Curve Demand Off Hold
           - type: history-graph
             title: Heating Curve temperature loop (2h)
             hours_to_show: 2
@@ -2277,6 +2283,9 @@ views:
               - `P_req` is the limited heat request after deadband/ramp limiter.
               - `Demand raw` and `Demand filtered` are 0..20 step signals towards compressor control.
               - `Power cap demand` shows active demand after electrical power limiting.
+              - `Low-load dynamic thresholds` shows live `pmin/off/on` thresholds.
+              - `Heat-enable state (shadow)` shows the shadow arbiter state
+                (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) for strategy validation.
 
               If `P_req` or demand looks unexpectedly high/low: check outside source, room setpoint/temp, and ramp/deadband tuning.
 
@@ -2297,6 +2306,16 @@ views:
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req
                 name: P_req
+              - entity: sensor.openquatt_low_load_dynamic_thresholds
+                name: Low-load dynamic thresholds
+              - entity: sensor.openquatt_heat_enable_state_shadow
+                name: Heat-enable state (shadow)
+              - entity: number.openquatt_low_load_off_fallback
+                name: Low-load OFF fallback
+              - entity: number.openquatt_low_load_on_fallback
+                name: Low-load ON fallback
+              - entity: number.openquatt_low_load_cm2_re_entry_block
+                name: Low-load CM2 re-entry block
               - entity: sensor.openquatt_demand_raw
                 name: Demand raw
               - entity: sensor.openquatt_demand_filtered

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -1761,6 +1761,13 @@ views:
               zone around room setpoint where room correction stays neutral.
               This lets users tune how much undershoot/overshoot is acceptable.
 
+              - **Comfort bias base/max** shifts the effective room target
+              upward (warm-leaning) and limits the maximum adaptive overshoot.
+              The upper correction edge is capped at `setpoint + bias max`.
+
+              - **Comfort bias up/down** and **room error avg tau** control
+              how quickly this warm bias adapts over time.
+
               - **Ramp up/down** limit rise/fall rate of requested heat.
 
               - **Heating strategy transition** defines how quickly the strategy
@@ -1786,6 +1793,16 @@ views:
                 name: Power House comfort below setpoint
               - entity: number.openquatt_power_house_comfort_above_setpoint
                 name: Power House comfort above setpoint
+              - entity: number.openquatt_power_house_comfort_bias_base
+                name: Power House comfort bias base
+              - entity: number.openquatt_power_house_comfort_bias_max
+                name: Power House comfort bias max
+              - entity: number.openquatt_power_house_comfort_bias_up
+                name: Power House comfort bias up
+              - entity: number.openquatt_power_house_comfort_bias_down
+                name: Power House comfort bias down
+              - entity: number.openquatt_power_house_room_error_avg_tau
+                name: Power House room error avg tau
               - entity: number.openquatt_power_house_ramp_up
                 name: Power House ramp up
               - entity: number.openquatt_power_house_ramp_down
@@ -2294,6 +2311,8 @@ views:
               - Relevant when `Heating mode = Power House`.
               - `P_house` is the model-based demand estimate from outside temperature.
               - `P_req` is the limited heat request after deadband/ramp limiter.
+              - `Effective room target` is room setpoint plus adaptive comfort bias.
+              - `Comfort bias` and `room error avg` show the adaptive warm-bias governor state.
               - `Demand raw` and `Demand filtered` are 0..20 step signals towards compressor control.
               - `Power cap demand` shows active demand after electrical power limiting.
               - `Low-load dynamic thresholds` shows live `pmin/off/on` thresholds.
@@ -2319,6 +2338,12 @@ views:
                 name: Room setpoint (CIC)
               - entity: sensor.openquatt_cic_ot_room_temperature
                 name: Room temp (CIC)
+              - entity: sensor.openquatt_power_house_effective_room_target
+                name: Effective room target
+              - entity: sensor.openquatt_power_house_comfort_bias
+                name: Comfort bias
+              - entity: sensor.openquatt_power_house_room_error_avg
+                name: Room error avg
               - entity: sensor.openquatt_power_house_p_house
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -1907,6 +1907,9 @@ views:
               - **Minimum runtime** prevents short-cycling and excessive
               start/stop behavior.
 
+              - **Demand filter ramp up** controls how many demand steps per
+              minute `Demand filtered` may rise toward `Demand raw`.
+
               - **Single HP assist ON/OFF deficit** defines at which thermal
               deficit extra HP assist is activated or released.
 
@@ -1924,6 +1927,8 @@ views:
             entities:
               - entity: number.openquatt_minimum_runtime
                 name: Minimum runtime
+              - entity: number.openquatt_demand_filter_ramp_up
+                name: Demand filter ramp up
               - entity: number.openquatt_single_hp_assist_on_deficit
                 name: Single HP assist ON deficit
               - entity: number.openquatt_single_hp_assist_off_deficit

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2309,6 +2309,10 @@ views:
               - `Low-load dynamic thresholds` toont live de `pmin/off/on` drempels.
               - `Heat-enable state (shadow)` toont de shadow arbiter-status
                 (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor strategievalidatie.
+              - `CM2 idle-exit reason` laat zien waarom idle-exit in deze cyclus
+                timet, geblokkeerd is, of getript heeft.
+              - `CM2 re-entry block active` toont of tijdelijke CM2-herstartblokkade
+                nu actief is.
 
               Als `P_req` of demand onverwacht hoog/laag is: controleer buitenbron, kamer setpoint/temp en de ramp/deadband instellingen.
 
@@ -2333,6 +2337,10 @@ views:
                 name: Low-load dynamic thresholds
               - entity: sensor.openquatt_heat_enable_state_shadow
                 name: Heat-enable state (shadow)
+              - entity: sensor.openquatt_cm2_idle_exit_reason
+                name: CM2 idle-exit reason
+              - entity: binary_sensor.openquatt_cm2_re_entry_block_active
+                name: CM2 re-entry block active
               - entity: number.openquatt_low_load_off_fallback
                 name: Low-load OFF fallback
               - entity: number.openquatt_low_load_on_fallback

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -1771,6 +1771,13 @@ views:
               comfortzone rond de kamersetpoint waarin de room-correctie neutraal
               blijft. Zo kan elke gebruiker eigen onder-/overshoot instellen.
 
+              - **Comfort bias base/max** verschuift de effectieve kamertarget
+              omhoog (warmte-voorkeur) en begrenst maximale adaptieve overshoot.
+              De bovenste correctierand is gemaximeerd op `setpoint + bias max`.
+
+              - **Comfort bias up/down** en **room error avg tau** bepalen hoe
+              snel deze warm-bias zich aanpast over de tijd.
+
               - **Ramp up/down** begrenzen stijg-/daalsnelheid van gevraagde
               warmte.
 
@@ -1797,6 +1804,16 @@ views:
                 name: Power House comfort below setpoint
               - entity: number.openquatt_power_house_comfort_above_setpoint
                 name: Power House comfort above setpoint
+              - entity: number.openquatt_power_house_comfort_bias_base
+                name: Power House comfort bias base
+              - entity: number.openquatt_power_house_comfort_bias_max
+                name: Power House comfort bias max
+              - entity: number.openquatt_power_house_comfort_bias_up
+                name: Power House comfort bias up
+              - entity: number.openquatt_power_house_comfort_bias_down
+                name: Power House comfort bias down
+              - entity: number.openquatt_power_house_room_error_avg_tau
+                name: Power House room error avg tau
               - entity: number.openquatt_power_house_ramp_up
                 name: Power House ramp up
               - entity: number.openquatt_power_house_ramp_down
@@ -2312,6 +2329,8 @@ views:
               - Relevant als `Heating mode = Power House`.
               - `P_house` is de modelschatting op basis van buitentemperatuur.
               - `P_req` is de begrensde warmtevraag na deadband/ramp-limiter.
+              - `Effective room target` is kamersetpoint plus adaptieve comfort-bias.
+              - `Comfort bias` en `room error avg` tonen de status van de adaptieve warm-bias regelaar.
               - `Demand raw` en `Demand filtered` zijn de 0..20 stapsignalen richting compressorregeling.
               - `Power cap demand` toont de actieve vraag na vermogensbegrenzing.
               - `Low-load dynamic thresholds` toont live de `pmin/off/on` drempels.
@@ -2337,6 +2356,12 @@ views:
                 name: Room setpoint (CIC)
               - entity: sensor.openquatt_cic_ot_room_temperature
                 name: Room temp (CIC)
+              - entity: sensor.openquatt_power_house_effective_room_target
+                name: Effective room target
+              - entity: sensor.openquatt_power_house_comfort_bias
+                name: Comfort bias
+              - entity: sensor.openquatt_power_house_room_error_avg
+                name: Room error avg
               - entity: sensor.openquatt_power_house_p_house
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -1767,6 +1767,10 @@ views:
 
               - **Deadband** voorkomt onrust bij kleine afwijkingen.
 
+              - **Comfort onder/boven setpoint** definieert een asymmetrische
+              comfortzone rond de kamersetpoint waarin de room-correctie neutraal
+              blijft. Zo kan elke gebruiker eigen onder-/overshoot instellen.
+
               - **Ramp up/down** begrenzen stijg-/daalsnelheid van gevraagde
               warmte.
 
@@ -1789,6 +1793,10 @@ views:
                 name: Power House Kp (W/K)
               - entity: number.openquatt_power_house_deadband
                 name: Power House deadband
+              - entity: number.openquatt_power_house_comfort_below_setpoint
+                name: Power House comfort below setpoint
+              - entity: number.openquatt_power_house_comfort_above_setpoint
+                name: Power House comfort above setpoint
               - entity: number.openquatt_power_house_ramp_up
                 name: Power House ramp up
               - entity: number.openquatt_power_house_ramp_down

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -1919,6 +1919,9 @@ views:
               - **Minimum runtime** voorkomt kortcyclen en overmatig
               start/stop-gedrag.
 
+              - **Demand filter ramp up** bepaalt met hoeveel demand-stappen per
+              minuut `Demand filtered` maximaal mag stijgen richting `Demand raw`.
+
               - **Single HP assist ON/OFF deficit** bepaalt bij welke thermische
               tekort-waarde extra HP-assist wordt geactiveerd of weer
               losgelaten.
@@ -1938,6 +1941,8 @@ views:
             entities:
               - entity: number.openquatt_minimum_runtime
                 name: Minimum runtime
+              - entity: number.openquatt_demand_filter_ramp_up
+                name: Demand filter ramp up
               - entity: number.openquatt_single_hp_assist_on_deficit
                 name: Single HP assist ON deficit
               - entity: number.openquatt_single_hp_assist_off_deficit

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2218,6 +2218,8 @@ views:
               - Vergelijk eerst `Supply target` met `Supply actual` om de regelafwijking te zien.
               - Controleer daarna de keten: `Demand curve raw (PID)` -> `Demand raw` -> `Demand filtered`.
               - `P_req` wordt in curve mode afgeleid uit demand en helpt bij CM3/tekort-logica.
+              - `Curve Temp Deadband` en `Curve Demand Off Hold` zijn de
+                belangrijkste anti-flip stabilisatie rond de nulvraag-rand.
 
               Let op: als `Supply actual` boven target zit maar demand hoog blijft, kijk dan naar PID-instellingen (`Kp/Ki/Kd`) en gedrag over tijd.
 
@@ -2250,6 +2252,10 @@ views:
                 name: PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: PID Kd
+              - entity: number.openquatt_curve_temp_deadband
+                name: Curve Temp Deadband
+              - entity: number.openquatt_curve_demand_off_hold
+                name: Curve Demand Off Hold
           - type: history-graph
             title: Heating Curve temperatuur-lus (2 uur)
             hours_to_show: 2
@@ -2295,6 +2301,9 @@ views:
               - `P_req` is de begrensde warmtevraag na deadband/ramp-limiter.
               - `Demand raw` en `Demand filtered` zijn de 0..20 stapsignalen richting compressorregeling.
               - `Power cap demand` toont de actieve vraag na vermogensbegrenzing.
+              - `Low-load dynamic thresholds` toont live de `pmin/off/on` drempels.
+              - `Heat-enable state (shadow)` toont de shadow arbiter-status
+                (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor strategievalidatie.
 
               Als `P_req` of demand onverwacht hoog/laag is: controleer buitenbron, kamer setpoint/temp en de ramp/deadband instellingen.
 
@@ -2315,6 +2324,16 @@ views:
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req
                 name: P_req
+              - entity: sensor.openquatt_low_load_dynamic_thresholds
+                name: Low-load dynamic thresholds
+              - entity: sensor.openquatt_heat_enable_state_shadow
+                name: Heat-enable state (shadow)
+              - entity: number.openquatt_low_load_off_fallback
+                name: Low-load OFF fallback
+              - entity: number.openquatt_low_load_on_fallback
+                name: Low-load ON fallback
+              - entity: number.openquatt_low_load_cm2_re_entry_block
+                name: Low-load CM2 re-entry block
               - entity: sensor.openquatt_demand_raw
                 name: Demand raw
               - entity: sensor.openquatt_demand_filtered

--- a/docs/home-assistant-dashboard.md
+++ b/docs/home-assistant-dashboard.md
@@ -96,6 +96,8 @@ Expected content pattern:
 - demand and cap tile row (`Demand raw`, `Demand filtered`, `Power cap demand`)
 - capacity gauges with visual deficit severity
 - trend charts for demand/power behavior
+- heating-curve anti-flip controls (`Curve Temp Deadband`, `Curve Demand Off Hold`)
+- heat allocation ramp control (`Demand filter ramp up`)
 
 Operational rule:
 
@@ -173,6 +175,13 @@ Expected content pattern:
 - side-by-side comparison of selected/local/CIC sources
 - debug-oriented status entities
 - low-level inspection cards that are too noisy for main operations
+- Power House low-load diagnostics:
+  - `Low-load dynamic thresholds`
+  - `CM2 idle-exit reason`
+  - `CM2 re-entry block active`
+  - `Low-load OFF fallback`, `Low-load ON fallback`, `Low-load CM2 re-entry block`
+- migration diagnostics:
+  - `Heat-enable state (shadow)` (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`)
 
 Operational rule:
 

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -140,6 +140,11 @@ Key entities:
 - `Power House deadband`
 - `Power House comfort below setpoint`
 - `Power House comfort above setpoint`
+- `Power House comfort bias base`
+- `Power House comfort bias max`
+- `Power House comfort bias up`
+- `Power House comfort bias down`
+- `Power House room error avg tau`
 - `Power House ramp up`
 - `Power House ramp down`
 - `Curve Tsupply @ -20/-10/0/5/10/15°C`
@@ -152,6 +157,7 @@ Intent:
 
 - define demand generation function
 - control aggressiveness and stability
+- tune adaptive warm-bias behavior around room setpoint
 
 ### 5.3 Heat allocation
 
@@ -255,6 +261,9 @@ Intent:
 - `Heat-enable state (shadow)`
 - `CM2 idle-exit reason`
 - `CM2 re-entry block active`
+- `Power House effective room target`
+- `Power House comfort bias`
+- `Power House room error avg`
 
 ### Flow telemetry
 

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -138,6 +138,8 @@ Key entities:
 - `Maximum heating outdoor temperature`
 - `Power House Kp (W-K)`
 - `Power House deadband`
+- `Power House comfort below setpoint`
+- `Power House comfort above setpoint`
 - `Power House ramp up`
 - `Power House ramp down`
 - `Curve Tsupply @ -20/-10/0/5/10/15°C`

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -159,6 +159,28 @@ Intent:
 - control aggressiveness and stability
 - tune adaptive warm-bias behavior around room setpoint
 
+Behavior summary (Power House comfort loop):
+
+- `Power House comfort bias` is adaptive and shifts the effective room target:
+  `effective_target = room_setpoint + comfort_bias`.
+- `comfort_bias` adapts from filtered room error (`Power House room error avg`):
+  - ramps up when average room error is sufficiently cold.
+  - ramps down when average room error is sufficiently warm.
+- `comfort_bias` is clamped between:
+  - `Power House comfort bias base` (minimum warm shift)
+  - `Power House comfort bias max` (maximum warm shift)
+- Asymmetric comfort window is built around `effective_target`:
+  - lower edge: `effective_target - comfort below setpoint`
+  - upper edge: `effective_target + comfort above setpoint`
+  - upper edge is additionally capped at `room_setpoint + comfort bias max`.
+- `Power House deadband` then suppresses tiny corrections around these edges.
+
+Interpretation tip:
+
+- `comfort bias max` limits where controller counter-action begins on the warm
+  side. It does not guarantee that room temperature can never exceed that value
+  due to building/system inertia.
+
 ### 5.3 Heat allocation
 
 Key entities:

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -118,6 +118,9 @@ Key entities:
 - `Silent end time`
 - `CM3 deficit ON threshold`
 - `CM3 deficit OFF threshold`
+- `Low-load OFF fallback`
+- `Low-load ON fallback`
+- `Low-load CM2 re-entry block`
 
 Intent:
 
@@ -140,6 +143,8 @@ Key entities:
 - `Curve Tsupply @ -20/-10/0/5/10/15°C`
 - `Heating Curve PID Kp/Ki/Kd`
 - `Curve Fallback Tsupply (No Outside Temp)`
+- `Curve Temp Deadband`
+- `Curve Demand Off Hold`
 
 Intent:
 
@@ -151,6 +156,7 @@ Intent:
 Key entities:
 
 - `Minimum runtime`
+- `Demand filter ramp up`
 - `Single HP Assist ON Deficit`
 - `Single HP Assist OFF Deficit`
 - `Single HP Assist ON Hold`
@@ -243,6 +249,10 @@ Intent:
 - `Demand raw`
 - `Demand filtered`
 - `Demand Curve (raw)`
+- `Low-load dynamic thresholds`
+- `Heat-enable state (shadow)`
+- `CM2 idle-exit reason`
+- `CM2 re-entry block active`
 
 ### Flow telemetry
 

--- a/docs/specifications/functional-specification.md
+++ b/docs/specifications/functional-specification.md
@@ -124,6 +124,8 @@ Normative safety principles:
 - FR-SUP-004: System shall enforce low-flow safety behavior when heating is requested.
 - FR-SUP-005: System shall support frost protection behavior when appropriate.
 - FR-SUP-006: System shall maintain a power-cap factor derived from electrical limits.
+- FR-SUP-007: In Power House mode, system shall apply low-load hysteresis and temporary CM2 re-entry blocking to reduce CM1<->CM2 chatter.
+- FR-SUP-008: System shall expose diagnostics indicating CM2 idle-exit cause and whether CM2 re-entry block is active.
 
 ### 7.2 Heating Strategy behavior
 
@@ -132,6 +134,7 @@ Normative safety principles:
 - FR-STR-003: Power House path shall include room-error correction and ramp limiting.
 - FR-STR-004: Heating-curve path shall include PID-based demand generation.
 - FR-STR-005: Invalid strategy inputs shall not produce uncontrolled demand.
+- FR-STR-006: Heating-curve path shall include near-zero demand stabilization to reduce rapid toggling around supply-target crossover.
 
 ### 7.3 Heat allocation behavior
 
@@ -141,6 +144,7 @@ Normative safety principles:
 - FR-HEAT-004: Allocation shall honor per-HP allowed-level switches.
 - FR-HEAT-005: Allocation shall enforce minimum-runtime anti-short-cycle behavior.
 - FR-HEAT-006: Allocation shall expose capacity/deficit telemetry.
+- FR-HEAT-007: Allocation shall support configurable upward demand ramp limiting.
 
 ### 7.4 Flow behavior
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -153,6 +153,15 @@ Computes requested power from:
 
 Then maps requested power to demand scale `0..20`.
 
+Power House stability guards in supervisory:
+
+- dynamic low-load thresholds from performance map level-1 thermal power (`pmin/off/on`)
+- fallback low-load OFF/ON thresholds when dynamic input is unavailable
+- low-load heat-request latch (OFF/ON hysteresis on `P_req`)
+- temporary CM2 re-entry block after CM2 idle-exit trip
+- CM2 startup-grace and high-load guard on idle-exit path
+- shadow heat-enable arbiter diagnostics (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`)
+
 ### Water Temperature Control mode
 
 Uses:
@@ -162,6 +171,12 @@ Uses:
 - PID output mapped to demand `0..20`
 
 When PID SP/PV is invalid, demand falls back to 0 and integral is reset.
+
+Heating-curve stability guards around zero-demand edge:
+
+- `Curve Temp Deadband`: caps curve demand near supply-target error zero
+- `Curve Demand Off Hold`: holds demand at 1 briefly before allowing 0
+- overtemp latch behavior to avoid direct CM2<->CM1 flip around the cutoff
 
 ## 6. Allocation and Optimization Mechanics
 
@@ -174,6 +189,11 @@ When PID SP/PV is invalid, demand falls back to 0 and integral is reset.
 5. allowed-level switch constraints
 6. min-runtime stop blocking
 7. write-on-change application and runtime counters
+
+Demand filter behavior is asymmetric:
+
+- downward path follows demand immediately
+- upward path is rate-limited by runtime control `Demand filter ramp up` (step/min)
 
 Power House optimizer cost considers:
 

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -70,6 +70,11 @@ Primary knobs:
 - `Power House deadband`
 - `Power House comfort below setpoint`
 - `Power House comfort above setpoint`
+- `Power House comfort bias base`
+- `Power House comfort bias max`
+- `Power House comfort bias up`
+- `Power House comfort bias down`
+- `Power House room error avg tau`
 - `Power House ramp up`
 - `Power House ramp down`
 
@@ -81,18 +86,27 @@ What to watch:
 - `Low-load dynamic thresholds`
 - `CM2 idle-exit reason`
 - `CM2 re-entry block active`
+- `Power House effective room target`
+- `Power House comfort bias`
+- `Power House room error avg`
 
 Typical adjustments:
 
 - Too aggressive demand swings: increase deadband or reduce ramp-up.
 - Slow recovery after setback: increase ramp-up or Kp.
 - Overreaction around setpoint: reduce Kp or increase deadband.
+- Persistent undershoot with stable low-load behavior: raise `comfort bias base` or `comfort bias max`.
+- Too warm for prolonged periods: reduce `comfort bias base` or increase `comfort bias down`.
 
 Low-load anti-flip controls (Power House):
 
 - `Low-load OFF fallback` and `Low-load ON fallback` are fallback thresholds when dynamic values are unavailable.
 - `Low-load CM2 re-entry block` defines how long CM2 re-entry is blocked after an idle-exit trip.
 - Dynamic thresholds (`pmin/off/on`) are clamped; this is expected and protects portability across installations.
+
+Adaptive comfort-bias guardrail:
+
+- Upper room correction edge is capped at `setpoint + comfort bias max`, so the configured max bias is the hard overshoot ceiling for the room loop.
 
 ### 4.2 Heating-curve path
 
@@ -212,6 +226,7 @@ Remember: fault state logic is timer-based and mode-context-dependent.
 |---|---|---|
 | Demand jumps too hard | `Demand raw`, strategy params | increase deadband / lower ramp-up |
 | CM1<->CM2 flips at low load | `Low-load dynamic thresholds`, `CM2 idle-exit reason`, `CM2 re-entry block active` | increase re-entry block or retune Power House ramp/deadband; verify `P_req` stays structurally below `off` when no sustained heat is needed |
+| Long periods below room setpoint | `Power House effective room target`, `Power House comfort bias`, `Power House room error avg` | increase comfort bias base/max, or lower deadband if correction starts too late |
 | Curve mode drops to 0 demand too quickly | `Curve Temp Deadband`, `Curve Demand Off Hold`, `Supply target` vs actual | increase deadband slightly or extend off-hold |
 | CM3 toggles often | deficit thresholds/timers | widen ON/OFF gap, increase hold times |
 | Flow oscillates | flow PI and setpoint | reduce Kp/Ki, verify hydraulics |

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -43,6 +43,9 @@ Before changing anything, record:
 - `Power House – P_req`
 - `Demand raw`
 - `Demand filtered`
+- `Low-load dynamic thresholds`
+- `CM2 idle-exit reason`
+- `CM2 re-entry block active`
 - `Total Power Input`
 - `Total Heat Power`
 - `Total COP`
@@ -73,12 +76,21 @@ What to watch:
 - `P_house` vs `P_req`
 - `Demand raw` and `Demand filtered`
 - CM2/CM3 stability
+- `Low-load dynamic thresholds`
+- `CM2 idle-exit reason`
+- `CM2 re-entry block active`
 
 Typical adjustments:
 
 - Too aggressive demand swings: increase deadband or reduce ramp-up.
 - Slow recovery after setback: increase ramp-up or Kp.
 - Overreaction around setpoint: reduce Kp or increase deadband.
+
+Low-load anti-flip controls (Power House):
+
+- `Low-load OFF fallback` and `Low-load ON fallback` are fallback thresholds when dynamic values are unavailable.
+- `Low-load CM2 re-entry block` defines how long CM2 re-entry is blocked after an idle-exit trip.
+- Dynamic thresholds (`pmin/off/on`) are clamped; this is expected and protects portability across installations.
 
 ### 4.2 Heating-curve path
 
@@ -93,12 +105,19 @@ What to watch:
 - `Heating Curve Supply Target`
 - selected supply temperature
 - `Demand Curve (raw)`
+- `Demand raw` and `Demand filtered` near zero edge
+
+Low-demand stabilization controls (Heating Curve):
+
+- `Curve Temp Deadband` reduces hunting around `Supply target`.
+- `Curve Demand Off Hold` delays final `1 -> 0` demand drop to avoid CM1/CM2 flip.
 
 ## 5. Heat Allocation Tuning
 
 Primary knobs:
 
 - `Minimum runtime`
+- `Demand filter ramp up`
 - `Single HP Assist ON Deficit`
 - `Single HP Assist OFF Deficit`
 - `Single HP Assist ON Hold`
@@ -190,6 +209,8 @@ Remember: fault state logic is timer-based and mode-context-dependent.
 | Symptom | First checks | Typical corrective action |
 |---|---|---|
 | Demand jumps too hard | `Demand raw`, strategy params | increase deadband / lower ramp-up |
+| CM1<->CM2 flips at low load | `Low-load dynamic thresholds`, `CM2 idle-exit reason`, `CM2 re-entry block active` | increase re-entry block or retune Power House ramp/deadband; verify `P_req` stays structurally below `off` when no sustained heat is needed |
+| Curve mode drops to 0 demand too quickly | `Curve Temp Deadband`, `Curve Demand Off Hold`, `Supply target` vs actual | increase deadband slightly or extend off-hold |
 | CM3 toggles often | deficit thresholds/timers | widen ON/OFF gap, increase hold times |
 | Flow oscillates | flow PI and setpoint | reduce Kp/Ki, verify hydraulics |
 | COP looks implausible | power and heat inputs | validate source values and power integration |

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -78,6 +78,11 @@ Primary knobs:
 - `Power House ramp up`
 - `Power House ramp down`
 
+Generic starting point:
+
+- For mixed/generic installations, start with `Power House Kp (W-K) = 2000`
+  and tune in steps of `200` based on comfort and mode-stability KPIs.
+
 Comfort loop behavior (exact order):
 
 1. Compute instantaneous room error against thermostat setpoint:

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -68,6 +68,8 @@ Primary knobs:
 - `Maximum heating outdoor temperature`
 - `Power House Kp (W-K)`
 - `Power House deadband`
+- `Power House comfort below setpoint`
+- `Power House comfort above setpoint`
 - `Power House ramp up`
 - `Power House ramp down`
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -682,12 +682,15 @@ sensor:
       const float bottom_plate_w = id(${hp_id}_bottom_plate_heater).state ? bottom_plate_heater_w : 0.0f;
       const float crankcase_w = id(${hp_id}_crankcase_heater).state ? crankcase_heater_w : 0.0f;
 
-      return standby_power_w
-           + (voltage_v * current_a * compressor_calibration)
-           + (fan_speed * fan_calibration)
-           + pump_power_w
-           + bottom_plate_w
-           + crankcase_w;
+      const float p_input_w = standby_power_w
+                            + (voltage_v * current_a * compressor_calibration)
+                            + (fan_speed * fan_calibration)
+                            + pump_power_w
+                            + bottom_plate_w
+                            + crankcase_w;
+
+      // Physical lower bound: electrical input power cannot be negative.
+      return (p_input_w < 0.0f) ? 0.0f : p_input_w;
 
   - platform: template
     id: ${hp_id}_heat_power

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -58,6 +58,21 @@ number:
     web_server:
       sorting_group_id: oq_tuning_heat
 
+  - platform: template
+    id: oq_demand_filter_ramp_up_step_min
+    name: "Demand filter ramp up"
+    icon: mdi:stairs-up
+    unit_of_measurement: "step/min"
+    min_value: 1
+    max_value: 20
+    step: 1
+    mode: slider
+    restore_value: true
+    optimistic: true
+    initial_value: 1
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
   # Single-HP assist ON threshold (W deficit) for enabling dual-HP support at low demand.
   - platform: template
     id: oq_single_hp_assist_on_deficit_w
@@ -370,9 +385,13 @@ interval:
           int raw = id(oq_demand_raw);
           raw = std::max(0, std::min(demand_max_f, raw));
 
+          int ramp_up_step_min = (int) lroundf(id(oq_demand_filter_ramp_up_step_min).state);
+          if (ramp_up_step_min < 1) ramp_up_step_min = 1;
+          if (ramp_up_step_min > demand_max_f) ramp_up_step_min = demand_max_f;
+
           int f = id(oq_demand_filtered);
           if (raw > f) {
-            f = std::min(f + 1, raw);              // increase max +1 per minute
+            f = std::min(f + ramp_up_step_min, raw); // configurable upward ramp (step/min)
           } else if (raw == 0 && f == 1) {
             // Prevent 1-step latch: allow clean idle transition when raw demand is zero.
             f = 0;

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -199,7 +199,9 @@ sensor:
       auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
       const float hp1_power_w = nz(id(hp1_power_input).state);
       const float hp2_power_w = nz(id(hp2_power_input).state);
-      return hp1_power_w + hp2_power_w;
+      const float total_input_w = hp1_power_w + hp2_power_w;
+      // Safety clamp against tiny negative noise from upstream math/rounding.
+      return (total_input_w < 0.0f) ? 0.0f : total_input_w;
 
   - platform: template
     id: oq_total_heat_power

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -132,6 +132,36 @@ number:
       sorting_group_id: oq_tuning_heat
 
   - platform: template
+    id: ph_comfort_band_below_c
+    name: "Power House comfort below setpoint"
+    icon: mdi:thermometer-chevron-down
+    unit_of_measurement: "°C"
+    min_value: 0
+    max_value: 2.0
+    step: 0.05
+    restore_value: true
+    optimistic: true
+    initial_value: 0.1
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: ph_comfort_band_above_c
+    name: "Power House comfort above setpoint"
+    icon: mdi:thermometer-chevron-up
+    unit_of_measurement: "°C"
+    min_value: 0
+    max_value: 2.0
+    step: 0.05
+    restore_value: true
+    optimistic: true
+    initial_value: 0.3
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
     id: ph_ramp_up_w_per_min
     name: "Power House ramp up"
     icon: mdi:chart-line-variant
@@ -807,7 +837,22 @@ interval:
             const float P_house = Pr * x;
 
             // Room correction
-            float e = Trsp - Tr; // K
+            // Asymmetric comfort band around room setpoint:
+            // - below band: lower edge where extra correction starts
+            // - above band: upper edge where negative correction starts
+            // Inside this comfort band, room correction is zero.
+            const float comfort_below = clampf(id(ph_comfort_band_below_c).state, 0.0f, 2.0f);
+            const float comfort_above = clampf(id(ph_comfort_band_above_c).state, 0.0f, 2.0f);
+            const float Tr_low = Trsp - comfort_below;
+            const float Tr_high = Trsp + comfort_above;
+
+            float e = 0.0f; // K
+            if (Tr < Tr_low) {
+              e = Tr_low - Tr;
+            } else if (Tr > Tr_high) {
+              e = Tr_high - Tr;
+            }
+
             const float db = id(ph_deadband_k).state;
             if (!isnan(db) && db > 0.0f && fabsf(e) < db) e = 0.0f;
 

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -113,7 +113,7 @@ number:
     step: 10
     restore_value: true
     optimistic: true
-    initial_value: 3800
+    initial_value: 2000
     entity_category: config
     web_server:
       sorting_group_id: oq_tuning_heat

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -126,7 +126,7 @@ number:
     step: 0.01
     restore_value: true
     optimistic: true
-    initial_value: 0.1430914729633485
+    initial_value: ${oq_ph_deadband_default_k}
     entity_category: config
     web_server:
       sorting_group_id: oq_tuning_heat

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -47,6 +47,8 @@ select:
         - lambda: |-
             id(oq_curve_zero_req_since_ms) = 0;
             id(oq_curve_overtemp_latch) = false;
+            id(oq_ph_comfort_bias_last_ms) = 0;
+            id(oq_ph_room_error_avg_init) = false;
 
 # ----------------------------
 # TUNING INPUTS
@@ -157,6 +159,81 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0.3
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: ph_comfort_bias_base_c
+    name: "Power House comfort bias base"
+    icon: mdi:thermometer-plus
+    unit_of_measurement: "°C"
+    min_value: 0.0
+    max_value: 0.5
+    step: 0.05
+    restore_value: true
+    optimistic: true
+    initial_value: 0.1
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: ph_comfort_bias_max_c
+    name: "Power House comfort bias max"
+    icon: mdi:thermometer-high
+    unit_of_measurement: "°C"
+    min_value: 0.0
+    max_value: 0.5
+    step: 0.05
+    restore_value: true
+    optimistic: true
+    initial_value: 0.5
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: ph_comfort_bias_up_c_per_h
+    name: "Power House comfort bias up"
+    icon: mdi:arrow-up-bold
+    unit_of_measurement: "°C/h"
+    min_value: 0.0
+    max_value: 0.5
+    step: 0.01
+    restore_value: true
+    optimistic: true
+    initial_value: 0.08
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: ph_comfort_bias_down_c_per_h
+    name: "Power House comfort bias down"
+    icon: mdi:arrow-down-bold
+    unit_of_measurement: "°C/h"
+    min_value: 0.0
+    max_value: 1.0
+    step: 0.01
+    restore_value: true
+    optimistic: true
+    initial_value: 0.20
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: ph_room_error_avg_tau_min
+    name: "Power House room error avg tau"
+    icon: mdi:chart-timeline-variant
+    unit_of_measurement: "min"
+    min_value: 5
+    max_value: 120
+    step: 5
+    restore_value: true
+    optimistic: true
+    initial_value: 30
     entity_category: config
     web_server:
       sorting_group_id: oq_tuning_heat
@@ -468,6 +545,29 @@ globals:
     restore_value: false
     initial_value: '0'  # 0=Power House, 1=Heating Curve
 
+  # DEBUG-RUNTIME START: Power House adaptive comfort-bias diagnostics
+  - id: oq_ph_comfort_bias_c
+    type: float
+    restore_value: false
+    initial_value: '0.1'
+  - id: oq_ph_room_error_avg_c
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+  - id: oq_ph_room_error_avg_init
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+  - id: oq_ph_comfort_bias_last_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_ph_room_target_effective_c
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+  # DEBUG-RUNTIME END
+
 # ----------------------------
 # SENSORS - outdoor temperature aggregation + heating curve target
 # ----------------------------
@@ -625,6 +725,50 @@ sensor:
       sorting_group_id: oq_diagnostics
     lambda: |-
       return (float) id(oq_demand_curve);
+
+  # DEBUG-RUNTIME START: Power House adaptive comfort-bias diagnostics
+  - platform: template
+    id: oq_phouse_room_error_avg_c_sensor
+    name: "Power House room error avg"
+    icon: mdi:chart-timeline-variant
+    unit_of_measurement: "°C"
+    state_class: measurement
+    accuracy_decimals: 3
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return id(oq_ph_room_error_avg_c);
+
+  - platform: template
+    id: oq_phouse_comfort_bias_c_sensor
+    name: "Power House comfort bias"
+    icon: mdi:thermometer-plus
+    unit_of_measurement: "°C"
+    state_class: measurement
+    accuracy_decimals: 3
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return id(oq_ph_comfort_bias_c);
+
+  - platform: template
+    id: oq_phouse_room_target_effective_c_sensor
+    name: "Power House effective room target"
+    icon: mdi:target
+    unit_of_measurement: "°C"
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return id(oq_ph_room_target_effective_c);
+  # DEBUG-RUNTIME END
 
 # ----------------------------
 # STATUS
@@ -810,6 +954,8 @@ interval:
             // Ramp state: force re-init when switching back to Power House
             id(oq_phouse_last_w) = P_req_est;
             id(oq_phouse_last_ms) = 0;
+            id(oq_ph_comfort_bias_last_ms) = 0;
+            id(oq_ph_room_target_effective_c) = id(ot_room_setpoint).state;
           } else {
             // ------------------------------------------------------------
             // POWER HOUSE MODE
@@ -836,15 +982,57 @@ interval:
             x = clampf(x, 0.0f, 1.0f);
             const float P_house = Pr * x;
 
+            // DEBUG-RUNTIME: adaptive comfort-bias governor for warm-leaning behavior.
+            const uint32_t now_ms = (uint32_t) millis();
+            const float bias_base_cfg = clampf(id(ph_comfort_bias_base_c).state, 0.0f, 0.5f);
+            const float bias_max_cfg = clampf(id(ph_comfort_bias_max_c).state, bias_base_cfg, 0.5f);
+            const float bias_up_cfg_per_s = clampf(id(ph_comfort_bias_up_c_per_h).state, 0.0f, 0.5f) / 3600.0f;
+            const float bias_down_cfg_per_s = clampf(id(ph_comfort_bias_down_c_per_h).state, 0.0f, 1.0f) / 3600.0f;
+            const float tau_s = clampf(id(ph_room_error_avg_tau_min).state * seconds_per_minute, 60.0f, 7200.0f);
+            float bias_c = id(oq_ph_comfort_bias_c);
+            if (isnan(bias_c)) bias_c = bias_base_cfg;
+            bias_c = clampf(bias_c, bias_base_cfg, bias_max_cfg);
+
+            const uint32_t bias_last_ms = id(oq_ph_comfort_bias_last_ms);
+            const float dt_bias_s = (bias_last_ms > 0 && now_ms >= bias_last_ms) ? ((now_ms - bias_last_ms) / 1000.0f) : 0.0f;
+            const float room_err_now_c = Tr - Trsp;
+            float room_err_avg_c = id(oq_ph_room_error_avg_c);
+            if (!id(oq_ph_room_error_avg_init) || isnan(room_err_avg_c)) {
+              room_err_avg_c = room_err_now_c;
+              id(oq_ph_room_error_avg_init) = true;
+            } else if (dt_bias_s > 0.0f) {
+              const float alpha = clampf(dt_bias_s / (tau_s + dt_bias_s), 0.0f, 1.0f);
+              room_err_avg_c += alpha * (room_err_now_c - room_err_avg_c);
+            }
+
+            constexpr float cold_err_on_c = -0.05f;
+            constexpr float warm_err_on_c = 0.20f;
+            if (dt_bias_s > 0.0f) {
+              if (room_err_avg_c < cold_err_on_c) {
+                bias_c += bias_up_cfg_per_s * dt_bias_s;
+              } else if (room_err_avg_c > warm_err_on_c) {
+                bias_c -= bias_down_cfg_per_s * dt_bias_s;
+              }
+            }
+            bias_c = clampf(bias_c, bias_base_cfg, bias_max_cfg);
+            id(oq_ph_comfort_bias_c) = bias_c;
+            id(oq_ph_room_error_avg_c) = room_err_avg_c;
+            id(oq_ph_comfort_bias_last_ms) = now_ms;
+
+            const float Trsp_eff = Trsp + bias_c;
+            id(oq_ph_room_target_effective_c) = Trsp_eff;
+
             // Room correction
             // Asymmetric comfort band around room setpoint:
             // - below band: lower edge where extra correction starts
             // - above band: upper edge where negative correction starts
             // Inside this comfort band, room correction is zero.
+            // Hard cap: upper edge never exceeds (setpoint + comfort bias max).
             const float comfort_below = clampf(id(ph_comfort_band_below_c).state, 0.0f, 2.0f);
             const float comfort_above = clampf(id(ph_comfort_band_above_c).state, 0.0f, 2.0f);
-            const float Tr_low = Trsp - comfort_below;
-            const float Tr_high = Trsp + comfort_above;
+            const float Tr_low = Trsp_eff - comfort_below;
+            const float Tr_high_uncapped = Trsp_eff + comfort_above;
+            const float Tr_high = std::min(Tr_high_uncapped, Trsp + bias_max_cfg);
 
             float e = 0.0f; // K
             if (Tr < Tr_low) {
@@ -861,12 +1049,11 @@ interval:
             P_raw = clampf(P_raw, 0.0f, Pr);
 
             // Ramp limiting
-            const uint32_t now = millis();
             uint32_t last = id(oq_phouse_last_ms);
             float lastw = id(oq_phouse_last_w);
-            if (last == 0) { last = now; lastw = P_raw; }
+            if (last == 0) { last = now_ms; lastw = P_raw; }
 
-            const float dt_s = (now >= last) ? ((now - last) / 1000.0f) : 0.0f;
+            const float dt_s = (now_ms >= last) ? ((now_ms - last) / 1000.0f) : 0.0f;
             const float up = id(ph_ramp_up_w_per_min).state / seconds_per_minute;     // W/s
             const float dn = id(ph_ramp_down_w_per_min).state / seconds_per_minute;   // W/s
 
@@ -881,7 +1068,7 @@ interval:
 
             id(oq_phouse_req_w) = P_limited;
             id(oq_phouse_last_w) = P_limited;
-            id(oq_phouse_last_ms) = now;
+            id(oq_phouse_last_ms) = now_ms;
 
             // Compat demand 0..20
             int d = (int) lroundf(${oq_strategy_demand_max_f} * (P_limited / Pr));

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -44,6 +44,9 @@ select:
       then:
         # Reset PID integral when strategy changes to prevent carry-over between modes.
         - climate.pid.reset_integral_term: oq_heating_curve_pid
+        - lambda: |-
+            id(oq_curve_zero_req_since_ms) = 0;
+            id(oq_curve_overtemp_latch) = false;
 
 # ----------------------------
 # TUNING INPUTS
@@ -347,6 +350,34 @@ number:
     web_server:
       sorting_group_id: oq_tuning_heat
 
+  - platform: template
+    id: curve_demand_off_hold_s
+    name: "Curve Demand Off Hold"
+    icon: mdi:timer-sand
+    unit_of_measurement: "s"
+    min_value: 0
+    max_value: 600
+    step: 5
+    restore_value: true
+    optimistic: true
+    initial_value: 120
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: curve_temp_deadband_c
+    name: "Curve Temp Deadband"
+    icon: mdi:arrow-expand-vertical
+    unit_of_measurement: "°C"
+    min_value: 0.00
+    max_value: 2.00
+    step: 0.05
+    restore_value: true
+    optimistic: true
+    initial_value: 0.25
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
 button:
   - platform: template
     id: reset_heating_curve_pid_integral
@@ -391,6 +422,17 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+
+  # Tracks how long curve PID has requested zero demand.
+  # Used to avoid immediate 0/1 chatter around the cutoff.
+  - id: oq_curve_zero_req_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_curve_overtemp_latch
+    type: bool
+    restore_value: false
+    initial_value: 'false'
   - id: oq_heat_mode_code
     type: int
     restore_value: false
@@ -604,11 +646,64 @@ output:
           const int demand_max = (int) ${oq_strategy_demand_max_f};
           if (isnan(state)) {
             id(oq_demand_curve) = 0;
+            id(oq_curve_zero_req_since_ms) = 0;
+            id(oq_curve_overtemp_latch) = false;
             return;
           }
+
           int d = (int) lroundf(state * ${oq_strategy_demand_max_f});
           if (d < 0) d = 0;
           if (d > demand_max) d = demand_max;
+
+          // Stabilize around supply target:
+          // - Overtemp latch keeps minimum demand (1) to avoid hard CM2->CM1 churn.
+          // - Within deadband around SP, cap demand to 1 to avoid hunting.
+          const float spw = id(oq_supply_target_temp).state;
+          const float pv = id(oq_system_supply_temp).state;
+          const float db = fmaxf(0.0f, id(curve_temp_deadband_c).state);
+          bool overtemp_latch = id(oq_curve_overtemp_latch);
+          if (!isnan(spw) && !isnan(pv)) {
+            const float err = spw - pv;      // + => too cold, - => too warm
+            const float on_th = -fmaxf(0.05f, db);
+            const float off_th = 0.05f;
+
+            if (!overtemp_latch && err <= on_th) {
+              overtemp_latch = true;
+            } else if (overtemp_latch && err >= off_th) {
+              overtemp_latch = false;
+            }
+
+              if (overtemp_latch) {
+                d = 1;
+              } else if (fabsf(err) <= db) {
+                d = std::min(d, 1);
+              }
+          }
+          id(oq_curve_overtemp_latch) = overtemp_latch;
+
+          // Anti-flip guard near zero demand:
+          // keep demand at 1 for a short hold period before allowing 0,
+          // except when overtemp-latch is actively forcing zero.
+          const uint32_t now_ms = (uint32_t) millis();
+          const uint32_t hold_ms = (uint32_t) lroundf(id(curve_demand_off_hold_s).state) * 1000UL;
+          const int prev = id(oq_demand_curve);
+          if (d <= 0) {
+            if (overtemp_latch) {
+              id(oq_curve_zero_req_since_ms) = 0;
+            } else {
+              if (prev > 0) {
+                if (id(oq_curve_zero_req_since_ms) == 0) {
+                  id(oq_curve_zero_req_since_ms) = now_ms;
+                }
+                const uint32_t dt = (uint32_t) (now_ms - id(oq_curve_zero_req_since_ms));
+                if (hold_ms > 0 && dt < hold_ms) d = 1;
+              }
+            }
+          } else {
+            id(oq_curve_zero_req_since_ms) = 0;
+          }
+          if (d == 0) id(oq_curve_zero_req_since_ms) = 0;
+
           id(oq_demand_curve) = d;
 
 # ----------------------------
@@ -753,10 +848,12 @@ interval:
       - if:
           condition:
             lambda: |-
-              // Anti-windup: if SP/PV drops out in heating-curve mode, reset integral term.
+              // Anti-windup:
+              // - if SP/PV drops out in heating-curve mode, reset integral term
+              // - if overtemp-latch is active, clear integral to avoid continued push
               if (id(oq_heat_mode_code) != 1) return false;
               const float spw = id(oq_supply_target_temp).state;
               const float pv  = id(oq_system_supply_temp).state;
-              return isnan(spw) || isnan(pv);
+              return isnan(spw) || isnan(pv) || id(oq_curve_overtemp_latch);
           then:
             - climate.pid.reset_integral_term: oq_heating_curve_pid

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -58,6 +58,7 @@ oq_cm0_pump_stop_ipwm: "1000.0"                       # iPWM setpoint that force
 oq_strategy_loop_s: "5"                               # Interval for strategy calculations and mode switching [s].
 oq_strategy_demand_max_f: "20.0"                      # Upper bound of demand scale for mapping PID/power -> f.
 oq_temp_guard_delta_c: "0.5"                          # Minimum valid margin between T0 and Tc in the house model [°C].
+oq_ph_deadband_default_k: "0.14"                      # Default Power House room-error deadband [K].
 
 # ----------------------------
 # HEAT CONTROL

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -92,6 +92,10 @@ globals:
     type: bool
     restore_value: false
     initial_value: 'false'
+  - id: oq_cm2_entered_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
 
   # Sticky Pump Protection (CM0-only)
   - id: oq_cm0_since_ms
@@ -658,6 +662,8 @@ interval:
 
           bool heating_req = heating_req_raw;
           float p_req_w = NAN;
+          float low_load_off_w = NAN;
+          float low_load_on_w = NAN;
           bool reentry_block_active = false;
           if (!curve_mode_active) {
             // Power House low-load hysteresis on P_req to prevent CM1<->CM2 chattering.
@@ -686,6 +692,8 @@ interval:
             if (on_w < off_w + 200.0f) on_w = off_w + 200.0f;
             if (on_w > 2200.0f) on_w = 2200.0f;
             if (off_w > on_w - 200.0f) off_w = fmaxf(500.0f, on_w - 200.0f);
+            low_load_off_w = off_w;
+            low_load_on_w = on_w;
             id(oq_low_load_pmin_dyn_w) = pmin_dyn;
             id(oq_low_load_off_dyn_w) = off_w;
             id(oq_low_load_on_dyn_w) = on_w;
@@ -719,8 +727,15 @@ interval:
           }
 
           const uint32_t cm2_idle_exit_ms = (uint32_t)(${oq_cm2_idle_exit_s}UL * 1000UL);
+          const uint32_t cm2_startup_grace_ms = (uint32_t)(${oq_cm2_min_run_s}UL * 1000UL);
+          const bool cm2_startup_grace_active =
+              in_cm2 && id(oq_cm2_entered_ms) != 0 &&
+              ((uint32_t)(now_ms - id(oq_cm2_entered_ms)) < cm2_startup_grace_ms);
+          const bool ph_high_load_idle_exit_block =
+              (!curve_mode_active) && !isnan(p_req_w) && !isnan(low_load_off_w) && (p_req_w > low_load_off_w);
           bool cm2_idle_exit_trip = false;
-          if (in_cm2 && heating_req && both_levels_off && both_units_idle) {
+          if (in_cm2 && heating_req && both_levels_off && both_units_idle &&
+              !cm2_startup_grace_active && !ph_high_load_idle_exit_block) {
             if (id(oq_cm2_idle_since_ms) == 0) id(oq_cm2_idle_since_ms) = now_ms;
             if ((uint32_t)(now_ms - id(oq_cm2_idle_since_ms)) >= cm2_idle_exit_ms) {
               heating_req = false;
@@ -1075,6 +1090,9 @@ interval:
           // -------------------------------------------------
           if (id(oq_control_mode).state != desired_cm) {
             id(oq_control_mode).publish_state(desired_cm);
+            if (desired == 2) {
+              id(oq_cm2_entered_ms) = now_ms;
+            }
           }
           static std::string last_control_mode_label;
           publish_text_if_changed(id(oq_control_mode_label), cm_code_to_label(desired), last_control_mode_label);

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -84,6 +84,14 @@ globals:
     type: uint32_t
     restore_value: false
     initial_value: '0'
+  - id: oq_cm2_reentry_block_until_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_lowload_heat_latch
+    type: bool
+    restore_value: false
+    initial_value: 'false'
 
   # Sticky Pump Protection (CM0-only)
   - id: oq_cm0_since_ms
@@ -152,6 +160,44 @@ globals:
     initial_value: '0'
   - id: oq_power_under_ok_s
     type: int
+    restore_value: false
+    initial_value: '0'
+  # Dynamic low-load diagnostics (Power House)
+  - id: oq_low_load_pmin_dyn_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_low_load_off_dyn_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_low_load_on_dyn_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  # Shadow heat-enable arbiter state machine (diagnostics only).
+  - id: oq_heat_enable_state_shadow
+    type: int
+    restore_value: false
+    initial_value: '0'  # 0=IDLE,1=PREHEAT,2=HEATING,3=POSTFLOW,4=LOCKOUT
+  - id: oq_heat_enable_preheat_until_ms_shadow
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_heat_enable_postflow_until_ms_shadow
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_heat_enable_lockout_until_ms_shadow
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_heat_enable_last_on_ms_shadow
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_heat_enable_last_off_ms_shadow
+    type: uint32_t
     restore_value: false
     initial_value: '0'
 
@@ -247,6 +293,51 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 400
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_control
+
+  - platform: template
+    id: oq_low_load_off_w
+    name: "Low-load OFF fallback"
+    icon: mdi:arrow-collapse-down
+    unit_of_measurement: "W"
+    min_value: 0
+    max_value: 3000
+    step: 25
+    optimistic: true
+    restore_value: true
+    initial_value: 900
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_control
+
+  - platform: template
+    id: oq_low_load_on_w
+    name: "Low-load ON fallback"
+    icon: mdi:arrow-expand-up
+    unit_of_measurement: "W"
+    min_value: 0
+    max_value: 3000
+    step: 25
+    optimistic: true
+    restore_value: true
+    initial_value: 1300
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_control
+
+  - platform: template
+    id: oq_low_load_reentry_block_s
+    name: "Low-load CM2 re-entry block"
+    icon: mdi:timer-lock-outline
+    unit_of_measurement: "s"
+    min_value: 0
+    max_value: 900
+    step: 5
+    optimistic: true
+    restore_value: true
+    initial_value: 300
     entity_category: config
     web_server:
       sorting_group_id: oq_control
@@ -354,6 +445,35 @@ text_sensor:
     id: oq_silent_status
     name: "Silent status"
     icon: mdi:information-outline
+    update_interval: never
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+
+  - platform: template
+    id: oq_low_load_dyn_status
+    name: "Low-load dynamic thresholds"
+    icon: mdi:chart-bell-curve
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      const float pmin = id(oq_low_load_pmin_dyn_w);
+      const float off  = id(oq_low_load_off_dyn_w);
+      const float on   = id(oq_low_load_on_dyn_w);
+      char b[96];
+      if (isnan(pmin) || isnan(off) || isnan(on)) {
+        snprintf(b, sizeof(b), "dynamic: n/a (fallback in use)");
+      } else {
+        snprintf(b, sizeof(b), "pmin=%.0fW off=%.0fW on=%.0fW", pmin, off, on);
+      }
+      return std::string(b);
+
+  - platform: template
+    id: oq_heat_enable_state_shadow_ts
+    name: "Heat-enable state (shadow)"
+    icon: mdi:state-machine
     update_interval: never
     entity_category: diagnostic
     web_server:
@@ -521,6 +641,7 @@ interval:
           const char* cur_cm_state = id(oq_control_mode).state.c_str();
           const bool in_cm2 = strcmp(cur_cm_state, "CM2") == 0;
           const bool heating_req_raw = (id(oq_demand_filtered) > 0);
+          const bool curve_mode_active = (id(oq_heat_mode_code) == 1);
 
           const int hp1_lvl = id(hp1_last_applied_level);
           const int hp2_lvl = id(hp2_last_applied_level);
@@ -536,14 +657,177 @@ interval:
           const bool both_units_idle = both_modes_known && !hp1_heating && !hp2_heating;
 
           bool heating_req = heating_req_raw;
+          float p_req_w = NAN;
+          bool reentry_block_active = false;
+          if (!curve_mode_active) {
+            // Power House low-load hysteresis on P_req to prevent CM1<->CM2 chattering.
+            // Prefer dynamic thresholds from perf-map level-1 thermal power.
+            auto clampf = [](float v, float lo, float hi)->float {
+              if (v < lo) return lo;
+              if (v > hi) return hi;
+              return v;
+            };
+            float off_w = id(oq_low_load_off_w).state; // fallback OFF
+            float on_w  = id(oq_low_load_on_w).state;  // fallback ON
+            if (isnan(off_w) || off_w < 0.0f) off_w = 900.0f;
+            if (isnan(on_w)  || on_w  < 0.0f) on_w  = 1300.0f;
+
+            const float Tamb = id(outside_temp_selected).state;
+            const float Tsup = id(oq_system_supply_temp).state;
+            float pmin_dyn = NAN;
+            if (!isnan(Tamb) && !isnan(Tsup)) {
+              pmin_dyn = oq_perf::interp_power_th_w(1, Tamb, Tsup);
+              if (isnan(pmin_dyn) || pmin_dyn <= 0.0f) pmin_dyn = NAN;
+            }
+            if (!isnan(pmin_dyn)) {
+              off_w = clampf(0.75f * pmin_dyn, 500.0f, 1600.0f);
+              on_w  = clampf(1.00f * pmin_dyn, 700.0f, 2200.0f);
+            }
+            if (on_w < off_w + 200.0f) on_w = off_w + 200.0f;
+            if (on_w > 2200.0f) on_w = 2200.0f;
+            if (off_w > on_w - 200.0f) off_w = fmaxf(500.0f, on_w - 200.0f);
+            id(oq_low_load_pmin_dyn_w) = pmin_dyn;
+            id(oq_low_load_off_dyn_w) = off_w;
+            id(oq_low_load_on_dyn_w) = on_w;
+
+            p_req_w = id(oq_phouse_req_w);
+            bool latch = id(oq_lowload_heat_latch);
+            if (!isnan(p_req_w)) {
+              if (!latch && p_req_w >= on_w) latch = true;
+              else if (latch && p_req_w <= off_w) latch = false;
+            } else {
+              // Fallback when P_req is unavailable.
+              latch = heating_req_raw;
+            }
+            id(oq_lowload_heat_latch) = latch;
+            heating_req = heating_req_raw && latch;
+
+            // Re-entry block: allow early release only when demand recovers clearly (P_req >= on_w).
+            reentry_block_active = ms_window_active(id(oq_cm2_reentry_block_until_ms));
+            if (reentry_block_active && !isnan(p_req_w) && p_req_w >= on_w) {
+              id(oq_cm2_reentry_block_until_ms) = 0;
+              reentry_block_active = false;
+            }
+          } else {
+            // Curve mode keeps original heat-request semantics.
+            id(oq_lowload_heat_latch) = heating_req_raw;
+            id(oq_cm2_reentry_block_until_ms) = 0;
+            reentry_block_active = false;
+            id(oq_low_load_pmin_dyn_w) = NAN;
+            id(oq_low_load_off_dyn_w) = NAN;
+            id(oq_low_load_on_dyn_w) = NAN;
+          }
+
           const uint32_t cm2_idle_exit_ms = (uint32_t)(${oq_cm2_idle_exit_s}UL * 1000UL);
-          if (in_cm2 && heating_req_raw && both_levels_off && both_units_idle) {
+          bool cm2_idle_exit_trip = false;
+          if (in_cm2 && heating_req && both_levels_off && both_units_idle) {
             if (id(oq_cm2_idle_since_ms) == 0) id(oq_cm2_idle_since_ms) = now_ms;
             if ((uint32_t)(now_ms - id(oq_cm2_idle_since_ms)) >= cm2_idle_exit_ms) {
               heating_req = false;
+              cm2_idle_exit_trip = true;
             }
           } else {
             id(oq_cm2_idle_since_ms) = 0;
+          }
+          if (!curve_mode_active) {
+            const uint32_t reentry_block_ms = (uint32_t) lroundf(id(oq_low_load_reentry_block_s).state) * 1000UL;
+            // Pad A behavior: set block only when CM2 idle-exit trips.
+            if (cm2_idle_exit_trip && reentry_block_ms > 0) {
+              id(oq_cm2_reentry_block_until_ms) = now_ms + reentry_block_ms;
+              reentry_block_active = true;
+            }
+            // During active block, CM2 may not be re-entered from non-CM2 states.
+            if (!in_cm2 && reentry_block_active) {
+              heating_req = false;
+            }
+          }
+
+          // -------------------------------------------------
+          // 1b) Shadow heat-enable arbiter (diagnostics only)
+          //     States: IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT
+          // -------------------------------------------------
+          {
+            const bool heat_req_shadow = heating_req;
+            const uint32_t min_run_ms = (uint32_t)(${oq_cm2_min_run_s}UL * 1000UL);
+            const uint32_t lockout_ms = curve_mode_active
+                ? 0
+                : (uint32_t) lroundf(id(oq_low_load_reentry_block_s).state) * 1000UL;
+
+            auto shadow_state_to_text = [](int st) -> const char* {
+              if (st == 1) return "PREHEAT";
+              if (st == 2) return "HEATING";
+              if (st == 3) return "POSTFLOW";
+              if (st == 4) return "LOCKOUT";
+              return "IDLE";
+            };
+
+            int st = id(oq_heat_enable_state_shadow);
+            if (st < 0 || st > 4) st = 0;
+
+            switch (st) {
+              case 0: { // IDLE
+                if (heat_req_shadow) {
+                  st = 1;
+                  id(oq_heat_enable_preheat_until_ms_shadow) = now_ms + prepost_ms;
+                }
+                break;
+              }
+              case 1: { // PREHEAT
+                if (!heat_req_shadow) {
+                  st = 0;
+                  id(oq_heat_enable_preheat_until_ms_shadow) = 0;
+                } else if (!ms_window_active(id(oq_heat_enable_preheat_until_ms_shadow))) {
+                  st = 2;
+                  id(oq_heat_enable_last_on_ms_shadow) = now_ms;
+                }
+                break;
+              }
+              case 2: { // HEATING
+                if (!heat_req_shadow &&
+                    (id(oq_heat_enable_last_on_ms_shadow) == 0 ||
+                     (uint32_t) (now_ms - id(oq_heat_enable_last_on_ms_shadow)) >= min_run_ms)) {
+                  st = 3;
+                  id(oq_heat_enable_postflow_until_ms_shadow) = now_ms + prepost_ms;
+                  id(oq_heat_enable_last_off_ms_shadow) = now_ms;
+                }
+                break;
+              }
+              case 3: { // POSTFLOW
+                if (heat_req_shadow) {
+                  st = 1;
+                  id(oq_heat_enable_preheat_until_ms_shadow) = now_ms + prepost_ms;
+                } else if (!ms_window_active(id(oq_heat_enable_postflow_until_ms_shadow))) {
+                  if (lockout_ms > 0) {
+                    st = 4;
+                    id(oq_heat_enable_lockout_until_ms_shadow) = now_ms + lockout_ms;
+                  } else {
+                    st = 0;
+                  }
+                }
+                break;
+              }
+              case 4: { // LOCKOUT
+                if (!ms_window_active(id(oq_heat_enable_lockout_until_ms_shadow))) {
+                  if (heat_req_shadow) {
+                    st = 1;
+                    id(oq_heat_enable_preheat_until_ms_shadow) = now_ms + prepost_ms;
+                  } else {
+                    st = 0;
+                  }
+                }
+                break;
+              }
+              default:
+                st = 0;
+                break;
+            }
+
+            id(oq_heat_enable_state_shadow) = st;
+            static std::string last_heat_enable_shadow_state;
+            publish_text_if_changed(
+                id(oq_heat_enable_state_shadow_ts),
+                std::string(shadow_state_to_text(st)),
+                last_heat_enable_shadow_state);
           }
 
           // -------------------------------------------------
@@ -696,8 +980,14 @@ interval:
                   else if (base_target == 98)          desired_local = 98;
                   else                                 desired_local = 0;
                 } else if (cm1_next_after == 0) {
-                  if (base_target == 98) desired_local = 98;
-                  else                   desired_local = 0;
+                  // Re-evaluate heating/frost when postflow expires.
+                  // If demand recovered during CM1-postflow, resume CM2 directly
+                  // instead of forcing an avoidable CM0 hop (anti-flip/chatter).
+                  // Scope this behavior to heating-curve strategy only; keep
+                  // Power House behavior unchanged.
+                  if (id(oq_heat_mode_code) == 1 && heating_req && base_target == 2) desired_local = 2;
+                  else if (base_target == 98)          desired_local = 98;
+                  else                                 desired_local = 0;
                 } else if (cm1_next_after == 98) {
                   desired_local = 98;
                 } else {

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -166,6 +166,7 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+  # DEBUG-RUNTIME START: Power House low-load + shadow heat-enable diagnostics
   # Dynamic low-load diagnostics (Power House)
   - id: oq_low_load_pmin_dyn_w
     type: float
@@ -204,6 +205,7 @@ globals:
     type: uint32_t
     restore_value: false
     initial_value: '0'
+  # DEBUG-RUNTIME END
 
 # ----------------------------
 # CONTROL INPUTS
@@ -410,6 +412,17 @@ binary_sensor:
     web_server:
       sorting_group_id: oq_diagnostics
 
+  # DEBUG-RUNTIME START: CM2 low-load / idle-exit diagnostics
+  - platform: template
+    id: oq_cm2_reentry_block_active_bs
+    name: "CM2 re-entry block active"
+    icon: mdi:timer-lock-outline
+    device_class: running
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+  # DEBUG-RUNTIME END
+
 text_sensor:
   - platform: template
     id: oq_control_mode
@@ -454,6 +467,7 @@ text_sensor:
     web_server:
       sorting_group_id: oq_diagnostics
 
+  # DEBUG-RUNTIME START: Power House low-load + shadow heat-enable diagnostics
   - platform: template
     id: oq_low_load_dyn_status
     name: "Low-load dynamic thresholds"
@@ -482,6 +496,16 @@ text_sensor:
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_diagnostics
+
+  - platform: template
+    id: oq_cm2_idle_exit_reason_ts
+    name: "CM2 idle-exit reason"
+    icon: mdi:information-outline
+    update_interval: never
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+  # DEBUG-RUNTIME END
 sensor:
   - platform: template
     id: power_cap_level
@@ -666,6 +690,7 @@ interval:
           float low_load_on_w = NAN;
           bool reentry_block_active = false;
           if (!curve_mode_active) {
+            // DEBUG-RUNTIME: dynamic low-load thresholds + latch/re-entry diagnostics (Power House).
             // Power House low-load hysteresis on P_req to prevent CM1<->CM2 chattering.
             // Prefer dynamic thresholds from perf-map level-1 thermal power.
             auto clampf = [](float v, float lo, float hi)->float {
@@ -733,6 +758,16 @@ interval:
               ((uint32_t)(now_ms - id(oq_cm2_entered_ms)) < cm2_startup_grace_ms);
           const bool ph_high_load_idle_exit_block =
               (!curve_mode_active) && !isnan(p_req_w) && !isnan(low_load_off_w) && (p_req_w > low_load_off_w);
+          // DEBUG-RUNTIME: expose why CM2 idle-exit path is armed/blocked/tripped.
+          std::string cm2_idle_exit_reason = "not_in_cm2";
+          if (in_cm2) {
+            if (!heating_req) cm2_idle_exit_reason = "no_heat_req";
+            else if (!both_levels_off) cm2_idle_exit_reason = "levels_on";
+            else if (!both_units_idle) cm2_idle_exit_reason = "units_not_idle";
+            else if (cm2_startup_grace_active) cm2_idle_exit_reason = "blocked_startup_grace";
+            else if (ph_high_load_idle_exit_block) cm2_idle_exit_reason = "blocked_high_load";
+            else cm2_idle_exit_reason = "timing";
+          }
           bool cm2_idle_exit_trip = false;
           if (in_cm2 && heating_req && both_levels_off && both_units_idle &&
               !cm2_startup_grace_active && !ph_high_load_idle_exit_block) {
@@ -740,6 +775,7 @@ interval:
             if ((uint32_t)(now_ms - id(oq_cm2_idle_since_ms)) >= cm2_idle_exit_ms) {
               heating_req = false;
               cm2_idle_exit_trip = true;
+              cm2_idle_exit_reason = "trip";
             }
           } else {
             id(oq_cm2_idle_since_ms) = 0;
@@ -756,12 +792,20 @@ interval:
               heating_req = false;
             }
           }
+          // DEBUG-RUNTIME: publish CM2 idle-exit reason + low-load re-entry block state.
+          static std::string last_cm2_idle_exit_reason;
+          publish_text_if_changed(
+              id(oq_cm2_idle_exit_reason_ts),
+              cm2_idle_exit_reason,
+              last_cm2_idle_exit_reason);
+          publish_binary_if_changed(id(oq_cm2_reentry_block_active_bs), reentry_block_active);
 
           // -------------------------------------------------
           // 1b) Shadow heat-enable arbiter (diagnostics only)
           //     States: IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT
           // -------------------------------------------------
           {
+            // DEBUG-RUNTIME: shadow state-machine for stepwise migration to a dedicated heat-enable arbiter.
             const bool heat_req_shadow = heating_req;
             const uint32_t min_run_ms = (uint32_t)(${oq_cm2_min_run_s}UL * 1000UL);
             const uint32_t lockout_ms = curve_mode_active


### PR DESCRIPTION
## Summary
This PR improves heating stability at low load and near setpoint, with a focus on **Power House behavior**, clearer diagnostics, and safer telemetry.

## What Changed
### 1) Power House low-load anti-flip stabilization
- Added low-load anti-flip behavior to prevent CM1<->CM2 chatter.
- Added CM2 startup grace + guarded idle-exit behavior.
- Added configurable demand-filter ramp-up.

### 2) Dynamic low-load thresholds + diagnostics
- Added dynamic low-load thresholds from perf-map (`pmin/off/on`) with safety clamps.
- Added low-load fallback OFF/ON and CM2 re-entry block controls.
- Added runtime diagnostics:
  - `Low-load dynamic thresholds`
  - `CM2 idle-exit reason`
  - `CM2 re-entry block active`
  - `Heat-enable state (shadow)` (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`)
- Added `DEBUG-RUNTIME` markers in relevant control-loop sections.

### 3) Water temperature loop stabilization
- Added/updated heating-curve stabilization settings and diagnostics.
- Extended dashboard debug visibility for demand chain and mode behavior.

### 4) Power House comfort control improvements
- Added asymmetric comfort band around setpoint:
  - `Power House comfort below setpoint`
  - `Power House comfort above setpoint`
- Set Power House deadband default via substitutions (`oq_ph_deadband_default_k = 0.14`).
- Added adaptive warm-leaning comfort bias governor with hard cap:
  - `Power House comfort bias base`
  - `Power House comfort bias max` (hard overshoot ceiling)
  - `Power House comfort bias up`
  - `Power House comfort bias down`
  - `Power House room error avg tau`
- Added diagnostics for this governor:
  - `Power House effective room target`
  - `Power House comfort bias`
  - `Power House room error avg`

### 5) Power input sanity fix
- Clamped per-HP electrical input power to `>= 0 W`.
- Added safety clamp on total electrical input power to `>= 0 W`.
- Prevents negative power-input noise from propagating to dashboards/energy metrics.

### 6) Dashboard & docs updates (EN + NL)
- Expanded HA Debug & Testing dashboard with new tuning and diagnostics entities.
- Updated settings/tuning documentation to cover low-load logic, adaptive comfort-bias behavior, and troubleshooting workflow.

## Validation
- `./scripts/validate_local.sh` passed.
- `esphome compile openquatt.yaml` passed.
- Dashboard YAML updates included for both EN/NL variants.
