### PR TITLE
Simplify Power House comfort model

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2318,36 +2318,17 @@ views:
               - **Maximum heating outdoor temperature** is the point where model
               heat demand approaches ~0.
 
-              - **PH Kp** defines how strongly room temperature error
-              is translated into heat demand (W).
+              - **PH temperature reaction** defines how strongly room
+              temperature error outside the comfort band is translated into heat
+              demand (W).
 
-              - **Deadband** suppresses tiny corrections and reduces hunting.
-
-              - `Effective room target = setpoint + comfort bias`.
-
-              - **Comfort bias base** is the minimum upward shift and is always
-              active. With `0.1`, control never targets below `setpoint + 0.1`.
-
-              - **Comfort bias max** is the maximum upward shift and also the
-              warm-side correction cap anchor: `setpoint + bias max`.
-
-              - **Comfort above setpoint** is extra warm margin above
-              `effective target` before negative correction starts, but only up
-              to the cap above.
+              - **Comfort above setpoint** defines how much room above setpoint
+              is still acceptable before warm-side correction starts.
 
               - **Comfort below setpoint** is the cold-side margin below
-              `effective target` before extra heating correction starts.
+              setpoint before extra heating correction starts.
 
-              - Warm-side edge:
-              `Tr_high = min(effective_target + comfort_above, setpoint + bias_max)`.
-
-              - Example: setpoint `20.0`, base `0.1`, max `0.4`, above `0.5`
-              yields a maximum warm edge of `20.4`. If this is too warm:
-              lower `comfort above`, then `bias base` (possibly `0.0`), and if
-              needed lower `bias max`.
-
-              - **Comfort bias up/down** and **room error avg tau** control
-              how quickly bias adapts over time.
+              - Inside this comfort band, extra room correction stays `0`.
 
               - **Response profile** is a quick preset for calmer, balanced, or
               more responsive Power House behavior. As soon as rise and fall
@@ -2381,24 +2362,12 @@ views:
                 name: Maximum heating outdoor temperature (P=0 temp)
               - entity: number.openquatt_rated_maximum_house_power
                 name: Rated maximum house power (Pr)
-              - entity: number.openquatt_power_house_kp_w_k
-                name: PH Kp (W/K)
-              - entity: number.openquatt_power_house_deadband
-                name: PH deadband
+              - entity: number.openquatt_power_house_temperature_reaction
+                name: PH temperature reaction (W/K)
               - entity: number.openquatt_power_house_comfort_below_setpoint
                 name: PH comfort below SP
               - entity: number.openquatt_power_house_comfort_above_setpoint
                 name: PH comfort above SP
-              - entity: number.openquatt_power_house_comfort_bias_base
-                name: PH bias base
-              - entity: number.openquatt_power_house_comfort_bias_max
-                name: PH bias max
-              - entity: number.openquatt_power_house_comfort_bias_up
-                name: PH bias up
-              - entity: number.openquatt_power_house_comfort_bias_down
-                name: PH bias down
-              - entity: number.openquatt_power_house_room_error_avg_tau
-                name: PH room avg tau
               - entity: select.openquatt_power_house_response_profile
                 name: PH response profile
               - entity: number.openquatt_power_house_demand_rise_time
@@ -2941,14 +2910,11 @@ views:
 
               - `P_house` is the model estimate based on outdoor temperature.
 
-              - `P_req` is the limited heat request after deadband/ramp limiter.
-
-              - `Effective room target = room setpoint + comfort bias`.
-
-              - `Comfort bias` shows the adaptive warm-bias governor state.
+              - `P_req` is the limited heat request after comfort band,
+              temperature reaction and ramp limiting.
 
               If `P_req` looks unexpectedly high/low: check outside source, room
-              setpoint/temp, and ramp/deadband tuning.
+              setpoint/temp, comfort band and response settings.
 
 
               </details>
@@ -2962,10 +2928,6 @@ views:
                 name: Room setpoint (selected)
               - entity: sensor.openquatt_room_temperature_selected
                 name: Room temp (selected)
-              - entity: sensor.openquatt_power_house_effective_room_target
-                name: Effective room target
-              - entity: sensor.openquatt_power_house_comfort_bias
-                name: Comfort bias
               - entity: sensor.openquatt_power_house_p_house
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2437,37 +2437,17 @@ views:
               - **Maximum heating outdoor temperature** is het punt waar
               modelmatig de warmtevraag naar ~0 gaat.
 
-              - **PH Kp** bepaalt hoe sterk kamertemperatuurfout naar
-              warmtevraag (W) wordt vertaald.
+              - **PH temperatuurreactie** bepaalt hoe sterk
+              kamertemperatuurfout buiten de comfortband naar warmtevraag (W)
+              wordt vertaald.
 
-              - **Deadband** voorkomt onrust bij kleine afwijkingen.
+              - **Comfort above setpoint** bepaalt hoeveel ruimte boven
+              setpoint nog acceptabel is voordat warme tegensturing begint.
 
-              - `Effective room target = setpoint + comfort bias`.
+              - **Comfort below setpoint** bepaalt hoeveel ruimte onder
+              setpoint nog acceptabel is voordat extra opwarming begint.
 
