### PR TITLE
Tame duo defrost compensation and short topology pulses

### DIFF
--- a/docs/diagnose-en-afstelling.md
+++ b/docs/diagnose-en-afstelling.md
@@ -96,6 +96,8 @@ Controleer eerst of de gebruikte kamer- en setpointwaarden kloppen. Te warm gedr
 
 Daarna kun je pas kijken naar een minder agressieve afstelling. In `Power House` betekent dat vaak eerst minder comfortmarge of een kortere `Power House demand fall time`, zodat gevraagde warmte sneller mag teruglopen.
 
+Als het vooral in `Duo` onrustig voelt, kijk dan eerst goed of het echt om comfort, om te korte compressor-runs of om optimizer-keuzes rond defrost gaat. Sinds de nieuwere duo-logica kijkt OpenQuatt bij defrost niet alleen naar een brede defrost-status, maar vooral naar de echte defrostfase via de `4-Way valve`. Daardoor hoort de regeling minder vroeg op te schalen en alleen extra te compenseren als de gekozen combinatie anders nog duidelijk tekort zou komen.
+
 ### De flow lijkt goed, maar verwarmen blijft toch geblokkeerd
 
 Dan is de kans groot dat een timer, veiligheid of bronkeuze meespeelt. Kijk naar:

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -108,7 +108,9 @@ Hoe dat precies gebeurt, hangt af van de gekozen verwarmingsstrategie:
 - in `Water Temperature Control` werkt OpenQuatt in de basis single-HP-first; de tweede warmtepomp mag pas meedoen als de vraag hoog genoeg blijft;
 - in `Power House` vergelijkt OpenQuatt de beste single- en duocombinaties en kiest normaal de variant met het laagste elektrische verbruik; alleen bij een duidelijk betere warmtematch mag een minder zuinige topology winnen.
 
-Bij `Power House` betekent dat dus niet automatisch "eerst 1 warmtepomp" of "liever altijd 2 warmtepompen". Soms is 1 warmtepomp zuiniger, soms 2 op lagere levels. OpenQuatt behandelt de single-versus-duokeuze efficiency-first, laat een minder zuinige topology alleen winnen bij duidelijk betere warmtematch en houdt vooral duurdere topologywissels kort vast om onrust te beperken.
+Bij `Power House` betekent dat dus niet automatisch "eerst 1 warmtepomp" of "liever altijd 2 warmtepompen". Soms is 1 warmtepomp zuiniger, soms 2 op lagere levels. OpenQuatt behandelt de single-versus-duokeuze efficiency-first, laat een minder zuinige topology alleen winnen bij duidelijk betere warmtematch en houdt een recente topologywissel iets langer vast als het alternatief maar een klein voordeel heeft.
+
+Rond defrost kijkt OpenQuatt nu nadrukkelijker naar de echte defrostfase. Daarvoor gebruikt het systeem de `4-Way valve` als teken dat de warmtepomp echt in defrost zit. Daardoor wordt het beschikbare thermische vermogen pas dan lager ingeschat en komt extra steun van de andere unit pas in beeld als dat echt nodig is. Dat voorkomt dat de duo-regeling al te hard gaat voorbelasten voordat het thermisch verlies werkelijk optreedt.
 
 ## Stabiliteit en pendelgedrag
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -199,7 +199,7 @@ Belangrijk onderscheid:
 - `oq_hp_min_off_s` is juist wel compile-time en bepaalt de minimale uit-tijd per compressor voor elke restart, ook in `Power House`.
 - `oq_optimizer_topology_power_margin_w` en `oq_optimizer_topology_heat_advantage_w` zijn compile-time marges voor de single-versus-duokeuze in `Power House`.
 
-Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een duurdere topologywissel kort afremt om op en neer schakelen te beperken.
+Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een recente topologywissel wat langer laat staan als het alternatief maar een klein voordeel heeft. Rond defrost baseert die afweging zich bovendien op de echte defrostfase via de `4-Way valve`, zodat te vroege voorbelasting wordt vermeden.
 
 ### Flow en pompregeling
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -290,9 +290,10 @@ Het doel daarvan is:
 
 Tijdens defrost wordt een warmtepomp niet als "normaal beschikbaar" gezien. OpenQuatt houdt rekening met:
 
