### PR TITLE
Docs: close post-import gaps for runtime diagnostics and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ OpenQuatt is a modular ESPHome controller for a dual heat pump setup with superv
 - Regulates pump flow using PI control and optional autotune tooling.
 - Supports CIC JSON feed ingestion and local-vs-cloud source selection.
 - Publishes dashboards and entities for operations, diagnostics, and tuning.
+- Includes built-in service utilities (firmware update checks, debug log controls, manual Modbus probe tools).
 
 ## Feature TODO
 
@@ -63,6 +64,7 @@ OpenQuatt is a modular ESPHome controller for a dual heat pump setup with superv
 │   ├── oq_energy.yaml
 │   ├── oq_cic.yaml
 │   ├── oq_local_sensors.yaml
+│   ├── oq_debug_testing.yaml         # Manual diagnostic/testing tools (one-shot Modbus reads)
 │   ├── oq_webserver.yaml
 │   ├── oq_HP_io.yaml
 │   └── includes/hp_perf_map.h

--- a/docs/home-assistant-dashboard.md
+++ b/docs/home-assistant-dashboard.md
@@ -17,10 +17,11 @@ The dashboard is designed as a practical operations console with the **Sections*
 - [5. Warmtecontrol View](#5-warmtecontrol-view)
 - [6. HPs View](#6-hps-view)
 - [7. CIC View](#7-cic-view)
-- [8. Diagnostics View](#8-diagnostics-view)
-- [9. Energy View](#9-energy-view)
-- [10. Advanced Settings View](#10-advanced-settings-view)
-- [11. Practical Maintenance Checklist](#11-practical-maintenance-checklist)
+- [8. Energy View](#8-energy-view)
+- [9. Advanced Settings View](#9-advanced-settings-view)
+- [10. Debug & Testing View](#10-debug--testing-view)
+- [11. Diagnostics View](#11-diagnostics-view)
+- [12. Practical Maintenance Checklist](#12-practical-maintenance-checklist)
 
 ## 1. Current View Set
 
@@ -31,9 +32,10 @@ The dashboard is designed as a practical operations console with the **Sections*
 | Warmtecontrol | `warmtecontrol` | Demand and heat allocation behavior |
 | HPs | `HPs` | HP1/HP2 deep diagnostics and visualization |
 | CIC | `cic` | Cloud feed health and source selection |
-| Diagnostics | `diagnostics` | Cross-source debug and validation |
 | Energy | `energy` | Daily/cumulative energy and efficiency metrics |
 | Advanced settings | `advanced-settings` | Expert tuning parameters with explanations |
+| Debug & Testing | `debug-testing` | Service utilities, runtime balancing checks, and manual probe tools |
+| Diagnostics | `diagnostics` | Cross-source debug and validation |
 
 ## 2. Design Rules Used
 
@@ -76,7 +78,7 @@ Expected content pattern:
 
 - flow status tiles
 - mode and setpoint controls
-- PI controls and mismatch threshold
+- PI controls and mismatch diagnostics
 - source and measurement trends
 - explanatory markdown for safe usage
 
@@ -123,19 +125,7 @@ Operational rule:
 
 - Use this tab when control values do not match expected cloud/local sources.
 
-## 8. Diagnostics View
-
-Expected content pattern:
-
-- side-by-side comparison of selected/local/CIC sources
-- debug-oriented status entities
-- low-level inspection cards that are too noisy for main operations
-
-Operational rule:
-
-- Prefer this tab when symptoms are ambiguous and source path must be proven.
-
-## 9. Energy View
+## 8. Energy View
 
 Expected content pattern:
 
@@ -151,7 +141,7 @@ Operational rule:
 
 - Validate tuning changes with this tab over full day windows.
 
-## 10. Advanced Settings View
+## 9. Advanced Settings View
 
 Expected content pattern:
 
@@ -163,7 +153,32 @@ Operational rule:
 
 - Treat this as engineering configuration, not a daily operations tab.
 
-## 11. Practical Maintenance Checklist
+## 10. Debug & Testing View
+
+Expected content pattern:
+
+- runtime balancing aids (`Runtime lead HP`, `Reset Runtime Counters (HP1+HP2)`)
+- manual Modbus probe controls (`Debug Modbus register`, `Debug Read HP1 register`, `Debug Read HP2 register`)
+- platform service utilities (`Firmware Update`, `Check Firmware Updates`)
+- runtime logger controls (`Debug Level`, `Debug Level Modbus`)
+
+Operational rule:
+
+- Use this tab for guided diagnostics and service actions, not for daily control tuning.
+
+## 11. Diagnostics View
+
+Expected content pattern:
+
+- side-by-side comparison of selected/local/CIC sources
+- debug-oriented status entities
+- low-level inspection cards that are too noisy for main operations
+
+Operational rule:
+
+- Prefer this tab when symptoms are ambiguous and source path must be proven.
+
+## 12. Practical Maintenance Checklist
 
 When editing the dashboard YAML:
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -30,6 +30,12 @@ This guide keeps the configuration maintainable and predictable while preserving
   - `oq_HP_io`: per-HP Modbus IO entities and actuators
 - Keep one change type per batch: formatting, comments, or logic.
 - Preserve package include order in `openquatt/oq_packages.yaml` unless dependencies are intentionally redesigned.
+- If you add/remove packages or user-facing entities, update the affected docs in the same PR:
+  - `README.md`
+  - `docs/system-overview.md`
+  - `docs/settings-reference.md`
+  - `docs/home-assistant-dashboard.md`
+  - `docs/specifications/technical-specification.md`
 
 ## Package Structure Convention
 

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -96,8 +96,10 @@ These are typically most relevant for behavior shaping:
   - `oq_defrost_comp_min_f`
   - `oq_defrost_comp_boost_steps`
 - Flow:
-  - `oq_flow_mismatch_fallback_lph`
+  - `oq_flow_mismatch_threshold_lph`
   - `oq_flow_mismatch_hyst_lph`
+  - `oq_flow_kp_min`, `oq_flow_kp_max`
+  - `oq_flow_ki_min`, `oq_flow_ki_max`
 - Boiler:
   - `oq_boiler_trip_c`, `oq_boiler_reset_c`
 - CIC:
@@ -172,11 +174,11 @@ Key entities:
 - `Flow AUTO start iPWM`
 - `Flow PI Kp`
 - `Flow PI Ki`
-- `Flow mismatch threshold`
 
 Intent:
 
 - regulate hydraulic behavior and pump output stability
+- monitor mismatch with compile-time thresholds (`oq_flow_mismatch_threshold_lph`, `oq_flow_mismatch_hyst_lph`)
 
 ### 5.5 Flow autotune
 
@@ -213,6 +215,24 @@ Key entities:
 Intent:
 
 - control cloud ingest and source arbitration for control inputs
+
+### 5.7 Service and diagnostics utilities
+
+Key entities:
+
+- `Firmware Update`
+- `Check Firmware Updates`
+- `Debug Level`
+- `Debug Level Modbus`
+- `Runtime lead HP`
+- `Reset Runtime Counters (HP1+HP2)`
+- `Debug Modbus register`
+- `Debug Read HP1 register`
+- `Debug Read HP2 register`
+
+Intent:
+
+- provide service operations and low-level diagnostics without changing control ownership
 
 ## 6. Operational Telemetry Entities (Key)
 

--- a/docs/specifications/technical-specification.md
+++ b/docs/specifications/technical-specification.md
@@ -57,6 +57,7 @@ Defined in `openquatt/oq_packages.yaml` and must be preserved unless dependencie
 
 | Component | Technical ownership |
 |---|---|
+| `oq_common` | shared runtime services (logger/api/ota/wifi/http/modbus) and service entities |
 | `oq_supervisory_controlmode` | Control Mode state machine, low-flow state, power cap factor |
 | `oq_heating_strategy` | strategy mode selection, demand generation, curve/PID path |
 | `oq_heat_control` | demand filtering, cap application, HP level optimization/application |
@@ -65,6 +66,7 @@ Defined in `openquatt/oq_packages.yaml` and must be preserved unless dependencie
 | `oq_boiler_control` | relay command and temperature lockout |
 | `oq_cic` | polling scheduler, backoff, parse/publish pipeline |
 | `oq_local_sensors` | DS18B20 ingest, selected-source synthesis |
+| `oq_debug_testing` | manual diagnostics helpers (one-shot Modbus register reads, probe entities) |
 | `oq_energy` | integration and daily/total energy entities |
 | `oq_HP_io` | Modbus register mapping and per-unit entities |
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -31,17 +31,19 @@ Shared runtime services are loaded from `openquatt/oq_common.yaml`, including:
 
 Package include order is intentional:
 
-1. `oq_supervisory_controlmode`
-2. `oq_heating_strategy`
-3. `oq_heat_control`
-4. `oq_flow_control`
-5. `oq_flow_autotune`
-6. `oq_boiler_control`
-7. `oq_energy`
-8. `oq_cic`
-9. `oq_local_sensors`
-10. `oq_webserver`
-11. `oq_HP_io` (HP1 and HP2 instances)
+1. `oq_common`
+2. `oq_supervisory_controlmode`
+3. `oq_heating_strategy`
+4. `oq_heat_control`
+5. `oq_flow_control`
+6. `oq_flow_autotune`
+7. `oq_boiler_control`
+8. `oq_energy`
+9. `oq_cic`
+10. `oq_local_sensors`
+11. `oq_debug_testing`
+12. `oq_webserver`
+13. `oq_HP_io` (HP1 and HP2 instances)
 
 This order mirrors data dependencies and ownership boundaries.
 
@@ -56,6 +58,8 @@ OpenQuatt follows strict subsystem ownership:
 - **Boiler relay control**: `oq_boiler_control`
 - **External feed ingest**: `oq_cic`
 - **Source selection and local DS18B20 ingest**: `oq_local_sensors`
+- **Shared runtime services and service entities**: `oq_common`
+- **Manual debug/testing probes**: `oq_debug_testing`
 
 This prevents hidden control coupling and keeps debugging deterministic.
 
@@ -127,6 +131,15 @@ Three switches decide whether selected values come from CIC or local/controller 
 - boiler thermal energy daily/total
 - system thermal energy daily/total
 - daily heat pump COP metric
+
+### 4.8 Service and diagnostics layer
+
+`oq_common` and `oq_debug_testing` provide:
+
+- firmware update entities and manual check trigger
+- runtime logger level controls
+- one-shot Modbus register read tools (HP1/HP2)
+- runtime balancing service entities (`Runtime lead HP`, runtime counter reset)
 
 ## 5. Heating Strategy Mechanics
 
@@ -220,6 +233,7 @@ Compile-time profile selection is done by choosing the firmware entrypoint:
 - HP1, HP2
 - Tuning groups
 - Diagnostics groups
+- Debug and testing groups surfaced in the dedicated dashboard tab
 
 This keeps ESPHome web UI and Home Assistant mapping coherent.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -134,12 +134,12 @@ Three switches decide whether selected values come from CIC or local/controller 
 
 ### 4.8 Service and diagnostics layer
 
-`oq_common` and `oq_debug_testing` provide:
+`oq_common`, `oq_debug_testing`, and `oq_heat_control` provide:
 
 - firmware update entities and manual check trigger
 - runtime logger level controls
 - one-shot Modbus register read tools (HP1/HP2)
-- runtime balancing service entities (`Runtime lead HP`, runtime counter reset)
+- runtime balancing service entities from heat control (`Runtime lead HP`, runtime counter reset)
 
 ## 5. Heating Strategy Mechanics
 

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -120,7 +120,13 @@ Primary knobs:
 - `Flow PI Kp`
 - `Flow PI Ki`
 - `Flow AUTO start iPWM`
-- `Flow mismatch threshold`
+
+Compile-time flow mismatch guardrails:
+
+- `oq_flow_mismatch_threshold_lph`
+- `oq_flow_mismatch_hyst_lph`
+
+These are firmware constants in `openquatt/oq_substitutions_common.yaml` and require compile/flash after changes.
 
 What to watch:
 
@@ -175,6 +181,7 @@ If behavior looks contradictory:
 - Check the selected flow source first.
 - Check low-flow fault timers/hysteresis, not only current flow value.
 - Check whether heating demand was active when low-flow state occurred.
+- Use the `Debug & Testing` dashboard view for one-shot Modbus validation if HP flow telemetry looks inconsistent.
 
 Remember: fault state logic is timer-based and mode-context-dependent.
 

--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -9,8 +9,9 @@
 # 5) Aggregation/energy telemetry
 # 6) External inputs (CIC)
 # 7) Local sensors/source selection
-# 8) Web UI
-# 9) Per-HP hardware adapters
+# 8) Debug/testing utilities
+# 9) Web UI
+# 10) Per-HP hardware adapters
 # ==============================================================================
 oq_common: !include oq_common.yaml
 oq_supervisory_controlmode: !include oq_supervisory_controlmode.yaml


### PR DESCRIPTION
## Summary
- align docs with current package/include reality by documenting oq_debug_testing and oq_common roles
- fix flow mismatch documentation drift: document as compile-time constants instead of a runtime entity
- synchronize dashboard docs with current views, including the Debug & Testing tab and key service/debug entities
- add maintenance guidance to require doc updates when packages or user-facing entities change
- update package header comments and README structure note to include debug/testing utilities

## Scope
- documentation and comments only
- no control logic changes

## Validation
- reviewed diffs for all touched docs and package comments
- branch pushed and ready for review