### PR TITLE
Tighten curve dispatch braking and dual gating

### DIFF
--- a/openquatt/includes/oq_heating_curve_logic.h
+++ b/openquatt/includes/oq_heating_curve_logic.h
@@ -149,11 +149,13 @@ inline float normalized_demand_u(float demand_continuous, int demand_max_f) {
 
 inline float phase_target_power_w(bool heat_phase,
                                   float demand_u,
+                                  float dispatch_u,
                                   float single_cap_w,
                                   float duo_cap_w) {
-  if (demand_u <= 0.0f) return 0.0f;
-  const float single_target_w = isnan(single_cap_w) ? 0.0f : (single_cap_w * demand_u);
-  const float duo_target_w = isnan(duo_cap_w) ? single_target_w : (duo_cap_w * demand_u);
+  const float effective_u = heat_phase ? demand_u : std::min(demand_u, dispatch_u);
+  if (effective_u <= 0.0f) return 0.0f;
+  const float single_target_w = isnan(single_cap_w) ? 0.0f : (single_cap_w * effective_u);
+  const float duo_target_w = isnan(duo_cap_w) ? single_target_w : (duo_cap_w * effective_u);
   return heat_phase ? single_target_w : duo_target_w;
 }
 

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -1045,6 +1045,7 @@ interval:
           float demand_continuous = id(oq_curve_demand_continuous);
           if (isnan(demand_continuous)) demand_continuous = (float) f;
           const float demand_u = oq_curve::normalized_demand_u(demand_continuous, demand_max_f);
+          const float dispatch_u = oq_curve::normalized_demand_u((float) f, demand_max_f);
           #if OQ_TOPOLOGY_DUO
           const auto tuning = oq_curve::control_profile(
               id(oq_curve_control_profile).has_state()
@@ -1121,9 +1122,9 @@ interval:
             }
           }
 
-          const bool demand_rundown = (demand_continuous <= (float) prev_curve_post);
+          const bool demand_rundown = (f < prev_curve_post);
           const float target_power_w =
