### PR TITLE
Configurable max water temperature limiter

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2066,6 +2066,43 @@ views:
       - type: grid
         cards:
           - type: heading
+            icon: mdi:water-thermometer
+            heading: Water temperature limit
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Uses `Water Supply Temp (Selected)` as the measured limit source.
+
+              - **Maximum water temperature** is the normal ceiling for measured
+              supply temperature.
+
+              - **Soft band** starts the rollback below that ceiling. Power House
+              reduces effective requested heat most strongly between `max - band`
+              and `max`.
+
+              - **Trip** is the absolute upper limit. In `CM3` the boiler drops
+              out first; a hard HP stop follows only if the overshoot persists.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_maximum_water_temperature
+                name: Maximum water temperature
+              - entity: number.openquatt_water_temperature_soft_band
+                name: Water temperature soft band
+              - entity: number.openquatt_maximum_water_temperature_trip
+                name: Maximum water temperature trip
+      - type: grid
+        cards:
+          - type: heading
             icon: mdi:heat-wave
             heading: Heat allocation
             heading_style: title
@@ -2168,6 +2205,9 @@ views:
 
               - **CM3 deficit ON/OFF thresholds** define when boiler assist may
               switch on/off.
+
+              - Boiler assist is still blocked by the water temperature limit
+              when measured supply temperature gets too high.
 
               - Keep ON clearly higher than OFF to reduce toggling around the
               threshold.

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2152,6 +2152,44 @@ views:
       - type: grid
         cards:
           - type: heading
+            icon: mdi:water-thermometer
+            heading: Watertempbegrenzing
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Gebruikt `Water Supply Temp (Selected)` als gemeten begrenzingsbron.
+
+              - **Maximum water temperature** is het normale plafond voor de
+              gemeten aanvoertemperatuur.
+
+              - **Soft band** laat de regeling daaronder al terugnemen. In
+              `Power House` gebeurt de sterkste afbouw tussen `max - band` en
+              `max`.
+
+              - **Trip** is de absolute bovengrens. In `CM3` valt eerst de
+              boiler weg; alleen bij aanhoudende overshoot volgt daarna een
+              harde HP-stop.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_maximum_water_temperature
+                name: Maximum water temperature
+              - entity: number.openquatt_water_temperature_soft_band
+                name: Water temperature soft band
+              - entity: number.openquatt_maximum_water_temperature_trip
+                name: Maximum water temperature trip
+      - type: grid
+        cards:
+          - type: heading
             icon: mdi:heat-wave
             heading: Heat allocation
             heading_style: title
@@ -2256,6 +2294,9 @@ views:
 
               - **CM3 deficit ON/OFF thresholds** bepalen wanneer boiler-assist
               mag inschakelen/uitschakelen.
+
+              - Boiler-assist wordt daarnaast geblokkeerd door de
+              watertempbegrenzing als de gemeten aanvoer te hoog wordt.
 
               - Houd ON duidelijk hoger dan OFF om schakelen rond de grens te
               beperken.

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1820,6 +1820,43 @@ views:
       - type: grid
         cards:
           - type: heading
+            icon: mdi:water-thermometer
+            heading: Water temperature limit
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Uses `Water Supply Temp (Selected)` as the measured limit source.
+
+              - **Maximum water temperature** is the normal ceiling for measured
+              supply temperature.
+
+              - **Soft band** starts the rollback below that ceiling. Power House
+              reduces effective requested heat most strongly between `max - band`
+              and `max`.
+
+              - **Trip** is the absolute upper limit. In `CM3` the boiler drops
+              out first; a hard HP stop follows only if the overshoot persists.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_maximum_water_temperature
+                name: Maximum water temperature
+              - entity: number.openquatt_water_temperature_soft_band
+                name: Water temperature soft band
+              - entity: number.openquatt_maximum_water_temperature_trip
+                name: Maximum water temperature trip
+      - type: grid
+        cards:
+          - type: heading
             icon: mdi:heat-wave
             heading: Heat allocation
             heading_style: title
@@ -1901,6 +1938,9 @@ views:
 
               - **CM3 deficit ON/OFF thresholds** define when boiler assist may
               switch on/off.
+
+              - Boiler assist is still blocked by the water temperature limit
+              when measured supply temperature gets too high.
 
               - Keep ON clearly higher than OFF to reduce toggling around the
               threshold.

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1904,6 +1904,44 @@ views:
       - type: grid
         cards:
           - type: heading
