### PR TITLE
Deploy Pages from main

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -2,7 +2,7 @@ name: Pages Deploy
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
     paths:
       - "docs/**"
       - "scripts/prepare_pages_site.sh"
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout site source
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: main
 
       - name: Download latest stable factory binaries
         env:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -41,9 +41,9 @@ Firmware should expose its channel explicitly via `release_channel` so Home Assi
     - move the mutable `dev-latest` tag to the newest `dev` commit
     - publish/update a prerelease that contains binaries + OTA manifests for the dev channel
 - `/.github/workflows/pages-deploy.yml`
-  - Trigger: push to `dev` when docs/install assets change, published stable release, manual dispatch
+  - Trigger: push to `main` when docs/install assets change, published stable release, manual dispatch
   - Actions:
-    - check out the `dev` branch docs as the Pages site source
+    - check out the `main` branch docs as the Pages site source
     - download the latest stable `*.firmware.factory.bin` assets from GitHub Releases
     - mirror those first-install binaries into the Pages artifact under `/firmware/main/`
     - deploy the resulting site via GitHub Pages Actions


### PR DESCRIPTION
## Summary
- make the Pages deployment workflow trigger from main instead of dev
- make the Pages build job check out main so stable docs and mirrored factory binaries stay aligned
- update the release docs so they describe the stable Pages source correctly

## Testing
- python3 scripts/check_docs_consistency.py --changed-only
- git diff --check

## Why
- the current workflow on main still points at dev, so stable Pages deployments are sourced from the wrong branch
- a later push to dev could otherwise overwrite the public installer site with integration-branch content