### PR TITLE
Remove stale and redundant diagnostics

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2949,10 +2949,6 @@ views:
 
               - `Comfort bias` shows the adaptive warm-bias governor state.
 
-              - `Low-load dynamic thresholds` shows live or cached
-              `pmin/off/on` thresholds and falls back to internal defaults when
-              dynamic input is unavailable.
-
               If `P_req` looks unexpectedly high/low: check outside source, room
               setpoint/temp, and ramp/deadband tuning.
 
@@ -2976,8 +2972,6 @@ views:
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req
                 name: P_req
-              - entity: sensor.openquatt_low_load_dynamic_thresholds
-                name: Low-load dynamic thresholds
       - type: grid
         column_span: 1
         cards:

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2953,10 +2953,6 @@ views:
               `pmin/off/on` thresholds and falls back to internal defaults when
               dynamic input is unavailable.
 
-              - `Heat-enable state (shadow)` shows the shadow arbiter state
-              (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) for strategy
-              validation.
-
               If `P_req` looks unexpectedly high/low: check outside source, room
               setpoint/temp, and ramp/deadband tuning.
 
@@ -2966,8 +2962,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_heat_enable_state_shadow
-                name: Heat-enable state (shadow)
               - entity: sensor.openquatt_outside_temperature_selected
                 name: Outside temp (selected)
               - entity: sensor.openquatt_room_setpoint_selected

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -3104,9 +3104,6 @@ views:
               `pmin/off/on` drempels en valt anders terug op interne
               fallbackwaarden.
 
