### PR TITLE
Fix Power House runtime floor and calm duo boundary switching

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -195,11 +195,11 @@ Belangrijk onderscheid:
 
 - `Dual HP Enable Level`, `Dual HP Enable Hold` en `Dual HP Disable Hold` horen bij de verdeling in `Water Temperature Control`;
 - in `Power House` wordt de Duo-keuze juist automatisch bepaald op basis van geldige combinaties, met een efficiency-first single-versus-duokeuze en alleen een warmte-override als het verschil echt duidelijk is.
-- `Minimum runtime` is een runtime slider in seconden. De ondergrens is `300 s`, zodat je korte compressor-runs niet per ongeluk weer mogelijk maakt.
+- `Minimum runtime` is een runtime slider in seconden. De ondergrens is `300 s`, en die ondergrens wordt ook in de regeling zelf afgedwongen zodat een oudere bewaarde waarde zoals `60` geen korte compressor-runs kan blijven veroorzaken.
 - `oq_hp_min_off_s` is juist wel compile-time en bepaalt de minimale uit-tijd per compressor voor elke restart, ook in `Power House`.
 - `oq_optimizer_topology_power_margin_w` en `oq_optimizer_topology_heat_advantage_w` zijn compile-time marges voor de single-versus-duokeuze in `Power House`.
 
-Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een recente topologywissel wat langer laat staan als het alternatief maar een klein voordeel heeft. Rond defrost baseert die afweging zich bovendien op de echte defrostfase via de `4-Way valve`, zodat te vroege voorbelasting wordt vermeden.
+Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een recente topologywissel niet laat plaatsvinden voor een klein voordeel. Rond defrost baseert die afweging zich bovendien op de echte defrostfase via de `4-Way valve`, zodat te vroege voorbelasting wordt vermeden.
 
 ### Flow en pompregeling
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -269,7 +269,7 @@ De Duo-keuze loopt in `Power House` grofweg zo:
 3. kies normaal de topology met het laagste elektrische verbruik;
 4. laat een minder zuinige topology alleen winnen als die de warmtevraag duidelijk beter volgt;
 5. wissel niet voor mini-verschillen;
-6. rem dure single-versus-duowissels kort af om geflipper te voorkomen.
+6. rem single-versus-duowissels af als het alternatief maar een klein voordeel heeft.
 
 Dat betekent:
 

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -1232,9 +1232,9 @@ interval:
               const float thermal_tie_band_w = fmaxf(150.0f, 0.05f * fmaxf(P_target, 1000.0f));
               const float thermal_keep_margin_w = fminf(90.0f, thermal_tie_band_w * 0.5f);
               float topology_power_margin_w = ${oq_optimizer_topology_power_margin_w};
-              if (isnan(topology_power_margin_w) || topology_power_margin_w < 0.0f) topology_power_margin_w = 80.0f;
+              if (isnan(topology_power_margin_w) || topology_power_margin_w < 0.0f) topology_power_margin_w = 150.0f;
               float topology_heat_advantage_w = ${oq_optimizer_topology_heat_advantage_w};
