### PR TITLE
Make heating curve ignore oil-return spikes and release low-load coast

### DIFF
--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -107,6 +107,11 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  - id: oq_curve_oil_return_hold_until_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
 select:
   - platform: template
     id: oq_curve_control_profile
@@ -136,6 +141,7 @@ select:
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
               id(oq_curve_regime_code));
+            id(oq_curve_oil_return_hold_until_ms) = 0;
             oq_curve::reset_outside_ema_state(
               id(oq_curve_outside_ema_c),
               id(oq_curve_outside_ema_initialized),
@@ -448,12 +454,24 @@ output:
           const bool low_pid_for_off = d <= off_pid_max_f;
           const float restart_bypass_delta_c = restart_delta_c + restart_bypass_extra_c;
           const uint32_t now_ms = (uint32_t) millis();
+          constexpr uint32_t oil_return_hold_ms = 180000UL;
+          bool oil_return_active = id(hp1_prot_oil_return).state;
+          #if OQ_TOPOLOGY_DUO
+          oil_return_active = oil_return_active || id(${curve_secondary_oil_return_id}).state;
+          #endif
+          if (oil_return_active) {
+            id(oq_curve_oil_return_hold_until_ms) = now_ms + oil_return_hold_ms;
+          }
+          const bool oil_return_mask_active =
+              oil_return_active ||
+              (id(oq_curve_oil_return_hold_until_ms) > 0 &&
+               now_ms < id(oq_curve_oil_return_hold_until_ms));
           bool heat_request_active = id(oq_curve_heat_request_active);
           bool restart_inhibit_active = false;
           uint32_t off_since_ms = id(oq_curve_off_since_ms);
           const bool was_heat_request_active = heat_request_active;
           if (heat_request_active) {
-            if (above_stop_band && low_pid_for_off && room_allows_off) {
+            if (!oil_return_mask_active && above_stop_band && low_pid_for_off && room_allows_off) {
               uint32_t armed_ms = id(oq_curve_stop_arm_ms);
               if (armed_ms == 0 || now_ms <= armed_ms) {
                 id(oq_curve_stop_arm_ms) = now_ms;
@@ -514,7 +532,8 @@ output:
             constexpr int recovery_reenter_min_f = 8;
             if (regime == 1) {
               if (supply_error_c <= recovery_exit_c) regime = 2;
-            } else if (supply_error_c >= recovery_enter_c &&
+            } else if (!oil_return_mask_active &&
+                       supply_error_c >= recovery_enter_c &&
                        d >= recovery_reenter_min_f &&
                        room_allows_recovery) {
               regime = 1;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -452,6 +452,15 @@ output:
 
           const bool above_stop_band = pv >= (spw + stop_delta_c);
           const bool low_pid_for_off = d <= off_pid_max_f;
+          const bool low_load_release_condition =
+              !oil_return_mask_active &&
+              heat_request_active &&
+              (id(oq_curve_regime_code) == 2) &&
+              (id(oq_curve_demand_pre_guardrail) <= 0) &&
+              ((!room_valid) || (room_c >= (room_sp_c - room_resume_heat_c))) &&
+              (pv >= (spw + 0.25f));
+          const bool normal_stop_condition =
+              !oil_return_mask_active && above_stop_band && low_pid_for_off && room_allows_off;
           const float restart_bypass_delta_c = restart_delta_c + restart_bypass_extra_c;
           const uint32_t now_ms = (uint32_t) millis();
           constexpr uint32_t oil_return_hold_ms = 180000UL;
@@ -471,11 +480,14 @@ output:
           uint32_t off_since_ms = id(oq_curve_off_since_ms);
           const bool was_heat_request_active = heat_request_active;
           if (heat_request_active) {
-            if (!oil_return_mask_active && above_stop_band && low_pid_for_off && room_allows_off) {
+            if (normal_stop_condition || low_load_release_condition) {
               uint32_t armed_ms = id(oq_curve_stop_arm_ms);
+              const uint32_t confirm_ms =
+                  low_load_release_condition ? std::min<uint32_t>(off_confirm_ms, 90000UL)
+                                             : off_confirm_ms;
               if (armed_ms == 0 || now_ms <= armed_ms) {
                 id(oq_curve_stop_arm_ms) = now_ms;
-              } else if ((now_ms - armed_ms) >= off_confirm_ms) {
+              } else if ((now_ms - armed_ms) >= confirm_ms) {
                 heat_request_active = false;
                 id(oq_curve_stop_arm_ms) = 0;
               }

--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -63,6 +63,7 @@ oq_heating_curve_strategy: !include
     curve_secondary_last_start_ms_id: "hp2_last_start_ms"
     curve_secondary_working_mode_id: "hp2_working_mode"
     curve_secondary_4_way_valve_id: "hp2_4_way_valve"
+    curve_secondary_oil_return_id: "hp2_prot_oil_return"
     curve_secondary_excluded_level_a_id: "hp2_excluded_level_a"
     curve_secondary_excluded_level_b_id: "hp2_excluded_level_b"
 oq_power_house_strategy: !include

--- a/openquatt/oq_packages_single.yaml
+++ b/openquatt/oq_packages_single.yaml
@@ -47,6 +47,7 @@ oq_heating_curve_strategy: !include
     curve_secondary_last_start_ms_id: "hp1_last_start_ms"
     curve_secondary_working_mode_id: "hp1_working_mode"
     curve_secondary_4_way_valve_id: "hp1_4_way_valve"
+    curve_secondary_oil_return_id: "hp1_prot_oil_return"
     curve_secondary_excluded_level_a_id: "hp1_excluded_level_a"
     curve_secondary_excluded_level_b_id: "hp1_excluded_level_b"
 oq_power_house_strategy: !include


### PR DESCRIPTION
## Summary
- mask curve stop/recovery decisions during HP oil-return protection cycles
- let curve maintain/coast fully release at very low load instead of sticking on level 1
- keep this as two focused commits on one PR for easier review

## Why
Recent curve runs showed two remaining issues:
- oil-return temporarily injects extra heat, which should not be treated as normal supply response
- outside those spikes, curve can stay stuck at post=1 / lvl 1 long after the underlying demand has fallen away

## Implementation
1. Mask curve control during oil return
   - uses existing per-HP Modbus protection bit on register 2119, bit 0x8
   - adds a short mask hold so curve does not promote back to recovery or arm stop/off on transient oil-return spikes
2. Let curve coast release at very low load
   - adds a maintain/coast low-load release path so curve may fully drop out when pre-guardrail demand is gone, room is not cold, and supply is already above target

## Validation
- python3 scripts/dev.py validate --config openquatt_single_heatpump_listener.yaml
- style/docs/config checks pass
- compile currently still fails on unrelated existing repo issue: missing src/esphome/components/openquatt_ot_slave/number.cpp
