### PR TITLE
Simplify max water temperature control

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2449,9 +2449,9 @@ views:
               - **Maximum water temperature** is the normal ceiling for measured
               supply temperature.
 
-              - OpenQuatt derives an internal rollback band and absolute safety
-              threshold from that setting. In `CM3` the boiler drops out first;
-              a hard HP stop follows only if the overshoot persists.
+              - OpenQuatt derives an internal rollback band and a hard trip at
+              `max + 5°C` from that setting. In `CM3` the boiler drops out
+              first; a hard HP stop follows only if the overshoot persists.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2449,12 +2449,9 @@ views:
               - **Maximum water temperature** is the normal ceiling for measured
               supply temperature.
 
-              - **Soft band** starts the rollback below that ceiling. Power House
-              reduces effective requested heat most strongly between `max - band`
-              and `max`.
-
-              - **Trip** is the absolute upper limit. In `CM3` the boiler drops
-              out first; a hard HP stop follows only if the overshoot persists.
+              - OpenQuatt derives an internal rollback band and absolute safety
+              threshold from that setting. In `CM3` the boiler drops out first;
+              a hard HP stop follows only if the overshoot persists.
 
 
               </details>
@@ -2464,10 +2461,6 @@ views:
             entities:
               - entity: number.openquatt_maximum_water_temperature
                 name: Maximum water temperature
-              - entity: number.openquatt_water_temperature_soft_band
-                name: Water temperature soft band
-              - entity: number.openquatt_maximum_water_temperature_trip
-                name: Maximum water temperature trip
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2571,13 +2571,10 @@ views:
               - **Maximum water temperature** is het normale plafond voor de
               gemeten aanvoertemperatuur.
 
-              - **Soft band** laat de regeling daaronder al terugnemen. In
-              `Power House` gebeurt de sterkste afbouw tussen `max - band` en
-              `max`.
-
-              - **Trip** is de absolute bovengrens. In `CM3` valt eerst de
-              boiler weg; alleen bij aanhoudende overshoot volgt daarna een
-              harde HP-stop.
+              - OpenQuatt leidt uit die instelling intern zelf een
+              terugregelband en absolute veiligheidsgrens af. In `CM3` valt
+              eerst de boiler weg; alleen bij aanhoudende overshoot volgt
+              daarna een harde HP-stop.
 
 
               </details>
@@ -2587,10 +2584,6 @@ views:
             entities:
               - entity: number.openquatt_maximum_water_temperature
                 name: Max. water temperature
-              - entity: number.openquatt_water_temperature_soft_band
-                name: Water temperature soft band
-              - entity: number.openquatt_maximum_water_temperature_trip
-                name: Max. water temperature trip
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2572,8 +2572,8 @@ views:
               gemeten aanvoertemperatuur.
 
               - OpenQuatt leidt uit die instelling intern zelf een
-              terugregelband en absolute veiligheidsgrens af. In `CM3` valt
-              eerst de boiler weg; alleen bij aanhoudende overshoot volgt
+              terugregelband en een harde trip op `max + 5°C` af. In `CM3`
+              valt eerst de boiler weg; alleen bij aanhoudende overshoot volgt
               daarna een harde HP-stop.
 
 

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2190,9 +2190,9 @@ views:
               - **Maximum water temperature** is the normal ceiling for measured
               supply temperature.
 
-              - OpenQuatt derives an internal rollback band and absolute safety
-              threshold from that setting. In `CM3` the boiler drops out first;
-              a hard HP stop follows only if the overshoot persists.
+              - OpenQuatt derives an internal rollback band and a hard trip at
+              `max + 5°C` from that setting. In `CM3` the boiler drops out
+              first; a hard HP stop follows only if the overshoot persists.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2190,12 +2190,9 @@ views:
               - **Maximum water temperature** is the normal ceiling for measured
               supply temperature.
 
