### PR TITLE
Avoid publishing OT room temperature as 0C on startup

### DIFF
--- a/components/openquatt_ot_slave/OpenQuattOTSlave.h
+++ b/components/openquatt_ot_slave/OpenQuattOTSlave.h
@@ -110,8 +110,8 @@ namespace esphome {
 					float ot_version = NAN;
 					float t_set = 0.0f;
 					float max_rel_mod_level_setting = NAN;
-					float t_room_set = 0.0f;
-					float t_room = 0.0f;
+					float t_room_set = NAN;
+					float t_room = NAN;
 				};
 
 				struct SlaveState {


### PR DESCRIPTION
## Summary
- initialize OT room temperature and room setpoint to `NaN` instead of `0.0`
- avoid publishing a fake `0 C` room reading before the first valid OT frame arrives
- prevent startup overshoot in thermal demand caused by a temporary OT room temperature of `0 C`

## Validation
- targeted `esphome compile` for `openquatt_duo_heatpump_listener.yaml` progressed cleanly through generated app and `OpenQuattOTSlave.cpp` compile stages before hitting unrelated local PlatformIO home-directory permission issues
- source-path review confirms selected sensor logic already ignores `NaN`, so this fixes the issue at the source