### PR TITLE
Refactor heating curve dispatch into strategy

### DIFF
--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <math.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -137,6 +138,23 @@ inline void reset_request_state(uint32_t &request_last_loop_ms,
 
 inline DispatchCandidate invalid_dispatch_candidate() {
   return DispatchCandidate{};
+}
+
+inline float normalized_demand_u(float demand_continuous, int demand_max_f) {
+  if (demand_max_f <= 0) return 0.0f;
+  if (isnan(demand_continuous)) return 0.0f;
+  const float clamped = std::max(0.0f, std::min((float) demand_max_f, demand_continuous));
+  return clamped / (float) demand_max_f;
+}
+
+inline float phase_target_power_w(bool heat_phase,
+                                  float demand_u,
+                                  float single_cap_w,
+                                  float duo_cap_w) {
+  if (demand_u <= 0.0f) return 0.0f;
+  const float single_target_w = isnan(single_cap_w) ? 0.0f : (single_cap_w * demand_u);
+  const float duo_target_w = isnan(duo_cap_w) ? single_target_w : (duo_cap_w * demand_u);
+  return heat_phase ? single_target_w : duo_target_w;
 }
 
 inline int pick_single_owner(bool demand_active,

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -112,16 +112,30 @@ inline void reset_outside_ema_state(float &outside_ema_c,
 
 inline void reset_request_state(uint32_t &request_last_loop_ms,
                                 int &request_total_level,
-                                int &request_owner_hp) {
+                                int &request_owner_hp,
+                                int &dispatch_hp1_level,
+                                int &dispatch_hp2_level,
+                                int &capacity_mode_code) {
   request_last_loop_ms = 0;
   request_total_level = 0;
   request_owner_hp = 0;
+  dispatch_hp1_level = 0;
+  dispatch_hp2_level = 0;
+  capacity_mode_code = 0;
 }
 
 inline const char *regime_name(int regime_code) {
   switch (regime_code) {
     case 1: return "recovery";
     case 2: return "maintain";
+    default: return "off";
+  }
+}
+
+inline const char *capacity_mode_name(int capacity_mode_code) {
+  switch (capacity_mode_code) {
+    case 1: return "single";
+    case 2: return "duo";
     default: return "off";
   }
 }

--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <math.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <string>
 
@@ -30,6 +31,16 @@ struct ControlProfileTuning {
   int dual_emergency_hold_min = 6;
   float dual_emergency_temp_err_c = 1.50f;
   float dual_disable_temp_err_max_c = 0.50f;
+};
+
+struct DispatchCandidate {
+  bool valid = false;
+  int hp1_level = 0;
+  int hp2_level = 0;
+  float power_w = 0.0f;
+  float error_w = 1.0e9f;
+  int active_hp_count = 0;
+  int balance_gap = 0;
 };
 
 inline ControlProfileTuning control_profile(const std::string &profile_option) {
@@ -122,6 +133,50 @@ inline void reset_request_state(uint32_t &request_last_loop_ms,
   dispatch_hp1_level = 0;
   dispatch_hp2_level = 0;
   capacity_mode_code = 0;
+}
+
+inline DispatchCandidate invalid_dispatch_candidate() {
+  return DispatchCandidate{};
+}
+
+inline int pick_single_owner(bool demand_active,
+                             int stored_owner_hp,
+                             bool prev_hp1_on,
+                             bool prev_hp2_on,
+                             bool lead_is_hp1) {
+  if (!demand_active) return 0;
+  if (prev_hp1_on != prev_hp2_on) return prev_hp1_on ? 1 : 2;
+  if (stored_owner_hp == 1 || stored_owner_hp == 2) return stored_owner_hp;
+  return lead_is_hp1 ? 1 : 2;
+}
+
+inline bool better_dispatch_candidate(const DispatchCandidate &candidate,
+                                      const DispatchCandidate &best,
+                                      int prev_hp1_level,
+                                      int prev_hp2_level) {
+  if (!candidate.valid) return false;
+  if (!best.valid) return true;
+  if (fabsf(candidate.error_w - best.error_w) > 50.0f) return candidate.error_w < best.error_w;
+
+  const int candidate_starts =
+      ((prev_hp1_level == 0) && (candidate.hp1_level > 0) ? 1 : 0) +
+      ((prev_hp2_level == 0) && (candidate.hp2_level > 0) ? 1 : 0);
+  const int best_starts =
+      ((prev_hp1_level == 0) && (best.hp1_level > 0) ? 1 : 0) +
+      ((prev_hp2_level == 0) && (best.hp2_level > 0) ? 1 : 0);
+  if (candidate_starts != best_starts) return candidate_starts < best_starts;
+
+  const int candidate_moves =
+      abs(candidate.hp1_level - prev_hp1_level) + abs(candidate.hp2_level - prev_hp2_level);
+  const int best_moves =
+      abs(best.hp1_level - prev_hp1_level) + abs(best.hp2_level - prev_hp2_level);
+  if (candidate_moves != best_moves) return candidate_moves < best_moves;
+
+  if (candidate.active_hp_count != best.active_hp_count) {
+    return candidate.active_hp_count < best.active_hp_count;
+  }
+  if (candidate.balance_gap != best.balance_gap) return candidate.balance_gap < best.balance_gap;
+  return candidate.power_w < best.power_w;
 }
 
 inline const char *regime_name(int regime_code) {

--- a/openquatt/includes/oq_thermal_request_logic.h
+++ b/openquatt/includes/oq_thermal_request_logic.h
@@ -21,12 +21,6 @@ struct PublishedRequest {
   int strategy_code;
 };
 
-struct PerHpRequestLevels {
-  int hp1_level;
-  int hp2_level;
-  int owner_hp;
-};
-
 inline int whole_minutes_floor(float elapsed_min) {
   return (int) floorf(elapsed_min + 1e-3f);
 }
@@ -97,32 +91,6 @@ inline PublishedRequest make_published_request(int mode_code,
       topology_code,
       sanitize_request_strategy_code(strategy_code),
   };
-}
-
-inline PerHpRequestLevels split_curve_total_request(int total_level_request,
-                                                    bool dual_enabled,
-                                                    bool lead_is_hp1,
-                                                    int owner_hp) {
-  total_level_request = clamp_level(total_level_request, 0, 20);
-  if (total_level_request <= 0) {
-    return PerHpRequestLevels{0, 0, 0};
-  }
-
-  if (!dual_enabled) {
-    const int effective_owner =
-        (owner_hp == 1 || owner_hp == 2) ? owner_hp : (lead_is_hp1 ? 1 : 2);
-    return (effective_owner == 1)
-               ? PerHpRequestLevels{total_level_request, 0, 1}
-               : PerHpRequestLevels{0, total_level_request, 2};
-  }
-
-  int hp1_level = total_level_request / 2;
-  int hp2_level = total_level_request / 2;
-  if ((total_level_request % 2) == 1) {
-    if (lead_is_hp1) hp1_level += 1;
-    else hp2_level += 1;
-  }
-  return PerHpRequestLevels{hp1_level, hp2_level, 0};
 }
 
 inline bool excluded_option_matches_level(const std::string &opt, int level) {

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -1054,7 +1054,6 @@ interval:
           }
           const bool demand_active = (f > 0);
           const bool heat_phase = demand_active && (id(oq_curve_regime_code) == 1);
-          const bool coast_phase = demand_active && (id(oq_curve_regime_code) == 2);
           const int prev_curve_post = id(oq_demand_filtered_prev);
           const bool demand_rundown = (f <= prev_curve_post);
 
@@ -1077,59 +1076,15 @@ interval:
             return oq_perf::interp_power_th_w(level, id(outside_temp_selected).state, id(oq_supply_target_temp).state);
           };
 
-          struct DispatchCandidate {
-            bool valid;
-            int hp1_level;
-            int hp2_level;
-            float power_w;
-            float error_w;
-            int active_hp_count;
-            int balance_gap;
-          };
-
-          auto invalid_candidate = [&]()->DispatchCandidate {
-            return DispatchCandidate{false, 0, 0, 0.0f, 1.0e9f, 0, 0};
-          };
-
           const int prev1 = id(hp1_last_applied_level);
           const int prev2 = id(${curve_secondary_last_applied_level_id});
-          auto better_candidate = [&](const DispatchCandidate &candidate,
-                                      const DispatchCandidate &best)->bool {
-            if (!candidate.valid) return false;
-            if (!best.valid) return true;
-            if (fabsf(candidate.error_w - best.error_w) > 50.0f) return candidate.error_w < best.error_w;
 
-            const int candidate_starts =
-                ((prev1 == 0) && (candidate.hp1_level > 0) ? 1 : 0) +
-                ((prev2 == 0) && (candidate.hp2_level > 0) ? 1 : 0);
-            const int best_starts =
-                ((prev1 == 0) && (best.hp1_level > 0) ? 1 : 0) +
-                ((prev2 == 0) && (best.hp2_level > 0) ? 1 : 0);
-            if (candidate_starts != best_starts) return candidate_starts < best_starts;
-
-            const int candidate_moves =
-                abs(candidate.hp1_level - prev1) + abs(candidate.hp2_level - prev2);
-            const int best_moves =
-                abs(best.hp1_level - prev1) + abs(best.hp2_level - prev2);
-            if (candidate_moves != best_moves) return candidate_moves < best_moves;
-
-            if (candidate.active_hp_count != best.active_hp_count) {
-              return candidate.active_hp_count < best.active_hp_count;
-            }
-            if (candidate.balance_gap != best.balance_gap) return candidate.balance_gap < best.balance_gap;
-            return candidate.power_w < best.power_w;
-          };
-
-          auto build_candidate = [&](int hp1_level, int hp2_level, float target_power_w)->DispatchCandidate {
+          auto build_candidate = [&](int hp1_level, int hp2_level, float target_power_w)->oq_curve::DispatchCandidate {
             float p1 = level_power_w(true, hp1_level);
-            #if OQ_TOPOLOGY_DUO
             float p2 = level_power_w(false, hp2_level);
-            #else
-            float p2 = (hp2_level <= 0) ? 0.0f : NAN;
-            #endif
-            if (isnan(p1) || isnan(p2)) return invalid_candidate();
+            if (isnan(p1) || isnan(p2)) return oq_curve::invalid_dispatch_candidate();
             const float power_w = p1 + p2;
-            return DispatchCandidate{
+            return oq_curve::DispatchCandidate{
               true,
               hp1_level,
               hp2_level,
@@ -1142,33 +1097,19 @@ interval:
 
           const bool prev_hp1_on = (prev1 > 0);
           const bool prev_hp2_on = (prev2 > 0);
-          int single_owner = demand_active ? id(oq_curve_single_owner_hp) : 0;
-          if (!demand_active) {
-            single_owner = 0;
-          } else if (prev_hp1_on != prev_hp2_on) {
-            single_owner = prev_hp1_on ? 1 : 2;
-          } else if (single_owner != 1 && single_owner != 2) {
-            single_owner = lead_is_hp1 ? 1 : 2;
-          }
-
-          #if OQ_TOPOLOGY_DUO
+          const int single_owner = oq_curve::pick_single_owner(
+              demand_active, id(oq_curve_single_owner_hp), prev_hp1_on, prev_hp2_on, lead_is_hp1);
           const int owner_max_single = (single_owner == 2)
               ? max_allowed_level_for_hp(false)
               : max_allowed_level_for_hp(true);
           const int hp1_max_single = max_allowed_level_for_hp(true);
           const int hp2_max_single = max_allowed_level_for_hp(false);
-          #else
-          const int owner_max_single = max_allowed_level_for_hp(true);
-          const int hp1_max_single = owner_max_single;
-          const int hp2_max_single = 0;
-          #endif
 
           const float owner_cap_w = (single_owner == 2)
               ? level_power_w(false, owner_max_single)
               : level_power_w(true, owner_max_single);
 
           float duo_cap_w = 0.0f;
-          #if OQ_TOPOLOGY_DUO
           for (int hp1_level = 1; hp1_level <= hp1_max_single; hp1_level++) {
             for (int hp2_level = 1; hp2_level <= hp2_max_single; hp2_level++) {
               if (abs(hp1_level - hp2_level) > 1) continue;
@@ -1177,7 +1118,6 @@ interval:
               if (candidate.power_w > duo_cap_w) duo_cap_w = candidate.power_w;
             }
           }
-          #endif
 
           float demand_continuous = id(oq_curve_demand_continuous);
           if (isnan(demand_continuous)) demand_continuous = (float) f;
@@ -1192,33 +1132,29 @@ interval:
             target_power_w = heat_phase ? single_target_w : duo_target_w;
           }
 
-          DispatchCandidate best_single = invalid_candidate();
+          oq_curve::DispatchCandidate best_single = oq_curve::invalid_dispatch_candidate();
           if (demand_active && single_owner == 1) {
             for (int hp1_level = 1; hp1_level <= hp1_max_single; hp1_level++) {
               const auto candidate = build_candidate(hp1_level, 0, target_power_w);
-              if (better_candidate(candidate, best_single)) best_single = candidate;
+              if (oq_curve::better_dispatch_candidate(candidate, best_single, prev1, prev2)) best_single = candidate;
             }
           } else if (demand_active && single_owner == 2) {
-            #if OQ_TOPOLOGY_DUO
             for (int hp2_level = 1; hp2_level <= hp2_max_single; hp2_level++) {
               const auto candidate = build_candidate(0, hp2_level, target_power_w);
-              if (better_candidate(candidate, best_single)) best_single = candidate;
+              if (oq_curve::better_dispatch_candidate(candidate, best_single, prev1, prev2)) best_single = candidate;
             }
-            #endif
           }
 
-          DispatchCandidate best_duo = invalid_candidate();
-          #if OQ_TOPOLOGY_DUO
+          oq_curve::DispatchCandidate best_duo = oq_curve::invalid_dispatch_candidate();
           if (demand_active) {
             for (int hp1_level = 1; hp1_level <= hp1_max_single; hp1_level++) {
               for (int hp2_level = 1; hp2_level <= hp2_max_single; hp2_level++) {
                 if (abs(hp1_level - hp2_level) > 1) continue;
                 const auto candidate = build_candidate(hp1_level, hp2_level, target_power_w);
-                if (better_candidate(candidate, best_duo)) best_duo = candidate;
+                if (oq_curve::better_dispatch_candidate(candidate, best_duo, prev1, prev2)) best_duo = candidate;
               }
             }
           }
-          #endif
 
           const int dual_on_hold_min = std::max(1, (int) roundf(id(oq_dual_hp_enable_hold_min).state));
           const int dual_off_hold_min = std::max(1, (int) roundf(id(oq_dual_hp_disable_hold_min).state));
@@ -1307,7 +1243,6 @@ interval:
               (force_dual_capacity || force_dual_defrost || id(oq_dual_hp_enabled));
 
           if (!demand_active) {
-            single_owner = 0;
             owner = 0;
             dispatch_hp1 = 0;
             dispatch_hp2 = 0;
@@ -1315,8 +1250,8 @@ interval:
           } else if (dual_enabled) {
             id(oq_curve_single_owner_hp) = 0;
             owner = 0;
-            dispatch_hp1 = best_duo.valid ? best_duo.hp1_level : 0;
-            dispatch_hp2 = best_duo.valid ? best_duo.hp2_level : 0;
+            dispatch_hp1 = best_duo.hp1_level;
+            dispatch_hp2 = best_duo.hp2_level;
             id(oq_curve_capacity_mode_code) = 2;
           } else {
             id(oq_curve_single_owner_hp) = single_owner;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -8,7 +8,7 @@
 # Ownership:
 #   - Computes curve supply target generation and PID demand
 #   - Owns curve-specific hysteresis, phase/regime state, and diagnostics
-#   - Decides curve total request and topology hints
+#   - Decides curve per-HP dispatch and capacity mode
 #   - Clears Power House-specific capacity/deficit telemetry while curve mode is active
 #   - Publishes curve request outputs for oq_thermal_request_control to finish
 #     into the shared request interface
@@ -92,6 +92,21 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  - id: oq_curve_dispatch_hp1_level
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_curve_dispatch_hp2_level
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_curve_capacity_mode_code
+    type: int
+    restore_value: false
+    initial_value: '0'
+
 select:
   - platform: template
     id: oq_curve_control_profile
@@ -128,7 +143,18 @@ select:
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_owner_hp));
+              id(oq_curve_request_owner_hp),
+              id(oq_curve_dispatch_hp1_level),
+              id(oq_curve_dispatch_hp2_level),
+              id(oq_curve_capacity_mode_code));
+            oq_request::reset_dual_runtime_state(
+              id(oq_dual_hp_enabled),
+              id(oq_dual_hp_enable_hold_elapsed_accum_min),
+              id(oq_dual_hp_disable_hold_elapsed_accum_min),
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+              id(oq_curve_single_owner_hp),
+              id(oq_duo_request_hold_until_ms),
+              0);
 
 number:
   - platform: template
@@ -711,6 +737,36 @@ sensor:
       return (float) id(oq_curve_request_total_level);
 
   - platform: template
+    id: oq_curve_dispatch_hp1_level_sensor
+    name: "Curve dispatch HP1 level"
+    disabled_by_default: true
+    icon: mdi:counter
+    unit_of_measurement: "step"
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return (float) id(oq_curve_dispatch_hp1_level);
+
+  - platform: template
+    id: oq_curve_dispatch_hp2_level_sensor
+    name: "Curve dispatch HP2 level"
+    disabled_by_default: true
+    icon: mdi:counter
+    unit_of_measurement: "step"
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 5s
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      return (float) id(oq_curve_dispatch_hp2_level);
+
+  - platform: template
     id: oq_curve_restart_inhibit_sensor
     name: "Curve restart inhibit"
     disabled_by_default: true
@@ -752,6 +808,19 @@ text_sensor:
         case 2: return std::string("MAINTAIN");
         default: return std::string("OFF");
       }
+
+  - platform: template
+    id: oq_curve_capacity_mode_sensor
+    name: "Curve capacity mode"
+    icon: mdi:state-machine
+    update_interval: 5s
+    entity_category: diagnostic
+    disabled_by_default: true
+    web_server:
+      sorting_group_id: oq_diagnostics
+    lambda: |-
+      const char *mode_name = oq_curve::capacity_mode_name(id(oq_curve_capacity_mode_code));
+      return std::string(mode_name);
 
 interval:
   - interval: ${oq_strategy_loop_s}s
@@ -864,14 +933,25 @@ interval:
     startup_delay: 4000ms
     then:
       - lambda: |-
-          // Heating-curve strategy: owns direct demand, total request, and topology hints.
+          // Heating-curve strategy: owns direct demand and per-HP dispatch output.
           const int cm_code = id(oq_control_mode_code);
           const bool active = (cm_code != 5) && (id(oq_heat_mode_code) == 1);
           if (!active) {
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_owner_hp));
+              id(oq_curve_request_owner_hp),
+              id(oq_curve_dispatch_hp1_level),
+              id(oq_curve_dispatch_hp2_level),
+              id(oq_curve_capacity_mode_code));
+            oq_request::reset_dual_runtime_state(
+              id(oq_dual_hp_enabled),
+              id(oq_dual_hp_enable_hold_elapsed_accum_min),
+              id(oq_dual_hp_disable_hold_elapsed_accum_min),
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+              id(oq_curve_single_owner_hp),
+              id(oq_duo_request_hold_until_ms),
+              0);
             return;
           }
 
