### PR TITLE
Add Power House and heating strategy documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,11 +15,13 @@ Gebruik je de standaardfirmware, dan is de web installer uit de README meestal d
 
 - [Installatie en ingebruikname](installatie-en-ingebruikname.md): eerste installatie en controle na de eerste start.
 - [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md): rolverdeling tussen thermostaat, OpenQuatt, warmtepomp en Home Assistant.
+- [Power House](power-house.md): uitleg van de Power House-strategie, belangrijke parameters en Single/Duo-gedrag.
 - [Dashboard installeren](dashboard/README.md): keuze van het juiste dashboardbestand en import in Home Assistant.
 - [Dashboardoverzicht](dashboardoverzicht.md): de belangrijkste dashboardtabs en de volgorde waarin je ze gebruikt.
 - [Diagnose en afstelling](diagnose-en-afstelling.md): diagnose, werkvolgorde en terughoudend afstellen.
 
 ## Naslag
 
+- [Power House](power-house.md): aparte uitleg van huismodel, comfortlogica, rise/fall time, laaglastgedrag en Duo-keuze.
 - [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md): systeemstanden, overgangen en flowregeling.
 - [Instellingen en meetwaarden](instellingen-en-meetwaarden.md): compile-time en runtime instellingen, plus de belangrijkste meetwaarden.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,13 +15,17 @@ Gebruik je de standaardfirmware, dan is de web installer uit de README meestal d
 
 - [Installatie en ingebruikname](installatie-en-ingebruikname.md): eerste installatie en controle na de eerste start.
 - [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md): rolverdeling tussen thermostaat, OpenQuatt, warmtepomp en Home Assistant.
+- [Heating Strategy](heating-strategy.md): overzicht van `Power House` en `Water Temperature Control`, en wanneer welke aanpak past.
 - [Power House](power-house.md): uitleg van de Power House-strategie, belangrijke parameters en Single/Duo-gedrag.
+- [Water Temperature Control](water-temperature-control.md): uitleg van stooklijn, PID, curvegedrag en Duo-opbouw in watercurve-modus.
 - [Dashboard installeren](dashboard/README.md): keuze van het juiste dashboardbestand en import in Home Assistant.
 - [Dashboardoverzicht](dashboardoverzicht.md): de belangrijkste dashboardtabs en de volgorde waarin je ze gebruikt.
 - [Diagnose en afstelling](diagnose-en-afstelling.md): diagnose, werkvolgorde en terughoudend afstellen.
 
 ## Naslag
 
+- [Heating Strategy](heating-strategy.md): bovenliggende uitleg van beide verwarmingsstrategieën.
 - [Power House](power-house.md): aparte uitleg van huismodel, comfortlogica, rise/fall time, laaglastgedrag en Duo-keuze.
+- [Water Temperature Control](water-temperature-control.md): aparte uitleg van stooklijn, PID, COAST/OFF-gedrag en Duo-hysterese.
 - [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md): systeemstanden, overgangen en flowregeling.
 - [Instellingen en meetwaarden](instellingen-en-meetwaarden.md): compile-time en runtime instellingen, plus de belangrijkste meetwaarden.

--- a/docs/diagnose-en-afstelling.md
+++ b/docs/diagnose-en-afstelling.md
@@ -168,6 +168,8 @@ Te veel aanpassen is een van de snelste manieren om onrust in het systeem te hou
 
 - Installatie en basiscontrole: [Installatie en ingebruikname](installatie-en-ingebruikname.md)
 - Uitleg van rollen en begrippen: [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md)
+- Overzicht van beide strategieën: [Heating Strategy](heating-strategy.md)
 - Power House in meer detail: [Power House](power-house.md)
+- Stooklijnregeling in meer detail: [Water Temperature Control](water-temperature-control.md)
 - Dashboard lezen: [Dashboardoverzicht](dashboardoverzicht.md)
 - Meer technische naslag: [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md) en [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)

--- a/docs/diagnose-en-afstelling.md
+++ b/docs/diagnose-en-afstelling.md
@@ -168,5 +168,6 @@ Te veel aanpassen is een van de snelste manieren om onrust in het systeem te hou
 
 - Installatie en basiscontrole: [Installatie en ingebruikname](installatie-en-ingebruikname.md)
 - Uitleg van rollen en begrippen: [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md)
+- Power House in meer detail: [Power House](power-house.md)
 - Dashboard lezen: [Dashboardoverzicht](dashboardoverzicht.md)
 - Meer technische naslag: [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md) en [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)

