### PR TITLE
Power House duo: adjust single vs duo behaviour

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2174,17 +2174,26 @@ views:
               allocation is single-HP-first with dual-enable hysteresis and
               sequential level steps.
 
+              - In Power House mode, OpenQuatt first keeps only combinations
+              that follow the requested heat closely enough and then picks the
+              lowest-power combination. It only switches when that gives a clear
+              benefit, with a short hold to reduce back-and-forth switching.
+
               - **Dual HP enable level (lvl)** defines at which sustained
-              single-HP compressor level a second HP may be enabled.
+              single-HP compressor level a second HP may be enabled in
+              heating-curve mode.
 
               - Disable level is derived internally as `enable - 1` to keep tuning
               compact.
 
-              - **Enable/disable hold** adds time hysteresis to damp frequent toggling.
+              - **Enable/disable hold** adds time hysteresis to damp frequent
+              toggling in heating-curve mode.
 
-              - Lower enable level or shorter enable-hold = faster second-HP activation.
+              - Lower enable level or shorter enable-hold = faster second-HP
+              activation in heating-curve mode.
 
-              - Longer disable-hold = dual-HP stays active longer.
+              - Longer disable-hold = dual-HP stays active longer in
+              heating-curve mode.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2283,18 +2283,26 @@ views:
               allocatie is single-HP-first met dual-enable hysterese en
               sequentiële levelstappen.
 
+              - In Power House mode kiest OpenQuatt eerst combinaties die de
+              warmtevraag goed genoeg volgen en daarna de zuinigste combinatie.
+              Wisselen gebeurt alleen als dat echt voordeel geeft, met een
+              korte houdtijd tegen op en neer schakelen.
+
               - **Dual HP enable level (lvl)** bepaalt bij welk aanhoudend
-              single-HP compressorlevel een tweede HP mag worden geactiveerd.
+              single-HP compressorlevel een tweede HP mag worden geactiveerd in
+              heating-curve mode.
 
               - Disable-level wordt intern afgeleid als `enable - 1` om het
               aantal instellingen beperkt te houden.
 
               - **Enable/disable hold** voegt tijdhysterese toe om op en neer
-              schakelen te dempen.
+              schakelen te dempen in heating-curve mode.
 
-              - Lager enable-level of kortere enable-hold = sneller 2 HP actief.
+              - Lager enable-level of kortere enable-hold = sneller 2 HP actief
+              in heating-curve mode.
 
-              - Hogere disable-hold = langer dual-HP actief.
+              - Hogere disable-hold = langer dual-HP actief in heating-curve
+              mode.
 
 
               </details>

--- a/docs/diagnose-en-afstelling.md
+++ b/docs/diagnose-en-afstelling.md
@@ -72,6 +72,8 @@ Veilige eerste acties:
 
 Bij `Duo` is het meestal wenselijk dat niet meteen beide units hard starten, maar dat het systeem rustig opbouwt.
 
+In `Power House` hoeft dat niet te betekenen dat 1 warmtepomp altijd voorrang krijgt. Daar probeert OpenQuatt juist de zuinigste geldige combinatie te kiezen, en wisselt het alleen als dat echt voordeel geeft.
+
 ### Het huis wordt niet warm genoeg
 
 Controleer in deze volgorde:
@@ -85,6 +87,8 @@ Controleer in deze volgorde:
 Pas als deze basis klopt, heeft het zin om verwarmingsinstellingen te wijzigen.
 
 Bij `Power House` kun je daarna eventueel kijken naar `Power House response profile` of een kortere `Power House demand rise time`, maar doe dat pas als bronwaarden en comfortinstellingen al logisch zijn.
+
+Bij `Duo` geldt daarbij: kijk niet alleen of er 1 of 2 warmtepompen actief zijn, maar vooral of de warmtevraag netjes gevolgd wordt zonder onrustig wisselen.
 
 ### Het wordt te warm of het systeem blijft te lang doorgaan
 

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -101,6 +101,13 @@ Het doel bij `Duo` is niet om direct beide units maximaal te laten werken. Rusti
 - de tweede unit alleen laten bijspringen als dat echt nodig is;
 - onnodig aan-uitgedrag beperken.
 