-              - **Soft band** starts the rollback below that ceiling. Power House
-              reduces effective requested heat most strongly between `max - band`
-              and `max`.
-
-              - **Trip** is the absolute upper limit. In `CM3` the boiler drops
-              out first; a hard HP stop follows only if the overshoot persists.
+              - OpenQuatt derives an internal rollback band and absolute safety
+              threshold from that setting. In `CM3` the boiler drops out first;
+              a hard HP stop follows only if the overshoot persists.
 
 
               </details>
@@ -2205,10 +2202,6 @@ views:
             entities:
               - entity: number.openquatt_maximum_water_temperature
                 name: Maximum water temperature
-              - entity: number.openquatt_water_temperature_soft_band
-                name: Water temperature soft band
-              - entity: number.openquatt_maximum_water_temperature_trip
-                name: Maximum water temperature trip
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2274,13 +2274,10 @@ views:
               - **Maximum water temperature** is het normale plafond voor de
               gemeten aanvoertemperatuur.
 
-              - **Soft band** laat de regeling daaronder al terugnemen. In
-              `Power House` gebeurt de sterkste afbouw tussen `max - band` en
-              `max`.
-
-              - **Trip** is de absolute bovengrens. In `CM3` valt eerst de
-              boiler weg; alleen bij aanhoudende overshoot volgt daarna een
-              harde HP-stop.
+              - OpenQuatt leidt uit die instelling intern zelf een
+              terugregelband en absolute veiligheidsgrens af. In `CM3` valt
+              eerst de boiler weg; alleen bij aanhoudende overshoot volgt
+              daarna een harde HP-stop.
 
 
               </details>
@@ -2290,10 +2287,6 @@ views:
             entities:
               - entity: number.openquatt_maximum_water_temperature
                 name: Maximum water temperature
-              - entity: number.openquatt_water_temperature_soft_band
-                name: Water temperature soft band
-              - entity: number.openquatt_maximum_water_temperature_trip
-                name: Maximum water temperature trip
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2275,8 +2275,8 @@ views:
               gemeten aanvoertemperatuur.
 
               - OpenQuatt leidt uit die instelling intern zelf een
-              terugregelband en absolute veiligheidsgrens af. In `CM3` valt
-              eerst de boiler weg; alleen bij aanhoudende overshoot volgt
+              terugregelband en een harde trip op `max + 5°C` af. In `CM3`
+              valt eerst de boiler weg; alleen bij aanhoudende overshoot volgt
               daarna een harde HP-stop.
 
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -161,7 +161,7 @@ Voor `Power House` geldt: `Power House response profile` is een snelle voorkeuze
 
 Deze tijden schalen mee met `Rated maximum house power` en zijn daardoor beter overdraagbaar tussen installaties dan oude absolute `W/min`-rampen.
 
-De watertempbegrenzing werkt op `water_supply_temp_selected`. In `Water Temperature Control` wordt `Heating Curve Supply Target` begrensd op `Maximum water temperature`. In `Power House` wordt `P_req` progressief teruggenomen, met de sterkste afbouw in de laatste paar graden onder die grens. In `CM3` wordt de boiler vanaf `Maximum water temperature` geblokkeerd. OpenQuatt leidt daarboven intern zelf een veiligheidsgrens af.
+De watertempbegrenzing werkt op `water_supply_temp_selected`. In `Water Temperature Control` wordt `Heating Curve Supply Target` begrensd op `Maximum water temperature`. In `Power House` wordt `P_req` progressief teruggenomen, met de sterkste afbouw in de laatste paar graden onder die grens. In `CM3` wordt de boiler vanaf `Maximum water temperature` geblokkeerd. OpenQuatt bewaakt daarboven een harde trip op `max + 5°C`.
 
 Verander niet meerdere instellingen uit deze groep tegelijk.
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -147,8 +147,6 @@ Belangrijke runtime-instellingen in deze groep zijn:
 - `Power House demand rise time`
 - `Power House demand fall time`
 - `Maximum water temperature`
-- `Water temperature soft band`
-- `Maximum water temperature trip`
 - `Curve Tsupply @ -20/-10/0/5/10/15°C`
 - `Heating Curve Control Profile`
 - `Heating Curve PID Kp/Ki/Kd`
