### PR TITLE
Simplify Auto outside temperature selection

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1672,13 +1672,10 @@ views:
               The local `HP1/HP2` aggregate is, in principle, the average of both flowmeters.
 
               For `Outside temperature source`, `Auto` is the recommended mode.
-              OpenQuatt then prefers the most trustworthy source: active
-              outdoor-unit readings first, HA input while both units are idle
-              if it is configured and valid, and idle local readings only as fallback.
-              When an outdoor unit has just become active, `Auto` also waits
-              briefly before switching to that local reading.
-              When HA outside temperature is valid, `Auto` also limits abrupt
-              warm jumps from the active local reading.
+              OpenQuatt then picks the lowest valid source between the local
+              Duo aggregate and HA outside temperature, when HA is configured
+              and valid. This keeps control robust when one source is
+              temporarily biased warm by sun or local heat.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1773,14 +1773,10 @@ views:
               flowmeters.
 
               Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand.
-              OpenQuatt kiest dan de meest betrouwbare bron: eerst actieve
-              buitenunitmetingen, daarna HA als beide units idle zijn mits die
-              bron is geconfigureerd en geldig is, en alleen als fallback idle
-              lokale metingen.
-              Als een buitenunit net actief wordt, wacht `Auto` bovendien kort
-              voordat die lokale meting wordt overgenomen.
-              Bij een geldige HA-buitentemperatuur begrenst `Auto` daarna ook
-              abrupte warme sprongen van de actieve lokale bron.
+              OpenQuatt kiest dan de laagste geldige bron tussen de lokale
+              Duo-aggregatie en de HA-buitentemperatuur, als die bron is
+              geconfigureerd en geldig is. Dat houdt de regeling robuust als
+              een bron tijdelijk te warm uitvalt door zon of lokale opwarming.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1421,13 +1421,10 @@ views:
               - validation of the effective control input
 
               For `Outside temperature source`, `Auto` is the recommended mode.
-              OpenQuatt then prefers the most trustworthy source: an active
-              outdoor-unit reading first, HA input while the unit is idle if it
-              is configured and valid, and the idle local reading only as fallback.
-              When an outdoor unit has just become active, `Auto` also waits
-              briefly before switching to that local reading.
-              When HA outside temperature is valid, `Auto` also limits abrupt
-              warm jumps from the active local reading.
+              OpenQuatt then picks the lowest valid source between the local
+              outdoor-unit reading and HA outside temperature, when HA is
+              configured and valid. This keeps control robust when one source
+              is temporarily biased warm by sun or local heat.
 
               </details>
             text_only: true

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1485,14 +1485,10 @@ views:
               - validatie van de effectieve regelinput
 
               Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand.
-              OpenQuatt kiest dan de meest betrouwbare bron: eerst de actieve
-              buitenunitmeting, daarna HA als de unit idle is mits die bron is
-              geconfigureerd en geldig is, en alleen als fallback de idle lokale
-              meting.
-              Als een buitenunit net actief wordt, wacht `Auto` bovendien kort
-              voordat die lokale meting wordt overgenomen.
-              Bij een geldige HA-buitentemperatuur begrenst `Auto` daarna ook
-              abrupte warme sprongen van de actieve lokale bron.
+              OpenQuatt kiest dan de laagste geldige bron tussen de lokale
+              buitenunitmeting en de HA-buitentemperatuur, als die bron is
+              geconfigureerd en geldig is. Dat houdt de regeling robuust als
+              een bron tijdelijk te warm uitvalt door zon of lokale opwarming.
 
               </details>
             text_only: true

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -243,19 +243,16 @@ Belangrijke instellingen en signalen:
 
 Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteerde bron niet klopt, helpt fijnregelen vrijwel nooit.
 
-Voor `Outside Temperature Source` is `Auto` de aanbevolen optie. OpenQuatt kiest dan niet simpelweg de koudste geldige bron, maar de meest betrouwbare.
-
-Als een buitenunit net actief wordt, neemt `Auto` die lokale meting niet meteen over. De sensor krijgt eerst kort de tijd om te stabiliseren, zodat een door zon of stilstand vertekende opstartwaarde niet direct de regeling omgooit. Daarna mag de actieve buitenunitmeting wel leidend worden, maar OpenQuatt begrenst nog steeds abrupte warme sprongen ten opzichte van een geldige HA-buitentemperatuur.
+Voor `Outside Temperature Source` is `Auto` de aanbevolen optie. OpenQuatt kiest dan de laagste geldige bron uit de beschikbare buitenmetingen. Daarmee blijft de regeling robuust tegen een bron die tijdelijk te warm uitvalt door zon, stilstand of lokale opwarming.
 
 In de lokale Duo-aggregatie kijkt OpenQuatt sinds `dev` explicieter naar de kwaliteit van de twee HP-metingen:
 