+            icon: mdi:water-thermometer
+            heading: Watertempbegrenzing
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Gebruikt `Water Supply Temp (Selected)` als gemeten begrenzingsbron.
+
+              - **Maximum water temperature** is het normale plafond voor de
+              gemeten aanvoertemperatuur.
+
+              - **Soft band** laat de regeling daaronder al terugnemen. In
+              `Power House` gebeurt de sterkste afbouw tussen `max - band` en
+              `max`.
+
+              - **Trip** is de absolute bovengrens. In `CM3` valt eerst de
+              boiler weg; alleen bij aanhoudende overshoot volgt daarna een
+              harde HP-stop.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_maximum_water_temperature
+                name: Maximum water temperature
+              - entity: number.openquatt_water_temperature_soft_band
+                name: Water temperature soft band
+              - entity: number.openquatt_maximum_water_temperature_trip
+                name: Maximum water temperature trip
+      - type: grid
+        cards:
+          - type: heading
             icon: mdi:heat-wave
             heading: Heat allocation
             heading_style: title
@@ -1988,6 +2026,9 @@ views:
 
               - **CM3 deficit ON/OFF thresholds** bepalen wanneer boiler-assist
               mag inschakelen/uitschakelen.
+
+              - Boiler-assist wordt daarnaast geblokkeerd door de
+              watertempbegrenzing als de gemeten aanvoer te hoog wordt.
 
               - Houd ON duidelijk hoger dan OFF om schakelen rond de grens te
               beperken.

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -81,6 +81,14 @@ Deze strategie kijkt vooral naar de warmtevraag van de woning. Dat past vaak bij
 
 Deze strategie kijkt vooral naar de gewenste watertemperatuur. Dat sluit beter aan bij gebruikers die liever werken met een stooklijn of een aanvoertemperatuurdoel.
 
+### Watertempbegrenzing
+
+Welke strategie je ook gebruikt, OpenQuatt kijkt daarnaast naar `Water Supply Temp (Selected)`. Daarmee kan het systeem:
+
+- in stooklijnmodus de gevraagde aanvoertemperatuur begrenzen;
+- in `Power House` de warmtevraag geleidelijk terugnemen als de aanvoer te hoog wordt;
+- in `CM3` de boiler blokkeren als de aanvoer op de ingestelde bovengrens komt.
+
 Je hoeft daarvoor niet eerst de interne berekening te kennen. Relevanter is welke strategie in jouw installatie het meest stabiele en voorspelbare gedrag geeft.
 
 ## Single en Duo

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -87,10 +87,9 @@ Niet elke instelling is even relevant. In de praktijk bepalen vooral deze groepe
 
 Belangrijk: `oq_flow_mismatch_threshold_lph` en `oq_flow_mismatch_hyst_lph` zijn compile-time constanten. Daarvoor is dus opnieuw compileren en flashen nodig.
 
-### Ketel en veiligheid
+### Ketel en hulpcircuit
 
-- `oq_boiler_trip_c`
-- `oq_boiler_reset_c`
+- `oq_boiler_loop_s`
 
 ### Externe bronnen
 
@@ -150,6 +149,9 @@ Belangrijke runtime-instellingen in deze groep zijn:
 - `Power House room error avg tau`
 - `Power House ramp up`
 - `Power House ramp down`
+- `Maximum water temperature`
+- `Water temperature soft band`
+- `Maximum water temperature trip`
 - `Curve Tsupply @ -20/-10/0/5/10/15°C`
 - `Heating Curve Control Profile`
 - `Heating Curve PID Kp/Ki/Kd`
@@ -159,6 +161,8 @@ Samengevat:
 
 - `Power House` is meer huis- en kamervraaggericht;
 - `Water Temperature Control` is meer stooklijn- en aanvoertemperatuurgericht.
+
+De watertempbegrenzing werkt op `water_supply_temp_selected`. In `Water Temperature Control` wordt `Heating Curve Supply Target` begrensd op `Maximum water temperature`. In `Power House` wordt `P_req` progressief teruggenomen, met de sterkste afbouw tussen `max - soft band` en `max`. In `CM3` wordt de boiler vanaf `Maximum water temperature` geblokkeerd.
 
 Verander niet meerdere instellingen uit deze groep tegelijk.
 
