### PR TITLE
Hold Power House comfort boost through the lower comfort band

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2331,8 +2331,9 @@ views:
               - Inside this comfort band, extra room correction stays `0`.
 
               - If the room stays clearly below the cold comfort boundary for
-              longer, Power House quietly adds a temporary comfort boost and
-              lets it fade again once the room returns to comfort.
+              longer, Power House quietly adds a temporary comfort boost,
+              keeps that boost through the colder half of the comfort band,
+              and lets it fade again in the warmer half.
 
               - **Response profile** is a quick preset for calmer, balanced, or
               more responsive Power House behavior. As soon as rise and fall

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2451,8 +2451,8 @@ views:
 
               - Als de kamer langere tijd duidelijk onder de koude
               comfortgrens blijft, voegt Power House automatisch een tijdelijke
-              comfortboost toe die daarna binnen de comfortband weer rustig
-              afbouwt.
+              comfortboost toe, houdt die vast in de koudere helft van de
+              comfortband, en bouwt hem pas in de warmere helft weer rustig af.
 
               - **Response profile** is een snelle voorkeuze voor rustige,
               gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd en

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2072,8 +2072,9 @@ views:
               - Inside this comfort band, extra room correction stays `0`.
 
               - If the room stays clearly below the cold comfort boundary for
-              longer, Power House quietly adds a temporary comfort boost and
-              lets it fade again once the room returns to comfort.
+              longer, Power House quietly adds a temporary comfort boost,
+              keeps that boost through the colder half of the comfort band,
+              and lets it fade again in the warmer half.
 
               - **Response profile** is a quick preset for calmer, balanced, or
               more responsive Power House behavior. As soon as rise and fall

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2155,8 +2155,8 @@ views:
 
               - Als de kamer langere tijd duidelijk onder de koude
               comfortgrens blijft, voegt Power House automatisch een tijdelijke
-              comfortboost toe die daarna binnen de comfortband weer rustig
-              afbouwt.
+              comfortboost toe, houdt die vast in de koudere helft van de
+              comfortband, en bouwt hem pas in de warmere helft weer rustig af.
 
               - **Response profile** is een snelle voorkeuze voor rustige,
               gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -129,7 +129,7 @@ Daarmee ontstaat een asymmetrische comfortband:
 
 Dat is bewust geen pure PID-benadering. Het systeem mag wat terughoudender zijn rond kleine afwijkingen en sterker reageren als de fout duidelijker wordt.
 
-Binnen deze comfortband blijft de extra kamercorrectie `0`.
+Binnen deze comfortband blijft de directe extra kamercorrectie `0`.
 
 ### Temperatuurreactie
 
@@ -145,8 +145,9 @@ Een hogere waarde maakt het systeem eerder fel. Een lagere waarde maakt het syst
 
 Als de kamer langdurig duidelijk onder de koude comfortgrens blijft, voegt
 Power House daarnaast automatisch een kleine tijdelijke comfortboost toe.
-Die boost bouwt langzaam op, helpt vooral bij hardnekkige ondershoot, en loopt
-weer rustig leeg zodra de kamer terug in de comfortband komt.
+Die boost bouwt langzaam op, helpt vooral bij hardnekkige ondershoot, en wordt
+bewust vastgehouden in de koudere helft van de comfortband. Pas richting de
+warmere helft van de band loopt hij weer rustig leeg.
 
 Belangrijk:
 

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -34,7 +34,9 @@ globals:
     initial_value: '0'
 
   # Internal comfort boost that slowly builds when the room stays clearly
-  # below the cold comfort boundary for a longer time.
+  # below the cold comfort boundary for a longer time. Once the room returns
+  # into the comfort band, the boost is kept through the colder half of the
+  # band and only starts fading in the warmer half.
   - id: oq_phouse_comfort_boost_w
     type: float
     restore_value: false
@@ -412,6 +414,7 @@ interval:
             const float dt_power_s = (now_ms >= last) ? ((now_ms - last) / 1000.0f) : 0.0f;
             const float comfort_boost_max_w = clampf(house_power_rating_w * 0.10f, 300.0f, 800.0f);
             const float comfort_boost_entry_c = 0.05f;
+            const float comfort_mid_c = Tr_low + 0.5f * (Tr_high - Tr_low);
             float comfort_boost_w = id(oq_phouse_comfort_boost_w);
             if (isnan(comfort_boost_w) || comfort_boost_w < 0.0f) comfort_boost_w = 0.0f;
 
@@ -423,6 +426,9 @@ interval:
                   (build_min_w_per_min + (build_max_w_per_min - build_min_w_per_min) * undershoot_norm) /
                   seconds_per_minute;
               comfort_boost_w += build_w_per_s * dt_power_s;
+            } else if (Tr <= comfort_mid_c) {
+              // Keep the accumulated comfort boost through the colder half of
+              // the comfort band so the room does not settle persistently low.
             } else if (Tr <= Tr_high) {
               const float decay_w_per_s = (comfort_boost_max_w / 12.0f) / seconds_per_minute;
               comfort_boost_w -= decay_w_per_s * dt_power_s;


### PR DESCRIPTION
## Summary
- keep the internal Power House comfort boost through the colder half of the configured comfort band
- only start fading that boost in the warmer half of the band
- update the Power House docs and dashboard help text to match the new comfort-band semantics

## Why
With settings like `setpoint=20.0`, `comfort below=0.0`, and `comfort above=0.3`, users expect Power House to keep the room inside that band instead of settling persistently below the lower edge. The previous boost logic started decaying as soon as the room re-entered the band, which still allowed a cool bias. This change gives the lower half of the band a warmer preference without silently shifting the setpoint.

## Validation
- `python3 scripts/simulate_thermal_refactor_regressions.py`
- targeted `esphome compile openquatt_duo_heatpump_listener.yaml` progressed cleanly through config generation and compile startup for this branch