### PR TITLE
Release v0.18.0

### DIFF
--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -13,7 +13,7 @@
 device_name: "openquatt"                              # Internal ESPHome device ID / hostname base.
 friendly_name: OpenQuatt                              # Display name in Home Assistant / UI.
 project_name: "openquatt.openquatt"                   # ESPHome project identifier shown in firmware metadata.
-project_version: "v0.17.1"                            # ESPHome project version shown in firmware metadata.
+project_version: "v0.18.0"                            # ESPHome project version shown in firmware metadata.
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 hp_perf_map_header: "openquatt/includes/hp_perf_map.h" # C++ performance-map header include path.
 


### PR DESCRIPTION
## Summary
- bump project version to v0.18.0
- ship the recent HA fallback improvements for CIC thermostat room signals
- include the current CIC stale-timeout tuning on the stable channel

## Validation
- CI on main for the feature merge is green
- CI will run for this release bump PR