-              - **Comfort bias base** is de minimale verschuiving omhoog en is
-              dus altijd actief. Bij `0.1` stuurt de regelaar minimaal op
-              `setpoint + 0.1`.
-
-              - **Comfort bias max** is de maximale verschuiving omhoog en ook
-              de bovencap voor de warme correctierand: `setpoint + bias max`.
-
-              - **Comfort above setpoint** is extra marge boven `effective
-              target` voordat warme tegensturing begint, maar alleen tot de
-              bovencap hierboven.
-
-              - **Comfort below setpoint** bepaalt de marge onder `effective
-              target` voordat extra opwarming begint.
-
-              - Warme randformule: `Tr_high = min(effective_target +
-              comfort_above, setpoint + bias_max)`.
-
-              - Voorbeeld: setpoint `20.0`, base `0.1`, max `0.4`, above `0.5`
-              geeft een maximale warme rand van `20.4`. Vind je het te warm:
-              verlaag eerst `comfort above`, daarna `bias base` (eventueel naar
-              `0.0`) en/of `bias max`.
-
-              - **Comfort bias up/down** en **room error avg tau** bepalen hoe
-              snel de bias zich over de tijd aanpast.
+              - Binnen deze comfortband blijft de extra kamercorrectie `0`.
 
               - **Response profile** is een snelle voorkeuze voor rustige,
               gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd en
@@ -2502,24 +2482,12 @@ views:
                 name: Maximum heating outdoor temperature (P=0 temp)
               - entity: number.openquatt_rated_maximum_house_power
                 name: Rated maximum house power (Pr)
-              - entity: number.openquatt_power_house_kp_w_k
-                name: PH Kp (W/K)
-              - entity: number.openquatt_power_house_deadband
-                name: PH deadband
+              - entity: number.openquatt_power_house_temperature_reaction
+                name: PH temperatuurreactie (W/K)
               - entity: number.openquatt_power_house_comfort_below_setpoint
                 name: PH comfort onder SP
               - entity: number.openquatt_power_house_comfort_above_setpoint
                 name: PH comfort boven SP
-              - entity: number.openquatt_power_house_comfort_bias_base
-                name: PH bias basis
-              - entity: number.openquatt_power_house_comfort_bias_max
-                name: PH bias max
-              - entity: number.openquatt_power_house_comfort_bias_up
-                name: PH bias omhoog
-              - entity: number.openquatt_power_house_comfort_bias_down
-                name: PH bias omlaag
-              - entity: number.openquatt_power_house_room_error_avg_tau
-                name: PH room avg tau
               - entity: select.openquatt_power_house_response_profile
                 name: PH reactieprofiel
               - entity: number.openquatt_power_house_demand_rise_time
@@ -3090,15 +3058,11 @@ views:
 
               - `P_house` is de modelschatting op basis van buitentemperatuur.
 
-              - `P_req` is de begrensde warmtevraag na deadband/ramp-limiter.
-
-              - `Effective room target = room setpoint + comfort bias`.
-
-              - `Comfort bias` toont de status van de adaptieve warm-bias
-              regelaar.
+              - `P_req` is de begrensde warmtevraag na comfortband,
+              temperatuurreactie en ramp-limiter.
 
               Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
-              setpoint/temp en de ramp/deadband instellingen.
+              setpoint/temp, comfortband en responsinstellingen.
 
 
               </details>
@@ -3112,10 +3076,6 @@ views:
                 name: Kamersetpoint (gekozen)
               - entity: sensor.openquatt_room_temperature_selected
                 name: Kamertemp (gekozen)
-              - entity: sensor.openquatt_power_house_effective_room_target
-                name: Effective room target
-              - entity: sensor.openquatt_power_house_comfort_bias
-                name: Comfort bias
               - entity: sensor.openquatt_power_house_p_house
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2059,36 +2059,17 @@ views:
               - **Maximum heating outdoor temperature** is the point where model
               heat demand approaches ~0.
 
-              - **PH Kp** defines how strongly room temperature error
-              is translated into heat demand (W).
+              - **PH temperature reaction** defines how strongly room
+              temperature error outside the comfort band is translated into heat
+              demand (W).
 
-              - **Deadband** suppresses tiny corrections and reduces hunting.
-
-              - `Effective room target = setpoint + comfort bias`.
-
-              - **Comfort bias base** is the minimum upward shift and is always
-              active. With `0.1`, control never targets below `setpoint + 0.1`.
-
-              - **Comfort bias max** is the maximum upward shift and also the
-              warm-side correction cap anchor: `setpoint + bias max`.
-
-              - **Comfort above setpoint** is extra warm margin above
-              `effective target` before negative correction starts, but only up
-              to the cap above.
+              - **Comfort above setpoint** defines how much room above setpoint
+              is still acceptable before warm-side correction starts.
 
               - **Comfort below setpoint** is the cold-side margin below
-              `effective target` before extra heating correction starts.
+              setpoint before extra heating correction starts.
 