+Hoe dat precies gebeurt, hangt af van de gekozen verwarmingsstrategie:
+
+- in `Water Temperature Control` werkt OpenQuatt in de basis single-HP-first; de tweede warmtepomp mag pas meedoen als de vraag hoog genoeg blijft;
+- in `Power House` rekent OpenQuatt meerdere geldige combinaties door en kiest daarna de combinatie die de warmtevraag goed genoeg volgt met het laagste elektrische verbruik.
+
+Bij `Power House` betekent dat dus niet automatisch "eerst 1 warmtepomp" of "liever altijd 2 warmtepompen". Soms is 1 warmtepomp zuiniger, soms 2 op lagere levels. OpenQuatt wisselt alleen als dat echt voordeel geeft en houdt een single-/duokeuze kort vast om onrust te beperken.
+
 ## Stabiliteit en pendelgedrag
 
 Snel schakelen rond de kamertemperatuur wordt vaak omschreven als "flipperen" of pendelen. OpenQuatt probeert dat te beperken door:

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -187,6 +187,13 @@ Deze groep bepaalt vooral:
 - hoe lang units blijven lopen;
 - wanneer een tweede unit bij een Duo-opstelling mag meedoen.
 
+Belangrijk onderscheid:
+
+- `Dual HP Enable Level`, `Dual HP Enable Hold` en `Dual HP Disable Hold` horen bij de verdeling in `Water Temperature Control`;
+- in `Power House` wordt de Duo-keuze juist automatisch bepaald op basis van geldige combinaties, warmtematch en elektrisch verbruik.
+
+Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf de zuinigste geldige combinatie kiest en die kort vasthoudt om op en neer schakelen te beperken.
+
 ### Flow en pompregeling
 
 Belangrijke instellingen:

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -104,6 +104,18 @@ Handige diagnose-entiteiten:
 
 `Low-load dynamic thresholds` toont live of cached `pmin/off/on`; als die dynamische input ontbreekt, valt OpenQuatt terug op interne fallbackdrempels.
 
+#### Duo-keuze in Power House
+
+In een `Duo`-opstelling gebruikt `Power House` geen vaste regel als "altijd eerst 1 warmtepomp" of "liever altijd 2". De keuze gaat in eenvoudige stappen:
+
+1. kijk welke levelcombinaties toegestaan en geldig zijn;
+2. houd alleen combinaties over die de gevraagde warmte goed genoeg volgen;
+3. kies daarbinnen de combinatie met het laagste elektrische verbruik;
+4. wissel alleen als dat echt voordeel geeft;
+5. houd een single-/duokeuze kort vast om op en neer schakelen te beperken.
+
+Als twee single-HP-keuzes verder gelijk zijn, krijgt de runtime lead warmtepomp voorrang. Tijdens defrost blijft OpenQuatt voorzichtiger en wordt het beschikbare thermische vermogen van de defrostende unit lager ingeschat.
+
 ### Water Temperature Control
 
 Bij deze strategie kijkt OpenQuatt vooral naar de gewenste aanvoertemperatuur via een stooklijn.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -197,7 +197,7 @@ Heating-curve stability guards around zero-demand edge:
 - room-temperature coupling trims supply target when room drifts warm
 - target clamp at `Maximum water temperature`
 - explicit per-HP slew-rate limiting with slower up and faster down behavior
-- single-HP-first allocation with dual-enable hysteresis and sequential HP step changes
+- in heating-curve mode: single-HP-first allocation with dual-enable hysteresis and sequential HP step changes
 
 ## 6. Allocation and Optimization Mechanics
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -216,14 +216,14 @@ Demand filter behavior is asymmetric:
 - downward path follows demand immediately
 - upward path is rate-limited by runtime control `Demand filter ramp up` (step/min, Power House path)
 
-Power House optimizer cost considers:
+Power House duo dispatch works in simple steps:
 
-- thermal tracking error
-- change penalty (anti-chatter)
-- low-load two-HP penalty
-- HP1/HP2 level balance penalty
-- electrical soft/peak guard
-- defrost derating and optional compensation boost
+- keep only combinations that follow the requested heat closely enough
+- within that group, choose the lowest electrical input
+- keep the current combination unless a switch gives clear heat or power benefit
+- hold a single-vs-dual choice briefly to reduce back-and-forth switching
+- if two single-HP options are equally good, choose the runtime lead HP
+- defrost still uses thermal derating and optional compensation boost
 
 ## 7. Flow Control Mechanics
 

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -12,7 +12,7 @@
 #   - Consumes oq_demand_raw (producer in oq_heating_strategy)
 #   - Applies demand filtering to damp noise/jitter in heat demand
 #   - Applies caps/limits on `f` before split