@@ -163,7 +161,7 @@ Voor `Power House` geldt: `Power House response profile` is een snelle voorkeuze
 
 Deze tijden schalen mee met `Rated maximum house power` en zijn daardoor beter overdraagbaar tussen installaties dan oude absolute `W/min`-rampen.
 
-De watertempbegrenzing werkt op `water_supply_temp_selected`. In `Water Temperature Control` wordt `Heating Curve Supply Target` begrensd op `Maximum water temperature`. In `Power House` wordt `P_req` progressief teruggenomen, met de sterkste afbouw tussen `max - soft band` en `max`. In `CM3` wordt de boiler vanaf `Maximum water temperature` geblokkeerd.
+De watertempbegrenzing werkt op `water_supply_temp_selected`. In `Water Temperature Control` wordt `Heating Curve Supply Target` begrensd op `Maximum water temperature`. In `Power House` wordt `P_req` progressief teruggenomen, met de sterkste afbouw in de laatste paar graden onder die grens. In `CM3` wordt de boiler vanaf `Maximum water temperature` geblokkeerd. OpenQuatt leidt daarboven intern zelf een veiligheidsgrens af.
 
 Verander niet meerdere instellingen uit deze groep tegelijk.
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -195,7 +195,7 @@ doet OpenQuatt drie dingen:
 
 1. al onder de maximale aanvoer voorzichtig terugnemen;
 2. in de laatste paar graden onder `max` steeds sterker afremmen;
-3. daarboven via een interne veiligheidsgrens uiteindelijk naar een harde stop kunnen gaan.
+3. daarboven via een harde trip op `max + 5°C` uiteindelijk naar een harde stop kunnen gaan.
 
 Daardoor kan `Power House` niet onbeperkt blijven vragen als de aanvoer al te hoog wordt.
 

--- a/docs/power-house.md
+++ b/docs/power-house.md
@@ -190,14 +190,12 @@ Ook in `Power House` blijft `Water Supply Temp (Selected)` belangrijk.
 Met:
 
 - `Maximum water temperature`
-- `Water temperature soft band`
-- `Maximum water temperature trip`
 
 doet OpenQuatt drie dingen:
 
 1. al onder de maximale aanvoer voorzichtig terugnemen;
-2. tussen `max - soft band` en `max` steeds sterker afremmen;
-3. rond `trip` uiteindelijk naar een harde stop kunnen gaan.
+2. in de laatste paar graden onder `max` steeds sterker afremmen;
+3. daarboven via een interne veiligheidsgrens uiteindelijk naar een harde stop kunnen gaan.
 
 Daardoor kan `Power House` niet onbeperkt blijven vragen als de aanvoer al te hoog wordt.
 
@@ -333,8 +331,6 @@ Gebruik deze vooral als het systeem in zacht weer te snel stopt en weer wil star
 ### 5. Watertempbegrenzing
 
 - `Maximum water temperature`
-- `Water temperature soft band`
-- `Maximum water temperature trip`
 
 Gebruik deze om te voorkomen dat `Power House` te lang blijft duwen terwijl de aanvoer al te hoog wordt.
 

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -133,14 +133,14 @@ OpenQuatt heeft daarnaast een gedeelde begrenzing op basis van `water_supply_tem
 Belangrijke eigenschappen:
 
 - `Maximum water temperature` is het normale bovendoel voor de gemeten aanvoer;
-- OpenQuatt leidt intern een terugregelband en absolute veiligheidsgrens af.
+- OpenQuatt leidt intern een terugregelband en een harde trip op `5°C` boven die grens af.
 
 Praktisch betekent dit:
 
 - in `Water Temperature Control` wordt `Heating Curve Supply Target` geclampt op `Maximum water temperature`;
 - in `Power House` wordt de effectieve warmtevraag progressief verlaagd, met de sterkste afbouw in de laatste paar graden onder `Maximum water temperature`;
 - in `CM3` wordt de boiler vanaf `Maximum water temperature` geblokkeerd;
-- daarboven bewaakt een interne veiligheidsgrens of een harde stop nodig is, zonder dat OpenQuatt de `Control Mode` zelf herschrijft.
+- daarboven bewaakt een harde trip op `max + 5°C` of een harde stop nodig is, zonder dat OpenQuatt de `Control Mode` zelf herschrijft.
 
 ## Flow Mode
 

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -133,15 +133,14 @@ OpenQuatt heeft daarnaast een gedeelde begrenzing op basis van `water_supply_tem
 Belangrijke eigenschappen:
 
 - `Maximum water temperature` is het normale bovendoel voor de gemeten aanvoer;
