### PR TITLE
Stabilize Power House warm-side pullback and defrost handoffs

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2318,17 +2318,15 @@ views:
               - **Maximum heating outdoor temperature** is the point where model
               heat demand approaches ~0.
 
-              - **PH temperature reaction** defines how strongly room
-              temperature error outside the comfort band is translated into heat
-              demand (W).
+              - **PH temperature reaction** defines how strongly Power House
+              adds heat below the cold comfort edge and how strongly it starts
+              pulling heat back again above room setpoint.
 
-              - **Comfort above setpoint** defines how much room above setpoint
-              is still acceptable before warm-side correction starts.
+              - **Comfort above setpoint** defines the acceptable upper side of
+              the comfort band.
 
               - **Comfort below setpoint** is the cold-side margin below
               setpoint before extra heating correction starts.
-
-              - Inside this comfort band, extra room correction stays `0`.
 
               - If the room stays too cold for longer, Power House keeps some
               extra heat demand active for longer. This helps the room stay

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2437,17 +2437,15 @@ views:
               - **Maximum heating outdoor temperature** is het punt waar
               modelmatig de warmtevraag naar ~0 gaat.
 
-              - **PH temperatuurreactie** bepaalt hoe sterk
-              kamertemperatuurfout buiten de comfortband naar warmtevraag (W)
-              wordt vertaald.
+              - **PH temperatuurreactie** bepaalt hoe sterk Power House extra
+              warmtevraag toevoegt onder de koude comfortgrens en hoe sterk het
+              boven het kamer-setpoint weer gas terugneemt.
 
-              - **Comfort above setpoint** bepaalt hoeveel ruimte boven
-              setpoint nog acceptabel is voordat warme tegensturing begint.
+              - **Comfort above setpoint** bepaalt de acceptabele bovenkant van
+              de comfortband.
 
               - **Comfort below setpoint** bepaalt hoeveel ruimte onder
               setpoint nog acceptabel is voordat extra opwarming begint.
-
-              - Binnen deze comfortband blijft de extra kamercorrectie `0`.
 
               - Als de kamer langere tijd te koud blijft, houdt Power House
               wat langer extra warmtevraag vast. Daardoor blijft de kamer

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2059,17 +2059,15 @@ views:
               - **Maximum heating outdoor temperature** is the point where model
               heat demand approaches ~0.
 
-              - **PH temperature reaction** defines how strongly room
-              temperature error outside the comfort band is translated into heat
-              demand (W).
+              - **PH temperature reaction** defines how strongly Power House
+              adds heat below the cold comfort edge and how strongly it starts
+              pulling heat back again above room setpoint.
 
-              - **Comfort above setpoint** defines how much room above setpoint
-              is still acceptable before warm-side correction starts.
+              - **Comfort above setpoint** defines the acceptable upper side of
+              the comfort band.
 
               - **Comfort below setpoint** is the cold-side margin below
               setpoint before extra heating correction starts.
-
-              - Inside this comfort band, extra room correction stays `0`.
 
               - If the room stays too cold for longer, Power House keeps some
               extra heat demand active for longer. This helps the room stay

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2141,17 +2141,15 @@ views:
               - **Maximum heating outdoor temperature** is het punt waar
               modelmatig de warmtevraag naar ~0 gaat.
 
-              - **PH temperatuurreactie** bepaalt hoe sterk
-              kamertemperatuurfout buiten de comfortband naar warmtevraag (W)
-              wordt vertaald.
+              - **PH temperatuurreactie** bepaalt hoe sterk Power House extra
+              warmtevraag toevoegt onder de koude comfortgrens en hoe sterk het
+              boven het kamer-setpoint weer gas terugneemt.
 
-              - **Comfort above setpoint** bepaalt hoeveel ruimte boven
-              setpoint nog acceptabel is voordat warme tegensturing begint.
+              - **Comfort above setpoint** bepaalt de acceptabele bovenkant van
+              de comfortband.
 
               - **Comfort below setpoint** bepaalt hoeveel ruimte onder
               setpoint nog acceptabel is voordat extra opwarming begint.
