### PR TITLE
Protect compressors from stop commands during defrost

### DIFF
--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -634,7 +634,66 @@ interval:
             #endif
           };
 
-          auto force_standby = [&](bool is_hp1)->void {
+          auto hp_selected_level = [&](bool is_hp1)->int {
+            if (is_hp1) {
+              if (!id(hp1_compressor_level).has_state()) return -1;
+              auto idx = id(hp1_compressor_level).active_index();
+              return idx.has_value() ? (int) idx.value() : -1;
+            }
+            if (!id(${hc_secondary_compressor_level_id}).has_state()) return -1;
+            auto idx = id(${hc_secondary_compressor_level_id}).active_index();
+            return idx.has_value() ? (int) idx.value() : -1;
+          };
+
+          auto defrost_stop_hold_level = [&](bool is_hp1)->int {
+            const bool defrost_active = is_hp1 ? id(hp1_defrost).state : id(${hc_secondary_defrost_id}).state;
+            if (!defrost_active) return 0;
+
+            const int selected_level = hp_selected_level(is_hp1);
+            if (selected_level > 0) return selected_level;
+
+            const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});
+            if (prev_applied > 0) return prev_applied;
+
+            return 0;
+          };
+
+          auto apply_defrost_stop_hold = [&](bool is_hp1, int retained_level)->bool {
+            if (retained_level <= 0) return false;
+
+            // Keep the HP in Heating and preserve its last non-zero level until defrost clears.
+            const char* opt = "Heating";
+            if (is_hp1) {
+              if (!id(hp1_set_working_mode).has_state() || id(hp1_set_working_mode).current_option() != opt) {
+                auto c = id(hp1_set_working_mode).make_call();
+                c.set_option(opt);
+                c.perform();
+              }
+              if (hp_selected_level(true) != retained_level) {
+                auto c = id(hp1_compressor_level).make_call();
+                c.set_index(retained_level);
+                c.perform();
+              }
+            } else {
+              if (!id(${hc_secondary_set_working_mode_id}).has_state() || id(${hc_secondary_set_working_mode_id}).current_option() != opt) {
+                auto c = id(${hc_secondary_set_working_mode_id}).make_call();
+                c.set_option(opt);
+                c.perform();
+              }
+              if (hp_selected_level(false) != retained_level) {
+                auto c = id(${hc_secondary_compressor_level_id}).make_call();
+                c.set_index(retained_level);
+                c.perform();
+              }
+            }
+
+            return true;
+          };
+
+          auto force_standby = [&](bool is_hp1)->bool {
+            const int retained_level = defrost_stop_hold_level(is_hp1);
+            if (apply_defrost_stop_hold(is_hp1, retained_level)) return false;
+
             const char* opt = "Standby";
             if (is_hp1) {
               if (!id(hp1_set_working_mode).has_state() || id(hp1_set_working_mode).current_option() != opt) {
@@ -659,6 +718,7 @@ interval:
                 c2.perform();
               }
             }
+            return true;
           };
 
           auto sync_forced_stop_state = [&](bool is_hp1)->void {
@@ -685,19 +745,28 @@ interval:
           };
 
           if (!cm_allows_hp) {
-            // Force both units to Standby + level 0
-            force_standby(true);
+            // Force both units to Standby + level 0, except while a unit is still in defrost.
+            const bool hp1_stopped = force_standby(true);
+            const int hp1_hold_level = hp1_stopped ? 0 : defrost_stop_hold_level(true);
             #if OQ_TOPOLOGY_DUO
-            force_standby(false);
+            const bool hp2_stopped = force_standby(false);
+            const int hp2_hold_level = hp2_stopped ? 0 : defrost_stop_hold_level(false);
+            const bool any_defrost_hold = (hp1_hold_level > 0) || (hp2_hold_level > 0);
+            #else
+            const int hp2_hold_level = 0;
             #endif
             // Keep internal state aligned with forced 0-level actuation to avoid stale optimizer/min-runtime state.
-            sync_forced_stop_state(true);
+            if (hp1_stopped) sync_forced_stop_state(true);
             #if OQ_TOPOLOGY_DUO
-            sync_forced_stop_state(false);
+            if (hp2_stopped) sync_forced_stop_state(false);
             #endif
             reset_dual_runtime_state(0);
-            publish_optimizer_reason("inactive");
-            publish_debug(0, 0, 0, 0);
+            #if OQ_TOPOLOGY_DUO
+            publish_optimizer_reason(any_defrost_hold ? "defrost_protect_hold" : "inactive");
+            #else
+            publish_optimizer_reason(hp1_hold_level > 0 ? "defrost_protect_hold" : "inactive");
+            #endif
+            publish_debug(hp1_hold_level, hp2_hold_level, hp1_hold_level, hp2_hold_level);
             return;
           }
           // =========================