-- `Water temperature soft band` bepaalt vanaf hoeveel graden daaronder OpenQuatt al terughoudend wordt;
-- `Maximum water temperature trip` is de absolute bovengrens.
+- OpenQuatt leidt intern een terugregelband en absolute veiligheidsgrens af.
 
 Praktisch betekent dit:
 
 - in `Water Temperature Control` wordt `Heating Curve Supply Target` geclampt op `Maximum water temperature`;
-- in `Power House` wordt de effectieve warmtevraag progressief verlaagd, met de sterkste afbouw tussen `max - soft band` en `max`;
+- in `Power House` wordt de effectieve warmtevraag progressief verlaagd, met de sterkste afbouw in de laatste paar graden onder `Maximum water temperature`;
 - in `CM3` wordt de boiler vanaf `Maximum water temperature` geblokkeerd;
-- bij `Maximum water temperature trip` kan een harde stop volgen zonder dat OpenQuatt de `Control Mode` zelf herschrijft.
+- daarboven bewaakt een interne veiligheidsgrens of een harde stop nodig is, zonder dat OpenQuatt de `Control Mode` zelf herschrijft.
 
 ## Flow Mode
 

--- a/docs/water-temperature-control.md
+++ b/docs/water-temperature-control.md
@@ -88,8 +88,6 @@ Ook in deze strategie blijft `Water Supply Temp (Selected)` belangrijk.
 Met:
 
 - `Maximum water temperature`
-- `Water temperature soft band`
-- `Maximum water temperature trip`
 
 wordt het target of gedrag begrensd als de aanvoer al te hoog wordt.
 
