### PR TITLE
Add Pages-based web installer

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -157,9 +157,7 @@ jobs:
             Commit: `${{ github.sha }}`
             Version: `${{ steps.dev_meta.outputs.version }}`
           files: |
-            openquatt-duo-install.manifest.json
             openquatt-duo-ota.manifest.json
-            openquatt-single-install.manifest.json
             openquatt-single-ota.manifest.json
             dist/openquatt-duo-waveshare.firmware.ota.bin
             dist/openquatt-duo-waveshare.firmware.factory.bin

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -105,9 +105,7 @@ jobs:
           generate_release_notes: true
           overwrite_files: true
           files: |
-            openquatt-duo-install.manifest.json
             openquatt-duo-ota.manifest.json
-            openquatt-single-install.manifest.json
             openquatt-single-ota.manifest.json
             dist/openquatt-duo-waveshare.firmware.ota.bin
             dist/openquatt-duo-waveshare.firmware.factory.bin

--- a/README.md
+++ b/README.md
@@ -54,31 +54,35 @@ Release coverage:
 
 ## Quick Start
 
-### 1. Download the correct firmware from the latest release
+### 1. Open the web installer
 
-Open the [latest OpenQuatt release](https://github.com/jeroen85/OpenQuatt/releases/latest) and download the `*.firmware.factory.bin` file that matches your setup:
+Open the [OpenQuatt installer](https://jeroen85.github.io/OpenQuatt/install/) and choose your exact combination:
 
-- Duo + Waveshare ESP32-S3-Relay-1CH: `openquatt-duo-waveshare.firmware.factory.bin`
-- Duo + Heatpump Listener: `openquatt-duo-heatpump-listener.firmware.factory.bin`
-- Single + Waveshare ESP32-S3-Relay-1CH: `openquatt-single-waveshare.firmware.factory.bin`
-- Single + Heatpump Listener: `openquatt-single-heatpump-listener.firmware.factory.bin`
+- Duo + Waveshare ESP32-S3-Relay-1CH
+- Duo + Heatpump Listener
+- Single + Waveshare ESP32-S3-Relay-1CH
+- Single + Heatpump Listener
 
-Use the `factory.bin` file for first installation.
+The installer always flashes the latest stable `factory.bin` from the current GitHub release.
 
 If you want custom changes, build from source via [Getting Started](docs/getting-started.md).
 
-### 2. Install the firmware with `web.esphome.io`
+### 2. Install the firmware over USB
 
-1. Open [web.esphome.io](https://web.esphome.io/).
+1. Open the installer page in Chrome or Edge.
 2. Connect your ESP board over USB.
-3. Start the manual installation flow.
-4. Select the `*.firmware.factory.bin` file you downloaded from the latest release.
-5. Complete the flashing process and wait for the board to reboot.
+3. Select the matching setup and hardware profile.
+4. Start the installation flow and wait for the board to reboot.
 
 Firmware file types:
 
 - `*.firmware.factory.bin` is for the first installation on a board over USB.
 - `*.firmware.ota.bin` is for updating a device that is already running OpenQuatt.
+
+Manual fallback:
+
+- Open the [latest OpenQuatt release](https://github.com/jeroen85/OpenQuatt/releases/latest) and download the matching `*.firmware.factory.bin`.
+- Flash it manually with [web.esphome.io](https://web.esphome.io/).
 
 ### 3. Configure Wi-Fi after first boot
 
@@ -92,7 +96,7 @@ Connect to that access point and complete the captive portal flow to enter your 
 Note:
 
 - Wi-Fi provisioning currently happens through the fallback AP and captive portal.
-- `web.esphome.io` is therefore used for flashing first, not for the final Wi-Fi setup flow.
+- The installer page only handles flashing; network setup still happens on the device itself after reboot.
 
 ### 4. Finish setup in Home Assistant
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,9 +13,10 @@ This documentation set is organized for fast onboarding and professional mainten
 
 ### Path A: First install / first run
 
-1. [Getting Started](getting-started.md)
-2. [System Overview](system-overview.md)
-3. [Home Assistant Dashboard](home-assistant-dashboard.md)
+1. [Web Installer](install/)
+2. [Getting Started](getting-started.md)
+3. [System Overview](system-overview.md)
+4. [Home Assistant Dashboard](home-assistant-dashboard.md)
 
 ### Path B: Daily operation, tuning, and troubleshooting
 
@@ -35,6 +36,10 @@ This documentation set is organized for fast onboarding and professional mainten
 ```text
 docs/
 ├── README.md
+├── install/
+│   ├── index.html
+│   ├── install.css
+│   └── install.js
 ├── getting-started.md
 ├── system-overview.md
 ├── control-modes-and-flow.md
@@ -59,6 +64,7 @@ docs/
 ## What Each Document Covers
 
 - `getting-started.md`: hardware prerequisites, baseline runtime, build/flash flow, first validation.
+- `install/`: GitHub Pages first-install flow that generates a profile-specific ESP Web Tools manifest for the latest stable release.
 - `system-overview.md`: package architecture, control ownership, data pipeline, safety model.
 - `control-modes-and-flow.md`: CM behavior, Flow Mode semantics, Heating Strategy modes, and precedence.
 - `settings-reference.md`: compile-time vs runtime settings, including low-load and anti-flip controls.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,10 @@
 
 This guide gets OpenQuatt from repository clone to a validated first run.
 
+If you only want the latest stable firmware without local builds, use the
+[OpenQuatt web installer](https://jeroen85.github.io/OpenQuatt/install/) first.
+This document is the source-build path.
+
 ## Table of Contents
 
 - [1. Prerequisites](#1-prerequisites)
@@ -125,7 +129,10 @@ Or run the helper script:
 
 ## 6. Flash and Boot
 
-Run:
+For the stock stable firmware, prefer the
+[OpenQuatt web installer](https://jeroen85.github.io/OpenQuatt/install/).
+
+For local source builds, run:
 
 ```bash
 esphome run openquatt_duo_waveshare.yaml

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenQuatt Installer</title>
+    <meta
+      name="description"
+      content="Install the latest stable OpenQuatt firmware on a supported Waveshare or Heatpump Listener board."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="install.css" />
+    <script
+      type="module"
+      src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"
+    ></script>
+    <script type="module" src="install.js"></script>
+  </head>
+  <body>
+    <div class="backdrop backdrop-left"></div>
+    <div class="backdrop backdrop-right"></div>
+    <main class="page-shell">
+      <section class="hero card reveal">
+        <p class="eyebrow">OpenQuatt / Main Channel</p>
+        <div class="hero-grid">
+          <div>
+            <div class="logo-frame">
+              <img
+                class="logo"
+                src="../assets/openquatt_logo.svg"
+                alt="OpenQuatt"
+                width="300"
+                height="101"
+              />
+            </div>
+            <h1>Install the latest stable firmware without hunting for binaries.</h1>
+            <p class="lead">
+              Choose your setup and hardware profile, then flash the matching
+              OpenQuatt factory image over USB. OTA updates stay on the existing
+              GitHub Release flow after first boot.
+            </p>
+          </div>
+          <aside class="hero-notes">
+            <p>Use Chrome or Edge on desktop.</p>
+            <p>Connect with a USB data cable, not power-only.</p>
+            <p>Wi-Fi is still configured on the device after reboot via the OpenQuatt fallback AP.</p>
+          </aside>
+        </div>
+      </section>
+
+      <section class="layout">
+        <section class="card chooser reveal">
+          <div class="step">
+            <p class="step-number">1</p>
+            <div>
+              <h2>Pick your setup</h2>
+              <p class="step-copy">This decides whether the firmware runs in Single or Duo topology.</p>
+            </div>
+          </div>
+          <div class="choice-grid" id="topology-grid">
+            <label class="choice-card">
+              <input type="radio" name="topology" value="duo" />
+              <span class="choice-title">Duo</span>
+              <span class="choice-body">Two heat pumps enabled in the compiled topology.</span>
+            </label>
+            <label class="choice-card">
+              <input type="radio" name="topology" value="single" />
+              <span class="choice-title">Single</span>
+              <span class="choice-body">Single heat pump topology with Duo-only logic compiled out.</span>
+            </label>
+          </div>
+
+          <div class="step">
+            <p class="step-number">2</p>
+            <div>
+              <h2>Pick your ESP module</h2>
+              <p class="step-copy">This decides the exact board mapping and factory image to flash.</p>
+            </div>
+          </div>
+          <div class="choice-grid" id="hardware-grid">
+            <label class="choice-card">
+              <input type="radio" name="hardware" value="waveshare" />
+              <span class="choice-title">Waveshare</span>
+              <span class="choice-body">ESP32-S3-Relay-1CH board using the ESP32-S3 build.</span>
+            </label>
+            <label class="choice-card">
+              <input type="radio" name="hardware" value="heatpump-listener" />
+              <span class="choice-title">Heatpump Listener</span>
+              <span class="choice-body">ESP32 Heatpump Listener board using the ESP32 build.</span>
+            </label>
+          </div>
+        </section>
+
+        <aside class="card summary reveal">
+          <p class="eyebrow">Selected Firmware</p>
+          <h2 id="selection-title">Choose setup and hardware first</h2>
+          <p class="summary-copy" id="selection-copy">
+            The installer will generate a one-off ESP Web Tools manifest for the exact profile you pick here.
+          </p>
+
+          <dl class="summary-list">
+            <div>
+              <dt>Setup</dt>
+              <dd id="selection-topology">Not selected</dd>
+            </div>
+            <div>
+              <dt>Hardware</dt>
+              <dd id="selection-hardware">Not selected</dd>
+            </div>
+            <div>
+              <dt>Chip Family</dt>
+              <dd id="selection-chip">Not selected</dd>
+            </div>
+            <div>
+              <dt>Factory Image</dt>
+              <dd id="selection-file">Not selected</dd>
+            </div>
+          </dl>
+
+          <div class="install-panel" id="install-panel" data-ready="false">
+            <p class="install-state" id="install-state">Finish both selections to unlock the installer.</p>
+            <esp-web-install-button id="install-button">
+              <button class="install-cta" slot="activate">Install OpenQuatt</button>
+              <span class="install-fallback" slot="unsupported">
+                Web Serial is not available in this browser. Use Chrome or Edge on desktop.
+              </span>
+              <span class="install-fallback" slot="not-allowed">
+                Open the installer over HTTPS to access Web Serial.
+              </span>
+            </esp-web-install-button>
+          </div>
+
+          <div class="manual-panel">
+            <p>Manual fallback</p>
+            <a href="https://github.com/jeroen85/OpenQuatt/releases/latest" target="_blank" rel="noreferrer">
+              Open the latest stable release
+            </a>
+            <a href="https://web.esphome.io/" target="_blank" rel="noreferrer">
+              Flash a downloaded factory binary in ESP Web Tools
+            </a>
+          </div>
+        </aside>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/install/install.css
+++ b/docs/install/install.css
@@ -1,0 +1,400 @@
+:root {
+  --bg: #f4efe6;
+  --panel: rgba(20, 25, 30, 0.9);
+  --panel-soft: rgba(255, 255, 255, 0.78);
+  --ink: #10161d;
+  --ink-soft: #49545f;
+  --line: rgba(16, 22, 29, 0.12);
+  --accent: #ff6a2b;
+  --accent-deep: #ca4f1a;
+  --accent-soft: rgba(255, 106, 43, 0.14);
+  --success: #12735c;
+  --radius-xl: 28px;
+  --radius-lg: 18px;
+  --shadow: 0 30px 80px rgba(16, 22, 29, 0.14);
+  --font-body: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-body);
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(255, 172, 115, 0.45), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(31, 154, 129, 0.18), transparent 24%),
+    linear-gradient(160deg, #f8f3ea 0%, #efe5d8 45%, #e8dfd4 100%);
+}
+
+.backdrop {
+  position: fixed;
+  inset: auto;
+  z-index: 0;
+  width: 34vw;
+  height: 34vw;
+  max-width: 440px;
+  max-height: 440px;
+  border-radius: 999px;
+  filter: blur(26px);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.backdrop-left {
+  top: -12vw;
+  left: -8vw;
+  background: rgba(255, 128, 59, 0.3);
+}
+
+.backdrop-right {
+  right: -10vw;
+  bottom: -12vw;
+  background: rgba(18, 115, 92, 0.24);
+}
+
+.page-shell {
+  position: relative;
+  z-index: 1;
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 56px;
+}
+
+.card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl);
+  background: var(--panel-soft);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.hero {
+  padding: 32px;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.65fr) minmax(280px, 0.9fr);
+  gap: 28px;
+  align-items: end;
+}
+
+.logo-frame {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 124px;
+  margin-bottom: 18px;
+  padding: 18px 24px;
+  border: 1px solid rgba(16, 22, 29, 0.08);
+  border-radius: 24px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 240, 231, 0.88));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+    0 20px 44px rgba(16, 22, 29, 0.08);
+}
+
+.logo {
+  display: block;
+  width: min(300px, 100%);
+  height: auto;
+}
+
+.eyebrow {
+  margin: 0 0 16px;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent-deep);
+}
+
+h1,
+h2 {
+  margin: 0;
+  line-height: 1;
+}
+
+h1 {
+  max-width: 12ch;
+  font-size: clamp(2.5rem, 5vw, 4.6rem);
+  letter-spacing: -0.05em;
+}
+
+h2 {
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  letter-spacing: -0.04em;
+}
+
+.lead,
+.step-copy,
+.summary-copy,
+.hero-notes p,
+.choice-body,
+.install-state,
+.manual-panel a {
+  color: var(--ink-soft);
+}
+
+.lead {
+  max-width: 54ch;
+  margin: 18px 0 0;
+  font-size: 1.08rem;
+  line-height: 1.6;
+}
+
+.hero-notes {
+  padding: 22px;
+  border-radius: var(--radius-lg);
+  background: var(--panel);
+}
+
+.hero-notes p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.hero-notes p + p {
+  margin-top: 14px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.85fr);
+  gap: 24px;
+  margin-top: 24px;
+}
+
+.chooser,
+.summary {
+  padding: 28px;
+}
+
+.step {
+  display: flex;
+  gap: 16px;
+  align-items: start;
+  margin-bottom: 18px;
+}
+
+.step + .step {
+  margin-top: 28px;
+}
+
+.step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  margin: 0;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-deep);
+  font-weight: 700;
+}
+
+.step-copy {
+  margin: 10px 0 0;
+  line-height: 1.5;
+}
+
+.choice-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.choice-card {
+  position: relative;
+  display: grid;
+  gap: 10px;
+  min-height: 156px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.72);
+  cursor: pointer;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    background 180ms ease;
+}
+
+.choice-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 106, 43, 0.32);
+  box-shadow: 0 18px 34px rgba(255, 106, 43, 0.08);
+}
+
+.choice-card input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  cursor: pointer;
+}
+
+.choice-card:has(input:checked) {
+  border-color: rgba(255, 106, 43, 0.78);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 239, 231, 0.92));
+  box-shadow: 0 18px 40px rgba(255, 106, 43, 0.18);
+}
+
+.choice-title {
+  font-size: 1.18rem;
+  font-weight: 700;
+}
+
+.choice-body {
+  line-height: 1.55;
+}
+
+.summary-copy {
+  margin: 14px 0 0;
+  line-height: 1.6;
+}
+
+.summary-list {
+  display: grid;
+  gap: 14px;
+  margin: 24px 0 0;
+}
+
+.summary-list div {
+  display: flex;
+  gap: 16px;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.summary-list dt {
+  color: var(--ink-soft);
+}
+
+.summary-list dd {
+  margin: 0;
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: 0.93rem;
+}
+
+.install-panel {
+  margin-top: 24px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  background: rgba(16, 22, 29, 0.94);
+}
+
+.install-panel[data-ready="false"] esp-web-install-button {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.install-state {
+  margin: 0 0 14px;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.5;
+}
+
+.install-cta {
+  width: 100%;
+  padding: 16px 18px;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent) 0%, #ff9c4a 100%);
+  color: #121212;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease;
+}
+
+.install-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 26px rgba(255, 106, 43, 0.24);
+}
+
+.install-fallback {
+  display: block;
+  margin-top: 12px;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.5;
+}
+
+.manual-panel {
+  display: grid;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.manual-panel p {
+  margin: 0;
+  font-size: 0.86rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-deep);
+}
+
+.manual-panel a {
+  text-decoration: none;
+}
+
+.manual-panel a:hover {
+  color: var(--accent-deep);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(18px);
+  animation: reveal 500ms ease forwards;
+}
+
+.chooser.reveal {
+  animation-delay: 100ms;
+}
+
+.summary.reveal {
+  animation-delay: 180ms;
+}
+
+@keyframes reveal {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 900px) {
+  .hero-grid,
+  .layout,
+  .choice-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page-shell {
+    width: min(100% - 20px, 980px);
+    padding-top: 20px;
+  }
+
+  .hero,
+  .chooser,
+  .summary {
+    padding: 22px;
+  }
+
+  .summary-list div {
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .summary-list dd {
+    text-align: left;
+  }
+}

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -1,0 +1,136 @@
+const RELEASE_ROOT = "https://github.com/jeroen85/OpenQuatt/releases/latest/download";
+
+const PROFILES = {
+  duo: {
+    label: "Duo",
+    waveshare: {
+      title: "OpenQuatt Duo / Waveshare",
+      chipFamily: "ESP32-S3",
+      hardwareLabel: "Waveshare ESP32-S3-Relay-1CH",
+      fileName: "openquatt-duo-waveshare.firmware.factory.bin",
+    },
+    "heatpump-listener": {
+      title: "OpenQuatt Duo / Heatpump Listener",
+      chipFamily: "ESP32",
+      hardwareLabel: "Heatpump Listener",
+      fileName: "openquatt-duo-heatpump-listener.firmware.factory.bin",
+    },
+  },
+  single: {
+    label: "Single",
+    waveshare: {
+      title: "OpenQuatt Single / Waveshare",
+      chipFamily: "ESP32-S3",
+      hardwareLabel: "Waveshare ESP32-S3-Relay-1CH",
+      fileName: "openquatt-single-waveshare.firmware.factory.bin",
+    },
+    "heatpump-listener": {
+      title: "OpenQuatt Single / Heatpump Listener",
+      chipFamily: "ESP32",
+      hardwareLabel: "Heatpump Listener",
+      fileName: "openquatt-single-heatpump-listener.firmware.factory.bin",
+    },
+  },
+};
+
+const selectionTitle = document.getElementById("selection-title");
+const selectionCopy = document.getElementById("selection-copy");
+const selectionTopology = document.getElementById("selection-topology");
+const selectionHardware = document.getElementById("selection-hardware");
+const selectionChip = document.getElementById("selection-chip");
+const selectionFile = document.getElementById("selection-file");
+const installPanel = document.getElementById("install-panel");
+const installState = document.getElementById("install-state");
+const installButton = document.getElementById("install-button");
+
+let activeManifestUrl;
+
+function getSelectedProfile() {
+  const topology = document.querySelector('input[name="topology"]:checked')?.value;
+  const hardware = document.querySelector('input[name="hardware"]:checked')?.value;
+
+  if (!topology || !hardware) {
+    return null;
+  }
+
+  return {
+    topology,
+    hardware,
+    ...PROFILES[topology][hardware],
+  };
+}
+
+function buildManifest(profile) {
+  return {
+    name: profile.title,
+    version: "latest",
+    new_install_prompt_erase: true,
+    builds: [
+      {
+        chipFamily: profile.chipFamily,
+        parts: [
+          {
+            path: `${RELEASE_ROOT}/${profile.fileName}`,
+            offset: 0,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function updateInstallManifest(profile) {
+  if (activeManifestUrl) {
+    URL.revokeObjectURL(activeManifestUrl);
+  }
+
+  const manifest = buildManifest(profile);
+  activeManifestUrl = URL.createObjectURL(
+    new Blob([JSON.stringify(manifest)], { type: "application/json" }),
+  );
+
+  installButton.manifest = activeManifestUrl;
+}
+
+function updateSummary() {
+  const profile = getSelectedProfile();
+
+  if (!profile) {
+    selectionTitle.textContent = "Choose setup and hardware first";
+    selectionCopy.textContent =
+      "The installer will generate a one-off ESP Web Tools manifest for the exact profile you pick here.";
+    selectionTopology.textContent = "Not selected";
+    selectionHardware.textContent = "Not selected";
+    selectionChip.textContent = "Not selected";
+    selectionFile.textContent = "Not selected";
+    installPanel.dataset.ready = "false";
+    installState.textContent = "Finish both selections to unlock the installer.";
+    installButton.manifest = "";
+    return;
+  }
+
+  updateInstallManifest(profile);
+
+  selectionTitle.textContent = profile.title;
+  selectionCopy.textContent =
+    "This installer points straight at the latest stable GitHub Release factory image for the selected profile.";
+  selectionTopology.textContent = PROFILES[profile.topology].label;
+  selectionHardware.textContent = profile.hardwareLabel;
+  selectionChip.textContent = profile.chipFamily;
+  selectionFile.textContent = profile.fileName;
+  installPanel.dataset.ready = "true";
+  installState.textContent =
+    "Ready to flash. After the install completes, let the board reboot and continue setup on the OpenQuatt access point.";
+}
+
+document.querySelectorAll('input[name="topology"], input[name="hardware"]').forEach((input) => {
+  input.addEventListener("change", updateSummary);
+});
+
+window.addEventListener("beforeunload", () => {
+  if (activeManifestUrl) {
+    URL.revokeObjectURL(activeManifestUrl);
+  }
+});
+
+updateSummary();

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -30,17 +30,16 @@ Firmware should expose its channel explicitly via `release_channel` so Home Assi
   - Actions:
     - validate + compile all four topology/hardware profiles
     - publish explicit Duo and Single release assets for both hardware targets
-    - generate `openquatt-duo-install.manifest.json` and `openquatt-single-install.manifest.json` for first install via `web.esphome.io`
     - generate `openquatt-duo-ota.manifest.json` and `openquatt-single-ota.manifest.json` for OTA update checks
     - create/update GitHub Release
-    - attach release firmware binaries and manifests to the release
+    - attach release firmware binaries and OTA manifests to the release
 - `/.github/workflows/dev-build.yml`
   - Trigger: push to `dev`, manual dispatch
   - Actions:
     - compile all four profiles with `release_channel=dev`
     - override `project_version` to `${base_version}-dev.<run_number>+<shortsha>`
     - move the mutable `dev-latest` tag to the newest `dev` commit
-    - publish/update a prerelease that contains install + OTA manifests for the dev channel
+    - publish/update a prerelease that contains binaries + OTA manifests for the dev channel
 
 ## ESPHome Version Pinning
 
@@ -114,9 +113,7 @@ git push origin main --tags
    - CI should be green.
    - Release workflow should publish artifacts.
 5. Verify GitHub Release contains:
-   - `openquatt-duo-install.manifest.json`
    - `openquatt-duo-ota.manifest.json`
-   - `openquatt-single-install.manifest.json`
    - `openquatt-single-ota.manifest.json`
    - `openquatt-duo-waveshare.firmware.ota.bin`
    - `openquatt-duo-waveshare.firmware.factory.bin`
@@ -130,7 +127,7 @@ git push origin main --tags
 ## Notes
 
 - The baseline `openquatt_duo_waveshare.yaml` is secrets-free and suitable for CI builds.
-- `openquatt-duo-install.manifest.json` and `openquatt-single-install.manifest.json` are intended for first install via `web.esphome.io`.
+- First-install UX now lives on the GitHub Pages installer at `https://jeroen85.github.io/OpenQuatt/install/`, which builds ESP Web Tools manifests dynamically in the browser against the latest stable release binaries.
 - `openquatt-duo-ota.manifest.json` and `openquatt-single-ota.manifest.json` are intended for OTA update flows.
 - Duo firmware reads `${release_manifest_url}` from `openquatt_base.yaml`, Single firmware reads it from `openquatt_base_single.yaml`.
 - Workflow files must remain directly under `.github/workflows/` (GitHub does not load workflows from nested subfolders).

--- a/scripts/prepare_release_assets.sh
+++ b/scripts/prepare_release_assets.sh
@@ -31,60 +31,6 @@ DUO_OTA_ESP32_MD5="$(md5sum "$DUO_OTA_ESP32_BIN" | awk '{print $1}')"
 SINGLE_OTA_S3_MD5="$(md5sum "$SINGLE_OTA_S3_BIN" | awk '{print $1}')"
 SINGLE_OTA_ESP32_MD5="$(md5sum "$SINGLE_OTA_ESP32_BIN" | awk '{print $1}')"
 
-cat > openquatt-duo-install.manifest.json <<EOF
-{
-  "name": "OpenQuatt Duo",
-  "version": "${VERSION}",
-  "builds": [
-    {
-      "chipFamily": "ESP32-S3",
-      "parts": [
-        {
-          "path": "${BASE_URL}/openquatt-duo-waveshare.firmware.factory.bin",
-          "offset": 0
-        }
-      ]
-    },
-    {
-      "chipFamily": "ESP32",
-      "parts": [
-        {
-          "path": "${BASE_URL}/openquatt-duo-heatpump-listener.firmware.factory.bin",
-          "offset": 0
-        }
-      ]
-    }
-  ]
-}
-EOF
-
-cat > openquatt-single-install.manifest.json <<EOF
-{
-  "name": "OpenQuatt Single",
-  "version": "${VERSION}",
-  "builds": [
-    {
-      "chipFamily": "ESP32-S3",
-      "parts": [
-        {
-          "path": "${BASE_URL}/openquatt-single-waveshare.firmware.factory.bin",
-          "offset": 0
-        }
-      ]
-    },
-    {
-      "chipFamily": "ESP32",
-      "parts": [
-        {
-          "path": "${BASE_URL}/openquatt-single-heatpump-listener.firmware.factory.bin",
-          "offset": 0
-        }
-      ]
-    }
-  ]
-}
-EOF
-
 cat > openquatt-duo-ota.manifest.json <<EOF
 {
   "name": "OpenQuatt Duo",


### PR DESCRIPTION
## Summary
- add a GitHub Pages installer at `/docs/install/` that lets users choose Single/Duo and Waveshare/Heatpump Listener and generates the ESP Web Tools manifest in-browser against the latest stable release factory image
- keep the OTA flow on GitHub Releases and stop publishing install manifests in stable/dev release jobs
- update README and docs so first install points to the Pages installer while manual `web.esphome.io` flashing remains documented as fallback

## Validation
- `./scripts/validate_local.sh`
- `python3 scripts/check_docs_consistency.py --changed-only`

## Not In This PR
- `improv_serial` and USB Wi-Fi provisioning changes; that will land as a separate PR
- any change to the existing OTA manifest URLs or runtime update-channel flow