### PR TITLE
Restrict defrost support to active duo

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -199,7 +199,7 @@ Belangrijk onderscheid:
 - `oq_hp_min_off_s` is juist wel compile-time en bepaalt de minimale uit-tijd per compressor voor elke restart, ook in `Power House`.
 - `oq_optimizer_topology_power_margin_w` en `oq_optimizer_topology_heat_advantage_w` zijn compile-time marges voor de single-versus-duokeuze in `Power House`.
 
-Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een recente topologywissel niet laat plaatsvinden voor een klein voordeel. Rond defrost gebruikt OpenQuatt de `defrost bit` als vroege voorbereiding en de `4-Way valve` als echte trigger voor thermische ondersteuning, zodat te vroege voorbelasting wordt vermeden maar de tweede unit wel op tijd klaar kan staan.
+Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een recente topologywissel niet laat plaatsvinden voor een klein voordeel. Rond defrost wordt een tweede warmtepomp niet speciaal opgestart vanuit single; alleen als duo al actief is mag de gezonde unit tijdens echte `4-Way valve`-defrost beperkt extra ondersteunen.
 
 ### Flow en pompregeling
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -290,13 +290,12 @@ Het doel daarvan is:
 
 Tijdens defrost wordt een warmtepomp niet als "normaal beschikbaar" gezien. OpenQuatt houdt rekening met:
 
-- de `defrost bit` als vroege waarschuwing: de gezonde unit mag dan alvast naar `Heating`, maar nog zonder extra compressorlevel;
 - lager effectief thermisch vermogen van een defrostende unit, maar pas zodra de `4-Way valve` aangeeft dat de echte defrost loopt;
-- geen zware voorbelasting alleen omdat de bredere defrost-status al actief is;
-- alleen een extra stapje op de andere unit als de gekozen combinatie anders nog duidelijk tekortkomt;
+- geen extra start van de tweede warmtepomp alleen voor een defrostdip als het systeem op dat moment nog single draait;
+- alleen een extra stapje op de andere unit als beide warmtepompen al actief zijn en de gekozen combinatie anders nog duidelijk tekortkomt;
 - terughoudender wisselgedrag tijdens echte defrost, met snellere terugkeer naar normaal gedrag zodra die fase voorbij is.
 
-Dat voorkomt dat de optimizer een defrostende unit te optimistisch inschat, terwijl de tweede warmtepomp wel al klaar kan staan op het moment dat de echte defrost begint.
+Dat voorkomt dat de optimizer een defrostende unit te optimistisch inschat zonder onrustige single-naar-duo starts te introduceren.
 
 ## Laaglastgedrag en anti-pendelen
 

--- a/openquatt/oq_heat_control.yaml
+++ b/openquatt/oq_heat_control.yaml
@@ -957,9 +957,6 @@ interval:
           auto hp_can_take_cooling_start = [&](bool is_hp1)->bool {
             return hp_has_any_allowed_level(is_hp1) && !hp_restart_blocked(is_hp1);
           };
