### PR TITLE
Guard against stale HP outside temperatures

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -253,7 +253,7 @@ Belangrijke instellingen en signalen:
 
 Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteerde bron niet klopt, helpt fijnregelen vrijwel nooit.
 
-Voor `Outside Temperature Source` is ook de optie `Lowest valid` beschikbaar. Dan vergelijkt OpenQuatt de lokale buitenunitmeting en de HA-invoer, gebruikt alleen geldige waarden en kiest de laagste van de twee.
+Voor `Outside Temperature Source` is ook de optie `Lowest valid` beschikbaar. Dan vergelijkt OpenQuatt de lokale buitenunitmeting en de HA-invoer, gebruikt alleen geldige waarden en kiest de laagste van de twee. In de lokale Duo-aggregatie telt een HP-buitenwaarde bovendien tijdelijk niet mee als die te lang exact stil blijft staan terwijl diezelfde warmtepomp verder nog wel verse activiteit laat zien.
 
 Bij een Duo-installatie en `Flow Source = Outdoor unit` is er ook een extra keuze voor de lokale flowbepaling:
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -77,6 +77,16 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  - id: ${hp_id}_outside_temp_last_change_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: ${hp_id}_outside_temp_activity_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
   # Modbus controller online/offline
   - id: ${hp_id}_is_online
     type: bool
@@ -284,6 +294,10 @@ sensor:
     register_type: holding
     address: 2099
     #skip_updates: 0
+    on_value:
+      then:
+        - lambda: |-
+            id(${hp_id}_outside_temp_activity_ms) = millis();
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -449,6 +463,12 @@ sensor:
           min_value: -30
           max_value: 100
           ignore_out_of_range: true
+    on_value:
+      then:
+        - lambda: |-
+            const uint32_t now_ms = millis();
+            id(${hp_id}_outside_temp_last_change_ms) = now_ms;
+            id(${hp_id}_outside_temp_activity_ms) = now_ms;
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -728,6 +748,10 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.618
+    on_value:
+      then:
+        - lambda: |-
+            id(${hp_id}_outside_temp_activity_ms) = millis();
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -912,6 +936,10 @@ binary_sensor:
     address: 2108
     bitmask: 0x40
     skip_updates: ${oq_skip_10s}
+    on_state:
+      then:
+        - lambda: |-
+            id(${hp_id}_outside_temp_activity_ms) = millis();
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -982,6 +1010,10 @@ binary_sensor:
     register_type: holding
     address: 2118
     #skip_updates: 0
+    on_state:
+      then:
+        - lambda: |-
+            id(${hp_id}_outside_temp_activity_ms) = millis();
     web_server:
       sorting_group_id: oq_${hp_id}
 

--- a/openquatt/oq_heating_strategy.yaml
+++ b/openquatt/oq_heating_strategy.yaml
@@ -936,11 +936,31 @@ sensor:
     web_server:
       sorting_group_id: oq_temperatures
     lambda: |-
+      // Ignore a local HP reading if that specific outside-temperature register stays
+      // frozen while the rest of the same HP still shows fresh activity.
+      const uint32_t now_ms = millis();
+      uint32_t stale_s = (uint32_t) ${oq_outside_temp_stale_s};
+      const uint32_t stale_ms = stale_s * 1000UL;
+      const bool dual_local_sources = (${secondary_outside_is_distinct} != 0);
       const float hp1_outside_c = id(hp1_outside_temp).state;
       const float hp2_outside_c = id(${secondary_outside_temp_id}).state;
 
-      const bool hp1_valid = !isnan(hp1_outside_c);
-      const bool hp2_valid = !isnan(hp2_outside_c);
+      auto trusted_local_outside = [&](float outside_c, uint32_t last_change_ms, uint32_t activity_ms)->bool {
+        if (isnan(outside_c)) return false;
+        if (!dual_local_sources || stale_ms == 0) return true;
+        if (last_change_ms == 0 || activity_ms == 0) return true;
+        if (activity_ms <= last_change_ms) return true;
+        if (now_ms <= last_change_ms || now_ms <= activity_ms) return true;
+        const bool outside_old = (uint32_t) (now_ms - last_change_ms) >= stale_ms;
+        const bool hp_recently_active = (uint32_t) (now_ms - activity_ms) < stale_ms;
+        if (outside_old && hp_recently_active) return false;
+        return true;
+      };
+
+      const bool hp1_valid =
+          trusted_local_outside(hp1_outside_c, id(hp1_outside_temp_last_change_ms), id(hp1_outside_temp_activity_ms));
+      const bool hp2_valid =
+          trusted_local_outside(hp2_outside_c, id(${secondary_outside_last_change_ms_id}), id(${secondary_outside_activity_ms_id}));
 
       if (hp1_valid && hp2_valid) return std::min(hp1_outside_c, hp2_outside_c);
       if (hp1_valid) return hp1_outside_c;

--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -35,6 +35,9 @@ oq_heating_strategy: !include
   file: oq_heating_strategy.yaml
   vars:
     secondary_outside_temp_id: "hp2_outside_temp"
+    secondary_outside_last_change_ms_id: "hp2_outside_temp_last_change_ms"
+    secondary_outside_activity_ms_id: "hp2_outside_temp_activity_ms"
+    secondary_outside_is_distinct: "1"
     secondary_water_out_temp_id: "hp2_water_out_temp"
     secondary_last_applied_level_id: "hp2_last_applied_level"
     secondary_working_mode_id: "hp2_working_mode"

--- a/openquatt/oq_packages_single.yaml
+++ b/openquatt/oq_packages_single.yaml
@@ -21,6 +21,9 @@ oq_heating_strategy: !include
   file: oq_heating_strategy.yaml
   vars:
     secondary_outside_temp_id: "hp1_outside_temp"
+    secondary_outside_last_change_ms_id: "hp1_outside_temp_last_change_ms"
+    secondary_outside_activity_ms_id: "hp1_outside_temp_activity_ms"
+    secondary_outside_is_distinct: "0"
     secondary_water_out_temp_id: "hp1_water_out_temp"
     secondary_last_applied_level_id: "hp1_last_applied_level"
     secondary_working_mode_id: "hp1_working_mode"

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -64,6 +64,7 @@ oq_strategy_loop_s: "5"                               # Interval for strategy ca
 oq_strategy_demand_max_f: "20.0"                      # Upper bound of demand scale for mapping PID/power -> f.
 oq_temp_guard_delta_c: "0.5"                          # Minimum valid margin between T0 and Tc in the house model [°C].
 oq_ph_deadband_default_k: "0.14"                      # Default Power House room-error deadband [K].
+oq_outside_temp_stale_s: "1200"                       # Ignore a local HP outside temperature if it stays unchanged this long while that HP otherwise still shows fresh activity [s].
 
 # ----------------------------
 # HEAT CONTROL


### PR DESCRIPTION
## Summary
- ignore a local HP outside-temperature reading when it stays unchanged too long while that same HP still shows fresh activity
- keep this guard fully internal so no new diagnostic entities appear in Home Assistant
- apply the trusted-local reading only in the local outside-temperature aggregation used by Outdoor unit / Lowest valid

## Validation
- python3 scripts/dev.py validate --jobs 4 --config openquatt_single_waveshare.yaml --config openquatt_single_heatpump_listener.yaml --config openquatt_duo_waveshare.yaml --config openquatt_duo_heatpump_listener.yaml