### PR TITLE
Heating curve optimisation: stabilize control, allocation, and diagnostics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ docs/
 - `control-modes-and-flow.md`: CM behavior, Flow Mode semantics, Heating Strategy modes, and precedence.
 - `settings-reference.md`: compile-time vs runtime settings, including low-load and anti-flip controls.
 - `tuning-and-troubleshooting.md`: practical workflows, symptom-driven diagnostics, and low-load/zero-edge stability tuning.
-- `home-assistant-dashboard.md`: dashboard structure and how to use new low-load and shadow-arbiter debug cards.
+- `home-assistant-dashboard.md`: dashboard structure and how to use low-load, shadow-arbiter, and heating-curve debug cards.
 - `release-process.md`: GitHub Actions CI/release flow, tag strategy, and release execution steps.
 - `dashboard/README.md`: dashboard language variants and Home Assistant import instructions.
 - `specifications/functional-specification.md`: what the system must do.

--- a/docs/control-modes-and-flow.md
+++ b/docs/control-modes-and-flow.md
@@ -114,8 +114,9 @@ Runtime entity: `select.openquatt_heating_mode`
 - Runs PID on selected supply temperature.
 - Maps PID output to demand `0..20`.
 - Resets integral when SP/PV is invalid.
-- Adds near-zero anti-flip guards: `Curve Temp Deadband` and `Curve Demand Off Hold`.
-- Uses an overtemp latch to avoid direct demand hard-drop chatter around the supply-target crossover.
+- Uses profile-based outside-temp smoothing and target quantization.
+- Uses start/stop temperature hysteresis around supply target to stabilize zero-demand behavior.
+- Applies explicit per-HP level slew-rate limiting (asymmetric up/down timing).
 
 ## 6. Flow Mode
 

--- a/docs/control-modes-and-flow.md
+++ b/docs/control-modes-and-flow.md
@@ -96,7 +96,7 @@ Threshold model:
 
 ## 5. Heating Strategy Modes
 
-Runtime entity: `select.openquatt_heating_mode`
+Runtime entity: `select.openquatt_heating_control_mode`
 
 ### 5.1 Power House
 
@@ -120,7 +120,7 @@ Runtime entity: `select.openquatt_heating_mode`
 
 ## 6. Flow Mode
 
-Runtime entity: `select.openquatt_flow_mode`
+Runtime entity: `select.openquatt_flow_control_mode`
 
 Options:
 

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2155,8 +2155,11 @@ views:
               - **Demand filter ramp up** controls how many demand steps per
               minute `Demand filtered` may rise toward `Demand raw`.
 
-              - **Single HP assist ON/OFF deficit** defines at which thermal
-              deficit extra HP assist is activated or released.
+              - **Single HP assist ON level (f)** defines above which filtered
+              demand level dual-HP assist may be activated.
+
+              - OFF level is derived internally as `ON - 2` to keep tuning
+              compact.
 
               - **ON/OFF hold** adds time hysteresis to damp frequent toggling.
 
@@ -2174,10 +2177,8 @@ views:
                 name: Minimum runtime
               - entity: number.openquatt_demand_filter_ramp_up
                 name: Demand filter ramp up
-              - entity: number.openquatt_single_hp_assist_on_deficit
-                name: Single HP assist ON deficit
-              - entity: number.openquatt_single_hp_assist_off_deficit
-                name: Single HP assist OFF deficit
+              - entity: number.openquatt_single_hp_assist_on_level
+                name: Single HP assist ON level
               - entity: number.openquatt_single_hp_assist_on_hold
                 name: Single HP assist ON hold
               - entity: number.openquatt_single_hp_assist_off_hold

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2153,7 +2153,11 @@ views:
               start/stop behavior.
 
               - **Demand filter ramp up** controls how many demand steps per
-              minute `Demand filtered` may rise toward `Demand raw`.
+              minute `Demand filtered` may rise toward `Demand raw` in Power
+              House mode.
+
+              - In heating-curve mode, PID demand is passed through directly;
+              per-HP slew limiting remains the guardrail.
 
               - **Single HP assist ON level (f)** defines above which filtered
               demand level dual-HP assist may be activated.

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2450,8 +2450,8 @@ views:
               - First compare `Supply target` and `Supply actual` to see control error.
               - Then verify the chain: `Demand curve raw (PID)` -> `Demand raw` -> `Demand filtered`.
               - In curve mode, `P_req` is derived from demand and is used by deficit/CM3 logic.
-              - `Curve Temp Deadband` and `Curve Demand Off Hold` are the main
-                anti-flip stabilizers around the zero-demand edge.
+              - `Heating Curve Control Profile` sets the built-in stability bundle
+                (smoothing, hysteresis, and slew-rate behavior).
 
               Note: if `Supply actual` is above target while demand stays high, check PID tuning (`Kp/Ki/Kd`) and time behavior.
 
@@ -2462,6 +2462,8 @@ views:
             entities:
               - entity: select.openquatt_heating_control_mode
                 name: Heating mode
+              - entity: select.openquatt_heating_curve_control_profile
+                name: Curve control profile
               - entity: climate.openquatt_heating_curve_pid
                 name: Heating Curve PID
               - entity: button.openquatt_reset_heating_curve_pid_integral
@@ -2484,10 +2486,6 @@ views:
                 name: PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: PID Kd
-              - entity: number.openquatt_curve_temp_deadband
-                name: Curve Temp Deadband
-              - entity: number.openquatt_curve_demand_off_hold
-                name: Curve Demand Off Hold
           - type: history-graph
             title: Heating Curve temperature loop (2h)
             hours_to_show: 2

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2157,19 +2157,20 @@ views:
               House mode.
 
               - In heating-curve mode, PID demand is passed through directly;
-              per-HP slew limiting remains the guardrail.
+              allocation is single-HP-first with dual-enable hysteresis and
+              sequential level steps.
 
-              - **Single HP assist ON level (f)** defines above which filtered
-              demand level dual-HP assist may be activated.
+              - **Dual HP enable level (lvl)** defines at which sustained
+              single-HP compressor level a second HP may be enabled.
 
-              - OFF level is derived internally as `ON - 2` to keep tuning
+              - Disable level is derived internally as `enable - 1` to keep tuning
               compact.
 
-              - **ON/OFF hold** adds time hysteresis to damp frequent toggling.
+              - **Enable/disable hold** adds time hysteresis to damp frequent toggling.
 
-              - Lower ON or shorter ON-hold = faster extra capacity.
+              - Lower enable level or shorter enable-hold = faster second-HP activation.
 
-              - Higher OFF or longer OFF-hold = dual-HP stays active longer.
+              - Longer disable-hold = dual-HP stays active longer.
 
 
               </details>
@@ -2181,12 +2182,12 @@ views:
                 name: Minimum runtime
               - entity: number.openquatt_demand_filter_ramp_up
                 name: Demand filter ramp up
-              - entity: number.openquatt_single_hp_assist_on_level
-                name: Single HP assist ON level
-              - entity: number.openquatt_single_hp_assist_on_hold
-                name: Single HP assist ON hold
-              - entity: number.openquatt_single_hp_assist_off_hold
-                name: Single HP assist OFF hold
+              - entity: number.openquatt_dual_hp_enable_level
+                name: Dual HP enable level
+              - entity: number.openquatt_dual_hp_enable_hold
+                name: Dual HP enable hold
+              - entity: number.openquatt_dual_hp_disable_hold
+                name: Dual HP disable hold
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -2454,10 +2454,16 @@ views:
 
               - This section is most relevant when `Heating mode = Curve`.
               - First compare `Supply target` and `Supply actual` to see control error.
-              - Then verify the chain: `Demand curve raw (PID)` -> `Demand raw` -> `Demand filtered`.
+              - Then verify the chain:
+                `Demand curve pre-guardrail` -> `Demand curve post-guardrail` -> `Demand raw` -> `Demand filtered`.
               - In curve mode, `P_req` is derived from demand and is used by deficit/CM3 logic.
+              - `Curve phase` (`HEAT`/`COAST`/`OFF`) and `Curve restart inhibit`
+                explain why demand may not restart immediately after an OFF phase.
               - `Heating Curve Control Profile` sets the built-in stability bundle
                 (smoothing, hysteresis, and slew-rate behavior).
+              - `Heating debug state` is a compact one-line trace
+                (mode/phase/raw/f/req/app/current levels/temps).
+                If it stays unavailable, enable it in the HA entity registry first.
 
               Note: if `Supply actual` is above target while demand stays high, check PID tuning (`Kp/Ki/Kd`) and time behavior.
 
@@ -2478,14 +2484,24 @@ views:
                 name: Supply target
               - entity: sensor.openquatt_water_supply_temp_selected
                 name: Supply actual (selected)
+              - entity: sensor.openquatt_demand_curve_pre_guardrail
+                name: Demand curve pre-guardrail
+              - entity: sensor.openquatt_demand_curve_post_guardrail
+                name: Demand curve post-guardrail
               - entity: sensor.openquatt_demand_curve_raw
-                name: Demand curve raw (PID)
+                name: Demand curve raw
+              - entity: sensor.openquatt_curve_phase
+                name: Curve phase
+              - entity: sensor.openquatt_curve_restart_inhibit
+                name: Curve restart inhibit
               - entity: sensor.openquatt_demand_raw
                 name: Demand raw
               - entity: sensor.openquatt_demand_filtered
                 name: Demand filtered
               - entity: sensor.openquatt_power_house_p_req
                 name: P_req
+              - entity: sensor.openquatt_heating_debug_state
+                name: Heating debug state
               - entity: number.openquatt_heating_curve_pid_kp
                 name: PID Kp
               - entity: number.openquatt_heating_curve_pid_ki

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2270,7 +2270,10 @@ views:
 
               - **Demand filter ramp up** bepaalt met hoeveel demand-stappen per
               minuut `Demand filtered` maximaal mag stijgen richting `Demand
-              raw`.
+              raw` in Power House mode.
+
+              - In heating-curve mode wordt PID-demand direct doorgezet; de
+              per-HP slew-limiter blijft de guardrail.
 
               - **Single HP assist ON level (f)** bepaalt boven welk gefilterd
               demand-level dual-HP-assist mag worden geactiveerd.

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2591,8 +2591,8 @@ views:
               - `P_req` wordt in curve mode afgeleid uit demand en helpt bij
               CM3/tekort-logica.
 
-              - `Curve Temp Deadband` en `Curve Demand Off Hold` zijn de
-                belangrijkste anti-flip stabilisatie rond de nulvraag-rand.
+              - `Heating Curve Control Profile` kiest de ingebouwde
+                stabiliteitsbundel (smoothing, hysterese en slew-rate gedrag).
 
               Let op: als `Supply actual` boven target zit maar demand hoog
               blijft, kijk dan naar PID-instellingen (`Kp/Ki/Kd`) en gedrag over
@@ -2606,6 +2606,8 @@ views:
             entities:
               - entity: select.openquatt_heating_control_mode
                 name: Heating mode
+              - entity: select.openquatt_heating_curve_control_profile
+                name: Curve control profile
               - entity: climate.openquatt_heating_curve_pid
                 name: Heating Curve PID
               - entity: button.openquatt_reset_heating_curve_pid_integral
@@ -2628,10 +2630,6 @@ views:
                 name: PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: PID Kd
-              - entity: number.openquatt_curve_temp_deadband
-                name: Curve Temp Deadband
-              - entity: number.openquatt_curve_demand_off_hold
-                name: Curve Demand Off Hold
           - type: history-graph
             title: Heating Curve temperatuur-lus (2 uur)
             hours_to_show: 2

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2272,9 +2272,11 @@ views:
               minuut `Demand filtered` maximaal mag stijgen richting `Demand
               raw`.
 
-              - **Single HP assist ON/OFF deficit** bepaalt bij welke thermische
-              tekort-waarde extra HP-assist wordt geactiveerd of weer
-              losgelaten.
+              - **Single HP assist ON level (f)** bepaalt boven welk gefilterd
+              demand-level dual-HP-assist mag worden geactiveerd.
+
+              - OFF-level wordt intern afgeleid als `ON - 2` om het aantal
+              instellingen beperkt te houden.
 
               - **ON/OFF hold** voegt tijdhysterese toe om op en neer schakelen
               te dempen.
@@ -2293,10 +2295,8 @@ views:
                 name: Minimum runtime
               - entity: number.openquatt_demand_filter_ramp_up
                 name: Demand filter ramp up
-              - entity: number.openquatt_single_hp_assist_on_deficit
-                name: Single HP assist ON deficit
-              - entity: number.openquatt_single_hp_assist_off_deficit
-                name: Single HP assist OFF deficit
+              - entity: number.openquatt_single_hp_assist_on_level
+                name: Single HP assist ON level
               - entity: number.openquatt_single_hp_assist_on_hold
                 name: Single HP assist ON hold
               - entity: number.openquatt_single_hp_assist_off_hold

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2273,20 +2273,21 @@ views:
               raw` in Power House mode.
 
               - In heating-curve mode wordt PID-demand direct doorgezet; de
-              per-HP slew-limiter blijft de guardrail.
+              allocatie is single-HP-first met dual-enable hysterese en
+              sequentiële levelstappen.
 
-              - **Single HP assist ON level (f)** bepaalt boven welk gefilterd
-              demand-level dual-HP-assist mag worden geactiveerd.
+              - **Dual HP enable level (lvl)** bepaalt bij welk aanhoudend
+              single-HP compressorlevel een tweede HP mag worden geactiveerd.
 
-              - OFF-level wordt intern afgeleid als `ON - 2` om het aantal
+              - Disable-level wordt intern afgeleid als `enable - 1` om het aantal
               instellingen beperkt te houden.
 
-              - **ON/OFF hold** voegt tijdhysterese toe om op en neer schakelen
+              - **Enable/disable hold** voegt tijdhysterese toe om op en neer schakelen
               te dempen.
 
-              - Lager ON of kortere ON-hold = sneller extra capaciteit.
+              - Lager enable-level of kortere enable-hold = sneller 2 HP actief.
 
-              - Hoger OFF of langere OFF-hold = langer dual-HP actief.
+              - Hogere disable-hold = langer dual-HP actief.
 
 
               </details>
@@ -2298,12 +2299,12 @@ views:
                 name: Minimum runtime
               - entity: number.openquatt_demand_filter_ramp_up
                 name: Demand filter ramp up
-              - entity: number.openquatt_single_hp_assist_on_level
-                name: Single HP assist ON level
-              - entity: number.openquatt_single_hp_assist_on_hold
-                name: Single HP assist ON hold
-              - entity: number.openquatt_single_hp_assist_off_hold
-                name: Single HP assist OFF hold
+              - entity: number.openquatt_dual_hp_enable_level
+                name: Dual HP enable level
+              - entity: number.openquatt_dual_hp_enable_hold
+                name: Dual HP enable hold
+              - entity: number.openquatt_dual_hp_disable_hold
+                name: Dual HP disable hold
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -2589,14 +2589,22 @@ views:
               - Vergelijk eerst `Supply target` met `Supply actual` om de
               regelafwijking te zien.
 
-              - Controleer daarna de keten: `Demand curve raw (PID)` -> `Demand
-              raw` -> `Demand filtered`.
+              - Controleer daarna de keten:
+              `Demand curve pre-guardrail` -> `Demand curve post-guardrail` ->
+              `Demand raw` -> `Demand filtered`.
 
               - `P_req` wordt in curve mode afgeleid uit demand en helpt bij
               CM3/tekort-logica.
 
+              - `Curve phase` (`HEAT`/`COAST`/`OFF`) en `Curve restart inhibit`
+                verklaren waarom demand soms niet direct opnieuw start na een OFF-fase.
+
               - `Heating Curve Control Profile` kiest de ingebouwde
                 stabiliteitsbundel (smoothing, hysterese en slew-rate gedrag).
+
+              - `Heating debug state` geeft een compacte one-line trace
+                (mode/phase/raw/f/req/app/current levels/temps).
+                Blijft deze unavailable, zet de entiteit eerst aan in de HA entity-registry.
 
               Let op: als `Supply actual` boven target zit maar demand hoog
               blijft, kijk dan naar PID-instellingen (`Kp/Ki/Kd`) en gedrag over
@@ -2620,14 +2628,24 @@ views:
                 name: Supply target
               - entity: sensor.openquatt_water_supply_temp_selected
                 name: Supply actual (selected)
+              - entity: sensor.openquatt_demand_curve_pre_guardrail
+                name: Demand curve pre-guardrail
+              - entity: sensor.openquatt_demand_curve_post_guardrail
+                name: Demand curve post-guardrail
               - entity: sensor.openquatt_demand_curve_raw
-                name: Demand curve raw (PID)
+                name: Demand curve raw
+              - entity: sensor.openquatt_curve_phase
+                name: Curve phase
+              - entity: sensor.openquatt_curve_restart_inhibit
+                name: Curve restart inhibit
               - entity: sensor.openquatt_demand_raw
                 name: Demand raw
               - entity: sensor.openquatt_demand_filtered
                 name: Demand filtered
               - entity: sensor.openquatt_power_house_p_req
                 name: P_req
+              - entity: sensor.openquatt_heating_debug_state
+                name: Heating debug state
               - entity: number.openquatt_heating_curve_pid_kp
                 name: PID Kp
               - entity: number.openquatt_heating_curve_pid_ki

--- a/docs/home-assistant-dashboard.md
+++ b/docs/home-assistant-dashboard.md
@@ -92,11 +92,11 @@ Expected content pattern:
 
 - compact explanation block ("Heat control in 30 seconds")
 - inline heating mode control tile
+- inline heating-curve control profile tile
 - core KPI tile grid (`P_house`, `P_req`, `HP capacity`, `HP deficit`)
 - demand and cap tile row (`Demand raw`, `Demand filtered`, `Power cap demand`)
 - capacity gauges with visual deficit severity
 - trend charts for demand/power behavior
-- heating-curve anti-flip controls (`Curve Temp Deadband`, `Curve Demand Off Hold`)
 - heat allocation ramp control (`Demand filter ramp up`)
 
 Operational rule:

--- a/docs/home-assistant-dashboard.md
+++ b/docs/home-assistant-dashboard.md
@@ -95,6 +95,7 @@ Expected content pattern:
 - inline heating-curve control profile tile
 - core KPI tile grid (`P_house`, `P_req`, `HP capacity`, `HP deficit`)
 - demand and cap tile row (`Demand raw`, `Demand filtered`, `Power cap demand`)
+- heating-curve trace row (`Demand curve pre/post-guardrail`, `Curve phase`, `Curve restart inhibit`)
 - capacity gauges with visual deficit severity
 - trend charts for demand/power behavior
 - heat allocation ramp control (`Demand filter ramp up`)
@@ -178,6 +179,7 @@ Expected content pattern:
 - manual Modbus probe controls (`Debug Modbus register`, `Debug Read HP1 register`, `Debug Read HP2 register`)
 - platform service utilities (`Firmware Update`, `Check Firmware Updates`)
 - runtime logger controls (`Debug Level`, `Debug Level Modbus`)
+- heating-curve loop diagnostics (`Supply target/actual`, demand chain pre/post guardrail, `Curve phase`, `Curve restart inhibit`, `Heating Debug State`)
 
 Operational rule:
 

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -203,8 +203,7 @@ Key entities:
 
 - `Minimum runtime`
 - `Demand filter ramp up`
-- `Single HP Assist ON Deficit`
-- `Single HP Assist OFF Deficit`
+- `Single HP Assist ON Level`
 - `Single HP Assist ON Hold`
 - `Single HP Assist OFF Hold`
 - HP level allow switches (`HP1/HP2 Allowed level 1..10`)
@@ -213,6 +212,7 @@ Intent:
 
 - control how demand is split and persisted
 - avoid short-cycling
+- keep dual-HP assist in low-demand band predictable (OFF level is derived as `ON - 2`)
 - optionally restrict level availability
 
 ### 5.4 Flow and pump

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -153,10 +153,9 @@ Key entities:
 - `Power House ramp up`
 - `Power House ramp down`
 - `Curve Tsupply @ -20/-10/0/5/10/15°C`
+- `Heating Curve Control Profile` (`Comfort` / `Balanced` / `Stable`)
 - `Heating Curve PID Kp/Ki/Kd`
 - `Curve Fallback Tsupply (No Outside Temp)`
-- `Curve Temp Deadband`
-- `Curve Demand Off Hold`
 
 Intent:
 

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -203,18 +203,18 @@ Key entities:
 
 - `Minimum runtime`
 - `Demand filter ramp up`
-- `Single HP Assist ON Level`
-- `Single HP Assist ON Hold`
-- `Single HP Assist OFF Hold`
+- `Dual HP Enable Level`
+- `Dual HP Enable Hold`
+- `Dual HP Disable Hold`
 - HP level allow switches (`HP1/HP2 Allowed level 1..10`)
 
 Intent:
 
 - control how demand is split and persisted
 - avoid short-cycling
-- in heating-curve mode: keep actuator changes calm via slew while strategy handles `HEAT/COAST/OFF`
+- in heating-curve mode: keep single-HP-first allocation with dual-enable hysteresis and calm actuator steps
 - in Power House mode: `Minimum runtime` can block fast stop
-- keep dual-HP assist in low-demand band predictable (OFF level is derived as `ON - 2`)
+- keep dual-HP enable predictable (disable level is derived as `enable - 1`)
 - optionally restrict level availability
 
 ### 5.4 Flow and pump

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -212,6 +212,8 @@ Intent:
 
 - control how demand is split and persisted
 - avoid short-cycling
+- in heating-curve mode: keep actuator changes calm via slew while strategy handles `HEAT/COAST/OFF`
+- in Power House mode: `Minimum runtime` can block fast stop
 - keep dual-HP assist in low-demand band predictable (OFF level is derived as `ON - 2`)
 - optionally restrict level availability
 

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -213,7 +213,7 @@ Intent:
 - control how demand is split and persisted
 - avoid short-cycling
 - in heating-curve mode: keep single-HP-first allocation with dual-enable hysteresis and calm actuator steps
