### PR TITLE
Add universal compressor min off time

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -76,6 +76,10 @@ Niet elke instelling is even relevant. In de praktijk bepalen vooral deze groepe
 - `oq_strategy_demand_max_f`
 - `oq_temp_guard_delta_c`
 
+### Compressor guardrails
+
+- `oq_hp_min_off_s`
+
 ### Flow en pomp
 
 - `oq_flow_mismatch_threshold_lph`
@@ -191,6 +195,8 @@ Belangrijk onderscheid:
 
 - `Dual HP Enable Level`, `Dual HP Enable Hold` en `Dual HP Disable Hold` horen bij de verdeling in `Water Temperature Control`;
 - in `Power House` wordt de Duo-keuze juist automatisch bepaald op basis van geldige combinaties, warmtematch en elektrisch verbruik.
+- `Minimum runtime` is een runtime slider met standaard `15` minuten; dat is dus geen compile-time substitution.
+- `oq_hp_min_off_s` is juist wel compile-time en bepaalt de minimale uit-tijd per compressor voor elke restart, ook in `Power House`.
 
 Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf de zuinigste geldige combinatie kiest en die kort vasthoudt om op en neer schakelen te beperken.
 

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -168,7 +168,7 @@ number:
     mode: slider
     restore_value: true
     optimistic: true
-    initial_value: 30
+    initial_value: 15
     web_server:
       sorting_group_id: oq_tuning_heat
 
@@ -1510,14 +1510,9 @@ interval:
             req_level = std::max(min_level, std::min(max_level, req_level));
             const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});
 
-            // Hard guardrail: after stop, enforce a profile-based minimum off-time before restart.
-            if (!is_power_house && req_level > 0 && prev_applied == 0) {
-              int min_off_s = 120;  // Balanced default
-              if (id(oq_curve_control_profile).has_state()) {
-                const auto profile = id(oq_curve_control_profile).current_option();
-                if (profile == "Comfort") min_off_s = 60;
-                else if (profile == "Stable") min_off_s = 180;
-              }
+            // Hard guardrail: after stop, enforce a universal per-HP minimum off-time before restart.
+            if (req_level > 0 && prev_applied == 0) {
+              int min_off_s = (int) ${oq_hp_min_off_s};
               if (min_off_s < 0) min_off_s = 0;
 
               const uint32_t last_stop_ms = is_hp1 ? id(hp1_last_stop_ms) : id(${hc_secondary_last_stop_ms_id});

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -71,6 +71,7 @@ oq_heat_loop_tick_s: "5"                              # Scheduler tick for heat-
 oq_heat_loop_curve_s: "30"                            # Effective heat-control cadence in Heating Curve mode [s].
 oq_heat_loop_powerhouse_s: "60"                       # Effective heat-control cadence in Power House mode [s].
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
+oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
 oq_optimizer_soft_w: "3400.0"                         # Soft limit for electrical HP power in optimizer [W]; peak limit follows oq_power_peak_w.
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].
 oq_defrost_power_factor: "0.764"                      # Thermal derate on a defrosting HP in duo dispatch.


### PR DESCRIPTION
## Summary
- add a universal per-HP minimum off time via substitutions with a default of 240 seconds
- lower the Minimum runtime default to 15 minutes
- document the new compressor guardrail and clarify runtime vs compile-time defaults

## Testing
- powershell -ExecutionPolicy Bypass -File .\\scripts\\validate_local.ps1 -ConfigOnly