@@ -324,8 +322,6 @@ Gebruik deze vooral als `Duo` te laat, te vroeg of te onrustig inschakelt. `Mini
 ### 4. Watertempbegrenzing
 
 - `Maximum water temperature`
-- `Water temperature soft band`
-- `Maximum water temperature trip`
 
 Gebruik deze om te voorkomen dat de aanvoerregeling te lang te hoog blijft mikken.
 

--- a/docs/water-temperature-control.md
+++ b/docs/water-temperature-control.md
@@ -85,11 +85,7 @@ Als de buitentemperatuur ontbreekt, gebruikt OpenQuatt:
 
 Ook in deze strategie blijft `Water Supply Temp (Selected)` belangrijk.
 
-Met:
-
-- `Maximum water temperature`
-
-wordt het target of gedrag begrensd als de aanvoer al te hoog wordt.
+Met `Maximum water temperature` wordt het target of gedrag begrensd als de aanvoer al te hoog wordt. OpenQuatt leidt daar intern ook een harde trip op `max + 5°C` uit af.
 
 In `Water Temperature Control` betekent dat vooral:
 

--- a/openquatt/oq_thermal_limits.yaml
+++ b/openquatt/oq_thermal_limits.yaml
@@ -63,36 +63,6 @@ number:
     web_server:
       sorting_group_id: oq_tuning_heat
 
-  - platform: template
-    id: water_temp_soft_band_c
-    name: "Water temperature soft band"
-    icon: mdi:arrow-expand-vertical
-    unit_of_measurement: "°C"
-    min_value: 0.5
-    max_value: 10
-    step: 0.5
-    restore_value: true
-    optimistic: true
-    initial_value: 3
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
-  - platform: template
-    id: max_water_temp_trip_c
-    name: "Maximum water temperature trip"
-    icon: mdi:alarm-light-outline
-    unit_of_measurement: "°C"
-    min_value: 30
-    max_value: 85
-    step: 0.5
-    restore_value: true
-    optimistic: true
-    initial_value: 65
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_heat
-
 sensor:
   # Shared abstractions and derived telemetry.
   - platform: template
@@ -151,13 +121,11 @@ interval:
           if (isnan(max_water_temp_c)) max_water_temp_c = 60.0f;
           max_water_temp_c = clampf(max_water_temp_c, 25.0f, 75.0f);
 
-          float soft_band_c = id(water_temp_soft_band_c).state;
-          if (isnan(soft_band_c)) soft_band_c = 3.0f;
-          soft_band_c = clampf(soft_band_c, 0.5f, 10.0f);
-
-          float trip_water_temp_c = id(max_water_temp_trip_c).state;
-          if (isnan(trip_water_temp_c)) trip_water_temp_c = 65.0f;
-          trip_water_temp_c = clampf(trip_water_temp_c, max_water_temp_c + 1.0f, 85.0f);
+          constexpr float derived_soft_band_c = 3.0f;
+          constexpr float derived_trip_offset_c = 5.0f;
+          const float soft_band_c = derived_soft_band_c;
+          const float trip_water_temp_c =
+              clampf(max_water_temp_c + derived_trip_offset_c, max_water_temp_c + 1.0f, 85.0f);
 
           const float soft_start_c = max_water_temp_c - soft_band_c;
           constexpr float water_temp_factor_at_max = 0.25f;

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -267,7 +267,6 @@
       ["Day max level", 10, 0, 10, 1, ""],
       ["Silent max level", 6, 0, 10, 1, ""],
       ["Maximum water temperature", 56, 25, 75, 1, "°C"],
-      ["Maximum water temperature trip", 65, 30, 85, 0.5, "°C"],
       ["Minimum runtime", 300, 300, 3600, 30, "s"],
       ["Rated maximum house power", 4500, 500, 12000, 100, "W"],
       ["House cold temp", -10, -25, 5, 0.5, "°C"],

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -108,7 +108,6 @@
     silentStartTime: { domain: "time", name: "Silent start time" },
     silentEndTime: { domain: "time", name: "Silent end time" },
     maxWater: { domain: "number", name: "Maximum water temperature" },
-    maxWaterTrip: { domain: "number", name: "Maximum water temperature trip" },
     minRuntime: { domain: "number", name: "Minimum runtime" },
     totalPower: { domain: "sensor", name: "Total Power Input" },
     totalCop: { domain: "sensor", name: "Total COP" },
@@ -379,7 +378,6 @@
     ...LIMIT_KEYS,
     ...POWER_HOUSE_KEYS,
     ...CURVE_SETTING_KEYS,
-    "maxWaterTrip",
     ...COMPRESSOR_SETTING_KEYS,
     ...SILENT_SETTING_KEYS,
   ];
@@ -3361,11 +3359,10 @@
     return renderSettingsSection(
       "Maximale watertemperatuur",
       "Watertemperatuur",
-      "Beschermt het systeem tegen te hoge aanvoertemperaturen en bepaalt wanneer de tripgrens in beeld komt.",
+      "Beschermt het systeem tegen te hoge aanvoertemperaturen. OpenQuatt leidt daar intern zelf de terugregelband en veiligheidsgrens uit af.",
       `
         <div class="oq-settings-grid">