-- een buitenmeting van een HP die actief in `Heating` of `Cooling` draait krijgt voorrang boven een idle HP-meting
-- als beide HP's actief zijn, gebruikt OpenQuatt de laagste van de twee actieve metingen
-- als alle HP's idle zijn, gebruikt OpenQuatt bij voorkeur de HA-buitentemperatuur als die is geconfigureerd en een geldige waarde levert
-- alleen als HA niet beschikbaar is, gebruikt OpenQuatt het gemiddelde van de geldige lokale metingen als fallback
+- een buitenmeting van een HP die actief in `Heating` of `Cooling` draait krijgt in de lokale Duo-aggregatie voorrang boven een idle HP-meting
+- als beide HP's actief zijn, gebruikt OpenQuatt lokaal de laagste van de twee actieve metingen
+- als alle HP's idle zijn, gebruikt de lokale Duo-aggregatie het gemiddelde van de geldige lokale metingen
 - een lokale HP-buitenwaarde telt tijdelijk niet mee als die te lang exact stil blijft staan terwijl diezelfde warmtepomp verder nog wel verse activiteit laat zien
 
-Daardoor telt bij een Duo-installatie niet langer automatisch de koudste lokale sensor mee als één unit actief is en de andere nog een vertekende stilstandmeting geeft.
+Daarna kiest `Auto` de laagste geldige bron tussen die lokale aggregatie en de HA-buitentemperatuur, als HA beschikbaar is.
 
 Bij een Duo-installatie en `Flow Source = Outdoor unit` is er ook een extra keuze voor de lokale flowbepaling:
 

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -40,14 +40,6 @@ globals:
     type: bool
     restore_value: false
     initial_value: 'false'
-  - id: oq_outside_temp_hp1_active_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_outside_temp_hp2_active_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
 
   - id: oq_room_temp_selected_last_valid_c
     type: float
@@ -380,73 +372,19 @@ sensor:
     accuracy_decimals: 1
     update_interval: 10s
     lambda: |-
-      // Auto prefers the most trustworthy outside temperature source, but a
-      // newly active outdoor-unit sensor first gets time to settle.
+      // Auto uses the lowest currently valid outside temperature source.
       if (!id(outside_temp_source).has_state()) return NAN;
       const auto source = id(outside_temp_source).current_option();
       const uint32_t now_ms = (uint32_t) millis();
       const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
-      const uint32_t active_warmup_ms = (uint32_t)(${oq_outside_temp_active_warmup_s}UL * 1000UL);
-      const float warm_cap_c = ${oq_outside_temp_auto_warm_cap_c};
-      const float max_rise_c_per_min = ${oq_outside_temp_auto_rise_limit_c_per_min};
       const bool hp_valid = id(outside_temp_hp_avg).has_state() && !isnan(id(outside_temp_hp_avg).state);
       const bool ha_valid = id(outside_temp_ha).has_state() && !isnan(id(outside_temp_ha).state);
-      const bool hp1_active =
-          id(hp1_working_mode).has_state() &&
-          !isnan(id(hp1_working_mode).state) &&
-          ((((int) roundf(id(hp1_working_mode).state)) == 1) || (((int) roundf(id(hp1_working_mode).state)) == 2));
-      const bool hp2_active =
-          id(${secondary_working_mode_id}).has_state() &&
-          !isnan(id(${secondary_working_mode_id}).state) &&
-          ((((int) roundf(id(${secondary_working_mode_id}).state)) == 1) || (((int) roundf(id(${secondary_working_mode_id}).state)) == 2));
-      if (hp1_active) {
-        if (id(oq_outside_temp_hp1_active_since_ms) == 0) id(oq_outside_temp_hp1_active_since_ms) = now_ms;
-      } else {
-        id(oq_outside_temp_hp1_active_since_ms) = 0;
-      }
-      if (hp2_active) {
-        if (id(oq_outside_temp_hp2_active_since_ms) == 0) id(oq_outside_temp_hp2_active_since_ms) = now_ms;
-      } else {
-        id(oq_outside_temp_hp2_active_since_ms) = 0;
-      }
-      const bool hp1_warmed =
-          hp1_active &&
-          (active_warmup_ms == 0 ||
-           (id(oq_outside_temp_hp1_active_since_ms) > 0 &&
-            (uint32_t)(now_ms - id(oq_outside_temp_hp1_active_since_ms)) >= active_warmup_ms));
-      const bool hp2_warmed =
-          hp2_active &&
-          (active_warmup_ms == 0 ||
-           (id(oq_outside_temp_hp2_active_since_ms) > 0 &&
-            (uint32_t)(now_ms - id(oq_outside_temp_hp2_active_since_ms)) >= active_warmup_ms));
-      const bool local_active = hp1_active || hp2_active;
-      const bool local_active_warmed = hp1_warmed || hp2_warmed;
-      const bool auto_active_warmup_hold = source == "Auto" && local_active && !local_active_warmed;
-      const bool hold_enabled = source == "HA input" || auto_active_warmup_hold;
+      const bool hold_enabled = source == "HA input";
 
       float selected_c = NAN;
