### PR TITLE
Add HA water supply source selection

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1631,6 +1631,8 @@ views:
                     name: Water supply temperature (ESP)
                   - entity: sensor.openquatt_cic_water_supply_temp
                     name: Water supply temperature (CIC)
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: Water supply temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1734,6 +1736,7 @@ views:
 
                   Example values:
                   - `sensor.outdoor_temperature`
+                  - `sensor.water_supply_temperature`
                   - `sensor.thermostat_setpoint`
                   - `sensor.thermostat_room_temperature`
                   - `climate.living_room | current_temperature`
@@ -1750,6 +1753,8 @@ views:
                 entities:
                   - entity: input_text.openquatt_source_outdoor_temperature
                     name: Outside source entity
+                  - entity: input_text.openquatt_source_water_supply_temperature
+                    name: Water supply source entity
                   - entity: input_text.openquatt_source_room_setpoint
                     name: Setpoint source entity
                   - entity: input_text.openquatt_source_room_temperature
@@ -1768,7 +1773,7 @@ views:
                   These are the stable HA proxy entities used as the contract towards
                   OpenQuatt.
 
-                  `Valid` should be `on` for all three signals.
+                  `Valid` should be `on` for all four signals.
                   If `Valid` is `off`, the current source is not numeric.
                   In that case the proxy value is `Unavailable` until the source
                   becomes valid again.
@@ -1781,6 +1786,10 @@ views:
                     name: Proxy outside temperature
                   - entity: binary_sensor.openquatt_ext_outdoor_temperature_valid
                     name: Outside temperature source valid
+                  - entity: sensor.openquatt_ext_water_supply_temperature
+                    name: Proxy water supply temperature
+                  - entity: binary_sensor.openquatt_ext_water_supply_temperature_valid
+                    name: Water supply source valid
                   - entity: sensor.openquatt_ext_room_setpoint
                     name: Proxy room setpoint
                   - entity: binary_sensor.openquatt_ext_room_setpoint_valid
@@ -1800,7 +1809,7 @@ views:
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  These are the three HA input signals as received by OpenQuatt.
+                  These are the four HA input signals as received by OpenQuatt.
                   They should follow the proxy values shown in the middle panel.
 
                   If a value stays `Unknown`, first check whether the matching
@@ -1813,6 +1822,8 @@ views:
                 entities:
                   - entity: sensor.openquatt_ha_outside_temperature
                     name: HA - Outside Temperature
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: HA - Water Supply Temperature
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: HA - Thermostat Setpoint
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1836,8 +1847,8 @@ views:
               `openquatt_ha_dynamic_sources_package.yaml` is not loaded.  
 
               With this optional package you can choose the Home Assistant source
-              entities for outside, room, and setpoint temperature at runtime,
-              without reflashing OpenQuatt.
+              entities for outside, water supply, room, and setpoint
+              temperature at runtime, without reflashing OpenQuatt.
 
 
               After installation, extra configuration blocks for dynamic source

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1721,6 +1721,8 @@ views:
                     name: Aanvoertemperatuur (ESP)
                   - entity: sensor.openquatt_cic_water_supply_temp
                     name: Aanvoertemperatuur (CIC)
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: Aanvoertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1824,6 +1826,7 @@ views:
 
                   Voorbeelden:
                   - `sensor.outdoor_temperature`
+                  - `sensor.water_supply_temperature`
                   - `sensor.thermostat_setpoint`
                   - `sensor.thermostat_room_temperature`
                   - `climate.woonkamer | current_temperature`
@@ -1840,6 +1843,8 @@ views:
                 entities:
                   - entity: input_text.openquatt_source_outdoor_temperature
                     name: Bronentity buitentemperatuur
+                  - entity: input_text.openquatt_source_water_supply_temperature
+                    name: Bronentity aanvoertemperatuur
                   - entity: input_text.openquatt_source_room_setpoint
                     name: Bronentity setpoint
                   - entity: input_text.openquatt_source_room_temperature
@@ -1862,7 +1867,7 @@ views:
                   OpenQuatt dienen.
 
 