-              if (isnan(topology_heat_advantage_w) || topology_heat_advantage_w < 0.0f) topology_heat_advantage_w = 300.0f;
+              if (isnan(topology_heat_advantage_w) || topology_heat_advantage_w < 0.0f) topology_heat_advantage_w = 450.0f;
               const float pel_switch_margin_w = 150.0f;
               const float soft_switch_margin_w = 40.0f;
               struct DuoCandidate {
@@ -1384,16 +1384,15 @@ interval:
                 const bool hold_window_active =
                     (id(oq_duo_dispatch_hold_until_ms) > 0) &&
                     (now_ms < id(oq_duo_dispatch_hold_until_ms));
-                const bool small_topology_power_gap =
-                    topology_change &&
-                    (fabsf(best_candidate.p_el_w - current_candidate.p_el_w) <= topology_power_margin_w);
-                const bool switching_to_higher_pel =
-                    topology_change &&
-                    (best_candidate.p_el_w > (current_candidate.p_el_w + topology_power_margin_w));
+                const bool topology_change_allowed =
+                    !topology_change ||
+                    (best_candidate.err_w + topology_heat_advantage_w < current_candidate.err_w) ||
+                    (best_candidate.p_el_w + topology_power_margin_w < current_candidate.p_el_w);
                 const bool hold_active =
                     hold_window_active &&
                     current_heat_ok &&
-                    (switching_to_higher_pel || small_topology_power_gap);
+                    topology_change &&
+                    !topology_change_allowed;
                 const bool better_soft_guard =
                     current_candidate.over_soft_w > (best_candidate.over_soft_w + soft_switch_margin_w);
                 const float efficiency_switch_margin_w =
@@ -1404,6 +1403,9 @@ interval:
                 if (hold_active && current_heat_ok) {
                   keep_current = true;
                   optimizer_reason = (hp1_valve_def || hp2_valve_def) ? "defrost_hold" : "hold_active";
+                } else if (topology_change && !topology_change_allowed && current_heat_ok) {
+                  keep_current = true;
+                  optimizer_reason = "hold_active";
                 } else if (!current_heat_ok) {
                   optimizer_reason = "better_heat";
                 } else if (better_soft_guard) {
@@ -1685,7 +1687,11 @@ interval:
           // Runtime is per-compressor and user-tunable, with a hard lower bound of 300 s.
           // Skipped during an absolute water-temperature hard trip.
           // =========================
-          const int min_rt_s = (int) roundf(id(oq_min_runtime_min).state);
+          int min_rt_s = (int) roundf(id(oq_min_runtime_min).state);
+          // Keep the runtime floor hard in code as well. Older installs may still
+          // restore a pre-migration numeric value such as 60, even though the UI
+          // slider now starts at 300 s.
+          if (min_rt_s > 0 && min_rt_s < 300) min_rt_s = 300;
           if (!id(oq_water_temp_hard_trip_active) && min_rt_s > 0) {
             // HP1/HP2: if request is 0 but measured heating start is still within
             // the minimum runtime window, keep that compressor alive at >=1.

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -75,8 +75,8 @@ oq_cop_min_input_w: "10.0"                            # Minimum electrical input
 oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
 oq_optimizer_soft_w: "3400.0"                         # Soft limit for electrical HP power in optimizer [W]; peak limit follows oq_power_peak_w.
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].
-oq_optimizer_topology_power_margin_w: "80.0"          # Required power delta before a single<->duo topology switch counts as a meaningful efficiency gain [W].
-oq_optimizer_topology_heat_advantage_w: "300.0"       # Required heat-match advantage before a less-efficient topology may override the efficiency-first choice [W].
+oq_optimizer_topology_power_margin_w: "150.0"         # Required power delta before a single<->duo topology switch counts as a meaningful efficiency gain [W].
+oq_optimizer_topology_heat_advantage_w: "450.0"       # Required heat-match advantage before a less-efficient topology may override the efficiency-first choice [W].
 oq_defrost_power_factor: "0.764"                      # Thermal derate on a defrosting HP in duo dispatch.
 oq_defrost_comp_min_f: "6"                            # Minimum demand f before single-defrost compensation is applied.
 oq_defrost_comp_boost_steps: "1"                      # Extra level steps on non-defrost HP during single-defrost compensation.


### PR DESCRIPTION
## Summary
- enforce the 300 s Power House minimum runtime floor in code so older restored values cannot keep short runs alive
- make single-versus-duo topology changes less eager around small heat and power differences
- update the Dutch docs to reflect the hard runtime floor and calmer topology switching

## Validation
- local docs consistency checks passed
- local compile succeeded for openquatt_single_waveshare.yaml
- local compile succeeded for openquatt_single_heatpump_listener.yaml
- local compile succeeded for openquatt_duo_waveshare.yaml
- local compile succeeded for openquatt_duo_heatpump_listener.yaml