-#   - Distributes `f` over HP1/HP2 (heating curve: single-HP-first with dual-enable hysteresis, power-house: W-based optimizer)
+#   - Distributes `f` over HP1/HP2 (heating curve: single-HP-first with dual-enable hysteresis, Power House: heat-good-enough + lowest-power duo dispatch)
 #   - Computes shared HP capacity/deficit (`oq_P_hp_cap_w`, `oq_P_deficit_w`) for supervisory CM3 logic
 #   - Sets compressor levels via `select` entities
 #
@@ -143,6 +143,12 @@ globals:
     restore_value: false
     initial_value: '0'
   - id: hp2_last_level_change_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  # Holds the current single-vs-dual choice briefly after an actual topology change.
+  - id: oq_duo_dispatch_hold_until_ms
     type: uint32_t
     restore_value: false
     initial_value: '0'
@@ -449,6 +455,24 @@ text_sensor:
     web_server:
       sorting_group_id: oq_diagnostics
 
+  # DEBUG-RUNTIME START: Duo Power House dispatch reason
+  - platform: template
+    id: oq_duo_optimizer_reason
+    name: "Duo optimizer reason"
+    icon: mdi:swap-horizontal
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: never
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      #if OQ_TOPOLOGY_DUO
+      return std::string("inactive");
+      #else
+      return std::string("single_topology");
+      #endif
+  # DEBUG-RUNTIME END
+
 # ----------------------------
 # MAIN LOOP
 # ----------------------------
@@ -461,7 +485,7 @@ interval:
 # - CM-gating (only CM2/CM3)
 # - strategy pad:
 #   heating curve => single-HP/split
-#   power-house => optimizer on thermal/electrical power
+#   power-house => duo dispatch on good-enough heat match, lowest electrical input, then anti-flip guards
 # - shared capacity/deficit publication
 # - allowed-level mapping + min-runtime + apply + runtime bookkeeping
 # ----------------------------
@@ -596,6 +620,20 @@ interval:
             }
           };
 
