### PR TITLE
Tune Power House low-load thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ __pycache__/
 tmp/
 .tmp/
 .cache/
+.venv/
 # Lokale referentiedocumenten die bewust niet in GitHub horen
 docs/_local_reference/

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1955,6 +1955,15 @@ views:
 
               - **Ramp up/down** limit rise/fall rate of requested heat.
 
+              - **Low-load dynamic OFF/ON factor** tune when Power House
+              may release or re-arm heat request around low load.
+
+              - **Low-load minimum hysteresis** keeps OFF and ON thresholds
+              sufficiently apart to reduce chattering.
+
+              - **Low-load CM2 re-entry block** delays CM2 re-entry after an
+              idle-exit trip unless demand clearly recovers.
+
               </details>
             text_only: true
           - type: entities
@@ -1988,6 +1997,14 @@ views:
                 name: PH ramp up
               - entity: number.openquatt_power_house_ramp_down
                 name: PH ramp down
+              - entity: number.openquatt_low_load_dynamic_off_factor
+                name: Low-load dynamic OFF factor
+              - entity: number.openquatt_low_load_dynamic_on_factor
+                name: Low-load dynamic ON factor
+              - entity: number.openquatt_low_load_minimum_hysteresis
+                name: Low-load minimum hysteresis
+              - entity: number.openquatt_low_load_cm2_re_entry_block
+                name: Low-load CM2 re-entry block
       - type: grid
         cards:
           - type: heading
@@ -2508,8 +2525,9 @@ views:
 
               - `Comfort bias` shows the adaptive warm-bias governor state.
 
-              - `Low-load dynamic thresholds` shows live `pmin/off/on`
-              thresholds.
+              - `Low-load dynamic thresholds` shows live or cached
+              `pmin/off/on` thresholds and falls back to internal defaults when
+              dynamic input is unavailable.
 
               - `Heat-enable state (shadow)` shows the shadow arbiter state
               (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) for strategy

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2039,6 +2039,16 @@ views:
               - **Ramp up/down** begrenzen stijg-/daalsnelheid van gevraagde
               warmte.
 
+              - **Low-load dynamic OFF/ON factor** bepalen wanneer Power
+              House de warmtevraag rond lage last weer vrijgeeft of opnieuw
+              oppakt.
+
+              - **Low-load minimum hysteresis** houdt OFF en ON voldoende
+              uit elkaar om pendelen te verminderen.
+
+              - **Low-load CM2 re-entry block** vertraagt CM2-herintrede na
+              een idle-exit trip tenzij de vraag duidelijk herstelt.
+
               </details>
             text_only: true
           - type: entities
@@ -2072,6 +2082,14 @@ views:
                 name: PH ramp up
               - entity: number.openquatt_power_house_ramp_down
                 name: PH ramp down
+              - entity: number.openquatt_low_load_dynamic_off_factor
+                name: Low-load dynamic OFF factor
+              - entity: number.openquatt_low_load_dynamic_on_factor
+                name: Low-load dynamic ON factor
+              - entity: number.openquatt_low_load_minimum_hysteresis
+                name: Low-load minimum hysteresis
+              - entity: number.openquatt_low_load_cm2_re_entry_block
+                name: Low-load CM2 re-entry block
       - type: grid
         cards:
           - type: heading
@@ -2605,8 +2623,9 @@ views:
               - `Comfort bias` toont de status van de adaptieve warm-bias
               regelaar.
 
