### PR TITLE
Refine HA dashboard flow tiles and docs

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -22,13 +22,13 @@ views:
 
               These values show the key system performance in real time:
 
-              - `Flow`: current volume flow used as the basis for flow safety.
-
               - `Power E`: total electrical input power of the heat pump(s).
 
               - `Power H`: total delivered thermal output power.
 
               - `COP`: ratio `Power H / Power E` (instant efficiency).
+
+              - `Flow`: current volume flow used as the basis for flow safety.
 
               - `Outside temp`: selected outdoor temperature source used in control.
 
@@ -38,13 +38,6 @@ views:
 
               </details>
             text_only: true
-          - type: tile
-            entity: sensor.openquatt_flow_average_selected
-            name: Flow
-            vertical: false
-            features:
-              - type: trend-graph
-            features_position: bottom
           - type: tile
             entity: sensor.openquatt_total_power_input
             name: Power E
@@ -62,6 +55,13 @@ views:
           - type: tile
             entity: sensor.openquatt_total_cop
             name: COP
+            vertical: false
+            features:
+              - type: trend-graph
+            features_position: bottom
+          - type: tile
+            entity: sensor.openquatt_flow_average_selected
+            name: Flow
             vertical: false
             features:
               - type: trend-graph
@@ -185,20 +185,28 @@ views:
 
               </details>
             text_only: true
-          - type: tile
-            entity: sensor.openquatt_room_temperature_selected
-            name: Current temperature
-            vertical: false
-            features:
-              - type: trend-graph
-            features_position: bottom
-          - type: tile
-            entity: sensor.openquatt_room_setpoint_selected
-            name: Setpoint
-            vertical: false
-            features:
-              - type: trend-graph
-            features_position: bottom
+          - type: custom:mini-graph-card
+            name: Current room temperature
+            entities:
+              - entity: sensor.openquatt_room_temperature_selected
+                name: Room temperature
+                show_legend_state: true
+              - entity: sensor.openquatt_room_setpoint_selected
+                name: Setpoint
+                show_fill: false
+                show_legend_state: true
+            show:
+              icon: true
+              name: true
+              state: true
+              legend: true
+              labels: false
+            points_per_hour: 30
+            hours_to_show: 2
+            line_width: 2
+            hour24: true
+            height: 80
+            decimals: 1
           - type: heading
             heading_style: title
             heading: Silent mode settings

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2266,7 +2266,7 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Auto start iPWM** defines initial pump command for flow control.
+              - **Auto start iPWM** is fallback start command; AUTO first uses remembered **last good iPWM** when valid.
 
               - **CM98 iPWM** is de circulatiesetting voor anti-freeze context.
 

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -722,24 +722,6 @@ views:
             icon: mdi:waves-arrow-right
             heading: Flow status & control
             heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Explanation</strong></summary>
-
-              This block combines quick status checks and key flow controls.
-
-              - `Flow mode` shows how flow control is currently active (usually
-              `AUTO` / `Flow Setpoint`).
-              - `Control mode` shows which operating phase the system is in.
-              - `Lowflow fault` should remain `Off` in normal operation.
-              - `Flow mismatch` should be `OK`; if not, HP1 and HP2 are
-              hydraulically unbalanced.
-              - `Flow setpoint`: target flow that the controller drives toward.
-              - `Manual iPWM`: direct pump command for tests; keep disabled in
-              normal operation.
-              </details>
-            text_only: true
           - type: heading
             icon: ''
             heading: Status
@@ -799,7 +781,7 @@ views:
 
               - `Flow control mode`: choose automatic flow control or manual behavior.
               - `Flow setpoint`: target flow in L/h for automatic control.
-              - `Manual iPWM`: direct pump command for testing only (keep disabled in normal operation).
+              - `Manual iPWM`: set iPWM value for manual control.
               </details>
             text_only: true
           - type: tile

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2388,8 +2388,8 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Auto start iPWM** bepaalt de initiële pompaansturing bij
-              flowregeling.
+              - **Auto start iPWM** is een fallback startwaarde; AUTO gebruikt
+              eerst de onthouden **last good iPWM** als die geldig is.
 
               - **CM98 iPWM** is de circulatiesetting voor anti-freeze context.
 

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -743,25 +743,6 @@ views:
             icon: mdi:waves-arrow-right
             heading: Flow status & control
             heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Uitleg</strong></summary>