-          ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf.")}
-          ${renderSettingsNumberField("maxWaterTrip", "Tripgrens watertemperatuur", "Veiligheidsgrens waarbij de regeling hard ingrijpt als de watertemperatuur te ver oploopt.")}
+          ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf. OpenQuatt begint enkele graden eerder al terug te regelen en bewaakt daarboven een interne veiligheidsgrens.")}
         </div>
       `,
     );
@@ -3602,10 +3599,9 @@
       <section class="oq-helper-panel">
         <p class="oq-helper-label">Stap 4</p>
         <h2 class="oq-helper-section-title">Watertemperatuur beveiligen</h2>
-        <p class="oq-helper-section-copy">Hier stel je de veilige bovengrens voor de watertemperatuur in.</p>
+        <p class="oq-helper-section-copy">Hier stel je de veilige bovengrens voor de watertemperatuur in. OpenQuatt leidt de interne beveiligingsmarges daar zelf uit af.</p>
         <div class="oq-settings-grid oq-settings-grid--quickstart">
-          ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf.")}
-          ${renderSettingsNumberField("maxWaterTrip", "Tripgrens watertemperatuur", "Veiligheidsgrens waarbij de regeling hard ingrijpt als de watertemperatuur te ver oploopt.")}
+          ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf. OpenQuatt begint enkele graden eerder al terug te regelen en bewaakt daarboven een interne veiligheidsgrens.")}
         </div>
         ${renderQuickStartStepNav()}
       </section>
@@ -3792,7 +3788,6 @@
 
     const waterLines = [
       ["Maximale watertemperatuur", formatValue("maxWater")],
-      ["Tripgrens", formatValue("maxWaterTrip")],
     ];
 
     const silentLines = [

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -3359,10 +3359,10 @@
     return renderSettingsSection(
       "Maximale watertemperatuur",
       "Watertemperatuur",
-      "Beschermt het systeem tegen te hoge aanvoertemperaturen. OpenQuatt leidt daar intern zelf de terugregelband en veiligheidsgrens uit af.",
+      "Beschermt het systeem tegen te hoge aanvoertemperaturen. OpenQuatt leidt daar intern zelf de terugregelband en een harde trip op 5°C boven deze grens uit af.",
       `
         <div class="oq-settings-grid">
-          ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf. OpenQuatt begint enkele graden eerder al terug te regelen en bewaakt daarboven een interne veiligheidsgrens.")}
+          ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf. OpenQuatt begint enkele graden eerder al terug te regelen en bewaakt een harde trip op 5°C boven deze grens.")}
         </div>
       `,
     );
@@ -3599,9 +3599,9 @@
       <section class="oq-helper-panel">
         <p class="oq-helper-label">Stap 4</p>
         <h2 class="oq-helper-section-title">Watertemperatuur beveiligen</h2>
-        <p class="oq-helper-section-copy">Hier stel je de veilige bovengrens voor de watertemperatuur in. OpenQuatt leidt de interne beveiligingsmarges daar zelf uit af.</p>
+        <p class="oq-helper-section-copy">Hier stel je de veilige bovengrens voor de watertemperatuur in. OpenQuatt leidt daar zelf de terugregelband en een harde trip op 5°C boven af.</p>
         <div class="oq-settings-grid oq-settings-grid--quickstart">
-          ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf. OpenQuatt begint enkele graden eerder al terug te regelen en bewaakt daarboven een interne veiligheidsgrens.")}
+          ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf. OpenQuatt begint enkele graden eerder al terug te regelen en bewaakt een harde trip op 5°C boven deze grens.")}
         </div>
         ${renderQuickStartStepNav()}
       </section>


### PR DESCRIPTION
## Summary
- reduce the user-facing water temperature guardrail to a single Maximum water temperature setting
- derive the rollback band and absolute trip internally from that max temperature
- update the OpenQuatt web app, mock device, and docs/dashboard copy to match the simplified model

## Details
This keeps the existing guardrail behavior model intact, but removes the need for users to configure a separate soft band and trip threshold.

The implementation now derives:
- an internal rollback band of 3°C below the configured max water temperature
- an internal absolute trip threshold of max water temperature + 5°C, clamped to the existing safety ceiling

That means users only set the normal operating ceiling, while OpenQuatt still preserves progressive rollback, boiler inhibit, and hard-trip behavior internally.

## Validation
- node --check openquatt/web/openquatt-app.js
- node --check openquatt/web/mock-device.js
- python3 scripts/dev.py validate --config-only
- python3 scripts/dev.py validate
