### PR TITLE
Improve dashboard UX, cumulative energy naming, and HA source persistence

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -462,7 +462,7 @@ views:
         cards:
           - type: heading
             icon: mdi:sigma
-            heading: Total
+            heading: Cumulative
             heading_style: title
           - type: heading
             icon: mdi:heat-pump
@@ -471,10 +471,12 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_electrical_energy_total
-                name: Electricity total
-              - entity: sensor.openquatt_heatpump_thermal_energy_total
-                name: Heat total
+              - entity: sensor.openquatt_electrical_energy_cumulative
+                name: Electricity cumulative
+              - entity: sensor.openquatt_heatpump_thermal_energy_cumulative
+                name: Heat cumulative
+              - entity: sensor.openquatt_heatpump_cop_cumulative
+                name: COP cumulative
           - type: heading
             icon: mdi:water-boiler
             heading: Boiler
@@ -483,7 +485,7 @@ views:
             show_header_toggle: false
             entities:
               - entity: sensor.openquatt_boiler_thermal_energy_total
-                name: Heat total
+                name: Heat cumulative
           - type: heading
             icon: mdi:sigma
             heading: System
@@ -492,7 +494,7 @@ views:
             show_header_toggle: false
             entities:
               - entity: sensor.openquatt_system_thermal_energy_total
-                name: Heat total
+                name: Heat cumulative
       - type: grid
         cards:
           - type: heading
@@ -545,7 +547,7 @@ views:
               <summary><strong>Explanation</strong></summary>
 
               Daily aggregation for energy:
-              - Electricity and heat as daily kWh (derived from total sensors)
+              - Electricity and heat as daily kWh (derived from cumulative sensors)
               - `COP today` as daily average
 
               </details>
@@ -586,7 +588,7 @@ views:
               tooltip:
                 shared: true
             series:
-              - entity: sensor.openquatt_electrical_energy_total
+              - entity: sensor.openquatt_electrical_energy_cumulative
                 name: Electricity/day
                 color: '#3B82F6'
                 yaxis_id: energy
@@ -594,7 +596,7 @@ views:
                 group_by:
                   func: delta
                   duration: 1d
-              - entity: sensor.openquatt_heatpump_thermal_energy_total
+              - entity: sensor.openquatt_heatpump_thermal_energy_cumulative
                 name: Heat pump heat/day
                 color: '#F59E0B'
                 yaxis_id: energy
@@ -664,7 +666,7 @@ views:
               tooltip:
                 shared: true
             series:
-              - entity: sensor.openquatt_electrical_energy_total
+              - entity: sensor.openquatt_electrical_energy_cumulative
                 name: Electricity/day
                 color: '#3B82F6'
                 yaxis_id: energy
@@ -672,7 +674,7 @@ views:
                 group_by:
                   func: delta
                   duration: 1d
-              - entity: sensor.openquatt_heatpump_thermal_energy_total
+              - entity: sensor.openquatt_heatpump_thermal_energy_cumulative
                 name: Heat pump heat/day
                 color: '#F59E0B'
                 yaxis_id: energy

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -399,8 +399,8 @@ views:
               HeatPump statistics (without boiler):
               - `Heat output power`: thermal output power of HP1+HP2 (W)
               - `Electricity daily`: electrical input today (kWh)
-              - `COP daily`: verhouding `daily heat kWh / daily electricity kWh`
               - `Heat daily`: heat production today (kWh)
+              - `COP daily`: ratio `daily heat kWh / daily electricity kWh`
               - `Electricity total`: cumulative electrical input (kWh)
               - `Heat total`: cumulative heat production (kWh)
 
@@ -452,9 +452,9 @@ views:
               <summary><strong>Explanation</strong></summary>
 
               Boiler statistics:
-              - `Boiler active`: shows whether relay control is active
               - `Heat output power`: current thermal boiler contribution (W)
               - `Heat daily`: boiler heat today (kWh)
+              - `Boiler active`: shows whether relay control is active
               - `Heat total`: cumulative boiler heat (kWh)
 
               </details>
@@ -500,7 +500,7 @@ views:
 
               System values (HeatPump + Boiler):
               - `Electricity input power`: total electrical input power (W)
-              - `Heat output power`: totale thermische output (W)
+              - `Heat output power`: total thermal output (W)
               - `Heat daily`: system heat today (kWh)
               - `Heat total`: cumulative system heat (kWh)
 

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -880,30 +880,6 @@ views:
             icon: mdi:radiator
             heading: Heat control status
             heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Explanation</strong></summary>
-
-              Heat control in 30 seconds:
-
-              - Use `Heating mode` to choose which source drives heat demand.
-              - Compare `P_req` (requested power) with `P_house` (model estimate).
-              - Check `Deficit`: above `0 W` means the system is short on delivered heat.
-              - Use `Demand raw` and `Demand filtered` to verify damping behavior.
-              - `Power cap demand` (0..20 step) is the supervisory demand cap applied before HP split.
-
-              Terms:
-
-              - `P_house`: modeled heat demand from house model and outdoor temperature.
-              - `P_req`: rate-limited live heat request in W after ramp limiter.
-              - `Demand raw`: raw demand step for compressor control.
-              - `Demand filtered`: damped demand step for more stable control.
-              - `Power cap demand`: active supervisory cap on demand steps.
-
-              </details>
-            text_only: true
           - type: heading
             icon: mdi:tune-variant
             heading: Control settings
@@ -924,6 +900,20 @@ views:
             features:
               - type: select-options
             features_position: inline
+          - type: tile
+            visibility:
+              - condition: state
+                entity: select.openquatt_heating_control_mode
+                state: Water Temperature Control (heating curve)
+            entity: select.openquatt_heating_curve_control_profile
+            name:
+              type: entity
+            show_entity_picture: false
+            hide_state: true
+            vertical: false
+            features:
+              - type: select-options
+            features_position: inline
           - type: heading
             icon: mdi:view-dashboard-outline
             heading: Core KPIs
@@ -937,91 +927,30 @@ views:
 
               - `P_req`: requested heating power after smoothing/ramp limits.
               - `P_house`: modeled house heat demand.
-              - `Max capacity`: estimated available HP heating capacity.
+              - `Max HP capacity`: estimated available HP heating capacity.
               - `Deficit`: positive value means demand is above available/delivered heat.
               </details>
             text_only: true
-          - type: grid
-            square: false
-            columns: 2
-            cards:
-              - type: tile
-                entity: sensor.openquatt_power_house_p_req
-                name: P_req
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_power_house_p_house
-                name: P_house
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_hp_capacity_w
-                name: Max capacity
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_hp_deficit_w
-                name: Deficit
-                vertical: false
-                features_position: bottom
-          - type: heading
-            icon: mdi:chart-line
-            heading: Demand & cap
-            heading_style: subtitle
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Explanation</strong></summary>
-
-              Demand shaping and limiting:
-
-              - `Demand raw`: direct demand step before filtering.
-              - `Demand filtered`: damped demand step used for more stable behavior.
-              - `Power cap demand`: supervisory cap applied to demand (0..20 step scale).
-              </details>
-            text_only: true
-          - type: grid
-            square: false
-            columns: 3
-            cards:
-              - type: tile
-                entity: sensor.openquatt_demand_raw
-                name: Demand raw
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_power_cap_demand
-                name: Power cap demand
-                vertical: false
-                features_position: bottom
-          - type: heading
-            icon: mdi:gauge
-            heading: Capacity
-            heading_style: subtitle
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Explanation</strong></summary>
-
-              Visual capacity check:
-
-              - Left gauge `Max capacity`: current estimated maximum HP heat output.
-              - Right gauge `Deficit`: how much heat is missing relative to demand.
-
-              A persistent high deficit indicates the system cannot currently keep up with demand.
-              </details>
-            text_only: true
-          - type: horizontal-stack
+          - square: false
+            type: grid
             cards:
               - type: gauge
+                entity: sensor.openquatt_power_house_p_house
+                min: 0
+                max: 12000
+                needle: true
+                name:
+                  type: entity
+              - type: gauge
+                entity: sensor.openquatt_power_house_p_req
+                min: 0
+                max: 12000
+                needle: true
+                name:
+                  type: entity
+              - type: gauge
                 entity: sensor.openquatt_hp_capacity_w
-                name: Max capacity
+                name: Max HP capacity
                 min: 0
                 max: 12000
                 needle: true
@@ -1035,6 +964,7 @@ views:
                   green: 0
                   yellow: 800
                   red: 2000
+            columns: 2
       - type: grid
         cards:
           - type: heading
@@ -1049,7 +979,6 @@ views:
 
               - `Heat demand` compares requested (`P_req`) versus delivered heat.
               - `HP input` and `HP output` show electrical input versus thermal output.
-              - `Compressor levels and frequency` shows setpoint versus actual compressor Hz.
               - `Temperature control` shows outside, supply, and room temperatures against targets.
 
               </details>
@@ -1087,21 +1016,6 @@ views:
                 name: HP1 heating power
               - entity: sensor.openquatt_hp2_heat_power
                 name: HP2 heating power
-            grid_options:
-              columns: full
-          - type: history-graph
-            title: Compressor levels and frequency (24h)
-            hours_to_show: 24
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_hp1_compressor_level
-                name: HP1 level
-              - entity: sensor.openquatt_hp2_compressor_level
-                name: HP2 level
-              - entity: sensor.openquatt_hp1_compressor_frequency
-                name: HP1 Hz
-              - entity: sensor.openquatt_hp2_compressor_frequency
-                name: HP2 Hz
             grid_options:
               columns: full
           - type: history-graph
@@ -1893,8 +1807,8 @@ views:
           the selected value and source status.
     top_margin: false
     dense_section_placement: false
-  - title: Advanced settings
-    path: advanced-settings
+  - title: Tuning
+    path: tuning
     icon: mdi:tune-vertical
     type: sections
     max_columns: 3
@@ -1902,8 +1816,8 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:window-maximize
-            heading: System limits and windows
+            icon: mdi:volume-off
+            heading: Silent mode settings
             heading_style: title
           - type: markdown
             content: >-
@@ -1918,15 +1832,6 @@ views:
               - **Silent start/end time** defines the time window in which the
               silent cap is active.
 
-              - **CM3 deficit ON/OFF thresholds** define when boiler assist may
-              switch on/off.
-
-              - Keep ON clearly higher than OFF to reduce toggling around the
-              threshold.
-
-              - If behavior is too aggressive: increase ON or decrease OFF.
-
-
               </details>
             text_only: true
           - type: entities
@@ -1940,10 +1845,6 @@ views:
                 name: Silent start time
               - entity: time.openquatt_silent_end_time
                 name: Silent end time
-              - entity: number.openquatt_cm3_deficit_on_threshold
-                name: CM3 deficit ON threshold
-              - entity: number.openquatt_cm3_deficit_off_threshold
-                name: CM3 deficit OFF threshold
       - type: grid
         cards:
           - type: heading
@@ -2033,7 +1934,7 @@ views:
         cards:
           - type: heading
             icon: mdi:chart-bell-curve
-            heading: Heating curve and PID
+            heading: Heating curve control
             heading_style: title
           - type: markdown
             content: >-
@@ -2049,6 +1950,9 @@ views:
 
               - **Fallback Tsupply** is used when outdoor temperature is
               temporarily unavailable.
+
+              - `Heating Curve Control Profile` selects the built-in control
+              behavior for stability (including smoothing/hysteresis behavior).
 
               - **PID Kp/Ki/Kd** defines correction on system supply
               temperature:
@@ -2075,67 +1979,15 @@ views:
                 name: Curve Tsupply @ 15C
               - entity: number.openquatt_curve_fallback_tsupply_no_outside_temp
                 name: Curve fallback Tsupply
+              - entity: select.openquatt_heating_curve_control_profile
+                name:
+                  type: entity
               - entity: number.openquatt_heating_curve_pid_kp
                 name: Heating Curve PID Kp
               - entity: number.openquatt_heating_curve_pid_ki
                 name: Heating Curve PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: Heating Curve PID Kd
