### PR TITLE
Update GitHub Actions workflows for Node 24

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -50,7 +50,7 @@ jobs:
         run: esphome compile ${{ matrix.profile.config }}
 
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: openquatt-${{ matrix.profile.id }}-firmware-${{ github.sha }}
           if-no-files-found: error

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: dev-release
   cancel-in-progress: true
@@ -38,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -78,7 +81,7 @@ jobs:
             compile "${{ matrix.profile.config }}"
 
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: openquatt-${{ matrix.profile.id }}-dev-release
           if-no-files-found: error
@@ -92,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/esphome-canary.yml
+++ b/.github/workflows/esphome-canary.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout site source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   compile-profiles:
     runs-on: ubuntu-latest
@@ -31,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -51,7 +54,7 @@ jobs:
         run: esphome compile ${{ matrix.profile.config }}
 
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: openquatt-${{ matrix.profile.id }}-release
           if-no-files-found: error
@@ -65,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Duo Waveshare artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- move checkout and setup-python to Node-24-ready majors
- move upload-artifact to the current Node-24-ready major
- force JavaScript actions to run on Node 24 in the dev/release publish workflows

## Why
GitHub now warns that Node.js 20 JavaScript actions are deprecated and will default to Node 24 starting June 2, 2026. This keeps our release and dev workflows compatible ahead of that cutoff.