### PR TITLE
Refine installer card spacing

### DIFF
--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -64,14 +64,14 @@
           </div>
           <div class="choice-grid" id="topology-grid">
             <label class="choice-card">
-              <input type="radio" name="topology" value="duo" />
-              <span class="choice-title">Duo</span>
-              <span class="choice-body">Two heat pumps enabled in the compiled topology.</span>
-            </label>
-            <label class="choice-card">
               <input type="radio" name="topology" value="single" />
               <span class="choice-title">Single</span>
               <span class="choice-body">Single heat pump topology with Duo-only logic compiled out.</span>
+            </label>
+            <label class="choice-card">
+              <input type="radio" name="topology" value="duo" />
+              <span class="choice-title">Duo</span>
+              <span class="choice-body">Two heat pumps enabled in the compiled topology.</span>
             </label>
           </div>
 

--- a/docs/install/install.css
+++ b/docs/install/install.css
@@ -175,14 +175,20 @@ h2 {
 }
 
 .step {
+  position: relative;
+  z-index: 2;
   display: flex;
   gap: 16px;
   align-items: start;
-  margin-bottom: 18px;
+  margin-bottom: 22px;
 }
 
 .step + .step {
   margin-top: 28px;
+}
+
+.choice-grid + .step {
+  margin-top: 44px;
 }
 
 .step-number {
@@ -204,6 +210,8 @@ h2 {
 }
 
 .choice-grid {
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;


### PR DESCRIPTION
## Summary
- add more vertical separation between the setup cards and the next section header on the installer page
- ensure the step header sits visually above the card layer so the cards no longer crowd the heading
- swap the setup card order so Single appears before Duo

## Validation
- visual diff only; HTML/CSS change limited to `docs/install/index.html` and `docs/install/install.css`

## Context
- follow-up to the already merged installer PR #20