-                  De status `Valid` hoort voor alle drie signalen op `on` te
+                  De status `Valid` hoort voor alle vier signalen op `on` te
                   staan.
 
                   Als `Valid` op `off` staat, is de huidige bron niet numeriek.
@@ -1881,6 +1886,10 @@ views:
                     name: Proxy buitentemperatuur
                   - entity: binary_sensor.openquatt_ext_outdoor_temperature_valid
                     name: Buitentemperatuur bron valid
+                  - entity: sensor.openquatt_ext_water_supply_temperature
+                    name: Proxy aanvoertemperatuur
+                  - entity: binary_sensor.openquatt_ext_water_supply_temperature_valid
+                    name: Aanvoertemperatuur bron valid
                   - entity: sensor.openquatt_ext_room_setpoint
                     name: Proxy kamer setpoint
                   - entity: binary_sensor.openquatt_ext_room_setpoint_valid
@@ -1900,7 +1909,7 @@ views:
                   <details>
                   <summary><strong>Uitleg</strong></summary>
 
-                  Dit zijn de drie HA-invoerwaarden zoals OpenQuatt ze ontvangt.
+                  Dit zijn de vier HA-invoerwaarden zoals OpenQuatt ze ontvangt.
                   Deze horen de proxywaarden uit het middelste blok te volgen.
 
                   Blijft een waarde op `Unknown`, controleer dan eerst of de
@@ -1913,6 +1922,8 @@ views:
                 entities:
                   - entity: sensor.openquatt_ha_outside_temperature
                     name: HA - Buitentemperatuur
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: HA - Aanvoertemperatuur
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: HA - Thermostat Doeltemperatuur
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1936,8 +1947,8 @@ views:
               `openquatt_ha_dynamic_sources_package.yaml` is niet geladen.  
 
               Met dit optionele package kun je in Home Assistant zelf de
-              bron-entities voor buiten-, kamer- en setpointtemperatuur kiezen,
-              zonder OpenQuatt opnieuw te flashen.
+              bron-entities voor buiten-, aanvoer-, kamer- en
+              setpointtemperatuur kiezen, zonder OpenQuatt opnieuw te flashen.
 
 
               Na installatie verschijnen hier extra configuratieblokken voor

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1385,6 +1385,8 @@ views:
                     name: Water supply temperature (ESP)
                   - entity: sensor.openquatt_cic_water_supply_temp
                     name: Water supply temperature (CIC)
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: Water supply temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1488,6 +1490,7 @@ views:
 
                   Example values:
                   - `sensor.outdoor_temperature`
+                  - `sensor.water_supply_temperature`
                   - `sensor.thermostat_setpoint`
                   - `sensor.thermostat_room_temperature`
                   - `climate.living_room | current_temperature`
@@ -1504,6 +1507,8 @@ views:
                 entities:
                   - entity: input_text.openquatt_source_outdoor_temperature
                     name: Outside source entity
+                  - entity: input_text.openquatt_source_water_supply_temperature
+                    name: Water supply source entity
                   - entity: input_text.openquatt_source_room_setpoint
                     name: Setpoint source entity
                   - entity: input_text.openquatt_source_room_temperature
@@ -1522,7 +1527,7 @@ views:
                   These are the stable HA proxy entities used as the contract towards
                   OpenQuatt.
 
-                  `Valid` should be `on` for all three signals.
+                  `Valid` should be `on` for all four signals.
                   If `Valid` is `off`, the current source is not numeric.
                   In that case the proxy value is `Unavailable` until the source
                   becomes valid again.
@@ -1535,6 +1540,10 @@ views:
                     name: Proxy outside temperature
                   - entity: binary_sensor.openquatt_ext_outdoor_temperature_valid
                     name: Outside temperature source valid
+                  - entity: sensor.openquatt_ext_water_supply_temperature
+                    name: Proxy water supply temperature
+                  - entity: binary_sensor.openquatt_ext_water_supply_temperature_valid
+                    name: Water supply source valid
                   - entity: sensor.openquatt_ext_room_setpoint
                     name: Proxy room setpoint
                   - entity: binary_sensor.openquatt_ext_room_setpoint_valid
