### PR TITLE
Power House single vs duo improvements

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2185,10 +2185,11 @@ views:
               allocation is single-HP-first with dual-enable hysteresis and
               sequential level steps.
 
-              - In Power House mode, OpenQuatt first keeps only combinations
-              that follow the requested heat closely enough and then picks the
-              lowest-power combination. It only switches when that gives a clear
-              benefit, with a short hold to reduce back-and-forth switching.
+              - In Power House mode, OpenQuatt compares the best single-HP and
+              dual-HP options, prefers the lower-power topology by default, and
+              lets a less efficient topology win only when heat match is clearly
+              better. Switches toward a higher-power topology are held briefly to
+              reduce back-and-forth switching.
 
               - **Dual HP enable level (lvl)** defines at which sustained
               single-HP compressor level a second HP may be enabled in

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2294,10 +2294,12 @@ views:
               allocatie is single-HP-first met dual-enable hysterese en
               sequentiële levelstappen.
 
-              - In Power House mode kiest OpenQuatt eerst combinaties die de
-              warmtevraag goed genoeg volgen en daarna de zuinigste combinatie.
-              Wisselen gebeurt alleen als dat echt voordeel geeft, met een
-              korte houdtijd tegen op en neer schakelen.
+              - In Power House mode vergelijkt OpenQuatt de beste single-HP- en
+              dual-HP-opties, kiest normaal de topology met het laagste
+              elektrische verbruik en laat een minder zuinige topology alleen
+              winnen als de warmtematch duidelijk beter is. Wissels naar een
+              duurdere topology worden kort vastgehouden om op en neer
+              schakelen te beperken.
 
               - **Dual HP enable level (lvl)** bepaalt bij welk aanhoudend
               single-HP compressorlevel een tweede HP mag worden geactiveerd in

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -106,9 +106,9 @@ Het doel bij `Duo` is niet om direct beide units maximaal te laten werken. Rusti
 Hoe dat precies gebeurt, hangt af van de gekozen verwarmingsstrategie:
 
 - in `Water Temperature Control` werkt OpenQuatt in de basis single-HP-first; de tweede warmtepomp mag pas meedoen als de vraag hoog genoeg blijft;
-- in `Power House` rekent OpenQuatt meerdere geldige combinaties door en kiest daarna de combinatie die de warmtevraag goed genoeg volgt met het laagste elektrische verbruik.
+- in `Power House` vergelijkt OpenQuatt de beste single- en duocombinaties en kiest normaal de variant met het laagste elektrische verbruik; alleen bij een duidelijk betere warmtematch mag een minder zuinige topology winnen.
 
-Bij `Power House` betekent dat dus niet automatisch "eerst 1 warmtepomp" of "liever altijd 2 warmtepompen". Soms is 1 warmtepomp zuiniger, soms 2 op lagere levels. OpenQuatt wisselt alleen als dat echt voordeel geeft en houdt een single-/duokeuze kort vast om onrust te beperken.
+Bij `Power House` betekent dat dus niet automatisch "eerst 1 warmtepomp" of "liever altijd 2 warmtepompen". Soms is 1 warmtepomp zuiniger, soms 2 op lagere levels. OpenQuatt behandelt de single-versus-duokeuze efficiency-first, laat een minder zuinige topology alleen winnen bij duidelijk betere warmtematch en houdt vooral duurdere topologywissels kort vast om onrust te beperken.
 
 ## Stabiliteit en pendelgedrag
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -194,11 +194,12 @@ Deze groep bepaalt vooral:
 Belangrijk onderscheid:
 
 - `Dual HP Enable Level`, `Dual HP Enable Hold` en `Dual HP Disable Hold` horen bij de verdeling in `Water Temperature Control`;
-- in `Power House` wordt de Duo-keuze juist automatisch bepaald op basis van geldige combinaties, warmtematch en elektrisch verbruik.
+- in `Power House` wordt de Duo-keuze juist automatisch bepaald op basis van geldige combinaties, met een efficiency-first single-versus-duokeuze en alleen een warmte-override als het verschil echt duidelijk is.
 - `Minimum runtime` is een runtime slider met standaard `15` minuten; dat is dus geen compile-time substitution.
 - `oq_hp_min_off_s` is juist wel compile-time en bepaalt de minimale uit-tijd per compressor voor elke restart, ook in `Power House`.
+- `oq_optimizer_topology_power_margin_w` en `oq_optimizer_topology_heat_advantage_w` zijn compile-time marges voor de single-versus-duokeuze in `Power House`.
 
-Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf de zuinigste geldige combinatie kiest en die kort vasthoudt om op en neer schakelen te beperken.
+Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een duurdere topologywissel kort afremt om op en neer schakelen te beperken.
 
 ### Flow en pompregeling
 

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -109,10 +109,11 @@ Handige diagnose-entiteiten:
 In een `Duo`-opstelling gebruikt `Power House` geen vaste regel als "altijd eerst 1 warmtepomp" of "liever altijd 2". De keuze gaat in eenvoudige stappen:
 
 1. kijk welke levelcombinaties toegestaan en geldig zijn;