@@ -256,6 +260,7 @@ Gebruik deze groep vooral voor onderhoud en diagnose, niet voor dagelijks gebrui
 - `Demand raw`
 - `Demand filtered`
 - `Heating Curve Supply Target`
+- `Water Supply Temp (Selected)`
 - `Power House effective room target`
 - `Power House comfort bias`
 - `Power House room error avg`

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -116,6 +116,23 @@ Belangrijke eigenschappen:
 
 Deze strategie past vaak beter bij gebruikers die hun installatie benaderen vanuit aanvoertemperatuur of stooklijn.
 
+### Watertempbegrenzing
+
+OpenQuatt heeft daarnaast een gedeelde begrenzing op basis van `water_supply_temp_selected`.
+
+Belangrijke eigenschappen:
+
+- `Maximum water temperature` is het normale bovendoel voor de gemeten aanvoer;
+- `Water temperature soft band` bepaalt vanaf hoeveel graden daaronder OpenQuatt al terughoudend wordt;
+- `Maximum water temperature trip` is de absolute bovengrens.
+
+Praktisch betekent dit:
+
+- in `Water Temperature Control` wordt `Heating Curve Supply Target` geclampt op `Maximum water temperature`;
+- in `Power House` wordt de effectieve warmtevraag progressief verlaagd, met de sterkste afbouw tussen `max - soft band` en `max`;
+- in `CM3` wordt de boiler vanaf `Maximum water temperature` geblokkeerd;
+- bij `Maximum water temperature trip` kan een harde stop volgen zonder dat OpenQuatt de `Control Mode` zelf herschrijft.
+
 ## Flow Mode
 
 `Flow Mode` bepaalt hoe de pompregeling werkt.

--- a/docs/releaseproces.md
+++ b/docs/releaseproces.md
@@ -5,10 +5,10 @@ Style and documentation consistency are validated locally via `./scripts/validat
 
 ## Branch Model
 
-- `main`: stable branch for tagged releases and the default OTA/update channel.
+- `main`: stable branch for tagged releases and the default OTA/update channel. Small docs/ops fixes may be committed directly to `main` when appropriate.
 - `dev`: integration branch for testers. Validate it like `main`, but do not cut stable tags from it.
 - feature branches: short-lived branches merged into `dev`; promote `dev` into `main` only after validation/soak.
-- after each stable release, reset `dev` back to the released `main` commit before starting the next development cycle. Then apply the next dev-version bump as a new commit on top.
+- if `main` and `dev` diverge after a release (for example because of a direct `main` fix or a non-fast-forward promotion), realign `dev` with the released `main` commit before starting the next development cycle. Then apply the next dev-version bump as a new commit on top.
 
 Firmware should expose its channel explicitly via `release_channel` so Home Assistant and the ESPHome web UI show whether a device is running `main` or `dev`.
 
@@ -110,10 +110,20 @@ The repository now backs that URL with `/.github/workflows/dev-build.yml`, which
 
 1. Update `project_version` in `openquatt/oq_substitutions_common.yaml` on `dev`.
 2. Push `dev` and wait for `CI` and `Dev Build` to go green.
-3. Open a release PR from `dev` to `main` with a curated summary of the release.
-4. Merge that PR into `main` using the repository-approved merge method.
-5. Wait for `CI` on `main` to go green.
-6. Create and push a tag from the merged `main` commit:
+3. Promote the validated `dev` commit to `main`. Recommended path: fast-forward `main` to `origin/dev`:
+
+```bash
+git fetch origin
+git checkout main
+git reset --hard origin/main
+git merge --ff-only origin/dev
+git push origin main
+```
+
+You may still use a release PR when you want a reviewed release summary on GitHub, but the ruleset no longer requires that path.
+
+4. Wait for `CI` on `main` to go green.
+5. Create and push a tag from the merged `main` commit:
 
 ```bash
 git fetch origin
@@ -121,10 +131,10 @@ git tag v0.13.0 origin/main
 git push origin v0.13.0
 ```
 
-7. Check GitHub Actions:
+6. Check GitHub Actions:
    - CI should be green.
    - Release workflow should publish artifacts.
-8. Verify GitHub Release contains:
+7. Verify GitHub Release contains:
    - `openquatt-duo-ota.manifest.json`
    - `openquatt-single-ota.manifest.json`
    - `openquatt-duo-waveshare.firmware.ota.bin`
@@ -135,7 +145,7 @@ git push origin v0.13.0
    - `openquatt-single-waveshare.firmware.factory.bin`
    - `openquatt-single-heatpump-listener.firmware.ota.bin`
    - `openquatt-single-heatpump-listener.firmware.factory.bin`
-9. Immediately realign `dev` with the released `main` commit, then bump to the next development version:
+8. If `main` and `dev` no longer point to the same release content, realign `dev` with the released `main` commit before bumping to the next development version:
 
 ```bash
 git fetch origin