@@ -960,26 +1040,23 @@ interval:
           id(oq_P_deficit_w) = 0.0f;
 
           int owner = 0;
+          int dispatch_hp1 = 0;
+          int dispatch_hp2 = 0;
           #if OQ_TOPOLOGY_DUO
-          const int dual_on_lvl =
-              std::max(1, std::min(max_level, (int) roundf(id(oq_dual_hp_enable_level).state)));
-          const int dual_off_lvl = std::max(1, dual_on_lvl - 1);
-          const int dual_on_hold_min = std::max(1, (int) roundf(id(oq_dual_hp_enable_hold_min).state));
-          const int dual_off_hold_min = std::max(1, (int) roundf(id(oq_dual_hp_disable_hold_min).state));
-
           const auto tuning = oq_curve::control_profile(
               id(oq_curve_control_profile).has_state()
                   ? id(oq_curve_control_profile).current_option()
                   : std::string());
-          const int startup_grace_s = std::max(0, tuning.dual_startup_grace_s);
-          const int emergency_hold_min = std::max(1, tuning.dual_emergency_hold_min);
-          const float emergency_temp_err_c = tuning.dual_emergency_temp_err_c;
-          const float dual_disable_temp_err_max_c = tuning.dual_disable_temp_err_max_c;
 
           float temp_err_c = NAN;
           if (!isnan(id(oq_supply_target_temp).state) && !isnan(id(oq_system_supply_temp).state)) {
             temp_err_c = id(oq_supply_target_temp).state - id(oq_system_supply_temp).state;
           }
+          const bool demand_active = (f > 0);
+          const bool heat_phase = demand_active && (id(oq_curve_regime_code) == 1);
+          const bool coast_phase = demand_active && (id(oq_curve_regime_code) == 2);
+          const int prev_curve_post = id(oq_demand_filtered_prev);
+          const bool demand_rundown = (f <= prev_curve_post);
 
           auto max_allowed_level_for_hp = [&](bool is_hp1)->int {
             int lvl_max = 0;
@@ -992,42 +1069,215 @@ interval:
             return lvl_max;
           };
 
-          const int lead_max_single = max_allowed_level_for_hp(lead_is_hp1);
-          const int lag_max_single = max_allowed_level_for_hp(!lead_is_hp1);
-          const int single_limit_lvl = std::max(lead_max_single, lag_max_single);
-          const int single_req_lvl = (single_limit_lvl > 0) ? std::min(f, single_limit_lvl) : f;
+          auto level_power_w = [&](bool is_hp1, int level)->float {
+            if (level <= 0) return 0.0f;
+            if (!level_allowed(is_hp1, level)) return NAN;
+            if (!id(outside_temp_selected).has_state() || isnan(id(outside_temp_selected).state)) return NAN;
+            if (!id(oq_supply_target_temp).has_state() || isnan(id(oq_supply_target_temp).state)) return NAN;
+            return oq_perf::interp_power_th_w(level, id(outside_temp_selected).state, id(oq_supply_target_temp).state);
+          };
 