@@ -1554,7 +1563,7 @@ views:
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  These are the three HA input signals as received by OpenQuatt.
+                  These are the four HA input signals as received by OpenQuatt.
                   They should follow the proxy values shown in the middle panel.
 
                   If a value stays `Unknown`, first check whether the matching
@@ -1567,6 +1576,8 @@ views:
                 entities:
                   - entity: sensor.openquatt_ha_outside_temperature
                     name: HA - Outside Temperature
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: HA - Water Supply Temperature
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: HA - Thermostat Setpoint
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1590,8 +1601,8 @@ views:
               `openquatt_ha_dynamic_sources_package.yaml` is not loaded.  
 
               With this optional package you can choose the Home Assistant source
-              entities for outside, room, and setpoint temperature at runtime,
-              without reflashing OpenQuatt.
+              entities for outside, water supply, room, and setpoint
+              temperature at runtime, without reflashing OpenQuatt.
 
 
               After installation, extra configuration blocks for dynamic source

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1451,6 +1451,8 @@ views:
                     name: Aanvoertemperatuur (ESP)
                   - entity: sensor.openquatt_cic_water_supply_temp
                     name: Aanvoertemperatuur (CIC)
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: Aanvoertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1554,6 +1556,7 @@ views:
 
                   Voorbeelden:
                   - `sensor.outdoor_temperature`
+                  - `sensor.water_supply_temperature`
                   - `sensor.thermostat_setpoint`
                   - `sensor.thermostat_room_temperature`
                   - `climate.woonkamer | current_temperature`
@@ -1570,6 +1573,8 @@ views:
                 entities:
                   - entity: input_text.openquatt_source_outdoor_temperature
                     name: Bronentity buitentemperatuur
+                  - entity: input_text.openquatt_source_water_supply_temperature
+                    name: Bronentity aanvoertemperatuur
                   - entity: input_text.openquatt_source_room_setpoint
                     name: Bronentity setpoint
                   - entity: input_text.openquatt_source_room_temperature
@@ -1592,7 +1597,7 @@ views:
                   OpenQuatt dienen.
 
 
-                  De status `Valid` hoort voor alle drie signalen op `on` te
+                  De status `Valid` hoort voor alle vier signalen op `on` te
                   staan.
 
                   Als `Valid` op `off` staat, is de huidige bron niet numeriek.
@@ -1611,6 +1616,10 @@ views:
                     name: Proxy buitentemperatuur
                   - entity: binary_sensor.openquatt_ext_outdoor_temperature_valid
                     name: Buitentemperatuur bron valid
+                  - entity: sensor.openquatt_ext_water_supply_temperature
+                    name: Proxy aanvoertemperatuur
+                  - entity: binary_sensor.openquatt_ext_water_supply_temperature_valid
+                    name: Aanvoertemperatuur bron valid
                   - entity: sensor.openquatt_ext_room_setpoint
                     name: Proxy kamer setpoint
                   - entity: binary_sensor.openquatt_ext_room_setpoint_valid
@@ -1630,7 +1639,7 @@ views:
                   <details>
                   <summary><strong>Uitleg</strong></summary>
 
-                  Dit zijn de drie HA-invoerwaarden zoals OpenQuatt ze ontvangt.
+                  Dit zijn de vier HA-invoerwaarden zoals OpenQuatt ze ontvangt.
                   Deze horen de proxywaarden uit het middelste blok te volgen.
 
                   Blijft een waarde op `Unknown`, controleer dan eerst of de
@@ -1643,6 +1652,8 @@ views:
                 entities:
                   - entity: sensor.openquatt_ha_outside_temperature
                     name: HA - Buitentemperatuur
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: HA - Aanvoertemperatuur
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: HA - Thermostat Doeltemperatuur
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
@@ -1666,8 +1677,8 @@ views:
               `openquatt_ha_dynamic_sources_package.yaml` is niet geladen.  
 
               Met dit optionele package kun je in Home Assistant zelf de
