### PR TITLE
Redeploy Pages after successful stable releases

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/pages-deploy.yml"
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Release Build"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -25,6 +28,7 @@ concurrency:
 jobs:
   build-pages:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout site source

--- a/docs/releaseproces.md
+++ b/docs/releaseproces.md
@@ -41,7 +41,7 @@ Firmware should expose its channel explicitly via `release_channel` so Home Assi
     - move the mutable `dev-latest` tag to the newest `dev` commit
     - publish/update a prerelease that contains binaries + OTA manifests for the dev channel
 - `/.github/workflows/pages-deploy.yml`
-  - Trigger: push to `main` when docs/install assets change, published stable release, manual dispatch
+  - Trigger: push to `main` when docs/install assets change, published stable release, successful `Release Build`, manual dispatch
   - Actions:
     - check out the `main` branch docs as the Pages site source
     - download the latest stable `*.firmware.factory.bin` assets from GitHub Releases


### PR DESCRIPTION
## Summary
- trigger Pages Deploy after successful Release Build runs
- keep the release process documentation aligned with the new trigger path

## Why
- the GitHub Pages installer reads mirrored release metadata from Pages
- stable releases created by the release workflow can otherwise leave Pages showing an older version until a later docs push or manual deploy

## Validation
- python3 scripts/check_docs_consistency.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pages-deploy.yml"); puts "YAML ok"'
- manually triggered Pages Deploy on main to refresh the live installer immediately