-          const bool demand_active = (f > 0);
-          const bool beyond_single_capacity = demand_active && (single_limit_lvl > 0) && (f > single_limit_lvl);
-          const bool severe_level_pressure =
-              (single_limit_lvl > 0) && (single_req_lvl >= std::min(max_level, dual_on_lvl + 2));
-          const bool severe_temp_deficit = !isnan(temp_err_c) && (temp_err_c >= emergency_temp_err_c);
+          struct DispatchCandidate {
+            bool valid;
+            int hp1_level;
+            int hp2_level;
+            float power_w;
+            float error_w;
+            int active_hp_count;
+            int balance_gap;
+          };
+
+          auto invalid_candidate = [&]()->DispatchCandidate {
+            return DispatchCandidate{false, 0, 0, 0.0f, 1.0e9f, 0, 0};
+          };
+
+          const int prev1 = id(hp1_last_applied_level);
+          const int prev2 = id(${curve_secondary_last_applied_level_id});
+          auto better_candidate = [&](const DispatchCandidate &candidate,
+                                      const DispatchCandidate &best)->bool {
+            if (!candidate.valid) return false;
+            if (!best.valid) return true;
+            if (fabsf(candidate.error_w - best.error_w) > 50.0f) return candidate.error_w < best.error_w;
+
+            const int candidate_starts =
+                ((prev1 == 0) && (candidate.hp1_level > 0) ? 1 : 0) +
+                ((prev2 == 0) && (candidate.hp2_level > 0) ? 1 : 0);
+            const int best_starts =
+                ((prev1 == 0) && (best.hp1_level > 0) ? 1 : 0) +
+                ((prev2 == 0) && (best.hp2_level > 0) ? 1 : 0);
+            if (candidate_starts != best_starts) return candidate_starts < best_starts;
+
+            const int candidate_moves =
+                abs(candidate.hp1_level - prev1) + abs(candidate.hp2_level - prev2);
+            const int best_moves =
+                abs(best.hp1_level - prev1) + abs(best.hp2_level - prev2);
+            if (candidate_moves != best_moves) return candidate_moves < best_moves;
+
+            if (candidate.active_hp_count != best.active_hp_count) {
+              return candidate.active_hp_count < best.active_hp_count;
+            }
+            if (candidate.balance_gap != best.balance_gap) return candidate.balance_gap < best.balance_gap;
+            return candidate.power_w < best.power_w;
+          };
+
+          auto build_candidate = [&](int hp1_level, int hp2_level, float target_power_w)->DispatchCandidate {
+            float p1 = level_power_w(true, hp1_level);
+            #if OQ_TOPOLOGY_DUO
+            float p2 = level_power_w(false, hp2_level);
+            #else
+            float p2 = (hp2_level <= 0) ? 0.0f : NAN;
+            #endif
+            if (isnan(p1) || isnan(p2)) return invalid_candidate();
+            const float power_w = p1 + p2;
+            return DispatchCandidate{
+              true,
+              hp1_level,
+              hp2_level,
+              power_w,
+              fabsf(power_w - target_power_w),
+              (hp1_level > 0 ? 1 : 0) + (hp2_level > 0 ? 1 : 0),
+              abs(hp1_level - hp2_level),
+            };
+          };
+
+          const bool prev_hp1_on = (prev1 > 0);
+          const bool prev_hp2_on = (prev2 > 0);
+          int single_owner = demand_active ? id(oq_curve_single_owner_hp) : 0;
+          if (!demand_active) {
+            single_owner = 0;
+          } else if (prev_hp1_on != prev_hp2_on) {
+            single_owner = prev_hp1_on ? 1 : 2;
+          } else if (single_owner != 1 && single_owner != 2) {
+            single_owner = lead_is_hp1 ? 1 : 2;
+          }
+
+          #if OQ_TOPOLOGY_DUO
+          const int owner_max_single = (single_owner == 2)
+              ? max_allowed_level_for_hp(false)
+              : max_allowed_level_for_hp(true);
+          const int hp1_max_single = max_allowed_level_for_hp(true);
+          const int hp2_max_single = max_allowed_level_for_hp(false);
+          #else
+          const int owner_max_single = max_allowed_level_for_hp(true);
+          const int hp1_max_single = owner_max_single;
+          const int hp2_max_single = 0;
+          #endif
+
+          const float owner_cap_w = (single_owner == 2)
+              ? level_power_w(false, owner_max_single)
+              : level_power_w(true, owner_max_single);
+
+          float duo_cap_w = 0.0f;
+          #if OQ_TOPOLOGY_DUO
+          for (int hp1_level = 1; hp1_level <= hp1_max_single; hp1_level++) {
+            for (int hp2_level = 1; hp2_level <= hp2_max_single; hp2_level++) {
+              if (abs(hp1_level - hp2_level) > 1) continue;
+              const auto candidate = build_candidate(hp1_level, hp2_level, 0.0f);
+              if (!candidate.valid) continue;
+              if (candidate.power_w > duo_cap_w) duo_cap_w = candidate.power_w;
+            }
+          }
+          #endif
+
+          float demand_continuous = id(oq_curve_demand_continuous);
+          if (isnan(demand_continuous)) demand_continuous = (float) f;
+          if (demand_continuous < 0.0f) demand_continuous = 0.0f;
+          if (demand_continuous > (float) demand_max_f) demand_continuous = (float) demand_max_f;
+          const float demand_u = demand_continuous / (float) demand_max_f;
+
+          float target_power_w = 0.0f;
+          if (demand_active) {
+            const float single_target_w = isnan(owner_cap_w) ? 0.0f : (owner_cap_w * demand_u);
+            const float duo_target_w = duo_cap_w * demand_u;
+            target_power_w = heat_phase ? single_target_w : duo_target_w;
+          }
+
+          DispatchCandidate best_single = invalid_candidate();
+          if (demand_active && single_owner == 1) {
+            for (int hp1_level = 1; hp1_level <= hp1_max_single; hp1_level++) {
+              const auto candidate = build_candidate(hp1_level, 0, target_power_w);
+              if (better_candidate(candidate, best_single)) best_single = candidate;
+            }
+          } else if (demand_active && single_owner == 2) {
+            #if OQ_TOPOLOGY_DUO
+            for (int hp2_level = 1; hp2_level <= hp2_max_single; hp2_level++) {
+              const auto candidate = build_candidate(0, hp2_level, target_power_w);
+              if (better_candidate(candidate, best_single)) best_single = candidate;
+            }
+            #endif
+          }
+
+          DispatchCandidate best_duo = invalid_candidate();
+          #if OQ_TOPOLOGY_DUO
+          if (demand_active) {
+            for (int hp1_level = 1; hp1_level <= hp1_max_single; hp1_level++) {
+              for (int hp2_level = 1; hp2_level <= hp2_max_single; hp2_level++) {
+                if (abs(hp1_level - hp2_level) > 1) continue;
+                const auto candidate = build_candidate(hp1_level, hp2_level, target_power_w);
+                if (better_candidate(candidate, best_duo)) best_duo = candidate;
+              }
+            }
+          }
+          #endif
+
+          const int dual_on_hold_min = std::max(1, (int) roundf(id(oq_dual_hp_enable_hold_min).state));
+          const int dual_off_hold_min = std::max(1, (int) roundf(id(oq_dual_hp_disable_hold_min).state));
+          const float dt_min = ((float) loop_target_ms / 1000.0f) / 60.0f;
           const uint32_t lead_last_start_ms =
               lead_is_hp1 ? id(hp1_last_start_ms) : id(${curve_secondary_last_start_ms_id});
           const bool startup_grace_active =
-              (startup_grace_s > 0) &&
+              (tuning.dual_startup_grace_s > 0) &&
               (lead_last_start_ms > 0) &&
               (now_ms > lead_last_start_ms) &&
-              ((now_ms - lead_last_start_ms) < ((uint32_t) startup_grace_s * 1000UL));
-
+              ((now_ms - lead_last_start_ms) < ((uint32_t) tuning.dual_startup_grace_s * 1000UL));
+          const float duo_enable_margin_w = heat_phase ? 700.0f : 450.0f;
+          const float duo_disable_margin_w = 250.0f;
+          const int duo_enable_min_f = heat_phase ? 18 : 16;
+          const int duo_disable_max_f = heat_phase ? 14 : 11;
+          const bool single_saturated =
+              best_single.valid &&
+              ((best_single.hp1_level >= std::max(6, hp1_max_single - 1)) ||
+               (best_single.hp2_level >= std::max(6, hp2_max_single - 1)));
+          const bool duo_clearly_better =
+              best_duo.valid && best_single.valid &&
+              (best_duo.error_w + duo_enable_margin_w < best_single.error_w);
+          const bool single_good_enough =
+              best_single.valid &&
+              (!best_duo.valid || (best_single.error_w <= (best_duo.error_w + duo_disable_margin_w)));
+          const bool force_dual_defrost = demand_active && hp1_valve_def && hp2_valve_def;
           const bool emergency_dual_condition =
-              demand_active && beyond_single_capacity && severe_level_pressure &&
-              (severe_temp_deficit || single_req_lvl >= (max_level - 1)) && !startup_grace_active;
+              demand_active && best_duo.valid && heat_phase &&
+              !startup_grace_active &&
+              !isnan(temp_err_c) &&
+              (temp_err_c >= tuning.dual_emergency_temp_err_c) &&
+              (f >= (demand_max_f - 1));
+
           if (emergency_dual_condition) {
-            id(oq_dual_hp_emergency_hold_elapsed_accum_min) += ((float) loop_target_ms / 1000.0f) / 60.0f;
+            id(oq_dual_hp_emergency_hold_elapsed_accum_min) += dt_min;
           } else {
             id(oq_dual_hp_emergency_hold_elapsed_accum_min) = 0.0f;
           }
           const bool force_dual_capacity =
-              id(oq_dual_hp_emergency_hold_elapsed_accum_min) >= (float) emergency_hold_min;
-          const bool force_dual_defrost = demand_active && hp1_valve_def && hp2_valve_def;
-          const bool dual_on_condition =
-              demand_active && (force_dual_capacity || force_dual_defrost || (single_req_lvl >= dual_on_lvl));
-          const bool dual_off_condition =
-              (!force_dual_capacity) && (!force_dual_defrost) && (single_req_lvl <= dual_off_lvl) &&
-              (isnan(temp_err_c) || temp_err_c <= dual_disable_temp_err_max_c);
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min) >= (float) std::max(1, tuning.dual_emergency_hold_min);
 