-- in Power House mode: `Minimum runtime` can block fast stop
+- in both heating-curve and Power House modes: `Minimum runtime` can block fast stop
 - keep dual-HP enable predictable (disable level is derived as `enable - 1`)
 - optionally restrict level availability
 

--- a/docs/specifications/technical-specification.md
+++ b/docs/specifications/technical-specification.md
@@ -179,13 +179,14 @@ Two technical branches:
 - computes `oq_supply_target_temp`
 - drives climate PID (`oq_heating_curve_pid`)
 - maps PID output (`heating_curve_pid_out`) to demand scale
-- applies `Curve Temp Deadband` and `Curve Demand Off Hold` around zero-demand edge
-- applies overtemp latch to reduce demand chatter near supply-target crossover
+- applies profile-based outside-temp smoothing and target quantization
+- applies start/stop temperature hysteresis around supply target near zero-demand edge
+- applies explicit per-HP level slew limiting in the heat allocator (asymmetric up/down timing)
 
 Technical guard:
 
 - invalid SP/PV triggers demand-safe behavior and PID integral reset.
-- overtemp latch also triggers PID integral reset to avoid continued push during over-target phase.
+- hysteresis gate OFF also triggers PID integral reset to avoid continued push during over-target phase.
 
 ## 9. Heat Allocation Engine (Technical)
 

--- a/docs/specifications/technical-specification.md
+++ b/docs/specifications/technical-specification.md
@@ -105,7 +105,7 @@ Defined in `openquatt/oq_packages.yaml` and must be preserved unless dependencie
 ### Heat allocation loop
 
 - Interval: `${oq_heat_loop_s}`
-- Intentionally slower for stable level decisions.
+- Fast execution; per-minute controls (for example demand ramp and assist hold) are elapsed-time scaled for stable behavior.
 
 ### Flow loop
 

--- a/docs/specifications/technical-specification.md
+++ b/docs/specifications/technical-specification.md
@@ -104,8 +104,11 @@ Defined in `openquatt/oq_packages.yaml` and must be preserved unless dependencie
 
 ### Heat allocation loop
 
-- Interval: `${oq_heat_loop_s}`
-- Fast execution; per-minute controls (for example demand ramp and assist hold) are elapsed-time scaled for stable behavior.
+- Tick interval: `${oq_heat_loop_tick_s}`
+- Effective control cadence:
+  - Heating Curve: `${oq_heat_loop_curve_s}`
+  - Power House: `${oq_heat_loop_powerhouse_s}`
+- Per-minute controls (for example demand ramp, dual-enable hold, and min-runtime timing) are elapsed-time scaled for stable behavior.
 
 ### Flow loop
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -181,9 +181,9 @@ When PID SP/PV is invalid, demand falls back to 0 and integral is reset.
 
 Heating-curve stability guards around zero-demand edge:
 
-- `Curve Temp Deadband`: caps curve demand near supply-target error zero
-- `Curve Demand Off Hold`: holds demand at 1 briefly before allowing 0
-- overtemp latch behavior to avoid direct CM2<->CM1 flip around the cutoff
+- profile-based outside-temperature smoothing and target quantization
+- start/stop temperature hysteresis around supply target
+- explicit per-HP slew-rate limiting with slower up and faster down behavior
 
 ## 6. Allocation and Optimization Mechanics
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -73,7 +73,7 @@ This prevents hidden control coupling and keeps debugging deterministic.
 |---|---:|---|
 | Supervisory | `${oq_supervisory_loop_s}` (default 5s) | Mode decisions, flow interlock, frost logic, power-cap safety net |
 | Heating Strategy | `${oq_strategy_loop_s}` (default 5s) | Demand generation (Power House / heating-curve path) |
-| Heat allocation | `${oq_heat_loop_s}` (default 60s) | Demand filtering, allocation, optimizer, level apply |
+| Heat allocation | `${oq_heat_loop_s}` (default 5s) | Demand filtering, allocation, optimizer, level apply (per-minute tuning is elapsed-time scaled) |
 | Flow control | `${oq_flow_loop_s}` (default 5s) | Pump iPWM control (AUTO/MANUAL/FROST/autotune override) |
 | Boiler control | `${oq_boiler_loop_s}` (default 5s) | CM3 gating and temperature lockout |
 | CIC polling tick | `${cic_poll_tick_ms}` (default 5s) | Poll scheduler, stale detection, feed invalidation |

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -182,9 +182,11 @@ When PID SP/PV is invalid, demand falls back to 0 and integral is reset.
 Heating-curve stability guards around zero-demand edge:
 
 - profile-based outside-temperature smoothing and target quantization
-- start/stop temperature hysteresis around supply target
+- start/stop gating with OFF-confirmation and low-PID requirement
 - near-target `COAST` phase (low modulation instead of immediate drop to `0`)
+- room-temperature coupling trims supply target when room drifts warm
 - explicit per-HP slew-rate limiting with slower up and faster down behavior
+- single-HP-first allocation with dual-enable hysteresis and sequential HP step changes
 
 ## 6. Allocation and Optimization Mechanics
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -175,7 +175,7 @@ Uses:
 
 - heating-curve interpolation to derive supply target
 - PID climate loop to track supply temperature
-- PID output mapped to demand `0..20`
+- PID output mapped to demand `0..20` with phased output behavior (`HEAT`/`COAST`/`OFF`)
 
 When PID SP/PV is invalid, demand falls back to 0 and integral is reset.
 
@@ -183,6 +183,7 @@ Heating-curve stability guards around zero-demand edge:
 
 - profile-based outside-temperature smoothing and target quantization
 - start/stop temperature hysteresis around supply target
+- near-target `COAST` phase (low modulation instead of immediate drop to `0`)
 - explicit per-HP slew-rate limiting with slower up and faster down behavior
 
 ## 6. Allocation and Optimization Mechanics
@@ -194,13 +195,13 @@ Heating-curve stability guards around zero-demand edge:
 3. Control Mode gating (CM2/CM3 only)
 4. strategy-specific level logic
 5. allowed-level switch constraints
-6. min-runtime stop blocking
+6. min-runtime stop blocking (Power House only)
 7. write-on-change application and runtime counters
 
 Demand filter behavior is asymmetric:
 
 - downward path follows demand immediately
-- upward path is rate-limited by runtime control `Demand filter ramp up` (step/min)
+- upward path is rate-limited by runtime control `Demand filter ramp up` (step/min, Power House path)
 
 Power House optimizer cost considers:
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -73,7 +73,7 @@ This prevents hidden control coupling and keeps debugging deterministic.
 |---|---:|---|
 | Supervisory | `${oq_supervisory_loop_s}` (default 5s) | Mode decisions, flow interlock, frost logic, power-cap safety net |
 | Heating Strategy | `${oq_strategy_loop_s}` (default 5s) | Demand generation (Power House / heating-curve path) |
-| Heat allocation | `${oq_heat_loop_s}` (default 5s) | Demand filtering, allocation, optimizer, level apply (per-minute tuning is elapsed-time scaled) |
+| Heat allocation | Tick `${oq_heat_loop_tick_s}` (default 5s), effective cadence `${oq_heat_loop_curve_s}` (Curve) / `${oq_heat_loop_powerhouse_s}` (Power House) | Demand filtering, allocation, optimizer, level apply (per-minute tuning is elapsed-time scaled) |
 | Flow control | `${oq_flow_loop_s}` (default 5s) | Pump iPWM control (AUTO/MANUAL/FROST/autotune override) |
 | Boiler control | `${oq_boiler_loop_s}` (default 5s) | CM3 gating and temperature lockout |
 | CIC polling tick | `${cic_poll_tick_ms}` (default 5s) | Poll scheduler, stale detection, feed invalidation |
@@ -197,7 +197,7 @@ Heating-curve stability guards around zero-demand edge:
 3. Control Mode gating (CM2/CM3 only)
 4. strategy-specific level logic
 5. allowed-level switch constraints
-6. min-runtime stop blocking (Power House only)
+6. min-runtime stop blocking (all strategies)
 7. write-on-change application and runtime counters
 
 Demand filter behavior is asymmetric:

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -215,7 +215,7 @@ What to watch:
 - short-cycling behavior
 
 Use allowed level switches if you need temporary level band limitations per HP.
-In heating-curve mode, demand rundown is profile-based and gradual (Comfort faster, Balanced/Stable softer) to reduce abrupt HP drop-outs.
+In heating-curve mode, PID demand is passed through directly; per-HP slew limiting remains as guardrail.
 
 ## 6. Flow and Pump Tuning
 

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -196,6 +196,7 @@ Low-demand stabilization controls (Heating Curve):
 
 - profile-based outside temperature smoothing and target quantization
 - start/stop temperature hysteresis around supply target
+- near-target `COAST` phase to reduce demand without immediately dropping to `0`
 - explicit per-HP level slew-rate limiting (up slower than down)
 
 ## 5. Heat Allocation Tuning
@@ -215,7 +216,8 @@ What to watch:
 - short-cycling behavior
 
 Use allowed level switches if you need temporary level band limitations per HP.
-In heating-curve mode, PID demand is passed through directly; per-HP slew limiting remains as guardrail.
+In heating-curve mode, PID demand is passed through directly with `HEAT/COAST/OFF` phasing; per-HP slew limiting remains as the actuator guardrail.
+`Minimum runtime` stop-blocking is applied in Power House mode.
 
 ## 6. Flow and Pump Tuning
 

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -205,9 +205,12 @@ Primary knobs:
 
 - `Minimum runtime`
 - `Demand filter ramp up`
-- `Single HP Assist ON Level`
-- `Single HP Assist ON Hold`
-- `Single HP Assist OFF Hold`
+- `Dual HP Enable Level`
+- `Dual HP Enable Hold`
+- `Dual HP Disable Hold`
+
+`Dual HP Enable Level` is interpreted as compressor level (`lvl 1..10`) in the
+single-HP path; dual-HP disable threshold is derived as `enable - 1`.
 
 What to watch:
 
@@ -216,7 +219,7 @@ What to watch:
 - short-cycling behavior
 
 Use allowed level switches if you need temporary level band limitations per HP.
-In heating-curve mode, PID demand is passed through directly with `HEAT/COAST/OFF` phasing; per-HP slew limiting remains as the actuator guardrail.
+In heating-curve mode, PID demand is passed through directly with `HEAT/COAST/OFF` phasing, while allocation is single-HP-first with dual-enable hysteresis and sequential level steps.
 `Minimum runtime` stop-blocking is applied in Power House mode.
 
 ## 6. Flow and Pump Tuning

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -204,8 +204,7 @@ Primary knobs:
 
 - `Minimum runtime`
 - `Demand filter ramp up`
-- `Single HP Assist ON Deficit`
-- `Single HP Assist OFF Deficit`
+- `Single HP Assist ON Level`
 - `Single HP Assist ON Hold`
 - `Single HP Assist OFF Hold`
 
@@ -216,6 +215,7 @@ What to watch:
 - short-cycling behavior
 
 Use allowed level switches if you need temporary level band limitations per HP.
+In heating-curve mode, demand rundown is profile-based and gradual (Comfort faster, Balanced/Stable softer) to reduce abrupt HP drop-outs.
 
 ## 6. Flow and Pump Tuning
 

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -181,6 +181,7 @@ Adaptive comfort-bias guardrail:
 Primary knobs:
 
 - curve setpoints (`Curve Tsupply @ ...`)
+- `Heating Curve Control Profile` (`Comfort` / `Balanced` / `Stable`)
 - `Heating Curve PID Kp/Ki/Kd`
 - `Curve Fallback Tsupply`
 
@@ -193,8 +194,9 @@ What to watch:
 
 Low-demand stabilization controls (Heating Curve):
 
-- `Curve Temp Deadband` reduces hunting around `Supply target`.
-- `Curve Demand Off Hold` delays final `1 -> 0` demand drop to avoid CM1/CM2 flip.
+- profile-based outside temperature smoothing and target quantization
+- start/stop temperature hysteresis around supply target
+- explicit per-HP level slew-rate limiting (up slower than down)
 
 ## 5. Heat Allocation Tuning
 
@@ -297,7 +299,7 @@ Remember: fault state logic is timer-based and mode-context-dependent.
 | Demand jumps too hard | `Demand raw`, strategy params | increase deadband / lower ramp-up |
 | CM1<->CM2 flips at low load | `Low-load dynamic thresholds`, `CM2 idle-exit reason`, `CM2 re-entry block active` | increase re-entry block or retune Power House ramp/deadband; verify `P_req` stays structurally below `off` when no sustained heat is needed |
 | Long periods below room setpoint | `Power House effective room target`, `Power House comfort bias`, `Power House room error avg` | increase comfort bias base/max, or lower deadband if correction starts too late |
-| Curve mode drops to 0 demand too quickly | `Curve Temp Deadband`, `Curve Demand Off Hold`, `Supply target` vs actual | increase deadband slightly or extend off-hold |
+| Curve mode drops to 0 demand too quickly | `Heating Curve Control Profile`, `Supply target` vs actual, `Demand curve raw` | move profile toward `Comfort` or retune curve points/PID |
 | CM3 toggles often | deficit thresholds/timers | widen ON/OFF gap, increase hold times |
 | Flow oscillates | flow PI and setpoint | reduce Kp/Ki, verify hydraulics |
 | COP looks implausible | power and heat inputs | validate source values and power integration |

--- a/docs/tuning-and-troubleshooting.md
+++ b/docs/tuning-and-troubleshooting.md
@@ -28,7 +28,7 @@ This guide provides a practical workflow for stable tuning and fast fault isolat
 
 1. **Signal and source sanity**
 2. **Heating Strategy behavior**
-3. **Heat allocation and assist thresholds**
+3. **Heat allocation and dual-enable thresholds**
 4. **Flow control PI behavior**
 5. **Supervisory limits and silent windows**
 6. **Energy trend validation**
@@ -190,7 +190,10 @@ What to watch:
 - `Heating Curve Supply Target`
 - selected supply temperature
 - `Demand Curve (raw)`
+- `Demand Curve (pre-guardrail)` and `Demand Curve (post-guardrail)`
+- `Curve Phase` and `Curve restart inhibit`
 - `Demand raw` and `Demand filtered` near zero edge
+- `Heating Debug State` (single-line trace of mode/phase/req/app/current levels)
 
 Low-demand stabilization controls (Heating Curve):
 
@@ -220,7 +223,7 @@ What to watch:
 
 Use allowed level switches if you need temporary level band limitations per HP.
 In heating-curve mode, PID demand is passed through directly with `HEAT/COAST/OFF` phasing, while allocation is single-HP-first with dual-enable hysteresis and sequential level steps.
-`Minimum runtime` stop-blocking is applied in Power House mode.
+`Minimum runtime` stop-blocking is applied in both heating-curve and Power House modes.
 
 ## 6. Flow and Pump Tuning
 

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -394,6 +394,16 @@ text_sensor:
       const bool lead_is_hp1 = (id(hp1_minutes) <= id(hp2_minutes));
       return std::string(lead_is_hp1 ? "HP1" : "HP2");
 
+  - platform: template
+    id: oq_heating_debug_state
+    name: "Heating Debug State"
+    icon: mdi:bug-outline
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: never
+    web_server:
+      sorting_group_id: oq_diagnostics
+
 # ----------------------------
 # BUTTON
 # ----------------------------
@@ -509,6 +519,49 @@ interval:
           // =========================
           const int cm_code = id(oq_control_mode_code);
           const bool cm_allows_hp = (cm_code == 2 || cm_code == 3);
+          auto publish_debug = [&](int req1, int req2, int app1, int app2)->void {
+            static std::string last_debug = "";
+            const char *mode_s = is_curve_mode ? "CURVE" : "PH";
+            const int phase_code = id(oq_curve_phase_code);
+            const char *phase_s = "OFF";
+            if (phase_code == 1) phase_s = "HEAT";
+            else if (phase_code == 2) phase_s = "COAST";
+            const uint32_t off_since_ms = id(oq_curve_off_since_ms);
+            uint32_t off_age_s = 0;
+            if (off_since_ms > 0 && now_ms > off_since_ms) off_age_s = (now_ms - off_since_ms) / 1000UL;
+            const float spw = id(oq_supply_target_temp).state;
+            const float pv = id(oq_system_supply_temp).state;
+            const float room_c = id(room_temp_selected).state;
+            const float room_sp_c = id(room_setpoint_selected).state;
+            const float tout_c = id(outside_temp_selected).state;
+            const float wm1 = id(hp1_working_mode).state;
+            const float wm2 = id(hp2_working_mode).state;
+            int cur1 = -1;
+            int cur2 = -1;
+            if (id(hp1_compressor_level).has_state()) cur1 = (int) id(hp1_compressor_level).active_index().value_or(-1);
+            if (id(hp2_compressor_level).has_state()) cur2 = (int) id(hp2_compressor_level).active_index().value_or(-1);
+            char buf[640];
+            snprintf(
+              buf, sizeof(buf),
+              "mode=%s cm=%d phase=%s raw=%d f=%d cap=%d pre=%d post=%d dual=%d on=%d off=%d em=%d lead=%d owner=%d req=%d+%d app=%d+%d cur=%d+%d wm=%.0f/%.0f sp=%.2f pv=%.2f room=%.2f/%.2f out=%.2f ri=%d off_age=%lus rt=%d/%d",
+              mode_s, cm_code, phase_s, raw, f, f_cap,
+              id(oq_curve_demand_pre_guardrail), id(oq_demand_curve),
+              (int) id(oq_dual_hp_enabled),
+              id(oq_dual_hp_enable_hold_elapsed_min),
+              id(oq_dual_hp_disable_hold_elapsed_min),
+              id(oq_dual_hp_emergency_hold_elapsed_min),
+              id(oq_last_lead_hp), id(oq_curve_single_owner_hp),
+              req1, req2, app1, app2,
+              cur1, cur2, wm1, wm2, spw, pv, room_c, room_sp_c, tout_c,
+              (int) id(oq_curve_restart_inhibit_active),
+              (unsigned long) off_age_s,
+              id(hp1_minutes), id(hp2_minutes));
+            const std::string s(buf);
+            if (s != last_debug) {
+              id(oq_heating_debug_state).publish_state(s.c_str());
+              last_debug = s;
+            }
+          };
 
           if (!cm_allows_hp) {
             // Force both units to Standby + level 0
@@ -561,6 +614,7 @@ interval:
             id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
             id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
             id(oq_curve_single_owner_hp) = 0;
+            publish_debug(0, 0, 0, 0);
             return;
           }
           // =========================
@@ -1290,3 +1344,4 @@ interval:
 
           log_transition(true, hp1_applied);
           log_transition(false, hp2_applied);
+          publish_debug(hp1_req, hp2_req, hp1_applied, hp2_applied);

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -149,7 +149,7 @@ globals:
     restore_value: false
     initial_value: 'false'
 
-  # Deficit hold counters (minutes in 60s loop).
+  # Assist hold counters (minutes in 60s loop).
   - id: oq_single_hp_assist_on_min
     type: int
     restore_value: false
@@ -386,14 +386,28 @@ interval:
           if (ramp_up_step_min < 1) ramp_up_step_min = 1;
           if (ramp_up_step_min > demand_max_f) ramp_up_step_min = demand_max_f;
 
+          // Heating-curve mode uses soft downward demand decay to avoid abrupt dual-HP stop.
+          const bool is_curve_mode = (id(oq_heat_mode_code) == 1);
+          int ramp_down_step_min = 1;  // Balanced/Stable default
+          if (is_curve_mode && id(oq_curve_control_profile).has_state()) {
+            const auto profile = id(oq_curve_control_profile).current_option();
+            if (profile == "Comfort") ramp_down_step_min = 2;
+            else ramp_down_step_min = 1;
+          }
+
           int f = id(oq_demand_filtered);
           if (raw > f) {
             f = std::min(f + ramp_up_step_min, raw); // configurable upward ramp (step/min)
-          } else if (raw == 0 && f == 1) {
-            // Prevent 1-step latch: allow clean idle transition when raw demand is zero.
-            f = 0;
-          } else if (raw <= (f - 2)) {
-            f = raw;                                // down only at raw <= filtered - 2
+          } else if (raw < f) {
+            if (is_curve_mode) {
+              const int down_step = std::max(1, std::min(ramp_down_step_min, f - raw));
+              f -= down_step; // profile-based soft rundown in heating-curve mode
+            } else if (raw == 0 && f == 1) {
+              // Prevent 1-step latch in Power House mode.
+              f = 0;
+            } else if (raw <= (f - 2)) {
+              f = raw; // keep Power House demand-down behavior unchanged
+            }
           }
           f = std::max(0, std::min(demand_max_f, f));
           id(oq_demand_filtered) = f;

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -377,7 +377,9 @@ interval:
           const int demand_max_f = (int) ${oq_strategy_demand_max_f};
 
           // =========================
-          // 1) Demand filtering (0..20)
+          // 1) Demand path (0..20)
+          // - Heating-curve: PID demand is leading (no extra filter layer)
+          // - Power House: filtered demand path keeps legacy ramp behavior
           // =========================
           int raw = id(oq_demand_raw);
           raw = std::max(0, std::min(demand_max_f, raw));
@@ -386,34 +388,22 @@ interval:
           if (ramp_up_step_min < 1) ramp_up_step_min = 1;
           if (ramp_up_step_min > demand_max_f) ramp_up_step_min = demand_max_f;
 
-          // Heating-curve mode uses soft downward demand decay to avoid abrupt dual-HP stop.
           const bool is_curve_mode = (id(oq_heat_mode_code) == 1);
-          int ramp_down_step_min = 1;  // Balanced/Stable default
-          if (is_curve_mode && id(oq_curve_control_profile).has_state()) {
-            const auto profile = id(oq_curve_control_profile).current_option();
-            if (profile == "Comfort") ramp_down_step_min = 2;
-            else ramp_down_step_min = 1;
-          }
+          const int prev_f = id(oq_demand_filtered);
 