-              - Warm-side edge:
-              `Tr_high = min(effective_target + comfort_above, setpoint + bias_max)`.
-
-              - Example: setpoint `20.0`, base `0.1`, max `0.4`, above `0.5`
-              yields a maximum warm edge of `20.4`. If this is too warm:
-              lower `comfort above`, then `bias base` (possibly `0.0`), and if
-              needed lower `bias max`.
-
-              - **Comfort bias up/down** and **room error avg tau** control
-              how quickly bias adapts over time.
+              - Inside this comfort band, extra room correction stays `0`.
 
               - **Response profile** is a quick preset for calmer, balanced, or
               more responsive Power House behavior. As soon as rise and fall
@@ -2122,24 +2103,12 @@ views:
                 name: Maximum heating outdoor temperature (P=0 temp)
               - entity: number.openquatt_rated_maximum_house_power
                 name: Rated maximum house power (Pr)
-              - entity: number.openquatt_power_house_kp_w_k
-                name: PH Kp (W/K)
-              - entity: number.openquatt_power_house_deadband
-                name: PH deadband
+              - entity: number.openquatt_power_house_temperature_reaction
+                name: PH temperature reaction (W/K)
               - entity: number.openquatt_power_house_comfort_below_setpoint
                 name: PH comfort below SP
               - entity: number.openquatt_power_house_comfort_above_setpoint
                 name: PH comfort above SP
-              - entity: number.openquatt_power_house_comfort_bias_base
-                name: PH bias base
-              - entity: number.openquatt_power_house_comfort_bias_max
-                name: PH bias max
-              - entity: number.openquatt_power_house_comfort_bias_up
-                name: PH bias up
-              - entity: number.openquatt_power_house_comfort_bias_down
-                name: PH bias down
-              - entity: number.openquatt_power_house_room_error_avg_tau
-                name: PH room avg tau
               - entity: select.openquatt_power_house_response_profile
                 name: PH response profile
               - entity: number.openquatt_power_house_demand_rise_time
@@ -2636,14 +2605,11 @@ views:
 
               - `P_house` is the model estimate based on outdoor temperature.
 
-              - `P_req` is the limited heat request after deadband/ramp limiter.
-
-              - `Effective room target = room setpoint + comfort bias`.
-
-              - `Comfort bias` shows the adaptive warm-bias governor state.
+              - `P_req` is the limited heat request after comfort band,
+              temperature reaction and ramp limiting.
 
               If `P_req` looks unexpectedly high/low: check outside source, room
-              setpoint/temp, and ramp/deadband tuning.
+              setpoint/temp, comfort band and response settings.
 
 
               </details>
@@ -2657,10 +2623,6 @@ views:
                 name: Room setpoint (selected)
               - entity: sensor.openquatt_room_temperature_selected
                 name: Room temp (selected)
-              - entity: sensor.openquatt_power_house_effective_room_target
-                name: Effective room target
-              - entity: sensor.openquatt_power_house_comfort_bias
-                name: Comfort bias
               - entity: sensor.openquatt_power_house_p_house
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2141,37 +2141,17 @@ views:
               - **Maximum heating outdoor temperature** is het punt waar
               modelmatig de warmtevraag naar ~0 gaat.
 
-              - **PH Kp** bepaalt hoe sterk kamertemperatuurfout naar
-              warmtevraag (W) wordt vertaald.
+              - **PH temperatuurreactie** bepaalt hoe sterk
+              kamertemperatuurfout buiten de comfortband naar warmtevraag (W)
+              wordt vertaald.
 
-              - **Deadband** voorkomt onrust bij kleine afwijkingen.
+              - **Comfort above setpoint** bepaalt hoeveel ruimte boven
+              setpoint nog acceptabel is voordat warme tegensturing begint.
 
-              - `Effective room target = setpoint + comfort bias`.
+              - **Comfort below setpoint** bepaalt hoeveel ruimte onder
+              setpoint nog acceptabel is voordat extra opwarming begint.
 
-              - **Comfort bias base** is de minimale verschuiving omhoog en is
-              dus altijd actief. Bij `0.1` stuurt de regelaar minimaal op
-              `setpoint + 0.1`.
-
-              - **Comfort bias max** is de maximale verschuiving omhoog en ook
-              de bovencap voor de warme correctierand: `setpoint + bias max`.
-
-              - **Comfort above setpoint** is extra marge boven `effective
-              target` voordat warme tegensturing begint, maar alleen tot de
-              bovencap hierboven.
-
-              - **Comfort below setpoint** bepaalt de marge onder `effective
-              target` voordat extra opwarming begint.
-
-              - Warme randformule: `Tr_high = min(effective_target +
-              comfort_above, setpoint + bias_max)`.
-
-              - Voorbeeld: setpoint `20.0`, base `0.1`, max `0.4`, above `0.5`
-              geeft een maximale warme rand van `20.4`. Vind je het te warm:
-              verlaag eerst `comfort above`, daarna `bias base` (eventueel naar
-              `0.0`) en/of `bias max`.
-
-              - **Comfort bias up/down** en **room error avg tau** bepalen hoe
-              snel de bias zich over de tijd aanpast.
+              - Binnen deze comfortband blijft de extra kamercorrectie `0`.
 
               - **Response profile** is een snelle voorkeuze voor rustige,
               gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd
@@ -2207,24 +2187,12 @@ views:
                 name: Maximum heating outdoor temperature (P=0 temp)
               - entity: number.openquatt_rated_maximum_house_power
                 name: Rated maximum house power (Pr)
-              - entity: number.openquatt_power_house_kp_w_k
-                name: PH Kp (W/K)
-              - entity: number.openquatt_power_house_deadband
-                name: PH deadband
+              - entity: number.openquatt_power_house_temperature_reaction
+                name: PH temperatuurreactie (W/K)
               - entity: number.openquatt_power_house_comfort_below_setpoint
                 name: PH comfort onder SP
               - entity: number.openquatt_power_house_comfort_above_setpoint
                 name: PH comfort boven SP
-              - entity: number.openquatt_power_house_comfort_bias_base
-                name: PH bias basis
-              - entity: number.openquatt_power_house_comfort_bias_max
-                name: PH bias max
-              - entity: number.openquatt_power_house_comfort_bias_up
-                name: PH bias omhoog
-              - entity: number.openquatt_power_house_comfort_bias_down
-                name: PH bias omlaag
-              - entity: number.openquatt_power_house_room_error_avg_tau
-                name: PH room avg tau
               - entity: select.openquatt_power_house_response_profile
                 name: PH reactieprofiel
               - entity: number.openquatt_power_house_demand_rise_time
@@ -2732,15 +2700,11 @@ views:
 
               - `P_house` is de modelschatting op basis van buitentemperatuur.
 
-              - `P_req` is de begrensde warmtevraag na deadband/ramp-limiter.
-
-              - `Effective room target = room setpoint + comfort bias`.
-
-              - `Comfort bias` toont de status van de adaptieve warm-bias
-              regelaar.
+              - `P_req` is de begrensde warmtevraag na comfortband,
+              temperatuurreactie en ramp-limiter.
 
               Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
-              setpoint/temp en de ramp/deadband instellingen.
+              setpoint/temp, comfortband en responsinstellingen.
 
 
               </details>
@@ -2754,10 +2718,6 @@ views:
                 name: Kamersetpoint (gekozen)
               - entity: sensor.openquatt_room_temperature_selected
                 name: Kamertemp (gekozen)
-              - entity: sensor.openquatt_power_house_effective_room_target
-                name: Effective room target
-              - entity: sensor.openquatt_power_house_comfort_bias
-                name: Comfort bias
               - entity: sensor.openquatt_power_house_p_house
                 name: P_house
               - entity: sensor.openquatt_power_house_p_req

--- a/docs/diagnose-en-afstelling.md
+++ b/docs/diagnose-en-afstelling.md
@@ -86,7 +86,7 @@ Controleer in deze volgorde:
 
 Pas als deze basis klopt, heeft het zin om verwarmingsinstellingen te wijzigen.
 
-Bij `Power House` kun je daarna eventueel kijken naar `Power House response profile` of een kortere `Power House demand rise time`, maar doe dat pas als bronwaarden en comfortinstellingen al logisch zijn.
+Bij `Power House` kun je daarna eventueel kijken naar `Power House temperature reaction`, `Power House response profile` of een kortere `Power House demand rise time`, maar doe dat pas als bronwaarden en comfortinstellingen al logisch zijn.
 
 Bij `Duo` geldt daarbij: kijk niet alleen of er 1 of 2 warmtepompen actief zijn, maar vooral of de warmtevraag netjes gevolgd wordt zonder onrustig wisselen.
 

--- a/docs/heating-strategy.md
+++ b/docs/heating-strategy.md
@@ -28,7 +28,7 @@ Belangrijke kenmerken:
 
 - werkt met buitentemperatuur, kamertemperatuur en setpoint;
 - gebruikt een huismodel als basis;
-- corrigeert daarop met comfortlogica en kamerafwijking;
+- corrigeert daarop met comfortband en kamerafwijking;
 - werkt met `P_house` en `P_req` in watt;
 - gebruikt een response profile met opbouw- en afbouwtijd;
 - kiest bij `Duo` automatisch de zuinigste geldige Single- of Duo-combinatie.
@@ -86,7 +86,7 @@ Dat verschil werkt door in bijna alles:
 - je kijkt naar kamercomfort en warmtevraag van de woning;
 - je liever niet te veel in een stooklijn denkt;
 - je wilt dat OpenQuatt bij `Duo` efficiënt tussen single en duo kiest;
-- je gedrag wilt afstellen met huismodel, comfortband en response profile.
+- je gedrag wilt afstellen met huismodel, comfortband, temperatuurreactie en response profile.
 
 ### Kies eerder `Water Temperature Control` als:
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -140,15 +140,9 @@ Belangrijke runtime-instellingen in deze groep zijn:
 - `House cold temp`
 - `Rated maximum house power`
 - `Maximum heating outdoor temperature`
