### PR TITLE
Stop dev from deploying Pages

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -2,7 +2,7 @@ name: Pages Deploy
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
     paths:
       - "docs/**"
       - "scripts/prepare_pages_site.sh"
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout site source
         uses: actions/checkout@v4
         with:
-          ref: dev
+          ref: main
 
       - name: Download latest stable factory binaries
         env:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -41,9 +41,9 @@ Firmware should expose its channel explicitly via `release_channel` so Home Assi
     - move the mutable `dev-latest` tag to the newest `dev` commit
     - publish/update a prerelease that contains binaries + OTA manifests for the dev channel
 - `/.github/workflows/pages-deploy.yml`
-  - Trigger: push to `dev` when docs/install assets change, published stable release, manual dispatch
+  - Trigger: push to `main` when docs/install assets change, published stable release, manual dispatch
   - Actions:
-    - check out the `dev` branch docs as the Pages site source
+    - check out the `main` branch docs as the Pages site source
     - download the latest stable `*.firmware.factory.bin` assets from GitHub Releases
     - mirror those first-install binaries into the Pages artifact under `/firmware/main/`
     - deploy the resulting site via GitHub Pages Actions


### PR DESCRIPTION
## Summary
- align the copy of the Pages workflow on dev with the stable branch settings
- make the workflow listen to main and check out main, so pushes to dev do not redeploy the public installer site
- keep the release docs in sync with the stable Pages source branch

## Testing
- python3 scripts/check_docs_consistency.py --changed-only
- git diff --check origin/dev...HEAD

## Why
- GitHub Actions workflows on dev can still run on pushes to dev
- without this guardrail, a future dev push could overwrite the public Pages site even after main is fixed