@@ -146,7 +156,7 @@ git push --force-with-lease origin dev
 # then bump to the next dev version, commit, and push
 ```
 
-This reset is intentional. `main` is merged via squash, while `dev` must stay linear and must not accumulate merge commits. Resetting `dev` to `origin/main` avoids misleading `ahead/behind` counters where the trees match but the commit graph does not.
+If you used the recommended fast-forward promotion and did not add extra `main`-only commits afterwards, `dev` and `main` already align and you can skip this reset.
 
 ## Notes
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -80,10 +80,10 @@ This prevents hidden control coupling and keeps debugging deterministic.
 | Subsystem | Interval | Purpose |
 |---|---:|---|
 | Supervisory | `${oq_supervisory_loop_s}` (default 5s) | Mode decisions, flow interlock, frost logic, power-cap safety net |
-| Heating Strategy | `${oq_strategy_loop_s}` (default 5s) | Demand generation (Power House / heating-curve path) |
+| Heating Strategy | `${oq_strategy_loop_s}` (default 5s) | Demand generation plus shared water-temperature limiting (Power House / heating-curve path) |
 | Heat allocation | Tick `${oq_heat_loop_tick_s}` (default 5s), effective cadence `${oq_heat_loop_curve_s}` (Curve) / `${oq_heat_loop_powerhouse_s}` (Power House) | Demand filtering, allocation, optimizer, level apply (per-minute tuning is elapsed-time scaled) |
 | Flow control | `${oq_flow_loop_s}` (default 5s) | Pump iPWM control (AUTO/MANUAL/FROST/autotune override) |
-| Boiler control | `${oq_boiler_loop_s}` (default 5s) | CM3 gating and temperature lockout |
+| Boiler control | `${oq_boiler_loop_s}` (default 5s) | CM3 gating under the shared water-temperature guardrail |
 | CIC polling tick | `${cic_poll_tick_ms}` (default 5s) | Poll scheduler, stale detection, feed invalidation |
 
 ## 4. Data Pipeline
@@ -177,6 +177,7 @@ Power House stability guards in supervisory:
 - temporary CM2 re-entry block after CM2 idle-exit trip
 - CM2 startup-grace and high-load guard on idle-exit path
 - shadow heat-enable arbiter diagnostics (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`)
+- shared water-temperature limiter on effective `P_req` using `water_supply_temp_selected`
 
 ### Water Temperature Control mode
 
@@ -194,6 +195,7 @@ Heating-curve stability guards around zero-demand edge:
 - start/stop gating with OFF-confirmation and low-PID requirement
 - near-target `COAST` phase (low modulation instead of immediate drop to `0`)
 - room-temperature coupling trims supply target when room drifts warm
+- target clamp at `Maximum water temperature`
 - explicit per-HP slew-rate limiting with slower up and faster down behavior
 - single-HP-first allocation with dual-enable hysteresis and sequential HP step changes
 
@@ -246,7 +248,7 @@ Safety is distributed but coordinated:
 
 - flow safety and CM gating in supervisory
 - compressor-zero enforcement outside CM2/CM3 in heat control
-- boiler trip/reset hysteresis in boiler control
+- shared water-temperature limiter/trip across heating strategy, heat control, and boiler control
 - stale feed invalidation in CIC ingest
 - conservative fallback on invalid numeric inputs
 

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -11,36 +11,28 @@
 # What this package DOES do:
 #   - Switch boiler relay via configured output pin (`oq_boiler_relay_pin`)
 #   - Enables boiler at CM3; disables in all other CMs
-#   - Apply max-temperature protection on `water_supply_temp_selected` (hard limit)
+#   - Follow the shared water-temperature guardrail state from `oq_heating_strategy`
 #   - Publish optional diagnostics (for example boiler status / optionally derived power)
 #
 # What this package DOES NOT do:
 #   - Does not determine Control Mode (supervisory does)
 #   - Does not control heat pumps or flow
