### PR TITLE
Stabilize Auto outside temperature source after startup

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1675,6 +1675,8 @@ views:
               OpenQuatt then prefers the most trustworthy source: active
               outdoor-unit readings first, HA input while both units are idle
               if it is configured and valid, and idle local readings only as fallback.
+              When an outdoor unit has just become active, `Auto` also waits
+              briefly before switching to that local reading.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1777,6 +1777,8 @@ views:
               buitenunitmetingen, daarna HA als beide units idle zijn mits die
               bron is geconfigureerd en geldig is, en alleen als fallback idle
               lokale metingen.
+              Als een buitenunit net actief wordt, wacht `Auto` bovendien kort
+              voordat die lokale meting wordt overgenomen.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1424,6 +1424,8 @@ views:
               OpenQuatt then prefers the most trustworthy source: an active
               outdoor-unit reading first, HA input while the unit is idle if it
               is configured and valid, and the idle local reading only as fallback.
+              When an outdoor unit has just become active, `Auto` also waits
+              briefly before switching to that local reading.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1489,6 +1489,8 @@ views:
               buitenunitmeting, daarna HA als de unit idle is mits die bron is
               geconfigureerd en geldig is, en alleen als fallback de idle lokale
               meting.
+              Als een buitenunit net actief wordt, wacht `Auto` bovendien kort
+              voordat die lokale meting wordt overgenomen.
 
               </details>
             text_only: true

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -245,6 +245,8 @@ Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteer
 
 Voor `Outside Temperature Source` is `Auto` de aanbevolen optie. OpenQuatt kiest dan niet simpelweg de koudste geldige bron, maar de meest betrouwbare.
 
+Als een buitenunit net actief wordt, neemt `Auto` die lokale meting niet meteen over. De sensor krijgt eerst kort de tijd om te stabiliseren, zodat een door zon of stilstand vertekende opstartwaarde niet direct de regeling omgooit.
+
 In de lokale Duo-aggregatie kijkt OpenQuatt sinds `dev` explicieter naar de kwaliteit van de twee HP-metingen:
 
 - een buitenmeting van een HP die actief in `Heating` of `Cooling` draait krijgt voorrang boven een idle HP-meting

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -40,6 +40,14 @@ globals:
     type: bool
     restore_value: false
     initial_value: 'false'
+  - id: oq_outside_temp_hp1_active_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_outside_temp_hp2_active_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
 
   - id: oq_room_temp_selected_last_valid_c
     type: float
@@ -372,9 +380,13 @@ sensor:
     accuracy_decimals: 1
     update_interval: 10s
     lambda: |-
-      // Auto prefers the most trustworthy outside temperature source.
+      // Auto prefers the most trustworthy outside temperature source, but a
+      // newly active outdoor-unit sensor first gets time to settle.
       if (!id(outside_temp_source).has_state()) return NAN;
       const auto source = id(outside_temp_source).current_option();
+      const uint32_t now_ms = (uint32_t) millis();
+      const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
+      const uint32_t active_warmup_ms = (uint32_t)(${oq_outside_temp_active_warmup_s}UL * 1000UL);
       const bool hp_valid = id(outside_temp_hp_avg).has_state() && !isnan(id(outside_temp_hp_avg).state);
       const bool ha_valid = id(outside_temp_ha).has_state() && !isnan(id(outside_temp_ha).state);
       const bool hp1_active =
@@ -385,16 +397,44 @@ sensor:
           id(${secondary_working_mode_id}).has_state() &&
           !isnan(id(${secondary_working_mode_id}).state) &&
           ((((int) roundf(id(${secondary_working_mode_id}).state)) == 1) || (((int) roundf(id(${secondary_working_mode_id}).state)) == 2));