-- `Power House Kp (W-K)`
-- `Power House deadband`
+- `Power House temperature reaction`
 - `Power House comfort below setpoint`
 - `Power House comfort above setpoint`
-- `Power House comfort bias base`
-- `Power House comfort bias max`
-- `Power House comfort bias up`
-- `Power House comfort bias down`
-- `Power House room error avg tau`
 - `Power House response profile`
 - `Power House demand rise time`
 - `Power House demand fall time`
@@ -285,9 +279,6 @@ Gebruik deze groep vooral voor onderhoud en diagnose, niet voor dagelijks gebrui
 - `Demand filtered`
 - `Heating Curve Supply Target`
 - `Water Supply Temp (Selected)`
-- `Power House effective room target`
-- `Power House comfort bias`
-- `Power House room error avg`
 
 ### Voor flow en veiligheid
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -45,7 +45,7 @@ Werk je liever direct met een stooklijn of aanvoertemperatuur, dan past `Water T
 1. bepaal de bronwaarden die echt gebruikt worden;
 2. bereken de basis warmtevraag van het huis;
 3. corrigeer die vraag met kamerafwijking en comfortlogica;
-4. begrens de warmtevraag met deadband, opbouw-/afbouwtijd en watertempbegrenzing;
+4. begrens de warmtevraag met opbouw-/afbouwtijd en watertempbegrenzing;
 5. vertaal de uitkomst naar compressorvraag;
 6. laat thermal request control daar de beste Single- of Duo-verdeling bij zoeken;
 7. laat supervisory bewaken of verwarmen in `CM2` logisch actief moet blijven.
@@ -115,43 +115,9 @@ Daarom is het goed om een langere periode te beoordelen met verschillend weer. E
 
 Daarna kijkt `Power House` naar de kamer.
 
-Belangrijke begrippen:
-
-- `Power House effective room target`
-- `Power House comfort bias`
-- `Power House room error avg`
-
-### Effective room target
-
-`Power House` werkt niet alleen met het kale setpoint. De strategie gebruikt:
-
-- `effective room target = room setpoint + comfort bias`
-
-Dat maakt het mogelijk om iets "warmer leunend" of juist neutraler gedrag te krijgen zonder meteen agressief te regelen.
-
-### Comfort bias
-
-De comfort-bias wordt opgebouwd en afgebouwd met:
-
-- `Power House comfort bias base`
-- `Power House comfort bias max`
-- `Power House comfort bias up`
-- `Power House comfort bias down`
-- `Power House room error avg tau`
-
-In gewone taal:
-
-- `base` is de minimale extra comfortmarge;
-- `max` is de bovengrens;
-- `up` bepaalt hoe snel de bias mag oplopen;
-- `down` bepaalt hoe snel die weer mag zakken;
-- `room error avg tau` maakt de kamerafwijking rustiger door te middelen.
-
-Deze bias is vooral bedoeld om het systeem niet te "nerveus exact op setpoint" te laten mikken, maar gecontroleerd iets meer comfortruimte te geven.
-
 ### Comfortband rond het setpoint
 
-Daarnaast gebruikt `Power House` twee comfortmarges:
+`Power House` gebruikt twee comfortmarges direct rond het kamer-setpoint:
 
 - `Power House comfort below setpoint`
 - `Power House comfort above setpoint`
@@ -163,19 +129,19 @@ Daarmee ontstaat een asymmetrische comfortband:
 
 Dat is bewust geen pure PID-benadering. Het systeem mag wat terughoudender zijn rond kleine afwijkingen en sterker reageren als de fout duidelijker wordt.
 
-### Kp en deadband
+Binnen deze comfortband blijft de extra kamercorrectie `0`.
+
+### Temperatuurreactie
 
 De kamerfout wordt daarna omgerekend naar extra of minder warmtevraag met:
 
-- `Power House Kp (W-K)`
-- `Power House deadband`
+- `Power House temperature reaction`
 
 Praktisch:
 
-- `Kp` bepaalt hoeveel watt correctie per graad kamerfout wordt toegevoegd of afgetrokken;
-- `deadband` voorkomt dat elke heel kleine afwijking direct tot nieuwe warmtevraag leidt.
+- `Power House temperature reaction` bepaalt hoeveel watt correctie per graad kamerfout buiten de comfortband wordt toegevoegd of afgetrokken.
 
-Een te hoge `Kp` maakt het systeem eerder fel. Een te lage `Kp` maakt het systeem eerder traag of slap. `Deadband` bepaalt hoeveel rust er rond het doel zit.
+Een hogere waarde maakt het systeem eerder fel. Een lagere waarde maakt het systeem eerder traag of slap.
 
 ## Stap 4: opbouwtijd en afbouwtijd maken het gedrag rustiger
 
@@ -331,17 +297,11 @@ Gebruik deze om het basisgedrag van het huis te laten kloppen.
 
 ### 2. Kamercorrectie en comfort
 
-- `Power House Kp (W-K)`
-- `Power House deadband`
+- `Power House temperature reaction`
 - `Power House comfort below setpoint`
 - `Power House comfort above setpoint`
-- `Power House comfort bias base`
-- `Power House comfort bias max`
-- `Power House comfort bias up`
-- `Power House comfort bias down`
-- `Power House room error avg tau`
 
-Gebruik deze om te bepalen hoe strak, comfortabel of warm-leaning de regeling zich rond setpoint gedraagt.
+Gebruik deze om te bepalen hoe strak of ruim de regeling zich rond setpoint gedraagt, en hoe sterk de kamercorrectie buiten die comfortband ingrijpt.
 
 ### 3. Reactiesnelheid
 
@@ -387,9 +347,6 @@ Als je `Power House` wilt begrijpen of tunen, zijn deze meetwaarden meestal het 
 - `Power House – P_req`
 - `Demand raw`
 - `Demand filtered`
-- `Power House effective room target`
-- `Power House comfort bias`
-- `Power House room error avg`
 - `Water Supply Temp (Selected)`
 - `Total Heat Power`
 - `Total Power Input`
@@ -412,7 +369,7 @@ Gebruik bij `Power House` bij voorkeur deze volgorde:
 1. controleer of de gekozen bronwaarden kloppen;
 2. controleer flow en algemeen systeemgedrag;
 3. laat eerst het huismodel ongeveer kloppen;
-4. stel daarna comfortmarges en `Kp` bij;
+4. stel daarna comfortmarges en `Power House temperature reaction` bij;
 5. kijk pas daarna naar response profile en rise/fall time;
 6. kijk pas als laatste naar laaglastgedrag en dieper Duo-gedrag.
 
@@ -426,7 +383,6 @@ Niet echt. Er zit wel kamerfout in, maar ook:
 
 - een huismodel;
 - comfortlogica;
-- deadband;
 - opbouw-/afbouwtijd;
 - watertempbegrenzing;
 - laaglastbewaking;

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -176,7 +176,7 @@ Strategy packages compute:
 Computes requested power from:
 
 - outdoor temperature model (`Tc`, `T0`, `Pr`)
-- room error (`room_setpoint - room_temp`) with deadband
+- room error outside the configured comfort band around room setpoint
 - response profile plus rise/fall times scaled to rated house power (`Pr`)
 
 Then maps requested power to demand scale `0..20`.

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -33,32 +33,6 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  - id: oq_ph_comfort_bias_c
-    type: float
-    restore_value: false
-    initial_value: '0.1'
-
-  - id: oq_ph_room_error_avg_c
-    type: float
-    restore_value: false
-    initial_value: '0.0'
-
-  - id: oq_ph_room_error_avg_init
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_ph_comfort_bias_last_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  # Power House effective room target after comfort biasing.
-  - id: oq_ph_room_target_effective_c
-    type: float
-    restore_value: false
-    initial_value: '0.0'
-
   - id: oq_demand_filter_ramp_up_budget
     type: float
     restore_value: false
@@ -187,7 +161,7 @@ number:
 
   - platform: template
     id: ph_kp_w_per_k
-    name: "Power House Kp (W-K)"
+    name: "Power House temperature reaction"
     icon: mdi:function-variant
     unit_of_measurement: "W/K"
     min_value: 0
@@ -196,21 +170,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 2000
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  - platform: template
-    id: ph_deadband_k
-    name: "Power House deadband"
-    icon: mdi:chart-bell-curve-cumulative
-    unit_of_measurement: "K"
-    min_value: 0
-    max_value: 1.0
-    step: 0.01
-    restore_value: true
-    optimistic: true
-    initial_value: ${oq_ph_deadband_default_k}
     entity_category: config
     web_server:
       sorting_group_id: oq_tuning_heat
@@ -241,81 +200,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0.3
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  - platform: template
-    id: ph_comfort_bias_base_c
-    name: "Power House comfort bias base"
-    icon: mdi:thermometer-plus
-    unit_of_measurement: "°C"
-    min_value: 0.0
-    max_value: 0.5
-    step: 0.05
-    restore_value: true
-    optimistic: true
-    initial_value: 0.1
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  - platform: template
-    id: ph_comfort_bias_max_c
-    name: "Power House comfort bias max"
-    icon: mdi:thermometer-high
-    unit_of_measurement: "°C"
-    min_value: 0.0
-    max_value: 0.5
-    step: 0.05
-    restore_value: true
-    optimistic: true
-    initial_value: 0.5
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  - platform: template
-    id: ph_comfort_bias_up_c_per_h
-    name: "Power House comfort bias up"
-    icon: mdi:arrow-up-bold
-    unit_of_measurement: "°C/h"
-    min_value: 0.0
-    max_value: 0.5
-    step: 0.01
-    restore_value: true
-    optimistic: true
-    initial_value: 0.08
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  - platform: template
-    id: ph_comfort_bias_down_c_per_h
-    name: "Power House comfort bias down"
-    icon: mdi:arrow-down-bold
-    unit_of_measurement: "°C/h"
-    min_value: 0.0
-    max_value: 1.0
-    step: 0.01
-    restore_value: true
-    optimistic: true
-    initial_value: 0.20
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  - platform: template
-    id: ph_room_error_avg_tau_min
-    name: "Power House room error avg tau"
-    icon: mdi:chart-timeline-variant
-    unit_of_measurement: "min"
-    min_value: 5
-    max_value: 120
-    step: 5
-    restore_value: true
-    optimistic: true
-    initial_value: 30
     entity_category: config
     web_server:
       sorting_group_id: oq_tuning_heat
@@ -424,49 +308,6 @@ sensor:
     lambda: |-
       return id(oq_phouse_req_w);
 
-  - platform: template
-    id: oq_phouse_room_error_avg_c_sensor
-    name: "Power House room error avg"
-    disabled_by_default: true
-    icon: mdi:chart-timeline-variant
-    unit_of_measurement: "°C"
-    state_class: measurement
-    accuracy_decimals: 3
-    update_interval: 5s
-    entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_diagnostics
-    lambda: |-
-      return id(oq_ph_room_error_avg_c);
-
-  - platform: template
-    id: oq_phouse_comfort_bias_c_sensor
-    name: "Power House comfort bias"
-    icon: mdi:thermometer-plus
-    unit_of_measurement: "°C"
-    state_class: measurement
-    accuracy_decimals: 3
-    update_interval: 5s
-    entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_diagnostics
-    lambda: |-
-      return id(oq_ph_comfort_bias_c);
-
-  - platform: template
-    id: oq_phouse_room_target_effective_c_sensor
-    name: "Power House effective room target"
-    icon: mdi:target
-    unit_of_measurement: "°C"
-    state_class: measurement
-    accuracy_decimals: 2
-    update_interval: 5s
-    entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_diagnostics
-    lambda: |-
-      return id(oq_ph_room_target_effective_c);
-
 interval:
   - interval: ${oq_heat_loop_tick_s}s
     startup_delay: 4000ms
@@ -483,8 +324,6 @@ interval:
             id(oq_ph_request_reason_code) = 0;
             id(oq_phouse_last_ms) = 0;
             id(oq_phouse_last_w) = 0.0f;
-            id(oq_ph_comfort_bias_last_ms) = 0;
-            id(oq_ph_room_error_avg_init) = false;
             return;
           }
 
@@ -522,63 +361,22 @@ interval:
               isnan(Tr) || isnan(Trsp) || (T0 <= Tc + ${oq_temp_guard_delta_c}f)) {
             id(oq_phouse_req_w) = 0.0f;
             id(oq_demand_raw) = 0;
-            id(oq_ph_room_target_effective_c) = Trsp;
           } else {
             float x = (T0 - Tout) / (T0 - Tc);
             x = clampf(x, 0.0f, 1.0f);
             const float P_house = house_power_rating_w * x;
 
-            const float bias_base_cfg = clampf(id(ph_comfort_bias_base_c).state, 0.0f, 0.5f);
-            const float bias_max_cfg = clampf(id(ph_comfort_bias_max_c).state, bias_base_cfg, 0.5f);
-            const float bias_up_cfg_per_s = clampf(id(ph_comfort_bias_up_c_per_h).state, 0.0f, 0.5f) / 3600.0f;
-            const float bias_down_cfg_per_s = clampf(id(ph_comfort_bias_down_c_per_h).state, 0.0f, 1.0f) / 3600.0f;
-            const float tau_s = clampf(id(ph_room_error_avg_tau_min).state * seconds_per_minute, 60.0f, 7200.0f);
-            float bias_c = id(oq_ph_comfort_bias_c);
-            if (isnan(bias_c)) bias_c = bias_base_cfg;
-            bias_c = clampf(bias_c, bias_base_cfg, bias_max_cfg);
-
-            const uint32_t bias_last_ms = id(oq_ph_comfort_bias_last_ms);
-            const float dt_bias_s =
-                (bias_last_ms > 0 && now_ms >= bias_last_ms) ? ((now_ms - bias_last_ms) / 1000.0f) : 0.0f;
-            const float room_err_now_c = Tr - Trsp;
-            float room_err_avg_c = id(oq_ph_room_error_avg_c);
-            if (!id(oq_ph_room_error_avg_init) || isnan(room_err_avg_c)) {
-              room_err_avg_c = room_err_now_c;
-              id(oq_ph_room_error_avg_init) = true;
-            } else if (dt_bias_s > 0.0f) {
-              const float alpha = clampf(dt_bias_s / (tau_s + dt_bias_s), 0.0f, 1.0f);
-              room_err_avg_c += alpha * (room_err_now_c - room_err_avg_c);
-            }
-
-            constexpr float cold_err_on_c = -0.05f;
-            constexpr float warm_err_on_c = 0.20f;
-            if (dt_bias_s > 0.0f) {
-              if (room_err_avg_c < cold_err_on_c) bias_c += bias_up_cfg_per_s * dt_bias_s;
-              else if (room_err_avg_c > warm_err_on_c) bias_c -= bias_down_cfg_per_s * dt_bias_s;
-            }
-            bias_c = clampf(bias_c, bias_base_cfg, bias_max_cfg);
-            id(oq_ph_comfort_bias_c) = bias_c;
-            id(oq_ph_room_error_avg_c) = room_err_avg_c;
-            id(oq_ph_comfort_bias_last_ms) = now_ms;
-
-            const float Trsp_eff = Trsp + bias_c;
-            id(oq_ph_room_target_effective_c) = Trsp_eff;
-
             const float comfort_below = clampf(id(ph_comfort_band_below_c).state, 0.0f, 2.0f);
             const float comfort_above = clampf(id(ph_comfort_band_above_c).state, 0.0f, 2.0f);
-            const float Tr_low = Trsp_eff - comfort_below;
-            const float Tr_high_uncapped = Trsp_eff + comfort_above;
-            const float Tr_high = std::min(Tr_high_uncapped, Trsp + bias_max_cfg);
+            const float Tr_low = Trsp - comfort_below;
+            const float Tr_high = Trsp + comfort_above;
 
             float e = 0.0f;
             if (Tr < Tr_low) e = Tr_low - Tr;
             else if (Tr > Tr_high) e = Tr_high - Tr;
 
-            const float db = id(ph_deadband_k).state;
-            if (!isnan(db) && db > 0.0f && fabsf(e) < db) e = 0.0f;
-
-            const float kp = id(ph_kp_w_per_k).state;
-            float P_raw = P_house + kp * e;
+            const float temperature_reaction_w_per_k = id(ph_kp_w_per_k).state;
+            float P_raw = P_house + temperature_reaction_w_per_k * e;
             P_raw = clampf(P_raw, 0.0f, house_power_rating_w);
 
             uint32_t last = id(oq_phouse_last_ms);

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -66,7 +66,6 @@ oq_strategy_loop_s: "5"                               # Interval for strategy ca
 oq_strategy_demand_max_f: "20.0"                      # Upper bound of demand scale for mapping PID/power -> f.
 oq_selected_input_stale_hold_s: "300"                 # Hold selected HA-backed inputs this long when they briefly disappear during reloads [s].
 oq_temp_guard_delta_c: "0.5"                          # Minimum valid margin between T0 and Tc in the house model [°C].
-oq_ph_deadband_default_k: "0.14"                      # Default Power House room-error deadband [K].
 oq_outside_temp_stale_s: "1200"                       # Ignore a local outdoor reading when it stays frozen while the same HP still shows fresh activity [s].
 
 # ----------------------------

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -671,7 +671,7 @@ interval:
             const float room_sp_c = id(room_setpoint_selected).state;
             const float phouse_w = is_power_house ? id(oq_phouse_house_w).state : NAN;
             const float preq_w = id(oq_strategy_requested_power_w);
-            const float room_target_c = is_power_house ? id(oq_ph_room_target_effective_c) : room_sp_c;
+            const float room_target_c = room_sp_c;
             const float tout_c = id(outside_temp_selected).state;
             const float wm1 = id(hp1_working_mode).state;
             float wm2 = 0.0f;


### PR DESCRIPTION
## Summary

This PR simplifies the Power House concept for users and maintainers.

The main goal is to remove overlapping and hard-to-explain comfort controls from Power House, while keeping the useful parts of the strategy intact.

Instead of combining comfort band, deadband, adaptive comfort bias, and room-error averaging, Power House now works from a much simpler model:

- house model (`P_house`)
- comfort band around room setpoint
- temperature reaction (`W/K`) outside that comfort band
- response profile / rise time / fall time

## What changed

### Power House control model

Removed from the runtime model and UI:

- Power House deadband
- Power House comfort bias base
- Power House comfort bias max
- Power House comfort bias up
- Power House comfort bias down
- Power House room error avg tau
- effective-room-target / comfort-bias diagnostics

Kept and simplified:

- `Power House comfort below setpoint`
- `Power House comfort above setpoint`
- `Power House response profile`
- `Power House demand rise time`
- `Power House demand fall time`
- `Rated maximum house power`
- `House cold temp`
- `Maximum heating outdoor temperature`

Renamed:

- `Power House Kp (W-K)` -> `Power House temperature reaction`

### Strategy behavior

Power House now computes room correction directly from the comfort band around the actual room setpoint.

That means:

- below the lower comfort edge: request more heat
- above the upper comfort edge: request less heat
- inside the comfort band: no extra room correction

This removes the previous overlap between comfort band and deadband, and removes the adaptive bias layer from the user-facing model.

### Docs and dashboards

Updated the docs and dashboard help text so the user-facing explanation matches the simplified behavior.

The new story is:

- comfort band decides when correction starts
- temperature reaction decides how strongly Power House reacts
- response profile decides how quickly `P_req` may move

## Why this is useful

Compared to `dev`, this reduces conceptual complexity much more than code complexity.

Benefits:

- easier to understand and explain to users
- fewer overlapping tuning knobs
- less confusion around setpoint vs comfort band vs deadband vs bias
- easier support and documentation
- keeps Power House tunable without requiring users to think in control-theory terms

## Validation

- `python3 scripts/dev.py validate --jobs 1`
- `python3 scripts/simulate_thermal_refactor_regressions.py`

Both passed locally.