-
-              - Binnen deze comfortband blijft de extra kamercorrectie `0`.
 
               - Als de kamer langere tijd te koud blijft, houdt Power House
               wat langer extra warmtevraag vast. Daardoor blijft de kamer

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -129,8 +129,6 @@ Daarmee ontstaat een asymmetrische comfortband:
 
 Dat is bewust geen pure PID-benadering. Het systeem mag wat terughoudender zijn rond kleine afwijkingen en sterker reageren als de fout duidelijker wordt.
 
-Binnen deze comfortband blijft de directe extra kamercorrectie `0`.
-
 ### Temperatuurreactie
 
 De kamerfout wordt daarna omgerekend naar extra of minder warmtevraag met:
@@ -139,7 +137,9 @@ De kamerfout wordt daarna omgerekend naar extra of minder warmtevraag met:
 
 Praktisch:
 
-- `Power House temperature reaction` bepaalt hoeveel watt correctie per graad kamerfout buiten de comfortband wordt toegevoegd of afgetrokken.
+- Onder de koude comfortgrens telt `Power House temperature reaction` extra warmtevraag op.
+- Boven het kamer-setpoint neemt `Power House temperature reaction` warmtevraag weer terug.
+- `Comfort above setpoint` blijft de bovenkant van de gewenste comfortband aangeven.
 
 Een hogere waarde maakt het systeem eerder fel. Een lagere waarde maakt het systeem eerder traag of slap.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -177,7 +177,7 @@ Strategy packages compute:
 Computes requested power from:
 
 - outdoor temperature model (`Tc`, `T0`, `Pr`)
-- room error outside the configured comfort band around room setpoint
+- room error below the cold comfort edge and warm-side pullback above room setpoint
 - response profile plus rise/fall times scaled to rated house power (`Pr`)
 
 Then maps requested power to demand scale `0..20`.

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -355,6 +355,10 @@ interval:
     then:
       - lambda: |-
           // Power House strategy: owns filtered demand and PH topology selection.
+          static bool hp1_prev_valve_def = false;
+          static bool hp2_prev_valve_def = false;
+          static uint32_t hp1_defrost_owner_hold_until_ms = 0;
+          static uint32_t hp2_defrost_owner_hold_until_ms = 0;
           const int cm_code = id(oq_control_mode_code);
           const bool active = (cm_code != 5) && (id(oq_heat_mode_code) != 1);
           if (!active) {
@@ -366,6 +370,10 @@ interval:
             id(oq_phouse_last_ms) = 0;
             id(oq_phouse_last_w) = 0.0f;
             id(oq_phouse_comfort_memory_c) = 0.0f;
+            hp1_prev_valve_def = false;
+            hp2_prev_valve_def = false;
+            hp1_defrost_owner_hold_until_ms = 0;
+            hp2_defrost_owner_hold_until_ms = 0;
             return;
           }
 
@@ -450,11 +458,10 @@ interval:
 
             const float Trsp_effective = Trsp + comfort_memory_c;
             const float Tr_low = Trsp_effective - comfort_below;
-            const float Tr_high = Tr_high_base;
 
             float e = 0.0f;
             if (Tr < Tr_low) e = Tr_low - Tr;
-            else if (Tr > Tr_high) e = Tr_high - Tr;
+            else if (Tr > Trsp) e = Trsp - Tr;
 
             const float temperature_reaction_w_per_k = id(ph_kp_w_per_k).state;
             float P_raw = P_house + temperature_reaction_w_per_k * e;
@@ -594,6 +601,12 @@ interval:
           const bool hp2_available = false;
           #endif
           const bool hp1_available = true;
