### PR TITLE
Add compact thermal request helper layer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Passive cooling wordt nu in hoofdlijnen beschreven in:
 ## Naslag
 
 - [Heating Strategy](heating-strategy.md): bovenliggende uitleg van beide verwarmingsstrategieën.
-- [Heating Strategy Development](heating-strategy-development.md): developer-uitleg van de strategy-interface, uitbreidregels en template voor nieuwe strategies.
+- [Heating Strategy Development](heating-strategy-development.md): developer-uitleg van de strategy-interface, uitbreidregels, YAML-template en de grens tussen YAML-structuur en pure `.h` helpers.
 - [Power House](power-house.md): aparte uitleg van huismodel, comfortlogica, rise/fall time, laaglastgedrag en Duo-keuze.
 - [Water Temperature Control](water-temperature-control.md): aparte uitleg van stooklijn, PID, COAST/OFF-gedrag en Duo-hysterese.
 - [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md): systeemstanden, overgangen en flowregeling.

--- a/docs/heating-strategy-development.md
+++ b/docs/heating-strategy-development.md
@@ -46,12 +46,55 @@ Een strategy module owns:
 - de eigen phase/state/diagnostics
 - de eigen compressor-request output
 - het invullen van de gedeelde `oq_strategy_*` status zolang die strategy actief is
+- de zichtbare YAML-structuur van de strategy: globals, intervals, selectors, tekstsensoren en publicatievolgorde
 
 Voorbeelden in de huidige codebase:
 
 - `openquatt/oq_power_house_strategy.yaml`
 - `openquatt/oq_heating_curve_strategy.yaml`
 - `openquatt/oq_cooling_strategy.yaml`
+
+## YAML en `.h` helpers
+
+De huidige thermal stack gebruikt bewust beide:
+
+- YAML voor strategy-structuur en publicatie
+- `.h` helpers voor pure herbruikbare logica
+
+De vuistregel is:
+
+- YAML owns de module-opbouw
+- `.h` owns pure functies en kleine value objects
+
+Dat betekent in de praktijk:
+
+- YAML bevat de `globals`, `interval` loops, `text_sensor` wiring en de expliciete `publish_state(...)` of shared-status publicatie
+- YAML laat zichtbaar zien welke inputs een strategy leest, welke state ze bijhoudt en welke `..._request_*` outputs eruit komen
+- `.h` files bevatten alleen rekenlogica, keuzehelpers en normalisatie die door meerdere packages gedeeld kan worden
+
+Goede kandidaten voor `.h` helpers:
+
+- herhaalde level- of topology-keuze
+- pure demand- of bias-berekeningen
+- state-machine helpers zonder side effects
+- gedeelde status- of resethelpers
+
+Slechte kandidaten voor `.h` helpers:
+
+- verborgen `publish_state(...)` calls
+- actuator writes
+- strategy-selectie
+- code die de YAML-flow onleesbaar maakt doordat alle hoofdlogica uit beeld verdwijnt
+
+Belangrijk ontwerpprincipe:
+
+- een nieuwe strategy moet nog steeds te begrijpen zijn door alleen het YAML-bestand te lezen
+- de `.h` helper mag de strategy ondersteunen, maar niet verbergen
+
+Kort samengevat:
+
+- YAML owns structure and publication
+- `.h` owns pure reusable logic
 
 ### `oq_thermal_request_control`
 
@@ -158,6 +201,12 @@ Gebruik als startpunt:
 
 - `docs/templates/heating-strategy-template.yaml`
 
+Optioneel:
+
+- gebruik de bestaande helperheader `openquatt/includes/oq_thermal_request_logic.h` voor gedeelde request-logica
+- maak alleen een extra strategy-helper als de pure logica echt herhaald of te groot wordt
+- hou helpercode side-effectvrij
+
 ### 2. Kies een nieuwe strategy code
 
 Reserveer een nieuwe `oq_strategy_active_code` voor de strategy.
@@ -240,6 +289,20 @@ Bij een nieuwe strategy horen minimaal updates in:
 - eventueel een eigen detailpagina
 - dashboards als er een nieuwe user-facing selector of status bijkomt
 
+### 9. Trek pure logica pas later uit naar helpers
+
+Begin een nieuwe strategy eerst leesbaar in YAML.
+
+Pas als er echt herhaling of complexe pure logica ontstaat, trek die uit naar:
+
+- `openquatt/includes/oq_thermal_request_logic.h` als het gedeelde request/actuator-logica is
+- eventueel `openquatt/includes/oq_<your_strategy>_logic.h` als het echt strategy-specifieke pure logica is
+
+Hou daarbij vast aan deze grens:
+
+- YAML blijft eigenaar van publication en flow
+- helpercode blijft side-effectvrij
+
 ## Ontwerpregels voor nieuwe strategies
 
 Hou een nieuwe strategy aan deze regels:
@@ -249,6 +312,8 @@ Hou een nieuwe strategy aan deze regels:
 - publiceer alleen strategy-eigen state in de strategy module
 - laat guards en limits in `oq_thermal_request_control`
 - laat echte mode/level writes in `oq_thermal_actuator`
+- hou de strategy-flow zichtbaar in YAML, ook als je helpers gebruikt
+- gebruik helperheaders alleen voor pure logica, niet voor verborgen control-flow
 
 Goede vraag om steeds te stellen:
 

--- a/docs/templates/heating-strategy-template.yaml
+++ b/docs/templates/heating-strategy-template.yaml
@@ -16,6 +16,17 @@
 # - Publish shared `oq_strategy_*` while active
 # - Publish local `..._request_*` outputs for thermal request control
 # - Do not write actuator entities directly
+# - Keep publication and flow visible in YAML
+# - Put only pure reusable logic in optional `.h` helpers
+#
+# Existing shared helper:
+# - `openquatt/includes/oq_thermal_request_logic.h`
+# - Intended for request/control glue that is reused across packages
+#
+# Optional strategy-specific helper:
+# - `openquatt/includes/oq_<your_strategy>_logic.h`
+# - Use only for pure calculations or small helper structs
+# - Do not hide `publish_state(...)`, strategy selection or actuator writes there
 # ==============================================================================
 
 globals:
@@ -122,7 +133,7 @@ interval:
           id(oq_strategy_supply_target_temp) = NAN;
           id(oq_strategy_heat_request_active) = (raw > 0);
 
-          // Optional shared debug text.
+          // Keep phase/debug text publication visible in YAML.
           id(oq_strategy_phase_text).publish_state((raw > 0) ? "active" : "idle");
           id(oq_strategy_debug_state).publish_state((raw > 0) ? "my_strategy_active" : "my_strategy_idle");
           id(oq_my_strategy_debug_state).publish_state((raw > 0) ? "active" : "idle");
@@ -164,3 +175,8 @@ interval:
           id(oq_my_strategy_request_hp2_level) = hp2_req;
           id(oq_my_strategy_request_owner_hp) = owner_hp;
           id(oq_my_strategy_request_reason_code) = reason_code;
+
+          // Tip:
+          // Keep request publication visible here in YAML.
+          // If you later extract helpers, move only pure calculations such as
+          // demand math, candidate scoring or split decisions.

--- a/openquatt/includes/oq_thermal_request_logic.h
+++ b/openquatt/includes/oq_thermal_request_logic.h
@@ -1,0 +1,191 @@
+#pragma once
+
+#include <algorithm>
+#include <math.h>
+#include <stdint.h>
+#include <string>
+
+namespace oq_request {
+
+struct ExcludedLevels {
+  std::string a;
+  std::string b;
+};
+
+struct PublishedRequest {
+  int mode_code;
+  int hp1_level;
+  int hp2_level;
+  int owner_hp;
+  int topology_code;
+  int strategy_code;
+};
+
+inline int clamp_level(int level, int min_level, int max_level) {
+  return std::max(min_level, std::min(max_level, level));
+}
+
+inline int request_topology_code(int hp1_level, int hp2_level) {
+  if (hp1_level > 0 && hp2_level > 0) return 3;
+  if (hp1_level > 0) return 1;
+  if (hp2_level > 0) return 2;
+  return 0;
+}
+
+inline int request_owner_from_topology_code(int topology_code) {
+  if (topology_code == 1) return 1;
+  if (topology_code == 2) return 2;
+  return 0;
+}
+
+inline int sanitize_request_mode_code(int mode_code) {
+  return (mode_code >= 0 && mode_code <= 2) ? mode_code : 0;
+}
+
+inline int sanitize_request_strategy_code(int strategy_code) {
+  return (strategy_code >= 0 && strategy_code <= 3) ? strategy_code : 0;
+}
+
+inline PublishedRequest make_published_request(int mode_code,
+                                               int hp1_level,
+                                               int hp2_level,
+                                               int strategy_code) {
+  constexpr int request_max_level = 10;
+  hp1_level = clamp_level(hp1_level, 0, request_max_level);
+  hp2_level = clamp_level(hp2_level, 0, request_max_level);
+  const int topology_code = request_topology_code(hp1_level, hp2_level);
+  return PublishedRequest{
+      sanitize_request_mode_code(mode_code),
+      hp1_level,
+      hp2_level,
+      request_owner_from_topology_code(topology_code),
+      topology_code,
+      sanitize_request_strategy_code(strategy_code),
+  };
+}
+
+inline bool excluded_option_matches_level(const std::string &opt, int level) {
+  switch (level) {
+    case 1: return opt == "L1 (H30/C30)";
+    case 2: return opt == "L2 (H39/C36)";
+    case 3: return opt == "L3 (H49/C42)";
+    case 4: return opt == "L4 (H55/C47)";
+    case 5: return opt == "L5 (H61/C52)";
+    case 6: return opt == "L6 (H67/C56)";
+    case 7: return opt == "L7 (H72/C61)";
+    case 8: return opt == "L8 (H79/C66)";
+    case 9: return opt == "L9 (H85/C71)";
+    case 10: return opt == "L10 (H90/C74)";
+    default: return false;
+  }
+}
+
+inline bool level_allowed_for_excluded_levels(const ExcludedLevels &excluded, int level) {
+  if (level <= 0 || level > 10) return true;
+  return !excluded_option_matches_level(excluded.a, level) &&
+         !excluded_option_matches_level(excluded.b, level);
+}
+
+inline int pick_allowed_level(int req,
+                              int min_level,
+                              int max_level,
+                              const ExcludedLevels &excluded) {
+  if (req <= 0) return 0;
+  req = clamp_level(req, min_level, max_level);
+  if (req <= 0) return 0;
+  if (level_allowed_for_excluded_levels(excluded, req)) return req;
+
+  for (int level = req - 1; level >= min_level; --level) {
+    if (level > 0 && level_allowed_for_excluded_levels(excluded, level)) return level;
+  }
+  for (int level = req + 1; level <= max_level; ++level) {
+    if (level > 0 && level_allowed_for_excluded_levels(excluded, level)) return level;
+  }
+  return 0;
+}
+
+inline int pick_allowed_capped_level(int req,
+                                     int min_level,
+                                     int max_level,
+                                     int cap_level,
+                                     const ExcludedLevels &excluded) {
+  if (req <= 0) return 0;
+  cap_level = clamp_level(cap_level, min_level, max_level);
+  if (cap_level <= 0) return 0;
+  req = clamp_level(req, min_level, cap_level);
+  if (req <= 0) return 0;
+  if (level_allowed_for_excluded_levels(excluded, req)) return req;
+
+  for (int level = req - 1; level >= min_level; --level) {
+    if (level > 0 && level_allowed_for_excluded_levels(excluded, level)) return level;
+  }
+  for (int level = req + 1; level <= cap_level; ++level) {
+    if (level > 0 && level_allowed_for_excluded_levels(excluded, level)) return level;
+  }
+  return 0;
+}
+
+inline bool thermal_mode_matches(float mode_raw, int mode_code) {
+  return !isnan(mode_raw) && ((int) roundf(mode_raw) == mode_code);
+}
+
+inline bool target_option_matches_mode(bool has_state,
+                                       const std::string &option,
+                                       int mode_code) {
+  if (!has_state) return false;
+  if (mode_code == 1) return option == "Cooling";
+  if (mode_code == 2) return option == "Heating";
+  if (mode_code == 0) return option == "Standby";
+  return false;
+}
+
+inline const char *request_mode_option(int request_mode_code) {
+  return (request_mode_code == 1) ? "Cooling"
+       : (request_mode_code == 2) ? "Heating"
+                                  : "Standby";
+}
+
+inline const char *retained_mode_name(bool cooling_active,
+                                      bool heating_active,
+                                      const char *fallback_mode_name) {
+  if (cooling_active) return "Cooling";
+  if (heating_active) return "Heating";
+  return fallback_mode_name;
+}
+
+inline int hold_request_mode_code(int hold1,
+                                  int hold2,
+                                  bool hp1_cooling_hold,
+                                  bool hp2_cooling_hold) {
+  if (hold1 <= 0 && hold2 <= 0) return 0;
+  return (hp1_cooling_hold || hp2_cooling_hold) ? 1 : 2;
+}
+
+inline int defrost_hold_level(bool defrost_active,
+                              bool cooling_mode_active,
+                              int selected_level,
+                              int previous_applied_level) {
+  if (!defrost_active) return 0;
+  if (cooling_mode_active) return 0;
+  if (selected_level > 0) return selected_level;
+  if (previous_applied_level > 0) return previous_applied_level;
+  return 0;
+}
+
+inline uint32_t capped_loop_dt_ms(uint32_t now_ms, uint32_t last_loop_ms, uint32_t base_tick_ms) {
+  if (base_tick_ms == 0) return 0;
+  if (last_loop_ms == 0 || now_ms <= last_loop_ms) return base_tick_ms;
+  const uint32_t dt_cap_ms = base_tick_ms * 2UL;
+  const uint32_t dt_ms = now_ms - last_loop_ms;
+  return (dt_cap_ms > 0 && dt_ms > dt_cap_ms) ? dt_cap_ms : dt_ms;
+}
+
+inline bool min_runtime_window_active(uint32_t now_ms,
+                                      uint32_t last_real_start_ms,
+                                      uint32_t min_runtime_ms) {
+  return last_real_start_ms > 0 &&
+         now_ms > last_real_start_ms &&
+         (uint32_t)(now_ms - last_real_start_ms) < min_runtime_ms;
+}
+
+}  // namespace oq_request

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -324,47 +324,34 @@ interval:
           const int lead_code = lead_is_hp1 ? 1 : 2;
           if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
 