-          int f = id(oq_demand_filtered);
-          if (raw > f) {
-            f = std::min(f + ramp_up_step_min, raw); // configurable upward ramp (step/min)
-          } else if (raw < f) {
-            if (is_curve_mode) {
-              // Dynamic rundown:
-              // - keep soft decay near target
-              // - accelerate when gap(raw->filtered) grows to avoid lagging overshoot
-              const int gap = f - raw;
-              int down_step = ramp_down_step_min;
-              if (gap >= 3) down_step += 1;
-              if (gap >= 6) down_step += 1;
-              down_step = std::max(1, std::min(down_step, gap));
-              f -= down_step;
+          int f = prev_f;
+          if (is_curve_mode) {
+            // Keep PID in the lead for heating-curve control.
+            f = raw;
+          } else {
+            // Power House filtered behavior.
+            if (raw > f) {
+              f = std::min(f + ramp_up_step_min, raw); // configurable upward ramp (step/min)
             } else if (raw == 0 && f == 1) {
               // Prevent 1-step latch in Power House mode.
               f = 0;
             } else if (raw <= (f - 2)) {
-              f = raw; // keep Power House demand-down behavior unchanged
+              f = raw; // down only at raw <= filtered - 2
             }
           }
           f = std::max(0, std::min(demand_max_f, f));
@@ -875,7 +865,7 @@ interval:
           //    - asymmetrical hold: slower up, faster down
           // =========================
           if (!is_power_house) {
-            const bool demand_rundown = (raw < f);
+            const bool demand_rundown = (raw < prev_f);
             int up_hold_s = 120;   // Balanced default
             int down_hold_s = 60;  // Balanced default
             if (id(oq_curve_control_profile).has_state()) {

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -180,6 +180,16 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  # Per-HP timestamp for explicit level slew limiting.
+  - id: hp1_last_level_change_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: hp2_last_level_change_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
 # ----------------------------
 # SENSORS (energie + status)
 # ----------------------------
@@ -455,6 +465,8 @@ interval:
               if (prev > 0) {
                 if (is_hp1) id(hp1_last_stop_ms) = now_ms;
                 else id(hp2_last_stop_ms) = now_ms;
+                if (is_hp1) id(hp1_last_level_change_ms) = now_ms;
+                else id(hp2_last_level_change_ms) = now_ms;
               }
               prev = 0;
             };
@@ -858,6 +870,49 @@ interval:
           hp2_req = pick_allowed(hp2_req, false);
 
           // =========================
+          // 4b) Explicit per-HP slew-rate limiting (heating-curve mode)
+          //    - max 1 level step per change
+          //    - asymmetrical hold: slower up, faster down
+          // =========================
+          if (!is_power_house) {
+            int up_hold_s = 120;   // Balanced default
+            int down_hold_s = 60;  // Balanced default
+            if (id(oq_curve_control_profile).has_state()) {
+              const auto profile = id(oq_curve_control_profile).current_option();
+              if (profile == "Comfort") {
+                up_hold_s = 60;
+                down_hold_s = 45;
+              } else if (profile == "Stable") {
+                up_hold_s = 180;
+                down_hold_s = 90;
+              }
+            }
+
+            auto limit_slew = [&](bool is_hp1, int req_level)->int {
+              const int prev = is_hp1 ? id(hp1_last_applied_level) : id(hp2_last_applied_level);
+              uint32_t &last_change_ms = is_hp1 ? id(hp1_last_level_change_ms) : id(hp2_last_level_change_ms);
+
+              if (req_level == prev) return req_level;
+
+              int limited = req_level;
+              if (limited > prev + 1) limited = prev + 1;
+              if (limited < prev - 1) limited = prev - 1;
+              if (limited == prev) return limited;
+
+              const bool moving_up = limited > prev;
+              const uint32_t hold_ms = (uint32_t) ((moving_up ? up_hold_s : down_hold_s) * 1000UL);
+              if (last_change_ms > 0 && now_ms > last_change_ms) {
+                const uint32_t dt_ms = now_ms - last_change_ms;
+                if (dt_ms < hold_ms) return prev;
+              }
+              return limited;
+            };
+
+            hp1_req = limit_slew(true, hp1_req);
+            hp2_req = limit_slew(false, hp2_req);
+          }
+
+          // =========================
           // 5) Minimum runtime (block stop)
           // =========================
           const int min_rt = (int) roundf(id(oq_min_runtime_min).state);
@@ -965,6 +1020,10 @@ interval:
           // =========================
           auto log_transition = [&](bool is_hp1, int new_lvl) {
             int &prev = is_hp1 ? id(hp1_last_applied_level) : id(hp2_last_applied_level);
+            if (prev != new_lvl) {
+              if (is_hp1) id(hp1_last_level_change_ms) = now_ms;
+              else id(hp2_last_level_change_ms) = now_ms;
+            }
 
             if (prev == 0 && new_lvl > 0) {
               // start

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -213,6 +213,13 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  # Latched single-HP owner in heating-curve mode (0=none, 1=HP1, 2=HP2).
+  # This prevents lead handovers while demand is continuously active.
+  - id: oq_curve_single_owner_hp
+    type: int
+    restore_value: false
+    initial_value: '0'
+
   # Per-HP timestamp for explicit level slew limiting.
   - id: hp1_last_level_change_ms
     type: uint32_t
@@ -553,6 +560,7 @@ interval:
             id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
             id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
             id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
+            id(oq_curve_single_owner_hp) = 0;
             return;
           }
           // =========================
@@ -775,10 +783,28 @@ interval:
             const bool dual_enabled = demand_active && (force_dual_capacity || force_dual_defrost || id(oq_dual_hp_enabled));
 
             if (!dual_enabled) {
-              // Single-HP-first: keep demand on runtime lead HP.
-              if (lead_is_hp1) hp1_req = f;
-              else             hp2_req = f;
+              // Single-HP-first with owner latch: only reselect owner from full idle.
+              int owner = id(oq_curve_single_owner_hp);
+              const bool prev_hp1_on = (id(hp1_last_applied_level) > 0);
+              const bool prev_hp2_on = (id(hp2_last_applied_level) > 0);
+
+              if (!demand_active) {
+                owner = 0;
+              } else if (prev_hp1_on && !prev_hp2_on) {
+                owner = 1;
+              } else if (prev_hp2_on && !prev_hp1_on) {
+                owner = 2;
+              } else if (owner != 1 && owner != 2) {
+                owner = lead_is_hp1 ? 1 : 2;
+              }
+
+              id(oq_curve_single_owner_hp) = owner;
+              if (owner == 1) hp1_req = f;
+              else if (owner == 2) hp2_req = f;
+              else if (lead_is_hp1) hp1_req = f;
+              else hp2_req = f;
             } else {
+              id(oq_curve_single_owner_hp) = 0;
               // When dual is enabled, split evenly and keep odd step on runtime lead.
               hp1_req = f / 2;
               hp2_req = f / 2;
@@ -1099,11 +1125,11 @@ interval:
           }
 
           // =========================
-          // 5) Minimum runtime (Power House only)
-          // In heating-curve mode, OFF/COAST/HEAT logic + slew guardrail are leading.
+          // 5) Minimum runtime (all strategies)
+          // Prevents very short compressor runs in both curve and Power House modes.
           // =========================
           const int min_rt = (int) roundf(id(oq_min_runtime_min).state);
-          if (is_power_house && min_rt > 0) {
+          if (min_rt > 0) {
             // HP1: if request is 0 but runtime < min -> force >=1
             const uint32_t min_rt_ms = (uint32_t) min_rt * 60000UL;
             const uint32_t hp1_rt_ms = (uint32_t)(now_ms - id(hp1_last_start_ms));

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -12,7 +12,7 @@
 #   - Consumes oq_demand_raw (producer in oq_heating_strategy)
 #   - Applies demand filtering to damp noise/jitter in heat demand
 #   - Applies caps/limits on `f` before split
-#   - Distributes `f` over HP1/HP2 (heating curve: single-HP preference with demand/hold assist hysteresis, power-house: W-based optimizer)
+#   - Distributes `f` over HP1/HP2 (heating curve: single-HP-first with dual-enable hysteresis, power-house: W-based optimizer)
 #   - Computes shared HP capacity/deficit (`oq_P_hp_cap_w`, `oq_P_deficit_w`) for supervisory CM3 logic
 #   - Sets compressor levels via `select` entities
 #
@@ -73,27 +73,27 @@ number:
     web_server:
       sorting_group_id: oq_tuning_heat
 
-  # Single-HP assist ON threshold on filtered demand f (0..20).
-  # OFF threshold is derived internally as max(1, ON - 2) to keep parameter count low.
+  # Dual-HP enable threshold on single-HP compressor level request (1..10).
+  # Disable threshold is derived internally as max(1, enable - 1) to keep parameter count low.
   - platform: template
-    id: oq_single_hp_assist_on_level_f
-    name: "Single HP Assist ON Level"
+    id: oq_dual_hp_enable_level
+    name: "Dual HP Enable Level"
     icon: mdi:arrow-up-bold-hexagon-outline
-    unit_of_measurement: "f"
-    min_value: 2
-    max_value: 20
+    unit_of_measurement: "lvl"
+    min_value: 1
+    max_value: 10
     step: 1
     mode: slider
     restore_value: true
     optimistic: true
-    initial_value: 7
+    initial_value: 5
     web_server:
       sorting_group_id: oq_tuning_heat
 
-  # Hold time before enabling single-HP assist.
+  # Hold time before enabling dual-HP in curve mode.
   - platform: template
-    id: oq_single_hp_assist_on_hold_min
-    name: "Single HP Assist ON Hold"
+    id: oq_dual_hp_enable_hold_min
+    name: "Dual HP Enable Hold"
     icon: mdi:timer-plus-outline
     unit_of_measurement: "min"
     min_value: 1
@@ -106,10 +106,10 @@ number:
     web_server:
       sorting_group_id: oq_tuning_heat
 
-  # Hold time before disabling single-HP assist.
+  # Hold time before disabling dual-HP in curve mode.
   - platform: template
-    id: oq_single_hp_assist_off_hold_min
-    name: "Single HP Assist OFF Hold"
+    id: oq_dual_hp_disable_hold_min
+    name: "Dual HP Disable Hold"
     icon: mdi:timer-minus-outline
     unit_of_measurement: "min"
     min_value: 1
@@ -143,28 +143,28 @@ globals:
     restore_value: false
     initial_value: '0.0'
 
-  # Tracks whether low-demand assist mode is active (dual-HP allowed in low-demand band).
-  - id: oq_single_hp_assist_active
+  # Tracks whether dual-HP is enabled by sustained curve demand.
+  - id: oq_dual_hp_enabled
     type: bool
     restore_value: false
     initial_value: 'false'
 
-  # Assist hold counters (elapsed minutes, derived from wall-clock time).
-  - id: oq_single_hp_assist_on_min
+  # Dual-enable hold counters (elapsed minutes, derived from wall-clock time).
+  - id: oq_dual_hp_enable_hold_elapsed_min
     type: int
     restore_value: false
     initial_value: '0'
-  - id: oq_single_hp_assist_off_min
+  - id: oq_dual_hp_disable_hold_elapsed_min
     type: int
     restore_value: false
     initial_value: '0'
 
-  # Fractional elapsed minutes for assist hold timing.
-  - id: oq_single_hp_assist_on_accum_min
+  # Fractional elapsed minutes for dual-enable hold timing.
+  - id: oq_dual_hp_enable_hold_elapsed_accum_min
     type: float
     restore_value: false
     initial_value: '0.0'
-  - id: oq_single_hp_assist_off_accum_min
+  - id: oq_dual_hp_disable_hold_elapsed_accum_min
     type: float
     restore_value: false
     initial_value: '0.0'
@@ -536,16 +536,16 @@ interval:
             };
             sync_forced_stop_state(true);
             sync_forced_stop_state(false);
-            id(oq_single_hp_assist_active) = false;
-            id(oq_single_hp_assist_on_min) = 0;
-            id(oq_single_hp_assist_off_min) = 0;
-            id(oq_single_hp_assist_on_accum_min) = 0.0f;
-            id(oq_single_hp_assist_off_accum_min) = 0.0f;
+            id(oq_dual_hp_enabled) = false;
+            id(oq_dual_hp_enable_hold_elapsed_min) = 0;
+            id(oq_dual_hp_disable_hold_elapsed_min) = 0;
+            id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
+            id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
             return;
           }
           // =========================
           // 2) HP level selection
-          //    - WATER TEMP: demand split with single-HP preference at low f and demand/hold assist hysteresis
+          //    - WATER TEMP: single-HP-first with dual-enable hysteresis
           //    - POWER HOUSE: level optimization on thermal power (W) via hp_perf_map.h
           // =========================
 
@@ -638,61 +638,85 @@ interval:
             const bool d1_pre = id(hp1_defrost).state;
             const bool d2_pre = id(hp2_defrost).state;
 
-            // Telemetry + deficit calculation also in heating-curve mode (for CM3 + assist hysteresis).
+            // Telemetry + deficit calculation also in heating-curve mode (for CM3 + dual-enable hysteresis).
             publish_capacity_and_deficit(id(oq_phouse_req_w));
 
-            // Single-HP preferred in low-demand band unless demand/hold hysteresis enables assist.
-            int assist_on_f = (int) roundf(id(oq_single_hp_assist_on_level_f).state);
-            if (assist_on_f < 2) assist_on_f = 2;
-            if (assist_on_f > demand_max_f) assist_on_f = demand_max_f;
-            int assist_off_f = assist_on_f - 2;
-            if (assist_off_f < 1) assist_off_f = 1;
+            // Curve mode: single-HP-first. Dual HP is enabled only by sustained high single-HP level.
+            int dual_on_lvl = (int) roundf(id(oq_dual_hp_enable_level).state);
+            if (dual_on_lvl < 1) dual_on_lvl = 1;
+            if (dual_on_lvl > max_level) dual_on_lvl = max_level;
+            int dual_off_lvl = dual_on_lvl - 1;
+            if (dual_off_lvl < 1) dual_off_lvl = 1;
 
-            const bool want_single = (f > 0 && f <= assist_on_f && !(d1_pre && d2_pre));
-            if (!want_single) {
-              id(oq_single_hp_assist_active) = false;
-              id(oq_single_hp_assist_on_min) = 0;
-              id(oq_single_hp_assist_off_min) = 0;
-              id(oq_single_hp_assist_on_accum_min) = 0.0f;
-              id(oq_single_hp_assist_off_accum_min) = 0.0f;
+            int dual_on_hold_min = (int) roundf(id(oq_dual_hp_enable_hold_min).state);
+            int dual_off_hold_min = (int) roundf(id(oq_dual_hp_disable_hold_min).state);
+            if (dual_on_hold_min < 1) dual_on_hold_min = 1;
+            if (dual_off_hold_min < 1) dual_off_hold_min = 1;
+
+            auto max_allowed_level_for_hp = [&](bool is_hp1)->int {
+              int lvl_max = 0;
+              for (int lvl = level_cap; lvl >= 1; lvl--) {
+                if (level_allowed(is_hp1, lvl)) {
+                  lvl_max = lvl;
+                  break;
+                }
+              }
+              return lvl_max;
+            };
+
+            const int lead_max_single = max_allowed_level_for_hp(lead_is_hp1);
+            const int lag_max_single = max_allowed_level_for_hp(!lead_is_hp1);
+            const int single_limit_lvl = std::max(lead_max_single, lag_max_single);
+            int single_req_lvl = f;
+            if (single_req_lvl < 0) single_req_lvl = 0;
+            if (single_limit_lvl > 0 && single_req_lvl > single_limit_lvl) single_req_lvl = single_limit_lvl;
+
+            const bool demand_active = (f > 0);
+            const bool force_dual_capacity = demand_active && (single_limit_lvl > 0) && (f > single_limit_lvl);
+            const bool force_dual_defrost = demand_active && (d1_pre && d2_pre);
+            const bool dual_on_condition =
+                demand_active && (force_dual_capacity || force_dual_defrost || (single_req_lvl >= dual_on_lvl));
+            const bool dual_off_condition =
+                (!force_dual_capacity) && (!force_dual_defrost) && (single_req_lvl <= dual_off_lvl);
+
+            if (!demand_active) {
+              id(oq_dual_hp_enabled) = false;
+              id(oq_dual_hp_enable_hold_elapsed_min) = 0;
+              id(oq_dual_hp_disable_hold_elapsed_min) = 0;
+              id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
+              id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
             } else {
-              int on_hold = (int) roundf(id(oq_single_hp_assist_on_hold_min).state);
-              int off_hold = (int) roundf(id(oq_single_hp_assist_off_hold_min).state);
-              if (on_hold < 1) on_hold = 1;
-              if (off_hold < 1) off_hold = 1;
+              if (dual_on_condition) id(oq_dual_hp_enable_hold_elapsed_accum_min) += dt_s / 60.0f;
+              else id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
 
-              if (f >= assist_on_f) id(oq_single_hp_assist_on_accum_min) += dt_s / 60.0f;
-              else id(oq_single_hp_assist_on_accum_min) = 0.0f;
+              if (dual_off_condition) id(oq_dual_hp_disable_hold_elapsed_accum_min) += dt_s / 60.0f;
+              else id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
 
-              if (f <= assist_off_f) id(oq_single_hp_assist_off_accum_min) += dt_s / 60.0f;
-              else id(oq_single_hp_assist_off_accum_min) = 0.0f;
-
-              if (!id(oq_single_hp_assist_active) && id(oq_single_hp_assist_on_accum_min) >= (float) on_hold) {
-                id(oq_single_hp_assist_active) = true;
-                id(oq_single_hp_assist_off_accum_min) = 0.0f;
-              } else if (id(oq_single_hp_assist_active) && id(oq_single_hp_assist_off_accum_min) >= (float) off_hold) {
-                id(oq_single_hp_assist_active) = false;
-                id(oq_single_hp_assist_on_accum_min) = 0.0f;
+              if (!id(oq_dual_hp_enabled) &&
+                  id(oq_dual_hp_enable_hold_elapsed_accum_min) >= (float) dual_on_hold_min) {
+                id(oq_dual_hp_enabled) = true;
+                id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
+              } else if (id(oq_dual_hp_enabled) &&
+                         id(oq_dual_hp_disable_hold_elapsed_accum_min) >= (float) dual_off_hold_min) {
+                id(oq_dual_hp_enabled) = false;
+                id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
               }
 
-              id(oq_single_hp_assist_on_min) = (int) floorf(id(oq_single_hp_assist_on_accum_min) + 1e-3f);
-              id(oq_single_hp_assist_off_min) = (int) floorf(id(oq_single_hp_assist_off_accum_min) + 1e-3f);
+              id(oq_dual_hp_enable_hold_elapsed_min) = (int) floorf(id(oq_dual_hp_enable_hold_elapsed_accum_min) + 1e-3f);
+              id(oq_dual_hp_disable_hold_elapsed_min) = (int) floorf(id(oq_dual_hp_disable_hold_elapsed_accum_min) + 1e-3f);
             }
 
-            const bool need_assist = (f > assist_on_f) || (want_single && id(oq_single_hp_assist_active));
+            const bool dual_enabled = demand_active && (force_dual_capacity || force_dual_defrost || id(oq_dual_hp_enabled));
 
-            if (want_single && !need_assist) {
-              // One HP carries the full demand (1..assist_on_f)
+            if (!dual_enabled) {
+              // Single-HP-first: keep demand on runtime lead HP.
               if (lead_is_hp1) hp1_req = f;
               else             hp2_req = f;
             } else {
-              // Baseline split (even/odd)
+              // When dual is enabled, split evenly and keep odd step on runtime lead.
               hp1_req = f / 2;
               hp2_req = f / 2;
-              const bool odd = (f % 2) == 1;
-
-              if (odd) {
-                // extra step to HP with fewer runtime minutes
+              if ((f % 2) == 1) {
                 if (lead_is_hp1) hp1_req += 1;
                 else             hp2_req += 1;
               }
@@ -715,7 +739,7 @@ interval:
             const bool perf_inputs_valid = !isnan(Tamb) && !isnan(Tsup) && level_cap > 0;
             if (!perf_inputs_valid) {
               // Fallback path when perf-map inputs are invalid: keep delivering demand using simple split.
-              int assist_on_f = (int) roundf(id(oq_single_hp_assist_on_level_f).state);
+              int assist_on_f = (int) roundf(id(oq_dual_hp_enable_level).state);
               if (assist_on_f < 2) assist_on_f = 2;
               if (assist_on_f > demand_max_f) assist_on_f = demand_max_f;
               int assist_off_f = assist_on_f - 2;
@@ -723,35 +747,35 @@ interval:
 
               const bool want_single = (f > 0 && f <= assist_on_f && !(hp1_def && hp2_def));
               if (!want_single) {
-                id(oq_single_hp_assist_active) = false;
-                id(oq_single_hp_assist_on_min) = 0;
-                id(oq_single_hp_assist_off_min) = 0;
-                id(oq_single_hp_assist_on_accum_min) = 0.0f;
-                id(oq_single_hp_assist_off_accum_min) = 0.0f;
+                id(oq_dual_hp_enabled) = false;
+                id(oq_dual_hp_enable_hold_elapsed_min) = 0;
+                id(oq_dual_hp_disable_hold_elapsed_min) = 0;
+                id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
+                id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
               } else {
-                int on_hold = (int) roundf(id(oq_single_hp_assist_on_hold_min).state);
-                int off_hold = (int) roundf(id(oq_single_hp_assist_off_hold_min).state);
+                int on_hold = (int) roundf(id(oq_dual_hp_enable_hold_min).state);
+                int off_hold = (int) roundf(id(oq_dual_hp_disable_hold_min).state);
                 if (on_hold < 1) on_hold = 1;
                 if (off_hold < 1) off_hold = 1;
 
-                if (f >= assist_on_f) id(oq_single_hp_assist_on_accum_min) += dt_s / 60.0f;
-                else id(oq_single_hp_assist_on_accum_min) = 0.0f;
+                if (f >= assist_on_f) id(oq_dual_hp_enable_hold_elapsed_accum_min) += dt_s / 60.0f;
+                else id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
 
-                if (f <= assist_off_f) id(oq_single_hp_assist_off_accum_min) += dt_s / 60.0f;
-                else id(oq_single_hp_assist_off_accum_min) = 0.0f;
+                if (f <= assist_off_f) id(oq_dual_hp_disable_hold_elapsed_accum_min) += dt_s / 60.0f;
+                else id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
 
-                if (!id(oq_single_hp_assist_active) && id(oq_single_hp_assist_on_accum_min) >= (float) on_hold) {
-                  id(oq_single_hp_assist_active) = true;
-                  id(oq_single_hp_assist_off_accum_min) = 0.0f;
-                } else if (id(oq_single_hp_assist_active) && id(oq_single_hp_assist_off_accum_min) >= (float) off_hold) {
-                  id(oq_single_hp_assist_active) = false;
-                  id(oq_single_hp_assist_on_accum_min) = 0.0f;
+                if (!id(oq_dual_hp_enabled) && id(oq_dual_hp_enable_hold_elapsed_accum_min) >= (float) on_hold) {
+                  id(oq_dual_hp_enabled) = true;
+                  id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
+                } else if (id(oq_dual_hp_enabled) && id(oq_dual_hp_disable_hold_elapsed_accum_min) >= (float) off_hold) {
+                  id(oq_dual_hp_enabled) = false;
+                  id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
                 }
 
-                id(oq_single_hp_assist_on_min) = (int) floorf(id(oq_single_hp_assist_on_accum_min) + 1e-3f);
-                id(oq_single_hp_assist_off_min) = (int) floorf(id(oq_single_hp_assist_off_accum_min) + 1e-3f);
+                id(oq_dual_hp_enable_hold_elapsed_min) = (int) floorf(id(oq_dual_hp_enable_hold_elapsed_accum_min) + 1e-3f);
+                id(oq_dual_hp_disable_hold_elapsed_min) = (int) floorf(id(oq_dual_hp_disable_hold_elapsed_accum_min) + 1e-3f);
               }
-              const bool need_assist = (f > assist_on_f) || (want_single && id(oq_single_hp_assist_active));
+              const bool need_assist = (f > assist_on_f) || (want_single && id(oq_dual_hp_enabled));
 
               if (want_single && !need_assist) {
                 if (lead_is_hp1) hp1_req = f;
@@ -983,6 +1007,29 @@ interval:
 
             hp1_req = limit_slew(true, hp1_req);
             hp2_req = limit_slew(false, hp2_req);
+
+            // Global guardrail: in curve mode allow at most one HP level change per cycle.
+            // This avoids tandem jumps like 1+1 -> 2+2 that create thermal overshoot.
+            const int prev1 = id(hp1_last_applied_level);
+            const int prev2 = id(hp2_last_applied_level);
+            const int d_hp1 = hp1_req - prev1;
+            const int d_hp2 = hp2_req - prev2;
+            if (d_hp1 != 0 && d_hp2 != 0) {
+              bool apply_hp1_change = true;
+              if (d_hp1 > 0 && d_hp2 > 0) {
+                // Ramp-up: prioritize runtime lead.
+                apply_hp1_change = lead_is_hp1;
+              } else if (d_hp1 < 0 && d_hp2 < 0) {
+                // Ramp-down: shed lag first.
+                apply_hp1_change = !lead_is_hp1;
+              } else {
+                // Mixed direction: prioritize the downward correction.
+                apply_hp1_change = (d_hp1 < 0);
+              }
+
+              if (apply_hp1_change) hp2_req = prev2;
+              else hp1_req = prev1;
+            }
           }
 
           // =========================

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -400,8 +400,15 @@ interval:
             f = std::min(f + ramp_up_step_min, raw); // configurable upward ramp (step/min)
           } else if (raw < f) {
             if (is_curve_mode) {
-              const int down_step = std::max(1, std::min(ramp_down_step_min, f - raw));
-              f -= down_step; // profile-based soft rundown in heating-curve mode
+              // Dynamic rundown:
+              // - keep soft decay near target
+              // - accelerate when gap(raw->filtered) grows to avoid lagging overshoot
+              const int gap = f - raw;
+              int down_step = ramp_down_step_min;
+              if (gap >= 3) down_step += 1;
+              if (gap >= 6) down_step += 1;
+              down_step = std::max(1, std::min(down_step, gap));
+              f -= down_step;
             } else if (raw == 0 && f == 1) {
               // Prevent 1-step latch in Power House mode.
               f = 0;
@@ -868,6 +875,7 @@ interval:
           //    - asymmetrical hold: slower up, faster down
           // =========================
           if (!is_power_house) {
+            const bool demand_rundown = (raw < f);
             int up_hold_s = 120;   // Balanced default
             int down_hold_s = 60;  // Balanced default
             if (id(oq_curve_control_profile).has_state()) {
@@ -893,6 +901,8 @@ interval:
               if (limited == prev) return limited;
 
               const bool moving_up = limited > prev;
+              // Guardrail: when demand is already running down, never keep stepping levels up.
+              if (demand_rundown && moving_up) return prev;
               const uint32_t hold_ms = (uint32_t) ((moving_up ? up_hold_s : down_hold_s) * 1000UL);
               if (last_change_ms > 0 && now_ms > last_change_ms) {
                 const uint32_t dt_ms = now_ms - last_change_ms;

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -12,7 +12,7 @@
 #   - Consumes oq_demand_raw (producer in oq_heating_strategy)
 #   - Applies demand filtering to damp noise/jitter in heat demand
 #   - Applies caps/limits on `f` before split
-#   - Distributes `f` over HP1/HP2 (heating curve: single-HP preference with deficit assist hysteresis, power-house: W-based optimizer)
+#   - Distributes `f` over HP1/HP2 (heating curve: single-HP preference with demand/hold assist hysteresis, power-house: W-based optimizer)
 #   - Computes shared HP capacity/deficit (`oq_P_hp_cap_w`, `oq_P_deficit_w`) for supervisory CM3 logic
 #   - Sets compressor levels via `select` entities
 #
@@ -73,39 +73,24 @@ number:
     web_server:
       sorting_group_id: oq_tuning_heat
 
-  # Single-HP assist ON threshold (W deficit) for enabling dual-HP support at low demand.
+  # Single-HP assist ON threshold on filtered demand f (0..20).
+  # OFF threshold is derived internally as max(1, ON - 2) to keep parameter count low.
   - platform: template
-    id: oq_single_hp_assist_on_deficit_w
-    name: "Single HP Assist ON Deficit"
+    id: oq_single_hp_assist_on_level_f
+    name: "Single HP Assist ON Level"
     icon: mdi:arrow-up-bold-hexagon-outline
-    unit_of_measurement: "W"
-    min_value: 0
-    max_value: 4000
-    step: 25
+    unit_of_measurement: "f"
+    min_value: 2
+    max_value: 20
+    step: 1
     mode: slider
     restore_value: true
     optimistic: true
-    initial_value: 350
+    initial_value: 7
     web_server:
       sorting_group_id: oq_tuning_heat
 
-  # Single-HP assist OFF threshold (W deficit) for returning to single-HP mode.
-  - platform: template
-    id: oq_single_hp_assist_off_deficit_w
-    name: "Single HP Assist OFF Deficit"
-    icon: mdi:arrow-down-bold-hexagon-outline
-    unit_of_measurement: "W"
-    min_value: 0
-    max_value: 4000
-    step: 25
-    mode: slider
-    restore_value: true
-    optimistic: true
-    initial_value: 150
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  # Deficit hold time before enabling single-HP assist.
+  # Hold time before enabling single-HP assist.
   - platform: template
     id: oq_single_hp_assist_on_hold_min
     name: "Single HP Assist ON Hold"
@@ -121,7 +106,7 @@ number:
     web_server:
       sorting_group_id: oq_tuning_heat
 
-  # Deficit hold time before disabling single-HP assist.
+  # Hold time before disabling single-HP assist.
   - platform: template
     id: oq_single_hp_assist_off_hold_min
     name: "Single HP Assist OFF Hold"
@@ -158,7 +143,7 @@ globals:
     restore_value: false
     initial_value: '0.0'
 
-  # Tracks whether low-demand assist mode is active (dual-HP allowed at f<=5).
+  # Tracks whether low-demand assist mode is active (dual-HP allowed in low-demand band).
   - id: oq_single_hp_assist_active
     type: bool
     restore_value: false
@@ -479,7 +464,7 @@ interval:
           }
           // =========================
           // 2) HP level selection
-          //    - WATER TEMP: demand split with single-HP preference at low f and deficit-based assist hysteresis
+          //    - WATER TEMP: demand split with single-HP preference at low f and demand/hold assist hysteresis
           //    - POWER HOUSE: level optimization on thermal power (W) via hp_perf_map.h
           // =========================
 
@@ -575,31 +560,28 @@ interval:
             // Telemetry + deficit calculation also in heating-curve mode (for CM3 + assist hysteresis).
             publish_capacity_and_deficit(id(oq_phouse_req_w));
 
-            // Single-HP preferred at low demand unless deficit hysteresis indicates assist is needed.
-            const bool want_single = (f > 0 && f <= 5 && !(d1_pre && d2_pre));
+            // Single-HP preferred in low-demand band unless demand/hold hysteresis enables assist.
+            int assist_on_f = (int) roundf(id(oq_single_hp_assist_on_level_f).state);
+            if (assist_on_f < 2) assist_on_f = 2;
+            if (assist_on_f > demand_max_f) assist_on_f = demand_max_f;
+            int assist_off_f = assist_on_f - 2;
+            if (assist_off_f < 1) assist_off_f = 1;
+
+            const bool want_single = (f > 0 && f <= assist_on_f && !(d1_pre && d2_pre));
             if (!want_single) {
               id(oq_single_hp_assist_active) = false;
               id(oq_single_hp_assist_on_min) = 0;
               id(oq_single_hp_assist_off_min) = 0;
             } else {
-              float on_th = id(oq_single_hp_assist_on_deficit_w).state;
-              float off_th = id(oq_single_hp_assist_off_deficit_w).state;
-              if (isnan(on_th) || on_th < 0.0f) on_th = 0.0f;
-              if (isnan(off_th) || off_th < 0.0f) off_th = 0.0f;
-              if (off_th > on_th) off_th = on_th;
-
               int on_hold = (int) roundf(id(oq_single_hp_assist_on_hold_min).state);
               int off_hold = (int) roundf(id(oq_single_hp_assist_off_hold_min).state);
               if (on_hold < 1) on_hold = 1;
               if (off_hold < 1) off_hold = 1;
 
-              float deficit_w = id(oq_P_deficit_w);
-              if (isnan(deficit_w)) deficit_w = 0.0f;
-
-              if (deficit_w >= on_th) id(oq_single_hp_assist_on_min) += 1;
+              if (f >= assist_on_f) id(oq_single_hp_assist_on_min) += 1;
               else id(oq_single_hp_assist_on_min) = 0;
 
-              if (deficit_w <= off_th) id(oq_single_hp_assist_off_min) += 1;
+              if (f <= assist_off_f) id(oq_single_hp_assist_off_min) += 1;
               else id(oq_single_hp_assist_off_min) = 0;
 
               if (!id(oq_single_hp_assist_active) && id(oq_single_hp_assist_on_min) >= on_hold) {
@@ -611,10 +593,10 @@ interval:
               }
             }
 
-            const bool need_assist = (f > 5) || (want_single && id(oq_single_hp_assist_active));
+            const bool need_assist = (f > assist_on_f) || (want_single && id(oq_single_hp_assist_active));
 
             if (want_single && !need_assist) {
-              // One HP carries the full demand (1..5)
+              // One HP carries the full demand (1..assist_on_f)
               if (lead_is_hp1) hp1_req = f;
               else             hp2_req = f;
             } else {
@@ -647,30 +629,27 @@ interval:
             const bool perf_inputs_valid = !isnan(Tamb) && !isnan(Tsup) && level_cap > 0;
             if (!perf_inputs_valid) {
               // Fallback path when perf-map inputs are invalid: keep delivering demand using simple split.
-              const bool want_single = (f > 0 && f <= 5 && !(hp1_def && hp2_def));
+              int assist_on_f = (int) roundf(id(oq_single_hp_assist_on_level_f).state);
+              if (assist_on_f < 2) assist_on_f = 2;
+              if (assist_on_f > demand_max_f) assist_on_f = demand_max_f;
+              int assist_off_f = assist_on_f - 2;
+              if (assist_off_f < 1) assist_off_f = 1;
+
+              const bool want_single = (f > 0 && f <= assist_on_f && !(hp1_def && hp2_def));
               if (!want_single) {
                 id(oq_single_hp_assist_active) = false;
                 id(oq_single_hp_assist_on_min) = 0;
                 id(oq_single_hp_assist_off_min) = 0;
               } else {
-                float on_th = id(oq_single_hp_assist_on_deficit_w).state;
-                float off_th = id(oq_single_hp_assist_off_deficit_w).state;
-                if (isnan(on_th) || on_th < 0.0f) on_th = 0.0f;
-                if (isnan(off_th) || off_th < 0.0f) off_th = 0.0f;
-                if (off_th > on_th) off_th = on_th;
-
                 int on_hold = (int) roundf(id(oq_single_hp_assist_on_hold_min).state);
                 int off_hold = (int) roundf(id(oq_single_hp_assist_off_hold_min).state);
                 if (on_hold < 1) on_hold = 1;
                 if (off_hold < 1) off_hold = 1;
 
-                float deficit_w = id(oq_P_deficit_w);
-                if (isnan(deficit_w)) deficit_w = 0.0f;
-
-                if (deficit_w >= on_th) id(oq_single_hp_assist_on_min) += 1;
+                if (f >= assist_on_f) id(oq_single_hp_assist_on_min) += 1;
                 else id(oq_single_hp_assist_on_min) = 0;
 
-                if (deficit_w <= off_th) id(oq_single_hp_assist_off_min) += 1;
+                if (f <= assist_off_f) id(oq_single_hp_assist_off_min) += 1;
                 else id(oq_single_hp_assist_off_min) = 0;
 
                 if (!id(oq_single_hp_assist_active) && id(oq_single_hp_assist_on_min) >= on_hold) {
@@ -681,7 +660,7 @@ interval:
                   id(oq_single_hp_assist_on_min) = 0;
                 }
               }
-              const bool need_assist = (f > 5) || (want_single && id(oq_single_hp_assist_active));
+              const bool need_assist = (f > assist_on_f) || (want_single && id(oq_single_hp_assist_active));
 
               if (want_single && !need_assist) {
                 if (lead_is_hp1) hp1_req = f;

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -986,10 +986,11 @@ interval:
           }
 
           // =========================
-          // 5) Minimum runtime (block stop)
+          // 5) Minimum runtime (Power House only)
+          // In heating-curve mode, OFF/COAST/HEAT logic + slew guardrail are leading.
           // =========================
           const int min_rt = (int) roundf(id(oq_min_runtime_min).state);
-          if (min_rt > 0) {
+          if (is_power_house && min_rt > 0) {
             // HP1: if request is 0 but runtime < min -> force >=1
             const uint32_t min_rt_ms = (uint32_t) min_rt * 60000UL;
             const uint32_t hp1_rt_ms = (uint32_t)(now_ms - id(hp1_last_start_ms));
@@ -1057,41 +1058,6 @@ interval:
                 const uint32_t min_off_ms = (uint32_t) min_off_s * 1000UL;
                 if (elapsed_off_ms < min_off_ms) req_level = 0;
               }
-            }
-
-            // Hard guardrail: explicit compressor soft-start phase (profile-based, no extra sliders).
-            if (!is_power_house && req_level > 0) {
-              int soft_start_s = 180;  // Balanced default
-              if (id(oq_curve_control_profile).has_state()) {
-                const auto profile = id(oq_curve_control_profile).current_option();
-                if (profile == "Comfort") soft_start_s = 60;
-                else if (profile == "Stable") soft_start_s = 240;
-              }
-              if (soft_start_s < 0) soft_start_s = 0;
-
-              int soft_start_cap = 1;
-              if (f >= 16) soft_start_cap = 5;
-              else if (f >= 12) soft_start_cap = 4;
-              else if (f >= 8) soft_start_cap = 3;
-              else if (f >= 4) soft_start_cap = 2;
-
-              if (id(oq_curve_control_profile).has_state()) {
-                const auto profile = id(oq_curve_control_profile).current_option();
-                if (profile == "Comfort" && soft_start_cap < max_level) soft_start_cap += 1;
-                else if (profile == "Stable" && soft_start_cap > 1) soft_start_cap -= 1;
-              }
-              if (soft_start_cap < 1) soft_start_cap = 1;
-              if (soft_start_cap > max_level) soft_start_cap = max_level;
-
-              const uint32_t last_start_ms = is_hp1 ? id(hp1_last_start_ms) : id(hp2_last_start_ms);
-              const bool starting_now = (prev_applied == 0);
-              bool soft_start_active = starting_now;
-              if (!soft_start_active && soft_start_s > 0 && last_start_ms > 0 && now_ms > last_start_ms) {
-                const uint32_t elapsed_start_ms = now_ms - last_start_ms;
-                const uint32_t soft_start_ms = (uint32_t) soft_start_s * 1000UL;
-                soft_start_active = elapsed_start_ms < soft_start_ms;
-              }
-              if (soft_start_active && req_level > soft_start_cap) req_level = soft_start_cap;
             }
 
             // at heat demand always switch to heating; with no demand switch to standby

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -181,6 +181,12 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  # Last heat mode code observed by heat-control loop (0=Power House, 1=Heating Curve).
+  - id: oq_heat_last_mode_code
+    type: int
+    restore_value: false
+    initial_value: '-1'
+
   # Fractional runtime accumulation; converted to whole minutes.
   - id: hp1_runtime_accum_ms
     type: uint32_t
@@ -394,7 +400,7 @@ button:
 interval:
 
 # ----------------------------
-# LOOP (${oq_heat_loop_s}s)
+# LOOP (mode cadence on ${oq_heat_loop_tick_s}s scheduler)
 # Fasen:
 # - demand filtering + power cap
 # - CM-gating (only CM2/CM3)
@@ -404,15 +410,27 @@ interval:
 # - shared capacity/deficit publication
 # - allowed-level mapping + min-runtime + apply + runtime bookkeeping
 # ----------------------------
-  - interval: ${oq_heat_loop_s}s
+  - interval: ${oq_heat_loop_tick_s}s
     then:
       - lambda: |-
           const uint32_t now_ms = (uint32_t) millis();
-          const uint32_t loop_default_ms = (uint32_t) (${oq_heat_loop_s} * 1000UL);
-          uint32_t dt_ms = loop_default_ms;
+          const int heat_mode_code = id(oq_heat_mode_code);
+          const bool is_curve_mode = (heat_mode_code == 1);
+          const uint32_t loop_target_ms = (uint32_t) ((is_curve_mode ? ${oq_heat_loop_curve_s} : ${oq_heat_loop_powerhouse_s}) * 1000UL);
+
+          // On mode switch, execute immediately on this tick instead of waiting for previous cadence window.
+          if (id(oq_heat_last_mode_code) != heat_mode_code) {
+            id(oq_heat_last_mode_code) = heat_mode_code;
+            id(oq_heat_last_loop_ms) = 0;
+          }
+
+          uint32_t dt_ms = loop_target_ms;
           if (id(oq_heat_last_loop_ms) > 0 && now_ms > id(oq_heat_last_loop_ms)) {
-            dt_ms = now_ms - id(oq_heat_last_loop_ms);
-            if (dt_ms > 60000UL) dt_ms = 60000UL;
+            const uint32_t elapsed_ms = now_ms - id(oq_heat_last_loop_ms);
+            if (elapsed_ms < loop_target_ms) return;
+            dt_ms = elapsed_ms;
+            const uint32_t dt_cap_ms = loop_target_ms * 2UL;
+            if (dt_cap_ms > 0 && dt_ms > dt_cap_ms) dt_ms = dt_cap_ms;
           }
           id(oq_heat_last_loop_ms) = now_ms;
           const float dt_s = (float) dt_ms / 1000.0f;
@@ -430,7 +448,6 @@ interval:
           if (ramp_up_step_min < 1) ramp_up_step_min = 1;
           if (ramp_up_step_min > demand_max_f) ramp_up_step_min = demand_max_f;
 
-          const bool is_curve_mode = (id(oq_heat_mode_code) == 1);
           const int prev_f = id(oq_demand_filtered);
 
           int f = prev_f;
@@ -929,16 +946,16 @@ interval:
           // =========================
           if (!is_power_house) {
             const bool demand_rundown = (raw < prev_f);
-            int up_hold_s = 120;   // Balanced default
-            int down_hold_s = 60;  // Balanced default
+            int up_hold_s = 180;  // Balanced default
+            int down_hold_s = 15; // Balanced default
             if (id(oq_curve_control_profile).has_state()) {
               const auto profile = id(oq_curve_control_profile).current_option();
               if (profile == "Comfort") {
-                up_hold_s = 60;
-                down_hold_s = 45;
+                up_hold_s = 90;
+                down_hold_s = 10;
               } else if (profile == "Stable") {
-                up_hold_s = 180;
-                down_hold_s = 90;
+                up_hold_s = 300;
+                down_hold_s = 30;
               }
             }
 
@@ -1022,6 +1039,60 @@ interval:
 
           auto apply_level = [&](bool is_hp1, int req_level) {
             req_level = std::max(min_level, std::min(max_level, req_level));
+            const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(hp2_last_applied_level);
+
+            // Hard guardrail: after stop, enforce a profile-based minimum off-time before restart.
+            if (!is_power_house && req_level > 0 && prev_applied == 0) {
+              int min_off_s = 120;  // Balanced default
+              if (id(oq_curve_control_profile).has_state()) {
+                const auto profile = id(oq_curve_control_profile).current_option();
+                if (profile == "Comfort") min_off_s = 60;
+                else if (profile == "Stable") min_off_s = 180;
+              }
+              if (min_off_s < 0) min_off_s = 0;
+
+              const uint32_t last_stop_ms = is_hp1 ? id(hp1_last_stop_ms) : id(hp2_last_stop_ms);
+              if (min_off_s > 0 && last_stop_ms > 0 && now_ms > last_stop_ms) {
+                const uint32_t elapsed_off_ms = now_ms - last_stop_ms;
+                const uint32_t min_off_ms = (uint32_t) min_off_s * 1000UL;
+                if (elapsed_off_ms < min_off_ms) req_level = 0;
+              }
+            }
+
+            // Hard guardrail: explicit compressor soft-start phase (profile-based, no extra sliders).
+            if (!is_power_house && req_level > 0) {
+              int soft_start_s = 180;  // Balanced default
+              if (id(oq_curve_control_profile).has_state()) {
+                const auto profile = id(oq_curve_control_profile).current_option();
+                if (profile == "Comfort") soft_start_s = 60;
+                else if (profile == "Stable") soft_start_s = 240;
+              }
+              if (soft_start_s < 0) soft_start_s = 0;
+
+              int soft_start_cap = 1;
+              if (f >= 16) soft_start_cap = 5;
+              else if (f >= 12) soft_start_cap = 4;
+              else if (f >= 8) soft_start_cap = 3;
+              else if (f >= 4) soft_start_cap = 2;
+
+              if (id(oq_curve_control_profile).has_state()) {
+                const auto profile = id(oq_curve_control_profile).current_option();
+                if (profile == "Comfort" && soft_start_cap < max_level) soft_start_cap += 1;
+                else if (profile == "Stable" && soft_start_cap > 1) soft_start_cap -= 1;
+              }
+              if (soft_start_cap < 1) soft_start_cap = 1;
+              if (soft_start_cap > max_level) soft_start_cap = max_level;
+
+              const uint32_t last_start_ms = is_hp1 ? id(hp1_last_start_ms) : id(hp2_last_start_ms);
+              const bool starting_now = (prev_applied == 0);
+              bool soft_start_active = starting_now;
+              if (!soft_start_active && soft_start_s > 0 && last_start_ms > 0 && now_ms > last_start_ms) {
+                const uint32_t elapsed_start_ms = now_ms - last_start_ms;
+                const uint32_t soft_start_ms = (uint32_t) soft_start_s * 1000UL;
+                soft_start_active = elapsed_start_ms < soft_start_ms;
+              }
+              if (soft_start_active && req_level > soft_start_cap) req_level = soft_start_cap;
+            }
 
             // at heat demand always switch to heating; with no demand switch to standby
             if (req_level > 0) set_mode(is_hp1, true);

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -149,13 +149,45 @@ globals:
     restore_value: false
     initial_value: 'false'
 
-  # Assist hold counters (minutes in 60s loop).
+  # Assist hold counters (elapsed minutes, derived from wall-clock time).
   - id: oq_single_hp_assist_on_min
     type: int
     restore_value: false
     initial_value: '0'
   - id: oq_single_hp_assist_off_min
     type: int
+    restore_value: false
+    initial_value: '0'
+
+  # Fractional elapsed minutes for assist hold timing.
+  - id: oq_single_hp_assist_on_accum_min
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+  - id: oq_single_hp_assist_off_accum_min
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+
+  # Fractional ramp budget for demand filter (Power House only).
+  - id: oq_demand_filter_ramp_up_budget
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+
+  # Last loop timestamp for elapsed-time scaling.
+  - id: oq_heat_last_loop_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  # Fractional runtime accumulation; converted to whole minutes.
+  - id: hp1_runtime_accum_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: hp2_runtime_accum_ms
+    type: uint32_t
     restore_value: false
     initial_value: '0'
 
@@ -353,6 +385,8 @@ button:
       - lambda: |-
           id(hp1_minutes) = 0;
           id(hp2_minutes) = 0;
+          id(hp1_runtime_accum_ms) = 0;
+          id(hp2_runtime_accum_ms) = 0;
           ESP_LOGW("quatt", "Runtime counters reset (HP1+HP2).");
 # ----------------------------
 # MAIN LOOP
@@ -360,7 +394,7 @@ button:
 interval:
 
 # ----------------------------
-# LOOP (60s)
+# LOOP (${oq_heat_loop_s}s)
 # Fasen:
 # - demand filtering + power cap
 # - CM-gating (only CM2/CM3)
@@ -374,6 +408,14 @@ interval:
     then:
       - lambda: |-
           const uint32_t now_ms = (uint32_t) millis();
+          const uint32_t loop_default_ms = (uint32_t) (${oq_heat_loop_s} * 1000UL);
+          uint32_t dt_ms = loop_default_ms;
+          if (id(oq_heat_last_loop_ms) > 0 && now_ms > id(oq_heat_last_loop_ms)) {
+            dt_ms = now_ms - id(oq_heat_last_loop_ms);
+            if (dt_ms > 60000UL) dt_ms = 60000UL;
+          }
+          id(oq_heat_last_loop_ms) = now_ms;
+          const float dt_s = (float) dt_ms / 1000.0f;
           const int demand_max_f = (int) ${oq_strategy_demand_max_f};
 
           // =========================
@@ -395,10 +437,19 @@ interval:
           if (is_curve_mode) {
             // Keep PID in the lead for heating-curve control.
             f = raw;
+            id(oq_demand_filter_ramp_up_budget) = 0.0f;
           } else {
             // Power House filtered behavior.
+            float ramp_budget = id(oq_demand_filter_ramp_up_budget) + (((float) ramp_up_step_min) / 60.0f) * dt_s;
+            if (ramp_budget > (float) demand_max_f) ramp_budget = (float) demand_max_f;
+            int ramp_steps = (int) floorf(ramp_budget);
+            if (ramp_steps < 0) ramp_steps = 0;
+            id(oq_demand_filter_ramp_up_budget) = ramp_budget - (float) ramp_steps;
+
             if (raw > f) {
-              f = std::min(f + ramp_up_step_min, raw); // configurable upward ramp (step/min)
+              if (ramp_steps > 0) {
+                f = std::min(f + ramp_steps, raw); // configurable upward ramp (step/min), elapsed-time scaled
+              }
             } else if (raw == 0 && f == 1) {
               // Prevent 1-step latch in Power House mode.
               f = 0;
@@ -471,6 +522,8 @@ interval:
             id(oq_single_hp_assist_active) = false;
             id(oq_single_hp_assist_on_min) = 0;
             id(oq_single_hp_assist_off_min) = 0;
+            id(oq_single_hp_assist_on_accum_min) = 0.0f;
+            id(oq_single_hp_assist_off_accum_min) = 0.0f;
             return;
           }
           // =========================
@@ -583,25 +636,30 @@ interval:
               id(oq_single_hp_assist_active) = false;
               id(oq_single_hp_assist_on_min) = 0;
               id(oq_single_hp_assist_off_min) = 0;
+              id(oq_single_hp_assist_on_accum_min) = 0.0f;
+              id(oq_single_hp_assist_off_accum_min) = 0.0f;
             } else {
               int on_hold = (int) roundf(id(oq_single_hp_assist_on_hold_min).state);
               int off_hold = (int) roundf(id(oq_single_hp_assist_off_hold_min).state);
               if (on_hold < 1) on_hold = 1;
               if (off_hold < 1) off_hold = 1;
 
-              if (f >= assist_on_f) id(oq_single_hp_assist_on_min) += 1;
-              else id(oq_single_hp_assist_on_min) = 0;
+              if (f >= assist_on_f) id(oq_single_hp_assist_on_accum_min) += dt_s / 60.0f;
+              else id(oq_single_hp_assist_on_accum_min) = 0.0f;
 
-              if (f <= assist_off_f) id(oq_single_hp_assist_off_min) += 1;
-              else id(oq_single_hp_assist_off_min) = 0;
+              if (f <= assist_off_f) id(oq_single_hp_assist_off_accum_min) += dt_s / 60.0f;
+              else id(oq_single_hp_assist_off_accum_min) = 0.0f;
 
-              if (!id(oq_single_hp_assist_active) && id(oq_single_hp_assist_on_min) >= on_hold) {
+              if (!id(oq_single_hp_assist_active) && id(oq_single_hp_assist_on_accum_min) >= (float) on_hold) {
                 id(oq_single_hp_assist_active) = true;
-                id(oq_single_hp_assist_off_min) = 0;
-              } else if (id(oq_single_hp_assist_active) && id(oq_single_hp_assist_off_min) >= off_hold) {
+                id(oq_single_hp_assist_off_accum_min) = 0.0f;
+              } else if (id(oq_single_hp_assist_active) && id(oq_single_hp_assist_off_accum_min) >= (float) off_hold) {
                 id(oq_single_hp_assist_active) = false;
-                id(oq_single_hp_assist_on_min) = 0;
+                id(oq_single_hp_assist_on_accum_min) = 0.0f;
               }
+
+              id(oq_single_hp_assist_on_min) = (int) floorf(id(oq_single_hp_assist_on_accum_min) + 1e-3f);
+              id(oq_single_hp_assist_off_min) = (int) floorf(id(oq_single_hp_assist_off_accum_min) + 1e-3f);
             }
 
             const bool need_assist = (f > assist_on_f) || (want_single && id(oq_single_hp_assist_active));
@@ -651,25 +709,30 @@ interval:
                 id(oq_single_hp_assist_active) = false;
                 id(oq_single_hp_assist_on_min) = 0;
                 id(oq_single_hp_assist_off_min) = 0;
+                id(oq_single_hp_assist_on_accum_min) = 0.0f;
+                id(oq_single_hp_assist_off_accum_min) = 0.0f;
               } else {
                 int on_hold = (int) roundf(id(oq_single_hp_assist_on_hold_min).state);
                 int off_hold = (int) roundf(id(oq_single_hp_assist_off_hold_min).state);
                 if (on_hold < 1) on_hold = 1;
                 if (off_hold < 1) off_hold = 1;
 
-                if (f >= assist_on_f) id(oq_single_hp_assist_on_min) += 1;
-                else id(oq_single_hp_assist_on_min) = 0;
+                if (f >= assist_on_f) id(oq_single_hp_assist_on_accum_min) += dt_s / 60.0f;
+                else id(oq_single_hp_assist_on_accum_min) = 0.0f;
 
-                if (f <= assist_off_f) id(oq_single_hp_assist_off_min) += 1;
-                else id(oq_single_hp_assist_off_min) = 0;
+                if (f <= assist_off_f) id(oq_single_hp_assist_off_accum_min) += dt_s / 60.0f;
+                else id(oq_single_hp_assist_off_accum_min) = 0.0f;
 
-                if (!id(oq_single_hp_assist_active) && id(oq_single_hp_assist_on_min) >= on_hold) {
+                if (!id(oq_single_hp_assist_active) && id(oq_single_hp_assist_on_accum_min) >= (float) on_hold) {
                   id(oq_single_hp_assist_active) = true;
-                  id(oq_single_hp_assist_off_min) = 0;
-                } else if (id(oq_single_hp_assist_active) && id(oq_single_hp_assist_off_min) >= off_hold) {
+                  id(oq_single_hp_assist_off_accum_min) = 0.0f;
+                } else if (id(oq_single_hp_assist_active) && id(oq_single_hp_assist_off_accum_min) >= (float) off_hold) {
                   id(oq_single_hp_assist_active) = false;
-                  id(oq_single_hp_assist_on_min) = 0;
+                  id(oq_single_hp_assist_on_accum_min) = 0.0f;
                 }
+
+                id(oq_single_hp_assist_on_min) = (int) floorf(id(oq_single_hp_assist_on_accum_min) + 1e-3f);
+                id(oq_single_hp_assist_off_min) = (int) floorf(id(oq_single_hp_assist_off_accum_min) + 1e-3f);
               }
               const bool need_assist = (f > assist_on_f) || (want_single && id(oq_single_hp_assist_active));
 
@@ -1030,12 +1093,19 @@ interval:
 
             // Runtime counting: only count when the specific unit is measured in Heating mode.
             // This avoids overcounting during command/mode transition, standby, or fault situations.
-            if (new_lvl > 0) {
+            if (new_lvl > 0 && dt_ms > 0) {
               const float working_mode_raw = is_hp1 ? id(hp1_working_mode).state : id(hp2_working_mode).state;
               const bool heating_now = !isnan(working_mode_raw) && ((int) roundf(working_mode_raw) == 2);
               if (heating_now) {
-                if (is_hp1) id(hp1_minutes)++;
-                else id(hp2_minutes)++;
+                uint32_t &runtime_accum_ms = is_hp1 ? id(hp1_runtime_accum_ms) : id(hp2_runtime_accum_ms);
+                int &runtime_minutes = is_hp1 ? id(hp1_minutes) : id(hp2_minutes);
+                uint32_t sum_ms = runtime_accum_ms + dt_ms;
+                if (sum_ms < runtime_accum_ms) sum_ms = 60000UL;  // overflow guard
+                runtime_accum_ms = sum_ms;
+                while (runtime_accum_ms >= 60000UL) {
+                  runtime_accum_ms -= 60000UL;
+                  runtime_minutes += 1;
+                }
               }
             }
 

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -169,6 +169,16 @@ globals:
     restore_value: false
     initial_value: '0.0'
 
+  # Emergency dual-enable hold timing (curve mode capacity/deficit override).
+  - id: oq_dual_hp_emergency_hold_elapsed_min
+    type: int
+    restore_value: false
+    initial_value: '0'
+  - id: oq_dual_hp_emergency_hold_elapsed_accum_min
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+
   # Fractional ramp budget for demand filter (Power House only).
   - id: oq_demand_filter_ramp_up_budget
     type: float
@@ -541,6 +551,8 @@ interval:
             id(oq_dual_hp_disable_hold_elapsed_min) = 0;
             id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
             id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
+            id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
+            id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
             return;
           }
           // =========================
@@ -653,6 +665,33 @@ interval:
             if (dual_on_hold_min < 1) dual_on_hold_min = 1;
             if (dual_off_hold_min < 1) dual_off_hold_min = 1;
 
+            // Hydraulic systems react slowly; dual emergency path is intentionally conservative.
+            int startup_grace_s = 480;      // Balanced default: 8 min single-HP settle
+            int emergency_hold_min = 6;     // Balanced default: sustained deficit before forcing dual
+            float emergency_temp_err_c = 1.50f;
+            float dual_disable_temp_err_max_c = 0.50f;
+            if (id(oq_curve_control_profile).has_state()) {
+              const auto profile = id(oq_curve_control_profile).current_option();
+              if (profile == "Comfort") {
+                startup_grace_s = 300;
+                emergency_hold_min = 4;
+                emergency_temp_err_c = 1.20f;
+                dual_disable_temp_err_max_c = 0.70f;
+              } else if (profile == "Stable") {
+                startup_grace_s = 600;
+                emergency_hold_min = 8;
+                emergency_temp_err_c = 1.80f;
+                dual_disable_temp_err_max_c = 0.40f;
+              }
+            }
+            if (startup_grace_s < 0) startup_grace_s = 0;
+            if (emergency_hold_min < 1) emergency_hold_min = 1;
+
+            float temp_err_c = NAN;
+            if (!isnan(id(oq_supply_target_temp).state) && !isnan(id(oq_system_supply_temp).state)) {
+              temp_err_c = id(oq_supply_target_temp).state - id(oq_system_supply_temp).state;
+            }
+
             auto max_allowed_level_for_hp = [&](bool is_hp1)->int {
               int lvl_max = 0;
               for (int lvl = level_cap; lvl >= 1; lvl--) {
@@ -672,12 +711,37 @@ interval:
             if (single_limit_lvl > 0 && single_req_lvl > single_limit_lvl) single_req_lvl = single_limit_lvl;
 
             const bool demand_active = (f > 0);
-            const bool force_dual_capacity = demand_active && (single_limit_lvl > 0) && (f > single_limit_lvl);
+            const bool beyond_single_capacity = demand_active && (single_limit_lvl > 0) && (f > single_limit_lvl);
+            const bool severe_level_pressure =
+                (single_limit_lvl > 0) && (single_req_lvl >= std::min(max_level, dual_on_lvl + 2));
+            const bool severe_temp_deficit = !isnan(temp_err_c) && (temp_err_c >= emergency_temp_err_c);
+            const bool startup_grace_active =
+                (startup_grace_s > 0) &&
+                (((lead_is_hp1 ? id(hp1_last_start_ms) : id(hp2_last_start_ms)) > 0) &&
+                 (now_ms > (lead_is_hp1 ? id(hp1_last_start_ms) : id(hp2_last_start_ms))) &&
+                 ((now_ms - (lead_is_hp1 ? id(hp1_last_start_ms) : id(hp2_last_start_ms))) <
+                  (uint32_t) startup_grace_s * 1000UL));
+
+            bool force_dual_capacity = false;
+            const bool emergency_dual_condition =
+                demand_active && beyond_single_capacity && severe_level_pressure &&
+                (severe_temp_deficit || single_req_lvl >= (max_level - 1)) && !startup_grace_active;
+            if (emergency_dual_condition) {
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min) += dt_s / 60.0f;
+            } else {
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
+            }
+            id(oq_dual_hp_emergency_hold_elapsed_min) =
+                (int) floorf(id(oq_dual_hp_emergency_hold_elapsed_accum_min) + 1e-3f);
+            if (id(oq_dual_hp_emergency_hold_elapsed_accum_min) >= (float) emergency_hold_min) {
+              force_dual_capacity = true;
+            }
             const bool force_dual_defrost = demand_active && (d1_pre && d2_pre);
             const bool dual_on_condition =
                 demand_active && (force_dual_capacity || force_dual_defrost || (single_req_lvl >= dual_on_lvl));
             const bool dual_off_condition =
-                (!force_dual_capacity) && (!force_dual_defrost) && (single_req_lvl <= dual_off_lvl);
+                (!force_dual_capacity) && (!force_dual_defrost) && (single_req_lvl <= dual_off_lvl) &&
+                (isnan(temp_err_c) || temp_err_c <= dual_disable_temp_err_max_c);
 
             if (!demand_active) {
               id(oq_dual_hp_enabled) = false;
@@ -685,6 +749,8 @@ interval:
               id(oq_dual_hp_disable_hold_elapsed_min) = 0;
               id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
               id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
+              id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
             } else {
               if (dual_on_condition) id(oq_dual_hp_enable_hold_elapsed_accum_min) += dt_s / 60.0f;
               else id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -885,14 +885,14 @@ interval:
             const bool perf_inputs_valid = !isnan(Tamb) && !isnan(Tsup) && level_cap > 0;
             if (!perf_inputs_valid) {
               // Fallback path when perf-map inputs are invalid: keep delivering demand using simple split.
-              int assist_on_f = (int) roundf(id(oq_dual_hp_enable_level).state);
-              if (assist_on_f < 2) assist_on_f = 2;
-              if (assist_on_f > demand_max_f) assist_on_f = demand_max_f;
-              int assist_off_f = assist_on_f - 2;
-              if (assist_off_f < 1) assist_off_f = 1;
+              int dual_on_f = (int) roundf(id(oq_dual_hp_enable_level).state);
+              if (dual_on_f < 2) dual_on_f = 2;
+              if (dual_on_f > demand_max_f) dual_on_f = demand_max_f;
+              int dual_off_f = dual_on_f - 2;
+              if (dual_off_f < 1) dual_off_f = 1;
 
-              const bool want_single = (f > 0 && f <= assist_on_f && !(hp1_def && hp2_def));
-              if (!want_single) {
+              const bool prefer_single = (f > 0 && f <= dual_on_f && !(hp1_def && hp2_def));
+              if (!prefer_single) {
                 id(oq_dual_hp_enabled) = false;
                 id(oq_dual_hp_enable_hold_elapsed_min) = 0;
                 id(oq_dual_hp_disable_hold_elapsed_min) = 0;
@@ -904,10 +904,10 @@ interval:
                 if (on_hold < 1) on_hold = 1;
                 if (off_hold < 1) off_hold = 1;
 
-                if (f >= assist_on_f) id(oq_dual_hp_enable_hold_elapsed_accum_min) += dt_s / 60.0f;
+                if (f >= dual_on_f) id(oq_dual_hp_enable_hold_elapsed_accum_min) += dt_s / 60.0f;
                 else id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
 
-                if (f <= assist_off_f) id(oq_dual_hp_disable_hold_elapsed_accum_min) += dt_s / 60.0f;
+                if (f <= dual_off_f) id(oq_dual_hp_disable_hold_elapsed_accum_min) += dt_s / 60.0f;
                 else id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
 
                 if (!id(oq_dual_hp_enabled) && id(oq_dual_hp_enable_hold_elapsed_accum_min) >= (float) on_hold) {
@@ -921,9 +921,9 @@ interval:
                 id(oq_dual_hp_enable_hold_elapsed_min) = (int) floorf(id(oq_dual_hp_enable_hold_elapsed_accum_min) + 1e-3f);
                 id(oq_dual_hp_disable_hold_elapsed_min) = (int) floorf(id(oq_dual_hp_disable_hold_elapsed_accum_min) + 1e-3f);
               }
-              const bool need_assist = (f > assist_on_f) || (want_single && id(oq_dual_hp_enabled));
+              const bool needs_dual = (f > dual_on_f) || (prefer_single && id(oq_dual_hp_enabled));
 
-              if (want_single && !need_assist) {
+              if (prefer_single && !needs_dual) {
                 if (lead_is_hp1) hp1_req = f;
                 else             hp2_req = f;
               } else {

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -536,6 +536,18 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  # Timestamp when curve phase entered OFF (for restart inhibit timing).
+  - id: oq_curve_off_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  # Diagnostic flag: restart from OFF is temporarily inhibited.
+  - id: oq_curve_restart_inhibit_active
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
   # Curve outside-temperature EMA state.
   - id: oq_curve_outside_ema_c
     type: float
@@ -846,6 +858,18 @@ sensor:
     lambda: |-
       return (float) id(oq_demand_curve);
 
+  - platform: template
+    id: oq_curve_restart_inhibit_sensor
+    name: "Curve restart inhibit"
+    icon: mdi:timer-sand-paused
+    accuracy_decimals: 0
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return id(oq_curve_restart_inhibit_active) ? 1.0f : 0.0f;
+
   # DEBUG-RUNTIME START: Power House adaptive comfort-bias diagnostics
   - platform: template
     id: oq_phouse_room_error_avg_c_sensor
@@ -962,6 +986,8 @@ output:
             id(oq_curve_demand_pre_guardrail) = 0;
             id(oq_curve_heat_request_active) = false;
             id(oq_curve_stop_arm_ms) = 0;
+            id(oq_curve_off_since_ms) = 0;
+            id(oq_curve_restart_inhibit_active) = false;
             id(oq_curve_phase_code) = 0;
             return;
           }
@@ -973,6 +999,8 @@ output:
             id(oq_curve_demand_pre_guardrail) = 0;
             id(oq_curve_heat_request_active) = false;
             id(oq_curve_stop_arm_ms) = 0;
+            id(oq_curve_off_since_ms) = 0;
+            id(oq_curve_restart_inhibit_active) = false;
             id(oq_curve_phase_code) = 0;
             return;
           }
@@ -991,6 +1019,8 @@ output:
           if (isnan(spw) || isnan(pv)) {
             id(oq_curve_heat_request_active) = false;
             id(oq_curve_stop_arm_ms) = 0;
+            id(oq_curve_off_since_ms) = 0;
+            id(oq_curve_restart_inhibit_active) = false;
             id(oq_demand_curve) = 0;
             id(oq_curve_demand_pre_guardrail) = 0;
             id(oq_curve_phase_code) = 0;
@@ -998,39 +1028,50 @@ output:
           }
 
           float start_delta_c = 0.45f;  // Balanced default
-          float stop_delta_c = 0.75f;   // Balanced default
+          float stop_delta_c = 0.90f;   // Balanced default (stricter OFF)
           float coast_enter_c = 0.35f;  // Balanced default
           int coast_floor_f = 1;
           int coast_cap_f = 6;
-          int off_pid_max_f = 2;
-          uint32_t off_confirm_ms = 180000UL;  // 180s
-          float room_overheat_off_c = 0.20f;
+          int off_pid_max_f = 1;
+          uint32_t off_confirm_ms = 360000UL;  // 360s
+          float room_overheat_off_c = 0.30f;
           float room_resume_heat_c = 0.05f;
+          float restart_delta_c = 0.80f;
+          float restart_bypass_extra_c = 0.45f;
+          uint32_t off_reentry_min_ms = 480000UL;  // 8 minutes
           if (id(oq_curve_control_profile).has_state()) {
             const auto profile = id(oq_curve_control_profile).current_option();
             if (profile == "Comfort") {
               start_delta_c = 0.30f;
-              stop_delta_c = 0.55f;
+              stop_delta_c = 0.70f;
               coast_enter_c = 0.25f;
               coast_floor_f = 2;
               coast_cap_f = 8;
               off_pid_max_f = 1;
-              off_confirm_ms = 120000UL;
-              room_overheat_off_c = 0.15f;
+              off_confirm_ms = 240000UL;
+              room_overheat_off_c = 0.20f;
               room_resume_heat_c = 0.03f;
+              restart_delta_c = 0.60f;
+              restart_bypass_extra_c = 0.35f;
+              off_reentry_min_ms = 300000UL;
             } else if (profile == "Stable") {
               start_delta_c = 0.65f;
-              stop_delta_c = 1.00f;
+              stop_delta_c = 1.10f;
               coast_enter_c = 0.55f;
               coast_floor_f = 1;
               coast_cap_f = 4;
-              off_pid_max_f = 2;
-              off_confirm_ms = 300000UL;
-              room_overheat_off_c = 0.30f;
+              off_pid_max_f = 1;
+              off_confirm_ms = 420000UL;
+              room_overheat_off_c = 0.35f;
               room_resume_heat_c = 0.08f;
+              restart_delta_c = 1.00f;
+              restart_bypass_extra_c = 0.55f;
+              off_reentry_min_ms = 600000UL;
             }
           }
           if (stop_delta_c < start_delta_c + 0.10f) stop_delta_c = start_delta_c + 0.10f;
+          if (restart_delta_c < start_delta_c + 0.05f) restart_delta_c = start_delta_c + 0.05f;
+          if (restart_bypass_extra_c < 0.20f) restart_bypass_extra_c = 0.20f;
           if (off_pid_max_f < 0) off_pid_max_f = 0;
           if (off_pid_max_f > demand_max) off_pid_max_f = demand_max;
           if (coast_floor_f < 1) coast_floor_f = 1;
@@ -1047,8 +1088,12 @@ output:
 
           const bool above_stop_band = pv >= (spw + stop_delta_c);
           const bool low_pid_for_off = d <= off_pid_max_f;
+          const float restart_bypass_delta_c = restart_delta_c + restart_bypass_extra_c;
           const uint32_t now_ms = (uint32_t) millis();
           bool heat_request_active = id(oq_curve_heat_request_active);
+          bool restart_inhibit_active = false;
+          uint32_t off_since_ms = id(oq_curve_off_since_ms);
+          const bool was_heat_request_active = heat_request_active;
           if (heat_request_active) {
             if (above_stop_band && low_pid_for_off && room_allows_off) {
               uint32_t armed_ms = id(oq_curve_stop_arm_ms);
@@ -1061,9 +1106,27 @@ output:
             } else {
               id(oq_curve_stop_arm_ms) = 0;
             }
+            if (!heat_request_active && was_heat_request_active) {
+              off_since_ms = now_ms;
+            }
           } else {
             id(oq_curve_stop_arm_ms) = 0;
-            if (pv <= (spw - start_delta_c) || room_requests_heat) heat_request_active = true;
+            if (off_since_ms == 0 || now_ms <= off_since_ms) off_since_ms = now_ms;
+            const bool below_restart_band = pv <= (spw - restart_delta_c);
+            const bool deep_undershoot_restart = pv <= (spw - restart_bypass_delta_c);
+            bool off_lock_active = false;
+            if (off_reentry_min_ms > 0 && now_ms > off_since_ms) {
+              off_lock_active = (now_ms - off_since_ms) < off_reentry_min_ms;
+            }
+            restart_inhibit_active = off_lock_active && !deep_undershoot_restart && !room_requests_heat;
+            if ((below_restart_band || room_requests_heat) && !restart_inhibit_active) {
+              heat_request_active = true;
+              off_since_ms = 0;
+            }
+          }
+          if (heat_request_active) {
+            restart_inhibit_active = false;
+            off_since_ms = 0;
           }
 
           int curve_phase_code = 1;  // HEAT
@@ -1087,6 +1150,8 @@ output:
           }
 
           id(oq_curve_heat_request_active) = heat_request_active;
+          id(oq_curve_off_since_ms) = off_since_ms;
+          id(oq_curve_restart_inhibit_active) = restart_inhibit_active;
           id(oq_demand_curve) = d;
           id(oq_curve_phase_code) = curve_phase_code;
 
@@ -1183,6 +1248,8 @@ interval:
             }
             id(oq_curve_heat_request_active) = false;
             id(oq_curve_stop_arm_ms) = 0;
+            id(oq_curve_off_since_ms) = 0;
+            id(oq_curve_restart_inhibit_active) = false;
             const float Tout = id(outside_temp_selected).state;
             const float Tc   = id(house_cold_temp_c).state;
             const float T0   = id(house_zero_power_temp_c).state;

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -46,6 +46,7 @@ select:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
         - lambda: |-
             id(oq_curve_heat_request_active) = false;
+            id(oq_curve_stop_arm_ms) = 0;
             id(oq_curve_outside_ema_initialized) = false;
             id(oq_curve_outside_ema_last_ms) = 0;
             id(oq_ph_comfort_bias_last_ms) = 0;
@@ -70,6 +71,7 @@ select:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
         - lambda: |-
             id(oq_curve_heat_request_active) = false;
+            id(oq_curve_stop_arm_ms) = 0;
             id(oq_curve_outside_ema_initialized) = false;
             id(oq_curve_outside_ema_last_ms) = 0;
 
@@ -528,6 +530,12 @@ globals:
     restore_value: false
     initial_value: 'false'
 
+  # Timestamp when curve stop condition was first armed (OFF confirm guardrail).
+  - id: oq_curve_stop_arm_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
   # Curve outside-temperature EMA state.
   - id: oq_curve_outside_ema_c
     type: float
@@ -755,6 +763,35 @@ sensor:
         }
       }
 
+      // Room thermostat coupling: when room drifts warm, trim curve target down.
+      // This keeps heating-curve control continuous, but prevents living-room overshoot.
+      const float room_c = id(room_temp_selected).state;
+      const float room_sp_c = id(room_setpoint_selected).state;
+      if (!isnan(target_c) && !isnan(room_c) && !isnan(room_sp_c)) {
+        float warm_err_c = room_c - room_sp_c;
+        float trim_start_c = 0.10f;   // Balanced default
+        float trim_gain = 1.50f;      // Balanced default
+        float trim_max_c = 2.00f;     // Balanced default
+        if (id(oq_curve_control_profile).has_state()) {
+          const auto profile = id(oq_curve_control_profile).current_option();
+          if (profile == "Comfort") {
+            trim_start_c = 0.05f;
+            trim_gain = 2.00f;
+            trim_max_c = 2.00f;
+          } else if (profile == "Stable") {
+            trim_start_c = 0.15f;
+            trim_gain = 1.00f;
+            trim_max_c = 2.50f;
+          }
+        }
+        if (warm_err_c > trim_start_c) {
+          float trim_c = (warm_err_c - trim_start_c) * trim_gain;
+          if (trim_c < 0.0f) trim_c = 0.0f;
+          if (trim_c > trim_max_c) trim_c = trim_max_c;
+          target_c -= trim_c;
+        }
+      }
+
       // Profile-based target quantization keeps supply target calm at low load.
       float quant_step_c = 0.5f;  // Balanced default
       if (id(oq_curve_control_profile).has_state()) {
@@ -924,6 +961,7 @@ output:
             id(oq_demand_curve) = 0;
             id(oq_curve_demand_pre_guardrail) = 0;
             id(oq_curve_heat_request_active) = false;
+            id(oq_curve_stop_arm_ms) = 0;
             id(oq_curve_phase_code) = 0;
             return;
           }
@@ -934,6 +972,7 @@ output:
             id(oq_demand_curve) = 0;
             id(oq_curve_demand_pre_guardrail) = 0;
             id(oq_curve_heat_request_active) = false;
+            id(oq_curve_stop_arm_ms) = 0;
             id(oq_curve_phase_code) = 0;
             return;
           }
@@ -943,14 +982,15 @@ output:
           if (d > demand_max) d = demand_max;
           id(oq_curve_demand_pre_guardrail) = d;
 
-          // Start/stop hysteresis near the zero-demand edge:
-          // - Start heating when supply is below (SP - start_delta)
-          // - Stop heating when supply is above (SP + stop_delta)
-          // This replaces the previous deadband/off-hold pair with a deterministic gate.
+          // Start/stop gating near the zero-demand edge:
+          // - Start when supply is below (SP - start_delta)
+          // - Stop only after sustained overshoot + low PID demand (+ optional room-warm condition)
+          // This avoids burst OFF cycling and keeps COAST as the default way to back off.
           const float spw = id(oq_supply_target_temp).state;
           const float pv = id(oq_system_supply_temp).state;
           if (isnan(spw) || isnan(pv)) {
             id(oq_curve_heat_request_active) = false;
+            id(oq_curve_stop_arm_ms) = 0;
             id(oq_demand_curve) = 0;
             id(oq_curve_demand_pre_guardrail) = 0;
             id(oq_curve_phase_code) = 0;
@@ -959,23 +999,71 @@ output:
 
           float start_delta_c = 0.45f;  // Balanced default
           float stop_delta_c = 0.75f;   // Balanced default
+          float coast_enter_c = 0.35f;  // Balanced default
+          int coast_floor_f = 1;
+          int coast_cap_f = 6;
+          int off_pid_max_f = 2;
+          uint32_t off_confirm_ms = 180000UL;  // 180s
+          float room_overheat_off_c = 0.20f;
+          float room_resume_heat_c = 0.05f;
           if (id(oq_curve_control_profile).has_state()) {
             const auto profile = id(oq_curve_control_profile).current_option();
             if (profile == "Comfort") {
               start_delta_c = 0.30f;
               stop_delta_c = 0.55f;
+              coast_enter_c = 0.25f;
+              coast_floor_f = 2;
+              coast_cap_f = 8;
+              off_pid_max_f = 1;
+              off_confirm_ms = 120000UL;
+              room_overheat_off_c = 0.15f;
+              room_resume_heat_c = 0.03f;
             } else if (profile == "Stable") {
               start_delta_c = 0.65f;
               stop_delta_c = 1.00f;
+              coast_enter_c = 0.55f;
+              coast_floor_f = 1;
+              coast_cap_f = 4;
+              off_pid_max_f = 2;
+              off_confirm_ms = 300000UL;
+              room_overheat_off_c = 0.30f;
+              room_resume_heat_c = 0.08f;
             }
           }
           if (stop_delta_c < start_delta_c + 0.10f) stop_delta_c = start_delta_c + 0.10f;
+          if (off_pid_max_f < 0) off_pid_max_f = 0;
+          if (off_pid_max_f > demand_max) off_pid_max_f = demand_max;
+          if (coast_floor_f < 1) coast_floor_f = 1;
+          if (coast_floor_f > demand_max) coast_floor_f = demand_max;
+          if (coast_cap_f < coast_floor_f) coast_cap_f = coast_floor_f;
+          if (coast_cap_f > demand_max) coast_cap_f = demand_max;
 
+          const float room_c = id(room_temp_selected).state;
+          const float room_sp_c = id(room_setpoint_selected).state;
+          const bool room_valid = !isnan(room_c) && !isnan(room_sp_c);
+          const bool room_warm_for_off = room_valid && (room_c >= (room_sp_c + room_overheat_off_c));
+          const bool room_requests_heat = room_valid && (room_c <= (room_sp_c - room_resume_heat_c));
+          const bool room_allows_off = (!room_valid) || room_warm_for_off;
+
+          const bool above_stop_band = pv >= (spw + stop_delta_c);
+          const bool low_pid_for_off = d <= off_pid_max_f;
+          const uint32_t now_ms = (uint32_t) millis();
           bool heat_request_active = id(oq_curve_heat_request_active);
           if (heat_request_active) {
-            if (pv >= (spw + stop_delta_c)) heat_request_active = false;
+            if (above_stop_band && low_pid_for_off && room_allows_off) {
+              uint32_t armed_ms = id(oq_curve_stop_arm_ms);
+              if (armed_ms == 0 || now_ms <= armed_ms) {
+                id(oq_curve_stop_arm_ms) = now_ms;
+              } else if ((now_ms - armed_ms) >= off_confirm_ms) {
+                heat_request_active = false;
+                id(oq_curve_stop_arm_ms) = 0;
+              }
+            } else {
+              id(oq_curve_stop_arm_ms) = 0;
+            }
           } else {
-            if (pv <= (spw - start_delta_c)) heat_request_active = true;
+            id(oq_curve_stop_arm_ms) = 0;
+            if (pv <= (spw - start_delta_c) || room_requests_heat) heat_request_active = true;
           }
 
           int curve_phase_code = 1;  // HEAT
@@ -988,26 +1076,6 @@ output:
             // - HEAT: PID-led modulation
             // - COAST: keep low modulation near target, avoid hard drop to 0
             // - OFF: only when stop hysteresis is reached
-            float coast_enter_c = 0.35f;  // Balanced default
-            int coast_floor_f = 1;
-            int coast_cap_f = 6;
-            if (id(oq_curve_control_profile).has_state()) {
-              const auto profile = id(oq_curve_control_profile).current_option();
-              if (profile == "Comfort") {
-                coast_enter_c = 0.25f;
-                coast_floor_f = 2;
-                coast_cap_f = 8;
-              } else if (profile == "Stable") {
-                coast_enter_c = 0.55f;
-                coast_floor_f = 1;
-                coast_cap_f = 4;
-              }
-            }
-            if (coast_floor_f < 1) coast_floor_f = 1;
-            if (coast_floor_f > demand_max) coast_floor_f = demand_max;
-            if (coast_cap_f < coast_floor_f) coast_cap_f = coast_floor_f;
-            if (coast_cap_f > demand_max) coast_cap_f = demand_max;
-
             const bool coast_phase = pv >= (spw - coast_enter_c);
             if (coast_phase) {
               curve_phase_code = 2;  // COAST
@@ -1063,6 +1131,7 @@ interval:
               // Fail-safe: no valid PV/SP => no heat demand
               id(oq_demand_curve) = 0;
               id(oq_curve_heat_request_active) = false;
+              id(oq_curve_stop_arm_ms) = 0;
               // Integral reset is handled explicitly in the if/then block below.
             } else {
               const float cur2 = id(oq_heating_curve_pid).target_temperature;
@@ -1113,6 +1182,7 @@ interval:
               c0.perform();
             }
             id(oq_curve_heat_request_active) = false;
+            id(oq_curve_stop_arm_ms) = 0;
             const float Tout = id(outside_temp_selected).state;
             const float Tc   = id(house_cold_temp_c).state;
             const float T0   = id(house_zero_power_temp_c).state;
@@ -1232,11 +1302,11 @@ interval:
             lambda: |-
               // Anti-windup:
               // - if SP/PV drops out in heating-curve mode, reset integral term
-              // - if hysteresis gate is OFF, clear integral to avoid continued push
+              // - while compressors are not yet delivering heat, keep integral empty
               if (id(oq_heat_mode_code) != 1) return false;
               const float spw = id(oq_supply_target_temp).state;
               const float pv  = id(oq_system_supply_temp).state;
-              if (isnan(spw) || isnan(pv) || !id(oq_curve_heat_request_active)) return true;
+              if (isnan(spw) || isnan(pv)) return true;
 
               // While compressors are not yet really delivering heat, keep integral empty.
               const bool hp1_level_on = id(hp1_last_applied_level) > 0;

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -728,6 +728,8 @@ sensor:
         - lambda: |-
             // Sync heating curve setpoint to Heating Curve PID
             if (isnan(x)) return;
+            const bool curve_mode_selected = id(oq_heat_control_mode).active_index().value_or(0) == 1;
+            if (!curve_mode_selected) return;
             float min_change_c = 0.10f;  // Balanced default
             if (id(oq_curve_control_profile).has_state()) {
               const auto profile = id(oq_curve_control_profile).current_option();

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -872,8 +872,8 @@ climate:
       max_integral: 3.0
       min_integral: -3.0
     deadband_parameters:
-      threshold_low: -0.20
-      threshold_high: 0.20
+      threshold_low: -1.00
+      threshold_high: 1.00
       deadband_output_averaging_samples: 6
     visual:
       min_temperature: 20
@@ -906,6 +906,7 @@ output:
             return;
           }
 
+          const int prev_d = id(oq_demand_curve);
           int d = (int) lroundf(state * ${oq_strategy_demand_max_f});
           if (d < 0) d = 0;
           if (d > demand_max) d = demand_max;
@@ -1010,6 +1011,15 @@ output:
             } else if (err_c <= err_soft_mid_c) {
               d = std::min(d, cap_soft_mid_f);
             }
+
+            // If supply is already above target + margin, never increase demand further.
+            float no_up_margin_c = 0.30f;  // Balanced default
+            if (id(oq_curve_control_profile).has_state()) {
+              const auto profile = id(oq_curve_control_profile).current_option();
+              if (profile == "Comfort") no_up_margin_c = 0.25f;
+              else if (profile == "Stable") no_up_margin_c = 0.40f;
+            }
+            if (pv > (spw + no_up_margin_c) && d > prev_d) d = prev_d;
           }
 
           id(oq_curve_heat_request_active) = heat_request_active;

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -48,6 +48,7 @@ select:
             id(oq_curve_heat_request_active) = false;
             id(oq_curve_outside_ema_initialized) = false;
             id(oq_curve_outside_ema_last_ms) = 0;
+            id(oq_curve_startup_until_ms) = 0;
             id(oq_ph_comfort_bias_last_ms) = 0;
             id(oq_ph_room_error_avg_init) = false;
 
@@ -72,6 +73,7 @@ select:
             id(oq_curve_heat_request_active) = false;
             id(oq_curve_outside_ema_initialized) = false;
             id(oq_curve_outside_ema_last_ms) = 0;
+            id(oq_curve_startup_until_ms) = 0;
 
 # ----------------------------
 # TUNING INPUTS
@@ -516,6 +518,12 @@ globals:
     restore_value: false
     initial_value: 'false'
 
+  # Startup demand guard window in curve mode (ms since boot).
+  - id: oq_curve_startup_until_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
   # Curve outside-temperature EMA state.
   - id: oq_curve_outside_ema_c
     type: float
@@ -928,20 +936,83 @@ output:
           }
           if (stop_delta_c < start_delta_c + 0.10f) stop_delta_c = start_delta_c + 0.10f;
 
-          bool heat_request_active = id(oq_curve_heat_request_active);
+          const bool was_heat_request_active = id(oq_curve_heat_request_active);
+          bool heat_request_active = was_heat_request_active;
           if (heat_request_active) {
             if (pv >= (spw + stop_delta_c)) heat_request_active = false;
           } else {
             if (pv <= (spw - start_delta_c)) heat_request_active = true;
           }
 
-          id(oq_curve_heat_request_active) = heat_request_active;
           if (!heat_request_active) {
             d = 0;
-          } else if (d < 1) {
-            d = 1;
+            id(oq_curve_startup_until_ms) = 0;
+          } else {
+            if (d < 1) d = 1;
+
+            // Smooth startup and near-setpoint behavior without adding user-facing knobs.
+            float err_soft_near_c = 1.0f;
+            float err_soft_mid_c = 2.0f;
+            int cap_soft_near_f = 6;
+            int cap_soft_mid_f = 12;
+            int startup_cap_f = 5;
+            uint32_t startup_hold_ms = 90000UL;
+            if (id(oq_curve_control_profile).has_state()) {
+              const auto profile = id(oq_curve_control_profile).current_option();
+              if (profile == "Comfort") {
+                err_soft_near_c = 0.90f;
+                err_soft_mid_c = 1.80f;
+                cap_soft_near_f = 8;
+                cap_soft_mid_f = 14;
+                startup_cap_f = 6;
+                startup_hold_ms = 60000UL;
+              } else if (profile == "Stable") {
+                err_soft_near_c = 1.20f;
+                err_soft_mid_c = 2.20f;
+                cap_soft_near_f = 5;
+                cap_soft_mid_f = 10;
+                startup_cap_f = 4;
+                startup_hold_ms = 120000UL;
+              }
+            }
+            if (cap_soft_near_f < 1) cap_soft_near_f = 1;
+            if (cap_soft_mid_f < cap_soft_near_f) cap_soft_mid_f = cap_soft_near_f;
+            if (cap_soft_mid_f > demand_max) cap_soft_mid_f = demand_max;
+            if (startup_cap_f < 1) startup_cap_f = 1;
+            if (startup_cap_f > demand_max) startup_cap_f = demand_max;
+
+            const uint32_t now_ms = (uint32_t) millis();
+            if (!was_heat_request_active) {
+              id(oq_curve_startup_until_ms) = now_ms + startup_hold_ms;
+            }
+            const uint32_t startup_until_ms = id(oq_curve_startup_until_ms);
+            const bool startup_active =
+                startup_until_ms != 0 && static_cast<uint32_t>(startup_until_ms - now_ms) < 0x80000000UL;
+
+            const bool hp1_level_on = id(hp1_last_applied_level) > 0;
+            const bool hp2_level_on = id(hp2_last_applied_level) > 0;
+            const float hp1_mode_raw = id(hp1_working_mode).state;
+            const float hp2_mode_raw = id(hp2_working_mode).state;
+            const bool hp1_heating = !isnan(hp1_mode_raw) && ((int) roundf(hp1_mode_raw) == 2);
+            const bool hp2_heating = !isnan(hp2_mode_raw) && ((int) roundf(hp2_mode_raw) == 2);
+            const bool hp_delivering =
+                (hp1_level_on && hp1_heating) || (hp2_level_on && hp2_heating);
+
+            // Keep early startup demand conservative until heat delivery is confirmed.
+            if (startup_active || !hp_delivering) {
+              d = std::min(d, startup_cap_f);
+            }
+
+            // Soft demand cap near setpoint to reduce burst/overshoot cycling.
+            const float err_c = spw - pv;
+            if (err_c <= err_soft_near_c) {
+              d = std::min(d, cap_soft_near_f);
+            } else if (err_c <= err_soft_mid_c) {
+              d = std::min(d, cap_soft_mid_f);
+            }
           }
 
+          id(oq_curve_heat_request_active) = heat_request_active;
           id(oq_demand_curve) = d;
 
 # ----------------------------
@@ -1158,6 +1229,17 @@ interval:
               if (id(oq_heat_mode_code) != 1) return false;
               const float spw = id(oq_supply_target_temp).state;
               const float pv  = id(oq_system_supply_temp).state;
-              return isnan(spw) || isnan(pv) || !id(oq_curve_heat_request_active);
+              if (isnan(spw) || isnan(pv) || !id(oq_curve_heat_request_active)) return true;
+
+              // While compressors are not yet really delivering heat, keep integral empty.
+              const bool hp1_level_on = id(hp1_last_applied_level) > 0;
+              const bool hp2_level_on = id(hp2_last_applied_level) > 0;
+              const float hp1_mode_raw = id(hp1_working_mode).state;
+              const float hp2_mode_raw = id(hp2_working_mode).state;
+              const bool hp1_heating = !isnan(hp1_mode_raw) && ((int) roundf(hp1_mode_raw) == 2);
+              const bool hp2_heating = !isnan(hp2_mode_raw) && ((int) roundf(hp2_mode_raw) == 2);
+              const bool hp_delivering =
+                  (hp1_level_on && hp1_heating) || (hp2_level_on && hp2_heating);
+              return !hp_delivering;
           then:
             - climate.pid.reset_integral_term: oq_heating_curve_pid

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -727,7 +727,8 @@ sensor:
               else if (profile == "Stable") min_change_c = 0.20f;
             }
             const float current_target_c = id(oq_heating_curve_pid).target_temperature;
-            if (isnan(current_target_c) || fabsf(current_target_c - x) >= min_change_c) {
+            if (id(oq_heating_curve_pid).mode != CLIMATE_MODE_HEAT ||
+                isnan(current_target_c) || fabsf(current_target_c - x) >= min_change_c) {
               auto call = id(oq_heating_curve_pid).make_call();
               call.set_mode(CLIMATE_MODE_HEAT);
               call.set_target_temperature(x);
@@ -987,7 +988,8 @@ interval:
               // Integral reset is handled explicitly in the if/then block below.
             } else {
               const float cur2 = id(oq_heating_curve_pid).target_temperature;
-              if (isnan(cur2) || fabsf(cur2 - spw) >= 0.10f) {
+              if (id(oq_heating_curve_pid).mode != CLIMATE_MODE_HEAT ||
+                  isnan(cur2) || fabsf(cur2 - spw) >= 0.10f) {
                 auto c2 = id(oq_heating_curve_pid).make_call();
 
                 // Set mode only when needed (fewer unnecessary calls)

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -510,6 +510,18 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  # Heating-curve diagnostics: demand before output guardrails.
+  - id: oq_curve_demand_pre_guardrail
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+  # Heating-curve diagnostics: 0=OFF, 1=HEAT, 2=COAST.
+  - id: oq_curve_phase_code
+    type: int
+    restore_value: false
+    initial_value: '0'
+
   # Curve-mode on/off hysteresis state near zero-demand edge.
   - id: oq_curve_heat_request_active
     type: bool
@@ -769,6 +781,34 @@ sensor:
     lambda: |-
       return (float) id(oq_demand_curve);
 
+  - platform: template
+    id: oq_curve_demand_pre_guardrail_sensor
+    name: "Demand Curve (pre-guardrail)"
+    icon: mdi:counter
+    unit_of_measurement: "step"
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return (float) id(oq_curve_demand_pre_guardrail);
+
+  - platform: template
+    id: oq_curve_demand_post_guardrail_sensor
+    name: "Demand Curve (post-guardrail)"
+    icon: mdi:counter
+    unit_of_measurement: "step"
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return (float) id(oq_demand_curve);
+
   # DEBUG-RUNTIME START: Power House adaptive comfort-bias diagnostics
   - platform: template
     id: oq_phouse_room_error_avg_c_sensor
@@ -827,6 +867,21 @@ text_sensor:
     lambda: |-
       return std::string(id(oq_heat_control_mode).current_option().c_str());
 
+  - platform: template
+    id: oq_curve_phase_sensor
+    name: "Curve Phase"
+    icon: mdi:state-machine
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      switch (id(oq_curve_phase_code)) {
+        case 1: return std::string("HEAT");
+        case 2: return std::string("COAST");
+        default: return std::string("OFF");
+      }
+
 # ----------------------------
 # TEMPERATURE CONTROLLER (PID climate)
 # ----------------------------
@@ -867,7 +922,9 @@ output:
           // In Power House mode, this output is diagnostic-only and must remain 0.
           if (id(oq_heat_mode_code) != 1) {
             id(oq_demand_curve) = 0;
+            id(oq_curve_demand_pre_guardrail) = 0;
             id(oq_curve_heat_request_active) = false;
+            id(oq_curve_phase_code) = 0;
             return;
           }
 
@@ -875,13 +932,16 @@ output:
           const int demand_max = (int) ${oq_strategy_demand_max_f};
           if (isnan(state)) {
             id(oq_demand_curve) = 0;
+            id(oq_curve_demand_pre_guardrail) = 0;
             id(oq_curve_heat_request_active) = false;
+            id(oq_curve_phase_code) = 0;
             return;
           }
 
           int d = (int) lroundf(state * ${oq_strategy_demand_max_f});
           if (d < 0) d = 0;
           if (d > demand_max) d = demand_max;
+          id(oq_curve_demand_pre_guardrail) = d;
 
           // Start/stop hysteresis near the zero-demand edge:
           // - Start heating when supply is below (SP - start_delta)
@@ -892,6 +952,8 @@ output:
           if (isnan(spw) || isnan(pv)) {
             id(oq_curve_heat_request_active) = false;
             id(oq_demand_curve) = 0;
+            id(oq_curve_demand_pre_guardrail) = 0;
+            id(oq_curve_phase_code) = 0;
             return;
           }
 
@@ -916,8 +978,10 @@ output:
             if (pv <= (spw - start_delta_c)) heat_request_active = true;
           }
 
+          int curve_phase_code = 1;  // HEAT
           if (!heat_request_active) {
             d = 0;
+            curve_phase_code = 0;  // OFF
           } else {
             if (d < 1) d = 1;
             // Three-phase control:
@@ -946,6 +1010,7 @@ output:
 
             const bool coast_phase = pv >= (spw - coast_enter_c);
             if (coast_phase) {
+              curve_phase_code = 2;  // COAST
               if (d < coast_floor_f) d = coast_floor_f;
               if (d > coast_cap_f) d = coast_cap_f;
               // Above setpoint we only allow low steady modulation while waiting for stop hysteresis.
@@ -955,6 +1020,7 @@ output:
 
           id(oq_curve_heat_request_active) = heat_request_active;
           id(oq_demand_curve) = d;
+          id(oq_curve_phase_code) = curve_phase_code;
 
 # ----------------------------
 # INTERVAL (5s)

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -390,12 +390,12 @@ number:
     name: "Heating Curve PID Kp"
     icon: mdi:alpha-k-circle-outline
     min_value: 0.000
-    max_value: 2.000
-    step: 0.001
+    max_value: 0.800
+    step: 0.010
     mode: slider
     restore_value: true
     optimistic: true
-    initial_value: 0.100
+    initial_value: 0.350
     web_server:
       sorting_group_id: oq_tuning_heat
     on_value:
@@ -412,12 +412,12 @@ number:
     name: "Heating Curve PID Ki"
     icon: mdi:alpha-i-circle-outline
     min_value: 0.00000
-    max_value: 0.05000
-    step: 0.00001
+    max_value: 0.00300
+    step: 0.00010
     mode: slider
     restore_value: true
     optimistic: true
-    initial_value: 0.00025
+    initial_value: 0.00120
     web_server:
       sorting_group_id: oq_tuning_heat
     on_value:
@@ -434,12 +434,12 @@ number:
     name: "Heating Curve PID Kd"
     icon: mdi:alpha-d-circle-outline
     min_value: 0.000
-    max_value: 1.000
-    step: 0.001
+    max_value: 0.400
+    step: 0.010
     mode: slider
     restore_value: true
     optimistic: true
-    initial_value: 0.000
+    initial_value: 0.200
     web_server:
       sorting_group_id: oq_tuning_heat
     on_value:
@@ -857,9 +857,9 @@ climate:
     default_target_temperature: 35 °C   # is synchronized with oq_supply_target_temp
     heat_output: heating_curve_pid_out
     control_parameters:
-      kp: 0.100
-      ki: 0.00025
-      kd: 0.0
+      kp: 0.350
+      ki: 0.00120
+      kd: 0.200
       max_integral: 3.0
       min_integral: -3.0
     deadband_parameters:

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -881,6 +881,14 @@ output:
     type: float
     write_action:
       - lambda: |-
+          // Guardrail: only let PID-path write curve demand in heating-curve mode.
+          // In Power House mode, this output is diagnostic-only and must remain 0.
+          if (id(oq_heat_mode_code) != 1) {
+            id(oq_demand_curve) = 0;
+            id(oq_curve_heat_request_active) = false;
+            return;
+          }
+
           // PID output is 0..1 (heat_output). Map to demand steps 0..20.
           const int demand_max = (int) ${oq_strategy_demand_max_f};
           if (isnan(state)) {
@@ -1019,6 +1027,11 @@ interval:
             // - Ramp limiter in W/min
             // - Compat: oq_demand_raw = round(20 * P_req / house_rated_power)
             // ------------------------------------------------------------
+            if (id(oq_heating_curve_pid).mode != CLIMATE_MODE_OFF) {
+              auto c0 = id(oq_heating_curve_pid).make_call();
+              c0.set_mode(CLIMATE_MODE_OFF);
+              c0.perform();
+            }
             id(oq_curve_heat_request_active) = false;
             const float Tout = id(outside_temp_selected).state;
             const float Tc   = id(house_cold_temp_c).state;

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -45,10 +45,33 @@ select:
         # Reset PID integral when strategy changes to prevent carry-over between modes.
         - climate.pid.reset_integral_term: oq_heating_curve_pid
         - lambda: |-
-            id(oq_curve_zero_req_since_ms) = 0;
-            id(oq_curve_overtemp_latch) = false;
+            id(oq_curve_heat_request_active) = false;
+            id(oq_curve_outside_ema_initialized) = false;
+            id(oq_curve_outside_ema_last_ms) = 0;
             id(oq_ph_comfort_bias_last_ms) = 0;
             id(oq_ph_room_error_avg_init) = false;
+
+  - platform: template
+    id: oq_curve_control_profile
+    name: "Heating Curve Control Profile"
+    icon: mdi:tune-variant
+    optimistic: true
+    restore_value: true
+    options:
+      - Comfort
+      - Balanced
+      - Stable
+    initial_option: Balanced
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+    on_value:
+      then:
+        - climate.pid.reset_integral_term: oq_heating_curve_pid
+        - lambda: |-
+            id(oq_curve_heat_request_active) = false;
+            id(oq_curve_outside_ema_initialized) = false;
+            id(oq_curve_outside_ema_last_ms) = 0;
 
 # ----------------------------
 # TUNING INPUTS
@@ -442,34 +465,6 @@ number:
     web_server:
       sorting_group_id: oq_tuning_heat
 
-  - platform: template
-    id: curve_demand_off_hold_s
-    name: "Curve Demand Off Hold"
-    icon: mdi:timer-sand
-    unit_of_measurement: "s"
-    min_value: 0
-    max_value: 600
-    step: 5
-    restore_value: true
-    optimistic: true
-    initial_value: 120
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  - platform: template
-    id: curve_temp_deadband_c
-    name: "Curve Temp Deadband"
-    icon: mdi:arrow-expand-vertical
-    unit_of_measurement: "°C"
-    min_value: 0.00
-    max_value: 2.00
-    step: 0.05
-    restore_value: true
-    optimistic: true
-    initial_value: 0.25
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
 button:
   - platform: template
     id: reset_heating_curve_pid_integral
@@ -515,16 +510,26 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # Tracks how long curve PID has requested zero demand.
-  # Used to avoid immediate 0/1 chatter around the cutoff.
-  - id: oq_curve_zero_req_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_curve_overtemp_latch
+  # Curve-mode on/off hysteresis state near zero-demand edge.
+  - id: oq_curve_heat_request_active
     type: bool
     restore_value: false
     initial_value: 'false'
+
+  # Curve outside-temperature EMA state.
+  - id: oq_curve_outside_ema_c
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+  - id: oq_curve_outside_ema_initialized
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+  - id: oq_curve_outside_ema_last_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
   - id: oq_heat_mode_code
     type: int
     restore_value: false
@@ -580,6 +585,56 @@ sensor:
       if (hp1_valid) return hp1_outside_c;
       if (hp2_valid) return hp2_outside_c;
       return NAN;
+
+  - platform: template
+    id: oq_curve_outside_temp_filtered
+    name: "Outside Temperature (Curve filtered)"
+    icon: mdi:thermometer-lines
+    internal: true
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 10s
+    lambda: |-
+      const float outside_c = id(outside_temp_selected).state;
+      if (isnan(outside_c)) {
+        id(oq_curve_outside_ema_initialized) = false;
+        id(oq_curve_outside_ema_last_ms) = 0;
+        return NAN;
+      }
+
+      // Profile-based smoothing time constant:
+      // Comfort = faster tracking, Stable = stronger smoothing.
+      float tau_s = 1800.0f;  // Balanced default
+      if (id(oq_curve_control_profile).has_state()) {
+        const auto profile = id(oq_curve_control_profile).current_option();
+        if (profile == "Comfort") tau_s = 900.0f;
+        else if (profile == "Stable") tau_s = 3600.0f;
+      }
+
+      const uint32_t now_ms = (uint32_t) millis();
+      if (!id(oq_curve_outside_ema_initialized) ||
+          id(oq_curve_outside_ema_last_ms) == 0 ||
+          now_ms <= id(oq_curve_outside_ema_last_ms)) {
+        id(oq_curve_outside_ema_c) = outside_c;
+        id(oq_curve_outside_ema_initialized) = true;
+        id(oq_curve_outside_ema_last_ms) = now_ms;
+        return outside_c;
+      }
+
+      const float dt_s = (now_ms - id(oq_curve_outside_ema_last_ms)) / 1000.0f;
+      float alpha = dt_s / (tau_s + dt_s);
+      if (alpha < 0.0f) alpha = 0.0f;
+      if (alpha > 1.0f) alpha = 1.0f;
+
+      float ema_c = id(oq_curve_outside_ema_c);
+      if (isnan(ema_c)) ema_c = outside_c;
+      ema_c += alpha * (outside_c - ema_c);
+
+      id(oq_curve_outside_ema_c) = ema_c;
+      id(oq_curve_outside_ema_last_ms) = now_ms;
+      return ema_c;
 
   - platform: template
     id: oq_system_supply_temp
@@ -665,16 +720,22 @@ sensor:
         - lambda: |-
             // Sync heating curve setpoint to Heating Curve PID
             if (isnan(x)) return;
+            float min_change_c = 0.10f;  // Balanced default
+            if (id(oq_curve_control_profile).has_state()) {
+              const auto profile = id(oq_curve_control_profile).current_option();
+              if (profile == "Comfort") min_change_c = 0.05f;
+              else if (profile == "Stable") min_change_c = 0.20f;
+            }
             const float current_target_c = id(oq_heating_curve_pid).target_temperature;
-            if (isnan(current_target_c) || fabsf(current_target_c - x) >= 0.05f) {
+            if (isnan(current_target_c) || fabsf(current_target_c - x) >= min_change_c) {
               auto call = id(oq_heating_curve_pid).make_call();
               call.set_mode(CLIMATE_MODE_HEAT);
               call.set_target_temperature(x);
               call.perform();
             }
     lambda: |-
-      const float outside_c = id(outside_temp_selected).state;
-      if (isnan(outside_c)) return id(curve_fallback_supply_temp).state;
+      const float outside_c = id(oq_curve_outside_temp_filtered).state;
+      float target_c = id(curve_fallback_supply_temp).state;
 
       struct Point { float outside_c; float target_c; };
       const Point points[6] = {
@@ -686,16 +747,31 @@ sensor:
         { 15.0f, id(curve_tsupply_15).state}
       };
 
-      if (outside_c <= -20.0f) return points[0].target_c;
-      if (outside_c >= 15.0f) return points[5].target_c;
-
-      for (int i = 0; i < 5; i++) {
-        if (outside_c >= points[i].outside_c && outside_c <= points[i + 1].outside_c) {
-          const float segment = (outside_c - points[i].outside_c) / (points[i + 1].outside_c - points[i].outside_c);
-          return points[i].target_c + segment * (points[i + 1].target_c - points[i].target_c);
+      if (!isnan(outside_c)) {
+        if (outside_c <= -20.0f) target_c = points[0].target_c;
+        else if (outside_c >= 15.0f) target_c = points[5].target_c;
+        else {
+          for (int i = 0; i < 5; i++) {
+            if (outside_c >= points[i].outside_c && outside_c <= points[i + 1].outside_c) {
+              const float segment = (outside_c - points[i].outside_c) / (points[i + 1].outside_c - points[i].outside_c);
+              target_c = points[i].target_c + segment * (points[i + 1].target_c - points[i].target_c);
+              break;
+            }
+          }
         }
       }
-      return NAN;
+
+      // Profile-based target quantization keeps supply target calm at low load.
+      float quant_step_c = 0.5f;  // Balanced default
+      if (id(oq_curve_control_profile).has_state()) {
+        const auto profile = id(oq_curve_control_profile).current_option();
+        if (profile == "Comfort") quant_step_c = 0.25f;
+        else if (profile == "Stable") quant_step_c = 1.0f;
+      }
+      if (!isnan(target_c) && quant_step_c > 0.0f) {
+        target_c = roundf(target_c / quant_step_c) * quant_step_c;
+      }
+      return target_c;
 
   # Diagnostics
   - platform: template
@@ -786,6 +862,10 @@ climate:
       kd: 0.0
       max_integral: 3.0
       min_integral: -3.0
+    deadband_parameters:
+      threshold_low: -0.20
+      threshold_high: 0.20
+      deadband_output_averaging_samples: 6
     visual:
       min_temperature: 20
       max_temperature: 70
@@ -805,8 +885,7 @@ output:
           const int demand_max = (int) ${oq_strategy_demand_max_f};
           if (isnan(state)) {
             id(oq_demand_curve) = 0;
-            id(oq_curve_zero_req_since_ms) = 0;
-            id(oq_curve_overtemp_latch) = false;
+            id(oq_curve_heat_request_active) = false;
             return;
           }
 
@@ -814,54 +893,45 @@ output:
           if (d < 0) d = 0;
           if (d > demand_max) d = demand_max;
 
-          // Stabilize around supply target:
-          // - Overtemp latch keeps minimum demand (1) to avoid hard CM2->CM1 churn.
-          // - Within deadband around SP, cap demand to 1 to avoid hunting.
+          // Start/stop hysteresis near the zero-demand edge:
+          // - Start heating when supply is below (SP - start_delta)
+          // - Stop heating when supply is above (SP + stop_delta)
+          // This replaces the previous deadband/off-hold pair with a deterministic gate.
           const float spw = id(oq_supply_target_temp).state;
           const float pv = id(oq_system_supply_temp).state;
-          const float db = fmaxf(0.0f, id(curve_temp_deadband_c).state);
-          bool overtemp_latch = id(oq_curve_overtemp_latch);
-          if (!isnan(spw) && !isnan(pv)) {
-            const float err = spw - pv;      // + => too cold, - => too warm
-            const float on_th = -fmaxf(0.05f, db);
-            const float off_th = 0.05f;
-
-            if (!overtemp_latch && err <= on_th) {
-              overtemp_latch = true;
-            } else if (overtemp_latch && err >= off_th) {
-              overtemp_latch = false;
-            }
-
-              if (overtemp_latch) {
-                d = 1;
-              } else if (fabsf(err) <= db) {
-                d = std::min(d, 1);
-              }
+          if (isnan(spw) || isnan(pv)) {
+            id(oq_curve_heat_request_active) = false;
+            id(oq_demand_curve) = 0;
+            return;
           }
-          id(oq_curve_overtemp_latch) = overtemp_latch;
 
-          // Anti-flip guard near zero demand:
-          // keep demand at 1 for a short hold period before allowing 0,
-          // except when overtemp-latch is actively forcing zero.
-          const uint32_t now_ms = (uint32_t) millis();
-          const uint32_t hold_ms = (uint32_t) lroundf(id(curve_demand_off_hold_s).state) * 1000UL;
-          const int prev = id(oq_demand_curve);
-          if (d <= 0) {
-            if (overtemp_latch) {
-              id(oq_curve_zero_req_since_ms) = 0;
-            } else {
-              if (prev > 0) {
-                if (id(oq_curve_zero_req_since_ms) == 0) {
-                  id(oq_curve_zero_req_since_ms) = now_ms;
-                }
-                const uint32_t dt = (uint32_t) (now_ms - id(oq_curve_zero_req_since_ms));
-                if (hold_ms > 0 && dt < hold_ms) d = 1;
-              }
+          float start_delta_c = 0.45f;  // Balanced default
+          float stop_delta_c = 0.75f;   // Balanced default
+          if (id(oq_curve_control_profile).has_state()) {
+            const auto profile = id(oq_curve_control_profile).current_option();
+            if (profile == "Comfort") {
+              start_delta_c = 0.30f;
+              stop_delta_c = 0.55f;
+            } else if (profile == "Stable") {
+              start_delta_c = 0.65f;
+              stop_delta_c = 1.00f;
             }
+          }
+          if (stop_delta_c < start_delta_c + 0.10f) stop_delta_c = start_delta_c + 0.10f;
+
+          bool heat_request_active = id(oq_curve_heat_request_active);
+          if (heat_request_active) {
+            if (pv >= (spw + stop_delta_c)) heat_request_active = false;
           } else {
-            id(oq_curve_zero_req_since_ms) = 0;
+            if (pv <= (spw - start_delta_c)) heat_request_active = true;
           }
-          if (d == 0) id(oq_curve_zero_req_since_ms) = 0;
+
+          id(oq_curve_heat_request_active) = heat_request_active;
+          if (!heat_request_active) {
+            d = 0;
+          } else if (d < 1) {
+            d = 1;
+          }
 
           id(oq_demand_curve) = d;
 
@@ -905,6 +975,7 @@ interval:
             if (isnan(spw) || isnan(pv)) {
               // Fail-safe: no valid PV/SP => no heat demand
               id(oq_demand_curve) = 0;
+              id(oq_curve_heat_request_active) = false;
               // Integral reset is handled explicitly in the if/then block below.
             } else {
               const float cur2 = id(oq_heating_curve_pid).target_temperature;
@@ -948,6 +1019,7 @@ interval:
             // - Ramp limiter in W/min
             // - Compat: oq_demand_raw = round(20 * P_req / house_rated_power)
             // ------------------------------------------------------------
+            id(oq_curve_heat_request_active) = false;
             const float Tout = id(outside_temp_selected).state;
             const float Tc   = id(house_cold_temp_c).state;
             const float T0   = id(house_zero_power_temp_c).state;
@@ -1067,10 +1139,10 @@ interval:
             lambda: |-
               // Anti-windup:
               // - if SP/PV drops out in heating-curve mode, reset integral term
-              // - if overtemp-latch is active, clear integral to avoid continued push
+              // - if hysteresis gate is OFF, clear integral to avoid continued push
               if (id(oq_heat_mode_code) != 1) return false;
               const float spw = id(oq_supply_target_temp).state;
               const float pv  = id(oq_system_supply_temp).state;
-              return isnan(spw) || isnan(pv) || id(oq_curve_overtemp_latch);
+              return isnan(spw) || isnan(pv) || !id(oq_curve_heat_request_active);
           then:
             - climate.pid.reset_integral_term: oq_heating_curve_pid

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -48,7 +48,6 @@ select:
             id(oq_curve_heat_request_active) = false;
             id(oq_curve_outside_ema_initialized) = false;
             id(oq_curve_outside_ema_last_ms) = 0;
-            id(oq_curve_startup_until_ms) = 0;
             id(oq_ph_comfort_bias_last_ms) = 0;
             id(oq_ph_room_error_avg_init) = false;
 
@@ -73,7 +72,6 @@ select:
             id(oq_curve_heat_request_active) = false;
             id(oq_curve_outside_ema_initialized) = false;
             id(oq_curve_outside_ema_last_ms) = 0;
-            id(oq_curve_startup_until_ms) = 0;
 
 # ----------------------------
 # TUNING INPUTS
@@ -518,12 +516,6 @@ globals:
     restore_value: false
     initial_value: 'false'
 
-  # Startup demand guard window in curve mode (ms since boot).
-  - id: oq_curve_startup_until_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
   # Curve outside-temperature EMA state.
   - id: oq_curve_outside_ema_c
     type: float
@@ -723,27 +715,6 @@ sensor:
     update_interval: 10s
     web_server:
       sorting_group_id: oq_temperatures
-    on_value:
-      then:
-        - lambda: |-
-            // Sync heating curve setpoint to Heating Curve PID
-            if (isnan(x)) return;
-            const bool curve_mode_selected = id(oq_heat_control_mode).active_index().value_or(0) == 1;
-            if (!curve_mode_selected) return;
-            float min_change_c = 0.10f;  // Balanced default
-            if (id(oq_curve_control_profile).has_state()) {
-              const auto profile = id(oq_curve_control_profile).current_option();
-              if (profile == "Comfort") min_change_c = 0.05f;
-              else if (profile == "Stable") min_change_c = 0.20f;
-            }
-            const float current_target_c = id(oq_heating_curve_pid).target_temperature;
-            if (id(oq_heating_curve_pid).mode != CLIMATE_MODE_HEAT ||
-                isnan(current_target_c) || fabsf(current_target_c - x) >= min_change_c) {
-              auto call = id(oq_heating_curve_pid).make_call();
-              call.set_mode(CLIMATE_MODE_HEAT);
-              call.set_target_temperature(x);
-              call.perform();
-            }
     lambda: |-
       const float outside_c = id(oq_curve_outside_temp_filtered).state;
       float target_c = id(curve_fallback_supply_temp).state;
@@ -908,7 +879,6 @@ output:
             return;
           }
 
-          const int prev_d = id(oq_demand_curve);
           int d = (int) lroundf(state * ${oq_strategy_demand_max_f});
           if (d < 0) d = 0;
           if (d > demand_max) d = demand_max;
@@ -939,8 +909,7 @@ output:
           }
           if (stop_delta_c < start_delta_c + 0.10f) stop_delta_c = start_delta_c + 0.10f;
 
-          const bool was_heat_request_active = id(oq_curve_heat_request_active);
-          bool heat_request_active = was_heat_request_active;
+          bool heat_request_active = id(oq_curve_heat_request_active);
           if (heat_request_active) {
             if (pv >= (spw + stop_delta_c)) heat_request_active = false;
           } else {
@@ -949,79 +918,39 @@ output:
 
           if (!heat_request_active) {
             d = 0;
-            id(oq_curve_startup_until_ms) = 0;
           } else {
             if (d < 1) d = 1;
-
-            // Smooth startup and near-setpoint behavior without adding user-facing knobs.
-            float err_soft_near_c = 1.0f;
-            float err_soft_mid_c = 2.0f;
-            int cap_soft_near_f = 6;
-            int cap_soft_mid_f = 12;
-            int startup_cap_f = 5;
-            uint32_t startup_hold_ms = 90000UL;
+            // Three-phase control:
+            // - HEAT: PID-led modulation
+            // - COAST: keep low modulation near target, avoid hard drop to 0
+            // - OFF: only when stop hysteresis is reached
+            float coast_enter_c = 0.35f;  // Balanced default
+            int coast_floor_f = 1;
+            int coast_cap_f = 6;
             if (id(oq_curve_control_profile).has_state()) {
               const auto profile = id(oq_curve_control_profile).current_option();
               if (profile == "Comfort") {
-                err_soft_near_c = 0.90f;
-                err_soft_mid_c = 1.80f;
-                cap_soft_near_f = 8;
-                cap_soft_mid_f = 14;
-                startup_cap_f = 6;
-                startup_hold_ms = 60000UL;
+                coast_enter_c = 0.25f;
+                coast_floor_f = 2;
+                coast_cap_f = 8;
               } else if (profile == "Stable") {
-                err_soft_near_c = 1.20f;
-                err_soft_mid_c = 2.20f;
-                cap_soft_near_f = 5;
-                cap_soft_mid_f = 10;
-                startup_cap_f = 4;
-                startup_hold_ms = 120000UL;
+                coast_enter_c = 0.55f;
+                coast_floor_f = 1;
+                coast_cap_f = 4;
               }
             }
-            if (cap_soft_near_f < 1) cap_soft_near_f = 1;
-            if (cap_soft_mid_f < cap_soft_near_f) cap_soft_mid_f = cap_soft_near_f;
-            if (cap_soft_mid_f > demand_max) cap_soft_mid_f = demand_max;
-            if (startup_cap_f < 1) startup_cap_f = 1;
-            if (startup_cap_f > demand_max) startup_cap_f = demand_max;
+            if (coast_floor_f < 1) coast_floor_f = 1;
+            if (coast_floor_f > demand_max) coast_floor_f = demand_max;
+            if (coast_cap_f < coast_floor_f) coast_cap_f = coast_floor_f;
+            if (coast_cap_f > demand_max) coast_cap_f = demand_max;
 
-            const uint32_t now_ms = (uint32_t) millis();
-            if (!was_heat_request_active) {
-              id(oq_curve_startup_until_ms) = now_ms + startup_hold_ms;
+            const bool coast_phase = pv >= (spw - coast_enter_c);
+            if (coast_phase) {
+              if (d < coast_floor_f) d = coast_floor_f;
+              if (d > coast_cap_f) d = coast_cap_f;
+              // Above setpoint we only allow low steady modulation while waiting for stop hysteresis.
+              if (pv >= spw && d > coast_floor_f) d = coast_floor_f;
             }
-            const uint32_t startup_until_ms = id(oq_curve_startup_until_ms);
-            const bool startup_active =
-                startup_until_ms != 0 && static_cast<uint32_t>(startup_until_ms - now_ms) < 0x80000000UL;
-
-            const bool hp1_level_on = id(hp1_last_applied_level) > 0;
-            const bool hp2_level_on = id(hp2_last_applied_level) > 0;
-            const float hp1_mode_raw = id(hp1_working_mode).state;
-            const float hp2_mode_raw = id(hp2_working_mode).state;
-            const bool hp1_heating = !isnan(hp1_mode_raw) && ((int) roundf(hp1_mode_raw) == 2);
-            const bool hp2_heating = !isnan(hp2_mode_raw) && ((int) roundf(hp2_mode_raw) == 2);
-            const bool hp_delivering =
-                (hp1_level_on && hp1_heating) || (hp2_level_on && hp2_heating);
-
-            // Keep early startup demand conservative until heat delivery is confirmed.
-            if (startup_active || !hp_delivering) {
-              d = std::min(d, startup_cap_f);
-            }
-
-            // Soft demand cap near setpoint to reduce burst/overshoot cycling.
-            const float err_c = spw - pv;
-            if (err_c <= err_soft_near_c) {
-              d = std::min(d, cap_soft_near_f);
-            } else if (err_c <= err_soft_mid_c) {
-              d = std::min(d, cap_soft_mid_f);
-            }
-
-            // If supply is already above target + margin, never increase demand further.
-            float no_up_margin_c = 0.30f;  // Balanced default
-            if (id(oq_curve_control_profile).has_state()) {
-              const auto profile = id(oq_curve_control_profile).current_option();
-              if (profile == "Comfort") no_up_margin_c = 0.25f;
-              else if (profile == "Stable") no_up_margin_c = 0.40f;
-            }
-            if (pv > (spw + no_up_margin_c) && d > prev_d) d = prev_d;
           }
 
           id(oq_curve_heat_request_active) = heat_request_active;

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -63,7 +63,9 @@ oq_ph_deadband_default_k: "0.14"                      # Default Power House room
 # ----------------------------
 # HEAT CONTROL
 # ----------------------------
-oq_heat_loop_s: "5"                                   # Heat-control loop interval [s]; per-minute tuning is elapsed-time scaled.
+oq_heat_loop_tick_s: "5"                              # Scheduler tick for heat-control loop [s].
+oq_heat_loop_curve_s: "30"                            # Effective heat-control cadence in Heating Curve mode [s].
+oq_heat_loop_powerhouse_s: "60"                       # Effective heat-control cadence in Power House mode [s].
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
 oq_optimizer_soft_w: "3400.0"                         # Soft limit for electrical HP power in optimizer [W]; peak limit follows oq_power_peak_w.
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -63,7 +63,7 @@ oq_ph_deadband_default_k: "0.14"                      # Default Power House room
 # ----------------------------
 # HEAT CONTROL
 # ----------------------------
-oq_heat_loop_s: "60"                                  # Main interval of heat-control allocation/filter [s].
+oq_heat_loop_s: "5"                                   # Heat-control loop interval [s]; per-minute tuning is elapsed-time scaled.
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
 oq_optimizer_soft_w: "3400.0"                         # Soft limit for electrical HP power in optimizer [W]; peak limit follows oq_power_peak_w.
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -669,8 +669,14 @@ interval:
           const bool hp2_mode_valid = !isnan(hp2_mode_raw);
           const bool hp1_heating = hp1_mode_valid && ((int) roundf(hp1_mode_raw) == 2);
           const bool hp2_heating = hp2_mode_valid && ((int) roundf(hp2_mode_raw) == 2);
-          const bool both_modes_known = hp1_mode_valid && hp2_mode_valid;
-          const bool both_units_idle = both_modes_known && !hp1_heating && !hp2_heating;
+          const bool hp1_target_heating =
+              id(hp1_set_working_mode).has_state() && id(hp1_set_working_mode).current_option() == "Heating";
+          const bool hp2_target_heating =
+              id(hp2_set_working_mode).has_state() && id(hp2_set_working_mode).current_option() == "Heating";
+          const bool hp1_active_guard = hp1_heating || hp1_target_heating || (hp1_lvl > 0);
+          const bool hp2_active_guard = hp2_heating || hp2_target_heating || (hp2_lvl > 0);
+          const bool any_hp_active_guard = hp1_active_guard || hp2_active_guard;
+          const bool both_units_idle = !any_hp_active_guard;
 
           bool heating_req = heating_req_raw;
           float p_req_w = NAN;
@@ -921,6 +927,15 @@ interval:
 
           // Publish lowflow fault status (writes-only-on-change)
           publish_binary_if_changed(id(oq_lowflow_fault_active_bs), id(oq_lowflow_fault_active));
+
+          // Hard safety path: persistent low-flow fault must force both HPs to Standby + level 0.
+          // This runs in supervisory as an explicit emergency override, independent from heat-control timing.
+          if (id(oq_lowflow_fault_active)) {
+            set_select_option(id(hp1_set_working_mode), "Standby");
+            set_select_option(id(hp2_set_working_mode), "Standby");
+            set_select_option(id(hp1_compressor_level), "0");
+            set_select_option(id(hp2_compressor_level), "0");
+          }
           // -------------------------------------------------
           // 3) Frost condition (hysteresis + fail-safe) [CM98]
           //    Relevant only when there is no heat demand.
@@ -1070,6 +1085,12 @@ interval:
                     desired_local = (base_target == 98) ? 98 : 0;
                   }
                 }
+              }
+
+              // Safety: never leave CM1 to CM0 while any HP still reports/targets activity.
+              // Keep CM1 (pump-on holding state) until both HPs are effectively idle.
+              if (strcmp(cur_cm, "CM1") == 0 && !heating_req && base_target == 0 && any_hp_active_guard) {
+                desired_local = 1;
               }
 
               // CM3 (boiler assist) auto-switching
@@ -1231,7 +1252,8 @@ interval:
             }
 
             const bool sticky_active = in_cm0 && ms_window_active(id(oq_sticky_until_ms));
-            const bool pump_on = (strcmp(desired_cm, "CM0") != 0) || sticky_active;
+            // Pump failsafe: never stop circulation while any HP is still active.
+            const bool pump_on = (strcmp(desired_cm, "CM0") != 0) || sticky_active || any_hp_active_guard;
             set_select_option(id(hp1_set_pump_mode), pump_on ? "On" : "Off");
             set_select_option(id(hp2_set_pump_mode), pump_on ? "On" : "Off");
 


### PR DESCRIPTION
## Summary
This PR refactors heating-curve control to reduce bursty behavior, avoid unnecessary ON/OFF cycling, and improve field diagnostics.

## Why
In real runs, the previous curve path could jump to high demand, overshoot, and then fall back to zero too aggressively. This caused unstable allocation behavior (including abrupt dual-HP transitions) and made root-cause analysis difficult.

## What Changed

### 1) Heating-curve strategy stabilization (`openquatt/oq_heating_strategy.yaml`)
- Added profile-driven control bundles (`Comfort` / `Balanced` / `Stable`).
- Added outside-temperature EMA smoothing (profile-based tau) and supply-target quantization.
- Added room-coupled target trim to reduce living-room overshoot while keeping curve control continuous.
- Tuned PID defaults/ranges and enabled PID deadband behavior.
- Introduced explicit curve phases:
  - `HEAT`: PID-led modulation
  - `COAST`: low steady modulation near target
  - `OFF`: only after sustained stop conditions
- Added robust start/stop/restart logic around the zero edge:
  - start/stop hysteresis around supply target
  - OFF confirmation timer + low-PID gate
  - room-aware OFF and resume conditions
  - restart inhibit lockout with bypass on deep undershoot / room heat request
- Added dedicated diagnostics:
  - `Demand Curve (pre-guardrail)`
  - `Demand Curve (post-guardrail)`
  - `Curve Phase`
  - `Curve restart inhibit`

### 2) Heat allocation and actuator behavior (`openquatt/oq_heat_control.yaml`)
- Split allocation cadence by strategy mode (5s scheduler tick; effective 30s in Curve, 60s in Power House) with elapsed-time scaling.
- Added single-owner latch in curve mode so single-HP ownership remains stable during active demand.
- Reworked dual-HP behavior in curve mode:
  - `Dual HP Enable Level` interpreted as sustained single-HP compressor level
  - disable threshold derived as `enable - 1`
  - enable/disable hold hysteresis
  - conservative emergency dual path for sustained severe deficit, with startup grace
- Added explicit curve actuator guardrails:
  - per-HP asymmetric slew limits (up slower than down)
  - at most one level step per HP change
  - global one-HP-change-per-cycle guardrail to avoid tandem jumps (`1+1 -> 2+2`)
- Applied minimum-runtime stop blocking to both strategy modes (not only Power House).
- Added profile-based minimum OFF time before restart in curve mode.
- Fixed strategy handover edge cases so curve PID does not chatter/toggle in Power House mode.

### 3) Supervisory/safety consistency
- Hardened control/safety interactions for mode transitions and shutdown sequencing where heating demand and HP state overlap.
- Kept capacity/deficit telemetry available in both modes for CM3 decisioning.

### 4) Debuggability and observability
- Added `Heating Debug State` diagnostic trace (single-line state snapshot) including:
  - strategy mode, CM, curve phase
  - raw/filtered/capped demand chain
  - dual-enable state and hold counters
  - lead/owner routing
  - requested/applied/current compressor levels
  - HP working modes
  - supply/room/outside temperatures
  - restart inhibit/off-age/runtime counters

## Documentation and Dashboards
- Updated docs to match actual runtime behavior and current entity names.
- Corrected outdated references (`select.openquatt_heating_control_mode`, `select.openquatt_flow_control_mode`).
- Added heating-curve diagnostics coverage to EN/NL HA dashboards:
  - pre/post guardrail demand
  - curve phase + restart inhibit
  - heating debug state
- Cleaned in-code naming/comments to match current dual-enable terminology.

## Validation
- `esphome compile openquatt.yaml` ✅
- `python3 scripts/check_docs_consistency.py` ✅