### PR TITLE
Refine Auto outside temperature source stability

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1677,6 +1677,8 @@ views:
               if it is configured and valid, and idle local readings only as fallback.
               When an outdoor unit has just become active, `Auto` also waits
               briefly before switching to that local reading.
+              When HA outside temperature is valid, `Auto` also limits abrupt
+              warm jumps from the active local reading.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1779,6 +1779,8 @@ views:
               lokale metingen.
               Als een buitenunit net actief wordt, wacht `Auto` bovendien kort
               voordat die lokale meting wordt overgenomen.
+              Bij een geldige HA-buitentemperatuur begrenst `Auto` daarna ook
+              abrupte warme sprongen van de actieve lokale bron.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1426,6 +1426,8 @@ views:
               is configured and valid, and the idle local reading only as fallback.
               When an outdoor unit has just become active, `Auto` also waits
               briefly before switching to that local reading.
+              When HA outside temperature is valid, `Auto` also limits abrupt
+              warm jumps from the active local reading.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1491,6 +1491,8 @@ views:
               meting.
               Als een buitenunit net actief wordt, wacht `Auto` bovendien kort
               voordat die lokale meting wordt overgenomen.
+              Bij een geldige HA-buitentemperatuur begrenst `Auto` daarna ook
+              abrupte warme sprongen van de actieve lokale bron.
 
               </details>
             text_only: true

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -245,7 +245,7 @@ Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteer
 
 Voor `Outside Temperature Source` is `Auto` de aanbevolen optie. OpenQuatt kiest dan niet simpelweg de koudste geldige bron, maar de meest betrouwbare.
 
-Als een buitenunit net actief wordt, neemt `Auto` die lokale meting niet meteen over. De sensor krijgt eerst kort de tijd om te stabiliseren, zodat een door zon of stilstand vertekende opstartwaarde niet direct de regeling omgooit.
+Als een buitenunit net actief wordt, neemt `Auto` die lokale meting niet meteen over. De sensor krijgt eerst kort de tijd om te stabiliseren, zodat een door zon of stilstand vertekende opstartwaarde niet direct de regeling omgooit. Daarna mag de actieve buitenunitmeting wel leidend worden, maar OpenQuatt begrenst nog steeds abrupte warme sprongen ten opzichte van een geldige HA-buitentemperatuur.
 
 In de lokale Duo-aggregatie kijkt OpenQuatt sinds `dev` explicieter naar de kwaliteit van de twee HP-metingen:
 

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -387,6 +387,8 @@ sensor:
       const uint32_t now_ms = (uint32_t) millis();
       const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
       const uint32_t active_warmup_ms = (uint32_t)(${oq_outside_temp_active_warmup_s}UL * 1000UL);
+      const float warm_cap_c = ${oq_outside_temp_auto_warm_cap_c};
+      const float max_rise_c_per_min = ${oq_outside_temp_auto_rise_limit_c_per_min};
       const bool hp_valid = id(outside_temp_hp_avg).has_state() && !isnan(id(outside_temp_hp_avg).state);
       const bool ha_valid = id(outside_temp_ha).has_state() && !isnan(id(outside_temp_ha).state);
       const bool hp1_active =
@@ -429,7 +431,22 @@ sensor:
           warmup_blocked_local = hp_valid;
           if (ha_valid) selected_c = id(outside_temp_ha).state;
         } else if (local_active_warmed && hp_valid) {
-          selected_c = id(outside_temp_hp_avg).state;
+          float candidate_c = id(outside_temp_hp_avg).state;
+          if (ha_valid && !isnan(warm_cap_c)) {
+            candidate_c = std::min(candidate_c, id(outside_temp_ha).state + warm_cap_c);
+          }
+          if (ha_valid &&
+              max_rise_c_per_min > 0.0f &&
+              id(oq_outside_temp_selected_last_valid_ms) > 0 &&
+              !isnan(id(oq_outside_temp_selected_last_valid_c)) &&
+              now_ms > id(oq_outside_temp_selected_last_valid_ms) &&
+              candidate_c > id(oq_outside_temp_selected_last_valid_c)) {
+            const float dt_min =
+                ((float) ((uint32_t) (now_ms - id(oq_outside_temp_selected_last_valid_ms)))) / 60000.0f;
+            const float max_rise_c = max_rise_c_per_min * dt_min;
+            candidate_c = std::min(candidate_c, id(oq_outside_temp_selected_last_valid_c) + max_rise_c);
+          }
+          selected_c = candidate_c;
         } else if (ha_valid) {
           selected_c = id(outside_temp_ha).state;
         } else if (hp_valid) {

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -68,6 +68,8 @@ oq_selected_input_stale_hold_s: "300"                 # Hold selected HA-backed 
 oq_temp_guard_delta_c: "0.5"                          # Minimum valid margin between T0 and Tc in the house model [°C].
 oq_outside_temp_stale_s: "1200"                       # Ignore a local outdoor reading when it stays frozen while the same HP still shows fresh activity [s].
 oq_outside_temp_active_warmup_s: "180"                # Let a newly active outdoor-unit sensor settle before Auto switches to it [s].
+oq_outside_temp_auto_warm_cap_c: "1.0"                # In Auto, limit how far an active local outside reading may run above valid HA input [°C].
+oq_outside_temp_auto_rise_limit_c_per_min: "0.25"     # In Auto, limit how fast selected outside temperature may rise toward a newly trusted active local reading [°C/min].
 
 # ----------------------------
 # HEAT CONTROL


### PR DESCRIPTION
## Summary
- refine `Outside Temperature Source = Auto` as a follow-up to #92
- keep the startup warmup, then bound active local warm-side mismatch against valid HA input
- limit how fast `outside_temperature_selected` may rise toward a newly trusted active local reading
- update docs and dashboard help text to describe the calmer `Auto` behavior

## Why
The first follow-up (#92) delays the handover to a newly active outdoor-unit sensor so startup spikes from a sun-heated sensor do not immediately flip the control input.

Replay analysis still showed daytime jumps after warmup: once the active local source became trusted, `outside_temperature_selected` could still step upward too abruptly and remain too warm relative to HA.

This PR keeps the same source priority model, but makes `Auto` calmer in two ways when HA is valid:
- the active local candidate is capped on the warm side relative to HA
- upward adoption of that candidate is rate-limited

That preserves the physical value of the active local sensor while keeping the control input much more stable.

## Validation
- `python3 scripts/dev.py validate --jobs 1`

## Follow-up to
- #92