+      if (hp1_active) {
+        if (id(oq_outside_temp_hp1_active_since_ms) == 0) id(oq_outside_temp_hp1_active_since_ms) = now_ms;
+      } else {
+        id(oq_outside_temp_hp1_active_since_ms) = 0;
+      }
+      if (hp2_active) {
+        if (id(oq_outside_temp_hp2_active_since_ms) == 0) id(oq_outside_temp_hp2_active_since_ms) = now_ms;
+      } else {
+        id(oq_outside_temp_hp2_active_since_ms) = 0;
+      }
+      const bool hp1_warmed =
+          hp1_active &&
+          (active_warmup_ms == 0 ||
+           (id(oq_outside_temp_hp1_active_since_ms) > 0 &&
+            (uint32_t)(now_ms - id(oq_outside_temp_hp1_active_since_ms)) >= active_warmup_ms));
+      const bool hp2_warmed =
+          hp2_active &&
+          (active_warmup_ms == 0 ||
+           (id(oq_outside_temp_hp2_active_since_ms) > 0 &&
+            (uint32_t)(now_ms - id(oq_outside_temp_hp2_active_since_ms)) >= active_warmup_ms));
       const bool local_active = hp1_active || hp2_active;
-      const bool hold_enabled = source == "HA input";
-      const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
-      const uint32_t now_ms = (uint32_t) millis();
+      const bool local_active_warmed = hp1_warmed || hp2_warmed;
+      const bool auto_active_warmup_hold = source == "Auto" && local_active && !local_active_warmed;
+      const bool hold_enabled = source == "HA input" || auto_active_warmup_hold;
 
       float selected_c = NAN;
+      bool warmup_blocked_local = false;
       if (source == "Auto" || source == "Lowest valid") {
-        if (local_active && hp_valid) selected_c = id(outside_temp_hp_avg).state;
-        else if (ha_valid) selected_c = id(outside_temp_ha).state;
-        else if (hp_valid) selected_c = id(outside_temp_hp_avg).state;
+        if (local_active && !local_active_warmed) {
+          warmup_blocked_local = hp_valid;
+          if (ha_valid) selected_c = id(outside_temp_ha).state;
+        } else if (local_active_warmed && hp_valid) {
+          selected_c = id(outside_temp_hp_avg).state;
+        } else if (ha_valid) {
+          selected_c = id(outside_temp_ha).state;
+        } else if (hp_valid) {
+          selected_c = id(outside_temp_hp_avg).state;
+        }
       }
       if (source == "HA input") {
         if (ha_valid) selected_c = id(outside_temp_ha).state;
@@ -420,6 +460,8 @@ sensor:
         id(oq_outside_temp_selected_hold_active) = true;
         return id(oq_outside_temp_selected_last_valid_c);
       }
+
+      if (warmup_blocked_local) return id(outside_temp_hp_avg).state;
 
       return NAN;
     web_server:

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -67,6 +67,7 @@ oq_strategy_demand_max_f: "20.0"                      # Upper bound of demand sc
 oq_selected_input_stale_hold_s: "300"                 # Hold selected HA-backed inputs this long when they briefly disappear during reloads [s].
 oq_temp_guard_delta_c: "0.5"                          # Minimum valid margin between T0 and Tc in the house model [°C].
 oq_outside_temp_stale_s: "1200"                       # Ignore a local outdoor reading when it stays frozen while the same HP still shows fresh activity [s].
+oq_outside_temp_active_warmup_s: "180"                # Let a newly active outdoor-unit sensor settle before Auto switches to it [s].
 
 # ----------------------------
 # HEAT CONTROL


### PR DESCRIPTION
## Summary
- add a short warmup window before `Auto` switches to a newly active outdoor-unit sensor
- keep using HA or the last selected outside temperature during that settling period when available
- update docs and HA dashboard help text to explain the new `Auto` behavior

## Why
Morning traces showed `outside_temperature_selected` jumping upward as soon as a heat pump became active. That made `P_house` and `P_req` collapse mid-start and caused CM0/CM1/CM2 oscillation. The local outdoor sensor is often more trustworthy once a unit is actively moving air, but not necessarily in the first minutes after startup when sun-heated or thermally stale readings may still dominate.

This PR keeps the existing `Auto` source priority, but delays the handover to a newly active local sensor long enough for it to settle first.

## Validation
- `python3 scripts/dev.py validate --jobs 1`