-          - type: custom:apexcharts-card
-            header:
-              show: true
-              title: Heating curve (setpoints)
-              show_states: false
-            update_interval: 10s
-            apex_config:
-              chart:
-                height: 320px
-              xaxis:
-                type: numeric
-                forceNiceScale: true
-                min: -20
-                max: 15
-                title:
-                  text: Outdoor temperature (°C)
-              yaxis:
-                forceNiceScale: true
-                title:
-                  text: Tsupply (°C)
-              tooltip:
-                x:
-                  formatter: |
-                    function (value) {
-                      return `${Number(value)} °C`;
-                    }
-              stroke:
-                curve: straight
-                width: 3
-              markers:
-                size: 5
-            series:
-              - entity: number.openquatt_curve_tsupply_20degc
-                name: Curve setpoints
-                type: line
-                data_generator: |
-                  const getNum = (eid) => {
-                    const s = hass.states[eid];
-                    if (!s) return null;
-                    const v = parseFloat(s.state);
-                    return Number.isFinite(v) ? v : null;
-                  };
-
-                  const pts = [
-                    { x: "-20", y: getNum("number.openquatt_curve_tsupply_20degc") },
-                    { x: "-10", y: getNum("number.openquatt_curve_tsupply_10degc") },
-                    { x: "0",   y: getNum("number.openquatt_curve_tsupply_0degc") },
-                    { x: "5",   y: getNum("number.openquatt_curve_tsupply_5degc") },
-                    { x: "10",  y: getNum("number.openquatt_curve_tsupply_10degc_2") },
-                    { x: "15",  y: getNum("number.openquatt_curve_tsupply_15degc") }
-                  ];
-
-                  return pts.filter((p) => p.y !== null);
-            grid_options:
-              columns: full
       - type: grid
         cards:
           - type: heading
@@ -2189,6 +2041,76 @@ views:
               - entity: number.openquatt_dual_hp_disable_hold
                 name: Dual HP disable hold
       - type: grid
+        cards:
+          - type: heading
+            icon: mdi:tune-variant
+            heading: Flow tuning
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - **Auto start iPWM** is fallback start command; AUTO first uses remembered **last good iPWM** when valid.
+
+              - **CM98 iPWM** is the circulation setting for anti-freeze context.
+
+              - **Flow PI Kp/Ki** defines flow-control dynamics; adjust in small
+              steps.
+
+              - **Sticky pump iPWM** is mainly for service/maintenance and is
+              rarely adjusted.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_flow_auto_start_ipwm
+                name: Auto start iPWM
+              - entity: number.openquatt_frost_circulation_ipwm
+                name: CM98 iPWM
+              - entity: number.openquatt_flow_pi_kp
+                name: Flow PI Kp
+              - entity: number.openquatt_flow_pi_ki
+                name: Flow PI Ki
+              - entity: number.openquatt_sticky_pump_ipwm
+                name: Sticky pump iPWM
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:fire
+            heading: Boiler control
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+              - **CM3 deficit ON/OFF thresholds** define when boiler assist may
+              switch on/off.
+
+              - Keep ON clearly higher than OFF to reduce toggling around the
+              threshold.
+
+              - If behavior is too aggressive: increase ON or decrease OFF.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_cm3_deficit_on_threshold
+                name: CM3 deficit ON threshold
+              - entity: number.openquatt_cm3_deficit_off_threshold
+                name: CM3 deficit OFF threshold
+      - type: grid
+        column_span: 2
         cards:
           - type: heading
             icon: mdi:speedometer-medium
@@ -2267,12 +2189,26 @@ views:
                 name: L9 (H85/C71)
               - entity: switch.openquatt_hp2_allowed_level_10_h_90hz_c_74hz
                 name: L10 (H90/C74)
-        column_span: 2
+    header:
+      card:
+        type: markdown
+        content: >-
+          # <ha-icon icon="mdi:tune-vertical"></ha-icon> Tuning
+
+          Structural control tuning for limits, house model, heating curve, heat
+          allocation, and flow.
+    cards: []
+  - title: Service & Test
+    path: service-test
+    icon: mdi:toolbox-outline
+    type: sections
+    max_columns: 3
+    sections:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:tune-variant
-            heading: Flow tuning
+            icon: mdi:tools
+            heading: Runtime / hours
             heading_style: title
           - type: markdown
             content: >-
@@ -2281,15 +2217,14 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Auto start iPWM** is fallback start command; AUTO first uses remembered **last good iPWM** when valid.
+              - **Reset runtime counters**. Note: it can take up to 1 minute
+              before the effect is visible.
 
-              - **CM98 iPWM** is de circulatiesetting voor anti-freeze context.
+              - **HP1/HP2 Runtime counters** show the current counters used for
+              runtime balancing.
 
-              - **Flow PI Kp/Ki** defines flow-control dynamics; adjust in small
-              steps.
-
-              - **Sticky pump iPWM** is mainly for service/maintenance and is
-              rarely adjusted.
+              - **Runtime lead HP** shows which unit is currently selected as
+              lead based on the lowest runtime.
 
 
               </details>
@@ -2297,16 +2232,14 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: number.openquatt_flow_auto_start_ipwm
-                name: Auto start iPWM
-              - entity: number.openquatt_frost_circulation_ipwm
-                name: CM98 iPWM
-              - entity: number.openquatt_flow_pi_kp
-                name: Flow PI Kp
-              - entity: number.openquatt_flow_pi_ki
-                name: Flow PI Ki
-              - entity: number.openquatt_sticky_pump_ipwm
-                name: Sticky pump iPWM
+              - entity: button.openquatt_reset_runtime_counters_hp1_hp2
+                name: Reset runtime counters
+              - entity: sensor.openquatt_hp1_runtime_hours
+                name: HP1 Runtime
+              - entity: sensor.openquatt_hp2_runtime_hours
+                name: HP2 Runtime
+              - entity: sensor.openquatt_runtime_lead_hp
+                name: Runtime lead HP
       - type: grid
         cards:
           - type: heading
@@ -2352,57 +2285,6 @@ views:
                 name: Autotune Ki suggested
               - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
-    header:
-      card:
-        type: markdown
-        content: >-
-          # <ha-icon icon="mdi:tune-vertical"></ha-icon> Advanced settings
-
-          Advanced tuning for limits, house model, heating curve, heat
-          allocation, and flow.
-    cards: []
-  - title: Debug & Testing
-    path: debug-testing
-    icon: mdi:flask-outline
-    type: sections
-    max_columns: 2
-    sections:
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: Runtime / hours
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - **Reset runtime counters**. Note: it can take up to 1 minute
-              before the effect is visible.
-
-              - **HP1/HP2 Runtime counters** show the current counters used for
-              runtime balancing.
-
-              - **Runtime lead HP** shows which unit is currently selected as
-              lead based on the lowest runtime.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_reset_runtime_counters_hp1_hp2
-                name: Reset runtime counters
-              - entity: sensor.openquatt_hp1_runtime_hours
-                name: HP1 Runtime
-              - entity: sensor.openquatt_hp2_runtime_hours
-                name: HP2 Runtime
-              - entity: sensor.openquatt_runtime_lead_hp
-                name: Runtime lead HP
       - type: grid
         cards:
           - type: heading
@@ -2418,7 +2300,7 @@ views:
 
               - First set the register number.
               - Then press **Debug Read HP1 register** or **Debug Read HP2 register**.
-              - Result is shown as `U16`, `S16`, and raw bytes.
+              - Result is shown as `U16` and `S16`.
 
               </details>
             text_only: true
@@ -2437,222 +2319,13 @@ views:
                 name: Result S16
               - entity: sensor.openquatt_debug_modbus_last_target
                 name: Last target
-              - entity: sensor.openquatt_debug_modbus_last_raw
-                name: Last raw bytes
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:radiator
-            heading: Heating Curve diagnostics
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Explanation</strong></summary>
-
-              Use this block to inspect the heating-curve control loop step by step.
-
-              - This section is most relevant when `Heating mode = Curve`.
-              - First compare `Supply target` and `Supply actual` to see control error.
-              - Then verify the chain:
-                `Demand curve pre-guardrail` -> `Demand curve post-guardrail` -> `Demand raw` -> `Demand filtered`.
-              - In curve mode, `P_req` is derived from demand and is used by deficit/CM3 logic.
-              - `Curve phase` (`HEAT`/`COAST`/`OFF`) and `Curve restart inhibit`
-                explain why demand may not restart immediately after an OFF phase.
-              - `Heating Curve Control Profile` sets the built-in stability bundle
-                (smoothing, hysteresis, and slew-rate behavior).
-              - `Heating debug state` is a compact one-line trace
-                (mode/phase/raw/f/req/app/current levels/temps).
-                If it stays unavailable, enable it in the HA entity registry first.
-
-              Note: if `Supply actual` is above target while demand stays high, check PID tuning (`Kp/Ki/Kd`) and time behavior.
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: select.openquatt_heating_control_mode
-                name: Heating mode
-              - entity: select.openquatt_heating_curve_control_profile
-                name: Curve control profile
-              - entity: climate.openquatt_heating_curve_pid
-                name: Heating Curve PID
-              - entity: button.openquatt_reset_heating_curve_pid_integral
-                name: Reset PID integral
-              - entity: sensor.openquatt_heating_curve_supply_target
-                name: Supply target
-              - entity: sensor.openquatt_water_supply_temp_selected
-                name: Supply actual (selected)
-              - entity: sensor.openquatt_demand_curve_pre_guardrail
-                name: Demand curve pre-guardrail
-              - entity: sensor.openquatt_demand_curve_post_guardrail
-                name: Demand curve post-guardrail
-              - entity: sensor.openquatt_demand_curve_raw
-                name: Demand curve raw
-              - entity: sensor.openquatt_curve_phase
-                name: Curve phase
-              - entity: sensor.openquatt_curve_restart_inhibit
-                name: Curve restart inhibit
-              - entity: sensor.openquatt_demand_raw
-                name: Demand raw
-              - entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-              - entity: sensor.openquatt_power_house_p_req
-                name: P_req
-              - entity: sensor.openquatt_heating_debug_state
-                name: Heating debug state
-              - entity: number.openquatt_heating_curve_pid_kp
-                name: PID Kp
-              - entity: number.openquatt_heating_curve_pid_ki
-                name: PID Ki
-              - entity: number.openquatt_heating_curve_pid_kd
-                name: PID Kd
-          - type: history-graph
-            title: Heating Curve temperature loop (2h)
-            hours_to_show: 2
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_heating_curve_supply_target
-                name: Supply target
-              - entity: sensor.openquatt_water_supply_temp_selected
-                name: Supply actual
-              - entity: sensor.openquatt_outside_temperature_selected
-                name: Outside temp
-            grid_options:
-              columns: full
-          - type: history-graph
-            title: Heating Curve demand chain (2h)
-            hours_to_show: 2
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_demand_curve_raw
-                name: Curve raw
-              - entity: sensor.openquatt_demand_raw
-                name: Demand raw
-              - entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-            grid_options:
-              columns: full
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:home-lightning-bolt
-            heading: Power House diagnostics
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Explanation</strong></summary>
-
-              Use this block to debug the Power House control chain.
-
-              - Relevant when `Heating mode = Power House`.
-              - `P_house` is the model-based demand estimate from outside temperature.
-              - `P_req` is the limited heat request after deadband/ramp limiter.
-              - `Effective room target = room setpoint + comfort bias`.
-              - Quick interpretation of comfort knobs:
-                - `bias base` = minimum warm offset (always active)
-                - `bias max` = maximum offset + cap on warm-side correction edge
-                - `comfort above` = extra warm margin above effective target (until cap)
-              - Warm-side edge:
-                `Tr_high = min(effective_target + comfort_above, setpoint + bias_max)`.
-              - If room stays too warm while `P_req` remains high:
-                lower `comfort above` first, then `bias base`, and if needed `bias max`.
-              - `Comfort bias` and `room error avg` show the adaptive warm-bias governor state.
-              - `Demand raw` and `Demand filtered` are 0..20 step signals towards compressor control.
-              - `Power cap demand` shows active demand after electrical power limiting.
-              - `Low-load dynamic thresholds` shows live `pmin/off/on` thresholds.
-              - `Heat-enable state (shadow)` shows the shadow arbiter state
-                (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) for strategy validation.
-              - `CM2 idle-exit reason` explains why idle-exit is timing, blocked,
-                or tripped in the current cycle.
-              - `CM2 re-entry block active` indicates whether temporary CM2
-                restart blocking is currently active.
-
-              If `P_req` or demand looks unexpectedly high/low: check outside source, room setpoint/temp, and ramp/deadband tuning.
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: select.openquatt_heating_control_mode
-                name: Heating mode
-              - entity: sensor.openquatt_outside_temperature_selected
-                name: Outside temp (selected)
-              - entity: sensor.openquatt_room_setpoint_selected
-                name: Room setpoint (selected)
-              - entity: sensor.openquatt_room_temperature_selected
-                name: Room temp (selected)
-              - entity: sensor.openquatt_power_house_effective_room_target
-                name: Effective room target
-              - entity: sensor.openquatt_power_house_comfort_bias
-                name: Comfort bias
-              - entity: sensor.openquatt_power_house_room_error_avg
-                name: Room error avg
-              - entity: sensor.openquatt_power_house_p_house
-                name: P_house
-              - entity: sensor.openquatt_power_house_p_req
-                name: P_req
-              - entity: sensor.openquatt_low_load_dynamic_thresholds
-                name: Low-load dynamic thresholds
-              - entity: sensor.openquatt_heat_enable_state_shadow
-                name: Heat-enable state (shadow)
-              - entity: sensor.openquatt_cm2_idle_exit_reason
-                name: CM2 idle-exit reason
-              - entity: binary_sensor.openquatt_cm2_re_entry_block_active
-                name: CM2 re-entry block active
-              - entity: number.openquatt_low_load_off_fallback
-                name: Low-load OFF fallback
-              - entity: number.openquatt_low_load_on_fallback
-                name: Low-load ON fallback
-              - entity: number.openquatt_low_load_cm2_re_entry_block
-                name: Low-load CM2 re-entry block
-              - entity: sensor.openquatt_demand_raw
-                name: Demand raw
-              - entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-              - entity: sensor.openquatt_power_cap_demand
-                name: Power cap demand
-          - type: history-graph
-            title: Power House model and inputs (2h)
-            hours_to_show: 2
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_outside_temperature_selected
-                name: Outside temp
-              - entity: sensor.openquatt_room_setpoint_selected
-                name: Room setpoint
-              - entity: sensor.openquatt_room_temperature_selected
-                name: Room temp
-              - entity: sensor.openquatt_power_house_p_house
-                name: P_house
-            grid_options:
-              columns: full
-          - type: history-graph
-            title: Power House output chain (2h)
-            hours_to_show: 2
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_power_house_p_req
-                name: P_req
-              - entity: sensor.openquatt_demand_raw
-                name: Demand raw
-              - entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-              - entity: sensor.openquatt_power_cap_demand
-                name: Power cap demand
-            grid_options:
-              columns: full
     header:
       card:
         type: markdown
         content: >-