-              demand_active ? oq_curve::phase_target_power_w(heat_phase, demand_u, owner_cap_w, duo_cap_w) : 0.0f;
+              demand_active ? oq_curve::phase_target_power_w(heat_phase, demand_u, dispatch_u, owner_cap_w, duo_cap_w) : 0.0f;
 
           oq_curve::DispatchCandidate best_single = oq_curve::invalid_dispatch_candidate();
           if (demand_active && single_owner == 1) {
@@ -1177,9 +1178,12 @@ interval:
           const bool emergency_dual_condition =
               demand_active && best_duo.valid && heat_phase &&
               !startup_grace_active &&
+              !demand_rundown &&
+              single_saturated &&
+              duo_clearly_better &&
               !isnan(temp_err_c) &&
               (temp_err_c >= tuning.dual_emergency_temp_err_c) &&
-              (demand_u >= 0.95f);
+              (dispatch_u >= 0.95f);
 
           if (emergency_dual_condition) {
             id(oq_dual_hp_emergency_hold_elapsed_accum_min) += dt_min;
@@ -1196,7 +1200,7 @@ interval:
               !demand_rundown &&
               (force_dual_capacity || force_dual_defrost ||
                (duo_clearly_better &&
-                (demand_u >= duo_enable_min_u) &&
+                (dispatch_u >= duo_enable_min_u) &&
                 (heat_phase ? single_saturated : !single_good_enough) &&
                 (isnan(temp_err_c) || temp_err_c >= -0.05f)));
           const bool dual_off_condition =
@@ -1204,7 +1208,7 @@ interval:
               (!best_duo.valid) ||
               (!id(oq_dual_hp_enabled) && !dual_on_condition) ||
               (single_good_enough &&
-               (demand_u <= duo_disable_max_u) &&
+               (dispatch_u <= duo_disable_max_u) &&
                (isnan(temp_err_c) || temp_err_c <= tuning.dual_disable_temp_err_max_c));
 
           if (!demand_active) {

--- a/scripts/simulate_heating_curve_history.py
+++ b/scripts/simulate_heating_curve_history.py
@@ -24,6 +24,7 @@ TRACKED_ENTITIES = {
     "select.openquatt_heating_control_mode": "heating_mode",
     "sensor.openquatt_control_mode_label": "control_mode",
     "sensor.openquatt_curve_phase": "curve_phase",
+    "sensor.openquatt_demand_curve_continuous": "curve_continuous",
     "sensor.openquatt_demand_curve_post_guardrail": "curve_post",
     "sensor.openquatt_heating_curve_supply_target": "supply_target",
     "sensor.openquatt_water_supply_temp_selected": "supply_actual",
@@ -83,6 +84,7 @@ class Snapshot:
     heating_mode: str
     control_mode: str
     curve_phase: str
+    curve_continuous: float
     curve_post: int
     supply_target: float
     supply_actual: float
@@ -236,6 +238,7 @@ def parse_history_csv(path: Path) -> List[Snapshot]:
             heating_mode=str(current["heating_mode"]),
             control_mode=str(current["control_mode"]),
             curve_phase=str(current["curve_phase"]),
+            curve_continuous=_curve_continuous_value(current),
             curve_post=int(current["curve_post"]),
             supply_target=float(current["supply_target"]),
             supply_actual=float(current["supply_actual"]),
@@ -248,6 +251,7 @@ def parse_history_csv(path: Path) -> List[Snapshot]:
             snapshot.heating_mode,
             snapshot.control_mode,
             snapshot.curve_phase,
+            round(snapshot.curve_continuous, 3),
             snapshot.curve_post,
             round(snapshot.supply_target, 3),
             round(snapshot.supply_actual, 3),
@@ -267,7 +271,7 @@ def _normalize_state(key: str, value: str) -> object:
         return value
     if key in {"curve_post", "hp1_level", "hp2_level"}:
         return int(round(float(value)))
-    if key in {"supply_target", "supply_actual", "outside_temp", "flow_lph"}:
+    if key in {"curve_continuous", "supply_target", "supply_actual", "outside_temp", "flow_lph"}:
         return float(value)
     return value
 
@@ -291,6 +295,13 @@ def _snapshot_ready(current: Dict[str, object]) -> bool:
         if current[key] in {"unknown", "unavailable", ""}:
             return False
     return True
+
+
+def _curve_continuous_value(current: Dict[str, object]) -> float:
+    value = current.get("curve_continuous")
+    if isinstance(value, (float, int)):
+        return float(value)
+    return float(current["curve_post"])
 
 
 def build_candidates(snapshot: Snapshot, perf_map: PerfMap, settings: SimSettings) -> List[Candidate]:
@@ -467,7 +478,7 @@ def choose_branch_strategy_levelcombination(
 ) -> Tuple[Candidate, BranchState, float]:
     demand_active = snapshot.curve_post > 0
     heat_phase = snapshot.curve_phase == "HEAT" and demand_active
-    demand_rundown = snapshot.curve_post <= state.previous_curve_post
+    demand_rundown = snapshot.curve_post < state.previous_curve_post
     temp_err_c = snapshot.supply_target - snapshot.supply_actual
 
     prev_hp1_on = previous.hp1_level > 0
@@ -499,8 +510,10 @@ def choose_branch_strategy_levelcombination(
             duo_candidates.append(candidate)
             duo_cap_w = max(duo_cap_w, p_th_w)
 
-    demand_u = max(0.0, min(1.0, snapshot.curve_post / 20.0))
-    target_power_w = (owner_cap_w if heat_phase else duo_cap_w) * demand_u if demand_active else 0.0
+    demand_u = max(0.0, min(1.0, snapshot.curve_continuous / 20.0))
+    dispatch_u = max(0.0, min(1.0, snapshot.curve_post / 20.0))
+    effective_u = demand_u if heat_phase else min(demand_u, dispatch_u)
+    target_power_w = (owner_cap_w if heat_phase else duo_cap_w) * effective_u if demand_active else 0.0
 
     def better_branch_candidate(candidate: Candidate, best: Optional[Candidate]) -> bool:
         if best is None:
@@ -589,8 +602,11 @@ def choose_branch_strategy_levelcombination(
         and best_duo_opt is not None
         and heat_phase
         and not startup_grace_active
+        and not demand_rundown
+        and single_saturated
+        and duo_clearly_better
         and temp_err_c >= settings.dual_emergency_temp_err_c
-        and snapshot.curve_post >= 19
+        and dispatch_u >= 0.95
     )
 
     dt_min = max(0.0, (snapshot.timestamp - state.previous_timestamp).total_seconds()) / 60.0


### PR DESCRIPTION
## Summary
- tighten the curve emergency-dual path so it only acts as a real backstop instead of a transient duo pulse
- make maintain/coast dispatch honor the clamped post-guardrail curve demand instead of the stickier continuous PID output
- update the replay simulator to track `Demand Curve (continuous)` and mirror the stricter branch dispatch logic

## Why
The first run on the new strategy-side dispatch still showed two clear problems:
- a pointless short `single -> duo -> single` switch around 2026-04-06 18:54 CEST
- maintain staying too sticky on a high single level even after the post-guardrail demand had already collapsed

This follow-up keeps the architecture from PR #81, but tightens the two remaining behaviors that the CSV review called out.

## Replay notes
On `/Users/jeroen/Downloads/history (2).csv`:
- actual run: `1` duo entry
- `branch_strategy_dispatch`: `0` duo entries
- `flow_delta_stateful`: still wants `1` duo entry, which matches the conclusion that `flow*dT` is not helping this case

On `/Users/jeroen/Downloads/history (1).csv --last-hours 3`:
- actual run: `17/17` HP1 starts/stops and `18` duo entries
- `branch_strategy_dispatch`: `0/0` HP1 starts/stops and `0` duo entries

## Validation
- `python3 -m py_compile scripts/simulate_heating_curve_history.py scripts/dev.py`
- `python3 scripts/simulate_heating_curve_history.py '/Users/jeroen/Downloads/history (2).csv'`
- `python3 scripts/simulate_heating_curve_history.py '/Users/jeroen/Downloads/history (1).csv' --last-hours 3`
- `python3 scripts/dev.py validate`
  - style/docs/config stages were green
  - compile phase in this worktree again stalled in the long-running duo compile step without returning a final summary
