### PR TITLE
Add Improv Serial provisioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you want custom changes, build from source via [Getting Started](docs/getting
 2. Connect your ESP board over USB.
 3. Select the matching setup and hardware profile.
 4. Start the installation flow and wait for the board to reboot.
+5. Keep the browser tab open after flashing so ESP Web Tools can offer Wi-Fi provisioning over USB.
 
 Firmware file types:
 
@@ -86,7 +87,9 @@ Manual fallback:
 
 ### 3. Configure Wi-Fi after first boot
 
-After flashing, OpenQuatt starts its fallback access point:
+After flashing, prefer the browser-based Wi-Fi setup offered by ESP Web Tools.
+
+If that flow is unavailable or interrupted, OpenQuatt still starts its fallback access point:
 
 - SSID: `OpenQuatt`
 - Password: `openquatt`
@@ -95,8 +98,8 @@ Connect to that access point and complete the captive portal flow to enter your 
 
 Note:
 
-- Wi-Fi provisioning currently happens through the fallback AP and captive portal.
-- The installer page only handles flashing; network setup still happens on the device itself after reboot.
+- The preferred first-install flow is now USB flashing plus browser-based Wi-Fi provisioning through `improv_serial`.
+- The fallback AP and captive portal remain available as the recovery path.
 
 ### 4. Finish setup in Home Assistant
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,6 +131,8 @@ Or run the helper script:
 
 For the stock stable firmware, prefer the
 [OpenQuatt web installer](https://jeroen85.github.io/OpenQuatt/install/).
+That flow now supports browser-based Wi-Fi provisioning after flashing, with the
+OpenQuatt fallback access point still available if provisioning is interrupted.
 
 For local source builds, run:
 

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -48,7 +48,8 @@
           <aside class="hero-notes">
             <p>Use Chrome or Edge on desktop.</p>
             <p>Connect with a USB data cable, not power-only.</p>
-            <p>Wi-Fi is still configured on the device after reboot via the OpenQuatt fallback AP.</p>
+            <p>Keep this page open after flashing so the browser can offer Wi-Fi setup over USB.</p>
+            <p>If that fails, the OpenQuatt fallback access point remains available.</p>
           </aside>
         </div>
       </section>

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -65,6 +65,7 @@ function buildManifest(profile) {
     name: profile.title,
     version: "latest",
     new_install_prompt_erase: true,
+    new_install_improv_wait_time: 30,
     builds: [
       {
         chipFamily: profile.chipFamily,
@@ -120,7 +121,7 @@ function updateSummary() {
   selectionFile.textContent = profile.fileName;
   installPanel.dataset.ready = "true";
   installState.textContent =
-    "Ready to flash. After the install completes, let the board reboot and continue setup on the OpenQuatt access point.";
+    "Ready to flash. Keep this page open after reboot so ESP Web Tools can offer Wi-Fi setup over USB, with the OpenQuatt access point as fallback.";
 }
 
 document.querySelectorAll('input[name="topology"], input[name="hardware"]').forEach((input) => {

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -33,7 +33,7 @@ Each entrypoint includes:
 Shared runtime services are loaded from `openquatt/oq_common.yaml`, including:
 
 - logging, API, and OTA
-- Wi-Fi fallback and captive portal
+- Improv Serial Wi-Fi provisioning plus captive portal fallback
 - HTTP client and Modbus transport
 
 Package include order is intentional:

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -14,7 +14,8 @@
 # ==============================================================================
 logger:
   level: DEBUG
-  baud_rate: 0
+  initial_level: INFO
+  baud_rate: 115200
   runtime_tag_levels: true
 
 api:
@@ -34,6 +35,10 @@ wifi:
     password: "openquatt"
 
 captive_portal:
+
+# Enable ESP Web Tools Wi-Fi provisioning while keeping AP fallback available.
+improv_serial:
+  next_url: "http://{{ip_address}}/"
 
 # ==============================================================================
 # HTTP REQUEST (shared CIC + OTA update)


### PR DESCRIPTION
## Summary
- enable  in the shared runtime so ESP Web Tools can offer Wi-Fi provisioning after flashing
- restore a serial logger for USB provisioning while keeping the fallback AP/captive portal path intact
- update the installer page and docs to describe the browser-first provisioning flow

## Testing
- PlatformIO core dir: /Users/jeroen/Downloads/Codex_projecten/OpenQuatt/.cache/platformio
Parallel compile jobs: 2
[docs] Valideren: docs consistency
Docs consistency checks passed.
[config 1/4] Valideren: openquatt_duo_waveshare.yaml
[ok] openquatt_duo_waveshare.yaml
[config 2/4] Valideren: openquatt_duo_heatpump_listener.yaml
[ok] openquatt_duo_heatpump_listener.yaml
[config 3/4] Valideren: openquatt_single_waveshare.yaml
[ok] openquatt_single_waveshare.yaml
[config 4/4] Valideren: openquatt_single_heatpump_listener.yaml
[ok] openquatt_single_heatpump_listener.yaml
[compile] openquatt_duo_waveshare.yaml -> /Users/jeroen/Downloads/Codex_projecten/OpenQuatt/.tmp/validate_local_logs/openquatt_duo_waveshare.log
[compile] openquatt_duo_heatpump_listener.yaml -> /Users/jeroen/Downloads/Codex_projecten/OpenQuatt/.tmp/validate_local_logs/openquatt_duo_heatpump_listener.log
[compile] openquatt_single_waveshare.yaml -> /Users/jeroen/Downloads/Codex_projecten/OpenQuatt/.tmp/validate_local_logs/openquatt_single_waveshare.log
[compile] openquatt_single_heatpump_listener.yaml -> /Users/jeroen/Downloads/Codex_projecten/OpenQuatt/.tmp/validate_local_logs/openquatt_single_heatpump_listener.log
[ok] openquatt_duo_waveshare.yaml
[ok] openquatt_duo_heatpump_listener.yaml
[ok] openquatt_single_waveshare.yaml
[ok] openquatt_single_heatpump_listener.yaml
Klaar: alle topology/hardware compilaties succesvol.

## Not in this PR
- OTA flow changes
- release workflow changes
- installer layout changes beyond the provisioning copy