-              bron-entities voor buiten-, kamer- en setpointtemperatuur kiezen,
-              zonder OpenQuatt opnieuw te flashen.
+              bron-entities voor buiten-, aanvoer-, kamer- en
+              setpointtemperatuur kiezen, zonder OpenQuatt opnieuw te flashen.
 
 
               Na installatie verschijnen hier extra configuratieblokken voor

--- a/docs/dashboard/openquatt_ha_dynamic_sources_package.yaml
+++ b/docs/dashboard/openquatt_ha_dynamic_sources_package.yaml
@@ -6,6 +6,7 @@
 #   - User can enter source entity IDs in HA input_text helpers.
 #   - This package publishes stable proxy sensors consumed by OpenQuatt ESPHome:
 #       sensor.openquatt_ext_outdoor_temperature
+#       sensor.openquatt_ext_water_supply_temperature
 #       sensor.openquatt_ext_room_setpoint
 #       sensor.openquatt_ext_room_temperature
 #
@@ -15,7 +16,7 @@
 #          packages: !include_dir_named packages
 #   2) Copy this file to: /config/packages/openquatt_dynamic_sources.yaml
 #   3) Reload Template Entities (or restart Home Assistant).
-#   4) Set the three input_text helpers once to your own source entity IDs.
+#   4) Set the four input_text helpers once to your own source entity IDs.
 #
 # Notes:
 #   - Trigger interval is 15s to support dynamic entity_id references.
@@ -31,6 +32,12 @@ input_text:
   openquatt_source_outdoor_temperature:
     name: OpenQuatt source outdoor temperature
     icon: mdi:thermometer
+    mode: text
+    max: 100
+
+  openquatt_source_water_supply_temperature:
+    name: OpenQuatt source water supply temperature
+    icon: mdi:water-thermometer
     mode: text
     max: 100
 
@@ -56,6 +63,7 @@ template:
       - platform: state
         entity_id:
           - input_text.openquatt_source_outdoor_temperature
+          - input_text.openquatt_source_water_supply_temperature
           - input_text.openquatt_source_room_setpoint
           - input_text.openquatt_source_room_temperature
       - platform: time_pattern
@@ -108,6 +116,56 @@ template:
             {{ parts[0] | trim if (parts | length > 0) else '' }}
           source_attribute: >-
             {% set selector = states('input_text.openquatt_source_outdoor_temperature') | trim %}
+            {% set parts = selector.split('|', 1) %}
+            {{ parts[1] | trim if (parts | length > 1) else '' }}
+
+      - name: OpenQuatt Ext Water Supply Temperature
+        unique_id: openquatt_ext_water_supply_temperature
+        unit_of_measurement: "°C"
+        device_class: temperature
+        state_class: measurement
+        icon: mdi:water-thermometer
+        availability: >-
+          {% set selector = states('input_text.openquatt_source_water_supply_temperature') | trim %}
+          {% set parts = selector.split('|', 1) %}
+          {% set entity = parts[0] | trim if (parts | length > 0) else '' %}
+          {% set attr_name = parts[1] | trim if (parts | length > 1) else '' %}
+          {% set state_raw = states(entity) | trim if entity else '' %}
+          {% set state_val = state_raw | replace(',', '.') | float(none) if state_raw else none %}
+          {% set attr_raw = state_attr(entity, attr_name) if entity and attr_name else none %}
+          {% if attr_raw is number %}
+            {% set attr_val = attr_raw %}
+          {% elif attr_raw is string %}
+            {% set attr_val = attr_raw | trim | replace(',', '.') | float(none) %}
+          {% else %}
+            {% set attr_val = none %}
+          {% endif %}
+          {% set val = attr_val if attr_name else state_val %}
+          {{ val is not none }}
+        state: >-
+          {% set selector = states('input_text.openquatt_source_water_supply_temperature') | trim %}
+          {% set parts = selector.split('|', 1) %}
+          {% set entity = parts[0] | trim if (parts | length > 0) else '' %}
+          {% set attr_name = parts[1] | trim if (parts | length > 1) else '' %}
+          {% set state_raw = states(entity) | trim if entity else '' %}
+          {% set state_val = state_raw | replace(',', '.') | float(none) if state_raw else none %}
+          {% set attr_raw = state_attr(entity, attr_name) if entity and attr_name else none %}
+          {% if attr_raw is number %}
+            {% set attr_val = attr_raw %}
+          {% elif attr_raw is string %}
+            {% set attr_val = attr_raw | trim | replace(',', '.') | float(none) %}
+          {% else %}
+            {% set attr_val = none %}
+          {% endif %}
+          {% set val = attr_val if attr_name else state_val %}
+          {{ val if val is not none else 0 }}
+        attributes:
+          source_entity: >-
+            {% set selector = states('input_text.openquatt_source_water_supply_temperature') | trim %}
+            {% set parts = selector.split('|', 1) %}
+            {{ parts[0] | trim if (parts | length > 0) else '' }}
+          source_attribute: >-
+            {% set selector = states('input_text.openquatt_source_water_supply_temperature') | trim %}
             {% set parts = selector.split('|', 1) %}
             {{ parts[1] | trim if (parts | length > 1) else '' }}
 
