### PR TITLE
Hold Power House topology during oil return

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -191,7 +191,7 @@ Belangrijk onderscheid:
 - `oq_hp_min_off_s` is juist wel compile-time en bepaalt de minimale uit-tijd per compressor voor elke restart, ook in `Power House`.
 - `oq_optimizer_topology_power_margin_w` en `oq_optimizer_topology_heat_advantage_w` zijn compile-time marges voor de single-versus-duokeuze in `Power House`.
 
-Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een recente topologywissel niet laat plaatsvinden voor een klein voordeel. Rond defrost wordt een tweede warmtepomp niet speciaal opgestart vanuit single; alleen als duo al actief is mag de gezonde unit tijdens echte `4-Way valve`-defrost beperkt extra ondersteunen.
+Je hoeft in `Power House` dus geen aparte single-versus-duo voorkeur af te stellen. De bedoeling is juist dat OpenQuatt zelf eerst naar efficientie kijkt, een minder zuinige topology alleen laat winnen bij duidelijk betere warmtematch, en een recente topologywissel niet laat plaatsvinden voor een klein voordeel. Rond defrost en compressor oil return worden topology- en ownerwissels tijdelijk vastgehouden, zodat korte verstoringen niet als normale plantrespons worden behandeld. Alleen als duo al actief is mag de gezonde unit tijdens echte `4-Way valve`-defrost beperkt extra ondersteunen.
 
 ### Flow en pompregeling
 

--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -71,6 +71,7 @@ oq_power_house_strategy: !include
   vars:
     ph_secondary_minutes_id: "hp2_minutes"
     ph_secondary_defrost_id: "hp2_defrost"
+    ph_secondary_oil_return_id: "hp2_prot_oil_return"
     ph_secondary_last_applied_level_id: "hp2_last_applied_level"
     ph_secondary_4_way_valve_id: "hp2_4_way_valve"
     ph_secondary_excluded_level_a_id: "hp2_excluded_level_a"

--- a/openquatt/oq_packages_single.yaml
+++ b/openquatt/oq_packages_single.yaml
@@ -55,6 +55,7 @@ oq_power_house_strategy: !include
   vars:
     ph_secondary_minutes_id: "hp1_minutes"
     ph_secondary_defrost_id: "hp1_defrost"
+    ph_secondary_oil_return_id: "hp1_prot_oil_return"
     ph_secondary_last_applied_level_id: "hp1_last_applied_level"
     ph_secondary_4_way_valve_id: "hp1_4_way_valve"
     ph_secondary_excluded_level_a_id: "hp1_excluded_level_a"

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -70,7 +70,8 @@ globals:
   # 0=idle, 1=fallback_idle, 2=fallback_single_hp1, 3=fallback_single_hp2,
   # 4=fallback_duo, 5=keep_current, 6=hold_active, 7=defrost_hold,
   # 8=better_heat, 9=soft_guard, 10=less_power, 11=no_candidate,
-  # 12=defrost_boost, 13=runtime_lead, 14=single_topology
+  # 12=defrost_boost, 13=runtime_lead, 14=single_topology,
+  # 15=oil_return_hold
   - id: oq_ph_request_reason_code
     type: int
     restore_value: false
@@ -357,8 +358,11 @@ interval:
           // Power House strategy: owns filtered demand and PH topology selection.
           static bool hp1_prev_valve_def = false;
           static bool hp2_prev_valve_def = false;
+          static bool hp1_prev_oil_return = false;
+          static bool hp2_prev_oil_return = false;
           static uint32_t hp1_defrost_owner_hold_until_ms = 0;
           static uint32_t hp2_defrost_owner_hold_until_ms = 0;
+          static uint32_t oil_return_hold_until_ms = 0;
           const int cm_code = id(oq_control_mode_code);
           const bool active = (cm_code != 5) && (id(oq_heat_mode_code) != 1);
           if (!active) {
@@ -372,8 +376,11 @@ interval:
             id(oq_phouse_comfort_memory_c) = 0.0f;
             hp1_prev_valve_def = false;
             hp2_prev_valve_def = false;
+            hp1_prev_oil_return = false;
+            hp2_prev_oil_return = false;
             hp1_defrost_owner_hold_until_ms = 0;
             hp2_defrost_owner_hold_until_ms = 0;
+            oil_return_hold_until_ms = 0;
             return;
           }
 
