### PR TITLE
Simplify heating curve control internals

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Passive cooling wordt nu in hoofdlijnen beschreven in:
 - [Heating Strategy](heating-strategy.md): bovenliggende uitleg van beide verwarmingsstrategieën.
 - [Heating Strategy Development](heating-strategy-development.md): developer-uitleg van de strategy-interface, uitbreidregels, YAML-template en de grens tussen YAML-structuur en pure `.h` helpers.
 - [Power House](power-house.md): aparte uitleg van huismodel, comfortlogica, rise/fall time, laaglastgedrag en Duo-keuze.
-- [Water Temperature Control](water-temperature-control.md): aparte uitleg van stooklijn, PID, COAST/OFF-gedrag en Duo-hysterese.
+- [Water Temperature Control](water-temperature-control.md): aparte uitleg van stooklijn, PID, curve phase/operating regime en Duo-hysterese.
 - [Regelgedrag van OpenQuatt](regelgedrag-van-openquatt.md): systeemstanden, overgangen en flowregeling.
 - [Instellingen en meetwaarden](instellingen-en-meetwaarden.md): compile-time en runtime instellingen, plus de belangrijkste meetwaarden.
 - [Ontwikkelen op Mac en WSL](ontwikkelen-op-mac-en-wsl.md): aanbevolen lokale ontwikkelworkflow voor onderhoud en builds.

--- a/docs/heating-strategy-development.md
+++ b/docs/heating-strategy-development.md
@@ -183,10 +183,12 @@ Belangrijke regel:
 
 - een strategy publiceert compressor-level intent
 - niet direct actuator writes
+- een strategy mag daarnaast ook een abstracter totaalrequest of topology-hints publiceren, zolang `oq_thermal_request_control` de gedeelde request-interface blijft ownen
 
 Dus:
 
 - goed: `hp1_level = 4`, `hp2_level = 0`
+- ook goed: `total_level = 4` plus voldoende hints zodat `oq_thermal_request_control` de per-HP requestsplit kan afmaken
 - niet goed: zelf `hp1_set_working_mode` of `hp1_compressor_level` schrijven
 
 ## Checklist: nieuwe heating strategy toevoegen

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -200,7 +200,7 @@ Uses:
 - heating-curve interpolation to derive supply target
 - PID climate loop to track supply temperature
 - PID output mapped to demand `0..20`
-- coarse curve phase (`HEAT`/`COAST`/`OFF`) plus detailed operating regime (`RECOVERY`/`MAINTAIN`/`ASSIST`)
+- coarse curve phase (`HEAT`/`COAST`/`OFF`) plus detailed operating regime (`RECOVERY`/`MAINTAIN`)
 
 When PID SP/PV is invalid, demand falls back to 0 and integral is reset.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -199,7 +199,8 @@ Uses:
 
 - heating-curve interpolation to derive supply target
 - PID climate loop to track supply temperature
-- PID output mapped to demand `0..20` with phased output behavior (`HEAT`/`COAST`/`OFF`)
+- PID output mapped to demand `0..20`
+- coarse curve phase (`HEAT`/`COAST`/`OFF`) plus detailed operating regime (`RECOVERY`/`MAINTAIN`/`ASSIST`)
 
 When PID SP/PV is invalid, demand falls back to 0 and integral is reset.
 
@@ -207,7 +208,7 @@ Heating-curve stability guards around zero-demand edge:
 
 - profile-based outside-temperature smoothing and target quantization
 - start/stop gating with OFF-confirmation and low-PID requirement
-- near-target `COAST` phase (low modulation instead of immediate drop to `0`)
+- near-target `COAST` phase and low-load operating regime (instead of immediate drop to `0`)
 - room-temperature coupling trims supply target when room drifts warm
 - target clamp at `Maximum water temperature`
 - explicit per-HP slew-rate limiting with slower up and faster down behavior

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -133,7 +133,7 @@ Strategy packages compute:
 
 - `oq_demand_filtered`
 - HP level requests and applied levels
-- `oq_P_hp_cap_w` and `oq_P_deficit_w`
+- shared `oq_P_hp_cap_w` and `oq_P_deficit_w` diagnostics for strategy paths that use them
 
 ### 4.5 Supervisory and safety layer
 

--- a/docs/water-temperature-control.md
+++ b/docs/water-temperature-control.md
@@ -147,7 +147,6 @@ De regeling kent twee lagen van status:
   - `OFF`
   - `RECOVERY`
   - `MAINTAIN`
-  - `ASSIST`
 
 ### HEAT
 
@@ -386,7 +385,6 @@ Als je preciezer wilt zien wat de regeling doet, kijk dan ook naar `Curve operat
 
 - `RECOVERY` betekent dat de regeling nog duidelijk naar target toe werkt;
 - `MAINTAIN` betekent dat de regeling rond het huidige werkpunt probeert vast te houden;
-- `ASSIST` betekent een tijdelijke ophoging boven dat werkpunt.
 
 ## Samenvatting
 

--- a/docs/water-temperature-control.md
+++ b/docs/water-temperature-control.md
@@ -132,6 +132,7 @@ Belangrijke begrippen:
 
 - `Curve Phase`
 - `Curve operating regime`
+- `Demand Curve (continuous)`
 - `Demand curve raw (PID)`
 - `Demand raw`
 - `Curve restart inhibit`
@@ -338,6 +339,7 @@ Als je deze strategie wilt begrijpen of afstellen, zijn deze waarden meestal het
 - `Heating Curve PID`
 - `Curve Phase`
 - `Curve operating regime`
+- `Demand Curve (continuous)`
 - `Demand curve raw (PID)`
 - `Demand raw`
 - `Curve restart inhibit`

--- a/docs/water-temperature-control.md
+++ b/docs/water-temperature-control.md
@@ -131,15 +131,22 @@ De huidige curve-regeling heeft extra guardrails rond lage vraag. Dat is belangr
 Belangrijke begrippen:
 
 - `Curve Phase`
+- `Curve operating regime`
 - `Demand curve raw (PID)`
 - `Demand raw`
 - `Curve restart inhibit`
 
-De regeling kent grofweg drie fasen:
+De regeling kent twee lagen van status:
 
-- `HEAT`
-- `COAST`
-- `OFF`
+- `Curve Phase` is de grove fase:
+  - `OFF`
+  - `HEAT`
+  - `COAST`
+- `Curve operating regime` is de fijnere low-load toestand:
+  - `OFF`
+  - `RECOVERY`
+  - `MAINTAIN`
+  - `ASSIST`
 
 ### HEAT
 
@@ -330,6 +337,7 @@ Als je deze strategie wilt begrijpen of afstellen, zijn deze waarden meestal het
 - `Water Supply Temp (Selected)`
 - `Heating Curve PID`
 - `Curve Phase`
+- `Curve operating regime`
 - `Demand curve raw (PID)`
 - `Demand raw`
 - `Curve restart inhibit`
@@ -371,6 +379,12 @@ Nee. Dat hoort bij de huidige `Power House`-aanpak. In `Water Temperature Contro
 ### "COAST betekent dat er iets mis is"
 
 Niet per se. `COAST` is juist een bewuste tussenfase om niet te abrupt van verwarmen naar helemaal uit te gaan.
