### PR TITLE
Add duo outdoor-unit flow mode selector

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1586,6 +1586,9 @@ views:
               - quick comparison between CIC, local, and HA Input
               - validation of the effective control input
               - verification of automatic HA fallback to HA inputs during CIC outages
+              - in Duo, `Flow source = Outdoor unit` reveals an extra choice for
+                `Flowmeter HP1`, `Flowmeter HP2`, or the existing local HP1/HP2
+                aggregate
 
               </details>
             text_only: true
@@ -1653,6 +1656,23 @@ views:
                     name: Flow rate (Outdoor unit)
                   - entity: sensor.openquatt_cic_flowrate_filtered
                     name: Flow rate (CIC)
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: select.openquatt_flow_source
+                    state: Outdoor unit
+                card:
+                  type: entities
+                  show_header_toggle: false
+                  entities:
+                    - entity: select.openquatt_outdoor_unit_flow_mode
+                      name: Outdoor unit flow mode
+                    - entity: sensor.openquatt_hp1_flow
+                      name: Flowmeter HP1
+                    - entity: sensor.openquatt_hp2_flow
+                      name: Flowmeter HP2
+                    - entity: sensor.openquatt_flow_average_local
+                      name: Local aggregate HP1/HP2
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1674,6 +1674,9 @@ views:
               - snelle vergelijking tussen CIC, lokaal en HA input
               - validatie van de effectieve regelinput
               - controle van automatische HA-terugval naar HA-inputs bij CIC-uitval
+              - bij `Flow bron = Outdoor unit` in een Duo-opstelling verschijnt een extra
+                keuze voor `Flowmeter HP1`, `Flowmeter HP2` of de bestaande lokale
+                aggregatie van HP1/HP2
 
               </details>
             text_only: true
@@ -1743,6 +1746,23 @@ views:
                     name: Flow (buitenunit)
                   - entity: sensor.openquatt_cic_flowrate_filtered
                     name: Flow (CIC)
+              - type: conditional
+                conditions:
+                  - condition: state
+                    entity: select.openquatt_flow_source
+                    state: Outdoor unit
+                card:
+                  type: entities
+                  show_header_toggle: false
+                  entities:
+                    - entity: select.openquatt_outdoor_unit_flow_mode
+                      name: Buitenunit flowmodus
+                    - entity: sensor.openquatt_hp1_flow
+                      name: Flowmeter HP1
+                    - entity: sensor.openquatt_hp2_flow
+                      name: Flowmeter HP2
+                    - entity: sensor.openquatt_flow_average_local
+                      name: Lokale aggregatie HP1/HP2
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -255,6 +255,13 @@ Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteer
 
 Voor `Outside Temperature Source` is ook de optie `Lowest valid` beschikbaar. Dan vergelijkt OpenQuatt de lokale buitenunitmeting en de HA-invoer, gebruikt alleen geldige waarden en kiest de laagste van de twee.
 
+Bij een Duo-installatie en `Flow Source = Outdoor unit` is er ook een extra keuze voor de lokale flowbepaling:
+
+- `Flowmeter HP1`
+- `Flowmeter HP2`
+- `Local aggregate HP1/HP2`
+
+Die laatste gebruikt de bestaande lokale duo-aggregatie. In normale gevallen is dat het gemiddelde van HP1 en HP2, maar bij een duidelijke mismatch gebruikt OpenQuatt bewust een plausibele hogere waarde om onderschatting te voorkomen.
 ### Service en diagnose
 
 Belangrijke hulpmiddelen:

--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -82,7 +82,10 @@ oq_cic: !include
     cic_hp2_sensor_internal: "false"
 oq_ha_inputs: !include oq_ha_inputs.yaml
 oq_local_sensors: !include oq_local_sensors.yaml
-oq_sensor_sources: !include oq_sensor_sources.yaml
+oq_sensor_sources: !include
+  file: oq_sensor_sources.yaml
+  vars:
+    sensor_sources_duo_flow_internal: "false"
 oq_debug_testing: !include oq_debug_testing.yaml
 oq_debug_testing_duo: !include oq_debug_testing_duo.yaml
 oq_webserver: !include oq_webserver.yaml

--- a/openquatt/oq_packages_single.yaml
+++ b/openquatt/oq_packages_single.yaml
@@ -71,7 +71,10 @@ oq_cic: !include
     cic_hp2_sensor_internal: "true"
 oq_ha_inputs: !include oq_ha_inputs.yaml
 oq_local_sensors: !include oq_local_sensors.yaml
-oq_sensor_sources: !include oq_sensor_sources.yaml
+oq_sensor_sources: !include
+  file: oq_sensor_sources.yaml
+  vars:
+    sensor_sources_duo_flow_internal: "true"
 oq_debug_testing: !include oq_debug_testing.yaml
 oq_webserver: !include oq_webserver.yaml
 heatpump1: !include

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -73,6 +73,22 @@ select:
       sorting_group_id: oq_cic
 
   - platform: template
+    name: "Outdoor Unit Flow Mode"
+    id: oq_duo_outdoor_flow_mode
+    internal: ${sensor_sources_duo_flow_internal}
+    icon: mdi:call-split
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - Flowmeter HP1
+      - Flowmeter HP2
+      - Local aggregate HP1/HP2
+    initial_option: Local aggregate HP1/HP2
+    web_server:
+      sorting_group_id: oq_cic
+
+  - platform: template
     name: "Outside Temperature Source"
     id: outside_temp_source
     icon: mdi:source-branch
@@ -200,6 +216,23 @@ sensor:
         return NAN;
       }
       if (source == "Outdoor unit") {
+        #if OQ_TOPOLOGY_DUO
+        // Duo-only local flow selector:
+        // - HP1/HP2 = direct individual flowmeter
+        // - Local aggregate HP1/HP2 = existing combined local flow signal
+        //   (normally average, but with mismatch guard inside flow_rate_hp_avg)
+        // This keeps the main flow source selector compact while still allowing
+        // per-flowmeter inspection and explicit selection for local Duo flow.
+        const auto local_mode = id(oq_duo_outdoor_flow_mode).current_option();
+        if (local_mode == "Flowmeter HP1") {
+          if (id(hp1_flow).has_state()) return id(hp1_flow).state;
+          return NAN;
+        }
+        if (local_mode == "Flowmeter HP2") {
+          if (id(${flow_secondary_flow_sensor_id}).has_state()) return id(${flow_secondary_flow_sensor_id}).state;
+          return NAN;
+        }
+        #endif
         if (id(flow_rate_hp_avg).has_state()) return id(flow_rate_hp_avg).state;
         return NAN;
       }


### PR DESCRIPTION
## Summary
- add a duo-only selector for local outdoor-unit flow choice
- allow HP1, HP2, or existing local aggregate HP1/HP2
- show the selector conditionally in the duo dashboard and document behavior