-          const float dt_min = ((float) loop_target_ms / 1000.0f) / 60.0f;
+          const bool dual_on_condition =
+              demand_active &&
+              best_duo.valid &&
+              !startup_grace_active &&
+              !demand_rundown &&
+              (force_dual_capacity || force_dual_defrost ||
+               (duo_clearly_better &&
+                (f >= duo_enable_min_f) &&
+                (heat_phase ? single_saturated : !single_good_enough) &&
+                (isnan(temp_err_c) || temp_err_c >= -0.05f)));
+          const bool dual_off_condition =
+              (!demand_active) ||
+              (!best_duo.valid) ||
+              (!id(oq_dual_hp_enabled) && !dual_on_condition) ||
+              (single_good_enough &&
+               (f <= duo_disable_max_f) &&
+               (isnan(temp_err_c) || temp_err_c <= tuning.dual_disable_temp_err_max_c));
+
           if (!demand_active) {
             oq_request::reset_dual_hold_state(
                 id(oq_dual_hp_enabled),
@@ -1053,20 +1303,27 @@ interval:
           }
 
           const bool dual_enabled =
-              demand_active && (force_dual_capacity || force_dual_defrost || id(oq_dual_hp_enabled));
+              demand_active && best_duo.valid &&
+              (force_dual_capacity || force_dual_defrost || id(oq_dual_hp_enabled));
 
-          if (!dual_enabled) {
-            const bool prev_hp1_on = (id(hp1_last_applied_level) > 0);
-            const bool prev_hp2_on = (id(${curve_secondary_last_applied_level_id}) > 0);
-            int single_owner = demand_active ? id(oq_curve_single_owner_hp) : 0;
-            if (prev_hp1_on != prev_hp2_on) single_owner = prev_hp1_on ? 1 : 2;
-            else if (single_owner != 1 && single_owner != 2) single_owner = lead_is_hp1 ? 1 : 2;
-
-            id(oq_curve_single_owner_hp) = single_owner;
-            owner = single_owner;
-          } else {
+          if (!demand_active) {
+            single_owner = 0;
+            owner = 0;
+            dispatch_hp1 = 0;
+            dispatch_hp2 = 0;
+            id(oq_curve_capacity_mode_code) = 0;
+          } else if (dual_enabled) {
             id(oq_curve_single_owner_hp) = 0;
             owner = 0;
+            dispatch_hp1 = best_duo.valid ? best_duo.hp1_level : 0;
+            dispatch_hp2 = best_duo.valid ? best_duo.hp2_level : 0;
+            id(oq_curve_capacity_mode_code) = 2;
+          } else {
+            id(oq_curve_single_owner_hp) = single_owner;
+            owner = single_owner;
+            dispatch_hp1 = best_single.valid ? best_single.hp1_level : 0;
+            dispatch_hp2 = best_single.valid ? best_single.hp2_level : 0;
+            id(oq_curve_capacity_mode_code) = (best_single.valid && (dispatch_hp1 > 0 || dispatch_hp2 > 0)) ? 1 : 0;
           }
           #else
           oq_request::reset_dual_runtime_state(
@@ -1078,7 +1335,12 @@ interval:
               id(oq_duo_request_hold_until_ms),
               1);
           owner = (f > 0) ? 1 : 0;
+          dispatch_hp1 = f;
+          dispatch_hp2 = 0;
+          id(oq_curve_capacity_mode_code) = (f > 0) ? 1 : 0;
           #endif
 
-          id(oq_curve_request_total_level) = f;
+          id(oq_curve_request_total_level) = dispatch_hp1 + dispatch_hp2;
           id(oq_curve_request_owner_hp) = owner;
+          id(oq_curve_dispatch_hp1_level) = dispatch_hp1;
+          id(oq_curve_dispatch_hp2_level) = dispatch_hp2;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -1042,6 +1042,9 @@ interval:
           int owner = 0;
           int dispatch_hp1 = 0;
           int dispatch_hp2 = 0;
+          float demand_continuous = id(oq_curve_demand_continuous);
+          if (isnan(demand_continuous)) demand_continuous = (float) f;
+          const float demand_u = oq_curve::normalized_demand_u(demand_continuous, demand_max_f);
           #if OQ_TOPOLOGY_DUO
           const auto tuning = oq_curve::control_profile(
               id(oq_curve_control_profile).has_state()
@@ -1055,7 +1058,6 @@ interval:
           const bool demand_active = (f > 0);
           const bool heat_phase = demand_active && (id(oq_curve_regime_code) == 1);
           const int prev_curve_post = id(oq_demand_filtered_prev);
-          const bool demand_rundown = (f <= prev_curve_post);
 
           auto max_allowed_level_for_hp = [&](bool is_hp1)->int {
             int lvl_max = 0;
@@ -1119,18 +1121,9 @@ interval:
             }
           }
 
-          float demand_continuous = id(oq_curve_demand_continuous);
-          if (isnan(demand_continuous)) demand_continuous = (float) f;
-          if (demand_continuous < 0.0f) demand_continuous = 0.0f;
-          if (demand_continuous > (float) demand_max_f) demand_continuous = (float) demand_max_f;
-          const float demand_u = demand_continuous / (float) demand_max_f;
-
-          float target_power_w = 0.0f;
-          if (demand_active) {
-            const float single_target_w = isnan(owner_cap_w) ? 0.0f : (owner_cap_w * demand_u);
-            const float duo_target_w = duo_cap_w * demand_u;
-            target_power_w = heat_phase ? single_target_w : duo_target_w;
-          }
+          const bool demand_rundown = (demand_continuous <= (float) prev_curve_post);
+          const float target_power_w =
+              demand_active ? oq_curve::phase_target_power_w(heat_phase, demand_u, owner_cap_w, duo_cap_w) : 0.0f;
 
           oq_curve::DispatchCandidate best_single = oq_curve::invalid_dispatch_candidate();
           if (demand_active && single_owner == 1) {
@@ -1168,8 +1161,8 @@ interval:
               ((now_ms - lead_last_start_ms) < ((uint32_t) tuning.dual_startup_grace_s * 1000UL));
           const float duo_enable_margin_w = heat_phase ? 700.0f : 450.0f;
           const float duo_disable_margin_w = 250.0f;
-          const int duo_enable_min_f = heat_phase ? 18 : 16;
-          const int duo_disable_max_f = heat_phase ? 14 : 11;
+          const float duo_enable_min_u = heat_phase ? 0.90f : 0.80f;
+          const float duo_disable_max_u = heat_phase ? 0.70f : 0.55f;
           const bool single_saturated =
               best_single.valid &&
               ((best_single.hp1_level >= std::max(6, hp1_max_single - 1)) ||
@@ -1186,7 +1179,7 @@ interval:
               !startup_grace_active &&
               !isnan(temp_err_c) &&
               (temp_err_c >= tuning.dual_emergency_temp_err_c) &&
-              (f >= (demand_max_f - 1));
+              (demand_u >= 0.95f);
 
           if (emergency_dual_condition) {
             id(oq_dual_hp_emergency_hold_elapsed_accum_min) += dt_min;
@@ -1203,7 +1196,7 @@ interval:
               !demand_rundown &&
               (force_dual_capacity || force_dual_defrost ||
                (duo_clearly_better &&
-                (f >= duo_enable_min_f) &&
+                (demand_u >= duo_enable_min_u) &&
                 (heat_phase ? single_saturated : !single_good_enough) &&
                 (isnan(temp_err_c) || temp_err_c >= -0.05f)));
           const bool dual_off_condition =
@@ -1211,7 +1204,7 @@ interval:
               (!best_duo.valid) ||
               (!id(oq_dual_hp_enabled) && !dual_on_condition) ||
               (single_good_enough &&
-               (f <= duo_disable_max_f) &&
+               (demand_u <= duo_disable_max_u) &&
                (isnan(temp_err_c) || temp_err_c <= tuning.dual_disable_temp_err_max_c));
 
           if (!demand_active) {
@@ -1269,10 +1262,10 @@ interval:
               id(oq_curve_single_owner_hp),
               id(oq_duo_request_hold_until_ms),
               1);
-          owner = (f > 0) ? 1 : 0;
-          dispatch_hp1 = f;
+          owner = (demand_u > 0.0f) ? 1 : 0;
+          dispatch_hp1 = std::max(0, std::min(max_level, (int) lroundf(demand_u * (float) max_level)));
           dispatch_hp2 = 0;
-          id(oq_curve_capacity_mode_code) = (f > 0) ? 1 : 0;
+          id(oq_curve_capacity_mode_code) = (dispatch_hp1 > 0) ? 1 : 0;
           #endif
 
           id(oq_curve_request_total_level) = dispatch_hp1 + dispatch_hp2;

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -113,7 +113,18 @@ select:
             oq_curve::reset_request_state(
               id(oq_curve_request_last_loop_ms),
               id(oq_curve_request_total_level),
-              id(oq_curve_request_owner_hp));
+              id(oq_curve_request_owner_hp),
+              id(oq_curve_dispatch_hp1_level),
+              id(oq_curve_dispatch_hp2_level),
+              id(oq_curve_capacity_mode_code));
+            oq_request::reset_dual_runtime_state(
+              id(oq_dual_hp_enabled),
+              id(oq_dual_hp_enable_hold_elapsed_accum_min),
+              id(oq_dual_hp_disable_hold_elapsed_accum_min),
+              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+              id(oq_curve_single_owner_hp),
+              id(oq_duo_request_hold_until_ms),
+              0);
             id(oq_strategy_phase_text).publish_state("idle");
             id(oq_strategy_debug_state).publish_state("strategy_switch");
 

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -973,19 +973,14 @@ interval:
                 default: request_reason = "cooling_idle"; break;
               }
             } else {
-              // Curve mode now publishes a total request plus routing hints.
-              const auto curve_request = oq_request::split_curve_total_request(
-                  id(oq_curve_request_total_level),
-                  id(oq_dual_hp_enabled),
-                  lead_is_hp1,
-                  id(oq_curve_request_owner_hp));
-              hp1_req = curve_request.hp1_level;
-              hp2_req = curve_request.hp2_level;
-              request_owner_hp = curve_request.owner_hp;
-              if (id(oq_curve_request_total_level) <= 0) request_reason = "curve_idle";
+              hp1_req = id(oq_curve_dispatch_hp1_level);
+              hp2_req = id(oq_curve_dispatch_hp2_level);
+              request_owner_hp = id(oq_curve_request_owner_hp);
+              if ((hp1_req + hp2_req) <= 0) request_reason = "curve_idle";
+              else if (id(oq_curve_capacity_mode_code) == 2) request_reason = "curve_dual";
               else if (request_owner_hp == 1) request_reason = "curve_single_hp1";
               else if (request_owner_hp == 2) request_reason = "curve_single_hp2";
-              else request_reason = "curve_dual";
+              else request_reason = "curve_single";
             }
 
           } else {
@@ -1024,12 +1019,9 @@ interval:
               request_owner_hp = id(oq_cooling_request_owner_hp);
               request_reason = (request_owner_hp > 0) ? "cooling_owner_hp1" : "cooling_idle";
             } else {
-              // Single-topology curve mode still flows through the same total-request contract.
-              const auto curve_request = oq_request::split_curve_total_request(
-                  id(oq_curve_request_total_level), false, true, id(oq_curve_request_owner_hp));
-              hp1_req = curve_request.hp1_level;
-              request_owner_hp = curve_request.owner_hp;
-              request_reason = (request_owner_hp > 0) ? "curve_single_owner_hp1" : "curve_idle";
+              hp1_req = id(oq_curve_dispatch_hp1_level);
+              request_owner_hp = id(oq_curve_request_owner_hp);
+              request_reason = (hp1_req > 0) ? "curve_single_hp1" : "curve_idle";
             }
           } else {
             hp1_req = id(oq_ph_request_hp1_level);
@@ -1083,13 +1075,13 @@ interval:
           #endif
 
           // =========================
-          // 4b) Explicit per-HP slew-rate limiting (heating-curve mode)
+          // 4b) Explicit per-HP slew-rate limiting for non-Power-House modes.
           //    - max 1 level step per change
           //    - asymmetrical hold: slower up, faster down
+          //    - the strategy owns curve dispatch semantics; this block only
+          //      shapes physical actuator movement
           // =========================
           if (!is_power_house) {
-            const int prev_post_guardrail = prev_f;
-            const bool demand_rundown = (raw < prev_post_guardrail);
             const int curve_regime = id(oq_curve_regime_code);
             const auto tuning = oq_curve::control_profile(
                 id(oq_curve_control_profile).has_state()
@@ -1098,21 +1090,6 @@ interval:
             int up_hold_s = tuning.steady_up_hold_s;
             int down_hold_s = tuning.steady_down_hold_s;
             if (curve_regime == 1) up_hold_s = tuning.recovery_up_hold_s;
-            const bool curve_target_valid =
-                id(oq_supply_target_temp).has_state() &&
-                id(oq_system_supply_temp).has_state() &&
-                !isnan(id(oq_supply_target_temp).state) &&
-                !isnan(id(oq_system_supply_temp).state);
-            const float curve_supply_error_c =
-                curve_target_valid ? (id(oq_supply_target_temp).state - id(oq_system_supply_temp).state) : NAN;
-            const bool braking_overshoot =
-                curve_target_valid && (curve_regime != 1) && (curve_supply_error_c <= 0.10f);
-            const bool recovery_stop_up =
-                curve_target_valid &&
-                (curve_regime == 1) &&
-                (curve_supply_error_c <= 0.90f) &&
-                (raw <= prev_post_guardrail);
-            if (braking_overshoot) down_hold_s = 0;
 
             auto limit_slew = [&](bool is_hp1, int req_level)->int {
               const int prev = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});
@@ -1122,13 +1099,10 @@ interval:
 
               int limited = req_level;
               if (limited > prev + 1) limited = prev + 1;
-              const int max_down_step = braking_overshoot ? 2 : 1;
-              if (limited < prev - max_down_step) limited = prev - max_down_step;
+              if (limited < prev - 1) limited = prev - 1;
               if (limited == prev) return limited;
 
               const bool moving_up = limited > prev;
-              // Guardrail: when demand is already running down, never keep stepping levels up.
-              if ((demand_rundown || recovery_stop_up) && moving_up) return prev;
               const uint32_t hold_ms = (uint32_t) ((moving_up ? up_hold_s : down_hold_s) * 1000UL);
               if (last_change_ms > 0 && now_ms > last_change_ms) {
                 const uint32_t dt_change_ms = now_ms - last_change_ms;

--- a/scripts/simulate_heating_curve_history.py
+++ b/scripts/simulate_heating_curve_history.py
@@ -1,0 +1,990 @@
+#!/usr/bin/env python3
+"""Replay heating-curve history exports and compare dispatch policies.
+
+This is a first-order dispatch simulator, not a full thermal plant model.
+It replays a Home Assistant history CSV, reconstructs the relevant curve-mode
+state, and compares the observed HP1/HP2 level combination against a simulated
+policy that selects level combinations using the performance map.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+CURVE_MODE_LABEL = "Water Temperature Control (heating curve)"
+TRACKED_ENTITIES = {
+    "select.openquatt_heating_control_mode": "heating_mode",
+    "sensor.openquatt_control_mode_label": "control_mode",
+    "sensor.openquatt_curve_phase": "curve_phase",
+    "sensor.openquatt_demand_curve_post_guardrail": "curve_post",
+    "sensor.openquatt_heating_curve_supply_target": "supply_target",
+    "sensor.openquatt_water_supply_temp_selected": "supply_actual",
+    "sensor.openquatt_outside_temperature_selected": "outside_temp",
+    "sensor.openquatt_flow_average_selected": "flow_lph",
+    "sensor.openquatt_hp1_compressor_level": "hp1_level",
+    "sensor.openquatt_hp2_compressor_level": "hp2_level",
+}
+
+
+@dataclass
+class PerfMap:
+    t_amb_bp: List[float]
+    t_sup_bp: List[float]
+    p_th_w: List[List[List[float]]]
+
+    def interp_power_th_w(self, level: int, tamb: float, tsup: float) -> float:
+        if level <= 0:
+            return 0.0
+        level = min(level, 10)
+        li = level - 1
+        ai = self._find_interval(self.t_amb_bp, tamb)
+        si = self._find_interval(self.t_sup_bp, tsup)
+        ax0, ax1 = self.t_amb_bp[ai], self.t_amb_bp[ai + 1]
+        sy0, sy1 = self.t_sup_bp[si], self.t_sup_bp[si + 1]
+        tx = 0.0 if ax1 == ax0 else (tamb - ax0) / (ax1 - ax0)
+        ty = 0.0 if sy1 == sy0 else (tsup - sy0) / (sy1 - sy0)
+        tx = max(0.0, min(1.0, tx))
+        ty = max(0.0, min(1.0, ty))
+
+        q11 = self.p_th_w[ai][si][li]
+        q21 = self.p_th_w[ai + 1][si][li]
+        q12 = self.p_th_w[ai][si + 1][li]
+        q22 = self.p_th_w[ai + 1][si + 1][li]
+        if any(math.isnan(v) for v in (q11, q21, q12, q22)):
+            return math.nan
+
+        r1 = q11 + (q21 - q11) * tx
+        r2 = q12 + (q22 - q12) * tx
+        return r1 + (r2 - r1) * ty
+
+    @staticmethod
+    def _find_interval(bp: Sequence[float], x: float) -> int:
+        if x <= bp[0]:
+            return 0
+        if x >= bp[-1]:
+            return len(bp) - 2
+        for i in range(len(bp) - 1):
+            if bp[i] <= x <= bp[i + 1]:
+                return i
+        return len(bp) - 2
+
+
+@dataclass
+class Snapshot:
+    timestamp: datetime
+    heating_mode: str
+    control_mode: str
+    curve_phase: str
+    curve_post: int
+    supply_target: float
+    supply_actual: float
+    outside_temp: float
+    flow_lph: float
+    hp1_level: int
+    hp2_level: int
+
+
+@dataclass
+class Candidate:
+    hp1_level: int
+    hp2_level: int
+    p_th_w: float
+
+    @property
+    def active_hp_count(self) -> int:
+        return int(self.hp1_level > 0) + int(self.hp2_level > 0)
+
+    @property
+    def topology(self) -> str:
+        if self.active_hp_count == 0:
+            return "off"
+        if self.active_hp_count == 1:
+            return "single"
+        return "duo"
+
+
+@dataclass
+class SimSettings:
+    min_single_dwell_s: int = 900
+    min_duo_dwell_s: int = 900
+    start_penalty_w: float = 1200.0
+    stop_penalty_w: float = 350.0
+    topology_switch_penalty_w: float = 700.0
+    level_step_penalty_w: float = 120.0
+    balance_penalty_w: float = 80.0
+    duo_penalty_w: float = 250.0
+    single_preference_margin_w: float = 500.0
+    max_duo_gap: int = 1
+    duo_enable_margin_w: float = 1200.0
+    duo_disable_margin_w: float = 300.0
+    duo_enable_min_post: int = 16
+    duo_disable_max_post: int = 12
+    only_allow_duo_in_heat: bool = True
+    dual_startup_grace_s: int = 480
+    dual_emergency_hold_min: int = 6
+    dual_emergency_temp_err_c: float = 1.5
+    dual_disable_temp_err_max_c: float = 0.5
+    lead_is_hp1_default: bool = False
+
+
+@dataclass(frozen=True)
+class Policy:
+    name: str
+    description: str
+    target_model: str
+    settings: SimSettings
+    flow_gain: float = 0.0
+    heat_phase_multiplier: float = 1.0
+    coast_phase_multiplier: float = 1.0
+
+
+@dataclass
+class BranchState:
+    previous: Candidate
+    previous_timestamp: datetime
+    previous_curve_post: int
+    previous_topology_change: datetime
+    stored_owner_hp: int
+    dual_enabled: bool
+    dual_enable_hold_min_accum: float
+    dual_disable_hold_min_accum: float
+    dual_emergency_hold_min_accum: float
+    hp1_last_start_ts: Optional[datetime]
+    hp2_last_start_ts: Optional[datetime]
+    lead_is_hp1: bool
+
+
+@dataclass
+class SimulationResult:
+    policy: Policy
+    snapshots: int
+    start_ts: datetime
+    end_ts: datetime
+    actual_hp1_starts: int
+    actual_hp1_stops: int
+    sim_hp1_starts: int
+    sim_hp1_stops: int
+    actual_duo_entries: int
+    sim_duo_entries: int
+    avg_abs_power_error_w: float
+    empirical_target_map: Dict[int, float]
+    differences: List[str]
+
+
+def load_perf_map(path: Path) -> PerfMap:
+    text = path.read_text()
+    t_amb = _parse_1d_array(text, "T_amb_bp")
+    t_sup = _parse_1d_array(text, "T_sup_bp")
+    p_th = _parse_3d_array(text, "P_th_W", dims=(5, 3, 10))
+    return PerfMap(t_amb_bp=t_amb, t_sup_bp=t_sup, p_th_w=p_th)
+
+
+def _parse_1d_array(text: str, name: str) -> List[float]:
+    m = re.search(rf"{name}\[[^]]+\]\s*=\s*\{{([^}}]*)\}}", text)
+    if not m:
+        raise ValueError(f"Could not parse array {name}")
+    return [float(v.replace("f", "")) for v in m.group(1).split(",")]
+
+
+def _parse_3d_array(text: str, name: str, dims: Tuple[int, int, int]) -> List[List[List[float]]]:
+    start = text.index(f"static constexpr float {name}")
+    if name == "P_th_W":
+        end = text.index("static constexpr float COP")
+    else:
+        end = text.index("static inline int find_interval")
+    block = text[start:end]
+    nums = re.findall(r"(-?\d+\.\d+f|NAN)", block)
+    vals = [math.nan if n == "NAN" else float(n[:-1]) for n in nums]
+    it = iter(vals)
+    return [[[next(it) for _ in range(dims[2])] for _ in range(dims[1])] for _ in range(dims[0])]
+
+
+def parse_history_csv(path: Path) -> List[Snapshot]:
+    rows: List[Tuple[datetime, str, str]] = []
+    with path.open() as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            entity_id = row["entity_id"]
+            if entity_id not in TRACKED_ENTITIES:
+                continue
+            timestamp = datetime.fromisoformat(row["last_changed"].replace("Z", "+00:00"))
+            rows.append((timestamp, entity_id, row["state"]))
+    rows.sort()
+
+    current: Dict[str, object] = {}
+    snapshots: List[Snapshot] = []
+    last_key: Optional[Tuple] = None
+
+    for timestamp, entity_id, state in rows:
+        key = TRACKED_ENTITIES[entity_id]
+        current[key] = _normalize_state(key, state)
+        if not _snapshot_ready(current):
+            continue
+        if current["heating_mode"] != CURVE_MODE_LABEL:
+            continue
+
+        snapshot = Snapshot(
+            timestamp=timestamp,
+            heating_mode=str(current["heating_mode"]),
+            control_mode=str(current["control_mode"]),
+            curve_phase=str(current["curve_phase"]),
+            curve_post=int(current["curve_post"]),
+            supply_target=float(current["supply_target"]),
+            supply_actual=float(current["supply_actual"]),
+            outside_temp=float(current["outside_temp"]),
+            flow_lph=float(current["flow_lph"]),
+            hp1_level=int(current["hp1_level"]),
+            hp2_level=int(current["hp2_level"]),
+        )
+        dedupe_key = (
+            snapshot.heating_mode,
+            snapshot.control_mode,
+            snapshot.curve_phase,
+            snapshot.curve_post,
+            round(snapshot.supply_target, 3),
+            round(snapshot.supply_actual, 3),
+            round(snapshot.outside_temp, 3),
+            round(snapshot.flow_lph, 3),
+            snapshot.hp1_level,
+            snapshot.hp2_level,
+        )
+        if dedupe_key != last_key:
+            snapshots.append(snapshot)
+            last_key = dedupe_key
+    return snapshots
+
+
+def _normalize_state(key: str, value: str) -> object:
+    if value in {"unknown", "unavailable", ""}:
+        return value
+    if key in {"curve_post", "hp1_level", "hp2_level"}:
+        return int(round(float(value)))
+    if key in {"supply_target", "supply_actual", "outside_temp", "flow_lph"}:
+        return float(value)
+    return value
+
+
+def _snapshot_ready(current: Dict[str, object]) -> bool:
+    required = {
+        "heating_mode",
+        "control_mode",
+        "curve_phase",
+        "curve_post",
+        "supply_target",
+        "supply_actual",
+        "outside_temp",
+        "flow_lph",
+        "hp1_level",
+        "hp2_level",
+    }
+    if not required.issubset(current):
+        return False
+    for key in required:
+        if current[key] in {"unknown", "unavailable", ""}:
+            return False
+    return True
+
+
+def build_candidates(snapshot: Snapshot, perf_map: PerfMap, settings: SimSettings) -> List[Candidate]:
+    candidates: List[Candidate] = []
+    for hp1 in range(0, 11):
+        for hp2 in range(0, 11):
+            if hp1 > 0 and hp2 > 0 and abs(hp1 - hp2) > settings.max_duo_gap:
+                continue
+            p1 = perf_map.interp_power_th_w(hp1, snapshot.outside_temp, snapshot.supply_target)
+            p2 = perf_map.interp_power_th_w(hp2, snapshot.outside_temp, snapshot.supply_target)
+            if math.isnan(p1) or math.isnan(p2):
+                continue
+            candidates.append(Candidate(hp1_level=hp1, hp2_level=hp2, p_th_w=p1 + p2))
+    candidates.sort(key=lambda c: (c.p_th_w, c.active_hp_count, abs(c.hp1_level - c.hp2_level)))
+    return candidates
+
+
+def target_power_fractional(snapshot: Snapshot, candidates: Sequence[Candidate]) -> float:
+    if not candidates:
+        return 0.0
+    max_power = max(c.p_th_w for c in candidates)
+    return max(0.0, min(1.0, snapshot.curve_post / 20.0)) * max_power
+
+
+def build_empirical_target_map(snapshots: Sequence[Snapshot], perf_map: PerfMap) -> Dict[int, float]:
+    grouped: Dict[int, List[float]] = {}
+    for index in range(1, len(snapshots) - 1):
+        snapshot = snapshots[index]
+        previous = snapshots[index - 1]
+        following = snapshots[index + 1]
+        if snapshot.hp1_level != previous.hp1_level or snapshot.hp2_level != previous.hp2_level:
+            continue
+        if snapshot.hp1_level != following.hp1_level or snapshot.hp2_level != following.hp2_level:
+            continue
+        p_th_w = perf_map.interp_power_th_w(snapshot.hp1_level, snapshot.outside_temp, snapshot.supply_target)
+        p_th_w += perf_map.interp_power_th_w(snapshot.hp2_level, snapshot.outside_temp, snapshot.supply_target)
+        if math.isnan(p_th_w):
+            continue
+        grouped.setdefault(snapshot.curve_post, []).append(p_th_w)
+
+    empirical: Dict[int, float] = {post: _quantile(values, 0.25) for post, values in grouped.items()}
+    if 0 not in empirical:
+        empirical[0] = 0.0
+
+    available = sorted(empirical)
+    for post in range(0, 21):
+        if post in empirical:
+            continue
+        lower = max((x for x in available if x < post), default=None)
+        upper = min((x for x in available if x > post), default=None)
+        if lower is None and upper is None:
+            empirical[post] = 0.0
+        elif lower is None:
+            empirical[post] = empirical[upper]
+        elif upper is None:
+            empirical[post] = empirical[lower]
+        else:
+            weight = (post - lower) / float(upper - lower)
+            empirical[post] = empirical[lower] + (empirical[upper] - empirical[lower]) * weight
+
+    monotone: Dict[int, float] = {}
+    running = 0.0
+    for post in range(0, 21):
+        running = max(running, empirical[post])
+        monotone[post] = running
+    return monotone
+
+
+def _quantile(values: Sequence[float], q: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    idx = int(round((len(ordered) - 1) * q))
+    idx = max(0, min(len(ordered) - 1, idx))
+    return ordered[idx]
+
+
+def target_power_empirical(snapshot: Snapshot, empirical_map: Dict[int, float]) -> float:
+    post = max(0, min(20, snapshot.curve_post))
+    return empirical_map.get(post, 0.0)
+
+
+def target_power_flow(snapshot: Snapshot, candidates: Sequence[Candidate], policy: Policy) -> float:
+    if not candidates:
+        return 0.0
+    dt_c = max(0.0, snapshot.supply_target - snapshot.supply_actual)
+    flow_kg_s = max(0.0, snapshot.flow_lph) / 3600.0
+    target_w = flow_kg_s * 4180.0 * dt_c * policy.flow_gain
+    if snapshot.curve_phase == "HEAT":
+        target_w *= policy.heat_phase_multiplier
+    elif snapshot.curve_phase == "COAST":
+        target_w *= policy.coast_phase_multiplier
+    max_power = max(c.p_th_w for c in candidates)
+    return max(0.0, min(max_power, target_w))
+
+
+def target_power_for_policy(
+    snapshot: Snapshot,
+    candidates: Sequence[Candidate],
+    empirical_map: Dict[int, float],
+    policy: Policy,
+) -> float:
+    if policy.target_model == "empirical":
+        return target_power_empirical(snapshot, empirical_map)
+    if policy.target_model == "flow":
+        return target_power_flow(snapshot, candidates, policy)
+    if policy.target_model == "hybrid_max":
+        return max(
+            target_power_empirical(snapshot, empirical_map),
+            target_power_flow(snapshot, candidates, policy),
+        )
+    raise ValueError(f"Unsupported target model: {policy.target_model}")
+
+
+def choose_levelcombination(
+    snapshot: Snapshot,
+    candidates: Sequence[Candidate],
+    target_power_w: float,
+    previous: Candidate,
+    previous_topology_change: datetime,
+    settings: SimSettings,
+) -> Candidate:
+    current_topology = previous.topology
+    elapsed_s = max(0.0, (snapshot.timestamp - previous_topology_change).total_seconds())
+    single_candidates = [candidate for candidate in candidates if candidate.topology == "single"]
+    duo_candidates = [candidate for candidate in candidates if candidate.topology == "duo"]
+    off_candidates = [candidate for candidate in candidates if candidate.topology == "off"]
+
+    best_single = _best_candidate_for_topology(single_candidates, target_power_w, previous, settings)
+    best_duo = _best_candidate_for_topology(duo_candidates, target_power_w, previous, settings)
+    best_off = _best_candidate_for_topology(off_candidates, target_power_w, previous, settings)
+
+    if target_power_w <= 1.0:
+        return best_off or Candidate(0, 0, 0.0)
+
+    single_allowed = best_single is not None
+    duo_allowed = best_duo is not None
+    if settings.only_allow_duo_in_heat and snapshot.curve_phase != "HEAT":
+        duo_allowed = False
+    if snapshot.curve_post < settings.duo_enable_min_post:
+        duo_allowed = False
+
+    single_err = abs(best_single.p_th_w - target_power_w) if best_single else math.inf
+    duo_err = abs(best_duo.p_th_w - target_power_w) if best_duo else math.inf
+
+    if current_topology == "duo":
+        if elapsed_s < settings.min_duo_dwell_s:
+            return best_duo or best_single or previous
+        if snapshot.curve_post <= settings.duo_disable_max_post and single_allowed:
+            if single_err <= (duo_err + settings.duo_disable_margin_w):
+                return best_single
+        return best_duo or best_single or previous
+
+    if current_topology == "single":
+        if elapsed_s < settings.min_single_dwell_s:
+            return best_single or best_duo or previous
+        if duo_allowed and best_single is not None:
+            if duo_err + settings.duo_enable_margin_w < single_err:
+                return best_duo
+        return best_single or best_duo or previous
+
+    if duo_allowed and best_single is not None:
+        if duo_err + settings.duo_enable_margin_w < single_err:
+            return best_duo
+    return best_single or best_duo or previous
+
+
+def choose_branch_strategy_levelcombination(
+    snapshot: Snapshot,
+    perf_map: PerfMap,
+    previous: Candidate,
+    state: BranchState,
+    settings: SimSettings,
+) -> Tuple[Candidate, BranchState, float]:
+    demand_active = snapshot.curve_post > 0
+    heat_phase = snapshot.curve_phase == "HEAT" and demand_active
+    demand_rundown = snapshot.curve_post <= state.previous_curve_post
+    temp_err_c = snapshot.supply_target - snapshot.supply_actual
+
+    prev_hp1_on = previous.hp1_level > 0
+    prev_hp2_on = previous.hp2_level > 0
+    if not demand_active:
+        single_owner = 0
+    elif prev_hp1_on != prev_hp2_on:
+        single_owner = 1 if prev_hp1_on else 2
+    elif state.stored_owner_hp in {1, 2}:
+        single_owner = state.stored_owner_hp
+    else:
+        single_owner = 1 if state.lead_is_hp1 else 2
+
+    hp1_max_single = 10
+    hp2_max_single = 10
+    owner_max_single = hp1_max_single if single_owner == 1 else hp2_max_single
+    owner_cap_w = perf_map.interp_power_th_w(owner_max_single, snapshot.outside_temp, snapshot.supply_target)
+
+    duo_cap_w = 0.0
+    best_duo = Candidate(0, 0, 0.0)
+    duo_candidates: List[Candidate] = []
+    for hp1_level in range(1, hp1_max_single + 1):
+        for hp2_level in range(1, hp2_max_single + 1):
+            if abs(hp1_level - hp2_level) > settings.max_duo_gap:
+                continue
+            p_th_w = perf_map.interp_power_th_w(hp1_level, snapshot.outside_temp, snapshot.supply_target)
+            p_th_w += perf_map.interp_power_th_w(hp2_level, snapshot.outside_temp, snapshot.supply_target)
+            candidate = Candidate(hp1_level=hp1_level, hp2_level=hp2_level, p_th_w=p_th_w)
+            duo_candidates.append(candidate)
+            duo_cap_w = max(duo_cap_w, p_th_w)
+
+    demand_u = max(0.0, min(1.0, snapshot.curve_post / 20.0))
+    target_power_w = (owner_cap_w if heat_phase else duo_cap_w) * demand_u if demand_active else 0.0
+
+    def better_branch_candidate(candidate: Candidate, best: Optional[Candidate]) -> bool:
+        if best is None:
+            return True
+        candidate_error = abs(candidate.p_th_w - target_power_w)
+        best_error = abs(best.p_th_w - target_power_w)
+        if abs(candidate_error - best_error) > 50.0:
+            return candidate_error < best_error
+        candidate_starts = int(previous.hp1_level == 0 and candidate.hp1_level > 0) + int(
+            previous.hp2_level == 0 and candidate.hp2_level > 0
+        )
+        best_starts = int(previous.hp1_level == 0 and best.hp1_level > 0) + int(
+            previous.hp2_level == 0 and best.hp2_level > 0
+        )
+        if candidate_starts != best_starts:
+            return candidate_starts < best_starts
+        candidate_moves = abs(candidate.hp1_level - previous.hp1_level) + abs(candidate.hp2_level - previous.hp2_level)
+        best_moves = abs(best.hp1_level - previous.hp1_level) + abs(best.hp2_level - previous.hp2_level)
+        if candidate_moves != best_moves:
+            return candidate_moves < best_moves
+        candidate_active = candidate.active_hp_count
+        best_active = best.active_hp_count
+        if candidate_active != best_active:
+            return candidate_active < best_active
+        candidate_gap = abs(candidate.hp1_level - candidate.hp2_level)
+        best_gap = abs(best.hp1_level - best.hp2_level)
+        if candidate_gap != best_gap:
+            return candidate_gap < best_gap
+        return candidate.p_th_w < best.p_th_w
+
+    best_single: Optional[Candidate] = None
+    if demand_active and single_owner == 1:
+        for hp1_level in range(1, hp1_max_single + 1):
+            candidate = Candidate(
+                hp1_level=hp1_level,
+                hp2_level=0,
+                p_th_w=perf_map.interp_power_th_w(hp1_level, snapshot.outside_temp, snapshot.supply_target),
+            )
+            if better_branch_candidate(candidate, best_single):
+                best_single = candidate
+    elif demand_active and single_owner == 2:
+        for hp2_level in range(1, hp2_max_single + 1):
+            candidate = Candidate(
+                hp1_level=0,
+                hp2_level=hp2_level,
+                p_th_w=perf_map.interp_power_th_w(hp2_level, snapshot.outside_temp, snapshot.supply_target),
+            )
+            if better_branch_candidate(candidate, best_single):
+                best_single = candidate
+
+    best_duo_opt: Optional[Candidate] = None
+    if demand_active:
+        for candidate in duo_candidates:
+            if better_branch_candidate(candidate, best_duo_opt):
+                best_duo_opt = candidate
+    if best_duo_opt is not None:
+        best_duo = best_duo_opt
+
+    lead_last_start = state.hp1_last_start_ts if state.lead_is_hp1 else state.hp2_last_start_ts
+    startup_grace_active = (
+        lead_last_start is not None
+        and (snapshot.timestamp - lead_last_start).total_seconds() < settings.dual_startup_grace_s
+    )
+    duo_enable_margin_w = 700.0 if heat_phase else 450.0
+    duo_disable_margin_w = 250.0
+    duo_enable_min_post = 18 if heat_phase else 16
+    duo_disable_max_post = 14 if heat_phase else 11
+    single_saturated = best_single is not None and (
+        best_single.hp1_level >= max(6, hp1_max_single - 1)
+        or best_single.hp2_level >= max(6, hp2_max_single - 1)
+    )
+    duo_clearly_better = (
+        best_single is not None
+        and best_duo_opt is not None
+        and (abs(best_duo_opt.p_th_w - target_power_w) + duo_enable_margin_w < abs(best_single.p_th_w - target_power_w))
+    )
+    single_good_enough = (
+        best_single is not None
+        and (
+            best_duo_opt is None
+            or abs(best_single.p_th_w - target_power_w) <= abs(best_duo_opt.p_th_w - target_power_w) + duo_disable_margin_w
+        )
+    )
+    emergency_dual_condition = (
+        demand_active
+        and best_duo_opt is not None
+        and heat_phase
+        and not startup_grace_active
+        and temp_err_c >= settings.dual_emergency_temp_err_c
+        and snapshot.curve_post >= 19
+    )
+
+    dt_min = max(0.0, (snapshot.timestamp - state.previous_timestamp).total_seconds()) / 60.0
+    dual_emergency_accum = state.dual_emergency_hold_min_accum + dt_min if emergency_dual_condition else 0.0
+    force_dual_capacity = dual_emergency_accum >= settings.dual_emergency_hold_min
+    dual_on_condition = (
+        demand_active
+        and best_duo_opt is not None
+        and not startup_grace_active
+        and not demand_rundown
+        and (
+            force_dual_capacity
+            or (
+                duo_clearly_better
+                and snapshot.curve_post >= duo_enable_min_post
+                and (single_saturated if heat_phase else not single_good_enough)
+                and temp_err_c >= -0.05
+            )
+        )
+    )
+    dual_off_condition = (
+        (not demand_active)
+        or (best_duo_opt is None)
+        or ((not state.dual_enabled) and (not dual_on_condition))
+        or (
+            single_good_enough
+            and snapshot.curve_post <= duo_disable_max_post
+            and temp_err_c <= settings.dual_disable_temp_err_max_c
+        )
+    )
+
+    if not demand_active:
+        dual_enabled = False
+        dual_enable_accum = 0.0
+        dual_disable_accum = 0.0
+        dual_emergency_accum = 0.0
+    else:
+        dual_enable_accum = state.dual_enable_hold_min_accum + dt_min if dual_on_condition else 0.0
+        dual_disable_accum = state.dual_disable_hold_min_accum + dt_min if dual_off_condition else 0.0
+        dual_enabled = state.dual_enabled
+        if (not dual_enabled) and dual_enable_accum >= 3.0:
+            dual_enabled = True
+            dual_disable_accum = 0.0
+        elif dual_enabled and dual_disable_accum >= 5.0:
+            dual_enabled = False
+            dual_enable_accum = 0.0
+
+    if not demand_active:
+        choice = Candidate(0, 0, 0.0)
+        stored_owner_hp = 0
+    elif dual_enabled and best_duo_opt is not None:
+        choice = best_duo_opt
+        stored_owner_hp = 0
+    else:
+        choice = best_single or Candidate(0, 0, 0.0)
+        stored_owner_hp = single_owner if choice.active_hp_count == 1 else 0
+
+    hp1_last_start_ts = state.hp1_last_start_ts
+    hp2_last_start_ts = state.hp2_last_start_ts
+    if previous.hp1_level == 0 and choice.hp1_level > 0:
+        hp1_last_start_ts = snapshot.timestamp
+    if previous.hp2_level == 0 and choice.hp2_level > 0:
+        hp2_last_start_ts = snapshot.timestamp
+
+    new_topology_change = state.previous_topology_change
+    if choice.topology != previous.topology:
+        new_topology_change = snapshot.timestamp
+
+    new_state = BranchState(
+        previous=choice,
+        previous_timestamp=snapshot.timestamp,
+        previous_curve_post=snapshot.curve_post,
+        previous_topology_change=new_topology_change,
+        stored_owner_hp=stored_owner_hp,
+        dual_enabled=dual_enabled,
+        dual_enable_hold_min_accum=dual_enable_accum,
+        dual_disable_hold_min_accum=dual_disable_accum,
+        dual_emergency_hold_min_accum=dual_emergency_accum,
+        hp1_last_start_ts=hp1_last_start_ts,
+        hp2_last_start_ts=hp2_last_start_ts,
+        lead_is_hp1=state.lead_is_hp1,
+    )
+    return choice, new_state, target_power_w
+
+
+def _best_candidate_for_topology(
+    candidates: Sequence[Candidate],
+    target_power_w: float,
+    previous: Candidate,
+    settings: SimSettings,
+) -> Optional[Candidate]:
+    best: Optional[Candidate] = None
+    best_score = math.inf
+    for candidate in candidates:
+        score = abs(candidate.p_th_w - target_power_w)
+
+        starts = int(previous.hp1_level == 0 and candidate.hp1_level > 0) + int(
+            previous.hp2_level == 0 and candidate.hp2_level > 0
+        )
+        stops = int(previous.hp1_level > 0 and candidate.hp1_level == 0) + int(
+            previous.hp2_level > 0 and candidate.hp2_level == 0
+        )
+        score += starts * settings.start_penalty_w
+        score += stops * settings.stop_penalty_w
+        score += (
+            abs(candidate.hp1_level - previous.hp1_level)
+            + abs(candidate.hp2_level - previous.hp2_level)
+        ) * settings.level_step_penalty_w
+        if candidate.active_hp_count == 2:
+            score += settings.duo_penalty_w
+            score += abs(candidate.hp1_level - candidate.hp2_level) * settings.balance_penalty_w
+        if score < best_score:
+            best = candidate
+            best_score = score
+    return best
+
+
+def count_hp1_starts_stops(levels: Iterable[Tuple[int, int]]) -> Tuple[int, int]:
+    starts = 0
+    stops = 0
+    previous: Optional[int] = None
+    for hp1, _ in levels:
+        if previous is not None:
+            if previous == 0 and hp1 > 0:
+                starts += 1
+            elif previous > 0 and hp1 == 0:
+                stops += 1
+        previous = hp1
+    return starts, stops
+
+
+def run_policy(
+    snapshots: Sequence[Snapshot],
+    perf_map: PerfMap,
+    empirical_target_map: Dict[int, float],
+    policy: Policy,
+) -> SimulationResult:
+    simulated: List[Tuple[Snapshot, Candidate, float]] = []
+    first = snapshots[0]
+    previous = Candidate(first.hp1_level, first.hp2_level, 0.0)
+    previous_topology_change = first.timestamp
+    branch_state = BranchState(
+        previous=previous,
+        previous_timestamp=first.timestamp,
+        previous_curve_post=first.curve_post,
+        previous_topology_change=first.timestamp,
+        stored_owner_hp=1 if first.hp1_level > 0 else (2 if first.hp2_level > 0 else 0),
+        dual_enabled=previous.topology == "duo",
+        dual_enable_hold_min_accum=0.0,
+        dual_disable_hold_min_accum=0.0,
+        dual_emergency_hold_min_accum=0.0,
+        hp1_last_start_ts=first.timestamp if first.hp1_level > 0 else None,
+        hp2_last_start_ts=first.timestamp if first.hp2_level > 0 else None,
+        lead_is_hp1=(first.hp1_level > 0 and first.hp2_level == 0) or policy.settings.lead_is_hp1_default,
+    )
+
+    for snapshot in snapshots:
+        candidates = build_candidates(snapshot, perf_map, policy.settings)
+        if policy.target_model == "branch_strategy":
+            choice, branch_state, target_power = choose_branch_strategy_levelcombination(
+                snapshot=snapshot,
+                perf_map=perf_map,
+                previous=previous,
+                state=branch_state,
+                settings=policy.settings,
+            )
+            previous_topology_change = branch_state.previous_topology_change
+        else:
+            target_power = target_power_for_policy(snapshot, candidates, empirical_target_map, policy)
+            choice = choose_levelcombination(
+                snapshot=snapshot,
+                candidates=candidates,
+                target_power_w=target_power,
+                previous=previous,
+                previous_topology_change=previous_topology_change,
+                settings=policy.settings,
+            )
+            if choice.topology != previous.topology:
+                previous_topology_change = snapshot.timestamp
+        if math.isnan(target_power):
+            target_power = 0.0
+        previous = choice
+        simulated.append((snapshot, choice, target_power))
+
+    actual_levels = [(s.hp1_level, s.hp2_level) for s in snapshots]
+    sim_levels = [(c.hp1_level, c.hp2_level) for _, c, _ in simulated]
+    actual_starts, actual_stops = count_hp1_starts_stops(actual_levels)
+    sim_starts, sim_stops = count_hp1_starts_stops(sim_levels)
+    actual_duo = _count_topology_entries(actual_levels, "duo")
+    sim_duo = _count_topology_entries(sim_levels, "duo")
+
+    power_errors: List[float] = []
+    differences: List[str] = []
+    for snapshot, choice, target_power in simulated:
+        actual_power = perf_map.interp_power_th_w(snapshot.hp1_level, snapshot.outside_temp, snapshot.supply_target)
+        actual_power += perf_map.interp_power_th_w(snapshot.hp2_level, snapshot.outside_temp, snapshot.supply_target)
+        if not math.isnan(choice.p_th_w):
+            power_errors.append(abs(choice.p_th_w - target_power))
+        if (snapshot.hp1_level, snapshot.hp2_level) != (choice.hp1_level, choice.hp2_level) and len(differences) < 20:
+            differences.append(
+                f"- {snapshot.timestamp.isoformat()} "
+                f"post={snapshot.curve_post:2d} phase={snapshot.curve_phase.lower():8s} "
+                f"sp={snapshot.supply_target:5.2f} pv={snapshot.supply_actual:5.2f} "
+                f"actual={snapshot.hp1_level}+{snapshot.hp2_level} ({round(actual_power):4d}W) "
+                f"sim={choice.hp1_level}+{choice.hp2_level} ({round(choice.p_th_w):4d}W) "
+                f"target~{round(target_power):4d}W"
+            )
+
+    avg_abs_power_error = sum(power_errors) / len(power_errors) if power_errors else 0.0
+    return SimulationResult(
+        policy=policy,
+        snapshots=len(snapshots),
+        start_ts=snapshots[0].timestamp,
+        end_ts=snapshots[-1].timestamp,
+        actual_hp1_starts=actual_starts,
+        actual_hp1_stops=actual_stops,
+        sim_hp1_starts=sim_starts,
+        sim_hp1_stops=sim_stops,
+        actual_duo_entries=actual_duo,
+        sim_duo_entries=sim_duo,
+        avg_abs_power_error_w=avg_abs_power_error,
+        empirical_target_map=empirical_target_map,
+        differences=differences,
+    )
+
+
+def build_policies() -> List[Policy]:
+    base = SimSettings()
+    return [
+        Policy(
+            name="branch_strategy_dispatch",
+            description="Replay the current branch strategy more literally: single-first in HEAT, balanced duo only with held curve-side gating.",
+            target_model="branch_strategy",
+            settings=replace(
+                base,
+                min_single_dwell_s=0,
+                min_duo_dwell_s=0,
+                duo_enable_margin_w=700.0,
+                duo_disable_margin_w=250.0,
+                duo_enable_min_post=16,
+                duo_disable_max_post=11,
+                start_penalty_w=1200.0,
+                duo_penalty_w=250.0,
+                max_duo_gap=1,
+                only_allow_duo_in_heat=False,
+                lead_is_hp1_default=False,
+            ),
+        ),
+        Policy(
+            name="single_first_empirical",
+            description="Empirical post_guardrail target, strong single preference, duo only for clear sustained deficits.",
+            target_model="empirical",
+            settings=replace(
+                base,
+                min_single_dwell_s=900,
+                min_duo_dwell_s=1200,
+                duo_enable_margin_w=1400.0,
+                duo_disable_margin_w=250.0,
+                duo_enable_min_post=17,
+                duo_disable_max_post=11,
+                start_penalty_w=1400.0,
+                duo_penalty_w=350.0,
+                max_duo_gap=1,
+            ),
+        ),
+        Policy(
+            name="flow_delta_stateful",
+            description="Flow*dT target with topology hysteresis; should react more physically to supply error.",
+            target_model="flow",
+            settings=replace(
+                base,
+                min_single_dwell_s=900,
+                min_duo_dwell_s=900,
+                duo_enable_margin_w=1000.0,
+                duo_disable_margin_w=300.0,
+                duo_enable_min_post=15,
+                duo_disable_max_post=10,
+                start_penalty_w=1100.0,
+                duo_penalty_w=220.0,
+                max_duo_gap=1,
+            ),
+            flow_gain=2.2,
+            heat_phase_multiplier=1.0,
+            coast_phase_multiplier=0.9,
+        ),
+        Policy(
+            name="hybrid_curve_dispatch",
+            description="Max of empirical intent and flow*dT, with conservative duo gating and balanced-duo preference.",
+            target_model="hybrid_max",
+            settings=replace(
+                base,
+                min_single_dwell_s=900,
+                min_duo_dwell_s=1200,
+                duo_enable_margin_w=1250.0,
+                duo_disable_margin_w=250.0,
+                duo_enable_min_post=16,
+                duo_disable_max_post=11,
+                start_penalty_w=1250.0,
+                duo_penalty_w=260.0,
+                max_duo_gap=1,
+            ),
+            flow_gain=1.8,
+            heat_phase_multiplier=1.0,
+            coast_phase_multiplier=0.85,
+        ),
+    ]
+
+
+def run_simulations(snapshots: Sequence[Snapshot], perf_map: PerfMap) -> List[SimulationResult]:
+    if not snapshots:
+        raise SystemExit("No usable heating-curve snapshots found in CSV.")
+    empirical_target_map = build_empirical_target_map(snapshots, perf_map)
+    return [run_policy(snapshots, perf_map, empirical_target_map, policy) for policy in build_policies()]
+
+
+def print_results(results: Sequence[SimulationResult]) -> None:
+    first = results[0]
+    print("Heating-curve dispatch replay")
+    print(f"- snapshots: {first.snapshots}")
+    print(f"- period: {first.start_ts.isoformat()} -> {first.end_ts.isoformat()}")
+    print(f"- actual HP1 starts/stops: {first.actual_hp1_starts}/{first.actual_hp1_stops}")
+    print(f"- actual duo entries: {first.actual_duo_entries}")
+    print("- empirical target power by post_guardrail:")
+    print("  " + ", ".join(f"{post}:{round(first.empirical_target_map[post])}" for post in range(0, 21)))
+    print()
+    print("Policy comparison")
+    for result in sorted(results, key=lambda item: (item.sim_hp1_starts, item.sim_duo_entries, item.avg_abs_power_error_w)):
+        print(
+            f"- {result.policy.name}: HP1 starts/stops {result.sim_hp1_starts}/{result.sim_hp1_stops}, "
+            f"duo entries {result.sim_duo_entries}, avg |P_target-P_sim| {round(result.avg_abs_power_error_w)} W"
+        )
+        print(f"  {result.policy.description}")
+    print()
+    best = sorted(results, key=lambda item: (item.sim_hp1_starts, item.sim_duo_entries, item.avg_abs_power_error_w))[0]
+    print(f"Best current candidate: {best.policy.name}")
+    print("First 20 meaningful differences")
+    for line in best.differences:
+        print(line)
+
+
+def _count_topology_entries(levels: Sequence[Tuple[int, int]], topology: str) -> int:
+    count = 0
+    previous = "off"
+    for hp1, hp2 in levels:
+        current = _topology_for_levels(hp1, hp2)
+        if current == topology and previous != topology:
+            count += 1
+        previous = current
+    return count
+
+
+def _topology_for_levels(hp1: int, hp2: int) -> str:
+    active = int(hp1 > 0) + int(hp2 > 0)
+    if active == 0:
+        return "off"
+    if active == 1:
+        return "single"
+    return "duo"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("history_csv", type=Path, help="Home Assistant history export CSV")
+    parser.add_argument(
+        "--perf-map",
+        type=Path,
+        default=Path("openquatt/includes/hp_perf_map.h"),
+        help="Path to hp_perf_map.h",
+    )
+    parser.add_argument("--min-single-dwell-s", type=int, default=900)
+    parser.add_argument("--min-duo-dwell-s", type=int, default=900)
+    parser.add_argument("--max-duo-gap", type=int, default=1)
+    parser.add_argument(
+        "--last-hours",
+        type=float,
+        default=0.0,
+        help="Only simulate the trailing N hours of the export (0 = full file)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    perf_map = load_perf_map(args.perf_map)
+    snapshots = parse_history_csv(args.history_csv)
+    if args.last_hours and snapshots:
+        cutoff = snapshots[-1].timestamp - timedelta(hours=args.last_hours)
+        snapshots = [snapshot for snapshot in snapshots if snapshot.timestamp >= cutoff]
+    results = run_simulations(snapshots, perf_map)
+    if args.max_duo_gap != 1 or args.min_single_dwell_s != 900 or args.min_duo_dwell_s != 900:
+        print("Note: CLI dwell/max-gap overrides are not yet wired into the named policy presets.")
+        print()
+    print_results(results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- move heating-curve HP1/HP2 dispatch selection into `oq_heating_curve_strategy.yaml`
- remove curve-specific topology/split decisions from `oq_thermal_request_control.yaml`
- keep `oq_thermal_request_control.yaml` focused on generic request publication, exclusions, slew and runtime guards
- make curve dispatch treat the PID output as a relative heat-intent signal instead of an implicit absolute level command
- add diagnostics for curve dispatch output and capacity mode
- add a replay simulator to compare branch dispatch behavior against exported history runs

## Why
Heating curve had accumulated too much behavior in `oq_thermal_request_control.yaml`. That made it hard to reason about where curve behavior really came from, and it also blurred the boundary introduced in PR73/74.

This PR pulls curve topology and dispatch decisions back into the curve strategy package itself:
- `HEAT` keeps a strong single-first bias so recovery starts on one HP before duo is considered
- `COAST` can keep or choose a balanced duo combination when stable high load really needs it
- the PID now acts more explicitly as a relative gas pedal; dispatch translates that relative intent into a concrete HP1/HP2 level combination

## Scope
This PR does **not** add new user-facing tuning controls. Existing curve points, PID settings and `Comfort / Balanced / Stable` remain the main control surface.

## Validation
- `python3 scripts/dev.py validate`
- `python3 scripts/simulate_heating_curve_history.py "/Users/jeroen/Downloads/history (1).csv" --last-hours 3`

## Replay notes
The branch-specific replay still shows the intended topology improvement clearly:
- actual last-3-hours run: `17/17` HP1 starts/stops, `18` duo entries
- branch strategy replay: `0/0` HP1 starts/stops, `0` duo entries

The replay also suggests there is still room to refine the target-power scaling used by dispatch, but the topology direction itself looks much healthier.

## Notes
This intentionally leaves only actuator-side guardrails in `oq_thermal_request_control.yaml`. Curve topology and curve dispatch semantics now live in the strategy package, in line with the PR73/74 split.