-              - `Low-load dynamic thresholds` toont live de `pmin/off/on`
-              drempels.
+              - `Low-load dynamic thresholds` toont live of cached de
+              `pmin/off/on` drempels en valt anders terug op interne
+              fallbackwaarden.
 
               - `Heat-enable state (shadow)` toont de shadow-arbiterstatus
               (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor strategievalidatie.

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1709,6 +1709,15 @@ views:
 
               - **Ramp up/down** limit rise/fall rate of requested heat.
 
+              - **Low-load dynamic OFF/ON factor** tune when Power House
+              may release or re-arm heat request around low load.
+
+              - **Low-load minimum hysteresis** keeps OFF and ON thresholds
+              sufficiently apart to reduce chattering.
+
+              - **Low-load CM2 re-entry block** delays CM2 re-entry after an
+              idle-exit trip unless demand clearly recovers.
+
               </details>
             text_only: true
           - type: entities
@@ -1742,6 +1751,14 @@ views:
                 name: PH ramp up
               - entity: number.openquatt_power_house_ramp_down
                 name: PH ramp down
+              - entity: number.openquatt_low_load_dynamic_off_factor
+                name: Low-load dynamic OFF factor
+              - entity: number.openquatt_low_load_dynamic_on_factor
+                name: Low-load dynamic ON factor
+              - entity: number.openquatt_low_load_minimum_hysteresis
+                name: Low-load minimum hysteresis
+              - entity: number.openquatt_low_load_cm2_re_entry_block
+                name: Low-load CM2 re-entry block
       - type: grid
         cards:
           - type: heading
@@ -2212,8 +2229,9 @@ views:
 
               - `Comfort bias` shows the adaptive warm-bias governor state.
 
-              - `Low-load dynamic thresholds` shows live `pmin/off/on`
-              thresholds.
+              - `Low-load dynamic thresholds` shows live or cached
+              `pmin/off/on` thresholds and falls back to internal defaults when
+              dynamic input is unavailable.
 
               - `Heat-enable state (shadow)` shows the shadow arbiter state
               (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) for strategy

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1791,6 +1791,16 @@ views:
               - **Ramp up/down** begrenzen stijg-/daalsnelheid van gevraagde
               warmte.
 
+              - **Low-load dynamic OFF/ON factor** bepalen wanneer Power
+              House de warmtevraag rond lage last weer vrijgeeft of opnieuw
+              oppakt.
+
+              - **Low-load minimum hysteresis** houdt OFF en ON voldoende
+              uit elkaar om pendelen te verminderen.
+
+              - **Low-load CM2 re-entry block** vertraagt CM2-herintrede na
+              een idle-exit trip tenzij de vraag duidelijk herstelt.
+
               </details>
             text_only: true
           - type: entities
@@ -1824,6 +1834,14 @@ views:
                 name: PH ramp up
               - entity: number.openquatt_power_house_ramp_down
                 name: PH ramp down
+              - entity: number.openquatt_low_load_dynamic_off_factor
+                name: Low-load dynamic OFF factor
+              - entity: number.openquatt_low_load_dynamic_on_factor
+                name: Low-load dynamic ON factor
+              - entity: number.openquatt_low_load_minimum_hysteresis
+                name: Low-load minimum hysteresis
+              - entity: number.openquatt_low_load_cm2_re_entry_block
+                name: Low-load CM2 re-entry block
       - type: grid
         cards:
           - type: heading
@@ -2307,8 +2325,9 @@ views:
               - `Comfort bias` toont de status van de adaptieve warm-bias
               regelaar.
 
-              - `Low-load dynamic thresholds` toont live de `pmin/off/on`
-              drempels.
+              - `Low-load dynamic thresholds` toont live of cached de
+              `pmin/off/on` drempels en valt anders terug op interne
+              fallbackwaarden.
 
               - `Heat-enable state (shadow)` toont de shadow-arbiterstatus
               (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor strategievalidatie.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,6 +127,13 @@ Or run the helper script:
 ./scripts/validate_local.sh
 ```
 
+On Windows, bootstrap a local venv once and then use the PowerShell helper (the validator automatically mirrors the repo into a no-space workspace when the checkout path contains spaces):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap_esphome_local.ps1
+powershell -ExecutionPolicy Bypass -File .\scripts\validate_local.ps1
+```
+
 ## 6. Flash and Boot
 
 For the stock stable firmware, prefer the

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -114,11 +114,12 @@ Deze instellingen gebruik je als eerste als je gedrag wilt begrenzen of verklare
 - `Silent end time`
 - `CM3 deficit ON threshold`
 - `CM3 deficit OFF threshold`
-- `Low-load OFF fallback`
-- `Low-load ON fallback`
+- `Low-load dynamic OFF factor`
+- `Low-load dynamic ON factor`
+- `Low-load minimum hysteresis`
 - `Low-load CM2 re-entry block`
 
-Praktisch bepaal je hiermee hoeveel ruimte OpenQuatt krijgt, wanneer stille uren gelden en hoe snel het systeem naar ketelhulp of terugschakelen beweegt.
+Praktisch bepaal je hiermee hoeveel ruimte OpenQuatt krijgt, wanneer stille uren gelden en hoe snel het systeem naar ketelhulp of terugschakelen beweegt. De vaste low-load fallbackdrempels zitten intern in substitutions; tijdens runtime tune je vooral de dynamische factoren, hysterese en re-entry block.
 
 ### Bronselectie en failover
 

--- a/docs/onderhoudsgids.md
+++ b/docs/onderhoudsgids.md
@@ -89,4 +89,4 @@ Use a consistent order per package where applicable:
    - `boiler_relay`
    - `hp1_set_working_mode`, `hp2_set_working_mode`
 10. Verify dashboard entity references are still valid.
-11. Run `./scripts/validate_local.sh` for full local gate parity.
+11. Run `./scripts/validate_local.sh` for full local gate parity on bash hosts, or `powershell -ExecutionPolicy Bypass -File .\scripts\validate_local.ps1` on Windows.

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -102,6 +102,8 @@ Handige diagnose-entiteiten:
 - `CM2 re-entry block active`
 - `Heat-enable state (shadow)`
 
+`Low-load dynamic thresholds` toont live of cached `pmin/off/on`; als die dynamische input ontbreekt, valt OpenQuatt terug op interne fallbackdrempels.
+
 ### Water Temperature Control
 
 Bij deze strategie kijkt OpenQuatt vooral naar de gewenste aanvoertemperatuur via een stooklijn.

--- a/docs/releaseproces.md
+++ b/docs/releaseproces.md
@@ -1,7 +1,7 @@
 # Release Process
 
 This project uses GitHub Actions for automated validation, firmware compilation, and release asset publishing.
-Documentation consistency is validated locally via `./scripts/validate_local.sh`.
+Documentation consistency is validated locally via `./scripts/validate_local.sh` on bash hosts or `.\scripts\validate_local.ps1` on Windows.
 
 ## Branch Model
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -171,7 +171,8 @@ Then maps requested power to demand scale `0..20`.
 Power House stability guards in supervisory:
 
 - dynamic low-load thresholds from performance map level-1 thermal power (`pmin/off/on`)
-- fallback low-load OFF/ON thresholds when dynamic input is unavailable
+- last-known-good dynamic thresholds across short telemetry dropouts
+- internal fallback low-load OFF/ON thresholds when dynamic input is unavailable
 - low-load heat-request latch (OFF/ON hysteresis on `P_req`)
 - temporary CM2 re-entry block after CM2 idle-exit trip
 - CM2 startup-grace and high-load guard on idle-exit path

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -13,7 +13,7 @@
 device_name: "openquatt"                              # Internal ESPHome device ID / hostname base.
 friendly_name: OpenQuatt                              # Display name in Home Assistant / UI.
 project_name: "openquatt.openquatt"                   # ESPHome project identifier shown in firmware metadata.
-project_version: "v0.18.0"                            # ESPHome project version shown in firmware metadata.
+project_version: "v0.18.1"                            # ESPHome project version shown in firmware metadata.
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 hp_perf_map_header: "openquatt/includes/hp_perf_map.h" # C++ performance-map header include path.
 

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -41,6 +41,9 @@ oq_cm_min_flow_lph: "250.0"                           # Minimum valid flow for c
 oq_cm_flow_fault_s: "60"                              # Low-flow duration before fault becomes active [s].
 oq_cm_flow_recover_s: "30"                            # Flow recovery duration before fault is cleared [s].
 oq_cm2_idle_exit_s: "90"                              # Exit CM2 if both HPs are idle for this duration while demand remains > 0 [s].
+oq_low_load_fallback_off_w: "900"                     # Internal fallback OFF threshold when no dynamic low-load input is available [W].
+oq_low_load_fallback_on_w: "1300"                     # Internal fallback ON threshold when no dynamic low-load input is available [W].
+oq_low_load_dyn_cache_max_s: "60"                     # Maximum age for reusing last-known-good dynamic low-load thresholds [s].
 oq_cm_frost_on_c: "5.0"                               # Frost protection enable threshold [°C].
 oq_cm_frost_off_c: "6.0"                              # Frost protection disable threshold (hysteresis) [°C].
 oq_cm_frost_nan_grace_s: "30"                         # Startup grace before NaN outside temp triggers frost fail-safe [s].

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -164,6 +164,10 @@ globals:
     type: float
     restore_value: false
     initial_value: 'NAN'
+  - id: oq_low_load_pmin_dyn_lkg_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
   - id: oq_low_load_off_dyn_w
     type: float
     restore_value: false
@@ -172,6 +176,14 @@ globals:
     type: float
     restore_value: false
     initial_value: 'NAN'
+  - id: oq_low_load_dyn_last_valid_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_low_load_dyn_source_state
+    type: int
+    restore_value: false
+    initial_value: '0'  # 0=inactive,1=live,2=cached,3=fallback
   # Shadow heat-enable arbiter state machine (diagnostics only).
   - id: oq_heat_enable_state_shadow
     type: int
@@ -292,31 +304,44 @@ number:
       sorting_group_id: oq_control
 
   - platform: template
-    id: oq_low_load_off_w
-    name: "Low-load OFF fallback"
-    icon: mdi:arrow-collapse-down
-    unit_of_measurement: "W"
-    min_value: 0
-    max_value: 3000
-    step: 25
+    id: oq_low_load_dyn_off_factor
+    name: "Low-load dynamic OFF factor"
+    icon: mdi:percent-outline
+    min_value: 0.60
+    max_value: 0.90
+    step: 0.05
     optimistic: true
     restore_value: true
-    initial_value: 900
+    initial_value: 0.75
     entity_category: config
     web_server:
       sorting_group_id: oq_control
 
   - platform: template
-    id: oq_low_load_on_w
-    name: "Low-load ON fallback"
-    icon: mdi:arrow-expand-up
+    id: oq_low_load_dyn_on_factor
+    name: "Low-load dynamic ON factor"
+    icon: mdi:percent-outline
+    min_value: 0.85
+    max_value: 1.10
+    step: 0.05
+    optimistic: true
+    restore_value: true
+    initial_value: 1.0
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_control
+
+  - platform: template
+    id: oq_low_load_min_hysteresis_w
+    name: "Low-load minimum hysteresis"
+    icon: mdi:arrow-expand-vertical
     unit_of_measurement: "W"
-    min_value: 0
-    max_value: 3000
+    min_value: 100
+    max_value: 400
     step: 25
     optimistic: true
     restore_value: true
-    initial_value: 1300
+    initial_value: 200
     entity_category: config
     web_server:
       sorting_group_id: oq_control
@@ -468,9 +493,14 @@ text_sensor:
       const float pmin = id(oq_low_load_pmin_dyn_w);
       const float off  = id(oq_low_load_off_dyn_w);
       const float on   = id(oq_low_load_on_dyn_w);
-      char b[96];
-      if (isnan(pmin) || isnan(off) || isnan(on)) {
+      const int source_state = id(oq_low_load_dyn_source_state);
+      char b[112];
+      if (source_state == 0) {
+        snprintf(b, sizeof(b), "inactive (Power House only)");
+      } else if (source_state == 3 || isnan(pmin) || isnan(off) || isnan(on)) {
         snprintf(b, sizeof(b), "dynamic: n/a (fallback in use)");
+      } else if (source_state == 2) {
+        snprintf(b, sizeof(b), "pmin=%.0fW off=%.0fW on=%.0fW (cached)", pmin, off, on);
       } else {
         snprintf(b, sizeof(b), "pmin=%.0fW off=%.0fW on=%.0fW", pmin, off, on);
       }
@@ -673,7 +703,7 @@ interval:
           const char* cur_cm_state = id(oq_control_mode).state.c_str();
           const bool in_cm2 = strcmp(cur_cm_state, "CM2") == 0;
           const bool heating_req_raw = (id(oq_demand_filtered) > 0);
-          const bool curve_mode_active = (id(oq_heat_mode_code) == 1);
+          const bool power_house_active = (id(oq_heat_mode_code) == 0);
 
           const int hp1_lvl = id(hp1_last_applied_level);
           #if OQ_TOPOLOGY_DUO
@@ -713,39 +743,70 @@ interval:
           float low_load_off_w = NAN;
           float low_load_on_w = NAN;
           bool reentry_block_active = false;
-          if (!curve_mode_active) {
+          if (power_house_active) {
             // DEBUG-RUNTIME: dynamic low-load thresholds + latch/re-entry diagnostics (Power House).
             // Power House low-load hysteresis on P_req to prevent CM1<->CM2 chattering.
-            // Prefer dynamic thresholds from perf-map level-1 thermal power.
+            // Prefer live dynamic thresholds from perf-map level-1 thermal power,
+            // then last-known-good dynamic values, then internal fallback defaults.
             auto clampf = [](float v, float lo, float hi)->float {
               if (v < lo) return lo;
               if (v > hi) return hi;
               return v;
             };
-            float off_w = id(oq_low_load_off_w).state; // fallback OFF
-            float on_w  = id(oq_low_load_on_w).state;  // fallback ON
+            float off_factor = id(oq_low_load_dyn_off_factor).state;
+            float on_factor = id(oq_low_load_dyn_on_factor).state;
+            float min_hyst_w = id(oq_low_load_min_hysteresis_w).state;
+            if (isnan(off_factor) || off_factor <= 0.0f) off_factor = 0.75f;
+            if (isnan(on_factor)  || on_factor  <= 0.0f) on_factor  = 1.00f;
+            if (isnan(min_hyst_w) || min_hyst_w <= 0.0f) min_hyst_w = 200.0f;
+            off_factor = clampf(off_factor, 0.60f, 0.90f);
+            on_factor = clampf(on_factor, 0.85f, 1.10f);
+            min_hyst_w = clampf(min_hyst_w, 100.0f, 400.0f);
+
+            float off_w = ${oq_low_load_fallback_off_w};
+            float on_w  = ${oq_low_load_fallback_on_w};
             if (isnan(off_w) || off_w < 0.0f) off_w = 900.0f;
             if (isnan(on_w)  || on_w  < 0.0f) on_w  = 1300.0f;
 
             const float Tamb = id(outside_temp_selected).state;
             const float Tsup = id(oq_system_supply_temp).state;
-            float pmin_dyn = NAN;
+            float pmin_dyn_live = NAN;
+            float pmin_dyn_effective = NAN;
+            int dyn_source_state = 3;
             if (!isnan(Tamb) && !isnan(Tsup)) {
-              pmin_dyn = oq_perf::interp_power_th_w(1, Tamb, Tsup);
-              if (isnan(pmin_dyn) || pmin_dyn <= 0.0f) pmin_dyn = NAN;
+              pmin_dyn_live = oq_perf::interp_power_th_w(1, Tamb, Tsup);
+              if (isnan(pmin_dyn_live) || pmin_dyn_live <= 0.0f) pmin_dyn_live = NAN;
             }
-            if (!isnan(pmin_dyn)) {
-              off_w = clampf(0.75f * pmin_dyn, 500.0f, 1600.0f);
-              on_w  = clampf(1.00f * pmin_dyn, 700.0f, 2200.0f);
+            const uint32_t cache_max_ms = (uint32_t)(${oq_low_load_dyn_cache_max_s}UL * 1000UL);
+            if (!isnan(pmin_dyn_live)) {
+              pmin_dyn_effective = pmin_dyn_live;
+              id(oq_low_load_pmin_dyn_lkg_w) = pmin_dyn_live;
+              id(oq_low_load_dyn_last_valid_ms) = now_ms;
+              dyn_source_state = 1;
+            } else {
+              const float pmin_dyn_lkg = id(oq_low_load_pmin_dyn_lkg_w);
+              const uint32_t last_valid_ms = id(oq_low_load_dyn_last_valid_ms);
+              const bool lkg_valid = !isnan(pmin_dyn_lkg) && pmin_dyn_lkg > 0.0f &&
+                  last_valid_ms != 0 &&
+                  ((uint32_t)(now_ms - last_valid_ms) <= cache_max_ms);
+              if (lkg_valid) {
+                pmin_dyn_effective = pmin_dyn_lkg;
+                dyn_source_state = 2;
+              }
             }
-            if (on_w < off_w + 200.0f) on_w = off_w + 200.0f;
+            if (!isnan(pmin_dyn_effective)) {
+              off_w = clampf(off_factor * pmin_dyn_effective, 500.0f, 1600.0f);
+              on_w  = clampf(on_factor  * pmin_dyn_effective, 600.0f, 2200.0f);
+            }
+            if (on_w < off_w + min_hyst_w) on_w = off_w + min_hyst_w;
             if (on_w > 2200.0f) on_w = 2200.0f;
-            if (off_w > on_w - 200.0f) off_w = fmaxf(500.0f, on_w - 200.0f);
+            if (off_w > on_w - min_hyst_w) off_w = fmaxf(500.0f, on_w - min_hyst_w);
             low_load_off_w = off_w;
             low_load_on_w = on_w;
-            id(oq_low_load_pmin_dyn_w) = pmin_dyn;
+            id(oq_low_load_pmin_dyn_w) = pmin_dyn_effective;
             id(oq_low_load_off_dyn_w) = off_w;
             id(oq_low_load_on_dyn_w) = on_w;
+            id(oq_low_load_dyn_source_state) = dyn_source_state;
 
             p_req_w = id(oq_phouse_req_w);
             bool latch = id(oq_lowload_heat_latch);
@@ -766,10 +827,11 @@ interval:
               reentry_block_active = false;
             }
           } else {
-            // Curve mode keeps original heat-request semantics.
+            // Non-Power-House modes keep original heat-request semantics.
             id(oq_lowload_heat_latch) = heating_req_raw;
             id(oq_cm2_reentry_block_until_ms) = 0;
             reentry_block_active = false;
+            id(oq_low_load_dyn_source_state) = 0;
             id(oq_low_load_pmin_dyn_w) = NAN;
             id(oq_low_load_off_dyn_w) = NAN;
             id(oq_low_load_on_dyn_w) = NAN;
@@ -781,7 +843,7 @@ interval:
               in_cm2 && id(oq_cm2_entered_ms) != 0 &&
               ((uint32_t)(now_ms - id(oq_cm2_entered_ms)) < cm2_startup_grace_ms);
           const bool ph_high_load_idle_exit_block =
-              (!curve_mode_active) && !isnan(p_req_w) && !isnan(low_load_off_w) && (p_req_w > low_load_off_w);
+              power_house_active && !isnan(p_req_w) && !isnan(low_load_off_w) && (p_req_w > low_load_off_w);
           // DEBUG-RUNTIME: expose why CM2 idle-exit path is armed/blocked/tripped.
           std::string cm2_idle_exit_reason = "not_in_cm2";
           if (in_cm2) {
@@ -804,7 +866,7 @@ interval:
           } else {
             id(oq_cm2_idle_since_ms) = 0;
           }
-          if (!curve_mode_active) {
+          if (power_house_active) {
             const uint32_t reentry_block_ms = (uint32_t) lroundf(id(oq_low_load_reentry_block_s).state) * 1000UL;
             // Pad A behavior: set block only when CM2 idle-exit trips.
             if (cm2_idle_exit_trip && reentry_block_ms > 0) {
@@ -832,9 +894,9 @@ interval:
             // DEBUG-RUNTIME: shadow state-machine for stepwise migration to a dedicated heat-enable arbiter.
             const bool heat_req_shadow = heating_req;
             const uint32_t min_run_ms = (uint32_t)(${oq_cm2_min_run_s}UL * 1000UL);
-            const uint32_t lockout_ms = curve_mode_active
-                ? 0
-                : (uint32_t) lroundf(id(oq_low_load_reentry_block_s).state) * 1000UL;
+            const uint32_t lockout_ms = power_house_active
+                ? (uint32_t) lroundf(id(oq_low_load_reentry_block_s).state) * 1000UL
+                : 0;
 
             auto shadow_state_to_text = [](int st) -> const char* {
               if (st == 1) return "PREHEAT";

--- a/scripts/bootstrap_esphome_local.ps1
+++ b/scripts/bootstrap_esphome_local.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param(
+    [string]$PythonExe = "",
+    [string]$VenvDir = ".venv"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path -Parent $PSScriptRoot
+$RequirementsFile = Join-Path $RootDir ".github\requirements-esphome.txt"
+
+if (-not $PythonExe) {
+    $PythonExe = Join-Path $env:LOCALAPPDATA "Programs\Python\Python312\python.exe"
+}
+
+if (-not (Test-Path $PythonExe -PathType Leaf)) {
+    throw "Python executable not found: $PythonExe"
+}
+
+$ResolvedVenvDir = if ([System.IO.Path]::IsPathRooted($VenvDir)) {
+    $VenvDir
+} else {
+    Join-Path $RootDir $VenvDir
+}
+
+Write-Host "Using Python: $PythonExe"
+Write-Host "Virtual environment: $ResolvedVenvDir"
+
+& $PythonExe -m venv $ResolvedVenvDir
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to create virtual environment."
+}
+
+$VenvPython = Join-Path $ResolvedVenvDir "Scripts\python.exe"
+$VenvEspHome = Join-Path $ResolvedVenvDir "Scripts\esphome.exe"
+
+& $VenvPython -m pip install --upgrade pip
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to upgrade pip."
+}
+
+& $VenvPython -m pip install -r $RequirementsFile
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to install ESPHome requirements."
+}
+
+& $VenvEspHome version
+if ($LASTEXITCODE -ne 0) {
+    throw "ESPHome installation did not validate correctly."
+}
+
+Write-Host ""
+Write-Host "Local ESPHome environment is ready."
+Write-Host "Bootstrap again: powershell -ExecutionPolicy Bypass -File .\scripts\bootstrap_esphome_local.ps1"
+Write-Host "Validate/compile: powershell -ExecutionPolicy Bypass -File .\scripts\validate_local.ps1"

--- a/scripts/validate_local.ps1
+++ b/scripts/validate_local.ps1
@@ -1,0 +1,202 @@
+[CmdletBinding()]
+param(
+    [string[]]$Configs = @(
+        "openquatt_duo_waveshare.yaml",
+        "openquatt_duo_heatpump_listener.yaml",
+        "openquatt_single_waveshare.yaml",
+        "openquatt_single_heatpump_listener.yaml"
+    ),
+    [switch]$ConfigOnly,
+    [string]$VenvDir = ".venv"
+)
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path -Parent $PSScriptRoot
+$ResolvedVenvDir = if ([System.IO.Path]::IsPathRooted($VenvDir)) {
+    $VenvDir
+} else {
+    Join-Path $RootDir $VenvDir
+}
+
+$PythonExe = Join-Path $ResolvedVenvDir "Scripts\python.exe"
+$EspHomeExe = Join-Path $ResolvedVenvDir "Scripts\esphome.exe"
+$LogDir = Join-Path $RootDir ".tmp\validate_local_logs"
+$CommandRoot = $RootDir
+$PioCoreDir = Join-Path $RootDir ".cache\platformio"
+
+if (-not (Test-Path $PythonExe -PathType Leaf) -or -not (Test-Path $EspHomeExe -PathType Leaf)) {
+    throw "Local ESPHome venv not found. Run .\scripts\bootstrap_esphome_local.ps1 first."
+}
+
+function Quote-Argument {
+    param([string]$Value)
+
+    if ($Value -match '[\s"]') {
+        return '"' + $Value.Replace('"', '\"') + '"'
+    }
+
+    return $Value
+}
+
+function Invoke-LoggedCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Exe,
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [Parameter(Mandatory = $true)]
+        [string]$LogFile,
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+        [Parameter(Mandatory = $true)]
+        [string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)]
+        [string]$PlatformIoCoreDir
+    )
+
+    $oldPioCoreDir = $env:PLATFORMIO_CORE_DIR
+    $env:PLATFORMIO_CORE_DIR = $PlatformIoCoreDir
+    try {
+        $stdoutLog = "$LogFile.stdout"
+        $stderrLog = "$LogFile.stderr"
+
+        foreach ($path in @($LogFile, $stdoutLog, $stderrLog)) {
+            if (Test-Path $path) {
+                Remove-Item $path -Force
+            }
+        }
+
+        $argumentString = (($Arguments | ForEach-Object { Quote-Argument $_ }) -join ' ')
+
+        $process = Start-Process `
+            -FilePath $Exe `
+            -ArgumentList $argumentString `
+            -WorkingDirectory $WorkingDirectory `
+            -RedirectStandardOutput $stdoutLog `
+            -RedirectStandardError $stderrLog `
+            -Wait `
+            -NoNewWindow `
+            -PassThru
+
+        foreach ($path in @($stdoutLog, $stderrLog)) {
+            if (Test-Path $path) {
+                Get-Content $path | Add-Content $LogFile
+            }
+        }
+
+        if ($process.ExitCode -ne 0) {
+            Write-Host "[FAIL] $Label" -ForegroundColor Red
+            Get-Content $LogFile -Tail 80
+            throw "$Label failed. Full log: $LogFile"
+        }
+
+        Write-Host "[ok] $Label" -ForegroundColor Green
+    } finally {
+        $env:PLATFORMIO_CORE_DIR = $oldPioCoreDir
+    }
+}
+
+function Sync-StagedWorkspace {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SourceDir,
+        [Parameter(Mandatory = $true)]
+        [string]$StageDir,
+        [Parameter(Mandatory = $true)]
+        [string]$LogFile
+    )
+
+    New-Item -ItemType Directory -Path $StageDir -Force | Out-Null
+    if (Test-Path $LogFile) {
+        Remove-Item $LogFile -Force
+    }
+
+    $arguments = @(
+        $SourceDir,
+        $StageDir,
+        '/MIR',
+        '/R:1',
+        '/W:1',
+        '/XD', '.git', '.venv', '.cache', '.tmp', 'build', '.esphome', '__pycache__',
+        '/XF', '*.pyc', '*.pyo',
+        "/LOG:$LogFile"
+    )
+    $argumentString = (($arguments | ForEach-Object { Quote-Argument $_ }) -join ' ')
+
+    $process = Start-Process `
+        -FilePath 'robocopy.exe' `
+        -ArgumentList $argumentString `
+        -WorkingDirectory $SourceDir `
+        -Wait `
+        -NoNewWindow `
+        -PassThru
+
+    if ($process.ExitCode -gt 7) {
+        Write-Host "[FAIL] workspace sync" -ForegroundColor Red
+        Get-Content $LogFile -Tail 80
+        throw "workspace sync failed. Full log: $LogFile"
+    }
+
+    Write-Host "[ok] workspace sync" -ForegroundColor Green
+}
+
+New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+
+if ($RootDir -match '\s') {
+    $StageBaseDir = Join-Path $env:LOCALAPPDATA 'OpenQuattBuild'
+    $CommandRoot = Join-Path $StageBaseDir 'workspace'
+    $PioCoreDir = Join-Path $StageBaseDir 'platformio'
+
+    Write-Host "Workspace path contains spaces; mirroring into $CommandRoot" -ForegroundColor Yellow
+    Sync-StagedWorkspace `
+        -SourceDir $RootDir `
+        -StageDir $CommandRoot `
+        -LogFile (Join-Path $LogDir 'workspace-sync.log')
+}
+
+$CommandScriptsDir = Join-Path $CommandRoot 'scripts'
+New-Item -ItemType Directory -Path $PioCoreDir -Force | Out-Null
+
+Write-Host "Workspace root: $RootDir"
+if ($CommandRoot -ne $RootDir) {
+    Write-Host "Command root: $CommandRoot"
+}
+Write-Host "PlatformIO core dir: $PioCoreDir"
+Write-Host "Log dir: $LogDir"
+
+$DocsLog = Join-Path $LogDir 'docs-consistency.log'
+Invoke-LoggedCommand `
+    -Exe $PythonExe `
+    -Arguments @((Join-Path $CommandScriptsDir 'check_docs_consistency.py')) `
+    -LogFile $DocsLog `
+    -Label 'docs consistency' `
+    -WorkingDirectory $CommandRoot `
+    -PlatformIoCoreDir $PioCoreDir
+
+foreach ($config in $Configs) {
+    $stem = [System.IO.Path]::GetFileNameWithoutExtension($config)
+    Invoke-LoggedCommand `
+        -Exe $EspHomeExe `
+        -Arguments @('config', $config) `
+        -LogFile (Join-Path $LogDir "$stem.config.log") `
+        -Label "config $config" `
+        -WorkingDirectory $CommandRoot `
+        -PlatformIoCoreDir $PioCoreDir
+}
+
+if (-not $ConfigOnly) {
+    foreach ($config in $Configs) {
+        $stem = [System.IO.Path]::GetFileNameWithoutExtension($config)
+        Invoke-LoggedCommand `
+            -Exe $EspHomeExe `
+            -Arguments @('compile', $config) `
+            -LogFile (Join-Path $LogDir "$stem.compile.log") `
+            -Label "compile $config" `
+            -WorkingDirectory $CommandRoot `
+            -PlatformIoCoreDir $PioCoreDir
+    }
+}
+
+Write-Host ""
+Write-Host "Validation complete."


### PR DESCRIPTION
## Summary
- tune the Power House low-load thresholds in the supervisory control logic
- update dashboards and docs to match the new low-load behavior
- add Windows PowerShell scripts for local ESPHome bootstrap and validation
- bump the project version to v0.18.1

## Included changes
- Tune Power House low-load thresholds
- Add Windows local ESPHome validation scripts
- Bump dev version to v0.18.1

## Validation
- local branches were synced to the latest remote refs before cutting this PR
- release PR CI will validate all four profiles