-      bool warmup_blocked_local = false;
       if (source == "Auto" || source == "Lowest valid") {
-        if (local_active && !local_active_warmed) {
-          warmup_blocked_local = hp_valid;
-          if (ha_valid) selected_c = id(outside_temp_ha).state;
-        } else if (local_active_warmed && hp_valid) {
-          float candidate_c = id(outside_temp_hp_avg).state;
-          if (ha_valid && !isnan(warm_cap_c)) {
-            candidate_c = std::min(candidate_c, id(outside_temp_ha).state + warm_cap_c);
-          }
-          if (ha_valid &&
-              max_rise_c_per_min > 0.0f &&
-              id(oq_outside_temp_selected_last_valid_ms) > 0 &&
-              !isnan(id(oq_outside_temp_selected_last_valid_c)) &&
-              now_ms > id(oq_outside_temp_selected_last_valid_ms) &&
-              candidate_c > id(oq_outside_temp_selected_last_valid_c)) {
-            const float dt_min =
-                ((float) ((uint32_t) (now_ms - id(oq_outside_temp_selected_last_valid_ms)))) / 60000.0f;
-            const float max_rise_c = max_rise_c_per_min * dt_min;
-            candidate_c = std::min(candidate_c, id(oq_outside_temp_selected_last_valid_c) + max_rise_c);
-          }
-          selected_c = candidate_c;
+        if (ha_valid && hp_valid) {
+          selected_c = std::min(id(outside_temp_ha).state, id(outside_temp_hp_avg).state);
         } else if (ha_valid) {
           selected_c = id(outside_temp_ha).state;
         } else if (hp_valid) {
@@ -477,8 +415,6 @@ sensor:
         id(oq_outside_temp_selected_hold_active) = true;
         return id(oq_outside_temp_selected_last_valid_c);
       }
-
-      if (warmup_blocked_local) return id(outside_temp_hp_avg).state;
 
       return NAN;
     web_server:

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -67,9 +67,6 @@ oq_strategy_demand_max_f: "20.0"                      # Upper bound of demand sc
 oq_selected_input_stale_hold_s: "300"                 # Hold selected HA-backed inputs this long when they briefly disappear during reloads [s].
 oq_temp_guard_delta_c: "0.5"                          # Minimum valid margin between T0 and Tc in the house model [°C].
 oq_outside_temp_stale_s: "1200"                       # Ignore a local outdoor reading when it stays frozen while the same HP still shows fresh activity [s].
-oq_outside_temp_active_warmup_s: "180"                # Let a newly active outdoor-unit sensor settle before Auto switches to it [s].
-oq_outside_temp_auto_warm_cap_c: "1.0"                # In Auto, limit how far an active local outside reading may run above valid HA input [°C].
-oq_outside_temp_auto_rise_limit_c_per_min: "0.25"     # In Auto, limit how fast selected outside temperature may rise toward a newly trusted active local reading [°C/min].
 
 # ----------------------------
 # HEAT CONTROL


### PR DESCRIPTION
## Summary
- simplify `Outside Temperature Source = Auto` to choose the lowest valid available source
- keep the existing local stale/activity guards in the local outside-temperature aggregation
- update docs and HA dashboard help text to match the simpler `Auto` behavior

## Why
Recent trace review showed that the more sophisticated `Auto` source-selection logic still introduced source-transition dynamics that were hard to reason about and could still lead to unstable control input.

Replay comparison against recent traces showed that a simpler rule is both calmer and easier to explain: after invalid or stale local sources are already filtered out by the existing local aggregation, `Auto` should just pick the lowest valid outside temperature from the available sources.

This keeps control robust against sources that are temporarily biased warm by sun, local heat, or startup behavior.

## Validation
- `python3 scripts/dev.py validate --jobs 1`