### PR TITLE
Fix missing flow sensor var in sensor sources package

### DIFF
--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -86,6 +86,7 @@ oq_sensor_sources: !include
   file: oq_sensor_sources.yaml
   vars:
     sensor_sources_duo_flow_internal: "false"
+    flow_secondary_flow_sensor_id: "hp2_flow"
 oq_debug_testing: !include oq_debug_testing.yaml
 oq_debug_testing_duo: !include oq_debug_testing_duo.yaml
 oq_webserver: !include oq_webserver.yaml

--- a/openquatt/oq_packages_single.yaml
+++ b/openquatt/oq_packages_single.yaml
@@ -75,6 +75,7 @@ oq_sensor_sources: !include
   file: oq_sensor_sources.yaml
   vars:
     sensor_sources_duo_flow_internal: "true"
+    flow_secondary_flow_sensor_id: "hp1_flow"
 oq_debug_testing: !include oq_debug_testing.yaml
 oq_webserver: !include oq_webserver.yaml
 heatpump1: !include


### PR DESCRIPTION
## Summary
- pass the secondary flow sensor package variable into oq_sensor_sources.yaml
- fix duo compile failures introduced by the duo outdoor-unit flow selector
- keep the existing flow selector behavior unchanged

## Validation
- confirmed the generated duo code now resolves to hp2_flow instead of a literal substitution token
- original GitHub failures were both duo compile jobs failing in oq_sensor_sources.yaml
