### PR TITLE
Add HA fallback for CIC thermostat room signals

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1572,8 +1572,16 @@ views:
                 entities:
                   - entity: select.openquatt_room_temperature_source
                     name: Room temperature source
+                  - entity: switch.openquatt_room_cic_auto_failover
+                    name: Room CIC auto failover
+                  - entity: text_sensor.openquatt_room_temperature_effective_source
+                    name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Selected room temperature
+                  - entity: binary_sensor.openquatt_room_cic_failover_active
+                    name: CIC failover active
+                  - entity: text_sensor.openquatt_room_cic_failover_status
+                    name: CIC failover status
                   - entity: sensor.openquatt_cic_ot_room_temperature
                     name: Room temperature (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1652,6 +1660,8 @@ views:
                 entities:
                   - entity: select.openquatt_room_setpoint_source
                     name: Room setpoint source
+                  - entity: text_sensor.openquatt_room_setpoint_effective_source
+                    name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Selected room setpoint
                   - entity: sensor.openquatt_cic_ot_room_setpoint

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1572,16 +1572,10 @@ views:
                 entities:
                   - entity: select.openquatt_room_temperature_source
                     name: Room temperature source
-                  - entity: switch.openquatt_room_cic_auto_failover
-                    name: Room CIC auto failover
-                  - entity: text_sensor.openquatt_room_temperature_effective_source
+                  - entity: sensor.openquatt_room_temperature_effective_source
                     name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Selected room temperature
-                  - entity: binary_sensor.openquatt_room_cic_failover_active
-                    name: CIC failover active
-                  - entity: text_sensor.openquatt_room_cic_failover_status
-                    name: CIC failover status
                   - entity: sensor.openquatt_cic_ot_room_temperature
                     name: Room temperature (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1660,7 +1654,7 @@ views:
                 entities:
                   - entity: select.openquatt_room_setpoint_source
                     name: Room setpoint source
-                  - entity: text_sensor.openquatt_room_setpoint_effective_source
+                  - entity: sensor.openquatt_room_setpoint_effective_source
                     name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Selected room setpoint
@@ -1668,6 +1662,24 @@ views:
                     name: Room setpoint (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: Room setpoint (HA Input)
+          - type: vertical-stack
+            cards:
+              - type: heading
+                icon: mdi:swap-horizontal-bold
+                heading: CIC thermostat fallback
+                heading_style: subtitle
+                grid_options:
+                  columns: 12
+                  rows: 1
+              - type: entities
+                show_header_toggle: false
+                entities:
+                  - entity: switch.openquatt_room_cic_auto_failover
+                    name: CIC thermostat auto failover
+                  - entity: binary_sensor.openquatt_room_cic_failover_active
+                    name: CIC thermostat fallback active
+                  - entity: sensor.openquatt_room_cic_failover_status
+                    name: CIC thermostat fallback status
         column_span: 3
       - type: grid
         cards:

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1640,8 +1640,16 @@ views:
                 entities:
                   - entity: select.openquatt_room_temperature_source
                     name: Ruimtetemperatuur bron
+                  - entity: switch.openquatt_room_cic_auto_failover
+                    name: Kamer CIC auto-failover
+                  - entity: text_sensor.openquatt_room_temperature_effective_source
+                    name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Geselecteerde kamertemperatuur
+                  - entity: binary_sensor.openquatt_room_cic_failover_active
+                    name: CIC failover actief
+                  - entity: text_sensor.openquatt_room_cic_failover_status
+                    name: CIC failover status
                   - entity: sensor.openquatt_cic_ot_room_temperature
                     name: Kamertemperatuur (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1720,6 +1728,8 @@ views:
                 entities:
                   - entity: select.openquatt_room_setpoint_source
                     name: Kamer setpoint bron
+                  - entity: text_sensor.openquatt_room_setpoint_effective_source
+                    name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Geselecteerd kamer setpoint
                   - entity: sensor.openquatt_cic_ot_room_setpoint

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1640,16 +1640,10 @@ views:
                 entities:
                   - entity: select.openquatt_room_temperature_source
                     name: Ruimtetemperatuur bron
-                  - entity: switch.openquatt_room_cic_auto_failover
-                    name: Kamer CIC auto-failover
-                  - entity: text_sensor.openquatt_room_temperature_effective_source
+                  - entity: sensor.openquatt_room_temperature_effective_source
                     name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Geselecteerde kamertemperatuur
-                  - entity: binary_sensor.openquatt_room_cic_failover_active
-                    name: CIC failover actief
-                  - entity: text_sensor.openquatt_room_cic_failover_status
-                    name: CIC failover status
                   - entity: sensor.openquatt_cic_ot_room_temperature
                     name: Kamertemperatuur (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1728,7 +1722,7 @@ views:
                 entities:
                   - entity: select.openquatt_room_setpoint_source
                     name: Kamer setpoint bron
-                  - entity: text_sensor.openquatt_room_setpoint_effective_source
+                  - entity: sensor.openquatt_room_setpoint_effective_source
                     name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Geselecteerd kamer setpoint
@@ -1736,6 +1730,24 @@ views:
                     name: Kamer setpoint (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: Kamer setpoint (HA-invoer)
+          - type: vertical-stack
+            cards:
+              - type: heading
+                icon: mdi:swap-horizontal-bold
+                heading: CIC thermostaat fallback
+                heading_style: subtitle
+                grid_options:
+                  columns: 12
+                  rows: 1
+              - type: entities
+                show_header_toggle: false
+                entities:
+                  - entity: switch.openquatt_room_cic_auto_failover
+                    name: CIC thermostaat auto-failover
+                  - entity: binary_sensor.openquatt_room_cic_failover_active
+                    name: CIC thermostaat fallback actief
+                  - entity: sensor.openquatt_room_cic_failover_status
+                    name: CIC thermostaat fallback status
         column_span: 3
       - type: grid
         cards:

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1326,8 +1326,16 @@ views:
                 entities:
                   - entity: select.openquatt_room_temperature_source
                     name: Room temperature source
+                  - entity: switch.openquatt_room_cic_auto_failover
+                    name: Room CIC auto failover
+                  - entity: text_sensor.openquatt_room_temperature_effective_source
+                    name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Selected room temperature
+                  - entity: binary_sensor.openquatt_room_cic_failover_active
+                    name: CIC failover active
+                  - entity: text_sensor.openquatt_room_cic_failover_status
+                    name: CIC failover status
                   - entity: sensor.openquatt_cic_ot_room_temperature
                     name: Room temperature (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1406,6 +1414,8 @@ views:
                 entities:
                   - entity: select.openquatt_room_setpoint_source
                     name: Room setpoint source
+                  - entity: text_sensor.openquatt_room_setpoint_effective_source
+                    name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Selected room setpoint
                   - entity: sensor.openquatt_cic_ot_room_setpoint

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1326,16 +1326,10 @@ views:
                 entities:
                   - entity: select.openquatt_room_temperature_source
                     name: Room temperature source
-                  - entity: switch.openquatt_room_cic_auto_failover
-                    name: Room CIC auto failover
-                  - entity: text_sensor.openquatt_room_temperature_effective_source
+                  - entity: sensor.openquatt_room_temperature_effective_source
                     name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Selected room temperature
-                  - entity: binary_sensor.openquatt_room_cic_failover_active
-                    name: CIC failover active
-                  - entity: text_sensor.openquatt_room_cic_failover_status
-                    name: CIC failover status
                   - entity: sensor.openquatt_cic_ot_room_temperature
                     name: Room temperature (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1414,7 +1408,7 @@ views:
                 entities:
                   - entity: select.openquatt_room_setpoint_source
                     name: Room setpoint source
-                  - entity: text_sensor.openquatt_room_setpoint_effective_source
+                  - entity: sensor.openquatt_room_setpoint_effective_source
                     name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Selected room setpoint
@@ -1422,6 +1416,24 @@ views:
                     name: Room setpoint (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: Room setpoint (HA Input)
+          - type: vertical-stack
+            cards:
+              - type: heading
+                icon: mdi:swap-horizontal-bold
+                heading: CIC thermostat fallback
+                heading_style: subtitle
+                grid_options:
+                  columns: 12
+                  rows: 1
+              - type: entities
+                show_header_toggle: false
+                entities:
+                  - entity: switch.openquatt_room_cic_auto_failover
+                    name: CIC thermostat auto failover
+                  - entity: binary_sensor.openquatt_room_cic_failover_active
+                    name: CIC thermostat fallback active
+                  - entity: sensor.openquatt_room_cic_failover_status
+                    name: CIC thermostat fallback status
         column_span: 3
       - type: grid
         cards:

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1392,8 +1392,16 @@ views:
                 entities:
                   - entity: select.openquatt_room_temperature_source
                     name: Ruimtetemperatuur bron
+                  - entity: switch.openquatt_room_cic_auto_failover
+                    name: Kamer CIC auto-failover
+                  - entity: text_sensor.openquatt_room_temperature_effective_source
+                    name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Geselecteerde kamertemperatuur
+                  - entity: binary_sensor.openquatt_room_cic_failover_active
+                    name: CIC failover actief
+                  - entity: text_sensor.openquatt_room_cic_failover_status
+                    name: CIC failover status
                   - entity: sensor.openquatt_cic_ot_room_temperature
                     name: Kamertemperatuur (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1472,6 +1480,8 @@ views:
                 entities:
                   - entity: select.openquatt_room_setpoint_source
                     name: Kamer setpoint bron
+                  - entity: text_sensor.openquatt_room_setpoint_effective_source
+                    name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Geselecteerd kamer setpoint
                   - entity: sensor.openquatt_cic_ot_room_setpoint

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1392,16 +1392,10 @@ views:
                 entities:
                   - entity: select.openquatt_room_temperature_source
                     name: Ruimtetemperatuur bron
-                  - entity: switch.openquatt_room_cic_auto_failover
-                    name: Kamer CIC auto-failover
-                  - entity: text_sensor.openquatt_room_temperature_effective_source
+                  - entity: sensor.openquatt_room_temperature_effective_source
                     name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Geselecteerde kamertemperatuur
-                  - entity: binary_sensor.openquatt_room_cic_failover_active
-                    name: CIC failover actief
-                  - entity: text_sensor.openquatt_room_cic_failover_status
-                    name: CIC failover status
                   - entity: sensor.openquatt_cic_ot_room_temperature
                     name: Kamertemperatuur (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1480,7 +1474,7 @@ views:
                 entities:
                   - entity: select.openquatt_room_setpoint_source
                     name: Kamer setpoint bron
-                  - entity: text_sensor.openquatt_room_setpoint_effective_source
+                  - entity: sensor.openquatt_room_setpoint_effective_source
                     name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Geselecteerd kamer setpoint
@@ -1488,6 +1482,24 @@ views:
                     name: Kamer setpoint (CIC OT)
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: Kamer setpoint (HA-invoer)
+          - type: vertical-stack
+            cards:
+              - type: heading
+                icon: mdi:swap-horizontal-bold
+                heading: CIC thermostaat fallback
+                heading_style: subtitle
+                grid_options:
+                  columns: 12
+                  rows: 1
+              - type: entities
+                show_header_toggle: false
+                entities:
+                  - entity: switch.openquatt_room_cic_auto_failover
+                    name: CIC thermostaat auto-failover
+                  - entity: binary_sensor.openquatt_room_cic_failover_active
+                    name: CIC thermostaat fallback actief
+                  - entity: sensor.openquatt_room_cic_failover_status
+                    name: CIC thermostaat fallback status
         column_span: 3
       - type: grid
         cards:

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -96,6 +96,7 @@ Belangrijk: `oq_flow_mismatch_threshold_lph` en `oq_flow_mismatch_hyst_lph` zijn
 - `cic_backoff_max_ms`
 - `cic_stale_after_ms`
 - `cic_feed_error_trip_n`
+- `oq_room_cic_recovery_hold_default_min`
 - `ha_outside_temp_entity_id`
 - `ha_room_setpoint_entity_id`
 - `ha_room_temp_entity_id`
@@ -118,6 +119,14 @@ Deze instellingen gebruik je als eerste als je gedrag wilt begrenzen of verklare
 - `Low-load CM2 re-entry block`
 
 Praktisch bepaal je hiermee hoeveel ruimte OpenQuatt krijgt, wanneer stille uren gelden en hoe snel het systeem naar ketelhulp of terugschakelen beweegt.
+
+### Bronselectie en failover
+
+Belangrijke runtime-instellingen in deze groep zijn:
+
+- `Room Temperature Source`
+- `Room Setpoint Source`
+- `Room CIC Auto Failover`
 
 ### Verwarmingsstrategie
 
@@ -211,6 +220,10 @@ Belangrijke instellingen en signalen:
 - `Outside Temperature Source`
 - `Room Temperature Source`
 - `Room Setpoint Source`
+- `Room Temperature Effective Source`
+- `Room Setpoint Effective Source`
+- `Room CIC Failover Active`
+- `Room CIC Failover Status`
 
 Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteerde bron niet klopt, helpt fijnregelen vrijwel nooit.
 

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -9,8 +9,30 @@
 # Scope:
 #   - Source selectors for water/flow/outside/room inputs
 #   - Merged selected outputs consumed by strategy/control packages
+#   - Optional room-signal failover from CIC to HA input on prolonged CIC outages
 #
 # ==============================================================================
+
+globals:
+  - id: oq_room_source_failover_active
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+  - id: oq_room_source_cic_recover_since_ms
+    type: uint32_t
+    restore_value: no
+    initial_value: '0'
+
+switch:
+  - platform: template
+    name: "Room CIC Auto Failover"
+    id: oq_room_cic_auto_failover
+    icon: mdi:swap-horizontal
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_cic
 
 select:
   - platform: template
@@ -80,6 +102,44 @@ select:
       - CIC
       - HA input
     initial_option: CIC
+    web_server:
+      sorting_group_id: oq_cic
+
+binary_sensor:
+  - platform: template
+    id: oq_room_cic_failover_active_bs
+    name: "Room CIC Failover Active"
+    icon: mdi:swap-horizontal-bold
+    device_class: running
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_cic
+
+text_sensor:
+  - platform: template
+    id: oq_room_temperature_effective_source
+    name: "Room Temperature Effective Source"
+    icon: mdi:source-branch
+    update_interval: never
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_cic
+
+  - platform: template
+    id: oq_room_setpoint_effective_source
+    name: "Room Setpoint Effective Source"
+    icon: mdi:source-branch
+    update_interval: never
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_cic
+
+  - platform: template
+    id: oq_room_cic_failover_status
+    name: "Room CIC Failover Status"
+    icon: mdi:information-outline
+    update_interval: never
+    entity_category: diagnostic
     web_server:
       sorting_group_id: oq_cic
 
@@ -167,7 +227,8 @@ sensor:
     update_interval: 10s
     lambda: |-
       if (!id(room_temp_source).has_state()) return NAN;
-      const auto source = id(room_temp_source).current_option();
+      const bool failover_active = id(oq_room_source_failover_active);
+      const auto source = failover_active ? std::string("HA input") : id(room_temp_source).current_option();
       if (source == "HA input") {
         if (id(thermostat_room_temp_ha).has_state()) return id(thermostat_room_temp_ha).state;
         return NAN;
@@ -191,7 +252,8 @@ sensor:
     update_interval: 10s
     lambda: |-
       if (!id(room_setpoint_source).has_state()) return NAN;
-      const auto source = id(room_setpoint_source).current_option();
+      const bool failover_active = id(oq_room_source_failover_active);
+      const auto source = failover_active ? std::string("HA input") : id(room_setpoint_source).current_option();
       if (source == "HA input") {
         if (id(thermostat_setpoint_ha).has_state()) return id(thermostat_setpoint_ha).state;
         return NAN;
@@ -203,3 +265,95 @@ sensor:
       return NAN;
     web_server:
       sorting_group_id: oq_temperatures
+
+interval:
+  - interval: 5s
+    then:
+      - lambda: |-
+          auto has_valid_float = [](auto *sensor) -> bool {
+            return sensor != nullptr && sensor->has_state() && !isnan(sensor->state);
+          };
+          auto publish_binary_if_changed = [](auto *binary, bool value) {
+            if (binary == nullptr) return;
+            if (binary->state != value) binary->publish_state(value);
+          };
+          auto publish_text_if_changed = [](auto *text, const std::string &value) {
+            if (text == nullptr) return;
+            if (text->state != value) text->publish_state(value);
+          };
+          const bool failover_enabled = id(oq_room_cic_auto_failover).state;
+          const bool room_source_cic = id(room_temp_source).has_state() && id(room_temp_source).current_option() == "CIC";
+          const bool setpoint_source_cic = id(room_setpoint_source).has_state() && id(room_setpoint_source).current_option() == "CIC";
+          const bool sources_allow_failover = room_source_cic && setpoint_source_cic;
+
+          const bool cic_room_valid = has_valid_float(id(ot_room_temp));
+          const bool cic_setpoint_valid = has_valid_float(id(ot_room_setpoint));
+          const bool cic_pair_valid = cic_room_valid && cic_setpoint_valid;
+
+          const bool ha_room_valid = has_valid_float(id(thermostat_room_temp_ha));
+          const bool ha_setpoint_valid = has_valid_float(id(thermostat_setpoint_ha));
+          const bool ha_pair_valid = ha_room_valid && ha_setpoint_valid;
+
+          const bool cic_stale = id(cic_data_stale).state;
+          const uint32_t now_ms = millis();
+          const uint32_t recovery_hold_ms =
+              (uint32_t) lroundf((float) ${oq_room_cic_recovery_hold_default_min} * 60000.0f);
+
+          bool failover_active = id(oq_room_source_failover_active);
+          uint32_t recover_since_ms = id(oq_room_source_cic_recover_since_ms);
+
+          if (!failover_enabled || !sources_allow_failover) {
+            failover_active = false;
+            recover_since_ms = 0;
+          } else if (!failover_active) {
+            recover_since_ms = 0;
+            if (cic_stale && ha_pair_valid) {
+              failover_active = true;
+            }
+          } else {
+            if (!ha_pair_valid) {
+              failover_active = false;
+              recover_since_ms = 0;
+            } else if (cic_stale || !cic_pair_valid) {
+              recover_since_ms = 0;
+            } else if (recovery_hold_ms == 0U) {
+              failover_active = false;
+              recover_since_ms = 0;
+            } else {
+              if (recover_since_ms == 0 || now_ms <= recover_since_ms) {
+                recover_since_ms = now_ms;
+              } else if ((int32_t) (now_ms - recover_since_ms) >= (int32_t) recovery_hold_ms) {
+                failover_active = false;
+                recover_since_ms = 0;
+              }
+            }
+          }
+
+          id(oq_room_source_failover_active) = failover_active;
+          id(oq_room_source_cic_recover_since_ms) = recover_since_ms;
+
+          std::string room_temp_effective = "Unknown";
+          if (failover_active) room_temp_effective = "HA input (failover)";
+          else if (id(room_temp_source).has_state()) room_temp_effective = id(room_temp_source).current_option().c_str();
+
+          std::string room_setpoint_effective = "Unknown";
+          if (failover_active) room_setpoint_effective = "HA input (failover)";
+          else if (id(room_setpoint_source).has_state()) room_setpoint_effective = id(room_setpoint_source).current_option().c_str();
+
+          std::string failover_status = "READY: CIC primary";
+          if (!failover_enabled) {
+            failover_status = "DISABLED";
+          } else if (!sources_allow_failover) {
+            failover_status = "INELIGIBLE: selectors not both CIC";
+          } else if (failover_active) {
+            if (cic_stale) failover_status = "ACTIVE: CIC stale -> HA";
+            else if (!cic_pair_valid) failover_status = "ACTIVE: waiting for CIC pair";
+            else failover_status = "RECOVERING: waiting to return to CIC";
+          } else if (cic_stale && !ha_pair_valid) {
+            failover_status = "BLOCKED: CIC stale, HA pair invalid";
+          }
+
+          publish_binary_if_changed(id(oq_room_cic_failover_active_bs), failover_active);
+          publish_text_if_changed(id(oq_room_temperature_effective_source), room_temp_effective);
+          publish_text_if_changed(id(oq_room_setpoint_effective_source), room_setpoint_effective);
+          publish_text_if_changed(id(oq_room_cic_failover_status), failover_status);

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -14,11 +14,19 @@
 # ==============================================================================
 
 globals:
-  - id: oq_room_source_failover_active
+  - id: oq_room_temp_failover_active
     type: bool
     restore_value: no
     initial_value: 'false'
-  - id: oq_room_source_cic_recover_since_ms
+  - id: oq_room_temp_cic_recover_since_ms
+    type: uint32_t
+    restore_value: no
+    initial_value: '0'
+  - id: oq_room_setpoint_failover_active
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+  - id: oq_room_setpoint_cic_recover_since_ms
     type: uint32_t
     restore_value: no
     initial_value: '0'
@@ -227,7 +235,7 @@ sensor:
     update_interval: 10s
     lambda: |-
       if (!id(room_temp_source).has_state()) return NAN;
-      const bool failover_active = id(oq_room_source_failover_active);
+      const bool failover_active = id(oq_room_temp_failover_active);
       const auto source = failover_active ? std::string("HA input") : id(room_temp_source).current_option();
       if (source == "HA input") {
         if (id(thermostat_room_temp_ha).has_state()) return id(thermostat_room_temp_ha).state;
@@ -252,7 +260,7 @@ sensor:
     update_interval: 10s
     lambda: |-
       if (!id(room_setpoint_source).has_state()) return NAN;
-      const bool failover_active = id(oq_room_source_failover_active);
+      const bool failover_active = id(oq_room_setpoint_failover_active);
       const auto source = failover_active ? std::string("HA input") : id(room_setpoint_source).current_option();
       if (source == "HA input") {
         if (id(thermostat_setpoint_ha).has_state()) return id(thermostat_setpoint_ha).state;
@@ -275,7 +283,7 @@ interval:
           };
           auto publish_binary_if_changed = [](auto *binary, bool value) {
             if (binary == nullptr) return;
-            if (binary->state != value) binary->publish_state(value);
+            if (!binary->has_state() || binary->state != value) binary->publish_state(value);
           };
           auto publish_text_if_changed = [](auto *text, const std::string &value) {
             if (text == nullptr) return;
@@ -284,76 +292,93 @@ interval:
           const bool failover_enabled = id(oq_room_cic_auto_failover).state;
           const bool room_source_cic = id(room_temp_source).has_state() && id(room_temp_source).current_option() == "CIC";
           const bool setpoint_source_cic = id(room_setpoint_source).has_state() && id(room_setpoint_source).current_option() == "CIC";
-          const bool sources_allow_failover = room_source_cic && setpoint_source_cic;
 
           const bool cic_room_valid = has_valid_float(id(ot_room_temp));
           const bool cic_setpoint_valid = has_valid_float(id(ot_room_setpoint));
-          const bool cic_pair_valid = cic_room_valid && cic_setpoint_valid;
 
           const bool ha_room_valid = has_valid_float(id(thermostat_room_temp_ha));
           const bool ha_setpoint_valid = has_valid_float(id(thermostat_setpoint_ha));
-          const bool ha_pair_valid = ha_room_valid && ha_setpoint_valid;
 
           const bool cic_stale = id(cic_data_stale).state;
           const uint32_t now_ms = millis();
           const uint32_t recovery_hold_ms =
               (uint32_t) lroundf((float) ${oq_room_cic_recovery_hold_default_min} * 60000.0f);
-
-          bool failover_active = id(oq_room_source_failover_active);
-          uint32_t recover_since_ms = id(oq_room_source_cic_recover_since_ms);
-
-          if (!failover_enabled || !sources_allow_failover) {
-            failover_active = false;
-            recover_since_ms = 0;
-          } else if (!failover_active) {
-            recover_since_ms = 0;
-            if (cic_stale && ha_pair_valid) {
-              failover_active = true;
+          auto update_failover_state = [&](bool source_cic, bool cic_valid, bool ha_valid, bool &active, uint32_t &recover_since_ms) {
+            if (!failover_enabled || !source_cic) {
+              active = false;
+              recover_since_ms = 0;
+              return;
             }
-          } else {
-            if (!ha_pair_valid) {
-              failover_active = false;
+            if (!active) {
               recover_since_ms = 0;
-            } else if (cic_stale || !cic_pair_valid) {
-              recover_since_ms = 0;
-            } else if (recovery_hold_ms == 0U) {
-              failover_active = false;
-              recover_since_ms = 0;
-            } else {
-              if (recover_since_ms == 0 || now_ms <= recover_since_ms) {
-                recover_since_ms = now_ms;
-              } else if ((int32_t) (now_ms - recover_since_ms) >= (int32_t) recovery_hold_ms) {
-                failover_active = false;
-                recover_since_ms = 0;
-              }
+              if (cic_stale && ha_valid) active = true;
+              return;
             }
-          }
+            if (!ha_valid) {
+              active = false;
+              recover_since_ms = 0;
+              return;
+            }
+            if (cic_stale || !cic_valid) {
+              recover_since_ms = 0;
+              return;
+            }
+            if (recovery_hold_ms == 0U) {
+              active = false;
+              recover_since_ms = 0;
+              return;
+            }
+            if (recover_since_ms == 0 || now_ms <= recover_since_ms) {
+              recover_since_ms = now_ms;
+            } else if ((int32_t) (now_ms - recover_since_ms) >= (int32_t) recovery_hold_ms) {
+              active = false;
+              recover_since_ms = 0;
+            }
+          };
+          auto describe_failover = [&](const char *label, bool source_cic, bool active, bool cic_valid, bool ha_valid) -> std::string {
+            if (!source_cic) return std::string(label) + "=BYPASS";
+            if (active) {
+              if (cic_stale) return std::string(label) + "=ACTIVE";
+              if (!cic_valid) return std::string(label) + "=ACTIVE(wait CIC)";
+              return std::string(label) + "=RECOVERING";
+            }
+            if (cic_stale && !ha_valid) return std::string(label) + "=BLOCKED(no HA)";
+            return std::string(label) + "=READY";
+          };
 
-          id(oq_room_source_failover_active) = failover_active;
-          id(oq_room_source_cic_recover_since_ms) = recover_since_ms;
+          bool room_temp_failover_active = id(oq_room_temp_failover_active);
+          uint32_t room_temp_recover_since_ms = id(oq_room_temp_cic_recover_since_ms);
+          bool room_setpoint_failover_active = id(oq_room_setpoint_failover_active);
+          uint32_t room_setpoint_recover_since_ms = id(oq_room_setpoint_cic_recover_since_ms);
+
+          update_failover_state(room_source_cic, cic_room_valid, ha_room_valid, room_temp_failover_active, room_temp_recover_since_ms);
+          update_failover_state(setpoint_source_cic, cic_setpoint_valid, ha_setpoint_valid, room_setpoint_failover_active, room_setpoint_recover_since_ms);
+
+          id(oq_room_temp_failover_active) = room_temp_failover_active;
+          id(oq_room_temp_cic_recover_since_ms) = room_temp_recover_since_ms;
+          id(oq_room_setpoint_failover_active) = room_setpoint_failover_active;
+          id(oq_room_setpoint_cic_recover_since_ms) = room_setpoint_recover_since_ms;
 
           std::string room_temp_effective = "Unknown";
-          if (failover_active) room_temp_effective = "HA input (failover)";
+          if (room_temp_failover_active) room_temp_effective = "HA input (failover)";
           else if (id(room_temp_source).has_state()) room_temp_effective = id(room_temp_source).current_option().c_str();
 
           std::string room_setpoint_effective = "Unknown";
-          if (failover_active) room_setpoint_effective = "HA input (failover)";
+          if (room_setpoint_failover_active) room_setpoint_effective = "HA input (failover)";
           else if (id(room_setpoint_source).has_state()) room_setpoint_effective = id(room_setpoint_source).current_option().c_str();
 
-          std::string failover_status = "READY: CIC primary";
+          const bool any_failover_active = room_temp_failover_active || room_setpoint_failover_active;
+          std::string failover_status = "TEMP=READY | SP=READY";
           if (!failover_enabled) {
             failover_status = "DISABLED";
-          } else if (!sources_allow_failover) {
-            failover_status = "INELIGIBLE: selectors not both CIC";
-          } else if (failover_active) {
-            if (cic_stale) failover_status = "ACTIVE: CIC stale -> HA";
-            else if (!cic_pair_valid) failover_status = "ACTIVE: waiting for CIC pair";
-            else failover_status = "RECOVERING: waiting to return to CIC";
-          } else if (cic_stale && !ha_pair_valid) {
-            failover_status = "BLOCKED: CIC stale, HA pair invalid";
+          } else {
+            failover_status =
+                describe_failover("TEMP", room_source_cic, room_temp_failover_active, cic_room_valid, ha_room_valid) +
+                " | " +
+                describe_failover("SP", setpoint_source_cic, room_setpoint_failover_active, cic_setpoint_valid, ha_setpoint_valid);
           }
 
-          publish_binary_if_changed(id(oq_room_cic_failover_active_bs), failover_active);
+          publish_binary_if_changed(id(oq_room_cic_failover_active_bs), any_failover_active);
           publish_text_if_changed(id(oq_room_temperature_effective_source), room_temp_effective);
           publish_text_if_changed(id(oq_room_setpoint_effective_source), room_setpoint_effective);
           publish_text_if_changed(id(oq_room_cic_failover_status), failover_status);

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -115,7 +115,7 @@ cic_backoff_start_ms: "5000"                          # Initial polling backoff 
 cic_backoff_max_ms: "120000"                          # Maximum exponential backoff on errors [ms].
 cic_poll_tick_ms: "5000"                              # Scheduler tick for CIC main loop [ms].
 cic_min_url_len: "10"                                 # Minimum URL length before starting a request [chars].
-cic_stale_after_ms: "30000"                           # Data becomes stale after this time without a successful fetch [ms].
+cic_stale_after_ms: "600000"                          # Data becomes stale after this time without a successful fetch [ms].
 cic_feed_error_trip_n: "3"                            # Feed OK becomes false after N consecutive fetch/parse errors.
 oq_room_cic_recovery_hold_default_min: "1"            # Default hold before room failover returns from HA to recovered CIC [min].
 

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -117,6 +117,7 @@ cic_poll_tick_ms: "5000"                              # Scheduler tick for CIC m
 cic_min_url_len: "10"                                 # Minimum URL length before starting a request [chars].
 cic_stale_after_ms: "600000"                          # Data becomes stale after this time without a successful fetch [ms].
 cic_feed_error_trip_n: "3"                            # Feed OK becomes false after N consecutive fetch/parse errors.
+oq_room_cic_recovery_hold_default_min: "1"            # Default hold before room failover returns from HA to recovered CIC [min].
 
 # ----------------------------
 # HA INPUT ENTITY MAPPING

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -115,7 +115,7 @@ cic_backoff_start_ms: "5000"                          # Initial polling backoff 
 cic_backoff_max_ms: "120000"                          # Maximum exponential backoff on errors [ms].
 cic_poll_tick_ms: "5000"                              # Scheduler tick for CIC main loop [ms].
 cic_min_url_len: "10"                                 # Minimum URL length before starting a request [chars].
-cic_stale_after_ms: "180000"                          # Data becomes stale after this time without a successful fetch [ms].
+cic_stale_after_ms: "600000"                          # Data becomes stale after this time without a successful fetch [ms].
 cic_feed_error_trip_n: "3"                            # Feed OK becomes false after N consecutive fetch/parse errors.
 
 # ----------------------------

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -115,7 +115,7 @@ cic_backoff_start_ms: "5000"                          # Initial polling backoff 
 cic_backoff_max_ms: "120000"                          # Maximum exponential backoff on errors [ms].
 cic_poll_tick_ms: "5000"                              # Scheduler tick for CIC main loop [ms].
 cic_min_url_len: "10"                                 # Minimum URL length before starting a request [chars].
-cic_stale_after_ms: "600000"                          # Data becomes stale after this time without a successful fetch [ms].
+cic_stale_after_ms: "30000"                           # Data becomes stale after this time without a successful fetch [ms].
 cic_feed_error_trip_n: "3"                            # Feed OK becomes false after N consecutive fetch/parse errors.
 oq_room_cic_recovery_hold_default_min: "1"            # Default hold before room failover returns from HA to recovered CIC [min].
 


### PR DESCRIPTION
## Summary
- add CIC thermostat fallback for room temperature and room setpoint via HA input
- split room failover per signal, so temperature and setpoint can fail over independently
- add dashboard visibility for effective sources and fallback status, and restore CIC stale timeout to 10 minutes

## Validation
- `esphome config openquatt_single_waveshare.yaml`