-#   - Does not regulate temperature setpoints (only absolute max-temp protection)
+#   - Does not regulate temperature setpoints
 #
 # Key assumptions:
 #   - Boiler is hydraulically in series after HP2; `water_supply_temp_selected` is available for max-temp protection
 #   - Boiler has its own electrical feed; net-power limiter does not apply to boiler
 #
 # Interaction with Control Modes:
-#   - CM3 -> boiler ON (unless max-temp trip is active)
+#   - CM3 -> boiler ON (unless the shared water-temperature guardrail blocks it)
 #   - CM0/CM1/CM2/CM98 → boiler OFF
 #
 # Safety / fail-safe:
-#   - Hard max-temp trip at 60°C with hysteresis (exact values defined in code)
+#   - Boiler is blocked from the configured maximum water temperature onwards
+#   - An absolute shared hard trip also forces boiler OFF
 #   - In CM1 (flow-holding), boiler is always off (via CM gating)
 #
 # ==============================================================================
-
-# ----------------------------
-# INTERNAL STATE
-# ----------------------------
-globals:
-  - id: boiler_max_temp_trip
-    type: bool
-    restore_value: false
-    initial_value: 'false'
 
 # ----------------------------
 # OUTPUTS
@@ -115,20 +107,16 @@ interval:
   - interval: ${oq_boiler_loop_s}s
     then:
       - lambda: |-
-          // Boiler follows Control Mode CM3 with max-temperature safety.
-          // OFF outside CM3.
+          // Boiler follows Control Mode CM3, but the shared water-temperature model
+          // may block it independently from CM ownership.
           const bool in_cm3 = (id(oq_control_mode_code) == 3);
-
-          // Max-temp safety (trip/reset with hysteresis)
           const float supply_c = id(water_supply_temp_selected).state;
-          if (!isnan(supply_c)) {
-            if (!id(boiler_max_temp_trip) && supply_c >= ${oq_boiler_trip_c}) id(boiler_max_temp_trip) = true;
-            if (id(boiler_max_temp_trip) && supply_c <= ${oq_boiler_reset_c}) id(boiler_max_temp_trip) = false;
-          }
-
-          // Fail-safe: never allow boiler without a valid supply temperature.
           const bool has_valid_supply_temp = !isnan(supply_c);
-          const bool boiler_allowed = in_cm3 && !id(boiler_max_temp_trip) && has_valid_supply_temp;
+          const bool boiler_allowed =
+              in_cm3 &&
+              has_valid_supply_temp &&
+              !id(oq_water_temp_boiler_inhibit_active) &&
+              !id(oq_water_temp_hard_trip_active);
 
           if (boiler_allowed) {
             if (!id(boiler_relay).state) id(boiler_relay).turn_on();

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -1319,11 +1319,26 @@ interval:
           }
 
           // =========================
-          // 5) Minimum runtime (all strategies)
+          // 5) Absolute water-temperature hard trip
+          // Shared with boiler-control and heating-strategy. This safety stop has
+          // higher priority than compressor minimum runtime.
+          // =========================
+          if (id(oq_water_temp_hard_trip_active)) {
+            hp1_req = 0;
+            #if OQ_TOPOLOGY_DUO
+            hp2_req = 0;
+            #else
+            hp2_req = 0;
+            #endif
+          }
+
+          // =========================
+          // 6) Minimum runtime (all strategies)
           // Prevents very short compressor runs in both curve and Power House modes.
+          // Skipped during an absolute water-temperature hard trip.
           // =========================
           const int min_rt = (int) roundf(id(oq_min_runtime_min).state);