@@ -271,6 +329,36 @@ template:
             {{ parts[0] | trim if (parts | length > 0) else '' }}
           source_attribute: >-
             {% set selector = states('input_text.openquatt_source_outdoor_temperature') | trim %}
+            {% set parts = selector.split('|', 1) %}
+            {{ parts[1] | trim if (parts | length > 1) else '' }}
+
+      - name: OpenQuatt Ext Water Supply Temperature Valid
+        unique_id: openquatt_ext_water_supply_temperature_valid
+        icon: mdi:check-decagram
+        state: >-
+          {% set selector = states('input_text.openquatt_source_water_supply_temperature') | trim %}
+          {% set parts = selector.split('|', 1) %}
+          {% set entity = parts[0] | trim if (parts | length > 0) else '' %}
+          {% set attr_name = parts[1] | trim if (parts | length > 1) else '' %}
+          {% set state_raw = states(entity) | trim if entity else '' %}
+          {% set state_val = state_raw | replace(',', '.') | float(none) if state_raw else none %}
+          {% set attr_raw = state_attr(entity, attr_name) if entity and attr_name else none %}
+          {% if attr_raw is number %}
+            {% set attr_val = attr_raw %}
+          {% elif attr_raw is string %}
+            {% set attr_val = attr_raw | trim | replace(',', '.') | float(none) %}
+          {% else %}
+            {% set attr_val = none %}
+          {% endif %}
+          {% set val = attr_val if attr_name else state_val %}
+          {{ val is not none }}
+        attributes:
+          source_entity: >-
+            {% set selector = states('input_text.openquatt_source_water_supply_temperature') | trim %}
+            {% set parts = selector.split('|', 1) %}
+            {{ parts[0] | trim if (parts | length > 0) else '' }}
+          source_attribute: >-
+            {% set selector = states('input_text.openquatt_source_water_supply_temperature') | trim %}
             {% set parts = selector.split('|', 1) %}
             {{ parts[1] | trim if (parts | length > 1) else '' }}
 

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -89,6 +89,8 @@ Welke strategie je ook gebruikt, OpenQuatt kijkt daarnaast naar `Water Supply Te
 - in `Power House` de warmtevraag geleidelijk terugnemen als de aanvoer te hoog wordt;
 - in `CM3` de boiler blokkeren als de aanvoer op de ingestelde bovengrens komt.
 
+Die geselecteerde aanvoertemperatuur kan uit de lokale ESP-sensor, uit CIC of uit een Home Assistant-input komen, afhankelijk van jouw bronkeuze.
+
 Je hoeft daarvoor niet eerst de interne berekening te kennen. Relevanter is welke strategie in jouw installatie het meest stabiele en voorspelbare gedrag geeft.
 
 ## Single en Duo

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -296,6 +296,7 @@ Gebruik deze groep vooral voor onderhoud en diagnose, niet voor dagelijks gebrui
 ### Voor broncontrole
 
 - `HA - Outside Temperature`
+- `HA - Water Supply Temperature`
 - `HA - Thermostat Setpoint`
 - `HA - Thermostat Room Temperature`
 

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -122,7 +122,7 @@ Bij deze strategie kijkt OpenQuatt vooral naar de gewenste aanvoertemperatuur vi
 
 Belangrijke eigenschappen:
 
-- de regeling gebruikt de gekozen aanvoertemperatuurbron;
+- de regeling gebruikt de gekozen aanvoertemperatuurbron (`Local`, `CIC` of `HA input`);
 - er zijn profielen en PID-instellingen;
 - rond lage vraag probeert het systeem niet abrupt naar nul te springen.
 

--- a/openquatt/oq_ha_inputs.yaml
+++ b/openquatt/oq_ha_inputs.yaml
@@ -30,6 +30,19 @@ sensor:
       sorting_group_id: oq_ha
 
   - platform: homeassistant
+    id: water_supply_temp_ha
+    name: "HA - Water Supply Temperature"
+    entity_id: ${ha_water_supply_temp_entity_id}
+    internal: false
+    icon: mdi:water-thermometer
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 2
+    web_server:
+      sorting_group_id: oq_ha
+
+  - platform: homeassistant
     id: thermostat_setpoint_ha
     name: "HA - Thermostat Setpoint"
     entity_id: ${ha_room_setpoint_entity_id}

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -53,6 +53,7 @@ select:
     options:
       - Local
       - CIC
+      - HA input
     initial_option: Local
     web_server:
       sorting_group_id: oq_cic
@@ -162,10 +163,15 @@ sensor:
     accuracy_decimals: 2
     update_interval: 2s
     lambda: |-
+      // Resolve the configured water supply source without implicit fallback.
       if (!id(water_supply_source).has_state()) return NAN;
       const auto source = id(water_supply_source).current_option();
       if (source == "CIC") {
         if (id(water_supply_temp_cic).has_state()) return id(water_supply_temp_cic).state;
+        return NAN;
+      }
+      if (source == "HA input") {
+        if (id(water_supply_temp_ha).has_state()) return id(water_supply_temp_ha).state;
         return NAN;
       }
       if (source == "Local") {

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -125,9 +125,10 @@ oq_room_cic_recovery_hold_default_min: "1"            # Default hold before room
 # ----------------------------
 # HA INPUT ENTITY MAPPING
 # ----------------------------
-ha_outside_temp_entity_id: "sensor.openquatt_ext_outdoor_temperature" # HA proxy entity for outside temperature [degC].
-ha_room_setpoint_entity_id: "sensor.openquatt_ext_room_setpoint"      # HA proxy entity for thermostat room setpoint [degC].
-ha_room_temp_entity_id: "sensor.openquatt_ext_room_temperature"        # HA proxy entity for thermostat room temperature [degC].
+ha_outside_temp_entity_id: "sensor.openquatt_ext_outdoor_temperature"      # HA proxy entity for outside temperature [degC].
+ha_water_supply_temp_entity_id: "sensor.openquatt_ext_water_supply_temperature" # HA proxy entity for water supply temperature [degC].
+ha_room_setpoint_entity_id: "sensor.openquatt_ext_room_setpoint"           # HA proxy entity for thermostat room setpoint [degC].
+ha_room_temp_entity_id: "sensor.openquatt_ext_room_temperature"             # HA proxy entity for thermostat room temperature [degC].
 
 # ----------------------------
 # HP IO (MODBUS POLLING)


### PR DESCRIPTION
## Summary
- add `HA input` as a third `Water Supply Source` option alongside `Local` and `CIC`
- add a Home Assistant water supply proxy sensor plus dynamic source helper/validity entities
- update single/duo dashboards and docs so the new source can be configured and inspected end-to-end

## Testing
- `./scripts/validate_local.sh`
- all topology/hardware compilations succeeded (`openquatt_duo_waveshare`, `openquatt_duo_heatpump_listener`, `openquatt_single_waveshare`, `openquatt_single_heatpump_listener`)