-              - `Heat-enable state (shadow)` toont de shadow-arbiterstatus
-              (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor strategievalidatie.
-
               Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
               setpoint/temp en de ramp/deadband instellingen.
 
@@ -3116,8 +3113,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_heat_enable_state_shadow
-                name: Heat-enable state (shadow)
               - entity: sensor.openquatt_outside_temperature_selected
                 name: Buitentemp (gekozen)
               - entity: sensor.openquatt_room_setpoint_selected

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -3100,10 +3100,6 @@ views:
               - `Comfort bias` toont de status van de adaptieve warm-bias
               regelaar.
 
-              - `Low-load dynamic thresholds` toont live of cached de
-              `pmin/off/on` drempels en valt anders terug op interne
-              fallbackwaarden.
-
               Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
               setpoint/temp en de ramp/deadband instellingen.
 
@@ -3127,8 +3123,6 @@ views:
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req
                 name: P_req
-              - entity: sensor.openquatt_low_load_dynamic_thresholds
-                name: Low-load dynamic thresholds
       - type: grid
         column_span: 1
         cards:

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2644,10 +2644,6 @@ views:
 
               - `Comfort bias` shows the adaptive warm-bias governor state.
 
-              - `Low-load dynamic thresholds` shows live or cached
-              `pmin/off/on` thresholds and falls back to internal defaults when
-              dynamic input is unavailable.
-
               If `P_req` looks unexpectedly high/low: check outside source, room
               setpoint/temp, and ramp/deadband tuning.
 
@@ -2671,8 +2667,6 @@ views:
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req
                 name: P_req
-              - entity: sensor.openquatt_low_load_dynamic_thresholds
-                name: Low-load dynamic thresholds
       - type: grid
         column_span: 1
         cards:

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2648,10 +2648,6 @@ views:
               `pmin/off/on` thresholds and falls back to internal defaults when
               dynamic input is unavailable.
 
-              - `Heat-enable state (shadow)` shows the shadow arbiter state
-              (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) for strategy
-              validation.
-
               If `P_req` looks unexpectedly high/low: check outside source, room
               setpoint/temp, and ramp/deadband tuning.
 
@@ -2661,8 +2657,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_heat_enable_state_shadow
-                name: Heat-enable state (shadow)
               - entity: sensor.openquatt_outside_temperature_selected
                 name: Outside temp (selected)
               - entity: sensor.openquatt_room_setpoint_selected

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2742,10 +2742,6 @@ views:
               - `Comfort bias` toont de status van de adaptieve warm-bias
               regelaar.
 
-              - `Low-load dynamic thresholds` toont live of cached de
-              `pmin/off/on` drempels en valt anders terug op interne
-              fallbackwaarden.
-
               Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
               setpoint/temp en de ramp/deadband instellingen.
 
@@ -2769,8 +2765,6 @@ views:
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req
                 name: P_req
-              - entity: sensor.openquatt_low_load_dynamic_thresholds
-                name: Low-load dynamic thresholds
       - type: grid
         column_span: 1
         cards:

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2746,9 +2746,6 @@ views:
               `pmin/off/on` drempels en valt anders terug op interne
               fallbackwaarden.
 
-              - `Heat-enable state (shadow)` toont de shadow-arbiterstatus
-              (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`) voor strategievalidatie.
-
               Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
               setpoint/temp en de ramp/deadband instellingen.
 
@@ -2758,8 +2755,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: sensor.openquatt_heat_enable_state_shadow
-                name: Heat-enable state (shadow)
               - entity: sensor.openquatt_outside_temperature_selected
                 name: Buitentemp (gekozen)
               - entity: sensor.openquatt_room_setpoint_selected

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -295,7 +295,6 @@ Gebruik deze groep vooral voor onderhoud en diagnose, niet voor dagelijks gebrui
 - `Flow average (Selected)`
 - `Flow mismatch (HP1 vs HP2)`
 - `Flow Mode`
-- `Flow Debug State`
 
 ### Voor vermogen en prestaties
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -306,7 +306,6 @@ Belangrijke signalen:
 - `Low-load dynamic thresholds`
 - `CM2 idle-exit reason`
 - `CM2 re-entry block active`
-- `Heat-enable state (shadow)`
 
 Wat daar gebeurt:
 
@@ -408,7 +407,6 @@ En voor laaglastgedrag:
 - `Low-load dynamic thresholds`
 - `CM2 idle-exit reason`
 - `CM2 re-entry block active`
-- `Heat-enable state (shadow)`
 
 ## Veilige volgorde van afstellen
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -303,9 +303,7 @@ Een belangrijk deel van `Power House` zit niet alleen in de warmtevraag, maar oo
 
 Belangrijke signalen:
 
-- `Low-load dynamic thresholds`
-- `CM2 idle-exit reason`
-- `CM2 re-entry block active`
+- `Low-load dynamic thresholds` (standaard verborgen)
 
 Wat daar gebeurt:
 
@@ -404,9 +402,7 @@ Bij `Duo` komen daar vaak bij:
 
 En voor laaglastgedrag:
 
-- `Low-load dynamic thresholds`
-- `CM2 idle-exit reason`
-- `CM2 re-entry block active`
+- `Low-load dynamic thresholds` (standaard verborgen)
 
 ## Veilige volgorde van afstellen
 

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -100,7 +100,6 @@ Handige diagnose-entiteiten:
 - `Low-load dynamic thresholds`
 - `CM2 idle-exit reason`
 - `CM2 re-entry block active`
-- `Heat-enable state (shadow)`
 
 `Low-load dynamic thresholds` toont live of cached `pmin/off/on`; als die dynamische input ontbreekt, valt OpenQuatt terug op interne fallbackdrempels.
 

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -97,9 +97,7 @@ Belangrijke eigenschappen:
 
 Handige diagnose-entiteiten:
 
-- `Low-load dynamic thresholds`
-- `CM2 idle-exit reason`
-- `CM2 re-entry block active`
+- `Low-load dynamic thresholds` (standaard verborgen)
 
 `Low-load dynamic thresholds` toont live of cached `pmin/off/on`; als die dynamische input ontbreekt, valt OpenQuatt terug op interne fallbackdrempels.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -177,7 +177,6 @@ Power House stability guards in supervisory:
 - low-load heat-request latch (OFF/ON hysteresis on `P_req`)
 - temporary CM2 re-entry block after CM2 idle-exit trip
 - CM2 startup-grace and high-load guard on idle-exit path
-- shadow heat-enable arbiter diagnostics (`IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT`)
 - shared water-temperature limiter on effective `P_req` using `water_supply_temp_selected`
 - per-compressor minimum runtime once a compressor has started (user-tunable, lower bound `300 s`)
 

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -304,16 +304,6 @@ text_sensor:
     web_server:
       sorting_group_id: oq_hydraulics
 
-  - platform: template
-    id: oq_flow_debug_state
-    name: "Flow Debug State"
-    icon: mdi:bug-outline
-    entity_category: diagnostic
-    disabled_by_default: true
-    update_interval: never
-    web_server:
-      sorting_group_id: oq_diagnostics
-
 # ----------------------------
 # MAIN LOOP (5s): PI + mode handling
 # ----------------------------
@@ -404,28 +394,6 @@ interval:
             sp_f = NAN;
             last_pi_e = 0.0f;
             stable_cnt = 0;
-          };
-          // Compact one-line diagnostics to compare mode decisions over time.
-          auto publish_debug = [&](FlowExecMode mode, int cm_code, int pwm) {
-            static std::string last_debug = "";
-            const char *mode_s = "AUTO";
-            switch (mode) {
-              case FLOW_MODE_CM0: mode_s = "CM0"; break;
-              case FLOW_MODE_AUTOTUNE: mode_s = "AUTOTUNE"; break;
-              case FLOW_MODE_MANUAL: mode_s = "MANUAL"; break;
-              case FLOW_MODE_FROST: mode_s = "CM98"; break;
-              case FLOW_MODE_AUTO_STARTING: mode_s = "AUTO_STARTING"; break;
-              case FLOW_MODE_AUTO_FAILSAFE: mode_s = "AUTO_FAILSAFE"; break;
-              default: mode_s = "AUTO"; break;
-            }
-            char buf[160];
-            snprintf(buf, sizeof(buf), "mode=%s cm=%d manual=%d failsafe=%d hold=%d pwm=%d",
-                     mode_s, cm_code, (int)(id(oq_flow_control_mode_code) == 1), (int)pi_failsafe, startup_hold, pwm);
-            const std::string s(buf);
-            if (s != last_debug) {
-              id(oq_flow_debug_state).publish_state(s.c_str());
-              last_debug = s;
-            }
           };
           // AUTO PI path only: setpoint ramp, PI, startup-hold, and last_good tracking.
           auto run_auto_pi = [&](int pwm_seed) -> int {
@@ -591,7 +559,6 @@ interval:
               id(oq_flow_mode).publish_state("AUTOTUNE");
               last_mode = "AUTOTUNE";
             }
-            publish_debug(FLOW_MODE_AUTOTUNE, cm_code, at_pwm);
             return;
           }
 
@@ -654,5 +621,3 @@ interval:
                      mode_txt.c_str(), id(oq_control_mode).state.c_str(), (int)want_manual, (int)pi_failsafe, startup_hold, pwm);
             last_mode = mode_txt;
           }
-
-          publish_debug(exec_mode, cm_code, pwm);

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -530,7 +530,6 @@ interval:
             // Keep manual-edge memory synchronized while idle.
             was_manual = want_manual;
             id(oq_flow_mode).publish_state("CM0");
-            publish_debug(FLOW_MODE_CM0, cm_code, (int) id(oq_flow_last_pwm));
             return;
           }
 

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -409,17 +409,6 @@ binary_sensor:
     web_server:
       sorting_group_id: oq_diagnostics
 
-  # DEBUG-RUNTIME START: CM2 low-load / idle-exit diagnostics
-  - platform: template
-    id: oq_cm2_reentry_block_active_bs
-    name: "CM2 re-entry block active"
-    icon: mdi:timer-lock-outline
-    device_class: running
-    entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_diagnostics
-  # DEBUG-RUNTIME END
-
 text_sensor:
   - platform: template
     id: oq_control_mode
@@ -471,6 +460,7 @@ text_sensor:
     icon: mdi:chart-bell-curve
     update_interval: 5s
     entity_category: diagnostic
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_diagnostics
     lambda: |-
@@ -492,15 +482,6 @@ text_sensor:
         snprintf(b, sizeof(b), "pmin=%.0fW off=%.0fW on=%.0fW", pmin, off, on);
       }
       return std::string(b);
-
-  - platform: template
-    id: oq_cm2_idle_exit_reason_ts
-    name: "CM2 idle-exit reason"
-    icon: mdi:information-outline
-    update_interval: never
-    entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_diagnostics
   # DEBUG-RUNTIME END
 sensor:
   - platform: template
@@ -911,14 +892,6 @@ interval:
               heating_req = false;
             }
           }
-          // DEBUG-RUNTIME: publish CM2 idle-exit reason + low-load re-entry block state.
-          static std::string last_cm2_idle_exit_reason;
-          publish_text_if_changed(
-              id(oq_cm2_idle_exit_reason_ts),
-              cm2_idle_exit_reason,
-              last_cm2_idle_exit_reason);
-          publish_binary_if_changed(id(oq_cm2_reentry_block_active_bs), reentry_block_active);
-
           const bool thermal_req = heating_req || cooling_req_raw;
 
           // -------------------------------------------------

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -163,7 +163,7 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
-  # DEBUG-RUNTIME START: Power House low-load + shadow heat-enable diagnostics
+  # DEBUG-RUNTIME START: Power House low-load diagnostics
   # Dynamic low-load diagnostics (Power House)
   - id: oq_low_load_pmin_dyn_w
     type: float
@@ -189,27 +189,6 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'  # 0=inactive,1=live,2=cached,3=fallback
-  # Shadow heat-enable arbiter state machine (diagnostics only).
-  - id: oq_heat_enable_state_shadow
-    type: int
-    restore_value: false
-    initial_value: '0'  # 0=IDLE,1=PREHEAT,2=HEATING,3=POSTFLOW,4=LOCKOUT
-  - id: oq_heat_enable_preheat_until_ms_shadow
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_heat_enable_postflow_until_ms_shadow
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_heat_enable_lockout_until_ms_shadow
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_heat_enable_last_on_ms_shadow
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
   # DEBUG-RUNTIME END
 
 # ----------------------------
@@ -485,7 +464,7 @@ text_sensor:
     web_server:
       sorting_group_id: oq_diagnostics
 
-  # DEBUG-RUNTIME START: Power House low-load + shadow heat-enable diagnostics
+  # DEBUG-RUNTIME START: Power House low-load diagnostics
   - platform: template
     id: oq_low_load_dyn_status
     name: "Low-load dynamic thresholds"
@@ -513,15 +492,6 @@ text_sensor:
         snprintf(b, sizeof(b), "pmin=%.0fW off=%.0fW on=%.0fW", pmin, off, on);
       }
       return std::string(b);
-
-  - platform: template
-    id: oq_heat_enable_state_shadow_ts
-    name: "Heat-enable state (shadow)"
-    icon: mdi:state-machine
-    update_interval: never
-    entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_diagnostics
 
   - platform: template
     id: oq_cm2_idle_exit_reason_ts
@@ -950,94 +920,6 @@ interval:
           publish_binary_if_changed(id(oq_cm2_reentry_block_active_bs), reentry_block_active);
 
           const bool thermal_req = heating_req || cooling_req_raw;
-
-          // -------------------------------------------------
-          // 1b) Shadow heat-enable arbiter (diagnostics only)
-          //     States: IDLE/PREHEAT/HEATING/POSTFLOW/LOCKOUT
-          // -------------------------------------------------
-          {
-            // DEBUG-RUNTIME: shadow state-machine for stepwise migration to a dedicated heat-enable arbiter.
-            const bool heat_req_shadow = heating_req;
-            const uint32_t min_run_ms = (uint32_t)(${oq_cm2_min_run_s}UL * 1000UL);
-            const uint32_t lockout_ms = power_house_active
-                ? (uint32_t) lroundf(id(oq_low_load_reentry_block_s).state) * 1000UL
-                : 0;
-
-            auto shadow_state_to_text = [](int st) -> const char* {
-              if (st == 1) return "PREHEAT";
-              if (st == 2) return "HEATING";
-              if (st == 3) return "POSTFLOW";
-              if (st == 4) return "LOCKOUT";
-              return "IDLE";
-            };
-
-            int st = id(oq_heat_enable_state_shadow);
-            if (st < 0 || st > 4) st = 0;
-
-            switch (st) {
-              case 0: { // IDLE
-                if (heat_req_shadow) {
-                  st = 1;
-                  id(oq_heat_enable_preheat_until_ms_shadow) = now_ms + prepost_ms;
-                }
-                break;
-              }
-              case 1: { // PREHEAT
-                if (!heat_req_shadow) {
-                  st = 0;
-                  id(oq_heat_enable_preheat_until_ms_shadow) = 0;
-                } else if (!ms_window_active(id(oq_heat_enable_preheat_until_ms_shadow))) {
-                  st = 2;
-                  id(oq_heat_enable_last_on_ms_shadow) = now_ms;
-                }
-                break;
-              }
-              case 2: { // HEATING
-                if (!heat_req_shadow &&
-                    (id(oq_heat_enable_last_on_ms_shadow) == 0 ||
-                     (uint32_t) (now_ms - id(oq_heat_enable_last_on_ms_shadow)) >= min_run_ms)) {
-                  st = 3;
-                  id(oq_heat_enable_postflow_until_ms_shadow) = now_ms + prepost_ms;
-                }
-                break;
-              }
-              case 3: { // POSTFLOW
-                if (heat_req_shadow) {
-                  st = 1;
-                  id(oq_heat_enable_preheat_until_ms_shadow) = now_ms + prepost_ms;
-                } else if (!ms_window_active(id(oq_heat_enable_postflow_until_ms_shadow))) {
-                  if (lockout_ms > 0) {
-                    st = 4;
-                    id(oq_heat_enable_lockout_until_ms_shadow) = now_ms + lockout_ms;
-                  } else {
-                    st = 0;
-                  }
-                }
-                break;
-              }
-              case 4: { // LOCKOUT
-                if (!ms_window_active(id(oq_heat_enable_lockout_until_ms_shadow))) {
-                  if (heat_req_shadow) {
-                    st = 1;
-                    id(oq_heat_enable_preheat_until_ms_shadow) = now_ms + prepost_ms;
-                  } else {
-                    st = 0;
-                  }
-                }
-                break;
-              }
-              default:
-                st = 0;
-                break;
-            }
-
-            id(oq_heat_enable_state_shadow) = st;
-            static std::string last_heat_enable_shadow_state;
-            publish_text_if_changed(
-                id(oq_heat_enable_state_shadow_ts),
-                std::string(shadow_state_to_text(st)),
-                last_heat_enable_shadow_state);
-          }
 
           // -------------------------------------------------
           // 2) Flow interlock status + timers


### PR DESCRIPTION
## Summary
- remove the unused heat-enable shadow diagnostics
- remove Flow Debug State, CM2 idle-exit reason, and CM2 re-entry block active
- keep Heating Debug State as the main hidden runtime/debug surface
- keep Low-load dynamic thresholds, but hide it by default and remove it from the standard dashboards

## Testing
- esphome compile openquatt_single_waveshare.yaml
- esphome compile openquatt_single_heatpump_listener.yaml
- esphome compile openquatt_duo_waveshare.yaml
- esphome compile openquatt_duo_heatpump_listener.yaml