-2. houd alleen combinaties over die de gevraagde warmte goed genoeg volgen;
-3. kies daarbinnen de combinatie met het laagste elektrische verbruik;
-4. wissel alleen als dat echt voordeel geeft;
-5. houd een single-/duokeuze kort vast om op en neer schakelen te beperken.
+2. bepaal apart de beste single-HP en beste dual-HP kandidaat;
+3. kies normaal de topology met het laagste elektrische verbruik;
+4. laat een minder zuinige topology alleen winnen als die de warmtevraag duidelijk beter volgt;
+5. wissel alleen als dat echt voordeel geeft;
+6. houd vooral topologywissels naar een duurdere keuze kort vast om op en neer schakelen te beperken.
 
 Als twee single-HP-keuzes verder gelijk zijn, krijgt de runtime lead warmtepomp voorrang. Tijdens defrost blijft OpenQuatt voorzichtiger en wordt het beschikbare thermische vermogen van de defrostende unit lager ingeschat.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -218,10 +218,11 @@ Demand filter behavior is asymmetric:
 
 Power House duo dispatch works in simple steps:
 
-- keep only combinations that follow the requested heat closely enough
-- within that group, choose the lowest electrical input
+- compare the best valid single-HP and dual-HP candidates separately
+- prefer the topology with the lower electrical input by default
+- allow a less-efficient topology only when it has a clear heat-match advantage
 - keep the current combination unless a switch gives clear heat or power benefit
-- hold a single-vs-dual choice briefly to reduce back-and-forth switching
+- hold only topology switches toward a higher-power choice briefly to reduce back-and-forth switching
 - if two single-HP options are equally good, choose the runtime lead HP
 - defrost still uses thermal derating and optional compensation boost
 

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -485,7 +485,7 @@ interval:
 # - CM-gating (only CM2/CM3)
 # - strategy pad:
 #   heating curve => single-HP/split
-#   power-house => duo dispatch on good-enough heat match, lowest electrical input, then anti-flip guards
+#   power-house => compare best single-vs-duo candidates, prefer lower electrical input, then apply anti-flip guards
 # - shared capacity/deficit publication
 # - allowed-level mapping + min-runtime + apply + runtime bookkeeping
 # ----------------------------