-          if (min_rt > 0) {
+          if (!id(oq_water_temp_hard_trip_active) && min_rt > 0) {
             // HP1: if request is 0 but runtime < min -> force >=1
             const uint32_t min_rt_ms = (uint32_t) min_rt * 60000UL;
             const uint32_t hp1_rt_ms = (uint32_t)(now_ms - id(hp1_last_start_ms));
@@ -1342,7 +1357,7 @@ interval:
           }
 
           // =========================
-          // 6) Working mode gate + apply compressor
+          // 7) Working mode gate + apply compressor
           // =========================
           auto set_mode = [&](bool is_hp1, bool heating) {
             const char* opt = heating ? "Heating" : "Standby";

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -10,10 +10,12 @@
 #   1) Power House
 #      - Computes a requested thermal power (`P_req`) from the house model, room temperature,
 #        adaptive comfort bias, comfort band, deadband, and ramp limits
+#      - Applies a shared water-temperature limiter on the effective requested heat
 #      - Converts that requested thermal power to compatible demand 0..20 (`oq_demand_raw`)
 #
 #   2) Heating Curve
 #      - 6-point heating curve (Tout -> Tsupply_target) with linear interpolation
+#      - Clamps the effective supply target with the same shared water-temperature limit
 #      - PI control on abstracted system supply temperature (PV = oq_system_supply_temp) to Tsupply_target
 #      - PI output is directly translated to demand 0..20
 #
@@ -134,6 +136,30 @@ globals:
     type: float
     restore_value: false
     initial_value: '0.0'
+
+  # Shared water-temperature guardrail state.
+  # One model drives curve-target clamping, Power House limiting, boiler inhibit,
+  # and the absolute hard trip seen by heat-control.
+  - id: oq_water_temp_limit_factor
+    type: float
+    restore_value: false
+    initial_value: '1.0'
+  - id: oq_water_temp_boiler_inhibit_active
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+  - id: oq_water_temp_trip_active
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+  - id: oq_water_temp_trip_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_water_temp_hard_trip_active
+    type: bool
+    restore_value: false
+    initial_value: 'false'
   # DEBUG-RUNTIME END
 
 # ----------------------------
@@ -401,6 +427,51 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 2421.504843770334
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: max_water_temp_limit_c
+    name: "Maximum water temperature"
+    icon: mdi:thermometer-high
+    unit_of_measurement: "°C"
+    min_value: 25
+    max_value: 75
+    step: 0.5
+    restore_value: true
+    optimistic: true
+    initial_value: 60
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: water_temp_soft_band_c
+    name: "Water temperature soft band"
+    icon: mdi:arrow-expand-vertical
+    unit_of_measurement: "°C"
+    min_value: 0.5
+    max_value: 10
+    step: 0.5
+    restore_value: true
+    optimistic: true
+    initial_value: 3
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_tuning_heat
+
+  - platform: template
+    id: max_water_temp_trip_c
+    name: "Maximum water temperature trip"
+    icon: mdi:alarm-light-outline
+    unit_of_measurement: "°C"
+    min_value: 30
+    max_value: 85
+    step: 0.5
+    restore_value: true
+    optimistic: true
+    initial_value: 65
     entity_category: config
     web_server:
       sorting_group_id: oq_tuning_heat
@@ -1029,6 +1100,13 @@ sensor:
       if (!isnan(target_c) && quant_step_c > 0.0f) {
         target_c = roundf(target_c / quant_step_c) * quant_step_c;
       }
+
+      // Curve mode limits the requested target itself; measured-temperature trip handling
+      // is applied elsewhere via the shared water-temperature guardrail state.
+      const float max_water_temp_c = id(max_water_temp_limit_c).state;
+      if (!isnan(target_c) && !isnan(max_water_temp_c)) {
+        target_c = fminf(target_c, max_water_temp_c);
+      }
       return target_c;
 
   # Diagnostics
@@ -1173,6 +1251,7 @@ interval:
           id(oq_heat_mode_code) = heat_mode_code;
           const int demand_max = (int) ${oq_strategy_demand_max_f};
           constexpr float seconds_per_minute = 60.0f;
+          const uint32_t now_ms = (uint32_t) millis();
 
           // Helper: clamp
           auto clampf = [&](float v, float lo, float hi)->float {
@@ -1185,6 +1264,97 @@ interval:
             if (demand > demand_max) return demand_max;
             return demand;
           };
+
+          // Shared water-temperature guardrail.
+          // - `water_supply_temp_selected` is the authoritative supply reading for this feature.
+          // - Power House applies a piecewise limiter on effective requested heat.
+          // - Heating Curve clamps its target and relies on the same absolute trip for hard stops.
+          // - This logic never rewrites CM; supervisory remains the only owner of Control Mode.
+          const float supply_c = id(water_supply_temp_selected).state;
+          float max_water_temp_c = id(max_water_temp_limit_c).state;
+          if (isnan(max_water_temp_c)) max_water_temp_c = 60.0f;
+          max_water_temp_c = clampf(max_water_temp_c, 25.0f, 75.0f);
+
+          float soft_band_c = id(water_temp_soft_band_c).state;
+          if (isnan(soft_band_c)) soft_band_c = 3.0f;
+          soft_band_c = clampf(soft_band_c, 0.5f, 10.0f);
+
+          float trip_water_temp_c = id(max_water_temp_trip_c).state;
+          if (isnan(trip_water_temp_c)) trip_water_temp_c = 65.0f;
+          trip_water_temp_c = clampf(trip_water_temp_c, max_water_temp_c + 1.0f, 85.0f);
+
+          const float soft_start_c = max_water_temp_c - soft_band_c;
+          constexpr float water_temp_factor_at_max = 0.25f;
+          constexpr uint32_t cm3_trip_hold_ms = 30000UL;
+
+          bool boiler_inhibit_active = id(oq_water_temp_boiler_inhibit_active);
+          bool trip_active = id(oq_water_temp_trip_active);
+          bool hard_trip_active = id(oq_water_temp_hard_trip_active);
+          uint32_t trip_since_ms = id(oq_water_temp_trip_since_ms);
+          float water_temp_limit_factor = id(oq_water_temp_limit_factor);
+          if (isnan(water_temp_limit_factor)) water_temp_limit_factor = 1.0f;
+
+          if (!isnan(supply_c)) {
+            // Boiler inhibit uses max / reset-at-soft-start hysteresis so CM3 does not chatter
+            // around the configured maximum water temperature.
+            if (!boiler_inhibit_active && supply_c >= max_water_temp_c) boiler_inhibit_active = true;
+            if (boiler_inhibit_active && supply_c <= soft_start_c) boiler_inhibit_active = false;
+
+            // Absolute trip is separate from boiler inhibit. It latches until the measured
+            // supply temperature is back at or below the configured max temperature.
+            if (!trip_active && supply_c >= trip_water_temp_c) trip_active = true;
+            if (trip_active && supply_c <= max_water_temp_c) trip_active = false;
+
+            // Piecewise soft limiter for Power House:
+            // - between soft-start and max: aggressively roll back effective heat demand
+            // - between max and trip: taper residual demand to zero without an immediate trip
+            if (supply_c <= soft_start_c) {
+              water_temp_limit_factor = 1.0f;
+            } else if (supply_c < max_water_temp_c && soft_band_c > 0.0f) {
+              const float segment = clampf((supply_c - soft_start_c) / soft_band_c, 0.0f, 1.0f);
+              water_temp_limit_factor = 1.0f + (water_temp_factor_at_max - 1.0f) * segment;
+            } else if (supply_c < trip_water_temp_c) {
+              const float span_c = trip_water_temp_c - max_water_temp_c;
+              const float segment =
+                  (span_c > 0.0f) ? clampf((supply_c - max_water_temp_c) / span_c, 0.0f, 1.0f) : 1.0f;
+              water_temp_limit_factor = water_temp_factor_at_max * (1.0f - segment);
+            } else {
+              water_temp_limit_factor = 0.0f;
+            }
+
+            // In CM3 we first drop the boiler and only escalate to a hard HP stop when the
+            // supply temperature actually keeps sitting at/above the absolute trip threshold.
+            if (hard_trip_active) {
+              if (supply_c <= max_water_temp_c) {
+                hard_trip_active = false;
+                trip_since_ms = 0;
+              }
+            } else if (supply_c >= trip_water_temp_c) {
+              if (id(oq_control_mode_code) == 3) {
+                if (trip_since_ms == 0) trip_since_ms = now_ms;
+                const uint32_t trip_elapsed_ms =
+                    (now_ms >= trip_since_ms) ? (now_ms - trip_since_ms) : 0UL;
+                hard_trip_active = trip_elapsed_ms >= cm3_trip_hold_ms;
+              } else {
+                trip_since_ms = now_ms;
+                hard_trip_active = true;
+              }
+            } else {
+              trip_since_ms = 0;
+            }
+          } else {
+            // Missing selected supply input must not create a new soft limiter, but any already
+            // armed absolute trip remains active until a valid measurement clears it.
+            water_temp_limit_factor = (trip_active || hard_trip_active) ? 0.0f : 1.0f;
+          }
+
+          if (hard_trip_active) water_temp_limit_factor = 0.0f;
+
+          id(oq_water_temp_limit_factor) = clampf(water_temp_limit_factor, 0.0f, 1.0f);
+          id(oq_water_temp_boiler_inhibit_active) = boiler_inhibit_active;
+          id(oq_water_temp_trip_active) = trip_active;
+          id(oq_water_temp_trip_since_ms) = trip_since_ms;
+          id(oq_water_temp_hard_trip_active) = hard_trip_active;
 
           if (heat_mode_code == 1) {
             // ------------------------------------------------------------
@@ -1218,7 +1388,8 @@ interval:
               }
             }
 
-            const int d_out = clamp_demand(id(oq_demand_curve));
+            int d_out = clamp_demand(id(oq_demand_curve));
+            if (id(oq_water_temp_hard_trip_active)) d_out = 0;
             id(oq_demand_raw) = d_out;
 
             // Power request (W) is also maintained in this mode (for deficit/CM3):
@@ -1275,7 +1446,6 @@ interval:
             const float P_house = Pr * x;
 
             // DEBUG-RUNTIME: adaptive comfort-bias governor for warm-leaning behavior.
-            const uint32_t now_ms = (uint32_t) millis();
             const float bias_base_cfg = clampf(id(ph_comfort_bias_base_c).state, 0.0f, 0.5f);
             const float bias_max_cfg = clampf(id(ph_comfort_bias_max_c).state, bias_base_cfg, 0.5f);
             const float bias_up_cfg_per_s = clampf(id(ph_comfort_bias_up_c_per_h).state, 0.0f, 0.5f) / 3600.0f;
@@ -1358,12 +1528,16 @@ interval:
               }
             }
 