-          # <ha-icon icon="mdi:flask-outline"></ha-icon> Debug & Testing
+          # <ha-icon icon="mdi:toolbox-outline"></ha-icon> Service & Test
 
-          Manual diagnostic tools for temporary measurements.
+          Manual service actions and temporary test tooling.
     cards: []
   - title: Diagnostics
     path: diagnostics
@@ -2696,8 +2369,6 @@ views:
                 name: Firmware Update
               - entity: button.openquatt_check_firmware_updates
                 name: Check Firmware Updates
-      - type: grid
-        cards:
           - type: heading
             icon: mdi:chip
             heading: Controller information
@@ -2738,6 +2409,117 @@ views:
                 name: ESPHome Version
               - entity: button.openquatt_restart
                 name: Restart
+      - type: grid
+        column_span: 1
+        cards:
+          - type: heading
+            icon: mdi:home-lightning-bolt
+            heading: Power House diagnostics
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+
+              <summary><strong>Explanation</strong></summary>
+
+
+              Use this block to inspect Power House control behavior.
+
+
+              - Relevant when Power House control is active.
+
+              - `P_house` is the model estimate based on outdoor temperature.
+
+              - `P_req` is the limited heat request after deadband/ramp limiter.
+
+              - `Effective room target = room setpoint + comfort bias`.
+
+              - `Comfort bias` shows the adaptive warm-bias governor state.
+
+              - `Low-load dynamic thresholds` shows live `pmin/off/on`
+              thresholds.
+
+              - `Heat-enable state (shadow)` shows the shadow arbiter state
+              (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) for strategy
+              validation.
+
+              If `P_req` looks unexpectedly high/low: check outside source, room
+              setpoint/temp, and ramp/deadband tuning.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_heat_enable_state_shadow
+                name: Heat-enable state (shadow)
+              - entity: sensor.openquatt_outside_temperature_selected
+                name: Outside temp (selected)
+              - entity: sensor.openquatt_room_setpoint_selected
+                name: Room setpoint (selected)
+              - entity: sensor.openquatt_room_temperature_selected
+                name: Room temp (selected)
+              - entity: sensor.openquatt_power_house_effective_room_target
+                name: Effective room target
+              - entity: sensor.openquatt_power_house_comfort_bias
+                name: Comfort bias
+              - entity: sensor.openquatt_power_house_p_house
+                name: P_house
+              - entity: sensor.openquatt_power_house_p_req
+                name: P_req
+              - entity: sensor.openquatt_low_load_dynamic_thresholds
+                name: Low-load dynamic thresholds
+      - type: grid
+        column_span: 1
+        cards:
+          - type: heading
+            icon: mdi:radiator
+            heading: Heating Curve diagnostics
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Explanation</strong></summary>
+
+
+              Use this block to inspect heating-curve behavior step by step.
+
+
+              - This section is most relevant when heating-curve control is active.
+
+              - First compare `Supply target` and `Supply actual` to see control
+              error.
+
+              - `Curve phase` (`HEAT`/`COAST`/`OFF`) explains the current phase
+              of curve control.
+
+              - Use `Heating Curve PID` and `Reset PID integral` for fine tuning
+              when response is too slow or too nervous.
+
+              - `Outside temp (selected)` helps explain why `Supply target`
+              rises or drops.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: climate.openquatt_heating_curve_pid
+                name: Heating Curve PID
+              - entity: sensor.openquatt_outside_temperature_selected
+                name: Outside temp (selected)
+              - entity: sensor.openquatt_heating_curve_supply_target
+                name: Supply target
+              - entity: sensor.openquatt_water_supply_temp_selected
+                name: Supply actual (selected)
+              - entity: sensor.openquatt_curve_phase
+                name: Curve phase
+              - entity: button.openquatt_reset_heating_curve_pid_integral
+                name: Reset PID integral
     cards: []
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_en.yaml
@@ -387,94 +387,129 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:heat-pump
-            heading: HeatPump
+            icon: mdi:gauge
+            heading: Current
             heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Explanation</strong></summary>
-
-              HeatPump statistics (without boiler):
-              - `Heat output power`: thermal output power of HP1+HP2 (W)
-              - `Electricity daily`: electrical input today (kWh)
-              - `Heat daily`: heat production today (kWh)
-              - `COP daily`: ratio `daily heat kWh / daily electricity kWh`
-              - `Electricity total`: cumulative electrical input (kWh)
-              - `Heat total`: cumulative heat production (kWh)
-
-              </details>
-            text_only: true
+          - type: heading
+            icon: mdi:heat-pump
+            heading: Heat pump
+            heading_style: subtitle
           - type: entities
-            title: Today
             show_header_toggle: false
             entities:
+              - entity: sensor.openquatt_total_power_input
+                name: Electrical input power
               - entity: sensor.openquatt_total_heat_power
                 name: Heat output power
-              - entity: sensor.openquatt_electrical_energy_daily
-                name: Electricity daily
-              - entity: sensor.openquatt_heatpump_thermal_energy_daily
-                name: Heat daily
-              - entity: sensor.openquatt_heatpump_cop_daily
-                name: COP daily
+              - entity: sensor.openquatt_total_cop
+                name: Current COP
+          - type: heading
+            icon: mdi:water-boiler
+            heading: Boiler
+            heading_style: subtitle
           - type: entities
-            title: Total
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_boiler_heat_power
+                name: Heat output power
+          - type: heading
+            icon: mdi:sigma
+            heading: System
+            heading_style: subtitle
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_system_heat_power
+                name: Heat output power
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:calendar-today
+            heading_style: title
+            heading: Today
+          - type: heading
+            icon: mdi:heat-pump
+            heading: Heat pump
+            heading_style: subtitle
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_electrical_energy_daily
+                name: Electricity today
+              - entity: sensor.openquatt_heatpump_thermal_energy_daily
+                name: Heat today
+              - entity: sensor.openquatt_heatpump_cop_daily
+                name: COP today
+          - type: heading
+            icon: mdi:water-boiler
+            heading: Boiler
+            heading_style: subtitle
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_boiler_thermal_energy_daily
+                name: Heat today
+          - type: heading
+            icon: mdi:sigma
+            heading: System
+            heading_style: subtitle
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_system_thermal_energy_daily
+                name: Heat today
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:sigma
+            heading: Total
+            heading_style: title
+          - type: heading
+            icon: mdi:heat-pump
+            heading: Heat pump
+            heading_style: subtitle
+          - type: entities
             show_header_toggle: false
             entities:
               - entity: sensor.openquatt_electrical_energy_total
                 name: Electricity total
               - entity: sensor.openquatt_heatpump_thermal_energy_total
                 name: Heat total
+          - type: heading
+            icon: mdi:water-boiler
+            heading: Boiler
+            heading_style: subtitle
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_boiler_thermal_energy_total
+                name: Heat total
+          - type: heading
+            icon: mdi:sigma
+            heading: System
+            heading_style: subtitle
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_system_thermal_energy_total
+                name: Heat total
+      - type: grid
+        cards:
+          - type: heading
+            heading: Trends (24h)
+            heading_style: title
+            icon: mdi:trending-up
           - type: history-graph
-            title: HeatPump trends (24h)
+            title: Heat pump trends (24h)
             hours_to_show: 24
             refresh_interval: 60
             entities:
               - entity: sensor.openquatt_total_heat_power
                 name: Heat output power
               - entity: sensor.openquatt_heatpump_cop_daily
-                name: COP daily
+                name: COP today
               - entity: sensor.openquatt_heatpump_thermal_energy_daily
-                name: Heat daily
-            grid_options:
-              columns: full
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:water-boiler
-            heading: Boiler
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Explanation</strong></summary>
-
-              Boiler statistics:
-              - `Heat output power`: current thermal boiler contribution (W)
-              - `Heat daily`: boiler heat today (kWh)
-              - `Boiler active`: shows whether relay control is active
-              - `Heat total`: cumulative boiler heat (kWh)
-
-              </details>
-            text_only: true
-          - type: entities
-            title: Today
-            show_header_toggle: false
-            entities:
-              - entity: sensor.openquatt_boiler_heat_power
-                name: Heat output power
-              - entity: sensor.openquatt_boiler_thermal_energy_daily
-                name: Heat daily
-              - entity: binary_sensor.openquatt_boiler_active
-                name: Boiler active
-          - type: entities
-            title: Total
-            show_header_toggle: false
-            entities:
-              - entity: sensor.openquatt_boiler_thermal_energy_total
-                name: Heat total
+                name: Heat today
           - type: history-graph
             title: Boiler trends (24h)
             hours_to_show: 24
@@ -483,58 +518,19 @@ views:
               - entity: sensor.openquatt_boiler_heat_power
                 name: Heat output power
               - entity: sensor.openquatt_boiler_thermal_energy_daily
-                name: Heat daily
-            grid_options:
-              columns: full
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:sigma
-            heading: System
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Explanation</strong></summary>
-
-              System values (HeatPump + Boiler):
-              - `Electricity input power`: total electrical input power (W)
-              - `Heat output power`: total thermal output (W)
-              - `Heat daily`: system heat today (kWh)
-              - `Heat total`: cumulative system heat (kWh)
-
-              </details>
-            text_only: true
-          - type: entities
-            title: Today
-            show_header_toggle: false
-            entities:
-              - entity: sensor.openquatt_total_power_input
-                name: Electricity input power
-              - entity: sensor.openquatt_system_heat_power
-                name: Heat output power
-              - entity: sensor.openquatt_system_thermal_energy_daily
-                name: Heat daily
-          - type: entities
-            title: Total
-            show_header_toggle: false
-            entities:
-              - entity: sensor.openquatt_system_thermal_energy_total
-                name: Heat total
+                name: Heat today
           - type: history-graph
             title: System trends (24h)
             hours_to_show: 24
             refresh_interval: 60
             entities:
               - entity: sensor.openquatt_total_power_input
-                name: Electricity input power
+                name: Electrical input power
               - entity: sensor.openquatt_system_heat_power
                 name: Heat output power
               - entity: sensor.openquatt_system_thermal_energy_daily
-                name: Heat daily
-            grid_options:
-              columns: full
+                name: Heat today
+        column_span: 3
       - type: grid
         column_span: 3
         cards:
@@ -550,7 +546,7 @@ views:
 
               Daily aggregation for energy:
               - Electricity and heat as daily kWh (derived from total sensors)
-              - `COP daily` as daily average
+              - `COP today` as daily average
 
               </details>
             text_only: true
@@ -561,6 +557,22 @@ views:
               show_states: false
             graph_span: 7d
             update_interval: 120s