+
+Als je preciezer wilt zien wat de regeling doet, kijk dan ook naar `Curve operating regime`:
+
+- `RECOVERY` betekent dat de regeling nog duidelijk naar target toe werkt;
+- `MAINTAIN` betekent dat de regeling rond het huidige werkpunt probeert vast te houden;
+- `ASSIST` betekent een tijdelijke ophoging boven dat werkpunt.
 
 ## Samenvatting
 

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -12,7 +12,6 @@ inline void reset_control_state(float &demand_continuous,
                                 uint32_t &stop_arm_ms,
                                 uint32_t &off_since_ms,
                                 bool &restart_inhibit_active,
-                                int &phase_code,
                                 int &regime_code) {
   demand_continuous = NAN;
   demand_curve = 0;
@@ -21,7 +20,6 @@ inline void reset_control_state(float &demand_continuous,
   stop_arm_ms = 0;
   off_since_ms = 0;
   restart_inhibit_active = false;
-  phase_code = 0;
   regime_code = 0;
 }
 
@@ -43,25 +41,12 @@ inline void reset_request_state(uint32_t &request_last_loop_ms,
   request_reason_code = 0;
 }
 
-inline const char *phase_name(int phase_code) {
-  switch (phase_code) {
-    case 1: return "heat";
-    case 2: return "coast";
-    default: return "off";
-  }
-}
-
 inline const char *regime_name(int regime_code) {
   switch (regime_code) {
     case 1: return "recovery";
     case 2: return "maintain";
     default: return "off";
   }
-}
-
-inline const char *strategy_phase_name(int phase_code, int regime_code) {
-  if (regime_code > 0) return regime_name(regime_code);
-  return phase_name(phase_code);
 }
 
 }  // namespace oq_curve

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -112,12 +112,10 @@ inline void reset_outside_ema_state(float &outside_ema_c,
 
 inline void reset_request_state(uint32_t &request_last_loop_ms,
                                 int &request_total_level,
-                                int &request_owner_hp,
-                                int &request_reason_code) {
+                                int &request_owner_hp) {
   request_last_loop_ms = 0;
   request_total_level = 0;
   request_owner_hp = 0;
-  request_reason_code = 0;
 }
 
 inline const char *regime_name(int regime_code) {

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -32,10 +32,8 @@ struct ControlProfileTuning {
   float dual_disable_temp_err_max_c = 0.50f;
 };
 
-inline ControlProfileTuning control_profile(bool has_state, const std::string &profile_option) {
+inline ControlProfileTuning control_profile(const std::string &profile_option) {
   ControlProfileTuning tuning;
-  if (!has_state) return tuning;
-
   if (profile_option == "Comfort") {
     tuning.start_delta_c = 0.30f;
     tuning.stop_delta_c = 0.70f;

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -2,8 +2,89 @@
 
 #include <math.h>
 #include <stdint.h>
+#include <string>
 
 namespace oq_curve {
+
+struct ControlProfileTuning {
+  float start_delta_c = 0.45f;
+  float stop_delta_c = 0.90f;
+  int off_pid_max_f = 1;
+  uint32_t off_confirm_ms = 360000UL;
+  float room_overheat_off_c = 0.30f;
+  float room_resume_heat_c = 0.05f;
+  float restart_delta_c = 0.80f;
+  float restart_bypass_extra_c = 0.45f;
+  uint32_t off_reentry_min_ms = 480000UL;
+  float recovery_enter_c = 0.75f;
+  float recovery_exit_c = 0.25f;
+  float outside_tau_s = 1800.0f;
+  float trim_start_c = 0.10f;
+  float trim_gain = 1.50f;
+  float trim_max_c = 2.00f;
+  float quant_step_c = 0.5f;
+  int steady_up_hold_s = 180;
+  int steady_down_hold_s = 15;
+  int recovery_up_hold_s = 45;
+  int dual_startup_grace_s = 480;
+  int dual_emergency_hold_min = 6;
+  float dual_emergency_temp_err_c = 1.50f;
+  float dual_disable_temp_err_max_c = 0.50f;
+};
+
+inline ControlProfileTuning control_profile(bool has_state, const std::string &profile_option) {
+  ControlProfileTuning tuning;
+  if (!has_state) return tuning;
+
+  if (profile_option == "Comfort") {
+    tuning.start_delta_c = 0.30f;
+    tuning.stop_delta_c = 0.70f;
+    tuning.off_confirm_ms = 240000UL;
+    tuning.room_overheat_off_c = 0.20f;
+    tuning.room_resume_heat_c = 0.03f;
+    tuning.restart_delta_c = 0.60f;
+    tuning.restart_bypass_extra_c = 0.35f;
+    tuning.off_reentry_min_ms = 300000UL;
+    tuning.recovery_enter_c = 0.55f;
+    tuning.recovery_exit_c = 0.15f;
+    tuning.outside_tau_s = 900.0f;
+    tuning.trim_start_c = 0.05f;
+    tuning.trim_gain = 2.00f;
+    tuning.quant_step_c = 0.25f;
+    tuning.steady_up_hold_s = 90;
+    tuning.steady_down_hold_s = 10;
+    tuning.recovery_up_hold_s = 30;
+    tuning.dual_startup_grace_s = 300;
+    tuning.dual_emergency_hold_min = 4;
+    tuning.dual_emergency_temp_err_c = 1.20f;
+    tuning.dual_disable_temp_err_max_c = 0.70f;
+  } else if (profile_option == "Stable") {
+    tuning.start_delta_c = 0.65f;
+    tuning.stop_delta_c = 1.10f;
+    tuning.off_confirm_ms = 420000UL;
+    tuning.room_overheat_off_c = 0.35f;
+    tuning.room_resume_heat_c = 0.08f;
+    tuning.restart_delta_c = 1.00f;
+    tuning.restart_bypass_extra_c = 0.55f;
+    tuning.off_reentry_min_ms = 600000UL;
+    tuning.recovery_enter_c = 1.00f;
+    tuning.recovery_exit_c = 0.35f;
+    tuning.outside_tau_s = 3600.0f;
+    tuning.trim_start_c = 0.15f;
+    tuning.trim_gain = 1.00f;
+    tuning.trim_max_c = 2.50f;
+    tuning.quant_step_c = 1.0f;
+    tuning.steady_up_hold_s = 300;
+    tuning.steady_down_hold_s = 30;
+    tuning.recovery_up_hold_s = 75;
+    tuning.dual_startup_grace_s = 600;
+    tuning.dual_emergency_hold_min = 8;
+    tuning.dual_emergency_temp_err_c = 1.80f;
+    tuning.dual_disable_temp_err_max_c = 0.40f;
+  }
+
+  return tuning;
+}
 
 inline void reset_control_state(float &demand_continuous,
                                 int &demand_curve,

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -13,13 +13,7 @@ inline void reset_control_state(float &demand_continuous,
                                 uint32_t &off_since_ms,
                                 bool &restart_inhibit_active,
                                 int &phase_code,
-                                int &regime_code,
-                                uint32_t &regime_since_ms,
-                                int &maintain_level,
-                                uint32_t &maintain_raise_arm_ms,
-                                uint32_t &maintain_lower_arm_ms,
-                                uint32_t &assist_enter_arm_ms,
-                                uint32_t &assist_exit_arm_ms) {
+                                int &regime_code) {
   demand_continuous = NAN;
   demand_curve = 0;
   demand_pre_guardrail = 0;
@@ -29,12 +23,6 @@ inline void reset_control_state(float &demand_continuous,
   restart_inhibit_active = false;
   phase_code = 0;
   regime_code = 0;
-  regime_since_ms = 0;
-  maintain_level = 0;
-  maintain_raise_arm_ms = 0;
-  maintain_lower_arm_ms = 0;
-  assist_enter_arm_ms = 0;
-  assist_exit_arm_ms = 0;
 }
 
 inline void reset_outside_ema_state(float &outside_ema_c,
@@ -67,7 +55,6 @@ inline const char *regime_name(int regime_code) {
   switch (regime_code) {
     case 1: return "recovery";
     case 2: return "maintain";
-    case 3: return "assist";
     default: return "off";
   }
 }

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace oq_curve {
+
+inline void reset_control_state(int &demand_curve,
+                                int &demand_pre_guardrail,
+                                bool &heat_request_active,
+                                uint32_t &stop_arm_ms,
+                                uint32_t &off_since_ms,
+                                bool &restart_inhibit_active,
+                                int &phase_code,
+                                int &regime_code,
+                                uint32_t &regime_since_ms,
+                                int &maintain_level,
+                                uint32_t &maintain_raise_arm_ms,
+                                uint32_t &maintain_lower_arm_ms,
+                                uint32_t &assist_enter_arm_ms,
+                                uint32_t &assist_exit_arm_ms) {
+  demand_curve = 0;
+  demand_pre_guardrail = 0;
+  heat_request_active = false;
+  stop_arm_ms = 0;
+  off_since_ms = 0;
+  restart_inhibit_active = false;
+  phase_code = 0;
+  regime_code = 0;
+  regime_since_ms = 0;
+  maintain_level = 0;
+  maintain_raise_arm_ms = 0;
+  maintain_lower_arm_ms = 0;
+  assist_enter_arm_ms = 0;
+  assist_exit_arm_ms = 0;
+}
+
+inline void reset_outside_ema_state(float &outside_ema_c,
+                                    bool &outside_ema_initialized,
+                                    uint32_t &outside_ema_last_ms) {
+  outside_ema_c = 0.0f;
+  outside_ema_initialized = false;
+  outside_ema_last_ms = 0;
+}
+
+inline void reset_request_state(uint32_t &request_last_loop_ms,
+                                int &request_hp1_level,
+                                int &request_hp2_level,
+                                int &request_owner_hp,
+                                int &request_reason_code) {
+  request_last_loop_ms = 0;
+  request_hp1_level = 0;
+  request_hp2_level = 0;
+  request_owner_hp = 0;
+  request_reason_code = 0;
+}
+
+inline const char *phase_name(int phase_code) {
+  switch (phase_code) {
+    case 1: return "heat";
+    case 2: return "coast";
+    default: return "off";
+  }
+}
+
+inline const char *regime_name(int regime_code) {
+  switch (regime_code) {
+    case 1: return "recovery";
+    case 2: return "maintain";
+    case 3: return "assist";
+    default: return "off";
+  }
+}
+
+inline const char *strategy_phase_name(int phase_code, int regime_code) {
+  if (regime_code > 0) return regime_name(regime_code);
+  return phase_name(phase_code);
+}
+
+}  // namespace oq_curve

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -47,14 +47,10 @@ inline void reset_outside_ema_state(float &outside_ema_c,
 
 inline void reset_request_state(uint32_t &request_last_loop_ms,
                                 int &request_total_level,
-                                int &request_hp1_level,
-                                int &request_hp2_level,
                                 int &request_owner_hp,
                                 int &request_reason_code) {
   request_last_loop_ms = 0;
   request_total_level = 0;
-  request_hp1_level = 0;
-  request_hp2_level = 0;
   request_owner_hp = 0;
   request_reason_code = 0;
 }

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <math.h>
 #include <stdint.h>
 
 namespace oq_curve {
 
-inline void reset_control_state(int &demand_curve,
+inline void reset_control_state(float &demand_continuous,
+                                int &demand_curve,
                                 int &demand_pre_guardrail,
                                 bool &heat_request_active,
                                 uint32_t &stop_arm_ms,
@@ -18,6 +20,7 @@ inline void reset_control_state(int &demand_curve,
                                 uint32_t &maintain_lower_arm_ms,
                                 uint32_t &assist_enter_arm_ms,
                                 uint32_t &assist_exit_arm_ms) {
+  demand_continuous = NAN;
   demand_curve = 0;
   demand_pre_guardrail = 0;
   heat_request_active = false;

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -46,11 +46,13 @@ inline void reset_outside_ema_state(float &outside_ema_c,
 }
 
 inline void reset_request_state(uint32_t &request_last_loop_ms,
+                                int &request_total_level,
                                 int &request_hp1_level,
                                 int &request_hp2_level,
                                 int &request_owner_hp,
                                 int &request_reason_code) {
   request_last_loop_ms = 0;
+  request_total_level = 0;
   request_hp1_level = 0;
   request_hp2_level = 0;
   request_owner_hp = 0;

--- a/openquatt/includes/oq_thermal_request_logic.h
+++ b/openquatt/includes/oq_thermal_request_logic.h
@@ -27,6 +27,35 @@ struct PerHpRequestLevels {
   int owner_hp;
 };
 
+inline int whole_minutes_floor(float elapsed_min) {
+  return (int) floorf(elapsed_min + 1e-3f);
+}
+
+inline void reset_dual_hold_state(bool &dual_enabled,
+                                     float &dual_enable_hold_elapsed_accum_min,
+                                     float &dual_disable_hold_elapsed_accum_min,
+                                     float &dual_emergency_hold_elapsed_accum_min) {
+  dual_enabled = false;
+  dual_enable_hold_elapsed_accum_min = 0.0f;
+  dual_disable_hold_elapsed_accum_min = 0.0f;
+  dual_emergency_hold_elapsed_accum_min = 0.0f;
+}
+
+inline void reset_dual_runtime_state(bool &dual_enabled,
+                                     float &dual_enable_hold_elapsed_accum_min,
+                                     float &dual_disable_hold_elapsed_accum_min,
+                                     float &dual_emergency_hold_elapsed_accum_min,
+                                     int &single_owner_hp,
+                                     uint32_t &duo_request_hold_until_ms,
+                                     int owner_hp) {
+  reset_dual_hold_state(dual_enabled,
+                        dual_enable_hold_elapsed_accum_min,
+                        dual_disable_hold_elapsed_accum_min,
+                        dual_emergency_hold_elapsed_accum_min);
+  single_owner_hp = owner_hp;
+  duo_request_hold_until_ms = 0;
+}
+
 inline int clamp_level(int level, int min_level, int max_level) {
   return std::max(min_level, std::min(max_level, level));
 }

--- a/openquatt/includes/oq_thermal_request_logic.h
+++ b/openquatt/includes/oq_thermal_request_logic.h
@@ -21,6 +21,12 @@ struct PublishedRequest {
   int strategy_code;
 };
 
+struct PerHpRequestLevels {
+  int hp1_level;
+  int hp2_level;
+  int owner_hp;
+};
+
 inline int clamp_level(int level, int min_level, int max_level) {
   return std::max(min_level, std::min(max_level, level));
 }
@@ -62,6 +68,32 @@ inline PublishedRequest make_published_request(int mode_code,
       topology_code,
       sanitize_request_strategy_code(strategy_code),
   };
+}
+
+inline PerHpRequestLevels split_curve_total_request(int total_level_request,
+                                                    bool dual_enabled,
+                                                    bool lead_is_hp1,
+                                                    int owner_hp) {
+  total_level_request = clamp_level(total_level_request, 0, 20);
+  if (total_level_request <= 0) {
+    return PerHpRequestLevels{0, 0, 0};
+  }
+
+  if (!dual_enabled) {
+    const int effective_owner =
+        (owner_hp == 1 || owner_hp == 2) ? owner_hp : (lead_is_hp1 ? 1 : 2);
+    return (effective_owner == 1)
+               ? PerHpRequestLevels{total_level_request, 0, 1}
+               : PerHpRequestLevels{0, total_level_request, 2};
+  }
+
+  int hp1_level = total_level_request / 2;
+  int hp2_level = total_level_request / 2;
+  if ((total_level_request % 2) == 1) {
+    if (lead_is_hp1) hp1_level += 1;
+    else hp2_level += 1;
+  }
+  return PerHpRequestLevels{hp1_level, hp2_level, 0};
 }
 
 inline bool excluded_option_matches_level(const std::string &opt, int level) {

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -387,18 +387,6 @@ interval:
             return std::max(last_start_ms, last_stop_ms);
           };
 
-          auto reset_dual_runtime_state = [&](int owner)->void {
-            id(oq_dual_hp_enabled) = false;
-            id(oq_dual_hp_enable_hold_elapsed_min) = 0;
-            id(oq_dual_hp_disable_hold_elapsed_min) = 0;
-            id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
-            id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
-            id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
-            id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
-            id(oq_curve_single_owner_hp) = owner;
-            id(oq_duo_request_hold_until_ms) = 0;
-          };
-
           int hp1_req = 0;
           int hp2_req = 0;
           int owner = 0;
@@ -438,11 +426,25 @@ interval:
             }
           }
 
-          reset_dual_runtime_state(owner);
+          oq_request::reset_dual_runtime_state(
+              id(oq_dual_hp_enabled),
+              id(oq_dual_hp_enable_hold_elapsed_accum_min),
+              id(oq_dual_hp_disable_hold_elapsed_accum_min),
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+              id(oq_curve_single_owner_hp),
+              id(oq_duo_request_hold_until_ms),
+              owner);
           if (owner == 1) hp1_req = f;
           else if (owner == 2) hp2_req = f;
           #else
-          reset_dual_runtime_state(1);
+          oq_request::reset_dual_runtime_state(
+              id(oq_dual_hp_enabled),
+              id(oq_dual_hp_enable_hold_elapsed_accum_min),
+              id(oq_dual_hp_disable_hold_elapsed_accum_min),
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+              id(oq_curve_single_owner_hp),
+              id(oq_duo_request_hold_until_ms),
+              1);
           owner = (f > 0) ? 1 : 0;
           hp1_req = f;
           hp2_req = 0;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -399,45 +399,20 @@ output:
             return;
           }
 
-          float start_delta_c = 0.45f;
-          float stop_delta_c = 0.90f;
-          int off_pid_max_f = 1;
-          uint32_t off_confirm_ms = 360000UL;
-          float room_overheat_off_c = 0.30f;
-          float room_resume_heat_c = 0.05f;
-          float restart_delta_c = 0.80f;
-          float restart_bypass_extra_c = 0.45f;
-          uint32_t off_reentry_min_ms = 480000UL;
-          float recovery_enter_c = 0.75f;
-          float recovery_exit_c = 0.25f;
-          if (id(oq_curve_control_profile).has_state()) {
-            const auto profile = id(oq_curve_control_profile).current_option();
-            if (profile == "Comfort") {
-              start_delta_c = 0.30f;
-              stop_delta_c = 0.70f;
-              off_pid_max_f = 1;
-              off_confirm_ms = 240000UL;
-              room_overheat_off_c = 0.20f;
-              room_resume_heat_c = 0.03f;
-              restart_delta_c = 0.60f;
-              restart_bypass_extra_c = 0.35f;
-              off_reentry_min_ms = 300000UL;
-              recovery_enter_c = 0.55f;
-              recovery_exit_c = 0.15f;
-            } else if (profile == "Stable") {
-              start_delta_c = 0.65f;
-              stop_delta_c = 1.10f;
-              off_pid_max_f = 1;
-              off_confirm_ms = 420000UL;
-              room_overheat_off_c = 0.35f;
-              room_resume_heat_c = 0.08f;
-              restart_delta_c = 1.00f;
-              restart_bypass_extra_c = 0.55f;
-              off_reentry_min_ms = 600000UL;
-              recovery_enter_c = 1.00f;
-              recovery_exit_c = 0.35f;
-            }
-          }
+          const bool has_curve_profile = id(oq_curve_control_profile).has_state();
+          const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
+          auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+          float start_delta_c = tuning.start_delta_c;
+          float stop_delta_c = tuning.stop_delta_c;
+          int off_pid_max_f = tuning.off_pid_max_f;
+          uint32_t off_confirm_ms = tuning.off_confirm_ms;
+          float room_overheat_off_c = tuning.room_overheat_off_c;
+          float room_resume_heat_c = tuning.room_resume_heat_c;
+          float restart_delta_c = tuning.restart_delta_c;
+          float restart_bypass_extra_c = tuning.restart_bypass_extra_c;
+          uint32_t off_reentry_min_ms = tuning.off_reentry_min_ms;
+          float recovery_enter_c = tuning.recovery_enter_c;
+          float recovery_exit_c = tuning.recovery_exit_c;
           if (stop_delta_c < start_delta_c + 0.10f) stop_delta_c = start_delta_c + 0.10f;
           if (restart_delta_c < start_delta_c + 0.05f) restart_delta_c = start_delta_c + 0.05f;
           if (restart_bypass_extra_c < 0.20f) restart_bypass_extra_c = 0.20f;
@@ -556,12 +531,10 @@ sensor:
         return NAN;
       }
 
-      float tau_s = 1800.0f;
-      if (id(oq_curve_control_profile).has_state()) {
-        const auto profile = id(oq_curve_control_profile).current_option();
-        if (profile == "Comfort") tau_s = 900.0f;
-        else if (profile == "Stable") tau_s = 3600.0f;
-      }
+      const bool has_curve_profile = id(oq_curve_control_profile).has_state();
+      const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
+      const auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+      const float tau_s = tuning.outside_tau_s;
 
       const uint32_t now_ms = (uint32_t) millis();
       if (!id(oq_curve_outside_ema_initialized) ||
@@ -601,6 +574,9 @@ sensor:
       // Generate the curve-mode supply target from outside temperature and room trim.
       const float outside_c = id(oq_curve_outside_temp_filtered).state;
       float target_c = id(curve_fallback_supply_temp).state;
+      const bool has_curve_profile = id(oq_curve_control_profile).has_state();
+      const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
+      const auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
 
       struct Point { float outside_c; float target_c; };
       const Point points[6] = {
@@ -630,21 +606,9 @@ sensor:
       const float room_sp_c = id(room_setpoint_selected).state;
       if (!isnan(target_c) && !isnan(room_c) && !isnan(room_sp_c)) {
         float warm_err_c = room_c - room_sp_c;
-        float trim_start_c = 0.10f;
-        float trim_gain = 1.50f;
-        float trim_max_c = 2.00f;
-        if (id(oq_curve_control_profile).has_state()) {
-          const auto profile = id(oq_curve_control_profile).current_option();
-          if (profile == "Comfort") {
-            trim_start_c = 0.05f;
-            trim_gain = 2.00f;
-            trim_max_c = 2.00f;
-          } else if (profile == "Stable") {
-            trim_start_c = 0.15f;
-            trim_gain = 1.00f;
-            trim_max_c = 2.50f;
-          }
-        }
+        const float trim_start_c = tuning.trim_start_c;
+        const float trim_gain = tuning.trim_gain;
+        const float trim_max_c = tuning.trim_max_c;
         if (warm_err_c > trim_start_c) {
           float trim_c = (warm_err_c - trim_start_c) * trim_gain;
           if (trim_c < 0.0f) trim_c = 0.0f;
@@ -653,12 +617,7 @@ sensor:
         }
       }
 
-      float quant_step_c = 0.5f;
-      if (id(oq_curve_control_profile).has_state()) {
-        const auto profile = id(oq_curve_control_profile).current_option();
-        if (profile == "Comfort") quant_step_c = 0.25f;
-        else if (profile == "Stable") quant_step_c = 1.0f;
-      }
+      const float quant_step_c = tuning.quant_step_c;
       if (!isnan(target_c) && quant_step_c > 0.0f) {
         target_c = roundf(target_c / quant_step_c) * quant_step_c;
       }
@@ -1024,24 +983,13 @@ interval:
           if (dual_on_hold_min < 1) dual_on_hold_min = 1;
           if (dual_off_hold_min < 1) dual_off_hold_min = 1;
 
-          int startup_grace_s = 480;
-          int emergency_hold_min = 6;
-          float emergency_temp_err_c = 1.50f;
-          float dual_disable_temp_err_max_c = 0.50f;
-          if (id(oq_curve_control_profile).has_state()) {
-            const auto profile = id(oq_curve_control_profile).current_option();
-            if (profile == "Comfort") {
-              startup_grace_s = 300;
-              emergency_hold_min = 4;
-              emergency_temp_err_c = 1.20f;
-              dual_disable_temp_err_max_c = 0.70f;
-            } else if (profile == "Stable") {
-              startup_grace_s = 600;
-              emergency_hold_min = 8;
-              emergency_temp_err_c = 1.80f;
-              dual_disable_temp_err_max_c = 0.40f;
-            }
-          }
+          const bool has_curve_profile = id(oq_curve_control_profile).has_state();
+          const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
+          const auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+          int startup_grace_s = tuning.dual_startup_grace_s;
+          int emergency_hold_min = tuning.dual_emergency_hold_min;
+          float emergency_temp_err_c = tuning.dual_emergency_temp_err_c;
+          float dual_disable_temp_err_max_c = tuning.dual_disable_temp_err_max_c;
           if (startup_grace_s < 0) startup_grace_s = 0;
           if (emergency_hold_min < 1) emergency_hold_min = 1;
 

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -8,10 +8,10 @@
 # Ownership:
 #   - Computes curve supply target generation and PID demand
 #   - Owns curve-specific hysteresis, phase/regime state, and diagnostics
-#   - Decides single-vs-dual curve topology
+#   - Decides curve total request and topology hints
 #   - Publishes level-derived capacity/deficit telemetry for diagnostics
-#   - Publishes curve request outputs for oq_thermal_request_control to use as
-#     the shared request interface
+#   - Publishes curve request outputs for oq_thermal_request_control to finish
+#     into the shared request interface
 # ==============================================================================
 
 globals:
@@ -124,6 +124,11 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  - id: oq_curve_request_total_level
+    type: int
+    restore_value: false
+    initial_value: '0'
+
   - id: oq_curve_request_hp1_level
     type: int
     restore_value: false
@@ -186,6 +191,13 @@ select:
               id(oq_curve_outside_ema_c),
               id(oq_curve_outside_ema_initialized),
               id(oq_curve_outside_ema_last_ms));
+            oq_curve::reset_request_state(
+              id(oq_curve_request_last_loop_ms),
+              id(oq_curve_request_total_level),
+              id(oq_curve_request_hp1_level),
+              id(oq_curve_request_hp2_level),
+              id(oq_curve_request_owner_hp),
+              id(oq_curve_request_reason_code));
 
 number:
   - platform: template
@@ -953,6 +965,21 @@ sensor:
       return (float) id(oq_demand_curve);
 
   - platform: template
+    id: oq_curve_request_total_level_sensor
+    name: "Curve request total level"
+    disabled_by_default: true
+    icon: mdi:counter
+    unit_of_measurement: "step"
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return (float) id(oq_curve_request_total_level);
+
+  - platform: template
     id: oq_curve_restart_inhibit_sensor
     name: "Curve restart inhibit"
     disabled_by_default: true
@@ -1138,12 +1165,13 @@ interval:
     startup_delay: 4000ms
     then:
       - lambda: |-
-          // Heating-curve strategy: owns direct demand and single-vs-dual request split.
+          // Heating-curve strategy: owns direct demand, total request, and topology hints.
           const int cm_code = id(oq_control_mode_code);
           const bool active = (cm_code != 5) && (id(oq_heat_mode_code) == 1);
           if (!active) {
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
+              id(oq_curve_request_total_level),
               id(oq_curve_request_hp1_level),
               id(oq_curve_request_hp2_level),
               id(oq_curve_request_owner_hp),
@@ -1317,6 +1345,7 @@ interval:
 
           int hp1_req = 0;
           int hp2_req = 0;
+          int total_req = 0;
           int owner = 0;
           int reason_code = 0;
 
@@ -1465,10 +1494,7 @@ interval:
             }
 
             id(oq_curve_single_owner_hp) = single_owner;
-            if (single_owner == 1) hp1_req = f;
-            else if (single_owner == 2) hp2_req = f;
-            else if (lead_is_hp1) hp1_req = f;
-            else hp2_req = f;
+            total_req = f;
             owner = single_owner;
             if (single_owner == 1) reason_code = 1;
             else if (single_owner == 2) reason_code = 2;
@@ -1476,12 +1502,7 @@ interval:
             else reason_code = 4;
           } else {
             id(oq_curve_single_owner_hp) = 0;
-            hp1_req = f / 2;
-            hp2_req = f / 2;
-            if ((f % 2) == 1) {
-              if (lead_is_hp1) hp1_req += 1;
-              else hp2_req += 1;
-            }
+            total_req = f;
             owner = 0;
             if (force_dual_capacity) reason_code = 5;
             else if (force_dual_defrost) reason_code = 6;
@@ -1490,12 +1511,18 @@ interval:
           #else
           reset_dual_runtime_state(1);
           publish_capacity_and_deficit(f);
-          hp1_req = f;
-          hp2_req = 0;
+          total_req = f;
           owner = (f > 0) ? 1 : 0;
           reason_code = (f > 0) ? 1 : 0;
           #endif
 
+          const auto per_hp_request =
+              oq_request::split_curve_total_request(total_req, id(oq_dual_hp_enabled), lead_is_hp1, owner);
+          hp1_req = per_hp_request.hp1_level;
+          hp2_req = per_hp_request.hp2_level;
+          owner = per_hp_request.owner_hp;
+
+          id(oq_curve_request_total_level) = total_req;
           id(oq_curve_request_hp1_level) = hp1_req;
           id(oq_curve_request_hp2_level) = hp2_req;
           id(oq_curve_request_owner_hp) = owner;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -9,7 +9,7 @@
 #   - Computes curve supply target generation and PID demand
 #   - Owns curve-specific hysteresis, phase/regime state, and diagnostics
 #   - Decides curve total request and topology hints
-#   - Publishes level-derived capacity/deficit telemetry for diagnostics
+#   - Clears Power House-specific capacity/deficit telemetry while curve mode is active
 #   - Publishes curve request outputs for oq_thermal_request_control to finish
 #     into the shared request interface
 # ==============================================================================
@@ -1235,8 +1235,6 @@ interval:
             #endif
           };
 
-          const float Tamb = id(outside_temp_selected).state;
-          const float Tsup = id(oq_system_supply_temp).state;
           int level_cap = (int) roundf(id(oq_day_max_level).state);
           if (id(oq_silent_active).state) level_cap = (int) roundf(id(oq_silent_max_level).state);
           if (level_cap < min_level) level_cap = min_level;
@@ -1250,72 +1248,8 @@ interval:
           const bool hp2_valve_def = false;
           const bool hp2_available = false;
           #endif
-          const bool hp1_available = true;
-
-          float def_fac_cfg = ${oq_defrost_power_factor};
-          if (isnan(def_fac_cfg)) def_fac_cfg = 0.55f;
-          const float def_fac = fmaxf(0.10f, fminf(1.00f, def_fac_cfg));
-          const float hp1_th_fac = hp1_valve_def ? def_fac : 1.0f;
-          const float hp2_th_fac = hp2_valve_def ? def_fac : 1.0f;
-
-          auto power_for_level = [&](bool is_hp1, int level)->float {
-            if (level <= 0) return 0.0f;
-            if ((is_hp1 && !hp1_available) || (!is_hp1 && !hp2_available)) return 0.0f;
-            float p = oq_perf::interp_power_th_w(level, Tamb, Tsup);
-            if (isnan(p)) return 0.0f;
-            p *= is_hp1 ? hp1_th_fac : hp2_th_fac;
-            return isnan(p) ? 0.0f : p;
-          };
-
-          auto max_cap_hp = [&](bool is_hp1)->float {
-            if ((is_hp1 && !hp1_available) || (!is_hp1 && !hp2_available)) return 0.0f;
-            float best = 0.0f;
-            for (int lvl = 1; lvl <= level_cap; lvl++) {
-              if (!level_allowed(is_hp1, lvl)) continue;
-              float p = oq_perf::interp_power_th_w(lvl, Tamb, Tsup);
-              if (!isnan(p)) p *= is_hp1 ? hp1_th_fac : hp2_th_fac;
-              if (!isnan(p) && p > best) best = p;
-            }
-            return best;
-          };
-
-          auto requested_power_from_total_levels = [&](int total_level_request)->float {
-            int total_req = total_level_request;
-            if (total_req < 0) total_req = 0;
-            if (isnan(Tamb) || isnan(Tsup) || total_req <= 0) return 0.0f;
-
-            float best = 0.0f;
-            #if OQ_TOPOLOGY_DUO
-            const int nominal_cap_total = max_level * 2;
-            if (total_req > nominal_cap_total) total_req = nominal_cap_total;
-            for (int l1 = 0; l1 <= std::min(max_level, total_req); l1++) {
-              const int l2_max = std::min(max_level, total_req - l1);
-              for (int l2 = 0; l2 <= l2_max; l2++) {
-                if ((l1 + l2) > total_req) continue;
-                const float req_power = power_for_level(true, l1) + power_for_level(false, l2);
-                if (req_power > best) best = req_power;
-              }
-            }
-            #else
-            if (total_req > max_level) total_req = max_level;
-            best = power_for_level(true, total_req);
-            #endif
-            return best;
-          };
-
-          auto publish_capacity_and_deficit = [&](int requested_level_total)->float {
-            float cap_total = 0.0f;
-            if (!isnan(Tamb) && !isnan(Tsup)) {
-              cap_total = max_cap_hp(true) + max_cap_hp(false);
-            }
-            id(oq_P_hp_cap_w) = cap_total;
-
-            float req = requested_power_from_total_levels(requested_level_total);
-            float deficit = req - cap_total;
-            if (deficit < 0.0f) deficit = 0.0f;
-            id(oq_P_deficit_w) = deficit;
-            return cap_total;
-          };
+          id(oq_P_hp_cap_w) = 0.0f;
+          id(oq_P_deficit_w) = 0.0f;
 
           auto reset_dual_runtime_state = [&](int owner)->void {
             id(oq_dual_hp_enabled) = false;
@@ -1334,7 +1268,6 @@ interval:
           int reason_code = 0;
 
           #if OQ_TOPOLOGY_DUO
-          publish_capacity_and_deficit(f);
           const bool d1_pre = hp1_valve_def;
           const bool d2_pre = hp2_valve_def;
 
@@ -1494,7 +1427,6 @@ interval:
           }
           #else
           reset_dual_runtime_state(1);
-          publish_capacity_and_deficit(f);
           total_req = f;
           owner = (f > 0) ? 1 : 0;
           reason_code = (f > 0) ? 1 : 0;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -7,9 +7,9 @@
 #
 # Ownership:
 #   - Computes curve supply target generation and PID demand
-#   - Owns curve-specific hysteresis, phase state, and diagnostics
+#   - Owns curve-specific hysteresis, phase/regime state, and diagnostics
 #   - Decides single-vs-dual curve topology
-#   - Publishes level-derived capacity/deficit telemetry for supervisory CM3 logic
+#   - Publishes level-derived capacity/deficit telemetry for diagnostics
 #   - Publishes curve request outputs for oq_thermal_request_control to use as
 #     the shared request interface
 # ==============================================================================
@@ -27,7 +27,7 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # Heating-curve diagnostics: 0=OFF, 1=HEAT, 2=COAST.
+  # Heating-curve coarse phase: 0=OFF, 1=HEAT, 2=COAST.
   - id: oq_curve_phase_code
     type: int
     restore_value: false
@@ -159,17 +159,26 @@ select:
       then:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
         - lambda: |-
-            id(oq_curve_heat_request_active) = false;
-            id(oq_curve_stop_arm_ms) = 0;
-            id(oq_curve_outside_ema_initialized) = false;
-            id(oq_curve_outside_ema_last_ms) = 0;
-            id(oq_curve_regime_code) = 0;
-            id(oq_curve_regime_since_ms) = 0;
-            id(oq_curve_maintain_level) = 0;
-            id(oq_curve_maintain_raise_arm_ms) = 0;
-            id(oq_curve_maintain_lower_arm_ms) = 0;
-            id(oq_curve_assist_enter_arm_ms) = 0;
-            id(oq_curve_assist_exit_arm_ms) = 0;
+            // Reset curve runtime state so a profile switch starts from a clean baseline.
+            oq_curve::reset_control_state(
+              id(oq_demand_curve),
+              id(oq_curve_demand_pre_guardrail),
+              id(oq_curve_heat_request_active),
+              id(oq_curve_stop_arm_ms),
+              id(oq_curve_off_since_ms),
+              id(oq_curve_restart_inhibit_active),
+              id(oq_curve_phase_code),
+              id(oq_curve_regime_code),
+              id(oq_curve_regime_since_ms),
+              id(oq_curve_maintain_level),
+              id(oq_curve_maintain_raise_arm_ms),
+              id(oq_curve_maintain_lower_arm_ms),
+              id(oq_curve_assist_enter_arm_ms),
+              id(oq_curve_assist_exit_arm_ms));
+            oq_curve::reset_outside_ema_state(
+              id(oq_curve_outside_ema_c),
+              id(oq_curve_outside_ema_initialized),
+              id(oq_curve_outside_ema_last_ms));
 
 number:
   - platform: template
@@ -381,39 +390,41 @@ output:
           // Guardrail: only let PID-path write curve demand in heating-curve mode.
           // In Power House mode, this output is diagnostic-only and must remain 0.
           if (id(oq_heat_mode_code) != 1) {
-            id(oq_demand_curve) = 0;
-            id(oq_curve_demand_pre_guardrail) = 0;
-            id(oq_curve_heat_request_active) = false;
-            id(oq_curve_stop_arm_ms) = 0;
-            id(oq_curve_off_since_ms) = 0;
-            id(oq_curve_restart_inhibit_active) = false;
-            id(oq_curve_phase_code) = 0;
-            id(oq_curve_regime_code) = 0;
-            id(oq_curve_regime_since_ms) = 0;
-            id(oq_curve_maintain_level) = 0;
-            id(oq_curve_maintain_raise_arm_ms) = 0;
-            id(oq_curve_maintain_lower_arm_ms) = 0;
-            id(oq_curve_assist_enter_arm_ms) = 0;
-            id(oq_curve_assist_exit_arm_ms) = 0;
+            oq_curve::reset_control_state(
+              id(oq_demand_curve),
+              id(oq_curve_demand_pre_guardrail),
+              id(oq_curve_heat_request_active),
+              id(oq_curve_stop_arm_ms),
+              id(oq_curve_off_since_ms),
+              id(oq_curve_restart_inhibit_active),
+              id(oq_curve_phase_code),
+              id(oq_curve_regime_code),
+              id(oq_curve_regime_since_ms),
+              id(oq_curve_maintain_level),
+              id(oq_curve_maintain_raise_arm_ms),
+              id(oq_curve_maintain_lower_arm_ms),
+              id(oq_curve_assist_enter_arm_ms),
+              id(oq_curve_assist_exit_arm_ms));
             return;
           }
 
           const int demand_max = (int) ${oq_strategy_demand_max_f};
           if (isnan(state)) {
-            id(oq_demand_curve) = 0;
-            id(oq_curve_demand_pre_guardrail) = 0;
-            id(oq_curve_heat_request_active) = false;
-            id(oq_curve_stop_arm_ms) = 0;
-            id(oq_curve_off_since_ms) = 0;
-            id(oq_curve_restart_inhibit_active) = false;
-            id(oq_curve_phase_code) = 0;
-            id(oq_curve_regime_code) = 0;
-            id(oq_curve_regime_since_ms) = 0;
-            id(oq_curve_maintain_level) = 0;
-            id(oq_curve_maintain_raise_arm_ms) = 0;
-            id(oq_curve_maintain_lower_arm_ms) = 0;
-            id(oq_curve_assist_enter_arm_ms) = 0;
-            id(oq_curve_assist_exit_arm_ms) = 0;
+            oq_curve::reset_control_state(
+              id(oq_demand_curve),
+              id(oq_curve_demand_pre_guardrail),
+              id(oq_curve_heat_request_active),
+              id(oq_curve_stop_arm_ms),
+              id(oq_curve_off_since_ms),
+              id(oq_curve_restart_inhibit_active),
+              id(oq_curve_phase_code),
+              id(oq_curve_regime_code),
+              id(oq_curve_regime_since_ms),
+              id(oq_curve_maintain_level),
+              id(oq_curve_maintain_raise_arm_ms),
+              id(oq_curve_maintain_lower_arm_ms),
+              id(oq_curve_assist_enter_arm_ms),
+              id(oq_curve_assist_exit_arm_ms));
             return;
           }
 
@@ -425,20 +436,21 @@ output:
           const float spw = id(oq_supply_target_temp).state;
           const float pv = id(oq_system_supply_temp).state;
           if (isnan(spw) || isnan(pv)) {
-            id(oq_curve_heat_request_active) = false;
-            id(oq_curve_stop_arm_ms) = 0;
-            id(oq_curve_off_since_ms) = 0;
-            id(oq_curve_restart_inhibit_active) = false;
-            id(oq_demand_curve) = 0;
-            id(oq_curve_demand_pre_guardrail) = 0;
-            id(oq_curve_phase_code) = 0;
-            id(oq_curve_regime_code) = 0;
-            id(oq_curve_regime_since_ms) = 0;
-            id(oq_curve_maintain_level) = 0;
-            id(oq_curve_maintain_raise_arm_ms) = 0;
-            id(oq_curve_maintain_lower_arm_ms) = 0;
-            id(oq_curve_assist_enter_arm_ms) = 0;
-            id(oq_curve_assist_exit_arm_ms) = 0;
+            oq_curve::reset_control_state(
+              id(oq_demand_curve),
+              id(oq_curve_demand_pre_guardrail),
+              id(oq_curve_heat_request_active),
+              id(oq_curve_stop_arm_ms),
+              id(oq_curve_off_since_ms),
+              id(oq_curve_restart_inhibit_active),
+              id(oq_curve_phase_code),
+              id(oq_curve_regime_code),
+              id(oq_curve_regime_since_ms),
+              id(oq_curve_maintain_level),
+              id(oq_curve_maintain_raise_arm_ms),
+              id(oq_curve_maintain_lower_arm_ms),
+              id(oq_curve_assist_enter_arm_ms),
+              id(oq_curve_assist_exit_arm_ms));
             return;
           }
 
@@ -1012,21 +1024,17 @@ interval:
             if (id(oq_water_temp_hard_trip_active)) d_out = 0;
             id(oq_demand_raw) = d_out;
 
-            id(oq_strategy_phase_code) = id(oq_curve_phase_code);
+            id(oq_strategy_phase_code) = id(oq_curve_regime_code);
             id(oq_strategy_requested_power_w) = NAN;
             id(oq_strategy_supply_target_temp) = id(oq_supply_target_temp).state;
             id(oq_strategy_heat_request_active) = id(oq_curve_heat_request_active);
 
             const int phase_code = id(oq_curve_phase_code);
-            const char *phase_text = "off";
-            if (phase_code == 1) phase_text = "heat";
-            else if (phase_code == 2) phase_text = "coast";
             const int regime_code = id(oq_curve_regime_code);
-            const char *regime_text = "off";
-            if (regime_code == 1) regime_text = "recovery";
-            else if (regime_code == 2) regime_text = "maintain";
-            else if (regime_code == 3) regime_text = "assist";
-            id(oq_strategy_phase_text).publish_state(phase_text);
+            const char *phase_text = oq_curve::phase_name(phase_code);
+            const char *regime_text = oq_curve::regime_name(regime_code);
+            id(oq_strategy_phase_text).publish_state(
+              oq_curve::strategy_phase_name(phase_code, regime_code));
 
             char debug_buf[192];
             const float target_c = id(oq_supply_target_temp).state;
@@ -1043,19 +1051,21 @@ interval:
               c0.set_mode(CLIMATE_MODE_OFF);
               c0.perform();
             }
-            id(oq_curve_heat_request_active) = false;
-            id(oq_curve_stop_arm_ms) = 0;
-            id(oq_curve_off_since_ms) = 0;
-            id(oq_curve_restart_inhibit_active) = false;
-            id(oq_curve_regime_code) = 0;
-            id(oq_curve_regime_since_ms) = 0;
-            id(oq_curve_maintain_level) = 0;
-            id(oq_curve_maintain_raise_arm_ms) = 0;
-            id(oq_curve_maintain_lower_arm_ms) = 0;
-            id(oq_curve_assist_enter_arm_ms) = 0;
-            id(oq_curve_assist_exit_arm_ms) = 0;
-            id(oq_curve_phase_code) = 0;
-            id(oq_demand_curve) = 0;
+            oq_curve::reset_control_state(
+              id(oq_demand_curve),
+              id(oq_curve_demand_pre_guardrail),
+              id(oq_curve_heat_request_active),
+              id(oq_curve_stop_arm_ms),
+              id(oq_curve_off_since_ms),
+              id(oq_curve_restart_inhibit_active),
+              id(oq_curve_phase_code),
+              id(oq_curve_regime_code),
+              id(oq_curve_regime_since_ms),
+              id(oq_curve_maintain_level),
+              id(oq_curve_maintain_raise_arm_ms),
+              id(oq_curve_maintain_lower_arm_ms),
+              id(oq_curve_assist_enter_arm_ms),
+              id(oq_curve_assist_exit_arm_ms));
           }
       - if:
           condition:
@@ -1087,11 +1097,12 @@ interval:
           const int cm_code = id(oq_control_mode_code);
           const bool active = (cm_code != 5) && (id(oq_heat_mode_code) == 1);
           if (!active) {
-            id(oq_curve_request_last_loop_ms) = 0;
-            id(oq_curve_request_hp1_level) = 0;
-            id(oq_curve_request_hp2_level) = 0;
-            id(oq_curve_request_owner_hp) = 0;
-            id(oq_curve_request_reason_code) = 0;
+            oq_curve::reset_request_state(
+              id(oq_curve_request_last_loop_ms),
+              id(oq_curve_request_hp1_level),
+              id(oq_curve_request_hp2_level),
+              id(oq_curve_request_owner_hp),
+              id(oq_curve_request_reason_code));
             return;
           }
 

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -399,9 +399,10 @@ output:
             return;
           }
 
-          const bool has_curve_profile = id(oq_curve_control_profile).has_state();
-          const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
-          auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+          auto tuning = oq_curve::control_profile(
+              id(oq_curve_control_profile).has_state()
+                  ? id(oq_curve_control_profile).current_option()
+                  : std::string());
           float start_delta_c = tuning.start_delta_c;
           float stop_delta_c = tuning.stop_delta_c;
           int off_pid_max_f = tuning.off_pid_max_f;
@@ -531,9 +532,10 @@ sensor:
         return NAN;
       }
 
-      const bool has_curve_profile = id(oq_curve_control_profile).has_state();
-      const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
-      const auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+      const auto tuning = oq_curve::control_profile(
+          id(oq_curve_control_profile).has_state()
+              ? id(oq_curve_control_profile).current_option()
+              : std::string());
       const float tau_s = tuning.outside_tau_s;
 
       const uint32_t now_ms = (uint32_t) millis();
@@ -574,9 +576,10 @@ sensor:
       // Generate the curve-mode supply target from outside temperature and room trim.
       const float outside_c = id(oq_curve_outside_temp_filtered).state;
       float target_c = id(curve_fallback_supply_temp).state;
-      const bool has_curve_profile = id(oq_curve_control_profile).has_state();
-      const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
-      const auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+      const auto tuning = oq_curve::control_profile(
+          id(oq_curve_control_profile).has_state()
+              ? id(oq_curve_control_profile).current_option()
+              : std::string());
 
       struct Point { float outside_c; float target_c; };
       const Point points[6] = {
@@ -983,9 +986,10 @@ interval:
           if (dual_on_hold_min < 1) dual_on_hold_min = 1;
           if (dual_off_hold_min < 1) dual_off_hold_min = 1;
 
-          const bool has_curve_profile = id(oq_curve_control_profile).has_state();
-          const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
-          const auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+          const auto tuning = oq_curve::control_profile(
+              id(oq_curve_control_profile).has_state()
+                  ? id(oq_curve_control_profile).current_option()
+                  : std::string());
           int startup_grace_s = tuning.dual_startup_grace_s;
           int emergency_hold_min = tuning.dual_emergency_hold_min;
           float emergency_temp_err_c = tuning.dual_emergency_temp_err_c;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -92,13 +92,6 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # 0=idle, 1=single_hp1, 2=single_hp2, 3=single_lead_hp1, 4=single_lead_hp2,
-  # 5=dual_emergency, 6=dual_defrost, 7=dual_enabled
-  - id: oq_curve_request_reason_code
-    type: int
-    restore_value: false
-    initial_value: '0'
-
 select:
   - platform: template
     id: oq_curve_control_profile
@@ -135,8 +128,7 @@ select:
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_owner_hp),
-              id(oq_curve_request_reason_code));
+              id(oq_curve_request_owner_hp));
 
 number:
   - platform: template
@@ -864,8 +856,7 @@ interval:
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_owner_hp),
-              id(oq_curve_request_reason_code));
+              id(oq_curve_request_owner_hp));
             return;
           }
 