@@ -1509,7 +1578,13 @@ interval:
           auto apply_level = [&](bool is_hp1, int req_level)->int {
             req_level = std::max(min_level, std::min(max_level, req_level));
             const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});
+            const int retained_level = defrost_stop_hold_level(is_hp1);
 
+            if (req_level == 0 && retained_level > 0) {
+              apply_defrost_stop_hold(is_hp1, retained_level);
+              publish_optimizer_reason("defrost_protect_hold");
+              return retained_level;
+            }
             // Hard guardrail: after stop, enforce a profile-based minimum off-time before restart.
             if (!is_power_house && req_level > 0 && prev_applied == 0) {
               int min_off_s = 120;  // Balanced default
@@ -1549,6 +1624,12 @@ interval:
             // This avoids losing a full control cycle on mode-transition latency.
             if (req_level > 0 && !mode_is_heating(is_hp1) && !mode_target_is_heating(is_hp1)) {
               applied = 0;
+            }
+
+            if (applied == 0 && retained_level > 0) {
+              apply_defrost_stop_hold(is_hp1, retained_level);
+              publish_optimizer_reason("defrost_protect_hold");
+              return retained_level;
             }
 
             // writes only on change
@@ -1632,3 +1713,4 @@ interval:
           log_transition(false, hp2_applied);
           #endif
           publish_debug(hp1_req, hp2_req, hp1_applied, hp2_applied);
+

--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -25,6 +25,7 @@ oq_supervisory_controlmode: !include
     supervisory_secondary_working_mode_id: "hp2_working_mode"
     supervisory_secondary_set_working_mode_id: "hp2_set_working_mode"
     supervisory_secondary_compressor_level_id: "hp2_compressor_level"
+    supervisory_secondary_defrost_id: "hp2_defrost"
     supervisory_secondary_low_noise_mode_id: "hp2_low_noise_mode"
     supervisory_secondary_set_pump_mode_id: "hp2_set_pump_mode"
     supervisory_secondary_pump_speed_id: "hp2_pump_speed"
@@ -97,3 +98,4 @@ heatpump2: !include
     hp_id: "hp2"
     prefix: "HP2 - "
     device_address: 0x02
+

--- a/openquatt/oq_packages_single.yaml
+++ b/openquatt/oq_packages_single.yaml
@@ -13,6 +13,7 @@ oq_supervisory_controlmode: !include
     supervisory_secondary_working_mode_id: "hp1_working_mode"
     supervisory_secondary_set_working_mode_id: "hp1_set_working_mode"
     supervisory_secondary_compressor_level_id: "hp1_compressor_level"
+    supervisory_secondary_defrost_id: "hp1_defrost"
     supervisory_secondary_low_noise_mode_id: "hp1_low_noise_mode"
     supervisory_secondary_set_pump_mode_id: "hp1_set_pump_mode"
     supervisory_secondary_pump_speed_id: "hp1_pump_speed"
@@ -79,3 +80,4 @@ heatpump1: !include
     hp_id: "hp1"
     prefix: "HP1 - "
     device_address: 0x01
+

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -709,8 +709,14 @@ interval:
           const bool power_house_active = (id(oq_heat_mode_code) == 0);
 
           const int hp1_lvl = id(hp1_last_applied_level);
+          const int hp1_cmd_lvl =
+              id(hp1_compressor_level).has_state() ? (int) id(hp1_compressor_level).active_index().value_or(-1) : -1;
           #if OQ_TOPOLOGY_DUO
           const int hp2_lvl = id(${supervisory_secondary_last_applied_level_id});
+          const int hp2_cmd_lvl =
+              id(${supervisory_secondary_compressor_level_id}).has_state()
+                  ? (int) id(${supervisory_secondary_compressor_level_id}).active_index().value_or(-1)
+                  : -1;
           const bool both_levels_off = (hp1_lvl <= 0) && (hp2_lvl <= 0);
 
           const float hp1_mode_raw = id(hp1_working_mode).state;
@@ -728,6 +734,7 @@ interval:
           const bool any_hp_active_guard = hp1_active_guard || hp2_active_guard;
           #else
           const int hp2_lvl = 0;
+          const int hp2_cmd_lvl = -1;
           const bool both_levels_off = (hp1_lvl <= 0);
 
           const float hp1_mode_raw = id(hp1_working_mode).state;
@@ -739,6 +746,18 @@ interval:
           const bool hp2_active_guard = false;
           const bool any_hp_active_guard = hp1_active_guard;
           #endif
+          auto defrost_stop_hold_level = [&](bool is_hp1)->int {
+            const bool defrost_active = is_hp1 ? id(hp1_defrost).state : id(${hc_secondary_defrost_id}).state;
+            if (!defrost_active) return 0;
+
+            const int selected_level = is_hp1 ? hp1_cmd_lvl : hp2_cmd_lvl;
+            if (selected_level > 0) return selected_level;
+
+            const int prev_level = is_hp1 ? hp1_lvl : hp2_lvl;
+            if (prev_level > 0) return prev_level;
+
+            return 0;
+          };
           const bool both_units_idle = !any_hp_active_guard;
 
           bool heating_req = heating_req_raw;
@@ -1024,15 +1043,18 @@ interval:
           publish_binary_if_changed(id(oq_lowflow_fault_active_bs), id(oq_lowflow_fault_active));
 
           // Hard safety path: persistent low-flow fault must force both HPs to Standby + level 0.
-          // This runs in supervisory as an explicit emergency override, independent from heat-control timing.
+          // Never issue that stop command to a unit that is actively defrosting; let heat-control
+          // keep its last non-zero command until defrost clears.
           if (id(oq_lowflow_fault_active)) {
-            set_select_option(id(hp1_set_working_mode), "Standby");
+            if (defrost_stop_hold_level(true) <= 0) {
+              set_select_option(id(hp1_set_working_mode), "Standby");
+              set_select_option(id(hp1_compressor_level), "0");
+            }
             #if OQ_TOPOLOGY_DUO
-            set_select_option(id(${supervisory_secondary_set_working_mode_id}), "Standby");
-            #endif
-            set_select_option(id(hp1_compressor_level), "0");
-            #if OQ_TOPOLOGY_DUO
-            set_select_option(id(${supervisory_secondary_compressor_level_id}), "0");
+            if (defrost_stop_hold_level(false) <= 0) {
+              set_select_option(id(${supervisory_secondary_set_working_mode_id}), "Standby");
+              set_select_option(id(${supervisory_secondary_compressor_level_id}), "0");
+            }
             #endif
           }
           // -------------------------------------------------
@@ -1374,3 +1396,4 @@ interval:
 
           apply_silent_window();
           apply_sticky_pump_policy();
+

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -747,7 +747,7 @@ interval:
           const bool any_hp_active_guard = hp1_active_guard;
           #endif
           auto defrost_stop_hold_level = [&](bool is_hp1)->int {
-            const bool defrost_active = is_hp1 ? id(hp1_defrost).state : id(${hc_secondary_defrost_id}).state;
+            const bool defrost_active = is_hp1 ? id(hp1_defrost).state : id(${supervisory_secondary_defrost_id}).state;
             if (!defrost_active) return 0;
 
             const int selected_level = is_hp1 ? hp1_cmd_lvl : hp2_cmd_lvl;
@@ -1396,4 +1396,3 @@ interval:
 
           apply_silent_window();
           apply_sticky_pump_policy();
-


### PR DESCRIPTION
## Summary
- hold a defrosting HP on its last non-zero command instead of issuing Standby or level 0
- apply the same protection in inactive-CM handling and supervisory low-flow stop handling
- publish defrost_protect_hold when stop commands are deferred during defrost