-            id(oq_phouse_req_w) = P_limited;
-            id(oq_phouse_last_w) = P_limited;
+            // The water-temperature limiter acts on effective requested heat, not on `P_house`.
+            // This preserves the raw house model for interpretation and troubleshooting.
+            const float P_effective = P_limited * id(oq_water_temp_limit_factor);
+
+            id(oq_phouse_req_w) = P_effective;
+            id(oq_phouse_last_w) = P_effective;
             id(oq_phouse_last_ms) = now_ms;
 
             // Backward-compatible demand 0..20 for the existing heat-control path.
-            int d = (int) lroundf(${oq_strategy_demand_max_f} * (P_limited / Pr));
+            int d = (int) lroundf(${oq_strategy_demand_max_f} * (P_effective / Pr));
             id(oq_demand_raw) = clamp_demand(d);
 
             // In Power House mode, curve demand is diagnostic-only and stays at 0.
@@ -1374,8 +1548,10 @@ interval:
             lambda: |-
               // Anti-windup:
               // - if SP/PV drops out in heating-curve mode, reset integral term
+              // - an absolute water-temperature hard trip forces heat output to zero
               // - while compressors are not yet delivering heat, keep integral empty
               if (id(oq_heat_mode_code) != 1) return false;
+              if (id(oq_water_temp_hard_trip_active)) return true;
               const float spw = id(oq_supply_target_temp).state;
               const float pv  = id(oq_system_supply_temp).state;
               if (isnan(spw) || isnan(pv)) return true;

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -13,7 +13,7 @@
 device_name: "openquatt"                              # Internal ESPHome device ID / hostname base.
 friendly_name: OpenQuatt                              # Display name in Home Assistant / UI.
 project_name: "openquatt.openquatt"                   # ESPHome project identifier shown in firmware metadata.