@@ -957,8 +948,6 @@ interval:
 
           int total_req = 0;
           int owner = 0;
-          int reason_code = 0;
-
           #if OQ_TOPOLOGY_DUO
           const bool d1_pre = hp1_valve_def;
           const bool d2_pre = hp2_valve_def;
@@ -1086,17 +1075,10 @@ interval:
             id(oq_curve_single_owner_hp) = single_owner;
             total_req = f;
             owner = single_owner;
-            if (single_owner == 1) reason_code = 1;
-            else if (single_owner == 2) reason_code = 2;
-            else if (lead_is_hp1) reason_code = 3;
-            else reason_code = 4;
           } else {
             id(oq_curve_single_owner_hp) = 0;
             total_req = f;
             owner = 0;
-            if (force_dual_capacity) reason_code = 5;
-            else if (force_dual_defrost) reason_code = 6;
-            else reason_code = 7;
           }
           #else
           oq_request::reset_dual_runtime_state(
@@ -1109,9 +1091,7 @@ interval:
               1);
           total_req = f;
           owner = (f > 0) ? 1 : 0;
-          reason_code = (f > 0) ? 1 : 0;
           #endif
 
           id(oq_curve_request_total_level) = total_req;
           id(oq_curve_request_owner_hp) = owner;
-          id(oq_curve_request_reason_code) = reason_code;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -129,16 +129,6 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  - id: oq_curve_request_hp1_level
-    type: int
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_curve_request_hp2_level
-    type: int
-    restore_value: false
-    initial_value: '0'
-
   - id: oq_curve_request_owner_hp
     type: int
     restore_value: false
