### PR TITLE
Add auto outside temperature source selection

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1671,6 +1671,11 @@ views:
 
               The local `HP1/HP2` aggregate is, in principle, the average of both flowmeters.
 
+              For `Outside temperature source`, `Auto` is the recommended mode.
+              OpenQuatt then prefers the most trustworthy source: active
+              outdoor-unit readings first, HA input while both units are idle,
+              and idle local readings only as fallback.
+
               </details>
             text_only: true
           - type: vertical-stack

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1673,8 +1673,8 @@ views:
 
               For `Outside temperature source`, `Auto` is the recommended mode.
               OpenQuatt then prefers the most trustworthy source: active
-              outdoor-unit readings first, HA input while both units are idle,
-              and idle local readings only as fallback.
+              outdoor-unit readings first, HA input while both units are idle
+              if it is configured and valid, and idle local readings only as fallback.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1774,8 +1774,9 @@ views:
 
               Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand.
               OpenQuatt kiest dan de meest betrouwbare bron: eerst actieve
-              buitenunitmetingen, daarna HA als beide units idle zijn, en
-              alleen als fallback idle lokale metingen.
+              buitenunitmetingen, daarna HA als beide units idle zijn mits die
+              bron is geconfigureerd en geldig is, en alleen als fallback idle
+              lokale metingen.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1772,6 +1772,11 @@ views:
 
               flowmeters.
 
+              Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand.
+              OpenQuatt kiest dan de meest betrouwbare bron: eerst actieve
+              buitenunitmetingen, daarna HA als beide units idle zijn, en
+              alleen als fallback idle lokale metingen.
+
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1420,6 +1420,11 @@ views:
               - quick comparison between CIC, local, and HA Input
               - validation of the effective control input
 
+              For `Outside temperature source`, `Auto` is the recommended mode.
+              OpenQuatt then prefers the most trustworthy source: an active
+              outdoor-unit reading first, HA input while the unit is idle, and
+              the idle local reading only as fallback.
+
               </details>
             text_only: true
           - type: vertical-stack

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1422,8 +1422,8 @@ views:
 
               For `Outside temperature source`, `Auto` is the recommended mode.
               OpenQuatt then prefers the most trustworthy source: an active
-              outdoor-unit reading first, HA input while the unit is idle, and
-              the idle local reading only as fallback.
+              outdoor-unit reading first, HA input while the unit is idle if it
+              is configured and valid, and the idle local reading only as fallback.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1484,6 +1484,11 @@ views:
               - snelle vergelijking tussen CIC, lokaal en HA input
               - validatie van de effectieve regelinput
 
+              Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand.
+              OpenQuatt kiest dan de meest betrouwbare bron: eerst de actieve
+              buitenunitmeting, daarna HA als de unit idle is, en alleen als
+              fallback de idle lokale meting.
+
               </details>
             text_only: true
             grid_options:

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1486,8 +1486,9 @@ views:
 
               Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand.
               OpenQuatt kiest dan de meest betrouwbare bron: eerst de actieve
-              buitenunitmeting, daarna HA als de unit idle is, en alleen als
-              fallback de idle lokale meting.
+              buitenunitmeting, daarna HA als de unit idle is mits die bron is
+              geconfigureerd en geldig is, en alleen als fallback de idle lokale
+              meting.
 
               </details>
             text_only: true

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -249,7 +249,7 @@ In de lokale Duo-aggregatie kijkt OpenQuatt sinds `dev` explicieter naar de kwal
 
 - een buitenmeting van een HP die actief in `Heating` of `Cooling` draait krijgt voorrang boven een idle HP-meting
 - als beide HP's actief zijn, gebruikt OpenQuatt de laagste van de twee actieve metingen
-- als alle HP's idle zijn, gebruikt OpenQuatt bij voorkeur de HA-buitentemperatuur
+- als alle HP's idle zijn, gebruikt OpenQuatt bij voorkeur de HA-buitentemperatuur als die is geconfigureerd en een geldige waarde levert
 - alleen als HA niet beschikbaar is, gebruikt OpenQuatt het gemiddelde van de geldige lokale metingen als fallback
 - een lokale HP-buitenwaarde telt tijdelijk niet mee als die te lang exact stil blijft staan terwijl diezelfde warmtepomp verder nog wel verse activiteit laat zien
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -243,13 +243,14 @@ Belangrijke instellingen en signalen:
 
 Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteerde bron niet klopt, helpt fijnregelen vrijwel nooit.
 
-Voor `Outside Temperature Source` is ook de optie `Lowest valid` beschikbaar. Dan vergelijkt OpenQuatt de lokale buitenunitmeting en de HA-invoer, gebruikt alleen geldige waarden en kiest de laagste van de twee.
+Voor `Outside Temperature Source` is `Auto` de aanbevolen optie. OpenQuatt kiest dan niet simpelweg de koudste geldige bron, maar de meest betrouwbare.
 
 In de lokale Duo-aggregatie kijkt OpenQuatt sinds `dev` explicieter naar de kwaliteit van de twee HP-metingen:
 
 - een buitenmeting van een HP die actief in `Heating` of `Cooling` draait krijgt voorrang boven een idle HP-meting
 - als beide HP's actief zijn, gebruikt OpenQuatt de laagste van de twee actieve metingen