-project_version: "v0.18.2"                            # ESPHome project version shown in firmware metadata.
+project_version: "v0.19.0"                            # ESPHome project version shown in firmware metadata.
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 hp_perf_map_header: "openquatt/includes/hp_perf_map.h" # C++ performance-map header include path.
 

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -107,8 +107,6 @@ oq_flow_autotune_lambda_min_s: "10.0"                 # Minimum IMC lambda for c
 # BOILER CONTROL
 # ----------------------------
 oq_boiler_loop_s: "5"                                 # Main interval for boiler gating/safety loop [s].
-oq_boiler_trip_c: "60.0"                              # Supply-water trip threshold for boiler lockout [°C].
-oq_boiler_reset_c: "58.0"                             # Reset threshold (hysteresis) for boiler lockout [°C].
 oq_boiler_cp_j_per_kgk: "4186.0"                      # Specific heat capacity of water [J/(kg*K)].
 
 # ----------------------------


### PR DESCRIPTION
## Summary
- add a configurable max water temperature limiter to the heating strategy and boiler-control path
- expose the new limiter in the HA dashboards and explain it in the docs
- keep the release procedure docs aligned with the current `main` ruleset and promotion flow
- bump the next stable release to `v0.19.0`

## Included commits
- `Add configurable max water temperature limiter`
- `Align release docs with main ruleset`
- `Bump project version to v0.19.0`