@@ -194,8 +184,6 @@ select:
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_hp1_level),
-              id(oq_curve_request_hp2_level),
               id(oq_curve_request_owner_hp),
               id(oq_curve_request_reason_code));
 
@@ -1172,8 +1160,6 @@ interval:
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_hp1_level),
-              id(oq_curve_request_hp2_level),
               id(oq_curve_request_owner_hp),
               id(oq_curve_request_reason_code));
             return;
@@ -1343,8 +1329,6 @@ interval:
             id(oq_duo_request_hold_until_ms) = 0;
           };
 
-          int hp1_req = 0;
-          int hp2_req = 0;
           int total_req = 0;
           int owner = 0;
           int reason_code = 0;
@@ -1516,14 +1500,6 @@ interval:
           reason_code = (f > 0) ? 1 : 0;
           #endif
 
-          const auto per_hp_request =
-              oq_request::split_curve_total_request(total_req, id(oq_dual_hp_enabled), lead_is_hp1, owner);
-          hp1_req = per_hp_request.hp1_level;
-          hp2_req = per_hp_request.hp2_level;
-          owner = per_hp_request.owner_hp;
-
           id(oq_curve_request_total_level) = total_req;
-          id(oq_curve_request_hp1_level) = hp1_req;
-          id(oq_curve_request_hp2_level) = hp2_req;
           id(oq_curve_request_owner_hp) = owner;
           id(oq_curve_request_reason_code) = reason_code;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -15,6 +15,12 @@
 # ==============================================================================
 
 globals:
+  # Continuous PID-derived demand before integer quantization or request guardrails.
+  - id: oq_curve_demand_continuous
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
   # Internal source (0..20) for heating-curve mode (PID -> demand)
   - id: oq_demand_curve
     type: int
@@ -161,6 +167,7 @@ select:
         - lambda: |-
             // Reset curve runtime state so a profile switch starts from a clean baseline.
             oq_curve::reset_control_state(
+              id(oq_curve_demand_continuous),
               id(oq_demand_curve),
               id(oq_curve_demand_pre_guardrail),
               id(oq_curve_heat_request_active),
@@ -391,6 +398,7 @@ output:
           // In Power House mode, this output is diagnostic-only and must remain 0.
           if (id(oq_heat_mode_code) != 1) {
             oq_curve::reset_control_state(
+              id(oq_curve_demand_continuous),
               id(oq_demand_curve),
               id(oq_curve_demand_pre_guardrail),
               id(oq_curve_heat_request_active),
@@ -411,6 +419,7 @@ output:
           const int demand_max = (int) ${oq_strategy_demand_max_f};
           if (isnan(state)) {
             oq_curve::reset_control_state(
+              id(oq_curve_demand_continuous),
               id(oq_demand_curve),
               id(oq_curve_demand_pre_guardrail),
               id(oq_curve_heat_request_active),
@@ -428,7 +437,12 @@ output:
             return;
           }
 
-          int d = (int) lroundf(state * ${oq_strategy_demand_max_f});
+          float d_cont = state * ${oq_strategy_demand_max_f};
+          if (d_cont < 0.0f) d_cont = 0.0f;
+          if (d_cont > (float) demand_max) d_cont = (float) demand_max;
+          id(oq_curve_demand_continuous) = d_cont;
+
+          int d = (int) lroundf(d_cont);
           if (d < 0) d = 0;
           if (d > demand_max) d = demand_max;
           id(oq_curve_demand_pre_guardrail) = d;
@@ -437,6 +451,7 @@ output:
           const float pv = id(oq_system_supply_temp).state;
           if (isnan(spw) || isnan(pv)) {
             oq_curve::reset_control_state(
+              id(oq_curve_demand_continuous),
               id(oq_demand_curve),
               id(oq_curve_demand_pre_guardrail),
               id(oq_curve_heat_request_active),
@@ -893,6 +908,21 @@ sensor:
       return (float) id(oq_demand_curve);
 
   - platform: template
+    id: oq_curve_demand_continuous_sensor
+    name: "Demand Curve (continuous)"
+    disabled_by_default: true
+    icon: mdi:sine-wave
+    unit_of_measurement: "step"
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return id(oq_curve_demand_continuous);
+
+  - platform: template
     id: oq_curve_demand_pre_guardrail_sensor
     name: "Demand Curve (pre-guardrail)"
     disabled_by_default: true
@@ -1004,9 +1034,22 @@ interval:
             const float spw = id(oq_supply_target_temp).state;
             const float pv = id(oq_system_supply_temp).state;
             if (isnan(spw) || isnan(pv)) {
-              id(oq_demand_curve) = 0;
-              id(oq_curve_heat_request_active) = false;
-              id(oq_curve_stop_arm_ms) = 0;
+              oq_curve::reset_control_state(
+                id(oq_curve_demand_continuous),
+                id(oq_demand_curve),
+                id(oq_curve_demand_pre_guardrail),
+                id(oq_curve_heat_request_active),
+                id(oq_curve_stop_arm_ms),
+                id(oq_curve_off_since_ms),
+                id(oq_curve_restart_inhibit_active),
+                id(oq_curve_phase_code),
+                id(oq_curve_regime_code),
+                id(oq_curve_regime_since_ms),
+                id(oq_curve_maintain_level),
+                id(oq_curve_maintain_raise_arm_ms),
+                id(oq_curve_maintain_lower_arm_ms),
+                id(oq_curve_assist_enter_arm_ms),
+                id(oq_curve_assist_exit_arm_ms));
             } else {
               const float cur2 = id(oq_heating_curve_pid).target_temperature;
               if (id(oq_heating_curve_pid).mode != CLIMATE_MODE_HEAT ||
@@ -1041,9 +1084,10 @@ interval:
             const float supply_c = id(oq_system_supply_temp).state;
             snprintf(
               debug_buf, sizeof(debug_buf),
-              "curve phase=%s reg=%s ml=%d d=%d pre=%d sp=%.2f pv=%.2f",
+              "curve phase=%s reg=%s ml=%d d=%.2f/%d pre=%d sp=%.2f pv=%.2f",
               phase_text, regime_text, id(oq_curve_maintain_level),
-              d_out, id(oq_curve_demand_pre_guardrail), target_c, supply_c);
+              id(oq_curve_demand_continuous), d_out,
+              id(oq_curve_demand_pre_guardrail), target_c, supply_c);
             id(oq_strategy_debug_state).publish_state(debug_buf);
           } else {
             if (id(oq_heating_curve_pid).mode != CLIMATE_MODE_OFF) {
@@ -1052,6 +1096,7 @@ interval:
               c0.perform();
             }
             oq_curve::reset_control_state(
+              id(oq_curve_demand_continuous),
               id(oq_demand_curve),
               id(oq_curve_demand_pre_guardrail),
               id(oq_curve_heat_request_active),

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -938,20 +938,14 @@ interval:
           const bool hp1_valve_def = valve_defrost_active(true);
           #if OQ_TOPOLOGY_DUO
           const bool hp2_valve_def = valve_defrost_active(false);
-          const bool hp2_available = true;
           #else
           const bool hp2_valve_def = false;
-          const bool hp2_available = false;
           #endif
           id(oq_P_hp_cap_w) = 0.0f;
           id(oq_P_deficit_w) = 0.0f;
 
-          int total_req = 0;
           int owner = 0;
           #if OQ_TOPOLOGY_DUO
-          const bool d1_pre = hp1_valve_def;
-          const bool d2_pre = hp2_valve_def;
-
           int dual_on_lvl = (int) roundf(id(oq_dual_hp_enable_level).state);
           if (dual_on_lvl < 1) dual_on_lvl = 1;
           if (dual_on_lvl > max_level) dual_on_lvl = max_level;
@@ -993,9 +987,7 @@ interval:
           const int lead_max_single = max_allowed_level_for_hp(lead_is_hp1);
           const int lag_max_single = max_allowed_level_for_hp(!lead_is_hp1);
           const int single_limit_lvl = std::max(lead_max_single, lag_max_single);
-          int single_req_lvl = f;
-          if (single_req_lvl < 0) single_req_lvl = 0;
-          if (single_limit_lvl > 0 && single_req_lvl > single_limit_lvl) single_req_lvl = single_limit_lvl;
+          const int single_req_lvl = (single_limit_lvl > 0) ? std::min(f, single_limit_lvl) : f;
 
           const bool demand_active = (f > 0);
           const bool beyond_single_capacity = demand_active && (single_limit_lvl > 0) && (f > single_limit_lvl);
@@ -1022,7 +1014,7 @@ interval:
           if (id(oq_dual_hp_emergency_hold_elapsed_accum_min) >= (float) emergency_hold_min) {
             force_dual_capacity = true;
           }
-          const bool force_dual_defrost = demand_active && (d1_pre && d2_pre);
+          const bool force_dual_defrost = demand_active && hp1_valve_def && hp2_valve_def;
           const bool dual_on_condition =
               demand_active && (force_dual_capacity || force_dual_defrost || (single_req_lvl >= dual_on_lvl));
           const bool dual_off_condition =
@@ -1073,11 +1065,9 @@ interval:
             }
 
             id(oq_curve_single_owner_hp) = single_owner;
-            total_req = f;
             owner = single_owner;
           } else {
             id(oq_curve_single_owner_hp) = 0;
-            total_req = f;
             owner = 0;
           }
           #else
@@ -1089,9 +1079,8 @@ interval:
               id(oq_curve_single_owner_hp),
               id(oq_duo_request_hold_until_ms),
               1);
-          total_req = f;
           owner = (f > 0) ? 1 : 0;
           #endif
 
-          id(oq_curve_request_total_level) = total_req;
+          id(oq_curve_request_total_level) = f;
           id(oq_curve_request_owner_hp) = owner;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -946,27 +946,20 @@ interval:
 
           int owner = 0;
           #if OQ_TOPOLOGY_DUO
-          int dual_on_lvl = (int) roundf(id(oq_dual_hp_enable_level).state);
-          if (dual_on_lvl < 1) dual_on_lvl = 1;
-          if (dual_on_lvl > max_level) dual_on_lvl = max_level;
-          int dual_off_lvl = dual_on_lvl - 1;
-          if (dual_off_lvl < 1) dual_off_lvl = 1;
-
-          int dual_on_hold_min = (int) roundf(id(oq_dual_hp_enable_hold_min).state);
-          int dual_off_hold_min = (int) roundf(id(oq_dual_hp_disable_hold_min).state);
-          if (dual_on_hold_min < 1) dual_on_hold_min = 1;
-          if (dual_off_hold_min < 1) dual_off_hold_min = 1;
+          const int dual_on_lvl =
+              std::max(1, std::min(max_level, (int) roundf(id(oq_dual_hp_enable_level).state)));
+          const int dual_off_lvl = std::max(1, dual_on_lvl - 1);
+          const int dual_on_hold_min = std::max(1, (int) roundf(id(oq_dual_hp_enable_hold_min).state));
+          const int dual_off_hold_min = std::max(1, (int) roundf(id(oq_dual_hp_disable_hold_min).state));
 
           const auto tuning = oq_curve::control_profile(
               id(oq_curve_control_profile).has_state()
                   ? id(oq_curve_control_profile).current_option()
                   : std::string());
-          int startup_grace_s = tuning.dual_startup_grace_s;
-          int emergency_hold_min = tuning.dual_emergency_hold_min;
-          float emergency_temp_err_c = tuning.dual_emergency_temp_err_c;
-          float dual_disable_temp_err_max_c = tuning.dual_disable_temp_err_max_c;
-          if (startup_grace_s < 0) startup_grace_s = 0;
-          if (emergency_hold_min < 1) emergency_hold_min = 1;
+          const int startup_grace_s = std::max(0, tuning.dual_startup_grace_s);
+          const int emergency_hold_min = std::max(1, tuning.dual_emergency_hold_min);
+          const float emergency_temp_err_c = tuning.dual_emergency_temp_err_c;
+          const float dual_disable_temp_err_max_c = tuning.dual_disable_temp_err_max_c;
 
           float temp_err_c = NAN;
           if (!isnan(id(oq_supply_target_temp).state) && !isnan(id(oq_system_supply_temp).state)) {
@@ -1002,7 +995,6 @@ interval:
               (now_ms > lead_last_start_ms) &&
               ((now_ms - lead_last_start_ms) < ((uint32_t) startup_grace_s * 1000UL));
 
-          bool force_dual_capacity = false;
           const bool emergency_dual_condition =
               demand_active && beyond_single_capacity && severe_level_pressure &&
               (severe_temp_deficit || single_req_lvl >= (max_level - 1)) && !startup_grace_active;
@@ -1011,9 +1003,8 @@ interval:
           } else {
             id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
           }
-          if (id(oq_dual_hp_emergency_hold_elapsed_accum_min) >= (float) emergency_hold_min) {
-            force_dual_capacity = true;
-          }
+          const bool force_dual_capacity =
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min) >= (float) emergency_hold_min;
           const bool force_dual_defrost = demand_active && hp1_valve_def && hp2_valve_def;
           const bool dual_on_condition =
               demand_active && (force_dual_capacity || force_dual_defrost || (single_req_lvl >= dual_on_lvl));
@@ -1050,19 +1041,11 @@ interval:
               demand_active && (force_dual_capacity || force_dual_defrost || id(oq_dual_hp_enabled));
 
           if (!dual_enabled) {
-            int single_owner = id(oq_curve_single_owner_hp);
             const bool prev_hp1_on = (id(hp1_last_applied_level) > 0);
             const bool prev_hp2_on = (id(${curve_secondary_last_applied_level_id}) > 0);
-
-            if (!demand_active) {
-              single_owner = 0;
-            } else if (prev_hp1_on && !prev_hp2_on) {
-              single_owner = 1;
-            } else if (prev_hp2_on && !prev_hp1_on) {
-              single_owner = 2;
-            } else if (single_owner != 1 && single_owner != 2) {
-              single_owner = lead_is_hp1 ? 1 : 2;
-            }
+            int single_owner = demand_active ? id(oq_curve_single_owner_hp) : 0;
+            if (prev_hp1_on != prev_hp2_on) single_owner = prev_hp1_on ? 1 : 2;
+            else if (single_owner != 1 && single_owner != 2) single_owner = lead_is_hp1 ? 1 : 2;
 
             id(oq_curve_single_owner_hp) = single_owner;
             owner = single_owner;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -39,45 +39,9 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # Curve operating regime: 0=OFF, 1=RECOVERY, 2=MAINTAIN, 3=ASSIST.
+  # Curve operating regime: 0=OFF, 1=RECOVERY, 2=MAINTAIN.
   - id: oq_curve_regime_code
     type: int
-    restore_value: false
-    initial_value: '0'
-
-  # Timestamp when the current curve regime became active.
-  - id: oq_curve_regime_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  # Learned base request level for low-load curve operation.
-  - id: oq_curve_maintain_level
-    type: int
-    restore_value: false
-    initial_value: '0'
-
-  # Arms a slow upward maintain-level correction after persistent undershoot.
-  - id: oq_curve_maintain_raise_arm_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  # Arms a slow downward maintain-level correction after persistent overshoot.
-  - id: oq_curve_maintain_lower_arm_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  # Arms the transition from MAINTAIN to ASSIST.
-  - id: oq_curve_assist_enter_arm_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  # Arms the transition from ASSIST back to MAINTAIN.
-  - id: oq_curve_assist_exit_arm_ms
-    type: uint32_t
     restore_value: false
     initial_value: '0'
 
@@ -170,13 +134,7 @@ select:
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
               id(oq_curve_phase_code),
-              id(oq_curve_regime_code),
-              id(oq_curve_regime_since_ms),
-              id(oq_curve_maintain_level),
-              id(oq_curve_maintain_raise_arm_ms),
-              id(oq_curve_maintain_lower_arm_ms),
-              id(oq_curve_assist_enter_arm_ms),
-              id(oq_curve_assist_exit_arm_ms));
+              id(oq_curve_regime_code));
             oq_curve::reset_outside_ema_state(
               id(oq_curve_outside_ema_c),
               id(oq_curve_outside_ema_initialized),
@@ -406,13 +364,7 @@ output:
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
               id(oq_curve_phase_code),
-              id(oq_curve_regime_code),
-              id(oq_curve_regime_since_ms),
-              id(oq_curve_maintain_level),
-              id(oq_curve_maintain_raise_arm_ms),
-              id(oq_curve_maintain_lower_arm_ms),
-              id(oq_curve_assist_enter_arm_ms),
-              id(oq_curve_assist_exit_arm_ms));
+              id(oq_curve_regime_code));
             return;
           }
 
@@ -427,13 +379,7 @@ output:
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
               id(oq_curve_phase_code),
-              id(oq_curve_regime_code),
-              id(oq_curve_regime_since_ms),
-              id(oq_curve_maintain_level),
-              id(oq_curve_maintain_raise_arm_ms),
-              id(oq_curve_maintain_lower_arm_ms),
-              id(oq_curve_assist_enter_arm_ms),
-              id(oq_curve_assist_exit_arm_ms));
+              id(oq_curve_regime_code));
             return;
           }
 