+          // DEBUG-RUNTIME: hidden text sensor that explains why the duo optimizer kept or changed dispatch.
+          auto publish_optimizer_reason = [&](const char* reason)->void {
+            #if OQ_TOPOLOGY_DUO
+            static std::string last_optimizer_reason = "";
+            const std::string s(reason);
+            if (s != last_optimizer_reason) {
+              id(oq_duo_optimizer_reason).publish_state(s.c_str());
+              last_optimizer_reason = s;
+            }
+            #else
+            (void) reason;
+            #endif
+          };
+
           auto force_standby = [&](bool is_hp1)->void {
             const char* opt = "Standby";
             if (is_hp1) {
@@ -643,6 +681,7 @@ interval:
             id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
             id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
             id(oq_curve_single_owner_hp) = owner;
+            id(oq_duo_dispatch_hold_until_ms) = 0;
           };
 
           if (!cm_allows_hp) {
@@ -657,6 +696,7 @@ interval:
             sync_forced_stop_state(false);
             #endif
             reset_dual_runtime_state(0);
+            publish_optimizer_reason("inactive");
             publish_debug(0, 0, 0, 0);
             return;
           }
@@ -782,6 +822,8 @@ interval:
 
           #if OQ_TOPOLOGY_DUO
           if (!is_power_house) {
+            id(oq_duo_dispatch_hold_until_ms) = 0;
+            publish_optimizer_reason("curve_mode");
             // ------------------------------------------------------------
             // HEATING CURVE MODE (demand path from heating-curve strategy)
             // ------------------------------------------------------------
@@ -960,6 +1002,7 @@ interval:
 
             const bool perf_inputs_valid = !isnan(Tamb) && !isnan(Tsup) && level_cap > 0;
             if (!perf_inputs_valid) {
+              id(oq_duo_dispatch_hold_until_ms) = 0;
               // Fallback path when perf-map inputs are invalid: keep delivering demand using simple split.
               int dual_on_f = (int) roundf(id(oq_dual_hp_enable_level).state);
               if (dual_on_f < 2) dual_on_f = 2;
@@ -1011,7 +1054,11 @@ interval:
                 }
               }
             } else {
-              // Optimize levels to match min(P_req_total, cap_total)
+              // Power House duo dispatch:
+              // 1) keep only combinations that follow requested heat closely enough
+              // 2) within that group, pick the lowest electrical input
+              // 3) only switch if it clearly improves heat match or power use
+              // 4) hold single-vs-dual briefly to prevent pendelen
               float P_target = P_req_total;
               if (isnan(P_target)) P_target = 0.0f;
               if (P_target > cap_total) P_target = cap_total;
@@ -1019,96 +1066,158 @@ interval:
 
               const int last1 = id(hp1_last_applied_level);
               const int last2 = id(${hc_secondary_last_applied_level_id});
-
-              float best_cost = 1e12f;
-              int best_l1 = 0;
-              int best_l2 = 0;
-
-              // Penalties
-              const float W_change_penalty_per_step = 50.0f;   // bias to reduce chattering
-              const float W_twohp_penalty = ${oq_optimizer_twohp_penalty};
-              const float W_balance_penalty_per_step = ${oq_optimizer_balance_penalty_per_step};
-              // 16A guard (electrical power) integrated via COP map
-              // - Candidates above peak are excluded
-              // - Candidates above soft get extra penalty to avoid overshoot.
               const float P_EL_SOFT_W = ${oq_optimizer_soft_w};
               const float P_EL_PEAK_W = ${oq_power_peak_w};
-              const float W_el_over_soft_penalty_per_W = ${oq_optimizer_penalty_per_w};
+              const float thermal_tie_band_w = fmaxf(150.0f, 0.05f * fmaxf(P_target, 1000.0f));
+              const float thermal_keep_margin_w = fminf(90.0f, thermal_tie_band_w * 0.5f);
+              const float pel_switch_margin_w = 120.0f;
+              const float soft_switch_margin_w = 40.0f;
+              struct DuoCandidate {
+                bool valid;
+                int l1;
+                int l2;
+                float p_th_w;
+                float p_el_w;
+                float err_w;
+                float over_soft_w;
+                int level_moves;
+                int active_hp_count;
+                int balance_steps;
+                bool single_on_lead;
+              };
 
-              for (int l1=0; l1<=level_cap; l1++) {
-                // allowed / availability
+              auto build_duo_candidate = [&](int l1, int l2)->DuoCandidate {
+                DuoCandidate c{};
+                c.valid = false;
+                c.l1 = l1;
+                c.l2 = l2;
+
                 if (l1 > 0) {
-                  if (!hp1_available) continue;
-                  if (!level_allowed(true, l1)) continue;
+                  if (!hp1_available || !level_allowed(true, l1)) return c;
                 }
-                float p1 = (l1==0) ? 0.0f : oq_perf::interp_power_th_w(l1, Tamb, Tsup);
-                if (l1>0 && isnan(p1)) continue;
+                if (l2 > 0) {
+                  if (!hp2_available || !level_allowed(false, l2)) return c;
+                }
+
+                float p1 = (l1 == 0) ? 0.0f : oq_perf::interp_power_th_w(l1, Tamb, Tsup);
+                if (l1 > 0 && isnan(p1)) return c;
                 p1 *= hp1_th_fac;
-                float pel1 = (l1==0) ? 0.0f : oq_perf::interp_power_el_w(l1, Tamb, Tsup);
-                if (l1>0 && isnan(pel1)) pel1 = 0.0f;
 
-                for (int l2=0; l2<=level_cap; l2++) {
-                  if (l2 > 0) {
-                    if (!hp2_available) continue;
-                    if (!level_allowed(false, l2)) continue;
+                float p2 = (l2 == 0) ? 0.0f : oq_perf::interp_power_th_w(l2, Tamb, Tsup);
+                if (l2 > 0 && isnan(p2)) return c;
+                p2 *= hp2_th_fac;
+
+                float pel1 = (l1 == 0) ? 0.0f : oq_perf::interp_power_el_w(l1, Tamb, Tsup);
+                if (l1 > 0 && isnan(pel1)) pel1 = 0.0f;
+                float pel2 = (l2 == 0) ? 0.0f : oq_perf::interp_power_el_w(l2, Tamb, Tsup);
+                if (l2 > 0 && isnan(pel2)) pel2 = 0.0f;
+
+                const float pel_sum = pel1 + pel2;
+                if (pel_sum > P_EL_PEAK_W) return c;
+
+                c.valid = true;
+                c.p_th_w = p1 + p2;
+                c.p_el_w = pel_sum;
+                c.err_w = fabsf(c.p_th_w - P_target);
+                c.over_soft_w = fmaxf(0.0f, pel_sum - P_EL_SOFT_W);
+                c.level_moves = abs(l1 - last1) + abs(l2 - last2);
+                c.active_hp_count = (l1 > 0 ? 1 : 0) + (l2 > 0 ? 1 : 0);
+                c.balance_steps = abs(l1 - l2);
+                c.single_on_lead =
+                    (c.active_hp_count == 1) &&
+                    (((l1 > 0) && lead_is_hp1) || ((l2 > 0) && !lead_is_hp1));
+                return c;
+              };
+
+              auto better_duo_candidate = [&](const DuoCandidate &a, const DuoCandidate &b)->bool {
+                const float soft_eps_w = 1.0f;
+                const float pel_eps_w = 1.0f;
+                const float err_eps_w = 1.0f;
+                if (fabsf(a.over_soft_w - b.over_soft_w) > soft_eps_w) return a.over_soft_w < b.over_soft_w;
+                if (fabsf(a.p_el_w - b.p_el_w) > pel_eps_w) return a.p_el_w < b.p_el_w;
+                if (fabsf(a.err_w - b.err_w) > err_eps_w) return a.err_w < b.err_w;
+                if (a.level_moves != b.level_moves) return a.level_moves < b.level_moves;
+                if (a.active_hp_count == 2 && b.active_hp_count == 2 && a.balance_steps != b.balance_steps) {
+                  return a.balance_steps < b.balance_steps;
+                }
+                if (a.active_hp_count == 1 && b.active_hp_count == 1) {
+                  const int a_single = (a.l1 > 0) ? a.l1 : a.l2;
+                  const int b_single = (b.l1 > 0) ? b.l1 : b.l2;
+                  if (a_single == b_single && a.single_on_lead != b.single_on_lead) {
+                    return a.single_on_lead;
                   }
-                  float p2 = (l2==0) ? 0.0f : oq_perf::interp_power_th_w(l2, Tamb, Tsup);
-                  if (l2>0 && isnan(p2)) continue;
-                  p2 *= hp2_th_fac;
-                  float pel2 = (l2==0) ? 0.0f : oq_perf::interp_power_el_w(l2, Tamb, Tsup);
-                  if (l2>0 && isnan(pel2)) pel2 = 0.0f;
+                }
+                if (a.l1 != b.l1) return a.l1 < b.l1;
+                return a.l2 < b.l2;
+              };
 
-                  float psum = p1 + p2;
-                  float err = fabsf(psum - P_target);
+              float best_err_w = 1e12f;
+              for (int l1 = 0; l1 <= level_cap; l1++) {
+                for (int l2 = 0; l2 <= level_cap; l2++) {
+                  const DuoCandidate c = build_duo_candidate(l1, l2);
+                  if (!c.valid) continue;
+                  if (c.err_w < best_err_w) best_err_w = c.err_w;
+                }
+              }
 
-                  float cost = err;
-                  cost += W_change_penalty_per_step * (float)(abs(l1 - last1) + abs(l2 - last2));
-                  // Keep a single-HP preference only at low load without defrost.
-                  if (l1>0 && l2>0 && f<=5 && !(hp1_def || hp2_def)) cost += W_twohp_penalty;
-                  // At medium/high load without defrost, bias toward balanced split.
-                  if (f>=6 && !(hp1_def || hp2_def)) cost += W_balance_penalty_per_step * (float) abs(l1 - l2);
-
-                  // 16A guard: electrical power (W) via COP map
-                  float pel_sum = pel1 + pel2;
-                  if (pel_sum > P_EL_PEAK_W) continue; // never allow above peak
-                  if (pel_sum > P_EL_SOFT_W) cost += (pel_sum - P_EL_SOFT_W) * W_el_over_soft_penalty_per_W;
-
-                  if (cost < best_cost) {
-                    best_cost = cost;
-                    best_l1 = l1;
-                    best_l2 = l2;
+              DuoCandidate best_candidate{};
+              bool have_best_candidate = false;
+              for (int l1 = 0; l1 <= level_cap; l1++) {
+                for (int l2 = 0; l2 <= level_cap; l2++) {
+                  const DuoCandidate c = build_duo_candidate(l1, l2);
+                  if (!c.valid) continue;
+                  if (c.err_w > (best_err_w + thermal_tie_band_w)) continue;
+                  if (!have_best_candidate || better_duo_candidate(c, best_candidate)) {
+                    best_candidate = c;
+                    have_best_candidate = true;
                   }
                 }
               }
 
-              // Lead/lag preference: if very low power, prefer lead HP only
-              hp1_req = best_l1;
-              hp2_req = best_l2;
+              const DuoCandidate current_candidate = build_duo_candidate(last1, last2);
+              bool keep_current = false;
+              const char* optimizer_reason = "keep_current";
 
-              if (P_target <= cap_total * 0.35f) {
-                // try single HP on lead if possible
-                int lead = lead_is_hp1 ? hp1_req : hp2_req;
-                int lag  = lead_is_hp1 ? hp2_req : hp1_req;
-                // Only bias to lead-only when both were active.
-                if (lag > 0 && lead > 0) {
-                  // attempt to move lag to 0 if lead alone can cover close enough
-                  float best_single_cost = best_cost;
-                  int best_single_level = lead;
-                  for (int l=1; l<=level_cap; l++) {
-                    if (!level_allowed(lead_is_hp1, l)) continue;
-                    float p = oq_perf::interp_power_th_w(l, Tamb, Tsup);
-                    if (isnan(p)) continue;
-                    p *= lead_is_hp1 ? hp1_th_fac : hp2_th_fac;
-                    float cost = fabsf(p - P_target) + W_change_penalty_per_step * (float)abs(l - (lead_is_hp1 ? last1 : last2));
-                    if (cost < best_single_cost) {
-                      best_single_cost = cost;
-                      best_single_level = l;
-                    }
-                  }
-                  if (lead_is_hp1) { hp1_req = best_single_level; hp2_req = 0; }
-                  else            { hp2_req = best_single_level; hp1_req = 0; }
+              if (have_best_candidate && current_candidate.valid) {
+                const bool current_heat_ok = current_candidate.err_w <= (best_candidate.err_w + thermal_keep_margin_w);
+                const bool topology_change =
+                    (current_candidate.active_hp_count > 0) &&
+                    (best_candidate.active_hp_count > 0) &&
+                    (current_candidate.active_hp_count != best_candidate.active_hp_count);
+                const bool hold_active =
+                    topology_change &&
+                    (id(oq_duo_dispatch_hold_until_ms) > 0) &&
+                    (now_ms < id(oq_duo_dispatch_hold_until_ms));
+                const bool better_soft_guard =
+                    current_candidate.over_soft_w > (best_candidate.over_soft_w + soft_switch_margin_w);
+                const bool better_efficiency =
+                    current_candidate.p_el_w > (best_candidate.p_el_w + pel_switch_margin_w);
+
+                if (hold_active && current_heat_ok) {
+                  keep_current = true;
+                  optimizer_reason = (hp1_def || hp2_def) ? "defrost_hold" : "hold_active";
+                } else if (!current_heat_ok) {
+                  optimizer_reason = "better_heat";
+                } else if (better_soft_guard) {
+                  optimizer_reason = "soft_guard";
+                } else if (better_efficiency) {
+                  optimizer_reason = "less_power";
+                } else {
+                  keep_current = true;
+                  optimizer_reason = "keep_current";
                 }
+              } else if (!have_best_candidate) {
+                keep_current = current_candidate.valid;
+                optimizer_reason = keep_current ? "keep_current" : "no_candidate";
+              } else {
+                optimizer_reason = "better_heat";
               }
+
+              const DuoCandidate chosen_candidate =
+                  (keep_current && current_candidate.valid) ? current_candidate : best_candidate;
+              hp1_req = chosen_candidate.valid ? chosen_candidate.l1 : 0;
+              hp2_req = chosen_candidate.valid ? chosen_candidate.l2 : 0;
+              publish_optimizer_reason(optimizer_reason);
 
               // Single-defrost compensation: allow the non-defrost HP to step up.
               int def_comp_min_f = (int) roundf(${oq_defrost_comp_min_f});
@@ -1118,8 +1227,14 @@ interval:
               if (def_comp_boost < 0) def_comp_boost = 0;
               if (def_comp_boost > 3) def_comp_boost = 3;
               if (def_comp_boost > 0 && f >= def_comp_min_f) {
-                if (hp1_def && !hp2_def && hp2_req > 0) hp2_req = std::min(level_cap, hp2_req + def_comp_boost);
-                if (hp2_def && !hp1_def && hp1_req > 0) hp1_req = std::min(level_cap, hp1_req + def_comp_boost);
+                if (hp1_def && !hp2_def && hp2_req > 0) {
+                  hp2_req = std::min(level_cap, hp2_req + def_comp_boost);
+                  publish_optimizer_reason("defrost_boost");
+                }
+                if (hp2_def && !hp1_def && hp1_req > 0) {
+                  hp1_req = std::min(level_cap, hp1_req + def_comp_boost);
+                  publish_optimizer_reason("defrost_boost");
+                }
               }
             }
           }
@@ -1142,11 +1257,13 @@ interval:
                   hp2_req = req_single;
                   hp1_req = 0;
                 }
+                if (is_power_house) publish_optimizer_reason("runtime_lead");
               }
             }
           }
           #else
           reset_dual_runtime_state(1);
+          publish_optimizer_reason("single_topology");
           if (!is_power_house) {
             publish_capacity_and_deficit(id(oq_phouse_req_w));
             hp1_req = f;
@@ -1459,6 +1576,12 @@ interval:
           int hp1_applied = apply_level(true, hp1_req);
           #if OQ_TOPOLOGY_DUO
           int hp2_applied = apply_level(false, hp2_req);
+          const int prev_topology_count =
+              (id(hp1_last_applied_level) > 0 ? 1 : 0) + (id(${hc_secondary_last_applied_level_id}) > 0 ? 1 : 0);
+          const int new_topology_count = (hp1_applied > 0 ? 1 : 0) + (hp2_applied > 0 ? 1 : 0);
+          if (prev_topology_count > 0 && new_topology_count > 0 && prev_topology_count != new_topology_count) {
+            id(oq_duo_dispatch_hold_until_ms) = now_ms + (uint32_t) ((hp1_def || hp2_def) ? 300000UL : 180000UL);
+          }
           #else
           const int hp2_applied = 0;
           #endif

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -73,9 +73,7 @@ oq_heat_loop_powerhouse_s: "60"                       # Effective heat-control c
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
 oq_optimizer_soft_w: "3400.0"                         # Soft limit for electrical HP power in optimizer [W]; peak limit follows oq_power_peak_w.
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].
-oq_optimizer_twohp_penalty: "10.4427"                 # Penalty for running both HPs at low load without defrost.
-oq_optimizer_balance_penalty_per_step: "18.7874"      # Penalty per level difference |HP1-HP2| at medium/high load without defrost.
-oq_defrost_power_factor: "0.7639"                     # Thermal derate on defrosting HP in optimizer.
+oq_defrost_power_factor: "0.764"                      # Thermal derate on a defrosting HP in duo dispatch.
 oq_defrost_comp_min_f: "6"                            # Minimum demand f before single-defrost compensation is applied.
 oq_defrost_comp_boost_steps: "1"                      # Extra level steps on non-defrost HP during single-defrost compensation.
 


### PR DESCRIPTION
## Summary
- rework duo Power House dispatch to first keep combinations that follow the requested heat closely enough and then choose the lowest-power combination
- only switch when that gives a clear heat or power benefit, with a short single-vs-dual hold to reduce back-and-forth switching
- keep existing runtime-lead behavior for equal single-HP choices
- remove the old low-load and balance penalties from the user-facing tuning surface
- update in-code comments, system documentation, and duo dashboard explanations to match the new behavior

## Notes
- oq_optimizer_twohp_penalty removed
- oq_optimizer_balance_penalty_per_step removed
- oq_defrost_power_factor kept and rounded to 0.764
- hidden diagnostic added: sensor.openquatt_duo_optimizer_reason (disabled by default)

## Validation
- ./scripts/validate_local.sh
- replay against /Users/jeroen/Downloads/history (1).csv showed slightly lower estimated electrical input with similar heat tracking, while topology switching stayed low in absolute terms