-
-              Dit blok combineert snelle statuscontrole en de belangrijkste
-              flow-bediening.
-
-              - `Flow mode` laat zien hoe de flowregeling actief is (meestal
-              `AUTO` / `Flow Setpoint`).
-              - `Control mode` toont in welke bedrijfsfase het systeem draait.
-              - `Lowflow fault` moet in normaal bedrijf `Off` blijven.
-              - `Flow mismatch` hoort `OK` te zijn; bij afwijking zijn HP1 en
-              HP2 hydraulisch niet in balans.
-              - `Flow setpoint`: gewenste flow waar de regeling naartoe stuurt.
-              - `Manual iPWM`: directe pompaansturing voor tests; in normaal
-              bedrijf uit laten.
-              </details>
-            text_only: true
           - type: heading
             icon: ''
             heading: Status
@@ -837,8 +818,7 @@ views:
 
               - `Flow setpoint`: doel-flow in L/h voor automatische regeling.
 
-              - `Manual iPWM`: directe pompaansturing voor tests (in normaal
-              bedrijf uit laten).
+              - `Manual iPWM`: stel iPWM waarde in voor handbediening.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -22,15 +22,15 @@ views:
 
               Deze waarden geven live de belangrijkste systeemprestatie:
 
-              - `Flow`: actuele volumestroom die als basis dient voor
-              flowbewaking.
-
               - `Power E`: totaal elektrisch ingangsvermogen van de
               warmtepomp(en).
 
               - `Power H`: totaal thermisch afgegeven vermogen.
 
               - `COP`: verhouding `Power H / Power E` (momentane efficientie).
+
+              - `Flow`: actuele volumestroom die als basis dient voor
+              flowbewaking.
 
               - `Buitentemp`: geselecteerde bron voor buitentemperatuur in de
               regeling.
@@ -41,13 +41,6 @@ views:
 
               </details>
             text_only: true
-          - type: tile
-            entity: sensor.openquatt_flow_average_selected
-            name: Flow
-            vertical: false
-            features:
-              - type: trend-graph
-            features_position: bottom
           - type: tile
             entity: sensor.openquatt_total_power_input
             name: Power E
@@ -65,6 +58,13 @@ views:
           - type: tile
             entity: sensor.openquatt_total_cop
             name: COP
+            vertical: false
+            features:
+              - type: trend-graph
+            features_position: bottom
+          - type: tile
+            entity: sensor.openquatt_flow_average_selected
+            name: Flow
             vertical: false
             features:
               - type: trend-graph
@@ -190,20 +190,28 @@ views:
 
               </details>
             text_only: true
-          - type: tile
-            entity: sensor.openquatt_room_temperature_selected
-            name: Huidige temperatuur
-            vertical: false
-            features:
-              - type: trend-graph
-            features_position: bottom
-          - type: tile
-            entity: sensor.openquatt_room_setpoint_selected
-            name: Setpoint
-            vertical: false
-            features:
-              - type: trend-graph
-            features_position: bottom
+          - type: custom:mini-graph-card
+            name: Huidige kamertemperatuur
+            entities:
+              - entity: sensor.openquatt_room_temperature_selected
+                name: Kamertemperatuur
+                show_legend_state: true
+              - entity: sensor.openquatt_room_setpoint_selected
+                name: Setpoint
+                show_fill: false
+                show_legend_state: true
+            show:
+              icon: true
+              name: true
+              state: true
+              legend: true
+              labels: false
+            points_per_hour: 30
+            hours_to_show: 2
+            line_width: 2
+            hour24: true
+            height: 80
+            decimals: 1
           - type: heading
             heading_style: title
             heading: Silent mode settings

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -219,6 +219,7 @@ Key entities:
 Intent:
 
 - regulate hydraulic behavior and pump output stability
+- on AUTO entry, `last_good_pwm` has priority; `Flow AUTO start iPWM` is fallback when no valid `last_good_pwm` is available
 - monitor mismatch with compile-time thresholds (`oq_flow_mismatch_threshold_lph`, `oq_flow_mismatch_hyst_lph`)
 
 ### 5.5 Flow autotune

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -209,6 +209,8 @@ Primary knobs:
 - `Flow PI Ki`
 - `Flow AUTO start iPWM`
 
+`Flow AUTO start iPWM` is a fallback start value. AUTO restarts first use remembered `last_good_pwm` when valid.
+
 Compile-time flow mismatch guardrails:
 
 - `oq_flow_mismatch_threshold_lph`


### PR DESCRIPTION
Summary
- move the Flow tile next to other system metrics and align English/Dutch descriptions so the overview matches the layout
- replace the room temperature tiles with a mini-graph card for better trend visibility and tweak the manual iPWM wording
- document the last_good_pwm fallback behavior in the flow references and troubleshooting guides

Testing
- Not run (not requested)