@@ -459,13 +405,7 @@ output:
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
               id(oq_curve_phase_code),
-              id(oq_curve_regime_code),
-              id(oq_curve_regime_since_ms),
-              id(oq_curve_maintain_level),
-              id(oq_curve_maintain_raise_arm_ms),
-              id(oq_curve_maintain_lower_arm_ms),
-              id(oq_curve_assist_enter_arm_ms),
-              id(oq_curve_assist_exit_arm_ms));
+              id(oq_curve_regime_code));
             return;
           }
 
@@ -480,16 +420,6 @@ output:
           uint32_t off_reentry_min_ms = 480000UL;
           float recovery_enter_c = 0.75f;
           float recovery_exit_c = 0.25f;
-          float assist_enter_c = 0.30f;
-          float assist_exit_c = 0.10f;
-          float maintain_raise_c = 0.35f;
-          float maintain_lower_c = 0.30f;
-          uint32_t assist_enter_ms = 120000UL;
-          uint32_t assist_exit_ms = 90000UL;
-          uint32_t maintain_raise_ms = 360000UL;
-          uint32_t maintain_lower_ms = 600000UL;
-          uint32_t assist_promote_ms = 300000UL;
-          int assist_step_f = 1;
           if (id(oq_curve_control_profile).has_state()) {
             const auto profile = id(oq_curve_control_profile).current_option();
             if (profile == "Comfort") {
@@ -504,15 +434,6 @@ output:
               off_reentry_min_ms = 300000UL;
               recovery_enter_c = 0.55f;
               recovery_exit_c = 0.15f;
-              assist_enter_c = 0.20f;
-              assist_exit_c = 0.05f;
-              maintain_raise_c = 0.25f;
-              maintain_lower_c = 0.20f;
-              assist_enter_ms = 60000UL;
-              assist_exit_ms = 60000UL;
-              maintain_raise_ms = 240000UL;
-              maintain_lower_ms = 420000UL;
-              assist_promote_ms = 180000UL;
             } else if (profile == "Stable") {
               start_delta_c = 0.65f;
               stop_delta_c = 1.10f;
@@ -525,15 +446,6 @@ output:
               off_reentry_min_ms = 600000UL;
               recovery_enter_c = 1.00f;
               recovery_exit_c = 0.35f;
-              assist_enter_c = 0.40f;
-              assist_exit_c = 0.15f;
-              maintain_raise_c = 0.45f;
-              maintain_lower_c = 0.35f;
-              assist_enter_ms = 180000UL;
-              assist_exit_ms = 120000UL;
-              maintain_raise_ms = 540000UL;
-              maintain_lower_ms = 900000UL;
-              assist_promote_ms = 420000UL;
             }
           }
           if (stop_delta_c < start_delta_c + 0.10f) stop_delta_c = start_delta_c + 0.10f;
@@ -541,7 +453,6 @@ output:
           if (restart_bypass_extra_c < 0.20f) restart_bypass_extra_c = 0.20f;
           if (off_pid_max_f < 0) off_pid_max_f = 0;
           if (off_pid_max_f > demand_max) off_pid_max_f = demand_max;
-          if (assist_step_f < 1) assist_step_f = 1;
 
           const float room_c = id(room_temp_selected).state;
           const float room_sp_c = id(room_setpoint_selected).state;
@@ -598,21 +509,8 @@ output:
             d = 0;
             curve_phase_code = 0;
             id(oq_curve_regime_code) = 0;
-            id(oq_curve_regime_since_ms) = 0;
-            id(oq_curve_maintain_level) = 0;
-            id(oq_curve_maintain_raise_arm_ms) = 0;
-            id(oq_curve_maintain_lower_arm_ms) = 0;
-            id(oq_curve_assist_enter_arm_ms) = 0;
-            id(oq_curve_assist_exit_arm_ms) = 0;
           } else {
             if (d < 1) d = 1;
-
-            auto reset_regime_arms = [&]() -> void {
-              id(oq_curve_maintain_raise_arm_ms) = 0;
-              id(oq_curve_maintain_lower_arm_ms) = 0;
-              id(oq_curve_assist_enter_arm_ms) = 0;
-              id(oq_curve_assist_exit_arm_ms) = 0;
-            };
 
             auto total_applied_level = [&]() -> int {
               int total = id(hp1_last_applied_level);
@@ -624,133 +522,27 @@ output:
               return total;
             };
 
-            auto arm_elapsed = [&](uint32_t armed_ms)->uint32_t {
-              if (armed_ms == 0 || now_ms <= armed_ms) return 0;
-              return now_ms - armed_ms;
-            };
-
-            auto set_regime = [&](int new_regime)->void {
-              if (new_regime < 0) new_regime = 0;
-              if (new_regime > 3) new_regime = 3;
-              if (id(oq_curve_regime_code) != new_regime) {
-                id(oq_curve_regime_code) = new_regime;
-                id(oq_curve_regime_since_ms) = (new_regime == 0) ? 0 : now_ms;
-                reset_regime_arms();
-              } else if (new_regime == 0) {
-                id(oq_curve_regime_since_ms) = 0;
-              } else if (id(oq_curve_regime_since_ms) == 0 || now_ms <= id(oq_curve_regime_since_ms)) {
-                id(oq_curve_regime_since_ms) = now_ms;
-              }
-            };
-
             const float supply_error_c = spw - pv;
-            int maintain_level = id(oq_curve_maintain_level);
             const int applied_total = total_applied_level();
-            if (maintain_level < 1) maintain_level = (applied_total > 0) ? applied_total : 1;
-            if (maintain_level > demand_max) maintain_level = demand_max;
-
             int regime = id(oq_curve_regime_code);
-            if (regime < 1 || regime > 3) {
+            if (regime != 1 && regime != 2) {
               regime = (supply_error_c >= recovery_enter_c) ? 1 : 2;
             }
+            if (regime == 1) {
+              if (supply_error_c <= recovery_exit_c) regime = 2;
+            } else if (supply_error_c >= recovery_enter_c) {
+              regime = 1;
+            }
 
+            id(oq_curve_regime_code) = regime;
             if (regime == 1) {
               curve_phase_code = 1;
-              const bool near_target = (supply_error_c <= recovery_exit_c) && (pv >= (spw - recovery_exit_c));
-              if (near_target) {
-                int seed_level = applied_total;
-                if (seed_level < 1) seed_level = d;
-                if (seed_level < 1) seed_level = 1;
-                if (seed_level > demand_max) seed_level = demand_max;
-                maintain_level = seed_level;
-                regime = 2;
-              }
-            }
-
-            if (regime == 2) {
-              curve_phase_code = 2;
-              if (supply_error_c >= recovery_enter_c) {
-                regime = 1;
-              } else {
-                if (supply_error_c >= assist_enter_c) {
-                  if (id(oq_curve_assist_enter_arm_ms) == 0 || now_ms <= id(oq_curve_assist_enter_arm_ms)) {
-                    id(oq_curve_assist_enter_arm_ms) = now_ms;
-                  } else if (arm_elapsed(id(oq_curve_assist_enter_arm_ms)) >= assist_enter_ms) {
-                    regime = 3;
-                  }
-                } else {
-                  id(oq_curve_assist_enter_arm_ms) = 0;
-                }
-
-                if (regime == 2) {
-                  if (supply_error_c >= maintain_raise_c) {
-                    if (id(oq_curve_maintain_raise_arm_ms) == 0 || now_ms <= id(oq_curve_maintain_raise_arm_ms)) {
-                      id(oq_curve_maintain_raise_arm_ms) = now_ms;
-                    } else if (arm_elapsed(id(oq_curve_maintain_raise_arm_ms)) >= maintain_raise_ms) {
-                      if (maintain_level < demand_max) maintain_level += 1;
-                      id(oq_curve_maintain_raise_arm_ms) = 0;
-                    }
-                  } else {
-                    id(oq_curve_maintain_raise_arm_ms) = 0;
-                  }
-
-                  if (pv >= (spw + maintain_lower_c)) {
-                    if (id(oq_curve_maintain_lower_arm_ms) == 0 || now_ms <= id(oq_curve_maintain_lower_arm_ms)) {
-                      id(oq_curve_maintain_lower_arm_ms) = now_ms;
-                    } else if (arm_elapsed(id(oq_curve_maintain_lower_arm_ms)) >= maintain_lower_ms) {
-                      if (maintain_level > 1) maintain_level -= 1;
-                      id(oq_curve_maintain_lower_arm_ms) = 0;
-                    }
-                  } else {
-                    id(oq_curve_maintain_lower_arm_ms) = 0;
-                  }
-                }
-              }
-            }
-
-            if (regime == 3) {
-              curve_phase_code = 2;
-              if (supply_error_c >= recovery_enter_c) {
-                regime = 1;
-              } else {
-                if (supply_error_c <= assist_exit_c) {
-                  if (id(oq_curve_assist_exit_arm_ms) == 0 || now_ms <= id(oq_curve_assist_exit_arm_ms)) {
-                    id(oq_curve_assist_exit_arm_ms) = now_ms;
-                  } else if (arm_elapsed(id(oq_curve_assist_exit_arm_ms)) >= assist_exit_ms) {
-                    regime = 2;
-                  }
-                } else {
-                  id(oq_curve_assist_exit_arm_ms) = 0;
-                }
-
-                const uint32_t regime_elapsed_ms = arm_elapsed(id(oq_curve_regime_since_ms));
-                if (regime == 3 && regime_elapsed_ms >= assist_promote_ms) {
-                  if (maintain_level < demand_max) maintain_level += 1;
-                  regime = 2;
-                }
-              }
-            }
-
-            if (maintain_level < 1) maintain_level = 1;
-            if (maintain_level > demand_max) maintain_level = demand_max;
-            id(oq_curve_maintain_level) = maintain_level;
-            set_regime(regime);
-
-            if (regime == 1) {
-              curve_phase_code = 1;
-              int recovery_floor = maintain_level + assist_step_f;
-              if (recovery_floor < 1) recovery_floor = 1;
+              int recovery_floor = applied_total + 1;
+              if (recovery_floor < 2) recovery_floor = 2;
               if (recovery_floor > demand_max) recovery_floor = demand_max;
               if (d < recovery_floor) d = recovery_floor;
-            } else if (regime == 2) {
-              curve_phase_code = 2;
-              d = maintain_level;
             } else {
               curve_phase_code = 2;
-              int assist_level = maintain_level + assist_step_f;
-              if (assist_level < 1) assist_level = 1;
-              if (assist_level > demand_max) assist_level = demand_max;
-              d = assist_level;
             }
           }
 
@@ -980,21 +772,6 @@ sensor:
     lambda: |-
       return id(oq_curve_restart_inhibit_active) ? 1.0f : 0.0f;
 
-  - platform: template
-    id: oq_curve_maintain_level_sensor
-    name: "Curve maintain level"
-    disabled_by_default: true
-    icon: mdi:stairs
-    unit_of_measurement: "step"
-    state_class: measurement
-    accuracy_decimals: 0
-    update_interval: 5s
-    entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_diagnostics
-    lambda: |-
-      return (float) id(oq_curve_maintain_level);
-
 text_sensor:
   - platform: template
     id: oq_curve_phase_sensor
@@ -1025,7 +802,6 @@ text_sensor:
       switch (id(oq_curve_regime_code)) {
         case 1: return std::string("RECOVERY");
         case 2: return std::string("MAINTAIN");
-        case 3: return std::string("ASSIST");
         default: return std::string("OFF");
       }
 
@@ -1058,13 +834,7 @@ interval:
                 id(oq_curve_off_since_ms),
                 id(oq_curve_restart_inhibit_active),
                 id(oq_curve_phase_code),
-                id(oq_curve_regime_code),
-                id(oq_curve_regime_since_ms),
-                id(oq_curve_maintain_level),
-                id(oq_curve_maintain_raise_arm_ms),
-                id(oq_curve_maintain_lower_arm_ms),
-                id(oq_curve_assist_enter_arm_ms),
-                id(oq_curve_assist_exit_arm_ms));
+                id(oq_curve_regime_code));
             } else {
               const float cur2 = id(oq_heating_curve_pid).target_temperature;
               if (id(oq_heating_curve_pid).mode != CLIMATE_MODE_HEAT ||
@@ -1099,8 +869,8 @@ interval:
             const float supply_c = id(oq_system_supply_temp).state;
             snprintf(
               debug_buf, sizeof(debug_buf),
-              "curve phase=%s reg=%s ml=%d d=%.2f/%d pre=%d sp=%.2f pv=%.2f",
-              phase_text, regime_text, id(oq_curve_maintain_level),
+              "curve phase=%s reg=%s d=%.2f/%d pre=%d sp=%.2f pv=%.2f",
+              phase_text, regime_text,
               id(oq_curve_demand_continuous), d_out,
               id(oq_curve_demand_pre_guardrail), target_c, supply_c);
             id(oq_strategy_debug_state).publish_state(debug_buf);
@@ -1119,13 +889,7 @@ interval:
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
               id(oq_curve_phase_code),
-              id(oq_curve_regime_code),
-              id(oq_curve_regime_since_ms),
-              id(oq_curve_maintain_level),
-              id(oq_curve_maintain_raise_arm_ms),
-              id(oq_curve_maintain_lower_arm_ms),
-              id(oq_curve_assist_enter_arm_ms),
-              id(oq_curve_assist_exit_arm_ms));
+              id(oq_curve_regime_code));
           }
       - if:
           condition:

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -33,12 +33,6 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # Heating-curve coarse phase: 0=OFF, 1=HEAT, 2=COAST.
-  - id: oq_curve_phase_code
-    type: int
-    restore_value: false
-    initial_value: '0'
-
   # Curve operating regime: 0=OFF, 1=RECOVERY, 2=MAINTAIN.
   - id: oq_curve_regime_code
     type: int
