### PR TITLE
Add Power House start confirmation and minimum runtime floor

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2174,8 +2174,8 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Minimum runtime** prevents short-cycling and excessive
-              start/stop behavior.
+              - **Minimum runtime** keeps a started compressor on for at least
+              `300 s`. You can lengthen this runtime, but not lower it.
 
               - **Demand filter ramp up** controls how many demand steps per
               minute `Demand filtered` may rise toward `Demand raw` in Power

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2283,8 +2283,9 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Minimum runtime** voorkomt kortcyclen en overmatig
-              start/stop-gedrag.
+              - **Minimum runtime** houdt een al gestarte compressor minimaal
+              `300 s` aan. Je kunt deze runtime verlengen, maar niet lager
+              zetten.
 
               - **Demand filter ramp up** bepaalt met hoeveel demand-stappen per
               minuut `Demand filtered` maximaal mag stijgen richting `Demand

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1928,8 +1928,8 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Minimum runtime** prevents short-cycling and excessive
-              start/stop behavior.
+              - **Minimum runtime** keeps a started compressor on for at least
+              `300 s`. You can lengthen this runtime, but not lower it.
 
               - **Demand filter ramp up** controls how many demand steps per
               minute `Demand filtered` may rise toward `Demand raw` in Power

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2013,8 +2013,9 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Minimum runtime** voorkomt kortcyclen en overmatig
-              start/stop-gedrag.
+              - **Minimum runtime** houdt een al gestarte compressor minimaal
+              `300 s` aan. Je kunt deze runtime verlengen, maar niet lager
+              zetten.
 
               - **Demand filter ramp up** bepaalt met hoeveel demand-stappen per
               minuut `Demand filtered` maximaal mag stijgen richting `Demand

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -188,14 +188,14 @@ Belangrijke instellingen:
 Deze groep bepaalt vooral:
 
 - hoe snel vraag mag oplopen;
-- hoe lang units blijven lopen;
+- hoe lang een al gestarte compressor minimaal moet blijven lopen;
 - wanneer een tweede unit bij een Duo-opstelling mag meedoen.
 
 Belangrijk onderscheid:
 
 - `Dual HP Enable Level`, `Dual HP Enable Hold` en `Dual HP Disable Hold` horen bij de verdeling in `Water Temperature Control`;
 - in `Power House` wordt de Duo-keuze juist automatisch bepaald op basis van geldige combinaties, met een efficiency-first single-versus-duokeuze en alleen een warmte-override als het verschil echt duidelijk is.
-- `Minimum runtime` is een runtime slider met standaard `15` minuten; dat is dus geen compile-time substitution.
+- `Minimum runtime` is een runtime slider in seconden. De ondergrens is `300 s`, zodat je korte compressor-runs niet per ongeluk weer mogelijk maakt.
 - `oq_hp_min_off_s` is juist wel compile-time en bepaalt de minimale uit-tijd per compressor voor elke restart, ook in `Power House`.
 - `oq_optimizer_topology_power_margin_w` en `oq_optimizer_topology_heat_advantage_w` zijn compile-time marges voor de single-versus-duokeuze in `Power House`.
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -309,10 +309,12 @@ Belangrijke signalen:
 
 Wat daar gebeurt:
 
+- voordat een nieuwe warmtevraag echt mag starten, moet die vraag kort stabiel blijven;
 - OpenQuatt schat een dynamische ondergrens in voor zinvol warmtepompbedrijf;
 - bij heel lage vraag mag `CM2` niet meteen blijven herstarten;
 - er zit hysterese tussen "uit laten" en "weer duidelijk genoeg vraag";
 - er zit een re-entry block tussen om `CM1 <-> CM2`-flipperen te beperken.
+- na een compressorstart geldt per compressor een instelbare minimale draaitijd, met een ondergrens van `300 s`.
 
 Dit deel is juist belangrijk in zacht weer of bij installaties die op lage load snel te veel warmte leveren.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -170,6 +170,7 @@ Then maps requested power to demand scale `0..20`.
 
 Power House stability guards in supervisory:
 
+- short start confirmation before a new Power House heating request may leave idle
 - dynamic low-load thresholds from performance map level-1 thermal power (`pmin/off/on`)
 - last-known-good dynamic thresholds across short telemetry dropouts
 - internal fallback low-load OFF/ON thresholds when dynamic input is unavailable