--- a/docs/heating-strategy.md
+++ b/docs/heating-strategy.md
@@ -1,0 +1,138 @@
+# Heating Strategy
+
+Deze pagina geeft het overzicht van de twee verwarmingsstrategieën in OpenQuatt:
+
+- `Power House`
+- `Water Temperature Control`
+
+Het doel is eenvoudig: je snel laten begrijpen **welke strategie wat doet**, **wanneer welke aanpak past**, en **waar de belangrijkste verschillen zitten**.
+
+## Wat is een Heating Strategy?
+
+De `Heating Strategy` bepaalt hoe OpenQuatt van meetwaarden en warmtevraag naar een bruikbare verwarmingsvraag komt.
+
+Dat gebeurt dus nog **voor** de verdeling over compressorlevels en nog **voor** de keuze tussen één of twee warmtepompen.
+
+In gewone taal:
+
+- de strategie bepaalt **hoeveel warmte** OpenQuatt denkt nodig te hebben;
+- daarna bepaalt heat-control **hoe** die warmtevraag door de warmtepomp(en) geleverd wordt.
+
+## De twee strategieën
+
+### 1. Power House
+
+`Power House` denkt vooral vanuit de woning als geheel.
+
+Belangrijke kenmerken:
+
+- werkt met buitentemperatuur, kamertemperatuur en setpoint;
+- gebruikt een huismodel als basis;
+- corrigeert daarop met comfortlogica en kamerafwijking;
+- werkt met `P_house` en `P_req` in watt;
+- gebruikt een response profile met opbouw- en afbouwtijd;
+- kiest bij `Duo` automatisch de zuinigste geldige Single- of Duo-combinatie.
+
+Deze strategie past vaak goed als je:
+
+- comfort en kamertemperatuur centraal wilt zetten;
+- rustig, langer gedrag wilt;
+- wilt dat OpenQuatt meer zelf beslist hoe de warmtevraag wordt ingevuld.
+
+Meer detail:
+
+- [Power House](power-house.md)
+
+### 2. Water Temperature Control
+
+`Water Temperature Control` denkt vooral vanuit de gewenste aanvoertemperatuur.
+
+Belangrijke kenmerken:
+
+- gebruikt een stooklijn op basis van buitentemperatuur;
+- bepaalt daarmee een `Heating Curve Supply Target`;
+- gebruikt een PID-regelaar om de gemeten aanvoer die doeltemperatuur te laten volgen;
+- vertaalt de PID-uitkomst naar demand `0..20`;
+- werkt bij `Duo` in de basis single-HP-first met hysterese voor de tweede unit.
+
+Deze strategie past vaak goed als je:
+
+- liever met aanvoertemperatuur of stooklijn werkt;
+- het systeem meer als klassieke CV-/aanvoerregeling wilt benaderen;
+- de warmtepomp primair op watertemperatuur wilt laten sturen.
+
+Meer detail:
+
+- [Water Temperature Control](water-temperature-control.md)
+
+## Belangrijkste verschil
+
+De kern is:
+
+- `Power House` denkt eerst in **warmtevraag van het huis**
+- `Water Temperature Control` denkt eerst in **gewenste aanvoertemperatuur**
+
+Dat verschil werkt door in bijna alles:
+
+- welke signalen het zwaarst meewegen;
+- hoe de regeling op afwijkingen reageert;
+- welke instellingen het belangrijkst zijn;
+- hoe `Single` en `Duo` zich in de praktijk gedragen.
+
+## Welke strategie past wanneer?
+
+### Kies eerder `Power House` als:
+
+- je kijkt naar kamercomfort en warmtevraag van de woning;
+- je liever niet te veel in een stooklijn denkt;
+- je wilt dat OpenQuatt bij `Duo` efficiënt tussen single en duo kiest;
+- je gedrag wilt afstellen met huismodel, comfortband en response profile.
+
+### Kies eerder `Water Temperature Control` als:
+
+- je gewend bent te werken met een stooklijn;
+- je aanvoertemperatuur en watergedrag centraal wilt zetten;
+- je liever eerst de curvepunten en PID instelt;
+- je een meer klassieke verwarmingsaanpak wilt.
+
+## Wat verandert niet per strategie?
+
+Welke strategy je ook kiest:
+
+- bronkeuze blijft belangrijk;
+- flow en veiligheidslogica blijven actief;
+- `Control Mode` blijft leidend voor wanneer verwarmen mag;
+- de gedeelde watertempbegrenzing blijft bestaan;
+- `CM3`-logica en ketelhulp blijven erboven liggen.
+
+Dus: de strategie is belangrijk, maar niet het enige wat het gedrag bepaalt.
+
+## Hoe kies je verstandig?
+
+Een veilige aanpak is:
+
+1. begin met de strategie die het beste past bij hoe jij naar je systeem kijkt;
+2. beoordeel eerst bronwaarden, flow en algemeen gedrag;
+3. stel daarna pas de strategie-specifieke parameters bij;
+4. wissel niet te snel heen en weer tussen strategieën tijdens één korte testperiode.
+
+## Samenvatting
+
+Als je het kort wilt onthouden:
+
+- `Power House` = woning- en comfortgericht
+- `Water Temperature Control` = aanvoer- en stooklijngericht
+
+Geen van beide is "altijd beter". Het hangt af van:
+
+- je installatie;
+- je huis;
+- je manier van afstellen;
+- en wat je als prettig en logisch gedrag ervaart.
+
+## Gerelateerde pagina's
+
+- [Power House](power-house.md)
+- [Water Temperature Control](water-temperature-control.md)
+- [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md)
+- [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md)

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -149,6 +149,8 @@ Belangrijk daarbij is:
 
 - Installeren en eerste controle: [Installatie en ingebruikname](installatie-en-ingebruikname.md)
 - Dashboard begrijpen: [Dashboardoverzicht](dashboardoverzicht.md)
+- Verwarmingsstrategieën in overzicht: [Heating Strategy](heating-strategy.md)
 - Specifiek over deze strategie: [Power House](power-house.md)