-- lager effectief thermisch vermogen van een defrostende unit;
-- extra stapje op de andere unit als dat nodig en logisch is;
-- terughoudender wisselgedrag tijdens of vlak rond defrost.
+- lager effectief thermisch vermogen van een defrostende unit, maar pas zodra de `4-Way valve` aangeeft dat de echte defrost loopt;
+- geen zware voorbelasting alleen omdat de bredere defrost-status al actief is;
+- alleen een extra stapje op de andere unit als de gekozen combinatie anders nog duidelijk tekortkomt;
+- terughoudender wisselgedrag tijdens echte defrost, met snellere terugkeer naar normaal gedrag zodra die fase voorbij is.
 
 Dat voorkomt dat de optimizer een defrostende unit te optimistisch inschat.
 

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -113,9 +113,9 @@ In een `Duo`-opstelling gebruikt `Power House` geen vaste regel als "altijd eers
 3. kies normaal de topology met het laagste elektrische verbruik;
 4. laat een minder zuinige topology alleen winnen als die de warmtevraag duidelijk beter volgt;
 5. wissel alleen als dat echt voordeel geeft;
-6. houd vooral topologywissels naar een duurdere keuze kort vast om op en neer schakelen te beperken.
+6. houd een recente single-versus-duowissel wat langer vast als het alternatief maar een klein voordeel geeft.
 
-Als twee single-HP-keuzes verder gelijk zijn, krijgt de runtime lead warmtepomp voorrang. Tijdens defrost blijft OpenQuatt voorzichtiger en wordt het beschikbare thermische vermogen van de defrostende unit lager ingeschat.
+Als twee single-HP-keuzes verder gelijk zijn, krijgt de runtime lead warmtepomp voorrang. Tijdens defrost blijft OpenQuatt voorzichtiger, maar nu pas zodra de `4-Way valve` aangeeft dat de echte defrost loopt. Daarmee wordt te vroege voorbelasting voorkomen en komt extra steun alleen in beeld als de gekozen combinatie anders nog duidelijk tekort zou komen.
 
 ### Water Temperature Control
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -224,9 +224,9 @@ Power House duo dispatch works in simple steps:
 - prefer the topology with the lower electrical input by default
 - allow a less-efficient topology only when it has a clear heat-match advantage
 - keep the current combination unless a switch gives clear heat or power benefit
-- hold only topology switches toward a higher-power choice briefly to reduce back-and-forth switching
+- after a recent single<->duo change, keep the current topology a bit longer if the alternative gives only a small advantage
 - if two single-HP options are equally good, choose the runtime lead HP
-- defrost still uses thermal derating and optional compensation boost
+- defrost derating now follows the real `4-Way valve` phase, and extra compensation is only added if the chosen combination would otherwise still underdeliver
 
 ## 7. Flow Control Mechanics
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -904,6 +904,7 @@ binary_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_4_way_valve
     name: "${prefix}4-Way valve"
     icon: mdi:valve
     device_class: running

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -719,8 +719,20 @@ interval:
             return idx.has_value() ? (int) idx.value() : -1;
           };
 