-          auto hp_can_prearm_thermal = [&](bool is_hp1)->bool {
-            return hp_has_any_allowed_level(is_hp1);
-          };
           auto hp_last_activity_ms = [&](bool is_hp1)->uint32_t {
             const uint32_t last_start_ms =
                 is_hp1 ? id(hp1_last_start_ms) : id(${hc_secondary_last_start_ms_id});
@@ -985,8 +982,6 @@ interval:
           const bool hp2_valve_def = false;
           const bool hp2_available = false;
           #endif
-          bool hp1_prearm_mode = false;
-          bool hp2_prearm_mode = false;
           // Command levels may remain active during defrost; model it as thermal derating.
           const bool hp1_available = true;
           // Defrost behavior is configured via substitutions:
@@ -1521,34 +1516,16 @@ interval:
               hp2_req = chosen_candidate.valid ? chosen_candidate.l2 : 0;
               publish_optimizer_reason(optimizer_reason);
 
-              // Defrost handling has two phases:
-              // 1) defrost bit ON, valve still OFF: optionally pre-arm the healthy HP by
-              //    switching its working mode to Heating while keeping compressor level at 0.
-              //    This removes mode-transition latency without adding early thermal power.
-              // 2) 4-way valve ON: only then allow real level boost, and only when the
-              //    chosen candidate still underdelivers materially.
+              // Defrost support is only allowed when both compressors are already active.
+              // A single-HP run should not start the second HP just to cover a short
+              // defrost dip. During real 4-way-valve defrost, the healthy HP may get a
+              // small extra step if the current duo combination would otherwise underdeliver.
               int def_comp_min_f = (int) roundf(${oq_defrost_comp_min_f});
               if (def_comp_min_f < 0) def_comp_min_f = 0;
               if (def_comp_min_f > demand_max_f) def_comp_min_f = demand_max_f;
               int def_comp_boost = (int) roundf(${oq_defrost_comp_boost_steps});
               if (def_comp_boost < 0) def_comp_boost = 0;
               if (def_comp_boost > 3) def_comp_boost = 3;
-              const bool hp1_prearm_window = hp1_def && !hp1_valve_def;
-              const bool hp2_prearm_window = hp2_def && !hp2_valve_def;
-              const bool allow_defrost_prearm =
-                  (f >= def_comp_min_f) &&
-                  chosen_candidate.valid &&
-                  (chosen_candidate.active_hp_count == 1);
-              if (allow_defrost_prearm) {
-                if (hp1_prearm_window && !hp2_def && !hp2_valve_def &&
-                    hp1_req > 0 && hp2_req == 0 && hp_can_prearm_thermal(false)) {
-                  hp2_prearm_mode = true;
-                }
-                if (hp2_prearm_window && !hp1_def && !hp1_valve_def &&
-                    hp2_req > 0 && hp1_req == 0 && hp_can_prearm_thermal(true)) {
-                  hp1_prearm_mode = true;
-                }
-              }
               const bool chosen_underdelivers =
                   chosen_candidate.valid && (chosen_candidate.p_th_w + thermal_tie_band_w < P_target);
               const bool allow_defrost_boost =
@@ -1556,7 +1533,7 @@ interval:
                   (f >= def_comp_min_f) &&
                   chosen_underdelivers &&
                   chosen_candidate.valid &&
-                  (chosen_candidate.active_hp_count == 1);
+                  (chosen_candidate.active_hp_count == 2);
               if (allow_defrost_boost) {
                 if (hp1_valve_def && !hp2_valve_def && hp2_req > 0) {
                   hp2_req = std::min(level_cap, hp2_req + def_comp_boost);
@@ -1566,8 +1543,6 @@ interval:
                   hp1_req = std::min(level_cap, hp1_req + def_comp_boost);
                   publish_optimizer_reason("defrost_boost");
                 }
-              } else if (hp1_prearm_mode || hp2_prearm_mode) {
-                publish_optimizer_reason("defrost_prearm");
               }
             }
           }
@@ -1867,16 +1842,7 @@ interval:
           // Note: options must exactly match the options map in oq_HP_io.yaml (levels 0..10)
           const char* lvl_opts[11] = {"0","1","2","3","4","5","6","7","8","9","10"};
 
-          bool hp1_force_active_mode = false;
-          #if OQ_TOPOLOGY_DUO
-          bool hp2_force_active_mode = false;
-          if (is_power_house) {
-            hp1_force_active_mode = hp1_prearm_mode;
-            hp2_force_active_mode = hp2_prearm_mode;
-          }
-          #endif
-
-          auto apply_level = [&](bool is_hp1, int req_level, bool force_active_mode)->int {
+          auto apply_level = [&](bool is_hp1, int req_level)->int {
             req_level = std::max(min_level, std::min(max_level, req_level));
             const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});
             const int retained_level = defrost_stop_hold_level(is_hp1);
@@ -1900,9 +1866,7 @@ interval:
             }
 
             // With active demand, switch to the current thermal mode; otherwise standby.
-            // Defrost pre-arm may also request Heating mode while keeping level 0, so the
-            // support HP is ready before the 4-way valve makes thermal power go negative.
-            if (req_level > 0 || force_active_mode) set_mode(is_hp1, true);
+            if (req_level > 0) set_mode(is_hp1, true);
             else set_mode(is_hp1, false);
 
             int applied = req_level;
@@ -1953,9 +1917,9 @@ interval:
             return applied;
           };
 
-          int hp1_applied = apply_level(true, hp1_req, hp1_force_active_mode);
+          int hp1_applied = apply_level(true, hp1_req);
           #if OQ_TOPOLOGY_DUO
-          int hp2_applied = apply_level(false, hp2_req, hp2_force_active_mode);
+          int hp2_applied = apply_level(false, hp2_req);
           const int prev_topology_count =
               (id(hp1_last_applied_level) > 0 ? 1 : 0) + (id(${hc_secondary_last_applied_level_id}) > 0 ? 1 : 0);
           const int new_topology_count = (hp1_applied > 0 ? 1 : 0) + (hp2_applied > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- stop starting the second HP from single operation just to cover a short defrost dip
- keep defrost support limited to cases where duo is already active
- keep extra support tied to real 4-way-valve defrost and only when the current duo combination would otherwise underdeliver
- update Dutch documentation to match the simpler, more Quatt-like behavior

## Validation
- python3 scripts/dev.py validate --jobs 2 --config openquatt_duo_waveshare.yaml --config openquatt_duo_heatpump_listener.yaml
- python3 scripts/dev.py validate --jobs 2 --config openquatt_single_waveshare.yaml --config openquatt_single_heatpump_listener.yaml