+- Specifiek over stooklijnregeling: [Water Temperature Control](water-temperature-control.md)
 - Problemen oplossen: [Diagnose en afstelling](diagnose-en-afstelling.md)
 - Meer technische naslag: [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md) en [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -149,5 +149,6 @@ Belangrijk daarbij is:
 
 - Installeren en eerste controle: [Installatie en ingebruikname](installatie-en-ingebruikname.md)
 - Dashboard begrijpen: [Dashboardoverzicht](dashboardoverzicht.md)
+- Specifiek over deze strategie: [Power House](power-house.md)
 - Problemen oplossen: [Diagnose en afstelling](diagnose-en-afstelling.md)
 - Meer technische naslag: [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md) en [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -338,7 +338,9 @@ Vuistregel:
 ## Gerelateerde pagina's
 
 - [Installatie en ingebruikname](installatie-en-ingebruikname.md)
+- [Heating Strategy](heating-strategy.md)
 - [Power House](power-house.md)
+- [Water Temperature Control](water-temperature-control.md)
 - [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md)
 - [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md)
 - [Diagnose en afstelling](diagnose-en-afstelling.md)

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -338,6 +338,7 @@ Vuistregel:
 ## Gerelateerde pagina's
 
 - [Installatie en ingebruikname](installatie-en-ingebruikname.md)
+- [Power House](power-house.md)
 - [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md)
 - [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md)
 - [Diagnose en afstelling](diagnose-en-afstelling.md)

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -1,0 +1,472 @@
+# Power House
+
+Deze pagina legt uit hoe `Power House` in OpenQuatt werkt. Het doel is dat je de strategie goed genoeg begrijpt om gedrag te kunnen duiden en gericht te kunnen afstellen, zonder dat je eerst door alle YAML of runtime-debug hoeft.
+
+De uitleg is gebaseerd op de huidige code in:
+
+- `openquatt/oq_heating_strategy.yaml`
+- `openquatt/oq_heat_control.yaml`
+- `openquatt/oq_supervisory_controlmode.yaml`
+
+## Wat is Power House?
+
+`Power House` is de verwarmingsstrategie die vooral denkt in **gevraagde warmte voor de woning** in plaats van in een directe aanvoertemperatuurdoelstelling.
+
+In plaats van te zeggen "ik wil 32 °C aanvoer", zegt `Power House` grofweg:
+
+- hoe koud is het buiten;
+- hoe warm of koud is de kamer ten opzichte van de gewenste temperatuur;
+- hoeveel warmte heeft het huis dan ongeveer nodig;
+- hoe snel mag die gevraagde warmte op- of afbouwen.
+
+Het resultaat daarvan is een gevraagde verwarmingspower in watt:
+
+- `P_house`: de basisvraag van het huis
+- `P_req`: de uiteindelijke warmtevraag na kamer- en begrenzingslogica
+
+Daarna vertaalt OpenQuatt die warmtevraag naar compressorlevels voor één of twee warmtepompen.
+
+## Wanneer past Power House goed?
+
+`Power House` past meestal goed als je:
+
+- vooral op comfort en kamertemperatuur wilt sturen;
+- de woning als systeem wilt benaderen in plaats van alleen de aanvoer;
+- rustige, langere runs wilt;
+- bij `Duo` wilt dat OpenQuatt zelf de zuinigste combinatie kiest.
+
+Werk je liever direct met een stooklijn of aanvoertemperatuur, dan past `Water Temperature Control` vaak beter.
+
+## Hoofdlijn: zo loopt de regeling
+
+`Power House` werkt in de praktijk in deze volgorde:
+
+1. bepaal de bronwaarden die echt gebruikt worden;
+2. bereken de basis warmtevraag van het huis;
+3. corrigeer die vraag met kamerafwijking en comfortlogica;
+4. begrens de warmtevraag met deadband, opbouw-/afbouwtijd en watertempbegrenzing;
+5. vertaal de uitkomst naar compressorvraag;
+6. laat heat-control daar de beste Single- of Duo-verdeling bij zoeken;
+7. laat supervisory bewaken of verwarmen in `CM2` logisch actief moet blijven.
+
+Die lagen zijn belangrijk. Vreemd gedrag komt vaak niet uit één losse parameter, maar uit de combinatie van:
+
+- bronwaarden;
+- `Power House` zelf;
+- de compressorverdeling;
+- `CM2`/`CM1`-bewaking.
+
+## Stap 1: welke meetwaarden gebruikt Power House?
+
+`Power House` werkt met de **geselecteerde** waarden. Dat zijn de waarden die OpenQuatt op dat moment echt vertrouwt.
+
+De belangrijkste zijn:
+
+- `Outside Temperature (Selected)`
+- `Room Temperature (Selected)`
+- `Room Setpoint (Selected)`
+- `Water Supply Temp (Selected)`
+
+Als hier een verkeerde bron gekozen is, gaat de hele strategie logisch lijken maar toch verkeerd uitpakken. Daarom is broncontrole altijd stap 1 bij diagnose.
+
+## Stap 2: het huismodel maakt `P_house`
+
+De basis van `Power House` is een eenvoudig huismodel. Dat model kijkt naar:
+
+- `House cold temp`
+- `Maximum heating outdoor temperature`
+- `Rated maximum house power`
+- de actuele buitentemperatuur
+
+De gedachte is:
+
+- bij zachter weer heeft het huis minder warmte nodig;
+- bij kouder weer heeft het huis meer warmte nodig;
+- bij `House cold temp` zit je ongeveer tegen de volle ontwerpvraag aan.
+
+Daaruit ontstaat `P_house`: de basisvraag van het huis in watt.
+
+Belangrijk om te beseffen: de code rekent hier met de **gekozen buitentemperatuur**, niet met een apart windmodel. In de praktijk kan het huis bij dezelfde gemeten buitentemperatuur toch meer warmte verliezen door:
+
+- wind;
+- nat en guur weer;
+- zon of juist geen zon;
+- open ramen of deuren.
+
+Het gaat hier dus niet om een aparte "gevoelstemperatuur" in de code, maar eerder om **windinvloed op warmteverlies** of **extra afkoeling van de woning door wind**. Het huismodel ziet dat niet direct als aparte grootheid, maar je merkt het wel terug in het gedrag: bij veel wind kan het huis zich "kouder gedragen" dan de kale buitentemperatuur doet vermoeden.
+
+Praktisch:
+
+- `Rated maximum house power` bepaalt de schaal;
+- `House cold temp` en `Maximum heating outdoor temperature` bepalen hoe steil het model reageert op buitentemperatuur.
+
+Als `P_house` structureel te hoog of te laag ligt, krijg je vaak blijvende over- of ondershoot, ook als de rest van de regeling netjes werkt.
+
+Dat extra warmteverlies wordt in de huidige regeling vooral indirect opgevangen via:
+
+- een dalende `Room Temperature (Selected)`;
+- een grotere afwijking ten opzichte van `Room Setpoint (Selected)`;
+- en daardoor meer kamercorrectie bovenop `P_house`.
+
+Daarom is het goed om een langere periode te beoordelen met verschillend weer. Een instelling die bij rustig, droog weer goed voelt, kan bij veel wind toch te slap of juist te agressief blijken.
+
+## Stap 3: kamerlogica maakt van `P_house` een echte warmtevraag
+
+Daarna kijkt `Power House` naar de kamer.
+
+Belangrijke begrippen:
+
+- `Power House effective room target`
+- `Power House comfort bias`
+- `Power House room error avg`
+
+### Effective room target
+
+`Power House` werkt niet alleen met het kale setpoint. De strategie gebruikt:
+
+- `effective room target = room setpoint + comfort bias`
+
+Dat maakt het mogelijk om iets "warmer leunend" of juist neutraler gedrag te krijgen zonder meteen agressief te regelen.
+
+### Comfort bias
+
+De comfort-bias wordt opgebouwd en afgebouwd met:
+
+- `Power House comfort bias base`
+- `Power House comfort bias max`
+- `Power House comfort bias up`
+- `Power House comfort bias down`
+- `Power House room error avg tau`
+
+In gewone taal:
+
+- `base` is de minimale extra comfortmarge;
+- `max` is de bovengrens;
+- `up` bepaalt hoe snel de bias mag oplopen;
+- `down` bepaalt hoe snel die weer mag zakken;
+- `room error avg tau` maakt de kamerafwijking rustiger door te middelen.
+
+Deze bias is vooral bedoeld om het systeem niet te "nerveus exact op setpoint" te laten mikken, maar gecontroleerd iets meer comfortruimte te geven.
+
+### Comfortband rond het setpoint
+
+Daarnaast gebruikt `Power House` twee comfortmarges:
+
+- `Power House comfort below setpoint`
+- `Power House comfort above setpoint`
+
+Daarmee ontstaat een asymmetrische comfortband:
+
+- hoeveel onder setpoint nog acceptabel is;
+- hoeveel boven setpoint nog acceptabel is.
+
+Dat is bewust geen pure PID-benadering. Het systeem mag wat terughoudender zijn rond kleine afwijkingen en sterker reageren als de fout duidelijker wordt.
+
+### Kp en deadband
+
+De kamerfout wordt daarna omgerekend naar extra of minder warmtevraag met:
+
+- `Power House Kp (W-K)`
+- `Power House deadband`
+
+Praktisch:
+
+- `Kp` bepaalt hoeveel watt correctie per graad kamerfout wordt toegevoegd of afgetrokken;
+- `deadband` voorkomt dat elke heel kleine afwijking direct tot nieuwe warmtevraag leidt.
+
+Een te hoge `Kp` maakt het systeem eerder fel. Een te lage `Kp` maakt het systeem eerder traag of slap. `Deadband` bepaalt hoeveel rust er rond het doel zit.
+
+## Stap 4: opbouwtijd en afbouwtijd maken het gedrag rustiger
+
+Als `Power House` een ruwe warmtevraag heeft berekend, wordt die niet direct één-op-één doorgezet. Eerst gaat er nog een reactieprofiel overheen:
+
+- `Power House response profile`
+- `Power House demand rise time`
+- `Power House demand fall time`
+
+Deze tijden beschrijven ongeveer:
+
+- hoe lang `P_req` nodig mag hebben om van `0` naar `Rated maximum house power` te lopen;
+- hoe lang `P_req` nodig mag hebben om weer terug naar `0` te zakken.
+
+Belangrijk:
+
+- dit is **geen** opwarmtijd van het huis;
+- dit is de interne reactiesnelheid van de regeling.
+
+Een kortere opbouwtijd betekent:
+
+- sneller opschakelen;
+- sneller reageren op echte vraag;
+- meer kans op onrust als de rest al scherp staat.
+
+Een kortere afbouwtijd betekent:
+
+- sneller terugnemen bij overshoot;
+- minder kans dat het systeem te lang door blijft duwen;
+- mogelijk wat minder "comfortbuffer".
+
+## Stap 5: watertempbegrenzing kan `P_req` terugnemen
+
+Ook in `Power House` blijft `Water Supply Temp (Selected)` belangrijk.
+
+Met:
+
+- `Maximum water temperature`
+- `Water temperature soft band`
+- `Maximum water temperature trip`
+
+doet OpenQuatt drie dingen:
+
+1. al onder de maximale aanvoer voorzichtig terugnemen;
+2. tussen `max - soft band` en `max` steeds sterker afremmen;
+3. rond `trip` uiteindelijk naar een harde stop kunnen gaan.
+
+Daardoor kan `Power House` niet onbeperkt blijven vragen als de aanvoer al te hoog wordt.
+
+## Stap 6: van `P_req` naar compressorvraag
+
+Na alle bovenstaande stappen houdt OpenQuatt een begrensde warmtevraag over:
+
+- `P_req`
+
+Die vraag wordt vertaald naar een genormaliseerde demand-schaal (`0..20`) en daarna doorgegeven aan `oq_heat_control`.
+
+Daar begint de verdeling over de warmtepomp(en).
+
+## Single: hoe kiest OpenQuatt dan?
+
+Bij `Single` is dit relatief eenvoudig:
+
+- OpenQuatt vertaalt de gevraagde warmte naar een compressorlevel;
+- de vraag wordt gefilterd en begrensd;
+- de bestaande guards tegen te snel stoppen en starten blijven actief.
+
+Daar zit dus nog steeds rust- en beveiligingslogica omheen, maar er is geen keuze tussen één of twee units.
+
+## Duo: de optimizer in Power House
+
+Bij `Duo` wordt het interessanter. Dan moet OpenQuatt niet alleen bepalen **hoeveel** warmte nodig is, maar ook **welke combinatie van twee warmtepompen** dat het beste levert.
+
+De huidige code doet dat niet met een vaste regel als:
+
+- altijd eerst 1 warmtepomp;
+- of juist altijd liever 2 op lage levels.
+
+In plaats daarvan kijkt OpenQuatt per kandidaatcombinatie naar:
+
+- hoeveel thermisch vermogen die combinatie levert;
+- hoeveel elektrisch vermogen die combinatie vraagt;
+- of die combinatie toegestaan is;
+- of die combinatie logisch is ten opzichte van de huidige situatie.
+
+### In gewone taal
+
+De Duo-keuze loopt in `Power House` grofweg zo:
+
+1. zoek geldige Single- en Duo-combinaties;
+2. bepaal per topology wat de beste kandidaat is;
+3. kies normaal de topology met het laagste elektrische verbruik;
+4. laat een minder zuinige topology alleen winnen als die de warmtevraag duidelijk beter volgt;
+5. wissel niet voor mini-verschillen;
+6. rem dure single-versus-duowissels kort af om geflipper te voorkomen.
+
+Dat betekent:
+
+- soms wint `Single`;
+- soms wint `Duo`;
+- dat hangt af van de perf-map, buitentemperatuur, aanvoer en gevraagde warmte.
+
+### Runtime lead
+
+Als twee single-HP-keuzes verder gelijkwaardig zijn, krijgt de runtime lead warmtepomp voorrang.
+
+Het doel daarvan is:
+
+- looptijd eerlijker verdelen;
+- geen onnodige willekeur tussen HP1 en HP2.
+
+### Defrost
+
+Tijdens defrost wordt een warmtepomp niet als "normaal beschikbaar" gezien. OpenQuatt houdt rekening met:
+
+- lager effectief thermisch vermogen van een defrostende unit;
+- extra stapje op de andere unit als dat nodig en logisch is;
+- terughoudender wisselgedrag tijdens of vlak rond defrost.
+
+Dat voorkomt dat de optimizer een defrostende unit te optimistisch inschat.
+
+## Laaglastgedrag en anti-pendelen
+
+Een belangrijk deel van `Power House` zit niet alleen in de warmtevraag, maar ook in de bewaking rond lage load.
+
+Belangrijke signalen:
+
+- `Low-load dynamic thresholds`
+- `CM2 idle-exit reason`
+- `CM2 re-entry block active`
+- `Heat-enable state (shadow)`
+
+Wat daar gebeurt:
+
+- OpenQuatt schat een dynamische ondergrens in voor zinvol warmtepompbedrijf;
+- bij heel lage vraag mag `CM2` niet meteen blijven herstarten;
+- er zit hysterese tussen "uit laten" en "weer duidelijk genoeg vraag";
+- er zit een re-entry block tussen om `CM1 <-> CM2`-flipperen te beperken.
+
+Dit deel is juist belangrijk in zacht weer of bij installaties die op lage load snel te veel warmte leveren.
+
+## Belangrijkste parameters
+
+Niet alles is even belangrijk. Voor de meeste gebruikers zijn dit de relevante groepen.
+
+### 1. Huismodel
+
+- `House cold temp`
+- `Maximum heating outdoor temperature`
+- `Rated maximum house power`
+
+Gebruik deze om het basisgedrag van het huis te laten kloppen.
+
+### 2. Kamercorrectie en comfort
+
+- `Power House Kp (W-K)`
+- `Power House deadband`
+- `Power House comfort below setpoint`
+- `Power House comfort above setpoint`
+- `Power House comfort bias base`
+- `Power House comfort bias max`
+- `Power House comfort bias up`
+- `Power House comfort bias down`
+- `Power House room error avg tau`
+
+Gebruik deze om te bepalen hoe strak, comfortabel of warm-leaning de regeling zich rond setpoint gedraagt.
+
+### 3. Reactiesnelheid
+
+- `Power House response profile`
+- `Power House demand rise time`
+- `Power House demand fall time`
+
+Gebruik deze om te bepalen hoe snel `P_req` intern op en neer mag bewegen.
+
+### 4. Laaglaststabiliteit
+
+- `Low-load dynamic OFF factor`
+- `Low-load dynamic ON factor`
+- `Low-load minimum hysteresis`
+- `Low-load CM2 re-entry block`
+
+Gebruik deze vooral als het systeem in zacht weer te snel stopt en weer wil starten.
+
+### 5. Watertempbegrenzing
+
+- `Maximum water temperature`
+- `Water temperature soft band`
+- `Maximum water temperature trip`
+
+Gebruik deze om te voorkomen dat `Power House` te lang blijft duwen terwijl de aanvoer al te hoog wordt.
+
+## Welke parameters zijn niet voor de meeste gebruikers?
+
+Er zijn ook compile-time of interne marges die wel bestaan, maar meestal niet bedoeld zijn voor normale tuning. Bijvoorbeeld:
+
+- `oq_optimizer_topology_power_margin_w`
+- `oq_optimizer_topology_heat_advantage_w`
+- `oq_defrost_power_factor`
+- `oq_hp_min_off_s`
+
+Die horen meer bij onderliggende beschermings- en optimizerlogica dan bij normale comfortafstelling.
+
+## Handige meetwaarden en diagnostics
+
+Als je `Power House` wilt begrijpen of tunen, zijn deze meetwaarden meestal het nuttigst:
+
+- `Power House – P_house`
+- `Power House – P_req`
+- `Demand raw`
+- `Demand filtered`
+- `Power House effective room target`
+- `Power House comfort bias`
+- `Power House room error avg`
+- `Water Supply Temp (Selected)`
+- `Total Heat Power`
+- `Total Power Input`
+
+Bij `Duo` komen daar vaak bij:
+
+- `Runtime lead HP`
+- `Duo optimizer reason` (diagnostic, standaard verborgen)
+- `HP1 defrost`
+- `HP2 defrost`
+
+En voor laaglastgedrag:
+
+- `Low-load dynamic thresholds`
+- `CM2 idle-exit reason`
+- `CM2 re-entry block active`
+- `Heat-enable state (shadow)`
+
+## Veilige volgorde van afstellen
+
+Gebruik bij `Power House` bij voorkeur deze volgorde:
+
+1. controleer of de gekozen bronwaarden kloppen;
+2. controleer flow en algemeen systeemgedrag;
+3. laat eerst het huismodel ongeveer kloppen;
+4. stel daarna comfortmarges en `Kp` bij;
+5. kijk pas daarna naar response profile en rise/fall time;
+6. kijk pas als laatste naar laaglastgedrag en dieper Duo-gedrag.
+
+Dat voorkomt dat je symptomen oplost in de verkeerde laag.
+
+## Veelvoorkomende misverstanden
+
+### "Power House is gewoon een kamer-PID"
+
+Niet echt. Er zit wel kamerfout in, maar ook:
+
+- een huismodel;
+- comfortlogica;
+- deadband;
+- opbouw-/afbouwtijd;
+- watertempbegrenzing;
+- laaglastbewaking;
+- bij `Duo` een aparte Single/Duo-keuze.
+
+### "Duo moet altijd liever 2 warmtepompen op lage levels kiezen"
+
+Ook niet. Soms is dat efficiënter, soms niet. Daarom gebruikt de huidige code geen vaste voorkeur "altijd 1" of "altijd 2", maar vergelijkt hij geldige kandidaten.
+
+### "Rise time en fall time zijn de opwarmtijd van het huis"
+
+Nee. Dat zijn interne reactiesnelheden van de regeling, niet de fysieke opwarmtijd van de woning.
+
+### "Als `P_req` laag is, hoort de warmtepomp direct uit te gaan"
+
+Niet automatisch. Er kan juist bewust hysterese en wachttijd actief zijn om onrustig starten en stoppen te voorkomen.
+
+## Samenvatting
+
+`Power House` is een warmtevraagstrategie die:
+
+- begint met een huismodel op basis van buitencondities;
+- daar kamer- en comfortlogica overheen legt;
+- de uitkomst begrenst met respons- en watertemplogica;
+- en die warmtevraag daarna laat verdelen over één of twee warmtepompen.
+
+Bij `Duo` kiest de huidige code niet op basis van een simpele voorkeur, maar op basis van:
+
+- geldige combinaties;
+- warmtematch;
+- elektrisch verbruik;
+- en rust in het schakelen.
+
+Dat maakt `Power House` krachtig, maar ook gelaagd. Juist daarom helpt het om eerst het huismodel en de bronwaarden te laten kloppen, en pas daarna aan fijnregeling te beginnen.
+
+## Gerelateerde pagina's
+
+- [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md)
+- [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md)
+- [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)
+- [Diagnose en afstelling](diagnose-en-afstelling.md)

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -218,6 +218,8 @@ Als deze geselecteerde waarden niet kloppen, lijkt het alsof modes verkeerd werk
 
 ## Verder lezen
 
+- [Heating Strategy](heating-strategy.md)
 - [Power House](power-house.md)
+- [Water Temperature Control](water-temperature-control.md)
 - [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)
 - [Diagnose en afstelling](diagnose-en-afstelling.md)

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -215,3 +215,9 @@ Als deze geselecteerde waarden niet kloppen, lijkt het alsof modes verkeerd werk
 2. Kijk welke bronwaarden daadwerkelijk geselecteerd zijn.
 3. Kijk of de flow logisch en stabiel is.
 4. Kijk pas daarna naar strategie- of tuninginstellingen.
+
+## Verder lezen
+
+- [Power House](power-house.md)
+- [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)
+- [Diagnose en afstelling](diagnose-en-afstelling.md)

--- a/docs/water-temperature-control.md
+++ b/docs/water-temperature-control.md
@@ -1,0 +1,346 @@
+# Water Temperature Control
+
+Deze pagina legt uit hoe `Water Temperature Control` werkt in OpenQuatt. In de praktijk wordt dit vaak ook gewoon de **stooklijnregeling** genoemd.
+
+Het doel is dat je begrijpt:
+
+- hoe de strategie een aanvoertemperatuurdoel maakt;
+- hoe de PID-regeling daarop werkt;
+- welke instellingen echt belangrijk zijn;
+- en hoe `Single` en `Duo` zich in deze modus gedragen.
+
+De uitleg is gebaseerd op de huidige code in:
+
+- `openquatt/oq_heating_strategy.yaml`
+- `openquatt/oq_heat_control.yaml`
+
+## Wat is Water Temperature Control?
+
+`Water Temperature Control` is de verwarmingsstrategie die vooral denkt in **gewenste aanvoertemperatuur**.
+
+In plaats van eerst te berekenen hoeveel watt het huis nodig heeft, zegt deze strategie grofweg:
+
+- hoe koud is het buiten;
+- welke aanvoertemperatuur hoort daar volgens de stooklijn bij;
+- hoe ver zit de gemeten aanvoer daarvan af;
+- hoeveel compressorvraag is nodig om die aanvoer te volgen.
+
+Dat maakt deze strategie herkenbaar voor gebruikers die gewend zijn aan:
+
+- een stooklijn;
+- aanvoertemperatuur als hoofddoel;
+- of meer klassieke weersafhankelijke regeling.
+
+## Hoofdlijn: zo loopt de regeling
+
+`Water Temperature Control` werkt in de praktijk in deze volgorde:
+
+1. bepaal de gekozen buitentemperatuur;
+2. leid daaruit een gewenste aanvoertemperatuur af via de stooklijn;
+3. begrens die gewenste aanvoertemperatuur met de gedeelde watertemplogica;
+4. laat een PID-regelaar de gemeten aanvoer naar dat doel sturen;
+5. vertaal de PID-uitkomst naar demand `0..20`;
+6. laat heat-control daar compressorlevels van maken;
+7. laat bij `Duo` de tweede warmtepomp pas meedoen als de vraag hoog genoeg en lang genoeg aanhoudt.
+
+## Stap 1: de buitentemperatuur
+
+De stooklijn gebruikt de **gekozen buitentemperatuur**:
+
+- `Outside Temperature (Selected)`
+
+Als die bron niet klopt, klopt de rest ook niet:
+
+- te lage buitenwaarde -> te hoge gevraagde aanvoer;
+- te hoge buitenwaarde -> te lage gevraagde aanvoer.
+
+Daarom blijft broncontrole ook hier de eerste stap.
+
+## Stap 2: de stooklijn maakt een supply target
+
+De stooklijn bestaat uit zes instelpunten:
+
+- `Curve Tsupply @ -20°C`
+- `Curve Tsupply @ -10°C`
+- `Curve Tsupply @ 0°C`
+- `Curve Tsupply @ 5°C`
+- `Curve Tsupply @ 10°C`
+- `Curve Tsupply @ 15°C`
+
+OpenQuatt interpoleert daar lineair tussen. Dat betekent:
+
+- tussen twee punten loopt het doel geleidelijk mee;
+- je hoeft dus niet voor elke buitentemperatuur apart iets in te stellen.
+
+Het resultaat is:
+
+- `Heating Curve Supply Target`
+
+Als de buitentemperatuur ontbreekt, gebruikt OpenQuatt:
+
+- `Curve Fallback Tsupply (No Outside Temp)`
+
+## Stap 3: gedeelde watertempbegrenzing
+
+Ook in deze strategie blijft `Water Supply Temp (Selected)` belangrijk.
+
+Met:
+
+- `Maximum water temperature`
+- `Water temperature soft band`
+- `Maximum water temperature trip`
+
+wordt het target of gedrag begrensd als de aanvoer al te hoog wordt.
+
+In `Water Temperature Control` betekent dat vooral:
+
+- het curve-target wordt geclamped;
+- bij een echte trip kan de vraag naar nul gaan;
+- de regeling blijft dus niet doorduwen als de aanvoer al te hoog is.
+
+## Stap 4: PID op de aanvoer
+
+Daarna gebruikt OpenQuatt een PID-regelaar:
+
+- `Heating Curve PID`
+
+De PID vergelijkt:
+
+- doelwaarde: `Heating Curve Supply Target`
+- meetwaarde: de gebruikte systeemaanvoer
+
+De PID-uitkomst wordt daarna omgezet naar demand `0..20`.
+
+Belangrijke instellingen:
+
+- `Heating Curve PID Kp`
+- `Heating Curve PID Ki`
+- `Heating Curve PID Kd`
+
+Praktisch:
+
+- `Kp` bepaalt hoe sterk de regeling direct op een fout reageert;
+- `Ki` bepaalt hoeveel langdurige afwijking wordt weggewerkt;
+- `Kd` dempt snelle veranderingen, maar wordt vaak laag of op nul gebruikt.
+
+## Stap 5: niet abrupt naar nul
+
+De huidige curve-regeling heeft extra guardrails rond lage vraag. Dat is belangrijk, want anders krijg je snel onrustig aan/uit-gedrag rond het omslagpunt.
+
+Belangrijke begrippen:
+
+- `Curve Phase`
+- `Demand curve raw (PID)`
+- `Demand raw`
+- `Curve restart inhibit`
+
+De regeling kent grofweg drie fasen:
+
+- `HEAT`
+- `COAST`
+- `OFF`
+
+### HEAT
+
+De PID stuurt normaal en de warmtepomp volgt de vraag.
+
+### COAST
+
+Als de vraag laag wordt of de aanvoer net boven doel zit, valt de regeling niet direct hard naar nul terug. Ze kan eerst in een lichtere fase blijven lopen.
+
+Dat helpt om:
+
+- pendelen te beperken;
+- de aanvoer rustiger te laten uitdempen;
+- onnodig vaak opnieuw starten te voorkomen.
+
+### OFF
+
+Pas als de stopvoorwaarde voldoende duidelijk en lang genoeg aanwezig is, valt de vraag echt weg.
+
+Daarna kan nog een korte restart-inhibit actief zijn, zodat het systeem niet direct weer opnieuw begint.
+
+## Stap 6: kamertemperatuur speelt nog steeds mee
+
+Ook al is dit geen kamergerichte strategie zoals `Power House`, de kamer kan nog steeds invloed hebben.
+
+De code gebruikt namelijk ook een warme-kamertrim op het supply target. In gewone taal:
+
+- als de kamer al warm wegdrijft, kan het target iets terughoudender worden;
+- de stooklijn werkt dus niet volledig blind op buitentemperatuur alleen.
+
+Dat maakt het gedrag vaak bruikbaarder in echte woningen.
+
+## Single: hoe werkt dit?
+
+Bij `Single` is de verdeling simpel:
+
+- demand wordt omgezet naar een compressorlevel;
+- guardrails, minimum runtime en andere beveiligingen blijven actief.
+
+De hoofdvraag is dan vooral:
+
+- klopt de stooklijn;
+- klopt de PID-afstelling;
+- is de aanvoerbron logisch.
+
+## Duo: hoe werkt dit hier?
+
+In `Water Temperature Control` werkt de verdeling anders dan in `Power House`.
+
+De basis is:
+
+- eerst één warmtepomp;
+- de tweede warmtepomp mag pas meedoen als de vraag hoog genoeg is en dat ook even blijft;
+- er zit dus hysterese en wachttijd in de overgang naar `Duo`.
+
+Belangrijke instellingen:
+
+- `Dual HP Enable Level`
+- `Dual HP Enable Hold`
+- `Dual HP Disable Hold`
+- `Minimum runtime`
+
+Dat betekent praktisch:
+
+- bij oplopende vraag gaat `Duo` niet meteen aan;
+- bij dalende vraag gaat `Duo` ook niet meteen weer uit;
+- zo voorkom je dat het systeem tussen single en duo gaat stuiteren.
+
+Als `Duo` actief is in deze strategie:
+
+- wordt de vraag in de basis gelijkmatig verdeeld;
+- een oneven stap gaat naar de runtime lead warmtepomp.
+
+Dus anders dan in `Power House` is dit hier **geen efficiency-first optimizer** tussen single en duo. Het is hier vooral een meer klassieke opbouw met hysterese.
+
+## Control profiles
+
+`Heating Curve Control Profile` geeft een ingebouwde karakterkeuze voor de curve-regeling.
+
+De opties zijn:
+
+- `Comfort`
+- `Balanced`
+- `Stable`
+
+In gewone taal:
+
+- `Comfort` reageert wat vlotter;
+- `Stable` is terughoudender;
+- `Balanced` zit ertussen.
+
+Daarnaast kan OpenQuatt ook:
+
+- de buitentemperatuur gladstrijken;
+- het target kwantiseren;
+- restartgedrag rustiger maken.
+
+Dat helpt tegen te veel micro-reacties op onrustige signalen.
+
+## Belangrijkste parameters
+
+Voor de meeste gebruikers zijn dit de relevante groepen.
+
+### 1. De stooklijn zelf
+
+- `Curve Tsupply @ -20/-10/0/5/10/15°C`
+- `Curve Fallback Tsupply (No Outside Temp)`
+
+Gebruik deze om het basisgedrag van de aanvoer passend te maken bij jouw huis.
+
+### 2. De curve-regelaar
+
+- `Heating Curve Control Profile`
+- `Heating Curve PID Kp`
+- `Heating Curve PID Ki`
+- `Heating Curve PID Kd`
+
+Gebruik deze om te bepalen hoe scherp of rustig de aanvoerregeling het target volgt.
+
+### 3. Duo-opbouw en looptijd
+
+- `Dual HP Enable Level`
+- `Dual HP Enable Hold`
+- `Dual HP Disable Hold`
+- `Minimum runtime`
+
+Gebruik deze vooral als `Duo` te laat, te vroeg of te onrustig inschakelt.
+
+### 4. Watertempbegrenzing
+
+- `Maximum water temperature`
+- `Water temperature soft band`
+- `Maximum water temperature trip`
+
+Gebruik deze om te voorkomen dat de aanvoerregeling te lang te hoog blijft mikken.
+
+## Handige meetwaarden en diagnostics
+
+Als je deze strategie wilt begrijpen of afstellen, zijn deze waarden meestal het nuttigst:
+
+- `Heating Curve Supply Target`
+- `Water Supply Temp (Selected)`
+- `Heating Curve PID`
+- `Curve Phase`
+- `Demand curve raw (PID)`
+- `Demand raw`
+- `Curve restart inhibit`
+
+Bij `Duo` komen daar vaak bij:
+
+- `Runtime lead HP`
+- `HP1 compressor level`
+- `HP2 compressor level`
+- `HP1 defrost`
+- `HP2 defrost`
+
+## Veilige volgorde van afstellen
+
+Een verstandige volgorde is:
+
+1. controleer eerst of de gekozen buitentemperatuur en aanvoer kloppen;
+2. stel daarna de stooklijnpunten in;
+3. pas daarna PID-instellingen aan;
+4. kijk daarna pas naar `Duo`-inschakeling en holds;
+5. beoordeel het effect over langere periodes, niet alleen een paar minuten.
+
+Dat voorkomt dat je een verkeerd curvepunt probeert op te lossen met PID-tuning, of andersom.
+
+## Veelvoorkomende misverstanden
+
+### "Als de curve klopt, maakt PID bijna niet uit"
+
+Niet helemaal. De curve bepaalt het doel, maar PID bepaalt nog steeds hoe strak of rustig dat doel gevolgd wordt.
+
+### "Meer Kp is altijd beter"
+
+Nee. Een te hoge `Kp` kan juist onrust, overshoot of snelle vraagwisselingen geven.
+
+### "Duo in stooklijnmodus kiest automatisch de zuinigste combinatie"
+
+Nee. Dat hoort bij de huidige `Power House`-aanpak. In `Water Temperature Control` werkt `Duo` vooral met single-first en hysterese.
+
+### "COAST betekent dat er iets mis is"
+
+Niet per se. `COAST` is juist een bewuste tussenfase om niet te abrupt van verwarmen naar helemaal uit te gaan.
+
+## Samenvatting
+
+`Water Temperature Control` is de strategie voor gebruikers die hun systeem vooral via aanvoertemperatuur en stooklijn willen benaderen.
+
+De kern is:
+
+- buitentemperatuur -> stooklijn -> supply target;
+- PID laat de aanvoer dat target volgen;
+- guardrails houden het gedrag rustig rond lage vraag;
+- bij `Duo` wordt de tweede unit met hysterese en wachttijd toegevoegd.
+
+Dat maakt deze strategie vaak goed voorspelbaar voor wie graag met aanvoertemperatuur werkt.
+
+## Gerelateerde pagina's
+
+- [Heating Strategy](heating-strategy.md)
+- [Power House](power-house.md)
+- [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md)
+- [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)


### PR DESCRIPTION
## Summary
- add a dedicated `Power House` documentation page
- add dedicated `Heating Strategy` and `Water Temperature Control` documentation pages
- link the new pages from the existing documentation flow and reference pages
- expand the control-behaviour docs so the strategy concepts are easier to find

## Why
- makes the control concepts easier to understand without having to infer them from multiple pages
- gives users and testers one clear place to read about `Power House` and heating-strategy behaviour
- improves discoverability from the main docs index and related troubleshooting/settings pages

## Scope
- documentation only
- no firmware logic changes
- no dashboard or runtime behaviour changes

## Testing
- not run (documentation-only changes)