@@ -591,13 +598,16 @@ interval:
 
           const bool hp1_def = id(hp1_defrost).state;
           const bool hp1_valve_def = valve_defrost_active(true);
+          const bool hp1_oil_return = id(hp1_prot_oil_return).state;
           #if OQ_TOPOLOGY_DUO
           const bool hp2_def = id(${ph_secondary_defrost_id}).state;
           const bool hp2_valve_def = valve_defrost_active(false);
+          const bool hp2_oil_return = id(${ph_secondary_oil_return_id}).state;
           const bool hp2_available = true;
           #else
           const bool hp2_def = false;
           const bool hp2_valve_def = false;
+          const bool hp2_oil_return = false;
           const bool hp2_available = false;
           #endif
           const bool hp1_available = true;
@@ -607,6 +617,17 @@ interval:
           if (hp2_valve_def || hp2_prev_valve_def) hp2_defrost_owner_hold_until_ms = now_ms + defrost_owner_hold_ms;
           hp1_prev_valve_def = hp1_valve_def;
           hp2_prev_valve_def = hp2_valve_def;
+
+          constexpr uint32_t oil_return_hold_ms = 120000UL;
+          const bool oil_return_active = hp1_oil_return || hp2_oil_return;
+          if (oil_return_active || hp1_prev_oil_return || hp2_prev_oil_return) {
+            oil_return_hold_until_ms = now_ms + oil_return_hold_ms;
+          }
+          hp1_prev_oil_return = hp1_oil_return;
+          hp2_prev_oil_return = hp2_oil_return;
+          const bool oil_return_hold_active =
+              oil_return_active ||
+              (oil_return_hold_until_ms > 0 && now_ms < oil_return_hold_until_ms);
 
           float def_fac_cfg = ${oq_defrost_power_factor};
           if (isnan(def_fac_cfg)) def_fac_cfg = 0.55f;
@@ -896,6 +917,10 @@ interval:
                   ((hp1_valve_def || hp2_valve_def) ||
                    (hp1_defrost_owner_hold_until_ms > now_ms) ||
                    (hp2_defrost_owner_hold_until_ms > now_ms));
+              const bool oil_return_topology_hold_active =
+                  oil_return_hold_active &&
+                  current_heat_ok &&
+                  (topology_change || single_owner_swap);
               const bool topology_change_allowed =
                   !topology_change ||
                   (best_candidate.err_w + topology_heat_advantage_w < current_candidate.err_w) ||
@@ -915,6 +940,9 @@ interval:
               if (defrost_owner_hold_active) {
                 keep_current = true;
                 optimizer_reason_code = 7;
+              } else if (oil_return_topology_hold_active) {
+                keep_current = true;
+                optimizer_reason_code = 15;
               } else if (hold_active && current_heat_ok) {
                 keep_current = true;
                 optimizer_reason_code = (hp1_valve_def || hp2_valve_def) ? 7 : 6;
@@ -952,6 +980,7 @@ interval:
               case 9: publish_optimizer_reason("soft_guard"); break;
               case 10: publish_optimizer_reason("less_power"); break;
               case 11: publish_optimizer_reason("no_candidate"); break;
+              case 15: publish_optimizer_reason("oil_return_hold"); break;
               default: break;
             }
 


### PR DESCRIPTION
## Summary
- hold Power House topology and single-owner swaps during active compressor oil return and a short post-bit hold window
- wire the secondary oil-return protection bit into the Power House package include for single and duo builds
- document that Power House now temporarily holds topology and owner changes around oil return, similar to defrost disturbance handling

## Why
In Heating Curve we already treat oil return as a short-lived disturbance instead of a normal plant response. Power House did not yet have an equivalent safeguard, even though oil return can also temporarily distort topology decisions through abnormal low-level thermal output.

This PR keeps the Power House comfort and `P_req` model unchanged. It only prevents topology and owner churn while the oil-return protection bit is active and for a short hold window afterwards.

## Behavior
- detect oil return from the real per-HP protection bits
- keep the current Power House topology/owner choice if a topology change or single-owner swap would otherwise happen during oil return
- keep normal level decisions within the current topology intact
- use a short post-bit hold (`120 s`) so the optimizer does not react to immediate settling noise

## Verification
- `python3 scripts/simulate_thermal_refactor_regressions.py`
- `python3 scripts/dev.py validate --jobs 1`