+            yaxis:
+              - id: energy
+                min: 0
+                decimals: 1
+                apex_config:
+                  title:
+                    text: kWh/day
+              - id: cop
+                opposite: true
+                min: 0
+                max: 8
+                decimals: 2
+                apex_config:
+                  tickAmount: 4
+                  title:
+                    text: COP today
             apex_config:
               chart:
                 height: 320
@@ -568,18 +580,6 @@ views:
                 show: true
                 position: top
                 clusterGroupedSeries: false
-              yaxis:
-                - id: energy
-                  min: 0
-                  decimalsInFloat: 1
-                  title:
-                    text: kWh/day
-                - id: cop
-                  opposite: true
-                  min: 0
-                  decimalsInFloat: 2
-                  title:
-                    text: COP daily
               stroke:
                 width: 2
                 curve: smooth
@@ -595,7 +595,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_heatpump_thermal_energy_total
-                name: HeatPump heat/day
+                name: Heat pump heat/day
                 color: '#F59E0B'
                 yaxis_id: energy
                 type: column
@@ -619,7 +619,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_heatpump_cop_daily
-                name: COP daily
+                name: COP today
                 color: '#A855F7'
                 yaxis_id: cop
                 type: line
@@ -635,6 +635,22 @@ views:
               show_states: false
             graph_span: 30d
             update_interval: 300s
+            yaxis:
+              - id: energy
+                min: 0
+                decimals: 1
+                apex_config:
+                  title:
+                    text: kWh/day
+              - id: cop
+                opposite: true
+                min: 0
+                max: 8
+                decimals: 2
+                apex_config:
+                  tickAmount: 4
+                  title:
+                    text: COP today
             apex_config:
               chart:
                 height: 320
@@ -642,18 +658,6 @@ views:
                 show: true
                 position: top
                 clusterGroupedSeries: false
-              yaxis:
-                - id: energy
-                  min: 0
-                  decimalsInFloat: 1
-                  title:
-                    text: kWh/day
-                - id: cop
-                  opposite: true
-                  min: 0
-                  decimalsInFloat: 2
-                  title:
-                    text: COP daily
               stroke:
                 width: 2
                 curve: smooth
@@ -669,7 +673,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_heatpump_thermal_energy_total
-                name: HeatPump heat/day
+                name: Heat pump heat/day
                 color: '#F59E0B'
                 yaxis_id: energy
                 type: column
@@ -693,7 +697,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_heatpump_cop_daily
-                name: COP daily
+                name: COP today
                 color: '#A855F7'
                 yaxis_id: cop
                 type: line
@@ -709,7 +713,7 @@ views:
         content: >-
           # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energy
 
-          Energy overview of HeatPump, Boiler, and total System (daily + cumulative).
+          Energy overview of heat pump, boiler, and total system (daily + cumulative).
   - title: Flow
     path: flow
     icon: mdi:waves

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -479,28 +479,30 @@ views:
         cards:
           - type: heading
             icon: mdi:sigma
-            heading: Totaal
+            heading: Cumulatief
             heading_style: title
           - *ref_0
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_electrical_energy_total
-                name: Elektriciteit totaal
-              - entity: sensor.openquatt_heatpump_thermal_energy_total
-                name: Warmte totaal
+              - entity: sensor.openquatt_electrical_energy_cumulative
+                name: Elektriciteit cumulatief
+              - entity: sensor.openquatt_heatpump_thermal_energy_cumulative
+                name: Warmte cumulatief
+              - entity: sensor.openquatt_heatpump_cop_cumulative
+                name: COP cumulatief
           - *ref_1
           - type: entities
             show_header_toggle: false
             entities:
               - entity: sensor.openquatt_boiler_thermal_energy_total
-                name: Warmte totaal
+                name: Warmte cumulatief
           - *ref_2
           - type: entities
             show_header_toggle: false
             entities:
               - entity: sensor.openquatt_system_thermal_energy_total
-                name: Warmte totaal
+                name: Warmte cumulatief
       - type: grid
         cards:
           - type: heading
@@ -557,7 +559,7 @@ views:
               Dagaggregatie voor energie:
 
               - Elektriciteit en warmte als dagelijkse kWh (afgeleid uit
-              totaalsensoren)
+              cumulatieve sensoren)
 
               - `COP vandaag` als daggemiddelde
 
@@ -600,7 +602,7 @@ views:
               tooltip:
                 shared: true
             series:
-              - entity: sensor.openquatt_electrical_energy_total
+              - entity: sensor.openquatt_electrical_energy_cumulative
                 name: Elektriciteit/dag
                 color: '#3B82F6'
                 yaxis_id: energy
@@ -608,7 +610,7 @@ views:
                 group_by:
                   func: delta
                   duration: 1d
-              - entity: sensor.openquatt_heatpump_thermal_energy_total
+              - entity: sensor.openquatt_heatpump_thermal_energy_cumulative
                 name: Warmtepomp warmte/dag
                 color: '#F59E0B'
                 yaxis_id: energy
@@ -678,7 +680,7 @@ views:
               tooltip:
                 shared: true
             series:
-              - entity: sensor.openquatt_electrical_energy_total
+              - entity: sensor.openquatt_electrical_energy_cumulative
                 name: Elektriciteit/dag
                 color: '#3B82F6'
                 yaxis_id: energy
@@ -686,7 +688,7 @@ views:
                 group_by:
                   func: delta
                   duration: 1d
-              - entity: sensor.openquatt_heatpump_thermal_energy_total
+              - entity: sensor.openquatt_heatpump_thermal_energy_cumulative
                 name: Warmtepomp warmte/dag
                 color: '#F59E0B'
                 yaxis_id: energy

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -392,7 +392,7 @@ views:
         state_content:
           - name
           - state
-  - title: Energy
+  - title: Energie
     path: energy
     icon: mdi:lightning-bolt-circle
     type: sections
@@ -401,160 +401,150 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:heat-pump
-            heading: HeatPump
+            icon: mdi:gauge
+            heading: Huidig
             heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg</strong></summary>
-
-              HeatPump-statistieken (zonder boiler):
-              - `Heat output power`: thermisch vermogen van HP1+HP2 (W)
-              - `Electricity daily`: elektrische input vandaag (kWh)
-              - `Heat daily`: warmteproductie vandaag (kWh)
-              - `COP daily`: verhouding `daily heat kWh / daily electricity kWh`
-              - `Electricity total`: cumulatieve elektrische input (kWh)
-              - `Heat total`: cumulatieve warmteproductie (kWh)
-
-              </details>
-            text_only: true
+          - type: heading
+            icon: mdi:heat-pump
+            heading: Warmtepomp
+            heading_style: subtitle
           - type: entities
-            title: Vandaag
             show_header_toggle: false
             entities:
+              - entity: sensor.openquatt_total_power_input
+                name: Elektrisch ingangsvermogen
               - entity: sensor.openquatt_total_heat_power
-                name: Heat output power
-              - entity: sensor.openquatt_electrical_energy_daily
-                name: Electricity daily
-              - entity: sensor.openquatt_heatpump_thermal_energy_daily
-                name: Heat daily
-              - entity: sensor.openquatt_heatpump_cop_daily
-                name: COP daily
+                name: Warmteafgifte
+              - entity: sensor.openquatt_total_cop
+                name: Huidige COP
+          - type: heading
+            icon: mdi:water-boiler
+            heading: CV-ketel
+            heading_style: subtitle
           - type: entities
-            title: Totaal
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_electrical_energy_total
-                name: Electricity total
-              - entity: sensor.openquatt_heatpump_thermal_energy_total
-                name: Heat total
-          - type: history-graph
-            title: HeatPump trends (24 uur)
-            hours_to_show: 24
-            refresh_interval: 60
+              - entity: sensor.openquatt_boiler_heat_power
+                name: Warmteafgifte
+          - type: heading
+            icon: mdi:sigma
+            heading: Systeem
+            heading_style: subtitle
+          - type: entities
+            show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_total_heat_power
-                name: Heat output power
-              - entity: sensor.openquatt_heatpump_cop_daily
-                name: COP daily
-              - entity: sensor.openquatt_heatpump_thermal_energy_daily
-                name: Heat daily
-            grid_options:
-              columns: full
+              - entity: sensor.openquatt_system_heat_power
+                name: Warmteafgifte
       - type: grid
         cards:
           - type: heading
-            icon: mdi:water-boiler
-            heading: Boiler
+            icon: mdi:calendar-today
             heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg</strong></summary>
-
-              Boiler-statistieken:
-              - `Heat output power`: actuele thermische boilerbijdrage (W)
-              - `Heat daily`: boilerwarmte vandaag (kWh)
-              - `Boiler active`: toont of de relais-aansturing actief is
-              - `Heat total`: cumulatieve boilerwarmte (kWh)
-
-              </details>
-            text_only: true
+            heading: Vandaag
+          - &ref_0
+            type: heading
+            icon: mdi:heat-pump
+            heading: Warmtepomp
+            heading_style: subtitle
           - type: entities
-            title: Vandaag
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_boiler_heat_power
-                name: Heat output power
-              - entity: sensor.openquatt_boiler_thermal_energy_daily
-                name: Heat daily
-              - entity: binary_sensor.openquatt_boiler_active
-                name: Boiler active
+              - entity: sensor.openquatt_electrical_energy_daily
+                name: Elektriciteit vandaag
+              - entity: sensor.openquatt_heatpump_thermal_energy_daily
+                name: Warmte vandaag
+              - entity: sensor.openquatt_heatpump_cop_daily
+                name: COP vandaag
+          - &ref_1
+            type: heading
+            icon: mdi:water-boiler
+            heading: CV-ketel
+            heading_style: subtitle
           - type: entities
-            title: Totaal
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_boiler_thermal_energy_total
-                name: Heat total
-          - type: history-graph
-            title: Boiler trends (24 uur)
-            hours_to_show: 24
-            refresh_interval: 60
-            entities:
-              - entity: sensor.openquatt_boiler_heat_power
-                name: Heat output power
               - entity: sensor.openquatt_boiler_thermal_energy_daily
-                name: Heat daily
-            grid_options:
-              columns: full
+                name: Warmte vandaag
+          - &ref_2
+            type: heading
+            icon: mdi:sigma
+            heading: Systeem
+            heading_style: subtitle
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_system_thermal_energy_daily
+                name: Warmte vandaag
       - type: grid
         cards:
           - type: heading
             icon: mdi:sigma
-            heading: System
+            heading: Totaal
             heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg</strong></summary>
-
-              Systeemwaarden (HeatPump + Boiler):
-              - `Electricity input power`: totaal elektrisch ingangsvermogen (W)
-              - `Heat output power`: totale thermische output (W)
-              - `Heat daily`: systeemwarmte vandaag (kWh)
-              - `Heat total`: cumulatieve systeemwarmte (kWh)
-
-              </details>
-            text_only: true
+          - *ref_0
           - type: entities
-            title: Vandaag
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_total_power_input
-                name: Electricity input power
-              - entity: sensor.openquatt_system_heat_power
-                name: Heat output power
-              - entity: sensor.openquatt_system_thermal_energy_daily
-                name: Heat daily
+              - entity: sensor.openquatt_electrical_energy_total
+                name: Elektriciteit totaal
+              - entity: sensor.openquatt_heatpump_thermal_energy_total
+                name: Warmte totaal
+          - *ref_1
           - type: entities
-            title: Totaal
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_boiler_thermal_energy_total
+                name: Warmte totaal
+          - *ref_2
+          - type: entities
             show_header_toggle: false
             entities:
               - entity: sensor.openquatt_system_thermal_energy_total
-                name: Heat total
+                name: Warmte totaal
+      - type: grid
+        cards:
+          - type: heading
+            heading: Trends (24 uur)
+            heading_style: title
+            icon: mdi:trending-up
           - type: history-graph
-            title: System trends (24 uur)
+            title: Warmtepomptrends (24 uur)
+            hours_to_show: 24
+            refresh_interval: 60
+            entities:
+              - entity: sensor.openquatt_total_heat_power
+                name: Warmteafgifte
+              - entity: sensor.openquatt_heatpump_cop_daily
+                name: COP vandaag
+              - entity: sensor.openquatt_heatpump_thermal_energy_daily
+                name: Warmte vandaag
+          - type: history-graph
+            title: Keteltrends (24 uur)
+            hours_to_show: 24
+            refresh_interval: 60
+            entities:
+              - entity: sensor.openquatt_boiler_heat_power
+                name: Warmteafgifte
+              - entity: sensor.openquatt_boiler_thermal_energy_daily
+                name: Warmte vandaag
+          - type: history-graph
+            title: Systeemtrends (24 uur)
             hours_to_show: 24
             refresh_interval: 60
             entities:
               - entity: sensor.openquatt_total_power_input