@@ -133,7 +127,6 @@ select:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
-              id(oq_curve_phase_code),
               id(oq_curve_regime_code));
             oq_curve::reset_outside_ema_state(
               id(oq_curve_outside_ema_c),
@@ -363,7 +356,6 @@ output:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
-              id(oq_curve_phase_code),
               id(oq_curve_regime_code));
             return;
           }
@@ -378,7 +370,6 @@ output:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
-              id(oq_curve_phase_code),
               id(oq_curve_regime_code));
             return;
           }
@@ -404,7 +395,6 @@ output:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
-              id(oq_curve_phase_code),
               id(oq_curve_regime_code));
             return;
           }
@@ -504,10 +494,8 @@ output:
             off_since_ms = 0;
           }
 
-          int curve_phase_code = 1;
           if (!heat_request_active) {
             d = 0;
-            curve_phase_code = 0;
             id(oq_curve_regime_code) = 0;
           } else {
             if (d < 1) d = 1;
@@ -536,13 +524,10 @@ output:
 
             id(oq_curve_regime_code) = regime;
             if (regime == 1) {
-              curve_phase_code = 1;
               int recovery_floor = applied_total + 1;
               if (recovery_floor < 2) recovery_floor = 2;
               if (recovery_floor > demand_max) recovery_floor = demand_max;
               if (d < recovery_floor) d = recovery_floor;
-            } else {
-              curve_phase_code = 2;
             }
           }
 
@@ -550,7 +535,6 @@ output:
           id(oq_curve_off_since_ms) = off_since_ms;
           id(oq_curve_restart_inhibit_active) = restart_inhibit_active;
           id(oq_demand_curve) = d;
-          id(oq_curve_phase_code) = curve_phase_code;
 
 sensor:
   - platform: template
@@ -783,11 +767,8 @@ text_sensor:
     web_server:
       sorting_group_id: oq_diagnostics
     lambda: |-
-      switch (id(oq_curve_phase_code)) {
-        case 1: return std::string("HEAT");
-        case 2: return std::string("COAST");
-        default: return std::string("OFF");
-      }
+      if (!id(oq_curve_heat_request_active)) return std::string("OFF");
+      return (id(oq_curve_regime_code) == 1) ? std::string("HEAT") : std::string("COAST");
 
   - platform: template
     id: oq_curve_regime_sensor
@@ -833,7 +814,6 @@ interval:
                 id(oq_curve_stop_arm_ms),
                 id(oq_curve_off_since_ms),
                 id(oq_curve_restart_inhibit_active),
-                id(oq_curve_phase_code),
                 id(oq_curve_regime_code));
             } else {
               const float cur2 = id(oq_heating_curve_pid).target_temperature;
@@ -857,12 +837,11 @@ interval:
             id(oq_strategy_supply_target_temp) = id(oq_supply_target_temp).state;
             id(oq_strategy_heat_request_active) = id(oq_curve_heat_request_active);
 
-            const int phase_code = id(oq_curve_phase_code);
             const int regime_code = id(oq_curve_regime_code);
-            const char *phase_text = oq_curve::phase_name(phase_code);
+            const char *phase_text =
+                !id(oq_curve_heat_request_active) ? "off" : (regime_code == 1 ? "heat" : "coast");
             const char *regime_text = oq_curve::regime_name(regime_code);
-            id(oq_strategy_phase_text).publish_state(
-              oq_curve::strategy_phase_name(phase_code, regime_code));
+            id(oq_strategy_phase_text).publish_state(regime_text);
 
             char debug_buf[192];
             const float target_c = id(oq_supply_target_temp).state;
@@ -888,7 +867,6 @@ interval:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
-              id(oq_curve_phase_code),
               id(oq_curve_regime_code));
           }
       - if:

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -955,18 +955,6 @@ interval:
           id(oq_P_hp_cap_w) = 0.0f;
           id(oq_P_deficit_w) = 0.0f;
 
-          auto reset_dual_runtime_state = [&](int owner)->void {
-            id(oq_dual_hp_enabled) = false;
-            id(oq_dual_hp_enable_hold_elapsed_min) = 0;
-            id(oq_dual_hp_disable_hold_elapsed_min) = 0;
-            id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
-            id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
-            id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
-            id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
-            id(oq_curve_single_owner_hp) = owner;
-            id(oq_duo_request_hold_until_ms) = 0;
-          };
-
           int total_req = 0;
           int owner = 0;
           int reason_code = 0;
@@ -1042,8 +1030,6 @@ interval:
           } else {
             id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
           }
-          id(oq_dual_hp_emergency_hold_elapsed_min) =
-              (int) floorf(id(oq_dual_hp_emergency_hold_elapsed_accum_min) + 1e-3f);
           if (id(oq_dual_hp_emergency_hold_elapsed_accum_min) >= (float) emergency_hold_min) {
             force_dual_capacity = true;
           }
@@ -1056,13 +1042,11 @@ interval:
 
           const float dt_min = ((float) loop_target_ms / 1000.0f) / 60.0f;
           if (!demand_active) {
-            id(oq_dual_hp_enabled) = false;
-            id(oq_dual_hp_enable_hold_elapsed_min) = 0;
-            id(oq_dual_hp_disable_hold_elapsed_min) = 0;
-            id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
-            id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
-            id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
-            id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
+            oq_request::reset_dual_hold_state(
+                id(oq_dual_hp_enabled),
+                id(oq_dual_hp_enable_hold_elapsed_accum_min),
+                id(oq_dual_hp_disable_hold_elapsed_accum_min),
+                id(oq_dual_hp_emergency_hold_elapsed_accum_min));
           } else {
             if (dual_on_condition) id(oq_dual_hp_enable_hold_elapsed_accum_min) += dt_min;
             else id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
@@ -1079,11 +1063,6 @@ interval:
               id(oq_dual_hp_enabled) = false;
               id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
             }
-
-            id(oq_dual_hp_enable_hold_elapsed_min) =
-                (int) floorf(id(oq_dual_hp_enable_hold_elapsed_accum_min) + 1e-3f);
-            id(oq_dual_hp_disable_hold_elapsed_min) =
-                (int) floorf(id(oq_dual_hp_disable_hold_elapsed_accum_min) + 1e-3f);
           }
 
           const bool dual_enabled =
@@ -1120,7 +1099,14 @@ interval:
             else reason_code = 7;
           }
           #else
-          reset_dual_runtime_state(1);
+          oq_request::reset_dual_runtime_state(
+              id(oq_dual_hp_enabled),
+              id(oq_dual_hp_enable_hold_elapsed_accum_min),
+              id(oq_dual_hp_disable_hold_elapsed_accum_min),
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+              id(oq_curve_single_owner_hp),
+              id(oq_duo_request_hold_until_ms),
+              1);
           total_req = f;
           owner = (f > 0) ? 1 : 0;
           reason_code = (f > 0) ? 1 : 0;

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -782,11 +782,11 @@ interval:
 
             const bool prefer_single = (f > 0 && f <= dual_on_f && !(hp1_def && hp2_def));
             if (!prefer_single) {
-              id(oq_dual_hp_enabled) = false;
-              id(oq_dual_hp_enable_hold_elapsed_min) = 0;
-              id(oq_dual_hp_disable_hold_elapsed_min) = 0;
-              id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
-              id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
+              oq_request::reset_dual_hold_state(
+                  id(oq_dual_hp_enabled),
+                  id(oq_dual_hp_enable_hold_elapsed_accum_min),
+                  id(oq_dual_hp_disable_hold_elapsed_accum_min),
+                  id(oq_dual_hp_emergency_hold_elapsed_accum_min));
             } else {
               int on_hold = (int) roundf(id(oq_dual_hp_enable_hold_min).state);
               int off_hold = (int) roundf(id(oq_dual_hp_disable_hold_min).state);
@@ -806,11 +806,6 @@ interval:
                 id(oq_dual_hp_enabled) = false;
                 id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
               }
-
-              id(oq_dual_hp_enable_hold_elapsed_min) =
-                  (int) floorf(id(oq_dual_hp_enable_hold_elapsed_accum_min) + 1e-3f);
-              id(oq_dual_hp_disable_hold_elapsed_min) =
-                  (int) floorf(id(oq_dual_hp_disable_hold_elapsed_accum_min) + 1e-3f);
             }
             const bool needs_dual = (f > dual_on_f) || (prefer_single && id(oq_dual_hp_enabled));
 

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -98,6 +98,7 @@ select:
             id(oq_strategy_supply_target_temp) = NAN;
             id(oq_strategy_heat_request_active) = false;
             oq_curve::reset_control_state(
+              id(oq_curve_demand_continuous),
               id(oq_demand_curve),
               id(oq_curve_demand_pre_guardrail),
               id(oq_curve_heat_request_active),

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -119,6 +119,7 @@ select:
               id(oq_curve_outside_ema_last_ms));
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
+              id(oq_curve_request_total_level),
               id(oq_curve_request_hp1_level),
               id(oq_curve_request_hp2_level),
               id(oq_curve_request_owner_hp),

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -120,8 +120,6 @@ select:
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_hp1_level),
-              id(oq_curve_request_hp2_level),
               id(oq_curve_request_owner_hp),
               id(oq_curve_request_reason_code));
             id(oq_strategy_phase_text).publish_state("idle");

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -106,13 +106,7 @@ select:
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
               id(oq_curve_phase_code),
-              id(oq_curve_regime_code),
-              id(oq_curve_regime_since_ms),
-              id(oq_curve_maintain_level),
-              id(oq_curve_maintain_raise_arm_ms),
-              id(oq_curve_maintain_lower_arm_ms),
-              id(oq_curve_assist_enter_arm_ms),
-              id(oq_curve_assist_exit_arm_ms));
+              id(oq_curve_regime_code));
             oq_curve::reset_outside_ema_state(
               id(oq_curve_outside_ema_c),
               id(oq_curve_outside_ema_initialized),

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -113,8 +113,7 @@ select:
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_owner_hp),
-              id(oq_curve_request_reason_code));
+              id(oq_curve_request_owner_hp));
             id(oq_strategy_phase_text).publish_state("idle");
             id(oq_strategy_debug_state).publish_state("strategy_switch");
 

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -97,13 +97,31 @@ select:
             id(oq_strategy_requested_power_w) = NAN;
             id(oq_strategy_supply_target_temp) = NAN;
             id(oq_strategy_heat_request_active) = false;