-          auto excluded_option_matches_level = [&](const std::string &opt, int level)->bool {
-            switch (level) {
-              case 1: return opt == "L1 (H30/C30)";
-              case 2: return opt == "L2 (H39/C36)";
-              case 3: return opt == "L3 (H49/C42)";
-              case 4: return opt == "L4 (H55/C47)";
-              case 5: return opt == "L5 (H61/C52)";
-              case 6: return opt == "L6 (H67/C56)";
-              case 7: return opt == "L7 (H72/C61)";
-              case 8: return opt == "L8 (H79/C66)";
-              case 9: return opt == "L9 (H85/C71)";
-              case 10: return opt == "L10 (H90/C74)";
-              default: return false;
+          auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
+            if (is_hp1) {
+              return oq_request::ExcludedLevels{
+                  id(hp1_excluded_level_a).has_state()
+                      ? id(hp1_excluded_level_a).current_option()
+                      : std::string("None"),
+                  id(hp1_excluded_level_b).has_state()
+                      ? id(hp1_excluded_level_b).current_option()
+                      : std::string("None"),
+              };
             }
+            #if OQ_TOPOLOGY_DUO
+            return oq_request::ExcludedLevels{
+                id(${cc_secondary_excluded_level_a_id}).has_state()
+                    ? id(${cc_secondary_excluded_level_a_id}).current_option()
+                    : std::string("None"),
+                id(${cc_secondary_excluded_level_b_id}).has_state()
+                    ? id(${cc_secondary_excluded_level_b_id}).current_option()
+                    : std::string("None"),
+            };
+            #else
+            (void) is_hp1;
+            return oq_request::ExcludedLevels{"None", "None"};
+            #endif
           };
 
           auto level_allowed = [&](bool is_hp1, int level)->bool {
-            if (level <= 0 || level > max_level) return true;
-
-            if (is_hp1) {
-              const std::string excl_a = id(hp1_excluded_level_a).has_state()
-                                             ? id(hp1_excluded_level_a).current_option()
-                                             : std::string("None");
-              const std::string excl_b = id(hp1_excluded_level_b).has_state()
-                                             ? id(hp1_excluded_level_b).current_option()
-                                             : std::string("None");
-              return !excluded_option_matches_level(excl_a, level) &&
-                     !excluded_option_matches_level(excl_b, level);
-            }
-            #if OQ_TOPOLOGY_DUO
-            const std::string excl_a = id(${cc_secondary_excluded_level_a_id}).has_state()
-                                           ? id(${cc_secondary_excluded_level_a_id}).current_option()
-                                           : std::string("None");
-            const std::string excl_b = id(${cc_secondary_excluded_level_b_id}).has_state()
-                                           ? id(${cc_secondary_excluded_level_b_id}).current_option()
-                                           : std::string("None");
-            return !excluded_option_matches_level(excl_a, level) &&
-                   !excluded_option_matches_level(excl_b, level);
-            #else
-            return false;
-            #endif
+            return oq_request::level_allowed_for_excluded_levels(excluded_levels(is_hp1), level);
           };
 
           auto hp_has_any_allowed_level = [&](bool is_hp1)->bool {

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -842,47 +842,34 @@ interval:
           const int lead_code = lead_is_hp1 ? 1 : 2;
           if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
 
-          auto excluded_option_matches_level = [&](const std::string &opt, int level)->bool {
-            switch (level) {
-              case 1: return opt == "L1 (H30/C30)";
-              case 2: return opt == "L2 (H39/C36)";
-              case 3: return opt == "L3 (H49/C42)";
-              case 4: return opt == "L4 (H55/C47)";
-              case 5: return opt == "L5 (H61/C52)";
-              case 6: return opt == "L6 (H67/C56)";
-              case 7: return opt == "L7 (H72/C61)";
-              case 8: return opt == "L8 (H79/C66)";
-              case 9: return opt == "L9 (H85/C71)";
-              case 10: return opt == "L10 (H90/C74)";
-              default: return false;
+          auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
+            if (is_hp1) {
+              return oq_request::ExcludedLevels{
+                  id(hp1_excluded_level_a).has_state()
+                      ? id(hp1_excluded_level_a).current_option()
+                      : std::string("None"),
+                  id(hp1_excluded_level_b).has_state()
+                      ? id(hp1_excluded_level_b).current_option()
+                      : std::string("None"),
+              };
             }
+            #if OQ_TOPOLOGY_DUO
+            return oq_request::ExcludedLevels{
+                id(${curve_secondary_excluded_level_a_id}).has_state()
+                    ? id(${curve_secondary_excluded_level_a_id}).current_option()
+                    : std::string("None"),
+                id(${curve_secondary_excluded_level_b_id}).has_state()
+                    ? id(${curve_secondary_excluded_level_b_id}).current_option()
+                    : std::string("None"),
+            };
+            #else
+            (void) is_hp1;
+            return oq_request::ExcludedLevels{"None", "None"};
+            #endif
           };
 
           auto level_allowed = [&](bool is_hp1, int level)->bool {
-            if (level <= 0 || level > max_level) return true;
-
-            if (is_hp1) {
-              const std::string excl_a = id(hp1_excluded_level_a).has_state()
-                                             ? id(hp1_excluded_level_a).current_option()
-                                             : std::string("None");
-              const std::string excl_b = id(hp1_excluded_level_b).has_state()
-                                             ? id(hp1_excluded_level_b).current_option()
-                                             : std::string("None");
-              return !excluded_option_matches_level(excl_a, level) &&
-                     !excluded_option_matches_level(excl_b, level);
-            }
-            #if OQ_TOPOLOGY_DUO
-            const std::string excl_a = id(${curve_secondary_excluded_level_a_id}).has_state()
-                                           ? id(${curve_secondary_excluded_level_a_id}).current_option()
-                                           : std::string("None");
-            const std::string excl_b = id(${curve_secondary_excluded_level_b_id}).has_state()
-                                           ? id(${curve_secondary_excluded_level_b_id}).current_option()
-                                           : std::string("None");
-            return !excluded_option_matches_level(excl_a, level) &&
-                   !excluded_option_matches_level(excl_b, level);
-            #else
-            return false;
-            #endif
+            return oq_request::level_allowed_for_excluded_levels(excluded_levels(is_hp1), level);
           };
 
           auto valve_defrost_active = [&](bool is_hp1)->bool {

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -665,47 +665,34 @@ interval:
           };
 
           constexpr int max_level = 10;
-          auto excluded_option_matches_level = [&](const std::string &opt, int level)->bool {
-            switch (level) {
-              case 1: return opt == "L1 (H30/C30)";
-              case 2: return opt == "L2 (H39/C36)";
-              case 3: return opt == "L3 (H49/C42)";
-              case 4: return opt == "L4 (H55/C47)";
-              case 5: return opt == "L5 (H61/C52)";
-              case 6: return opt == "L6 (H67/C56)";
-              case 7: return opt == "L7 (H72/C61)";
-              case 8: return opt == "L8 (H79/C66)";
-              case 9: return opt == "L9 (H85/C71)";
-              case 10: return opt == "L10 (H90/C74)";
-              default: return false;
+          auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
+            if (is_hp1) {
+              return oq_request::ExcludedLevels{
+                  id(hp1_excluded_level_a).has_state()
+                      ? id(hp1_excluded_level_a).current_option()
+                      : std::string("None"),
+                  id(hp1_excluded_level_b).has_state()
+                      ? id(hp1_excluded_level_b).current_option()
+                      : std::string("None"),
+              };
             }
+            #if OQ_TOPOLOGY_DUO
+            return oq_request::ExcludedLevels{
+                id(${ph_secondary_excluded_level_a_id}).has_state()
+                    ? id(${ph_secondary_excluded_level_a_id}).current_option()
+                    : std::string("None"),
+                id(${ph_secondary_excluded_level_b_id}).has_state()
+                    ? id(${ph_secondary_excluded_level_b_id}).current_option()
+                    : std::string("None"),
+            };
+            #else
+            (void) is_hp1;
+            return oq_request::ExcludedLevels{"None", "None"};
+            #endif
           };
 
           auto level_allowed = [&](bool is_hp1, int level)->bool {
-            if (level <= 0 || level > max_level) return true;
-
-            if (is_hp1) {
-              const std::string excl_a = id(hp1_excluded_level_a).has_state()
-                                             ? id(hp1_excluded_level_a).current_option()
-                                             : std::string("None");
-              const std::string excl_b = id(hp1_excluded_level_b).has_state()
-                                             ? id(hp1_excluded_level_b).current_option()
-                                             : std::string("None");
-              return !excluded_option_matches_level(excl_a, level) &&
-                     !excluded_option_matches_level(excl_b, level);
-            }
-            #if OQ_TOPOLOGY_DUO
-            const std::string excl_a = id(${ph_secondary_excluded_level_a_id}).has_state()
-                                           ? id(${ph_secondary_excluded_level_a_id}).current_option()
-                                           : std::string("None");
-            const std::string excl_b = id(${ph_secondary_excluded_level_b_id}).has_state()
-                                           ? id(${ph_secondary_excluded_level_b_id}).current_option()
-                                           : std::string("None");
-            return !excluded_option_matches_level(excl_a, level) &&
-                   !excluded_option_matches_level(excl_b, level);
-            #else
-            return false;
-            #endif
+            return oq_request::level_allowed_for_excluded_levels(excluded_levels(is_hp1), level);
           };
 
           auto valve_defrost_active = [&](bool is_hp1)->bool {

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -16,6 +16,7 @@ project_name: "openquatt.openquatt"                   # ESPHome project identifi
 project_version: "v0.27.0"                            # ESPHome project version shown in firmware metadata.
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 hp_perf_map_header: "openquatt/includes/hp_perf_map.h" # C++ performance-map header include path.
+thermal_request_logic_header: "openquatt/includes/oq_thermal_request_logic.h" # Shared C++ helper include for request/control glue.
 
 # ----------------------------
 # HARDWARE

--- a/openquatt/oq_thermal_actuator.yaml
+++ b/openquatt/oq_thermal_actuator.yaml
@@ -36,11 +36,10 @@ interval:
           const int max_level = 10;
 
           uint32_t dt_ms = (uint32_t) ${oq_heat_loop_tick_s} * 1000UL;
-          if (id(oq_thermal_actuator_last_loop_ms) > 0 && now_ms > id(oq_thermal_actuator_last_loop_ms)) {
-            dt_ms = now_ms - id(oq_thermal_actuator_last_loop_ms);
-            const uint32_t dt_cap_ms = ((uint32_t) ${oq_heat_loop_tick_s} * 1000UL) * 2UL;
-            if (dt_cap_ms > 0 && dt_ms > dt_cap_ms) dt_ms = dt_cap_ms;
-          }
+          dt_ms = oq_request::capped_loop_dt_ms(
+              now_ms,
+              id(oq_thermal_actuator_last_loop_ms),
+              (uint32_t) ${oq_heat_loop_tick_s} * 1000UL);
           id(oq_thermal_actuator_last_loop_ms) = now_ms;
 
           auto publish_optimizer_reason = [&](const char* reason)->void {
@@ -56,61 +55,35 @@ interval:
             #endif
           };
 
-          auto excluded_option_matches_level = [&](const std::string &opt, int level)->bool {
-            switch (level) {
-              case 1: return opt == "L1 (H30/C30)";
-              case 2: return opt == "L2 (H39/C36)";
-              case 3: return opt == "L3 (H49/C42)";
-              case 4: return opt == "L4 (H55/C47)";
-              case 5: return opt == "L5 (H61/C52)";
-              case 6: return opt == "L6 (H67/C56)";
-              case 7: return opt == "L7 (H72/C61)";
-              case 8: return opt == "L8 (H79/C66)";
-              case 9: return opt == "L9 (H85/C71)";
-              case 10: return opt == "L10 (H90/C74)";
-              default: return false;
-            }
-          };
-
-          auto level_allowed = [&](bool is_hp1, int level)->bool {
-            if (level <= 0 || level > max_level) return true;
-
+          auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
             if (is_hp1) {
-              const std::string excl_a = id(hp1_excluded_level_a).has_state()
-                                             ? id(hp1_excluded_level_a).current_option()
-                                             : std::string("None");
-              const std::string excl_b = id(hp1_excluded_level_b).has_state()
-                                             ? id(hp1_excluded_level_b).current_option()
-                                             : std::string("None");
-              return !excluded_option_matches_level(excl_a, level) &&
-                     !excluded_option_matches_level(excl_b, level);
+              return oq_request::ExcludedLevels{
+                  id(hp1_excluded_level_a).has_state()
+                      ? id(hp1_excluded_level_a).current_option()
+                      : std::string("None"),
+                  id(hp1_excluded_level_b).has_state()
+                      ? id(hp1_excluded_level_b).current_option()
+                      : std::string("None"),
+              };
             }
             #if OQ_TOPOLOGY_DUO
-            const std::string excl_a = id(${ta_secondary_excluded_level_a_id}).has_state()
-                                           ? id(${ta_secondary_excluded_level_a_id}).current_option()
-                                           : std::string("None");
-            const std::string excl_b = id(${ta_secondary_excluded_level_b_id}).has_state()
-                                           ? id(${ta_secondary_excluded_level_b_id}).current_option()
-                                           : std::string("None");
-            return !excluded_option_matches_level(excl_a, level) &&
-                   !excluded_option_matches_level(excl_b, level);
+            return oq_request::ExcludedLevels{
+                id(${ta_secondary_excluded_level_a_id}).has_state()
+                    ? id(${ta_secondary_excluded_level_a_id}).current_option()
+                    : std::string("None"),
+                id(${ta_secondary_excluded_level_b_id}).has_state()
+                    ? id(${ta_secondary_excluded_level_b_id}).current_option()
+                    : std::string("None"),
+            };
             #else
-            return false;
+            (void) is_hp1;
+            return oq_request::ExcludedLevels{"None", "None"};
             #endif
           };
 
           auto pick_allowed_capped = [&](int req, bool is_hp1, int cap_level)->int {
-            if (req <= 0) return 0;
-            cap_level = std::max(min_level, std::min(max_level, cap_level));
-            if (cap_level <= 0) return 0;
-            req = std::max(1, std::min(cap_level, req));
-
-            if (level_allowed(is_hp1, req)) return req;
-
-            for (int l = req - 1; l >= 1; l--) if (level_allowed(is_hp1, l)) return l;
-            for (int l = req + 1; l <= cap_level; l++) if (level_allowed(is_hp1, l)) return l;
-
-            return 0;
+            return oq_request::pick_allowed_capped_level(
+                req, min_level, max_level, cap_level, excluded_levels(is_hp1));
           };
 
           auto hp_selected_level = [&](bool is_hp1)->int {
@@ -126,38 +99,49 @@ interval:
 
           auto hp_mode_is_cooling = [&](bool is_hp1)->bool {
             const float mode_raw = is_hp1 ? id(hp1_working_mode).state : id(${ta_secondary_working_mode_id}).state;
-            return !isnan(mode_raw) && ((int) roundf(mode_raw) == 1);
+            return oq_request::thermal_mode_matches(mode_raw, 1);
           };
 
           auto hp_mode_is_heating = [&](bool is_hp1)->bool {
             const float mode_raw = is_hp1 ? id(hp1_working_mode).state : id(${ta_secondary_working_mode_id}).state;
-            return !isnan(mode_raw) && ((int) roundf(mode_raw) == 2);
+            return oq_request::thermal_mode_matches(mode_raw, 2);
           };
 
           auto hp_mode_target_is_cooling = [&](bool is_hp1)->bool {
             if (is_hp1) {
-              return id(hp1_set_working_mode).has_state() && id(hp1_set_working_mode).current_option() == "Cooling";
+              return oq_request::target_option_matches_mode(
+                  id(hp1_set_working_mode).has_state(),
+                  id(hp1_set_working_mode).current_option(),
+                  1);
             }
-            return id(${ta_secondary_set_working_mode_id}).has_state() &&
-                   id(${ta_secondary_set_working_mode_id}).current_option() == "Cooling";
+            return oq_request::target_option_matches_mode(
+                id(${ta_secondary_set_working_mode_id}).has_state(),
+                id(${ta_secondary_set_working_mode_id}).current_option(),
+                1);
           };
 
           auto hp_mode_target_is_heating = [&](bool is_hp1)->bool {
             if (is_hp1) {
-              return id(hp1_set_working_mode).has_state() && id(hp1_set_working_mode).current_option() == "Heating";
+              return oq_request::target_option_matches_mode(
+                  id(hp1_set_working_mode).has_state(),
+                  id(hp1_set_working_mode).current_option(),
+                  2);
             }
-            return id(${ta_secondary_set_working_mode_id}).has_state() &&
-                   id(${ta_secondary_set_working_mode_id}).current_option() == "Heating";
+            return oq_request::target_option_matches_mode(
+                id(${ta_secondary_set_working_mode_id}).has_state(),
+                id(${ta_secondary_set_working_mode_id}).current_option(),
+                2);
           };
 
           const int request_mode_code = id(oq_request_mode_code);
           const bool request_thermal_active = (request_mode_code == 1 || request_mode_code == 2);
-          const char* request_thermal_mode_opt = (request_mode_code == 1) ? "Cooling" : "Heating";
+          const char* request_thermal_mode_opt = oq_request::request_mode_option(request_mode_code);
 
           auto hp_hold_mode_opt = [&](bool is_hp1)->const char* {
-            if (hp_mode_is_cooling(is_hp1) || hp_mode_target_is_cooling(is_hp1)) return "Cooling";
-            if (hp_mode_is_heating(is_hp1) || hp_mode_target_is_heating(is_hp1)) return "Heating";
-            return request_thermal_mode_opt;
+            return oq_request::retained_mode_name(
+                hp_mode_is_cooling(is_hp1) || hp_mode_target_is_cooling(is_hp1),
+                hp_mode_is_heating(is_hp1) || hp_mode_target_is_heating(is_hp1),
+                request_thermal_mode_opt);
           };
 
           auto valve_defrost_active = [&](bool is_hp1)->bool {
@@ -174,20 +158,12 @@ interval:
             // 4-way valve is active. The broader defrost bit can assert earlier and
             // caused the duo optimizer to pre-load far too aggressively.
             const bool defrost_active = valve_defrost_active(is_hp1);
-            if (!defrost_active) return 0;
-
-            // During passive cooling the reverse valve is expected to be active; do not
-            // mistake that for a heating defrost hold or CM1/CM0 transitions may re-arm
-            // the unit in the wrong thermal mode while leaving CM5.
-            if (hp_mode_is_cooling(is_hp1) || hp_mode_target_is_cooling(is_hp1)) return 0;
-
             const int selected_level = hp_selected_level(is_hp1);
-            if (selected_level > 0) return selected_level;
-
             const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${ta_secondary_last_applied_level_id});
-            if (prev_applied > 0) return prev_applied;
-
-            return 0;
+            const bool cooling_mode_active =
+                hp_mode_is_cooling(is_hp1) || hp_mode_target_is_cooling(is_hp1);
+            return oq_request::defrost_hold_level(
+                defrost_active, cooling_mode_active, selected_level, prev_applied);
           };
 
           auto apply_active_mode_hold = [&](bool is_hp1, int retained_level)->bool {
@@ -224,7 +200,7 @@ interval:
           };
 
           auto set_mode = [&](bool is_hp1, bool active) {
-            const char* opt = (active && request_thermal_active) ? request_thermal_mode_opt : "Standby";
+            const char* opt = (active && request_thermal_active) ? request_thermal_mode_opt : oq_request::request_mode_option(0);
             if (is_hp1) {
               if (id(hp1_set_working_mode).current_option() != opt) {
                 auto c = id(hp1_set_working_mode).make_call();
@@ -243,17 +219,21 @@ interval:
           auto mode_is_active_thermal = [&](bool is_hp1)->bool {
             const float mode_raw = is_hp1 ? id(hp1_working_mode).state : id(${ta_secondary_working_mode_id}).state;
             if (isnan(mode_raw)) return false;
-            return request_thermal_active && (((int) roundf(mode_raw)) == request_mode_code);
+            return request_thermal_active && oq_request::thermal_mode_matches(mode_raw, request_mode_code);
           };
 
           auto mode_target_is_active_thermal = [&](bool is_hp1)->bool {
             if (!request_thermal_active) return false;
             if (is_hp1) {
-              return id(hp1_set_working_mode).has_state() &&
-                     id(hp1_set_working_mode).current_option() == request_thermal_mode_opt;
+              return oq_request::target_option_matches_mode(
+                  id(hp1_set_working_mode).has_state(),
+                  id(hp1_set_working_mode).current_option(),
+                  request_mode_code);
             }
-            return id(${ta_secondary_set_working_mode_id}).has_state() &&
-                   id(${ta_secondary_set_working_mode_id}).current_option() == request_thermal_mode_opt;
+            return oq_request::target_option_matches_mode(
+                id(${ta_secondary_set_working_mode_id}).has_state(),
+                id(${ta_secondary_set_working_mode_id}).current_option(),
+                request_mode_code);
           };
 
           // Note: options must exactly match the options map in oq_HP_io.yaml (levels 0..10)

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -736,27 +736,16 @@ interval:
           };
 
           auto publish_request = [&](int mode_code, int req1, int req2, int strategy_code, int owner_hp, const char* reason)->void {
-            constexpr int request_max_level = 10;
-            req1 = std::max(0, std::min(request_max_level, req1));
-            req2 = std::max(0, std::min(request_max_level, req2));
-            if (mode_code < 0 || mode_code > 2) mode_code = 0;
-            if (strategy_code < 0 || strategy_code > 3) strategy_code = 0;
+            (void) owner_hp;
+            const auto published = oq_request::make_published_request(
+                mode_code, req1, req2, strategy_code);
 
-            int topology_code = 0;
-            if (req1 > 0 && req2 > 0) topology_code = 3;
-            else if (req1 > 0) topology_code = 1;
-            else if (req2 > 0) topology_code = 2;
-
-            if (topology_code == 1) owner_hp = 1;
-            else if (topology_code == 2) owner_hp = 2;
-            else owner_hp = 0;
-
-            id(oq_request_mode_code) = mode_code;
-            id(oq_request_hp1_level) = req1;
-            id(oq_request_hp2_level) = req2;
-            id(oq_request_owner_hp) = owner_hp;
-            id(oq_request_topology_code) = topology_code;
-            id(oq_request_strategy_code) = strategy_code;
+            id(oq_request_mode_code) = published.mode_code;
+            id(oq_request_hp1_level) = published.hp1_level;
+            id(oq_request_hp2_level) = published.hp2_level;
+            id(oq_request_owner_hp) = published.owner_hp;
+            id(oq_request_topology_code) = published.topology_code;
+            id(oq_request_strategy_code) = published.strategy_code;
 
             static std::string last_request_reason = "";
             const std::string s = reason ? std::string(reason) : std::string("inactive");
@@ -779,20 +768,23 @@ interval:
 
           auto hp_mode_is_cooling = [&](bool is_hp1)->bool {
             const float mode_raw = is_hp1 ? id(hp1_working_mode).state : id(${hc_secondary_working_mode_id}).state;
-            return !isnan(mode_raw) && ((int) roundf(mode_raw) == 1);
+            return oq_request::thermal_mode_matches(mode_raw, 1);
           };
 
           auto hp_mode_target_is_cooling = [&](bool is_hp1)->bool {
             if (is_hp1) {
-              return id(hp1_set_working_mode).has_state() && id(hp1_set_working_mode).current_option() == "Cooling";
+              return oq_request::target_option_matches_mode(
+                  id(hp1_set_working_mode).has_state(),
+                  id(hp1_set_working_mode).current_option(),
+                  1);
             }
-            return id(${hc_secondary_set_working_mode_id}).has_state() &&
-                   id(${hc_secondary_set_working_mode_id}).current_option() == "Cooling";
+            return oq_request::target_option_matches_mode(
+                id(${hc_secondary_set_working_mode_id}).has_state(),
+                id(${hc_secondary_set_working_mode_id}).current_option(),
+                1);
           };
 
           auto hold_request_mode_code = [&](int hold1, int hold2)->int {
-            if (hold1 <= 0 && hold2 <= 0) return 0;
-
             const bool hp1_cooling_hold =
                 (hold1 > 0) && (hp_mode_is_cooling(true) || hp_mode_target_is_cooling(true));
             #if OQ_TOPOLOGY_DUO
@@ -805,8 +797,8 @@ interval:
             // Preserve passive-cooling holds across CM5 -> CM1/CM0 transitions.
             // Otherwise the generic inactive-CM fallback would reinterpret the hold
             // as Heating and re-arm the compressor in the wrong thermal mode.
-            if (hp1_cooling_hold || hp2_cooling_hold) return 1;
-            return 2;
+            return oq_request::hold_request_mode_code(
+                hold1, hold2, hp1_cooling_hold, hp2_cooling_hold);
           };
 
           auto valve_defrost_active = [&](bool is_hp1)->bool {
@@ -823,20 +815,12 @@ interval:
             // 4-way valve is active. The broader defrost bit can assert earlier and
             // caused the duo optimizer to pre-load far too aggressively.
             const bool defrost_active = valve_defrost_active(is_hp1);
-            if (!defrost_active) return 0;
-
-            // During passive cooling the reverse valve is expected to be active; do not
-            // mistake that for a heating defrost hold or CM1/CM0 transitions may re-arm
-            // the unit in the wrong thermal mode while leaving CM5.
-            if (hp_mode_is_cooling(is_hp1) || hp_mode_target_is_cooling(is_hp1)) return 0;
-
             const int selected_level = hp_selected_level(is_hp1);
-            if (selected_level > 0) return selected_level;
-
             const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});
-            if (prev_applied > 0) return prev_applied;
-
-            return 0;
+            const bool cooling_mode_active =
+                hp_mode_is_cooling(is_hp1) || hp_mode_target_is_cooling(is_hp1);
+            return oq_request::defrost_hold_level(
+                defrost_active, cooling_mode_active, selected_level, prev_applied);
           };
 
           auto reset_dual_runtime_state = [&](int owner)->void {
@@ -860,8 +844,7 @@ interval:
           auto min_runtime_hold_level = [&](bool is_hp1)->int {
             if (id(oq_water_temp_hard_trip_active) || min_rt_ms == 0) return 0;
             const uint32_t last_real_start_ms = is_hp1 ? id(hp1_last_real_heat_start_ms) : id(hp2_last_real_heat_start_ms);
-            if (last_real_start_ms == 0 || now_ms <= last_real_start_ms) return 0;
-            if ((uint32_t)(now_ms - last_real_start_ms) >= min_rt_ms) return 0;
+            if (!oq_request::min_runtime_window_active(now_ms, last_real_start_ms, min_rt_ms)) return 0;
 
             const int last_applied = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});
             const bool measured_thermal = is_hp1 ? hp1_measured_thermal : hp2_measured_thermal;
@@ -959,47 +942,29 @@ interval:
           const int min_level = 0;
           const int max_level = 10;
 
-          auto excluded_option_matches_level = [&](const std::string &opt, int level)->bool {
-            switch (level) {
-              case 1: return opt == "L1 (H30/C30)";
-              case 2: return opt == "L2 (H39/C36)";
-              case 3: return opt == "L3 (H49/C42)";
-              case 4: return opt == "L4 (H55/C47)";
-              case 5: return opt == "L5 (H61/C52)";
-              case 6: return opt == "L6 (H67/C56)";
-              case 7: return opt == "L7 (H72/C61)";
-              case 8: return opt == "L8 (H79/C66)";
-              case 9: return opt == "L9 (H85/C71)";
-              case 10: return opt == "L10 (H90/C74)";
-              default: return false;
-            }
-          };
-
-          // Single source of truth for per-HP level exclusions to avoid drift between branches.
-          auto level_allowed = [&](bool is_hp1, int level)->bool {
-            if (level <= 0 || level > max_level) return true;
-
+          auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
             if (is_hp1) {
-              const std::string excl_a = id(hp1_excluded_level_a).has_state()
-                                             ? id(hp1_excluded_level_a).current_option()
-                                             : std::string("None");
-              const std::string excl_b = id(hp1_excluded_level_b).has_state()
-                                             ? id(hp1_excluded_level_b).current_option()
-                                             : std::string("None");
-              return !excluded_option_matches_level(excl_a, level) &&
-                     !excluded_option_matches_level(excl_b, level);
+              return oq_request::ExcludedLevels{
+                  id(hp1_excluded_level_a).has_state()
+                      ? id(hp1_excluded_level_a).current_option()
+                      : std::string("None"),
+                  id(hp1_excluded_level_b).has_state()
+                      ? id(hp1_excluded_level_b).current_option()
+                      : std::string("None"),
+              };
             }
             #if OQ_TOPOLOGY_DUO
-            const std::string excl_a = id(${hc_secondary_excluded_level_a_id}).has_state()
-                                           ? id(${hc_secondary_excluded_level_a_id}).current_option()
-                                           : std::string("None");
-            const std::string excl_b = id(${hc_secondary_excluded_level_b_id}).has_state()
-                                           ? id(${hc_secondary_excluded_level_b_id}).current_option()
-                                           : std::string("None");
-            return !excluded_option_matches_level(excl_a, level) &&
-                   !excluded_option_matches_level(excl_b, level);
+            return oq_request::ExcludedLevels{
+                id(${hc_secondary_excluded_level_a_id}).has_state()
+                    ? id(${hc_secondary_excluded_level_a_id}).current_option()
+                    : std::string("None"),
+                id(${hc_secondary_excluded_level_b_id}).has_state()
+                    ? id(${hc_secondary_excluded_level_b_id}).current_option()
+                    : std::string("None"),
+            };
             #else
-            return false;
+            (void) is_hp1;
+            return oq_request::ExcludedLevels{"None", "None"};
             #endif
           };
           int level_cap = (int) roundf(id(oq_day_max_level).state);
@@ -1110,34 +1075,13 @@ interval:
           //    - if requested level is excluded: search down first, then up
           // =========================
           auto pick_allowed = [&](int req, bool is_hp1)->int {
-            if (req <= 0) return 0;
-            req = std::max(1, std::min(max_level, req));
-
-            if (level_allowed(is_hp1, req)) return req;
-
-            // first down
-            for (int l = req - 1; l >= 1; l--) if (level_allowed(is_hp1, l)) return l;
-            // then up
-            for (int l = req + 1; l <= max_level; l++) if (level_allowed(is_hp1, l)) return l;
-
-            return 0;
+            return oq_request::pick_allowed_level(req, 1, max_level, excluded_levels(is_hp1));
           };
 
           // Like pick_allowed(), but never returns above cap_level.
           auto pick_allowed_capped = [&](int req, bool is_hp1, int cap_level)->int {
-            if (req <= 0) return 0;
-            cap_level = std::max(min_level, std::min(max_level, cap_level));
-            if (cap_level <= 0) return 0;
-            req = std::max(1, std::min(cap_level, req));
-
-            if (level_allowed(is_hp1, req)) return req;
-
-            // first down within cap
-            for (int l = req - 1; l >= 1; l--) if (level_allowed(is_hp1, l)) return l;
-            // then up within cap
-            for (int l = req + 1; l <= cap_level; l++) if (level_allowed(is_hp1, l)) return l;
-
-            return 0;
+            return oq_request::pick_allowed_capped_level(
+                req, min_level, max_level, cap_level, excluded_levels(is_hp1));
           };
 
           hp1_req = pick_allowed(hp1_req, true);

--- a/openquatt_base.yaml
+++ b/openquatt_base.yaml
@@ -30,6 +30,7 @@ esphome:
   name_add_mac_suffix: false
   includes:
     - ${hp_perf_map_header}
+    - ${thermal_request_logic_header}
   platformio_options:
     build_flags:
       # Hard-pinned for Duo entrypoints to prevent accidental topology drift.

--- a/openquatt_base_single.yaml
+++ b/openquatt_base_single.yaml
@@ -30,6 +30,7 @@ esphome:
   name_add_mac_suffix: false
   includes:
     - ${hp_perf_map_header}
+    - ${thermal_request_logic_header}
   platformio_options:
     build_flags:
       # Hard-pinned for Single entrypoints to prevent accidental topology drift.


### PR DESCRIPTION
## Summary

This PR adds a compact shared helper layer for thermal request/control logic.

The goal is to keep the thermal architecture from `dev` intact while reducing duplicated low-level request logic across:

- `oq_thermal_request_control`
- `oq_thermal_actuator`
- the strategy modules that read excluded compressor levels

This is intentionally a smaller follow-up than the earlier helper exploration: it keeps the strategy flow visible in YAML and introduces only a single shared helper header.

## What changed

- added `openquatt/includes/oq_thermal_request_logic.h`
- moved shared request/control helpers into that single header:
  - request publication normalization
  - topology/owner derivation
  - excluded-level matching
  - allowed/capped level selection
  - mode/target matching
  - defrost hold helper
  - capped loop dt helper
  - min-runtime window helper
- reused the same excluded-level helper pattern in:
  - `oq_cooling_strategy.yaml`
  - `oq_heating_curve_strategy.yaml`
  - `oq_power_house_strategy.yaml`
- updated the strategy development docs/template to clarify the intended boundary:
  - YAML owns structure and publication
  - `.h` owns pure reusable logic

## Why this is useful

Compared to `dev`, this PR aims for a narrow maintenance win:

- less duplicated request/actuator glue
- less drift risk between request-control and actuator behavior
- a single place for repeated excluded-level and mode-matching logic
- strategy files remain mostly readable as YAML instead of being split across many helper headers

So this should give us some of the maintainability benefit of helper extraction without the cost of a larger helper tree.

## Validation

- `python3 scripts/dev.py validate --jobs 1`
- `python3 scripts/simulate_thermal_refactor_regressions.py`

Both passed locally.
