### PR TITLE
Add internal Power House comfort boost

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2330,6 +2330,10 @@ views:
 
               - Inside this comfort band, extra room correction stays `0`.
 
+              - If the room stays clearly below the cold comfort boundary for
+              longer, Power House quietly adds a temporary comfort boost and
+              lets it fade again once the room returns to comfort.
+
               - **Response profile** is a quick preset for calmer, balanced, or
               more responsive Power House behavior. As soon as rise and fall
               time no longer match a preset, the profile automatically shows

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2449,6 +2449,11 @@ views:
 
               - Binnen deze comfortband blijft de extra kamercorrectie `0`.
 
+              - Als de kamer langere tijd duidelijk onder de koude
+              comfortgrens blijft, voegt Power House automatisch een tijdelijke
+              comfortboost toe die daarna binnen de comfortband weer rustig
+              afbouwt.
+
               - **Response profile** is een snelle voorkeuze voor rustige,
               gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd en
               afbouwtijd niet meer bij een preset horen, toont het profiel

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2071,6 +2071,10 @@ views:
 
               - Inside this comfort band, extra room correction stays `0`.
 
+              - If the room stays clearly below the cold comfort boundary for
+              longer, Power House quietly adds a temporary comfort boost and
+              lets it fade again once the room returns to comfort.
+
               - **Response profile** is a quick preset for calmer, balanced, or
               more responsive Power House behavior. As soon as rise and fall
               time no longer match a preset, the profile automatically shows

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2153,6 +2153,11 @@ views:
 
               - Binnen deze comfortband blijft de extra kamercorrectie `0`.
 
+              - Als de kamer langere tijd duidelijk onder de koude
+              comfortgrens blijft, voegt Power House automatisch een tijdelijke
+              comfortboost toe die daarna binnen de comfortband weer rustig
+              afbouwt.
+
               - **Response profile** is een snelle voorkeuze voor rustige,
               gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd
               en afbouwtijd niet meer bij een preset horen, toont het profiel

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -143,6 +143,17 @@ Praktisch:
 
 Een hogere waarde maakt het systeem eerder fel. Een lagere waarde maakt het systeem eerder traag of slap.
 
+Als de kamer langdurig duidelijk onder de koude comfortgrens blijft, voegt
+Power House daarnaast automatisch een kleine tijdelijke comfortboost toe.
+Die boost bouwt langzaam op, helpt vooral bij hardnekkige ondershoot, en loopt
+weer rustig leeg zodra de kamer terug in de comfortband komt.
+
+Belangrijk:
+
+- dit is interne logica en geen extra gebruikersinstelling;
+- de comfortband blijft dus het hoofdmodel;
+- `Power House temperature reaction` blijft bepalen hoe sterk de directe reactie is.
+
 ## Stap 4: opbouwtijd en afbouwtijd maken het gedrag rustiger
 
 Als `Power House` een ruwe warmtevraag heeft berekend, wordt die niet direct één-op-één doorgezet. Eerst gaat er nog een reactieprofiel overheen:

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -33,6 +33,13 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  # Internal comfort boost that slowly builds when the room stays clearly
+  # below the cold comfort boundary for a longer time.
+  - id: oq_phouse_comfort_boost_w
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+
   - id: oq_demand_filter_ramp_up_budget
     type: float
     restore_value: false
@@ -308,6 +315,22 @@ sensor:
     lambda: |-
       return id(oq_phouse_req_w);
 
+  - platform: template
+    id: oq_phouse_comfort_boost_w_sensor
+    name: "Power House – comfort boost"
+    icon: mdi:thermometer-plus
+    unit_of_measurement: "W"
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 5s
+    entity_category: diagnostic
+    disabled_by_default: true
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return id(oq_phouse_comfort_boost_w);
+
 interval:
   - interval: ${oq_heat_loop_tick_s}s
     startup_delay: 4000ms
@@ -324,6 +347,7 @@ interval:
             id(oq_ph_request_reason_code) = 0;
             id(oq_phouse_last_ms) = 0;
             id(oq_phouse_last_w) = 0.0f;