-                name: Electricity input power
+                name: Elektrisch ingangsvermogen
               - entity: sensor.openquatt_system_heat_power
-                name: Heat output power
+                name: Warmteafgifte
               - entity: sensor.openquatt_system_thermal_energy_daily
-                name: Heat daily
-            grid_options:
-              columns: full
+                name: Warmte vandaag
+        column_span: 3
       - type: grid
         column_span: 3
         cards:
           - type: heading
             icon: mdi:chart-bar
-            heading: Energy trends (7d/30d)
+            heading: Energietrends (7d/30d)
             heading_style: title
           - type: markdown
             content: >-
@@ -567,9 +557,9 @@ views:
               Dagaggregatie voor energie:
 
               - Elektriciteit en warmte als dagelijkse kWh (afgeleid uit
-              total-sensoren)
+              totaalsensoren)
 
-              - `COP daily` als daggemiddelde
+              - `COP vandaag` als daggemiddelde
 
 
               </details>
@@ -577,10 +567,26 @@ views:
           - type: custom:apexcharts-card
             header:
               show: true
-              title: Energy trends (7 dagen)
+              title: Energietrends (7 dagen)
               show_states: false
             graph_span: 7d
             update_interval: 120s
+            yaxis:
+              - id: energy
+                min: 0
+                decimals: 1
+                apex_config:
+                  title:
+                    text: kWh/dag
+              - id: cop
+                opposite: true
+                min: 0
+                max: 8
+                decimals: 2
+                apex_config:
+                  tickAmount: 4
+                  title:
+                    text: COP vandaag
             apex_config:
               chart:
                 height: 320
@@ -588,18 +594,6 @@ views:
                 show: true
                 position: top
                 clusterGroupedSeries: false
-              yaxis:
-                - id: energy
-                  min: 0
-                  decimalsInFloat: 1
-                  title:
-                    text: kWh/day
-                - id: cop
-                  opposite: true
-                  min: 0
-                  decimalsInFloat: 2
-                  title:
-                    text: COP daily
               stroke:
                 width: 2
                 curve: smooth
@@ -607,7 +601,7 @@ views:
                 shared: true
             series:
               - entity: sensor.openquatt_electrical_energy_total
-                name: Electricity/day
+                name: Elektriciteit/dag
                 color: '#3B82F6'
                 yaxis_id: energy
                 type: column
@@ -615,7 +609,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_heatpump_thermal_energy_total
-                name: HeatPump heat/day
+                name: Warmtepomp warmte/dag
                 color: '#F59E0B'
                 yaxis_id: energy
                 type: column
@@ -623,7 +617,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_boiler_thermal_energy_total
-                name: Boiler heat/day
+                name: Ketelwarmte/dag
                 color: '#EF4444'
                 yaxis_id: energy
                 type: column
@@ -631,7 +625,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_system_thermal_energy_total
-                name: System heat/day
+                name: Systeemwarmte/dag
                 color: '#10B981'
                 yaxis_id: energy
                 type: line
@@ -639,7 +633,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_heatpump_cop_daily
-                name: COP daily
+                name: COP vandaag
                 color: '#A855F7'
                 yaxis_id: cop
                 type: line
@@ -651,10 +645,26 @@ views:
           - type: custom:apexcharts-card
             header:
               show: true
-              title: Energy trends (30 dagen)
+              title: Energietrends (30 dagen)
               show_states: false
             graph_span: 30d
             update_interval: 300s
+            yaxis:
+              - id: energy
+                min: 0
+                decimals: 1
+                apex_config:
+                  title:
+                    text: kWh/dag
+              - id: cop
+                opposite: true
+                min: 0
+                max: 8
+                decimals: 2
+                apex_config:
+                  tickAmount: 4
+                  title:
+                    text: COP vandaag
             apex_config:
               chart:
                 height: 320
@@ -662,18 +672,6 @@ views:
                 show: true
                 position: top
                 clusterGroupedSeries: false
-              yaxis:
-                - id: energy
-                  min: 0
-                  decimalsInFloat: 1
-                  title:
-                    text: kWh/day
-                - id: cop
-                  opposite: true
-                  min: 0
-                  decimalsInFloat: 2
-                  title:
-                    text: COP daily
               stroke:
                 width: 2
                 curve: smooth
@@ -681,7 +679,7 @@ views:
                 shared: true
             series:
               - entity: sensor.openquatt_electrical_energy_total
-                name: Electricity/day
+                name: Elektriciteit/dag
                 color: '#3B82F6'
                 yaxis_id: energy
                 type: column
@@ -689,7 +687,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_heatpump_thermal_energy_total
-                name: HeatPump heat/day
+                name: Warmtepomp warmte/dag
                 color: '#F59E0B'
                 yaxis_id: energy
                 type: column
@@ -697,7 +695,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_boiler_thermal_energy_total
-                name: Boiler heat/day
+                name: Ketelwarmte/dag
                 color: '#EF4444'
                 yaxis_id: energy
                 type: column
@@ -705,7 +703,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_system_thermal_energy_total
-                name: System heat/day
+                name: Systeemwarmte/dag
                 color: '#10B981'
                 yaxis_id: energy
                 type: line
@@ -713,7 +711,7 @@ views:
                   func: delta
                   duration: 1d
               - entity: sensor.openquatt_heatpump_cop_daily
-                name: COP daily
+                name: COP vandaag
                 color: '#A855F7'
                 yaxis_id: cop
                 type: line
@@ -727,9 +725,9 @@ views:
       card:
         type: markdown
         content: >-
-          # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energy
+          # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energie
 
