### PR TITLE
Mirror installer firmware on Pages

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,66 @@
+name: Pages Deploy
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "docs/**"
+      - "scripts/prepare_pages_site.sh"
+      - ".github/workflows/pages-deploy.yml"
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-pages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout site source
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Download latest stable factory binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p .tmp/pages-firmware
+          gh release download \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "*.firmware.factory.bin" \
+            --dir .tmp/pages-firmware \
+            --clobber
+
+      - name: Assemble Pages site
+        run: ./scripts/prepare_pages_site.sh site .tmp/pages-firmware
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy-pages:
+    runs-on: ubuntu-latest
+    needs: build-pages
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ docs/
 ## What Each Document Covers
 
 - `getting-started.md`: hardware prerequisites, baseline runtime, build/flash flow, first validation.
-- `install/`: GitHub Pages first-install flow that generates a profile-specific ESP Web Tools manifest for the latest stable release.
+- `install/`: GitHub Pages first-install flow that generates a profile-specific ESP Web Tools manifest against the stable factory binaries mirrored onto Pages.
 - `system-overview.md`: package architecture, control ownership, data pipeline, safety model.
 - `control-modes-and-flow.md`: CM behavior, Flow Mode semantics, Heating Strategy modes, and precedence.
 - `settings-reference.md`: compile-time vs runtime settings, including low-load and anti-flip controls.

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -1,4 +1,4 @@
-const RELEASE_ROOT = "https://github.com/jeroen85/OpenQuatt/releases/latest/download";
+const FACTORY_ROOT = new URL("../firmware/main/", window.location.href).toString().replace(/\/$/, "");
 
 const PROFILES = {
   duo: {
@@ -70,7 +70,7 @@ function buildManifest(profile) {
         chipFamily: profile.chipFamily,
         parts: [
           {
-            path: `${RELEASE_ROOT}/${profile.fileName}`,
+            path: `${FACTORY_ROOT}/${profile.fileName}`,
             offset: 0,
           },
         ],
@@ -113,7 +113,7 @@ function updateSummary() {
 
   selectionTitle.textContent = profile.title;
   selectionCopy.textContent =
-    "This installer points straight at the latest stable GitHub Release factory image for the selected profile.";
+    "This installer points at the stable factory image mirrored on this site for the selected profile.";
   selectionTopology.textContent = PROFILES[profile.topology].label;
   selectionHardware.textContent = profile.hardwareLabel;
   selectionChip.textContent = profile.chipFamily;

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -40,6 +40,13 @@ Firmware should expose its channel explicitly via `release_channel` so Home Assi
     - override `project_version` to `${base_version}-dev.<run_number>+<shortsha>`
     - move the mutable `dev-latest` tag to the newest `dev` commit
     - publish/update a prerelease that contains binaries + OTA manifests for the dev channel
+- `/.github/workflows/pages-deploy.yml`
+  - Trigger: push to `dev` when docs/install assets change, published stable release, manual dispatch
+  - Actions:
+    - check out the `dev` branch docs as the Pages site source
+    - download the latest stable `*.firmware.factory.bin` assets from GitHub Releases
+    - mirror those first-install binaries into the Pages artifact under `/firmware/main/`
+    - deploy the resulting site via GitHub Pages Actions
 
 ## ESPHome Version Pinning
 
@@ -127,7 +134,8 @@ git push origin main --tags
 ## Notes
 
 - The baseline `openquatt_duo_waveshare.yaml` is secrets-free and suitable for CI builds.
-- First-install UX now lives on the GitHub Pages installer at `https://jeroen85.github.io/OpenQuatt/install/`, which builds ESP Web Tools manifests dynamically in the browser against the latest stable release binaries.
+- First-install UX now lives on the GitHub Pages installer at `https://jeroen85.github.io/OpenQuatt/install/`, which builds ESP Web Tools manifests dynamically in the browser against same-origin stable factory binaries mirrored onto Pages.
 - `openquatt-duo-ota.manifest.json` and `openquatt-single-ota.manifest.json` are intended for OTA update flows.
 - Duo firmware reads `${release_manifest_url}` from `openquatt_base.yaml`, Single firmware reads it from `openquatt_base_single.yaml`.
+- OTA manifests and OTA binaries remain on GitHub Releases; only first-install factory binaries are mirrored onto Pages for Web Serial/CORS compatibility.
 - Workflow files must remain directly under `.github/workflows/` (GitHub does not load workflows from nested subfolders).

--- a/scripts/prepare_pages_site.sh
+++ b/scripts/prepare_pages_site.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <site-dir> <factory-bin-dir>" >&2
+  exit 64
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SITE_DIR="$1"
+FACTORY_DIR="$2"
+
+FACTORY_FILES=(
+  "openquatt-duo-waveshare.firmware.factory.bin"
+  "openquatt-duo-heatpump-listener.firmware.factory.bin"
+  "openquatt-single-waveshare.firmware.factory.bin"
+  "openquatt-single-heatpump-listener.firmware.factory.bin"
+)
+
+rm -rf "${SITE_DIR}"
+mkdir -p "${SITE_DIR}/firmware/main"
+
+cp -R "${ROOT_DIR}/docs/." "${SITE_DIR}/"
+touch "${SITE_DIR}/.nojekyll"
+
+for file in "${FACTORY_FILES[@]}"; do
+  install -m 0644 "${FACTORY_DIR}/${file}" "${SITE_DIR}/firmware/main/${file}"
+done


### PR DESCRIPTION
## Summary
- stop pointing the web installer at GitHub release download URLs that fail CORS from Pages
- add a Pages deployment workflow that mirrors the latest stable factory binaries onto the site under /firmware/main/
- update the installer manifest generation to use same-origin firmware URLs
- document that OTA stays on GitHub Releases while first-install binaries move to Pages

## Testing
- python3 scripts/check_docs_consistency.py --changed-only
- bash -n scripts/prepare_pages_site.sh
- git diff --check
- local dry run of scripts/prepare_pages_site.sh with placeholder factory binaries

## Rollout note
- current Pages config is still legacy build mode with source dev/docs
- switch Pages to GitHub Actions before merging, or immediately after and then manually run the Pages Deploy workflow, so the live installer never points at missing /firmware/main assets

## Not in this PR
- OTA manifest changes
- firmware changes
- release asset naming changes