+            id(oq_phouse_comfort_boost_w) = 0.0f;
             return;
           }
 
@@ -360,6 +384,7 @@ interval:
           if (isnan(Tout) || isnan(Tc) || isnan(T0) || isnan(house_power_rating_w) || (house_power_rating_w <= 0.0f) ||
               isnan(Tr) || isnan(Trsp) || (T0 <= Tc + ${oq_temp_guard_delta_c}f)) {
             id(oq_phouse_req_w) = 0.0f;
+            id(oq_phouse_comfort_boost_w) = 0.0f;
             id(oq_demand_raw) = 0;
           } else {
             float x = (T0 - Tout) / (T0 - Tc);
@@ -376,17 +401,40 @@ interval:
             else if (Tr > Tr_high) e = Tr_high - Tr;
 
             const float temperature_reaction_w_per_k = id(ph_kp_w_per_k).state;
-            float P_raw = P_house + temperature_reaction_w_per_k * e;
-            P_raw = clampf(P_raw, 0.0f, house_power_rating_w);
 
             uint32_t last = id(oq_phouse_last_ms);
             float lastw = id(oq_phouse_last_w);
             if (last == 0) {
               last = now_ms;
-              lastw = P_raw;
+              lastw = P_house;
             }
 
             const float dt_power_s = (now_ms >= last) ? ((now_ms - last) / 1000.0f) : 0.0f;
+            const float comfort_boost_max_w = clampf(house_power_rating_w * 0.10f, 300.0f, 800.0f);
+            const float comfort_boost_entry_c = 0.05f;
+            float comfort_boost_w = id(oq_phouse_comfort_boost_w);
+            if (isnan(comfort_boost_w) || comfort_boost_w < 0.0f) comfort_boost_w = 0.0f;
+
+            if (Tr < (Tr_low - comfort_boost_entry_c)) {
+              const float undershoot_norm = clampf((Tr_low - Tr - comfort_boost_entry_c) / 0.45f, 0.0f, 1.0f);
+              const float build_min_w_per_min = comfort_boost_max_w / 90.0f;
+              const float build_max_w_per_min = comfort_boost_max_w / 24.0f;
+              const float build_w_per_s =
+                  (build_min_w_per_min + (build_max_w_per_min - build_min_w_per_min) * undershoot_norm) /
+                  seconds_per_minute;
+              comfort_boost_w += build_w_per_s * dt_power_s;
+            } else if (Tr <= Tr_high) {
+              const float decay_w_per_s = (comfort_boost_max_w / 12.0f) / seconds_per_minute;
+              comfort_boost_w -= decay_w_per_s * dt_power_s;
+            } else {
+              comfort_boost_w = 0.0f;
+            }
+            comfort_boost_w = clampf(comfort_boost_w, 0.0f, comfort_boost_max_w);
+            id(oq_phouse_comfort_boost_w) = comfort_boost_w;
+
+            float P_raw = P_house + temperature_reaction_w_per_k * e + comfort_boost_w;
+            P_raw = clampf(P_raw, 0.0f, house_power_rating_w);
+
             const float rise_time_min = clampf(id(ph_demand_rise_time_min).state, 2.0f, 20.0f);
             const float fall_time_min = clampf(id(ph_demand_fall_time_min).state, 1.0f, 10.0f);
             const float up = (house_power_rating_w / rise_time_min) / seconds_per_minute;


### PR DESCRIPTION
## Summary
- add a hidden, bounded Power House comfort boost that slowly builds when the room stays clearly below the cold comfort boundary
- let the boost decay again inside the comfort band and reset it on warm-side overshoot or when Power House is inactive
- document the updated behavior in the Power House docs and dashboard parameter help text

## Why
A higher `Power House temperature reaction` helps some houses, but it is not a universal default. This change keeps the user model simple while making Power House more robust for houses that otherwise stay slightly too cold for too long at low load.

## Validation
- `python3 scripts/simulate_thermal_refactor_regressions.py` ✅
- `python3 scripts/dev.py validate --jobs 1` started cleanly and passed style/docs/config checks, but the fresh worktree still had first-run PlatformIO toolchain provisioning in progress when I stopped it