-          Energie-overzicht van HeatPump, Boiler en totaal System (dag +
+          Energie-overzicht van Warmtepomp, boiler en totaal systeem (dag +
           cumulatief).
   - title: Flow
     path: flow
@@ -931,9 +929,8 @@ views:
               - `Regelmodus`: kiest welke strategie de warmtevraag opbouwt
               (bijv. Stooklijn of Power House).
 
-              - Bij stooklijnregeling verschijnt ook
-              `Heating Curve Control Profile` voor de ingebouwde
-              regelkarakteristiek.
+              - Bij stooklijnregeling verschijnt ook `Heating Curve Control
+              Profile` voor de ingebouwde regelkarakteristiek.
 
               - Controleer daarna bij `Kern KPI` hoe dit doorwerkt in `P_req`,
               `P_house` en `Tekort`.
@@ -983,8 +980,7 @@ views:
 
               - `P_house`: gemodelleerde warmtevraag van de woning.
 
-              - `Max HP capaciteit`: geschatte beschikbare
-              warmtepompcapaciteit.
+              - `Max HP capaciteit`: geschatte beschikbare warmtepompcapaciteit.
 
               - `Tekort`: positieve waarde betekent dat vraag boven
               beschikbare/geleverde warmte ligt.
@@ -2045,8 +2041,8 @@ views:
               - **Fallback Tsupply** wordt gebruikt als buitentemperatuur
               tijdelijk ontbreekt.
 
-              - `Heating Curve Control Profile` kiest het ingebouwde
-              regelgedrag voor stabiliteit (o.a. smoothing/hysterese).
+              - `Heating Curve Control Profile` kiest het ingebouwde regelgedrag
+              voor stabiliteit (o.a. smoothing/hysterese).
 
               - **PID Kp/Ki/Kd** bepaalt de correctie op de
               systeem-aanvoertemperatuur:
@@ -2547,8 +2543,7 @@ views:
               drempels.
 
               - `Heat-enable state (shadow)` toont de shadow-arbiterstatus
-              (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor
-              strategievalidatie.
+              (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor strategievalidatie.
 
               Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
               setpoint/temp en de ramp/deadband instellingen.
@@ -2606,8 +2601,8 @@ views:
               - Gebruik `Heating Curve PID` en `Reset PID integral` bij
               finetuning als de regeling te traag of te nerveus reageert.
 
-              - `Outside temp (selected)` helpt verklaren waarom het
-              `Supply target` stijgt of daalt.
+              - `Outside temp (selected)` helpt verklaren waarom het `Supply
+              target` stijgt of daalt.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -917,50 +917,6 @@ views:
             icon: mdi:radiator
             heading: Warmtecontrol status
             heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-
-              <summary><strong>Uitleg</strong></summary>
-
-
-              Warmtecontrol in 30 seconden:
-
-
-              - Kies met `Heating mode` welke bron de warmtevraag bepaalt.
-
-              - Vergelijk `P_req` (gevraagd vermogen) met `P_house`
-              (modelschatting).
-
-              - Check `Deficit`: boven `0 W` vraagt het systeem meer dan nu
-              geleverd wordt.
-
-              - Bekijk `Ruwe vraag` (`Demand raw`) en `Gefilterde vraag`
-              (`Demand filtered`) om te zien hoe sterk filtering dempt.
-
-              - `Vermogenscap vraag` (`Power cap demand`, 0..20 step) is de
-              supervisory vraaglimiet vóór verdeling over HP1/HP2.
-
-
-              Termen:
-
-
-              - `P_house`: berekende warmtevraag op basis van huismodel en
-              buitentemperatuur.
-
-              - `P_req`: begrensde actuele warmtevraag in W na ramp-limiter.
-
-              - `Demand raw`: ruwe vraagstap voor compressorsturing.
-
-              - `Demand filtered`: gedempte vraagstap voor stabielere regeling.
-
-              - `Power cap demand`: actieve supervisory limiet op
-              demand-stappen.
-
-
-              </details>
-            text_only: true
           - type: heading
             icon: mdi:tune-variant
             heading: Regelinstellingen
@@ -975,11 +931,32 @@ views:
               - `Regelmodus`: kiest welke strategie de warmtevraag opbouwt
               (bijv. Stooklijn of Power House).
 
+              - Bij stooklijnregeling verschijnt ook
+              `Heating Curve Control Profile` voor de ingebouwde
+              regelkarakteristiek.
+
+              - Controleer daarna bij `Kern KPI` hoe dit doorwerkt in `P_req`,
+              `P_house` en `Tekort`.
+
               </details>
             text_only: true
           - type: tile
             entity: select.openquatt_heating_control_mode
             name: Regelmodus
+            hide_state: true
+            vertical: false
+            features:
+              - type: select-options
+            features_position: inline
+          - type: tile
+            visibility:
+              - condition: state
+                entity: select.openquatt_heating_control_mode
+                state: Water Temperature Control (heating curve)
+            entity: select.openquatt_heating_curve_control_profile
+            name:
+              type: entity
+            show_entity_picture: false
             hide_state: true
             vertical: false
             features:
@@ -999,120 +976,52 @@ views:
               Kernindicatoren voor warmtebalans:
 
 
+              - Vergelijk `P_req` (gevraagd vermogen) met `P_house`
+              (modelschatting).
+
               - `P_req`: gevraagde verwarmingspower na filtering/ramp-limiet.
 
               - `P_house`: gemodelleerde warmtevraag van de woning.
 
-              - `Max capaciteit`: geschatte beschikbare warmtepompcapaciteit.
+              - `Max HP capaciteit`: geschatte beschikbare
+              warmtepompcapaciteit.
 
-              - `Deficit`: positieve waarde betekent dat vraag boven
+              - `Tekort`: positieve waarde betekent dat vraag boven
               beschikbare/geleverde warmte ligt.
 
-              </details>
-            text_only: true
-          - type: grid
-            square: false
-            columns: 2
-            cards:
-              - type: tile
-                entity: sensor.openquatt_power_house_p_req
-                name: P_req
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_power_house_p_house
-                name: P_house
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_hp_capacity_w
-                name: Max capaciteit
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_hp_deficit_w
-                name: Deficit
-                vertical: false
-                features_position: bottom
-          - type: heading
-            icon: mdi:chart-line
-            heading: Vraag & limiet
-            heading_style: subtitle
-          - type: markdown
-            content: >-
-              <details>
+              - Richtlijn: bij `Tekort > 0 W` vraagt het systeem meer dan nu
+              geleverd wordt.
 
-              <summary><strong>Uitleg</strong></summary>
-
-
-              Vraagvorming en begrenzing:
-
-
-              - `Ruwe vraag`: directe vraagstap zonder filtering.
-
-              - `Gefilterde vraag`: gedempte vraagstap voor stabieler gedrag.
-
-              - `Vermogenscap vraag`: supervisory limiet op de vraag (0..20 step
-              schaal).
+              - Gebruik `Trends` voor het gedrag over tijd.
 
               </details>
             text_only: true
-          - type: grid
-            square: false
-            columns: 3
-            cards:
-              - type: tile
-                entity: sensor.openquatt_demand_raw
-                name: Ruwe vraag
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_demand_filtered
-                name: Gefilterde vraag
-                vertical: false
-                features_position: bottom
-              - type: tile
-                entity: sensor.openquatt_power_cap_demand
-                name: Vermogenscap vraag
-                vertical: false
-                features_position: bottom
-          - type: heading
-            icon: mdi:gauge
-            heading: Capaciteit
-            heading_style: subtitle
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Uitleg</strong></summary>
-
-
-              Visuele capaciteitscheck:
-
-
-              - Linker meter `Max capaciteit`: huidige geschatte maximale
-              warmteafgifte.
-
-              - Rechter meter `Deficit`: hoeveel warmte momenteel ontbreekt
-              t.o.v. de vraag.
-
-
-              Blijvend hoge deficit betekent dat het systeem de warmtevraag nu
-              niet kan bijhouden.
-
-              </details>
-            text_only: true
-          - type: horizontal-stack
+          - square: false
+            type: grid
             cards:
               - type: gauge
+                entity: sensor.openquatt_power_house_p_house
+                min: 0
+                max: 12000
+                needle: true
+                name:
+                  type: entity
+              - type: gauge
+                entity: sensor.openquatt_power_house_p_req
+                min: 0
+                max: 12000
+                needle: true
+                name:
+                  type: entity
+              - type: gauge
                 entity: sensor.openquatt_hp_capacity_w
-                name: Max capaciteit
+                name: Max HP capaciteit
                 min: 0
                 max: 12000
                 needle: true
               - type: gauge
                 entity: sensor.openquatt_hp_deficit_w
-                name: Deficit
+                name: Tekort
                 min: 0
                 max: 8000
                 needle: true
@@ -1120,6 +1029,7 @@ views:
                   green: 0
                   yellow: 800
                   red: 2000
+            columns: 2
       - type: grid
         cards:
           - type: heading
@@ -1139,9 +1049,6 @@ views:
 
               - `HP powerinput` en `HP heat output` tonen elektrisch in versus
               thermisch uit.
-
-              - `Compressorlevels en frequentie` laat setpoint versus werkelijke
-              compressor-Hz zien.
 
               - `Temperatuurregeling` toont buiten-, supply- en kamertemperatuur
               tegen targets.
@@ -1182,21 +1089,6 @@ views:
                 name: HP1 heating power
               - entity: sensor.openquatt_hp2_heat_power
                 name: HP2 heating power
-            grid_options:
-              columns: full
-          - type: history-graph
-            title: Compressorlevels en frequentie (24 uur)
-            hours_to_show: 24
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_hp1_compressor_level
-                name: HP1 level
-              - entity: sensor.openquatt_hp2_compressor_level
-                name: HP2 level
-              - entity: sensor.openquatt_hp1_compressor_frequency
-                name: HP1 Hz
-              - entity: sensor.openquatt_hp2_compressor_frequency
-                name: HP2 Hz
             grid_options:
               columns: full
           - type: history-graph
@@ -2005,8 +1897,8 @@ views:
           de geselecteerde waarde en bronstatus.
     top_margin: false
     dense_section_placement: false
-  - title: Advanced settings
-    path: advanced-settings
+  - title: Tuning
+    path: tuning
     icon: mdi:tune-vertical
     type: sections
     max_columns: 3
@@ -2014,8 +1906,8 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:window-maximize
-            heading: Systeemlimieten en vensters
+            icon: mdi:volume-off
+            heading: Silent mode settings
             heading_style: title
           - type: markdown
             content: >-
@@ -2029,14 +1921,6 @@ views:
 
               - **Silent start/end time** definieert het tijdvenster waarin de
               silent-begrenzing actief is.
-
-              - **CM3 deficit ON/OFF thresholds** bepalen wanneer boiler-assist
-              mag inschakelen/uitschakelen.
-
-              - Houd ON duidelijk hoger dan OFF om schakelen rond de grens te
-              beperken.
-
-              - Bij te agressief gedrag: ON verhogen of OFF verlagen.
 
 
               </details>
@@ -2052,10 +1936,6 @@ views:
                 name: Silent start time
               - entity: time.openquatt_silent_end_time
                 name: Silent end time
-              - entity: number.openquatt_cm3_deficit_on_threshold
-                name: CM3 deficit ON threshold
-              - entity: number.openquatt_cm3_deficit_off_threshold
-                name: CM3 deficit OFF threshold
       - type: grid
         cards:
           - type: heading
@@ -2087,18 +1967,17 @@ views:
               `setpoint + 0.1`.
 
               - **Comfort bias max** is de maximale verschuiving omhoog en ook
-              de bovencap voor de warme correctierand:
-              `setpoint + bias max`.
+              de bovencap voor de warme correctierand: `setpoint + bias max`.
 
-              - **Comfort above setpoint** is extra marge boven
-              `effective target` voordat warme tegensturing begint, maar alleen
-              tot de bovencap hierboven.
+              - **Comfort above setpoint** is extra marge boven `effective
+              target` voordat warme tegensturing begint, maar alleen tot de
+              bovencap hierboven.
 
-              - **Comfort below setpoint** bepaalt de marge onder
-              `effective target` voordat extra opwarming begint.
+              - **Comfort below setpoint** bepaalt de marge onder `effective
+              target` voordat extra opwarming begint.
 
-              - Warme randformule:
-              `Tr_high = min(effective_target + comfort_above, setpoint + bias_max)`.
+              - Warme randformule: `Tr_high = min(effective_target +
+              comfort_above, setpoint + bias_max)`.
 
               - Voorbeeld: setpoint `20.0`, base `0.1`, max `0.4`, above `0.5`
               geeft een maximale warme rand van `20.4`. Vind je het te warm:
@@ -2148,7 +2027,7 @@ views:
         cards:
           - type: heading
             icon: mdi:chart-bell-curve
-            heading: Stooklijn en PID
+            heading: Stooklijnregeling
             heading_style: title
           - type: markdown
             content: >-
@@ -2165,6 +2044,9 @@ views:
 
               - **Fallback Tsupply** wordt gebruikt als buitentemperatuur
               tijdelijk ontbreekt.
+
+              - `Heating Curve Control Profile` kiest het ingebouwde
+              regelgedrag voor stabiliteit (o.a. smoothing/hysterese).
 
               - **PID Kp/Ki/Kd** bepaalt de correctie op de
               systeem-aanvoertemperatuur:
@@ -2191,67 +2073,15 @@ views:
                 name: Curve Tsupply @ 15C
               - entity: number.openquatt_curve_fallback_tsupply_no_outside_temp
                 name: Curve fallback Tsupply
+              - entity: select.openquatt_heating_curve_control_profile
+                name:
+                  type: entity
               - entity: number.openquatt_heating_curve_pid_kp
                 name: Heating Curve PID Kp
               - entity: number.openquatt_heating_curve_pid_ki
                 name: Heating Curve PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: Heating Curve PID Kd
-          - type: custom:apexcharts-card
-            header:
-              show: true
-              title: Stooklijn (instelpunten)
-              show_states: false
-            update_interval: 10s
-            apex_config:
-              chart:
-                height: 320px
-              xaxis:
-                type: numeric
-                forceNiceScale: true
-                min: -20
-                max: 15
-                title:
-                  text: Buiten temperatuur (°C)
-              yaxis:
-                forceNiceScale: true
-                title:
-                  text: Tsupply (°C)
-              tooltip:
-                x:
-                  formatter: |
-                    function (value) {
-                      return `${Number(value)} °C`;
-                    }
-              stroke:
-                curve: straight
-                width: 3
-              markers:
-                size: 5
-            series:
-              - entity: number.openquatt_curve_tsupply_20degc
-                name: Curve setpoints
-                type: line
-                data_generator: |
-                  const getNum = (eid) => {
-                    const s = hass.states[eid];
-                    if (!s) return null;
-                    const v = parseFloat(s.state);
-                    return Number.isFinite(v) ? v : null;
-                  };
-
-                  const pts = [
-                    { x: "-20", y: getNum("number.openquatt_curve_tsupply_20degc") },
-                    { x: "-10", y: getNum("number.openquatt_curve_tsupply_10degc") },
-                    { x: "0",   y: getNum("number.openquatt_curve_tsupply_0degc") },
-                    { x: "5",   y: getNum("number.openquatt_curve_tsupply_5degc") },
-                    { x: "10",  y: getNum("number.openquatt_curve_tsupply_10degc_2") },
-                    { x: "15",  y: getNum("number.openquatt_curve_tsupply_15degc") }
-                  ];
-
-                  return pts.filter((p) => p.y !== null);
-            grid_options:
-              columns: full
       - type: grid
         cards:
           - type: heading
@@ -2279,11 +2109,11 @@ views:
               - **Dual HP enable level (lvl)** bepaalt bij welk aanhoudend
               single-HP compressorlevel een tweede HP mag worden geactiveerd.
 
-              - Disable-level wordt intern afgeleid als `enable - 1` om het aantal
-              instellingen beperkt te houden.
+              - Disable-level wordt intern afgeleid als `enable - 1` om het
+              aantal instellingen beperkt te houden.
 
-              - **Enable/disable hold** voegt tijdhysterese toe om op en neer schakelen
-              te dempen.
+              - **Enable/disable hold** voegt tijdhysterese toe om op en neer
+              schakelen te dempen.
 
               - Lager enable-level of kortere enable-hold = sneller 2 HP actief.
 
@@ -2306,6 +2136,77 @@ views:
               - entity: number.openquatt_dual_hp_disable_hold
                 name: Dual HP disable hold
       - type: grid
+        cards:
+          - type: heading
+            icon: mdi:tune-variant
+            heading: Flow tuning
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - **Auto start iPWM** is een fallback startwaarde; AUTO gebruikt
+              eerst de onthouden **last good iPWM** als die geldig is.
+
+              - **CM98 iPWM** is de circulatiesetting voor anti-freeze context.
+
+              - **Flow PI Kp/Ki** bepaalt de dynamiek van flowregeling; wijzig
+              in kleine stappen.
+
+              - **Sticky pump iPWM** is vooral service/onderhoud en wordt zelden
+              aangepast.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_flow_auto_start_ipwm
+                name: Auto start iPWM
+              - entity: number.openquatt_frost_circulation_ipwm
+                name: CM98 iPWM
+              - entity: number.openquatt_flow_pi_kp
+                name: Flow PI Kp
+              - entity: number.openquatt_flow_pi_ki
+                name: Flow PI Ki
+              - entity: number.openquatt_sticky_pump_ipwm
+                name: Sticky pump iPWM
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:fire
+            heading: Ketelregeling
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+              - **CM3 deficit ON/OFF thresholds** bepalen wanneer boiler-assist
+              mag inschakelen/uitschakelen.
+
+              - Houd ON duidelijk hoger dan OFF om schakelen rond de grens te
+              beperken.
+
+              - Bij te agressief gedrag: ON verhogen of OFF verlagen.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_cm3_deficit_on_threshold
+                name: CM3 deficit ON threshold
+              - entity: number.openquatt_cm3_deficit_off_threshold
+                name: CM3 deficit OFF threshold
+      - type: grid
+        column_span: 2
         cards:
           - type: heading
             icon: mdi:speedometer-medium
@@ -2386,12 +2287,26 @@ views:
                 name: L9 (H85/C71)
               - entity: switch.openquatt_hp2_allowed_level_10_h_90hz_c_74hz
                 name: L10 (H90/C74)
-        column_span: 2
+    header:
+      card:
+        type: markdown
+        content: >-
+          # <ha-icon icon="mdi:tune-vertical"></ha-icon> Tuning
+
+          Structurele regelinstellingen voor limieten, huismodel, stooklijn,
+          heat-allocation en flow.
+    cards: []
+  - title: Service & Test
+    path: service-test
+    icon: mdi:toolbox-outline
+    type: sections
+    max_columns: 3
+    sections:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:tune-variant
-            heading: Flow tuning
+            icon: mdi:tools
+            heading: Runtime / draaiuren
             heading_style: title
           - type: markdown
             content: >-
@@ -2400,16 +2315,14 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Auto start iPWM** is een fallback startwaarde; AUTO gebruikt
-              eerst de onthouden **last good iPWM** als die geldig is.
+              - **Reset runtime counters**. Let op: het kan maximaal 1 minuut
+              duren voordat je effect ziet.
 
-              - **CM98 iPWM** is de circulatiesetting voor anti-freeze context.
+              - **HP1/HP2 Runtime counters** tonen de actuele teller waarop de
+              runtime-balans wordt gebaseerd.
 
-              - **Flow PI Kp/Ki** bepaalt de dynamiek van flowregeling; wijzig
-              in kleine stappen.
-
-              - **Sticky pump iPWM** is vooral service/onderhoud en wordt zelden
-              aangepast.
+              - **Runtime lead HP** toont welke unit momenteel lead is op basis
+              van de laagste runtime.
 
 
               </details>
@@ -2417,16 +2330,14 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: number.openquatt_flow_auto_start_ipwm
-                name: Auto start iPWM
-              - entity: number.openquatt_frost_circulation_ipwm
-                name: CM98 iPWM
-              - entity: number.openquatt_flow_pi_kp
-                name: Flow PI Kp
-              - entity: number.openquatt_flow_pi_ki
-                name: Flow PI Ki
-              - entity: number.openquatt_sticky_pump_ipwm
-                name: Sticky pump iPWM
+              - entity: button.openquatt_reset_runtime_counters_hp1_hp2
+                name: Reset runtime counters
+              - entity: sensor.openquatt_hp1_runtime_hours
+                name: HP1 Runtime
+              - entity: sensor.openquatt_hp2_runtime_hours
+                name: HP2 Runtime
+              - entity: sensor.openquatt_runtime_lead_hp
+                name: Runtime lead HP
       - type: grid
         cards:
           - type: heading
@@ -2473,57 +2384,6 @@ views:
                 name: Autotune Ki suggested
               - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
-    header:
-      card:
-        type: markdown
-        content: >-
-          # <ha-icon icon="mdi:tune-vertical"></ha-icon> Advanced settings
-
-          Geavanceerde tuning van limieten, huismodel, stooklijn,
-          heat-allocation en flow.
-    cards: []
-  - title: Debug & Testing
-    path: debug-testing
-    icon: mdi:flask-outline
-    type: sections
-    max_columns: 2
-    sections:
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: Runtime / draaiuren
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - **Reset runtime counters**. Let op: het kan maximaal 1 minuut
-              duren voordat je effect ziet.
-
-              - **HP1/HP2 Runtime counters** tonen de actuele teller waarop de
-              runtime-balans wordt gebaseerd.
-
-              - **Runtime lead HP** toont welke unit momenteel lead is op basis
-              van de laagste runtime.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_reset_runtime_counters_hp1_hp2
-                name: Reset runtime counters
-              - entity: sensor.openquatt_hp1_runtime_hours
-                name: HP1 Runtime
-              - entity: sensor.openquatt_hp2_runtime_hours
-                name: HP2 Runtime
-              - entity: sensor.openquatt_runtime_lead_hp
-                name: Runtime lead HP
       - type: grid
         cards:
           - type: heading
@@ -2545,7 +2405,7 @@ views:
               - Druk daarna op **Debug Read HP1 register** of **Debug Read HP2
               register**.
 
-              - Resultaat verschijnt als `U16`, `S16` en raw bytes.
+              - Resultaat verschijnt als `U16` en `S16`.
 
 
               </details>
@@ -2565,260 +2425,12 @@ views:
                 name: Result S16
               - entity: sensor.openquatt_debug_modbus_last_target
                 name: Last target
-              - entity: sensor.openquatt_debug_modbus_last_raw
-                name: Last raw bytes
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:radiator
-            heading: Heating Curve diagnose
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Uitleg</strong></summary>
-
-
-              Gebruik dit blok om de curve-regeling stap voor stap te
-              controleren.
-
-
-              - Deze sectie is vooral relevant bij `Heating mode = Curve`.
-
-              - Vergelijk eerst `Supply target` met `Supply actual` om de
-              regelafwijking te zien.
-
-              - Controleer daarna de keten:
-              `Demand curve pre-guardrail` -> `Demand curve post-guardrail` ->
-              `Demand raw` -> `Demand filtered`.
-
-              - `P_req` wordt in curve mode afgeleid uit demand en helpt bij
-              CM3/tekort-logica.
-
-              - `Curve phase` (`HEAT`/`COAST`/`OFF`) en `Curve restart inhibit`
-                verklaren waarom demand soms niet direct opnieuw start na een OFF-fase.
-
-              - `Heating Curve Control Profile` kiest de ingebouwde
-                stabiliteitsbundel (smoothing, hysterese en slew-rate gedrag).
-
-              - `Heating debug state` geeft een compacte one-line trace
-                (mode/phase/raw/f/req/app/current levels/temps).
-                Blijft deze unavailable, zet de entiteit eerst aan in de HA entity-registry.
-
-              Let op: als `Supply actual` boven target zit maar demand hoog
-              blijft, kijk dan naar PID-instellingen (`Kp/Ki/Kd`) en gedrag over
-              tijd.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: select.openquatt_heating_control_mode
-                name: Heating mode
-              - entity: select.openquatt_heating_curve_control_profile
-                name: Curve control profile
-              - entity: climate.openquatt_heating_curve_pid
-                name: Heating Curve PID
-              - entity: button.openquatt_reset_heating_curve_pid_integral
-                name: Reset PID integral
-              - entity: sensor.openquatt_heating_curve_supply_target
-                name: Supply target
-              - entity: sensor.openquatt_water_supply_temp_selected
-                name: Supply actual (selected)
-              - entity: sensor.openquatt_demand_curve_pre_guardrail
-                name: Demand curve pre-guardrail
-              - entity: sensor.openquatt_demand_curve_post_guardrail
-                name: Demand curve post-guardrail
-              - entity: sensor.openquatt_demand_curve_raw
-                name: Demand curve raw
-              - entity: sensor.openquatt_curve_phase
-                name: Curve phase
-              - entity: sensor.openquatt_curve_restart_inhibit
-                name: Curve restart inhibit
-              - entity: sensor.openquatt_demand_raw
-                name: Demand raw
-              - entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-              - entity: sensor.openquatt_power_house_p_req
-                name: P_req
-              - entity: sensor.openquatt_heating_debug_state
-                name: Heating debug state
-              - entity: number.openquatt_heating_curve_pid_kp
-                name: PID Kp
-              - entity: number.openquatt_heating_curve_pid_ki
-                name: PID Ki
-              - entity: number.openquatt_heating_curve_pid_kd
-                name: PID Kd
-          - type: history-graph
-            title: Heating Curve temperatuur-lus (2 uur)
-            hours_to_show: 2
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_heating_curve_supply_target
-                name: Supply target
-              - entity: sensor.openquatt_water_supply_temp_selected
-                name: Supply actual
-              - entity: sensor.openquatt_outside_temperature_selected
-                name: Outside temp
-            grid_options:
-              columns: full
-          - type: history-graph
-            title: Heating Curve demand-keten (2 uur)
-            hours_to_show: 2
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_demand_curve_raw
-                name: Curve raw
-              - entity: sensor.openquatt_demand_raw
-                name: Demand raw
-              - entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-            grid_options:
-              columns: full
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:home-lightning-bolt
-            heading: Power House diagnose
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-
-              <summary><strong>Uitleg</strong></summary>
-
-
-              Gebruik dit blok om de Power House-regelketen te debuggen.
-
-
-              - Relevant als `Heating mode = Power House`.
-
-              - `P_house` is de modelschatting op basis van buitentemperatuur.
-
-              - `P_req` is de begrensde warmtevraag na deadband/ramp-limiter.
-
-              - `Effective room target = room setpoint + comfort bias`.
-
-              - Snelle duiding van de comfortknoppen:
-                - `bias base` = minimale warme offset (altijd actief)
-                - `bias max` = maximale offset + cap op warme correctierand
-                - `comfort above` = extra warme marge boven effectieve target
-                  (tot de cap)
-
-              - Warme rand:
-              `Tr_high = min(effective_target + comfort_above, setpoint + bias_max)`.
-
-              - Als kamer langdurig te warm is en `P_req` hoog blijft:
-              verlaag eerst `comfort above`, daarna `bias base`, en zo nodig
-              `bias max`.
-
-              - `Comfort bias` en `room error avg` tonen de status van de
-              adaptieve warm-bias regelaar.
-
-              - `Demand raw` en `Demand filtered` zijn de 0..20 stapsignalen
-              richting compressorregeling.
-
-              - `Power cap demand` toont de actieve vraag na
-              vermogensbegrenzing.
-
-              - `Low-load dynamic thresholds` toont live de `pmin/off/on`
-              drempels.
-
-              - `Heat-enable state (shadow)` toont de shadow arbiter-status
-                (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor strategievalidatie.
-              - `CM2 idle-exit reason` laat zien waarom idle-exit in deze cyclus
-                timet, geblokkeerd is, of getript heeft.
-              - `CM2 re-entry block active` toont of tijdelijke
-              CM2-herstartblokkade
-                nu actief is.
-
-              Als `P_req` of demand onverwacht hoog/laag is: controleer
-              buitenbron, kamer setpoint/temp en de ramp/deadband instellingen.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: select.openquatt_heating_control_mode
-                name: Heating mode
-              - entity: sensor.openquatt_outside_temperature_selected
-                name: Outside temp (selected)
-              - entity: sensor.openquatt_room_setpoint_selected
-                name: Room setpoint (selected)
-              - entity: sensor.openquatt_room_temperature_selected
-                name: Room temp (selected)
-              - entity: sensor.openquatt_power_house_effective_room_target
-                name: Effective room target
-              - entity: sensor.openquatt_power_house_comfort_bias
-                name: Comfort bias
-              - entity: sensor.openquatt_power_house_room_error_avg
-                name: Room error avg
-              - entity: sensor.openquatt_power_house_p_house
-                name: P_house
-              - entity: sensor.openquatt_power_house_p_req
-                name: P_req
-              - entity: sensor.openquatt_low_load_dynamic_thresholds
-                name: Low-load dynamic thresholds
-              - entity: sensor.openquatt_heat_enable_state_shadow
-                name: Heat-enable state (shadow)
-              - entity: sensor.openquatt_cm2_idle_exit_reason
-                name: CM2 idle-exit reason
-              - entity: binary_sensor.openquatt_cm2_re_entry_block_active
-                name: CM2 re-entry block active
-              - entity: number.openquatt_low_load_off_fallback
-                name: Low-load OFF fallback
-              - entity: number.openquatt_low_load_on_fallback
-                name: Low-load ON fallback
-              - entity: number.openquatt_low_load_cm2_re_entry_block
-                name: Low-load CM2 re-entry block
-              - entity: sensor.openquatt_demand_raw
-                name: Demand raw
-              - entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-              - entity: sensor.openquatt_power_cap_demand
-                name: Power cap demand
-          - type: history-graph
-            title: Power House model en input (2 uur)
-            hours_to_show: 2
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_outside_temperature_selected
-                name: Outside temp
-              - entity: sensor.openquatt_room_setpoint_selected
-                name: Room setpoint
-              - entity: sensor.openquatt_room_temperature_selected
-                name: Room temp
-              - entity: sensor.openquatt_power_house_p_house
-                name: P_house
-            grid_options:
-              columns: full
-          - type: history-graph
-            title: Power House output-keten (2 uur)
-            hours_to_show: 2
-            refresh_interval: 30
-            entities:
-              - entity: sensor.openquatt_power_house_p_req
-                name: P_req
-              - entity: sensor.openquatt_demand_raw
-                name: Demand raw
-              - entity: sensor.openquatt_demand_filtered
-                name: Demand filtered
-              - entity: sensor.openquatt_power_cap_demand
-                name: Power cap demand
-            grid_options:
-              columns: full
     header:
       card:
         type: markdown
         content: |-
-          # <ha-icon icon="mdi:flask-outline"></ha-icon> Debug & Testing
-          Handmatige diagnose-tools voor tijdelijke metingen.
+          # <ha-icon icon="mdi:toolbox-outline"></ha-icon> Service & Test
+          Handmatige service-acties en tijdelijke testtools.
     cards: []
   - title: Diagnostics
     path: diagnostics
@@ -2862,8 +2474,6 @@ views:
                 name: Firmware Update
               - entity: button.openquatt_check_firmware_updates
                 name: Check Firmware Updates
-      - type: grid
-        cards:
           - type: heading
             icon: mdi:chip
             heading: Controller informatie
@@ -2904,6 +2514,119 @@ views:
                 name: ESPHome Version
               - entity: button.openquatt_restart
                 name: Restart
+      - type: grid
+        column_span: 1
+        cards:
+          - type: heading
+            icon: mdi:home-lightning-bolt
+            heading: Power House diagnose
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+
+              <summary><strong>Uitleg</strong></summary>
+
+
+              Gebruik dit blok om de Power House-regelketen te debuggen.
+
+
+              - Relevant bij actieve Power House-regeling.
+
+              - `P_house` is de modelschatting op basis van buitentemperatuur.
+
+              - `P_req` is de begrensde warmtevraag na deadband/ramp-limiter.
+
+              - `Effective room target = room setpoint + comfort bias`.
+
+              - `Comfort bias` toont de status van de adaptieve warm-bias
+              regelaar.
+
+              - `Low-load dynamic thresholds` toont live de `pmin/off/on`
+              drempels.
+
+              - `Heat-enable state (shadow)` toont de shadow-arbiterstatus
+              (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor
+              strategievalidatie.
+
+              Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
+              setpoint/temp en de ramp/deadband instellingen.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: sensor.openquatt_heat_enable_state_shadow
+                name: Heat-enable state (shadow)
+              - entity: sensor.openquatt_outside_temperature_selected
+                name: Outside temp (selected)
+              - entity: sensor.openquatt_room_setpoint_selected
+                name: Room setpoint (selected)
+              - entity: sensor.openquatt_room_temperature_selected
+                name: Room temp (selected)
+              - entity: sensor.openquatt_power_house_effective_room_target
+                name: Effective room target
+              - entity: sensor.openquatt_power_house_comfort_bias
+                name: Comfort bias
+              - entity: sensor.openquatt_power_house_p_house
+                name: P_house
+              - entity: sensor.openquatt_power_house_p_req
+                name: P_req
+              - entity: sensor.openquatt_low_load_dynamic_thresholds
+                name: Low-load dynamic thresholds
+      - type: grid
+        column_span: 1
+        cards:
+          - type: heading
+            icon: mdi:radiator
+            heading: Heating Curve diagnose
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg</strong></summary>
+
+
+              Gebruik dit blok om de curve-regeling stap voor stap te
+              controleren.
+
+
+              - Deze sectie is vooral relevant bij actieve stooklijnregeling.
+
+              - Vergelijk eerst `Supply target` met `Supply actual` om de
+              regelafwijking te zien.
+
+              - `Curve phase` (`HEAT`/`COAST`/`OFF`) verklaart de actuele fase
+              van de curve-regeling.
+
+              - Gebruik `Heating Curve PID` en `Reset PID integral` bij
+              finetuning als de regeling te traag of te nerveus reageert.
+
+              - `Outside temp (selected)` helpt verklaren waarom het
+              `Supply target` stijgt of daalt.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: climate.openquatt_heating_curve_pid
+                name: Heating Curve PID
+              - entity: sensor.openquatt_outside_temperature_selected
+                name: Outside temp (selected)
+              - entity: sensor.openquatt_heating_curve_supply_target
+                name: Supply target
+              - entity: sensor.openquatt_water_supply_temp_selected
+                name: Supply actual (selected)
+              - entity: sensor.openquatt_curve_phase
+                name: Curve phase
+              - entity: button.openquatt_reset_heating_curve_pid_integral
+                name: Reset PID integral
     cards: []
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_nl.yaml
@@ -413,8 +413,8 @@ views:
               HeatPump-statistieken (zonder boiler):
               - `Heat output power`: thermisch vermogen van HP1+HP2 (W)
               - `Electricity daily`: elektrische input vandaag (kWh)
-              - `COP daily`: verhouding `daily heat kWh / daily electricity kWh`
               - `Heat daily`: warmteproductie vandaag (kWh)
+              - `COP daily`: verhouding `daily heat kWh / daily electricity kWh`
               - `Electricity total`: cumulatieve elektrische input (kWh)
               - `Heat total`: cumulatieve warmteproductie (kWh)
 
@@ -466,9 +466,9 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
               Boiler-statistieken:
-              - `Boiler active`: toont of de relais-aansturing actief is
               - `Heat output power`: actuele thermische boilerbijdrage (W)
               - `Heat daily`: boilerwarmte vandaag (kWh)
+              - `Boiler active`: toont of de relais-aansturing actief is
               - `Heat total`: cumulatieve boilerwarmte (kWh)
 
               </details>

--- a/docs/dashboard/openquatt_ha_dynamic_sources_package.yaml
+++ b/docs/dashboard/openquatt_ha_dynamic_sources_package.yaml
@@ -14,8 +14,8 @@
 #        homeassistant:
 #          packages: !include_dir_named packages
 #   2) Copy this file to: /config/packages/openquatt_dynamic_sources.yaml
-#   3) Adjust initial input_text values to your own source entity IDs.
-#   4) Reload Template Entities (or restart Home Assistant).
+#   3) Reload Template Entities (or restart Home Assistant).
+#   4) Set the three input_text helpers once to your own source entity IDs.
 #
 # Notes:
 #   - Trigger interval is 15s to support dynamic entity_id references.
@@ -33,21 +33,18 @@ input_text:
     icon: mdi:thermometer
     mode: text
     max: 100
-    initial: sensor.outdoor_temperature
 
   openquatt_source_room_setpoint:
     name: OpenQuatt source room setpoint
     icon: mdi:thermostat
     mode: text
     max: 100
-    initial: sensor.thermostat_setpoint
 
   openquatt_source_room_temperature:
     name: OpenQuatt source room temperature
     icon: mdi:home-thermometer
     mode: text
     max: 100
-    initial: sensor.thermostat_room_temperature
 
 template:
   - trigger:

--- a/docs/home-assistant-dashboard.md
+++ b/docs/home-assistant-dashboard.md
@@ -18,8 +18,8 @@ The dashboard is designed as a practical operations console with the **Sections*
 - [6. HPs View](#6-hps-view)
 - [7. Sensor Configuration View](#7-sensor-configuration-view)
 - [8. Energy View](#8-energy-view)
-- [9. Advanced Settings View](#9-advanced-settings-view)
-- [10. Debug & Testing View](#10-debug--testing-view)
+- [9. Tuning View](#9-tuning-view)
+- [10. Service & Test View](#10-service--test-view)
 - [11. Diagnostics View](#11-diagnostics-view)
 - [12. Practical Maintenance Checklist](#12-practical-maintenance-checklist)
 
@@ -33,8 +33,8 @@ The dashboard is designed as a practical operations console with the **Sections*
 | HPs | `HPs` | HP1/HP2 deep diagnostics and visualization |
 | Sensor Configuration | `sensor-configuration` | Source setup (CIC/HA/selectors) plus per-signal diagnostics and feedback |
 | Energy | `energy` | Daily/cumulative energy and efficiency metrics |
-| Advanced settings | `advanced-settings` | Expert tuning parameters with explanations |
-| Debug & Testing | `debug-testing` | Service utilities, runtime balancing checks, and manual probe tools |
+| Tuning | `tuning` | Expert tuning parameters with explanations |
+| Service & Test | `service-test` | Service utilities, runtime balancing checks, and manual probe tools |
 | Diagnostics | `diagnostics` | Controller and firmware diagnostics |
 
 ## 2. Design Rules Used
@@ -159,7 +159,7 @@ Operational rule:
 
 - Validate tuning changes with this tab over full day windows.
 
-## 9. Advanced Settings View
+## 9. Tuning View
 
 Expected content pattern:
 
@@ -171,7 +171,7 @@ Operational rule:
 
 - Treat this as engineering configuration, not a daily operations tab.
 
-## 10. Debug & Testing View
+## 10. Service & Test View
 
 Expected content pattern:
 

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -82,6 +82,7 @@ sensor:
   - platform: uptime
     name: Uptime
     id: uptime_sensor
+    internal: true
     icon: mdi:timer-outline
     update_interval: 60s
     device_class: duration
@@ -152,6 +153,36 @@ text_sensor:
     icon: mdi:information-outline
     hide_timestamp: true
     entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+  - platform: template
+    id: uptime_readable_text
+    name: Uptime
+    icon: mdi:timer-outline
+    entity_category: diagnostic
+    update_interval: 60s
+    lambda: |-
+      if (isnan(id(uptime_sensor).state)) {
+        return {"unknown"};
+      }
+
+      const uint32_t total_seconds = static_cast<uint32_t>(id(uptime_sensor).state);
+      const uint32_t days = total_seconds / 86400U;
+      const uint32_t hours = (total_seconds % 86400U) / 3600U;
+      const uint32_t minutes = (total_seconds % 3600U) / 60U;
+      const uint32_t seconds = total_seconds % 60U;
+
+      char buffer[32];
+      if (days > 0U) {
+        snprintf(buffer, sizeof(buffer), "%ud %uh %um", days, hours, minutes);
+      } else if (hours > 0U) {
+        snprintf(buffer, sizeof(buffer), "%uh %um", hours, minutes);
+      } else if (minutes > 0U) {
+        snprintf(buffer, sizeof(buffer), "%um", minutes);
+      } else {
+        snprintf(buffer, sizeof(buffer), "%us", seconds);
+      }
+      return {buffer};
     web_server:
       sorting_group_id: oq_diagnostics
 

--- a/openquatt/oq_energy.yaml
+++ b/openquatt/oq_energy.yaml
@@ -25,8 +25,8 @@ sensor:
 
   # Electrical input energy (cumulative, kWh).
   - platform: integration
-    id: oq_electrical_energy_total
-    name: "Electrical Energy Total"
+    id: oq_electrical_energy_cumulative
+    name: "Electrical Energy Cumulative"
     sensor: oq_total_power_input
     time_unit: h
     unit_of_measurement: "kWh"
@@ -94,8 +94,8 @@ sensor:
 
   # HeatPump thermal energy (cumulative, kWh).
   - platform: integration
-    id: oq_heatpump_thermal_energy_total
-    name: "HeatPump Thermal Energy Total"
+    id: oq_heatpump_thermal_energy_cumulative
+    name: "HeatPump Thermal Energy Cumulative"
     sensor: oq_total_heat_power
     time_unit: h
     unit_of_measurement: "kWh"
@@ -107,6 +107,25 @@ sensor:
     restore: true
     web_server:
       sorting_group_id: oq_performance
+
+  # HeatPump COP based on cumulative thermal/electrical energy (kWh/kWh).
+  - platform: template
+    id: oq_heatpump_cop_cumulative
+    name: "HeatPump COP Cumulative"
+    icon: mdi:chart-bell-curve-cumulative
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_performance
+    lambda: |-
+      const float heat_kwh = id(oq_heatpump_thermal_energy_cumulative).state;
+      const float elec_kwh = id(oq_electrical_energy_cumulative).state;
+
+      if (isnan(heat_kwh) || isnan(elec_kwh)) return NAN;
+      if (elec_kwh < 0.01f) return NAN;
+
+      return heat_kwh / elec_kwh;
 
   # Boiler thermal energy (daily, kWh).
   - platform: total_daily_energy

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -207,19 +207,19 @@ def main() -> int:
             "Heat control",
             "HPs",
             "Sensor Configuration",
-            "Advanced settings",
-            "Debug & Testing",
+            "Tuning",
+            "Service & Test",
             "Diagnostics",
         ]
         nl_expected = [
             "Overzicht",
-            "Energy",
+            "Energie",
             "Flow",
             "Warmtecontrol",
             "HPs",
             "Sensorconfiguratie",
-            "Advanced settings",
-            "Debug & Testing",
+            "Tuning",
+            "Service & Test",
             "Diagnostics",
         ]
         en_actual = parse_dashboard_titles(dash_en)
@@ -232,10 +232,10 @@ def main() -> int:
 
         home_text = read_text(docs_home)
         required_phrases = [
-            "Debug & Testing View",
-            "`debug-testing`",
+            "Service & Test View",
+            "`service-test`",
             "Diagnostics View",
-            "Advanced Settings View",
+            "Tuning View",
         ]
         for phrase in required_phrases:
             if phrase not in home_text:


### PR DESCRIPTION
## Summary
- Improves the Home Assistant dashboards (NL and EN) with clearer structure, naming, and explanation blocks.
- Reworks the Energy tab layout and terminology for better readability.
- Renames heat-pump cumulative energy/COP identifiers from `*_total` to `*_cumulative` for clearer semantics.
- Adds a cumulative heat-pump COP metric based on cumulative thermal/electrical energy.
- Makes HA dynamic source selector helpers persistent across Home Assistant restarts by removing startup `initial` overrides.
- Includes heating-curve/control-mode refinements and related docs updates that are present on this branch.

## Breaking Changes
- Renamed entity IDs:
  - `sensor.openquatt_electrical_energy_total` -> `sensor.openquatt_electrical_energy_cumulative`
  - `sensor.openquatt_heatpump_thermal_energy_total` -> `sensor.openquatt_heatpump_thermal_energy_cumulative`
  - `sensor.openquatt_heatpump_cop_total` -> `sensor.openquatt_heatpump_cop_cumulative`

## Validation
- Ran local validation/compile: `./scripts/validate_local.sh` (success)