@@ -1124,10 +1124,10 @@ interval:
               }
             } else {
               // Power House duo dispatch:
-              // 1) keep only combinations that follow requested heat closely enough
-              // 2) within that group, pick the lowest electrical input
-              // 3) only switch if it clearly improves heat match or power use
-              // 4) hold single-vs-dual briefly to prevent pendelen
+              // 1) find the best single-HP and best dual-HP candidates separately
+              // 2) prefer the lower-power topology by default
+              // 3) allow a less-efficient topology only when it has a clear heat-match advantage
+              // 4) hold costlier single-vs-dual switches briefly to prevent pendelen
               float P_target = P_req_total;
               if (isnan(P_target)) P_target = 0.0f;
               if (P_target > cap_total) P_target = cap_total;
@@ -1139,6 +1139,10 @@ interval:
               const float P_EL_PEAK_W = ${oq_power_peak_w};
               const float thermal_tie_band_w = fmaxf(150.0f, 0.05f * fmaxf(P_target, 1000.0f));
               const float thermal_keep_margin_w = fminf(90.0f, thermal_tie_band_w * 0.5f);
+              float topology_power_margin_w = ${oq_optimizer_topology_power_margin_w};
+              if (isnan(topology_power_margin_w) || topology_power_margin_w < 0.0f) topology_power_margin_w = 40.0f;
+              float topology_heat_advantage_w = ${oq_optimizer_topology_heat_advantage_w};
+              if (isnan(topology_heat_advantage_w) || topology_heat_advantage_w < 0.0f) topology_heat_advantage_w = 225.0f;
               const float pel_switch_margin_w = 120.0f;
               const float soft_switch_margin_w = 40.0f;
               struct DuoCandidate {
@@ -1220,30 +1224,62 @@ interval:
                 return a.l2 < b.l2;
               };
 
-              float best_err_w = 1e12f;
-              for (int l1 = 0; l1 <= level_cap; l1++) {
-                for (int l2 = 0; l2 <= level_cap; l2++) {
-                  const DuoCandidate c = build_duo_candidate(l1, l2);
-                  if (!c.valid) continue;
-                  if (c.err_w < best_err_w) best_err_w = c.err_w;
+              const DuoCandidate current_candidate = build_duo_candidate(last1, last2);
+              auto pick_topology_candidate = [&](int active_hp_count, DuoCandidate &chosen)->bool {
+                float topology_best_err_w = 1e12f;
+                bool have_topology_candidate = false;
+                for (int l1 = 0; l1 <= level_cap; l1++) {
+                  for (int l2 = 0; l2 <= level_cap; l2++) {
+                    const DuoCandidate c = build_duo_candidate(l1, l2);
+                    if (!c.valid || c.active_hp_count != active_hp_count) continue;
+                    have_topology_candidate = true;
+                    if (c.err_w < topology_best_err_w) topology_best_err_w = c.err_w;
+                  }
                 }
-              }
+                if (!have_topology_candidate) return false;
+
+                bool have_chosen = false;
+                for (int l1 = 0; l1 <= level_cap; l1++) {
+                  for (int l2 = 0; l2 <= level_cap; l2++) {
+                    const DuoCandidate c = build_duo_candidate(l1, l2);
+                    if (!c.valid || c.active_hp_count != active_hp_count) continue;
+                    if (c.err_w > (topology_best_err_w + thermal_tie_band_w)) continue;
+                    if (!have_chosen || better_duo_candidate(c, chosen)) {
+                      chosen = c;
+                      have_chosen = true;
+                    }
+                  }
+                }
+                return have_chosen;
+              };
+
+              DuoCandidate best_single_candidate{};
+              const bool have_best_single = pick_topology_candidate(1, best_single_candidate);
+              DuoCandidate best_duo_candidate{};
+              const bool have_best_duo = pick_topology_candidate(2, best_duo_candidate);
 
               DuoCandidate best_candidate{};
               bool have_best_candidate = false;
-              for (int l1 = 0; l1 <= level_cap; l1++) {
-                for (int l2 = 0; l2 <= level_cap; l2++) {
-                  const DuoCandidate c = build_duo_candidate(l1, l2);
-                  if (!c.valid) continue;
-                  if (c.err_w > (best_err_w + thermal_tie_band_w)) continue;
-                  if (!have_best_candidate || better_duo_candidate(c, best_candidate)) {
-                    best_candidate = c;
-                    have_best_candidate = true;
-                  }
+              if (have_best_single && have_best_duo) {
+                const DuoCandidate *preferred_candidate = &best_single_candidate;
+                const DuoCandidate *alternate_candidate = &best_duo_candidate;
+                if (best_duo_candidate.p_el_w < best_single_candidate.p_el_w) {
+                  preferred_candidate = &best_duo_candidate;
+                  alternate_candidate = &best_single_candidate;
                 }
+                best_candidate = *preferred_candidate;
+                if (alternate_candidate->err_w + topology_heat_advantage_w < preferred_candidate->err_w) {
+                  best_candidate = *alternate_candidate;
+                }
+                have_best_candidate = true;
+              } else if (have_best_single) {
+                best_candidate = best_single_candidate;
+                have_best_candidate = true;
+              } else if (have_best_duo) {
+                best_candidate = best_duo_candidate;
+                have_best_candidate = true;
               }
 
-              const DuoCandidate current_candidate = build_duo_candidate(last1, last2);
               bool keep_current = false;
               const char* optimizer_reason = "keep_current";
 
@@ -1253,14 +1289,19 @@ interval:
                     (current_candidate.active_hp_count > 0) &&
                     (best_candidate.active_hp_count > 0) &&
                     (current_candidate.active_hp_count != best_candidate.active_hp_count);
-                const bool hold_active =
+                const bool switching_to_higher_pel =
                     topology_change &&
+                    (best_candidate.p_el_w > (current_candidate.p_el_w + topology_power_margin_w));
+                const bool hold_active =
+                    switching_to_higher_pel &&
                     (id(oq_duo_dispatch_hold_until_ms) > 0) &&
                     (now_ms < id(oq_duo_dispatch_hold_until_ms));
                 const bool better_soft_guard =
                     current_candidate.over_soft_w > (best_candidate.over_soft_w + soft_switch_margin_w);
+                const float efficiency_switch_margin_w =
+                    topology_change ? topology_power_margin_w : pel_switch_margin_w;
                 const bool better_efficiency =
-                    current_candidate.p_el_w > (best_candidate.p_el_w + pel_switch_margin_w);
+                    current_candidate.p_el_w > (best_candidate.p_el_w + efficiency_switch_margin_w);
 
                 if (hold_active && current_heat_ok) {
                   keep_current = true;

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -74,6 +74,8 @@ oq_cop_min_input_w: "10.0"                            # Minimum electrical input
 oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
 oq_optimizer_soft_w: "3400.0"                         # Soft limit for electrical HP power in optimizer [W]; peak limit follows oq_power_peak_w.
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].
+oq_optimizer_topology_power_margin_w: "40.0"          # Required power delta before a single<->duo topology switch counts as a meaningful efficiency gain [W].
+oq_optimizer_topology_heat_advantage_w: "225.0"       # Required heat-match advantage before a less-efficient topology may override the efficiency-first choice [W].
 oq_defrost_power_factor: "0.764"                      # Thermal derate on a defrosting HP in duo dispatch.
 oq_defrost_comp_min_f: "6"                            # Minimum demand f before single-defrost compensation is applied.
 oq_defrost_comp_boost_steps: "1"                      # Extra level steps on non-defrost HP during single-defrost compensation.


### PR DESCRIPTION
## Summary
- make the Power House single-vs-duo choice efficiency-first
- only let a less-efficient topology win on a clear heat-match advantage
- keep the anti-chatter topology hold focused on switches toward a higher-power topology
- document the updated optimizer behavior and compile-time margins