+
+          constexpr uint32_t defrost_owner_hold_ms = 180000UL;
+          if (hp1_valve_def || hp1_prev_valve_def) hp1_defrost_owner_hold_until_ms = now_ms + defrost_owner_hold_ms;
+          if (hp2_valve_def || hp2_prev_valve_def) hp2_defrost_owner_hold_until_ms = now_ms + defrost_owner_hold_ms;
+          hp1_prev_valve_def = hp1_valve_def;
+          hp2_prev_valve_def = hp2_valve_def;
 
           float def_fac_cfg = ${oq_defrost_power_factor};
           if (isnan(def_fac_cfg)) def_fac_cfg = 0.55f;
@@ -871,9 +884,18 @@ interval:
                   (current_candidate.active_hp_count > 0) &&
                   (best_candidate.active_hp_count > 0) &&
                   (current_candidate.active_hp_count != best_candidate.active_hp_count);
+              const bool single_owner_swap =
+                  (current_candidate.active_hp_count == 1) &&
+                  (best_candidate.active_hp_count == 1) &&
+                  ((current_candidate.l1 > 0) != (best_candidate.l1 > 0));
               const bool hold_window_active =
                   (id(oq_duo_request_hold_until_ms) > 0) &&
                   (now_ms < id(oq_duo_request_hold_until_ms));
+              const bool defrost_owner_hold_active =
+                  single_owner_swap &&
+                  ((hp1_valve_def || hp2_valve_def) ||
+                   (hp1_defrost_owner_hold_until_ms > now_ms) ||
+                   (hp2_defrost_owner_hold_until_ms > now_ms));
               const bool topology_change_allowed =
                   !topology_change ||
                   (best_candidate.err_w + topology_heat_advantage_w < current_candidate.err_w) ||
@@ -890,7 +912,10 @@ interval:
               const bool better_efficiency =
                   current_candidate.p_el_w > (best_candidate.p_el_w + efficiency_switch_margin_w);
 
-              if (hold_active && current_heat_ok) {
+              if (defrost_owner_hold_active) {
+                keep_current = true;
+                optimizer_reason_code = 7;
+              } else if (hold_active && current_heat_ok) {
                 keep_current = true;
                 optimizer_reason_code = (hp1_valve_def || hp2_valve_def) ? 7 : 6;
               } else if (topology_change && !topology_change_allowed && current_heat_ok) {


### PR DESCRIPTION
## Summary
- start Power House warm-side pullback above room setpoint instead of only above the upper comfort edge
- keep single-owner Power House requests on the current HP during defrost and short post-defrost recovery
- update Power House docs and dashboard help text to match the new warm/cold semantics

## Why
Recent overnight traces showed two linked issues:
- room temperature stayed too far above setpoint while `P_req` remained high, because warm-side correction only started above `setpoint + comfort_above`
- during defrost, Power House could still hand off from `HP1 single` to `HP2 single` and back because the existing hold only covered single-versus-dual topology changes, not single-owner swaps

This change keeps the user-facing model simple while making the behavior more intuitive:
- below the cold comfort edge, Power House still adds heat
- above room setpoint, Power House now starts pulling heat back immediately
- `comfort_above` still defines the acceptable upper side of the comfort band
- single-owner swaps are held during active defrost and for a short recovery window afterwards

## Verification
- `python3 scripts/simulate_thermal_refactor_regressions.py`
- local replay against `history (5).csv` showed current `dev` behavior closely matched the trace and the proposed warm-side change reduced `P_req` by about 1 kW in the warm overshoot windows around 04:30 and 07:30
- `esphome compile openquatt_single_heatpump_listener.yaml` succeeded from a clean worktree on this branch
- `python3 scripts/dev.py validate --jobs 1` in the original worktree hit a stale local build error referencing `openquatt_ot_slave/number.cpp`; a clean compile from a fresh `origin/dev` worktree also proceeded normally past `openquatt_ot_slave`, confirming that error was not caused by this branch base