@@ -178,6 +179,7 @@ Power House stability guards in supervisory:
 - CM2 startup-grace and high-load guard on idle-exit path
 - shadow heat-enable arbiter diagnostics (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`)
 - shared water-temperature limiter on effective `P_req` using `water_supply_temp_selected`
+- per-compressor minimum runtime once a compressor has started (user-tunable, lower bound `300 s`)
 
 ### Water Temperature Control mode
 

--- a/docs/water-temperature-control.md
+++ b/docs/water-temperature-control.md
@@ -242,10 +242,10 @@ De basis is:
 
 Belangrijke instellingen:
 
+- `Minimum runtime`
 - `Dual HP Enable Level`
 - `Dual HP Enable Hold`
 - `Dual HP Disable Hold`
-- `Minimum runtime`
 
 Dat betekent praktisch:
 
@@ -306,12 +306,12 @@ Gebruik deze om te bepalen hoe scherp of rustig de aanvoerregeling het target vo
 
 ### 3. Duo-opbouw en looptijd
 
+- `Minimum runtime`
 - `Dual HP Enable Level`
 - `Dual HP Enable Hold`
 - `Dual HP Disable Hold`
-- `Minimum runtime`
 
-Gebruik deze vooral als `Duo` te laat, te vroeg of te onrustig inschakelt.
+Gebruik deze vooral als `Duo` te laat, te vroeg of te onrustig inschakelt. `Minimum runtime` werkt per compressor en heeft een ondergrens van `300 s` om korte start/stop-cycli te vermijden.
 
 ### 4. Watertempbegrenzing
 

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -165,14 +165,14 @@ number:
     id: oq_min_runtime_min
     name: "Minimum runtime"
     icon: mdi:timer-cog-outline
-    unit_of_measurement: "min"
-    min_value: 0
-    max_value: 240
-    step: 1
+    unit_of_measurement: "s"
+    min_value: 300
+    max_value: 3600
+    step: 30
     mode: slider
     restore_value: true
     optimistic: true
-    initial_value: 15
+    initial_value: 300
     web_server:
       sorting_group_id: oq_tuning_heat
 
@@ -1596,12 +1596,13 @@ interval:
           // =========================
           // 6) Minimum runtime (all strategies)
           // Prevents very short compressor runs in both curve and Power House modes.
+          // Runtime is per-compressor and user-tunable, with a hard lower bound of 300 s.
           // Skipped during an absolute water-temperature hard trip.
           // =========================
-          const int min_rt = (int) roundf(id(oq_min_runtime_min).state);
-          if (!id(oq_water_temp_hard_trip_active) && min_rt > 0) {
+          const int min_rt_s = (int) roundf(id(oq_min_runtime_min).state);
+          if (!id(oq_water_temp_hard_trip_active) && min_rt_s > 0) {
             // HP1: if request is 0 but runtime < min -> force >=1
-            const uint32_t min_rt_ms = (uint32_t) min_rt * 60000UL;
+            const uint32_t min_rt_ms = (uint32_t) min_rt_s * 1000UL;
             const uint32_t hp1_rt_ms = (uint32_t)(now_ms - id(hp1_last_start_ms));
             if (hp1_req == 0 && id(hp1_last_applied_level) > 0 && hp1_rt_ms < min_rt_ms) {
               hp1_req = pick_allowed(1, true);

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -41,6 +41,7 @@ oq_cm_min_flow_lph: "250.0"                           # Minimum valid flow for c
 oq_cm_flow_fault_s: "60"                              # Low-flow duration before fault becomes active [s].
 oq_cm_flow_recover_s: "30"                            # Flow recovery duration before fault is cleared [s].
 oq_cm2_idle_exit_s: "90"                              # Exit CM2 if both HPs are idle for this duration while demand remains > 0 [s].
+oq_ph_start_confirm_s: "30"                          # Power House start confirmation: demand must stay active for this time before CM1/CM2 startup [s].
 oq_low_load_fallback_off_w: "900"                     # Internal fallback OFF threshold when no dynamic low-load input is available [W].
 oq_low_load_fallback_on_w: "1300"                     # Internal fallback ON threshold when no dynamic low-load input is available [W].
 oq_low_load_dyn_cache_max_s: "60"                     # Maximum age for reusing last-known-good dynamic low-load thresholds [s].

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -96,6 +96,10 @@ globals:
     type: uint32_t
     restore_value: false
     initial_value: '0'
+  - id: oq_ph_start_confirm_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
 
   # Sticky Pump Protection (CM0-only)
   - id: oq_cm0_since_ms
@@ -853,10 +857,28 @@ interval:
             id(oq_lowload_heat_latch) = heating_req_raw;
             id(oq_cm2_reentry_block_until_ms) = 0;
             reentry_block_active = false;
+            id(oq_ph_start_confirm_since_ms) = 0;
             id(oq_low_load_dyn_source_state) = 0;
             id(oq_low_load_pmin_dyn_w) = NAN;
             id(oq_low_load_off_dyn_w) = NAN;
             id(oq_low_load_on_dyn_w) = NAN;
+          }
+
+          // Power House startup confirmation:
+          // from a non-heating state, demand must stay active briefly before we enter CM1/CM2.
+          // This filters short-lived P_req spikes (for example sun on the outside sensor)
+          // before they turn into a real compressor start.
+          if (power_house_active) {
+            const uint32_t start_confirm_ms = (uint32_t)(${oq_ph_start_confirm_s}UL * 1000UL);
+            const bool start_pending_scope = !in_cm2 && !any_hp_active_guard;
+            if (start_confirm_ms > 0 && heating_req && start_pending_scope) {
+              if (id(oq_ph_start_confirm_since_ms) == 0) id(oq_ph_start_confirm_since_ms) = now_ms;
+              if ((uint32_t)(now_ms - id(oq_ph_start_confirm_since_ms)) < start_confirm_ms) {
+                heating_req = false;
+              }
+            } else {
+              id(oq_ph_start_confirm_since_ms) = 0;
+            }
           }
 
           const uint32_t cm2_idle_exit_ms = (uint32_t)(${oq_cm2_idle_exit_s}UL * 1000UL);


### PR DESCRIPTION
## Summary
- add Power House start confirmation before leaving idle
- keep minimum runtime user-tunable with a 300s floor
- update dashboards and docs to match

## Notes
- intended to reduce short false starts from brief demand spikes