-            id(oq_demand_curve) = 0;
-            id(oq_curve_heat_request_active) = false;
-            id(oq_curve_stop_arm_ms) = 0;
-            id(oq_curve_off_since_ms) = 0;
-            id(oq_curve_restart_inhibit_active) = false;
-            id(oq_curve_outside_ema_initialized) = false;
-            id(oq_curve_outside_ema_last_ms) = 0;
+            oq_curve::reset_control_state(
+              id(oq_demand_curve),
+              id(oq_curve_demand_pre_guardrail),
+              id(oq_curve_heat_request_active),
+              id(oq_curve_stop_arm_ms),
+              id(oq_curve_off_since_ms),
+              id(oq_curve_restart_inhibit_active),
+              id(oq_curve_phase_code),
+              id(oq_curve_regime_code),
+              id(oq_curve_regime_since_ms),
+              id(oq_curve_maintain_level),
+              id(oq_curve_maintain_raise_arm_ms),
+              id(oq_curve_maintain_lower_arm_ms),
+              id(oq_curve_assist_enter_arm_ms),
+              id(oq_curve_assist_exit_arm_ms));
+            oq_curve::reset_outside_ema_state(
+              id(oq_curve_outside_ema_c),
+              id(oq_curve_outside_ema_initialized),
+              id(oq_curve_outside_ema_last_ms));
+            oq_curve::reset_request_state(
+              id(oq_curve_request_last_loop_ms),
+              id(oq_curve_request_hp1_level),
+              id(oq_curve_request_hp2_level),
+              id(oq_curve_request_owner_hp),
+              id(oq_curve_request_reason_code));
             id(oq_strategy_phase_text).publish_state("idle");
             id(oq_strategy_debug_state).publish_state("strategy_switch");
 

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -105,7 +105,6 @@ select:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
-              id(oq_curve_phase_code),
               id(oq_curve_regime_code));
             oq_curve::reset_outside_ema_state(
               id(oq_curve_outside_ema_c),

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -17,6 +17,7 @@ project_version: "v0.27.0"                            # ESPHome project version 
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 hp_perf_map_header: "openquatt/includes/hp_perf_map.h" # C++ performance-map header include path.
 thermal_request_logic_header: "openquatt/includes/oq_thermal_request_logic.h" # Shared C++ helper include for request/control glue.
+heating_curve_logic_header: "openquatt/includes/oq_heating_curve_logic.h" # Shared C++ helper include for curve runtime state and naming.
 
 # ----------------------------
 # HARDWARE

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -982,16 +982,10 @@ interval:
               hp1_req = curve_request.hp1_level;
               hp2_req = curve_request.hp2_level;
               request_owner_hp = curve_request.owner_hp;
-              switch (id(oq_curve_request_reason_code)) {
-                case 1: request_reason = "curve_single_owner_hp1"; break;
-                case 2: request_reason = "curve_single_owner_hp2"; break;
-                case 3: request_reason = "curve_single_lead_hp1"; break;
-                case 4: request_reason = "curve_single_lead_hp2"; break;
-                case 5: request_reason = "curve_dual_emergency"; break;
-                case 6: request_reason = "curve_dual_defrost"; break;
-                case 7: request_reason = "curve_dual_enabled"; break;
-                default: request_reason = "curve_idle"; break;
-              }
+              if (id(oq_curve_request_total_level) <= 0) request_reason = "curve_idle";
+              else if (request_owner_hp == 1) request_reason = "curve_single_hp1";
+              else if (request_owner_hp == 2) request_reason = "curve_single_hp2";
+              else request_reason = "curve_dual";
             }
 
           } else {

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -992,9 +992,15 @@ interval:
                 default: request_reason = "cooling_idle"; break;
               }
             } else {
-              hp1_req = id(oq_curve_request_hp1_level);
-              hp2_req = id(oq_curve_request_hp2_level);
-              request_owner_hp = id(oq_curve_request_owner_hp);
+              // Curve mode now publishes a total request plus routing hints.
+              const auto curve_request = oq_request::split_curve_total_request(
+                  id(oq_curve_request_total_level),
+                  id(oq_dual_hp_enabled),
+                  lead_is_hp1,
+                  id(oq_curve_request_owner_hp));
+              hp1_req = curve_request.hp1_level;
+              hp2_req = curve_request.hp2_level;
+              request_owner_hp = curve_request.owner_hp;
               switch (id(oq_curve_request_reason_code)) {
                 case 1: request_reason = "curve_single_owner_hp1"; break;
                 case 2: request_reason = "curve_single_owner_hp2"; break;
@@ -1036,8 +1042,11 @@ interval:
               request_owner_hp = id(oq_cooling_request_owner_hp);
               request_reason = (request_owner_hp > 0) ? "cooling_owner_hp1" : "cooling_idle";
             } else {
-              hp1_req = id(oq_curve_request_hp1_level);
-              request_owner_hp = id(oq_curve_request_owner_hp);
+              // Single-topology curve mode still flows through the same total-request contract.
+              const auto curve_request = oq_request::split_curve_total_request(
+                  id(oq_curve_request_total_level), false, true, id(oq_curve_request_owner_hp));
+              hp1_req = curve_request.hp1_level;
+              request_owner_hp = curve_request.owner_hp;
               request_reason = (request_owner_hp > 0) ? "curve_single_owner_hp1" : "curve_idle";
             }
           } else {

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -1108,9 +1108,10 @@ interval:
           if (!is_power_house) {
             const bool demand_rundown = (raw < prev_f);
             const int curve_regime = id(oq_curve_regime_code);
-            const bool has_curve_profile = id(oq_curve_control_profile).has_state();
-            const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
-            const auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+            const auto tuning = oq_curve::control_profile(
+                id(oq_curve_control_profile).has_state()
+                    ? id(oq_curve_control_profile).current_option()
+                    : std::string());
             int up_hold_s = tuning.steady_up_hold_s;
             const int down_hold_s = tuning.steady_down_hold_s;
             if (curve_regime == 1) up_hold_s = tuning.recovery_up_hold_s;

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -129,16 +129,6 @@ globals:
     restore_value: false
     initial_value: 'false'
 
-  # Dual-enable hold counters (elapsed minutes, derived from wall-clock time).
-  - id: oq_dual_hp_enable_hold_elapsed_min
-    type: int
-    restore_value: false
-    initial_value: '0'
-  - id: oq_dual_hp_disable_hold_elapsed_min
-    type: int
-    restore_value: false
-    initial_value: '0'
-
   # Fractional elapsed minutes for dual-enable hold timing.
   - id: oq_dual_hp_enable_hold_elapsed_accum_min
     type: float
@@ -150,10 +140,6 @@ globals:
     initial_value: '0.0'
 
   # Emergency dual-enable hold timing (curve mode capacity/deficit override).
-  - id: oq_dual_hp_emergency_hold_elapsed_min
-    type: int
-    restore_value: false
-    initial_value: '0'
   - id: oq_dual_hp_emergency_hold_elapsed_accum_min
     type: float
     restore_value: false
@@ -705,9 +691,9 @@ interval:
               mode_s, cm_code, phase_s, raw, f_post_cap, f_cap,
               id(oq_curve_demand_pre_guardrail), id(oq_demand_curve),
               (int) id(oq_dual_hp_enabled),
-              id(oq_dual_hp_enable_hold_elapsed_min),
-              id(oq_dual_hp_disable_hold_elapsed_min),
-              id(oq_dual_hp_emergency_hold_elapsed_min),
+              oq_request::whole_minutes_floor(id(oq_dual_hp_enable_hold_elapsed_accum_min)),
+              oq_request::whole_minutes_floor(id(oq_dual_hp_disable_hold_elapsed_accum_min)),
+              oq_request::whole_minutes_floor(id(oq_dual_hp_emergency_hold_elapsed_accum_min)),
               id(oq_last_lead_hp), id(oq_curve_single_owner_hp),
               req1, req2, app1, app2,
               cur1, cur2, wm1, wm2, spw, pv, room_c, room_sp_c, room_target_c, phouse_w, preq_w, tout_c,
@@ -823,18 +809,6 @@ interval:
                 defrost_active, cooling_mode_active, selected_level, prev_applied);
           };
 
-          auto reset_dual_runtime_state = [&](int owner)->void {
-            id(oq_dual_hp_enabled) = false;
-            id(oq_dual_hp_enable_hold_elapsed_min) = 0;
-            id(oq_dual_hp_disable_hold_elapsed_min) = 0;
-            id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
-            id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
-            id(oq_dual_hp_emergency_hold_elapsed_min) = 0;
-            id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
-            id(oq_curve_single_owner_hp) = owner;
-            id(oq_duo_request_hold_until_ms) = 0;
-          };
-
           int min_rt_s = (int) roundf(id(oq_min_runtime_min).state);
           // Keep the runtime floor hard in code as well. Older installs may still
           // restore a pre-migration numeric value such as 60, even though the UI
@@ -876,7 +850,14 @@ interval:
             const int hp2_hold_level = 0;
             const bool any_hold = (hp1_hold_level > 0);
             #endif
-            reset_dual_runtime_state(0);
+            oq_request::reset_dual_runtime_state(
+                id(oq_dual_hp_enabled),
+                id(oq_dual_hp_enable_hold_elapsed_accum_min),
+                id(oq_dual_hp_disable_hold_elapsed_accum_min),
+                id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+                id(oq_curve_single_owner_hp),
+                id(oq_duo_request_hold_until_ms),
+                0);
             #if OQ_TOPOLOGY_DUO
             publish_optimizer_reason(any_hold ? "keep_current" : "inactive");
             #else
@@ -1035,7 +1016,14 @@ interval:
             }
           }
           #else
-          reset_dual_runtime_state(1);
+          oq_request::reset_dual_runtime_state(
+              id(oq_dual_hp_enabled),
+              id(oq_dual_hp_enable_hold_elapsed_accum_min),
+              id(oq_dual_hp_disable_hold_elapsed_accum_min),
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+              id(oq_curve_single_owner_hp),
+              id(oq_duo_request_hold_until_ms),
+              1);
           if (!is_power_house) {
             if (is_cooling_mode) {
               hp1_req = id(oq_cooling_request_hp1_level);

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -1131,16 +1131,6 @@ interval:
               } else {
                 up_hold_s = 45;
               }
-            } else if (curve_regime == 3) {
-              // ASSIST is a temporary bump above the learned maintain level.
-              if (id(oq_curve_control_profile).has_state()) {
-                const auto profile = id(oq_curve_control_profile).current_option();
-                if (profile == "Comfort") up_hold_s = 45;
-                else if (profile == "Stable") up_hold_s = 120;
-                else up_hold_s = 75;
-              } else {
-                up_hold_s = 75;
-              }
             }
 
             auto limit_slew = [&](bool is_hp1, int req_level)->int {

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -1108,30 +1108,12 @@ interval:
           if (!is_power_house) {
             const bool demand_rundown = (raw < prev_f);
             const int curve_regime = id(oq_curve_regime_code);
-            int up_hold_s = 180;  // Balanced default
-            int down_hold_s = 15; // Balanced default
-            if (id(oq_curve_control_profile).has_state()) {
-              const auto profile = id(oq_curve_control_profile).current_option();
-              if (profile == "Comfort") {
-                up_hold_s = 90;
-                down_hold_s = 10;
-              } else if (profile == "Stable") {
-                up_hold_s = 300;
-                down_hold_s = 30;
-              }
-            }
-
-            if (curve_regime == 1) {
-              // RECOVERY should climb materially faster than steady low-load control.
-              if (id(oq_curve_control_profile).has_state()) {
-                const auto profile = id(oq_curve_control_profile).current_option();
-                if (profile == "Comfort") up_hold_s = 30;
-                else if (profile == "Stable") up_hold_s = 75;
-                else up_hold_s = 45;
-              } else {
-                up_hold_s = 45;
-              }
-            }
+            const bool has_curve_profile = id(oq_curve_control_profile).has_state();
+            const auto curve_profile = has_curve_profile ? id(oq_curve_control_profile).current_option() : std::string();
+            const auto tuning = oq_curve::control_profile(has_curve_profile, curve_profile);
+            int up_hold_s = tuning.steady_up_hold_s;
+            const int down_hold_s = tuning.steady_down_hold_s;
+            if (curve_regime == 1) up_hold_s = tuning.recovery_up_hold_s;
 
             auto limit_slew = [&](bool is_hp1, int req_level)->int {
               const int prev = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});

--- a/openquatt_base.yaml
+++ b/openquatt_base.yaml
@@ -31,6 +31,7 @@ esphome:
   includes:
     - ${hp_perf_map_header}
     - ${thermal_request_logic_header}
+    - ${heating_curve_logic_header}
   platformio_options:
     build_flags:
       # Hard-pinned for Duo entrypoints to prevent accidental topology drift.

--- a/openquatt_base_single.yaml
+++ b/openquatt_base_single.yaml
@@ -31,6 +31,7 @@ esphome:
   includes:
     - ${hp_perf_map_header}
     - ${thermal_request_logic_header}
+    - ${heating_curve_logic_header}
   platformio_options:
     build_flags:
       # Hard-pinned for Single entrypoints to prevent accidental topology drift.


### PR DESCRIPTION
## Summary
- simplify the heating-curve control stack after the PR73/74 split
- remove duplicate curve request bookkeeping and curve-side deficit modeling
- centralize shared curve/thermal helpers and trim duo/runtime state handling

## What changed
- reduce the curve regime/state machinery and derive phase/debug state more directly
- publish and route a continuous curve demand / total request contract, then remove duplicate per-HP curve request state
- centralize curve control profile tuning in shared helpers
- simplify shared dual-runtime bookkeeping across curve, cooling and request control
- drop curve request reason bookkeeping and trim curve duo owner selection

## Validation
- `python3 scripts/dev.py validate`
- all style/docs/config checks passed
- all 4 compile targets passed

## Notes
- net diff vs `dev`: 14 files changed, 495 insertions, 691 deletions
- code under `openquatt/`: 468 insertions, 683 deletions
- this PR is intended as cleanup/refactor groundwork; it reduces complexity without a new functional redesign of curve mode