### PR TITLE
Add lowest-valid outside temperature source option

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1673,6 +1673,10 @@ views:
                     name: Outside temperature (Outdoor unit)
                   - entity: sensor.openquatt_ha_outside_temperature
                     name: Outside temperature (HA Input)
+                  - type: attribute
+                    entity: select.openquatt_outside_temperature_source
+                    attribute: options
+                    name: Available source options
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1763,6 +1763,10 @@ views:
                     name: Buitentemperatuur (buitenunit)
                   - entity: sensor.openquatt_ha_outside_temperature
                     name: Buitentemperatuur (HA-invoer)
+                  - type: attribute
+                    entity: select.openquatt_outside_temperature_source
+                    attribute: options
+                    name: Beschikbare bronopties
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1427,6 +1427,10 @@ views:
                     name: Outside temperature (Outdoor unit)
                   - entity: sensor.openquatt_ha_outside_temperature
                     name: Outside temperature (HA Input)
+                  - type: attribute
+                    entity: select.openquatt_outside_temperature_source
+                    attribute: options
+                    name: Available source options
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1493,6 +1493,10 @@ views:
                     name: Buitentemperatuur (buitenunit)
                   - entity: sensor.openquatt_ha_outside_temperature
                     name: Buitentemperatuur (HA-invoer)
+                  - type: attribute
+                    entity: select.openquatt_outside_temperature_source
+                    attribute: options
+                    name: Beschikbare bronopties
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -253,6 +253,8 @@ Belangrijke instellingen en signalen:
 
 Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteerde bron niet klopt, helpt fijnregelen vrijwel nooit.
 
+Voor `Outside Temperature Source` is ook de optie `Lowest valid` beschikbaar. Dan vergelijkt OpenQuatt de lokale buitenunitmeting en de HA-invoer, gebruikt alleen geldige waarden en kiest de laagste van de twee.
+
 ### Service en diagnose
 
 Belangrijke hulpmiddelen:

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -82,6 +82,7 @@ select:
     options:
       - Outdoor unit
       - HA input
+      - Lowest valid
     initial_option: Outdoor unit
     web_server:
       sorting_group_id: oq_cic
@@ -218,12 +219,20 @@ sensor:
     lambda: |-
       if (!id(outside_temp_source).has_state()) return NAN;
       const auto source = id(outside_temp_source).current_option();
+      const bool hp_valid = id(outside_temp_hp_avg).has_state() && !isnan(id(outside_temp_hp_avg).state);
+      const bool ha_valid = id(outside_temp_ha).has_state() && !isnan(id(outside_temp_ha).state);
+      if (source == "Lowest valid") {
+        if (hp_valid && ha_valid) return fminf(id(outside_temp_hp_avg).state, id(outside_temp_ha).state);
+        if (hp_valid) return id(outside_temp_hp_avg).state;
+        if (ha_valid) return id(outside_temp_ha).state;
+        return NAN;
+      }
       if (source == "HA input") {
-        if (id(outside_temp_ha).has_state()) return id(outside_temp_ha).state;
+        if (ha_valid) return id(outside_temp_ha).state;
         return NAN;
       }
       if (source == "Outdoor unit") {
-        if (id(outside_temp_hp_avg).has_state()) return id(outside_temp_hp_avg).state;
+        if (hp_valid) return id(outside_temp_hp_avg).state;
         return NAN;
       }
       return NAN;


### PR DESCRIPTION
## Summary
- add a new outside temperature source mode: Lowest valid
- choose the lowest valid value from Outdoor unit and HA input
- update dashboards and docs