-- als beide HP's idle zijn, gebruikt OpenQuatt het gemiddelde van de geldige lokale metingen als fallback
+- als alle HP's idle zijn, gebruikt OpenQuatt bij voorkeur de HA-buitentemperatuur
+- alleen als HA niet beschikbaar is, gebruikt OpenQuatt het gemiddelde van de geldige lokale metingen als fallback
 - een lokale HP-buitenwaarde telt tijdelijk niet mee als die te lang exact stil blijft staan terwijl diezelfde warmtepomp verder nog wel verse activiteit laat zien
 
 Daardoor telt bij een Duo-installatie niet langer automatisch de koudste lokale sensor mee als één unit actief is en de andere nog een vertekende stilstandmeting geeft.

--- a/openquatt/oq_packages.yaml
+++ b/openquatt/oq_packages.yaml
@@ -133,6 +133,7 @@ oq_sensor_sources: !include
   vars:
     sensor_sources_duo_flow_internal: "false"
     flow_secondary_flow_sensor_id: "hp2_flow"
+    secondary_working_mode_id: "hp2_working_mode"
 oq_ot_slave: !include
   file: oq_ot_slave.yaml
   vars:

--- a/openquatt/oq_packages_single.yaml
+++ b/openquatt/oq_packages_single.yaml
@@ -118,6 +118,7 @@ oq_sensor_sources: !include
   vars:
     sensor_sources_duo_flow_internal: "true"
     flow_secondary_flow_sensor_id: "hp1_flow"
+    secondary_working_mode_id: "hp1_working_mode"
 oq_ot_slave: !include
   file: oq_ot_slave.yaml
   vars:

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -121,10 +121,10 @@ select:
     optimistic: true
     restore_value: true
     options:
+      - Auto
       - Outdoor unit
       - HA input
-      - Lowest valid
-    initial_option: Outdoor unit
+    initial_option: Auto
     web_server:
       sorting_group_id: oq_cic
 
@@ -372,20 +372,29 @@ sensor:
     accuracy_decimals: 1
     update_interval: 10s
     lambda: |-
-      // Hold the selected HA outdoor temperature briefly through HA reload gaps.
+      // Auto prefers the most trustworthy outside temperature source.
       if (!id(outside_temp_source).has_state()) return NAN;
       const auto source = id(outside_temp_source).current_option();
       const bool hp_valid = id(outside_temp_hp_avg).has_state() && !isnan(id(outside_temp_hp_avg).state);
       const bool ha_valid = id(outside_temp_ha).has_state() && !isnan(id(outside_temp_ha).state);
+      const bool hp1_active =
+          id(hp1_working_mode).has_state() &&
+          !isnan(id(hp1_working_mode).state) &&
+          ((((int) roundf(id(hp1_working_mode).state)) == 1) || (((int) roundf(id(hp1_working_mode).state)) == 2));
+      const bool hp2_active =
+          id(${secondary_working_mode_id}).has_state() &&
+          !isnan(id(${secondary_working_mode_id}).state) &&
+          ((((int) roundf(id(${secondary_working_mode_id}).state)) == 1) || (((int) roundf(id(${secondary_working_mode_id}).state)) == 2));
+      const bool local_active = hp1_active || hp2_active;
       const bool hold_enabled = source == "HA input";
       const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
       const uint32_t now_ms = (uint32_t) millis();
 
       float selected_c = NAN;
-      if (source == "Lowest valid") {
-        if (hp_valid && ha_valid) selected_c = fminf(id(outside_temp_hp_avg).state, id(outside_temp_ha).state);
-        else if (hp_valid) selected_c = id(outside_temp_hp_avg).state;
+      if (source == "Auto" || source == "Lowest valid") {
+        if (local_active && hp_valid) selected_c = id(outside_temp_hp_avg).state;
         else if (ha_valid) selected_c = id(outside_temp_ha).state;
+        else if (hp_valid) selected_c = id(outside_temp_hp_avg).state;
       }
       if (source == "HA input") {
         if (ha_valid) selected_c = id(outside_temp_ha).state;


### PR DESCRIPTION
## Summary
- replace the user-facing Lowest valid outside temperature mode with Auto
- make Auto choose the most trustworthy source instead of the coldest valid source
- document the new behavior in the settings guide and HA dashboards

## Auto behavior
- prefer local outdoor-unit readings while a heat pump is actively heating or cooling
- prefer the HA outside temperature while all heat pumps are idle, if HA is configured and provides a valid reading
- fall back to idle local outdoor-unit readings only when HA is unavailable

## Validation
- python3 scripts/dev.py validate --jobs 1