+          auto valve_defrost_active = [&](bool is_hp1)->bool {
+            if (is_hp1) return id(hp1_4_way_valve).state;
+            #if OQ_TOPOLOGY_DUO
+            return id(hp2_4_way_valve).state;
+            #else
+            return false;
+            #endif
+          };
+
           auto defrost_stop_hold_level = [&](bool is_hp1)->int {
-            const bool defrost_active = is_hp1 ? id(hp1_defrost).state : id(${hc_secondary_defrost_id}).state;
+            // Only keep the last non-zero level during real defrost, i.e. once the
+            // 4-way valve is active. The broader defrost bit can assert earlier and
+            // caused the duo optimizer to pre-load far too aggressively.
+            const bool defrost_active = valve_defrost_active(is_hp1);
             if (!defrost_active) return 0;
 
             const int selected_level = hp_selected_level(is_hp1);
@@ -917,11 +929,14 @@ interval:
           if (level_cap < 0) level_cap = 0;
           if (level_cap > max_level) level_cap = max_level;
           const bool hp1_def = id(hp1_defrost).state;
+          const bool hp1_valve_def = valve_defrost_active(true);
           #if OQ_TOPOLOGY_DUO
           const bool hp2_def = id(${hc_secondary_defrost_id}).state;
+          const bool hp2_valve_def = valve_defrost_active(false);
           const bool hp2_available = true;
           #else
           const bool hp2_def = false;
+          const bool hp2_valve_def = false;
           const bool hp2_available = false;
           #endif
           // Command levels may remain active during defrost; model it as thermal derating.
@@ -933,8 +948,11 @@ interval:
           float def_fac_cfg = ${oq_defrost_power_factor};
           if (isnan(def_fac_cfg)) def_fac_cfg = 0.55f;
           const float def_fac = fmaxf(0.10f, fminf(1.00f, def_fac_cfg));
-          const float hp1_th_fac = hp1_def ? def_fac : 1.0f;
-          const float hp2_th_fac = hp2_def ? def_fac : 1.0f;
+          // Thermal derating only applies during real defrost. Using the broader
+          // defrost bit here made the optimizer overreact before power actually
+          // dropped negative.
+          const float hp1_th_fac = hp1_valve_def ? def_fac : 1.0f;
+          const float hp2_th_fac = hp2_valve_def ? def_fac : 1.0f;
 
           auto max_cap_hp = [&](bool is_hp1)->float {
             if ((is_hp1 && !hp1_available) || (!is_hp1 && !hp2_available)) return 0.0f;
@@ -970,8 +988,8 @@ interval:
             // ------------------------------------------------------------
             // HEATING CURVE MODE (demand path from heating-curve strategy)
             // ------------------------------------------------------------
-            const bool d1_pre = id(hp1_defrost).state;
-            const bool d2_pre = id(${hc_secondary_defrost_id}).state;
+            const bool d1_pre = hp1_valve_def;
+            const bool d2_pre = hp2_valve_def;
 
             // Telemetry + deficit calculation also in heating-curve mode (for CM3 + dual-enable hysteresis).
             publish_capacity_and_deficit(id(oq_phouse_req_w));
@@ -1214,10 +1232,10 @@ interval:
               const float thermal_tie_band_w = fmaxf(150.0f, 0.05f * fmaxf(P_target, 1000.0f));
               const float thermal_keep_margin_w = fminf(90.0f, thermal_tie_band_w * 0.5f);
               float topology_power_margin_w = ${oq_optimizer_topology_power_margin_w};
-              if (isnan(topology_power_margin_w) || topology_power_margin_w < 0.0f) topology_power_margin_w = 40.0f;
+              if (isnan(topology_power_margin_w) || topology_power_margin_w < 0.0f) topology_power_margin_w = 80.0f;
               float topology_heat_advantage_w = ${oq_optimizer_topology_heat_advantage_w};
-              if (isnan(topology_heat_advantage_w) || topology_heat_advantage_w < 0.0f) topology_heat_advantage_w = 225.0f;
-              const float pel_switch_margin_w = 120.0f;
+              if (isnan(topology_heat_advantage_w) || topology_heat_advantage_w < 0.0f) topology_heat_advantage_w = 300.0f;
+              const float pel_switch_margin_w = 150.0f;
               const float soft_switch_margin_w = 40.0f;
               struct DuoCandidate {
                 bool valid;
@@ -1363,13 +1381,19 @@ interval:
                     (current_candidate.active_hp_count > 0) &&
                     (best_candidate.active_hp_count > 0) &&
                     (current_candidate.active_hp_count != best_candidate.active_hp_count);
+                const bool hold_window_active =
+                    (id(oq_duo_dispatch_hold_until_ms) > 0) &&
+                    (now_ms < id(oq_duo_dispatch_hold_until_ms));
+                const bool small_topology_power_gap =
+                    topology_change &&
+                    (fabsf(best_candidate.p_el_w - current_candidate.p_el_w) <= topology_power_margin_w);
                 const bool switching_to_higher_pel =
                     topology_change &&
                     (best_candidate.p_el_w > (current_candidate.p_el_w + topology_power_margin_w));
                 const bool hold_active =
-                    switching_to_higher_pel &&
-                    (id(oq_duo_dispatch_hold_until_ms) > 0) &&
-                    (now_ms < id(oq_duo_dispatch_hold_until_ms));
+                    hold_window_active &&
+                    current_heat_ok &&
+                    (switching_to_higher_pel || small_topology_power_gap);
                 const bool better_soft_guard =
                     current_candidate.over_soft_w > (best_candidate.over_soft_w + soft_switch_margin_w);
                 const float efficiency_switch_margin_w =
@@ -1379,7 +1403,7 @@ interval:
 
                 if (hold_active && current_heat_ok) {
                   keep_current = true;
-                  optimizer_reason = (hp1_def || hp2_def) ? "defrost_hold" : "hold_active";
+                  optimizer_reason = (hp1_valve_def || hp2_valve_def) ? "defrost_hold" : "hold_active";
                 } else if (!current_heat_ok) {
                   optimizer_reason = "better_heat";
                 } else if (better_soft_guard) {
@@ -1403,19 +1427,30 @@ interval:
               hp2_req = chosen_candidate.valid ? chosen_candidate.l2 : 0;
               publish_optimizer_reason(optimizer_reason);
 
-              // Single-defrost compensation: allow the non-defrost HP to step up.
+              // Single-defrost compensation: only help during real valve-on defrost,
+              // and only when the chosen candidate still underdelivers materially.
+              // If duo dispatch already covers the request well enough, extra boost
+              // just creates the overshoot spikes we saw in history.
               int def_comp_min_f = (int) roundf(${oq_defrost_comp_min_f});
               if (def_comp_min_f < 0) def_comp_min_f = 0;
               if (def_comp_min_f > demand_max_f) def_comp_min_f = demand_max_f;
               int def_comp_boost = (int) roundf(${oq_defrost_comp_boost_steps});
               if (def_comp_boost < 0) def_comp_boost = 0;
               if (def_comp_boost > 3) def_comp_boost = 3;
-              if (def_comp_boost > 0 && f >= def_comp_min_f) {
-                if (hp1_def && !hp2_def && hp2_req > 0) {
+              const bool chosen_underdelivers =
+                  chosen_candidate.valid && (chosen_candidate.p_th_w + thermal_tie_band_w < P_target);
+              const bool allow_defrost_boost =
+                  (def_comp_boost > 0) &&
+                  (f >= def_comp_min_f) &&
+                  chosen_underdelivers &&
+                  chosen_candidate.valid &&
+                  (chosen_candidate.active_hp_count == 1);
+              if (allow_defrost_boost) {
+                if (hp1_valve_def && !hp2_valve_def && hp2_req > 0) {
                   hp2_req = std::min(level_cap, hp2_req + def_comp_boost);
                   publish_optimizer_reason("defrost_boost");
                 }
-                if (hp2_def && !hp1_def && hp1_req > 0) {
+                if (hp2_valve_def && !hp1_valve_def && hp1_req > 0) {
                   hp1_req = std::min(level_cap, hp1_req + def_comp_boost);
                   publish_optimizer_reason("defrost_boost");
                 }
@@ -1795,7 +1830,7 @@ interval:
               (id(hp1_last_applied_level) > 0 ? 1 : 0) + (id(${hc_secondary_last_applied_level_id}) > 0 ? 1 : 0);
           const int new_topology_count = (hp1_applied > 0 ? 1 : 0) + (hp2_applied > 0 ? 1 : 0);
           if (prev_topology_count > 0 && new_topology_count > 0 && prev_topology_count != new_topology_count) {
-            id(oq_duo_dispatch_hold_until_ms) = now_ms + (uint32_t) ((hp1_def || hp2_def) ? 300000UL : 180000UL);
+            id(oq_duo_dispatch_hold_until_ms) = now_ms + 180000UL;
           }
           #else
           const int hp2_applied = 0;

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -722,7 +722,7 @@ interval:
           auto valve_defrost_active = [&](bool is_hp1)->bool {
             if (is_hp1) return id(hp1_4_way_valve).state;
             #if OQ_TOPOLOGY_DUO
-            return id(hp2_4_way_valve).state;
+            return id(${hc_secondary_4_way_valve_id}).state;
             #else
             return false;
             #endif

--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -49,6 +49,7 @@ oq_heat_control: !include
     hc_secondary_minutes_id: "hp2_minutes"
     hc_secondary_set_working_mode_id: "hp2_set_working_mode"
     hc_secondary_working_mode_id: "hp2_working_mode"
+    hc_secondary_4_way_valve_id: "hp2_4_way_valve"
     hc_secondary_lvl_1_id: "hp2_lvl_1"
     hc_secondary_lvl_2_id: "hp2_lvl_2"
     hc_secondary_lvl_3_id: "hp2_lvl_3"

--- a/openquatt/oq_packages_single.yaml
+++ b/openquatt/oq_packages_single.yaml
@@ -37,6 +37,7 @@ oq_heat_control: !include
     hc_secondary_minutes_id: "hp1_minutes"
     hc_secondary_set_working_mode_id: "hp1_set_working_mode"
     hc_secondary_working_mode_id: "hp1_working_mode"
+    hc_secondary_4_way_valve_id: "hp1_4_way_valve"
     hc_secondary_lvl_1_id: "hp1_lvl_1"
     hc_secondary_lvl_2_id: "hp1_lvl_2"
     hc_secondary_lvl_3_id: "hp1_lvl_3"

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -75,8 +75,8 @@ oq_cop_min_input_w: "10.0"                            # Minimum electrical input
 oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
 oq_optimizer_soft_w: "3400.0"                         # Soft limit for electrical HP power in optimizer [W]; peak limit follows oq_power_peak_w.
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].
-oq_optimizer_topology_power_margin_w: "40.0"          # Required power delta before a single<->duo topology switch counts as a meaningful efficiency gain [W].
-oq_optimizer_topology_heat_advantage_w: "225.0"       # Required heat-match advantage before a less-efficient topology may override the efficiency-first choice [W].
+oq_optimizer_topology_power_margin_w: "80.0"          # Required power delta before a single<->duo topology switch counts as a meaningful efficiency gain [W].
+oq_optimizer_topology_heat_advantage_w: "300.0"       # Required heat-match advantage before a less-efficient topology may override the efficiency-first choice [W].
 oq_defrost_power_factor: "0.764"                      # Thermal derate on a defrosting HP in duo dispatch.
 oq_defrost_comp_min_f: "6"                            # Minimum demand f before single-defrost compensation is applied.
 oq_defrost_comp_boost_steps: "1"                      # Extra level steps on non-defrost HP during single-defrost compensation.


### PR DESCRIPTION
## Summary
- treat real defrost from the 4-Way valve instead of the broader defrost bit
- stop pre-loading aggressively before the valve actually flips
- only allow extra defrost boost when the chosen combination would otherwise still clearly underdeliver
- make recent single<->duo changes a bit stickier when the alternative has only a small advantage
- update the docs to describe the new defrost behavior more clearly

## Why
The history analysis showed two separate issues in duo Power House dispatch:
- around real defrost, compensation started too early and pushed the duo levels too hard
- around the single/duo boundary, there were a few short topology pulses that did not look useful

This PR keeps the overall optimizer model intact, but makes defrost handling more faithful to the real thermal event and reduces small back-and-forth topology changes.

## Validation
- local config validation: green for both duo profiles
- local compile: openquatt_duo_heatpump_listener green
- local compile: openquatt_duo_waveshare green
