### PR TITLE
Refine ESPHome webserver category structure

### DIFF
--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -286,11 +286,12 @@ Compile-time profile selection is done by choosing the firmware entrypoint:
 
 `oq_webserver.yaml` defines stable sorting groups used across packages:
 
-- Overview, Control, Temperatures, Flow & Pump, Performance, Boiler, CIC
-- HP1, HP2
-- Tuning groups
-- Diagnostics groups
-- Diagnostics groups surfaced in the dedicated dashboard tab
+- Quick Start and Overview
+- System Control, Heating Strategy, Heating Curve, Power House, Cooling
+- Sensor Selection, OpenTherm, CIC Feed, HA Inputs
+- Temperatures, Flow & Pump, Flow Tuning, Performance, Boiler
+- HP1, HP2, Advanced HP Levels
+- System Diagnostics and HP Diagnostics
 
 This keeps ESPHome web UI and Home Assistant mapping coherent.
 

--- a/docs/templates/heating-strategy-template.yaml
+++ b/docs/templates/heating-strategy-template.yaml
@@ -76,7 +76,7 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return std::string("init");
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -192,7 +192,7 @@ select:
       - "L9 (H85/C71)"
       - "L10 (H90/C74)"
     web_server:
-      sorting_group_id: oq_advanced_levels_${hp_id}
+      sorting_group_id: oq_advanced_hp_levels
       sorting_weight: 41
 
   - platform: template
@@ -215,7 +215,7 @@ select:
       - "L9 (H85/C71)"
       - "L10 (H90/C74)"
     web_server:
-      sorting_group_id: oq_advanced_levels_${hp_id}
+      sorting_group_id: oq_advanced_hp_levels
       sorting_weight: 42
 
 # ----------------------------
@@ -958,7 +958,7 @@ binary_sensor:
     entity_category: diagnostic
     skip_updates: ${oq_skip_30s}
     web_server:
-      sorting_group_id: oq_diagnostics_hp
+      sorting_group_id: oq_hp_diagnostics
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -973,7 +973,7 @@ binary_sensor:
     entity_category: diagnostic
     skip_updates: ${oq_skip_30s}
     web_server:
-      sorting_group_id: oq_diagnostics_hp
+      sorting_group_id: oq_hp_diagnostics
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -988,7 +988,7 @@ binary_sensor:
     entity_category: diagnostic
     skip_updates: ${oq_skip_30s}
     web_server:
-      sorting_group_id: oq_diagnostics_hp
+      sorting_group_id: oq_hp_diagnostics
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -1022,7 +1022,7 @@ binary_sensor:
       }
       return (static_cast<uint16_t>(lroundf(raw)) & 0x0008u) != 0;
     web_server:
-      sorting_group_id: oq_diagnostics_hp
+      sorting_group_id: oq_hp_diagnostics
 
   - platform: template
     id: ${hp_id}_ot_fault_active
@@ -1107,7 +1107,7 @@ text_sensor:
     icon: mdi:speedometer-slow
     update_interval: 10s
     web_server:
-      sorting_group_id: oq_advanced_levels_${hp_id}
+      sorting_group_id: oq_advanced_hp_levels
       sorting_weight: 43
     lambda: |-
       // Summarize the two exclusion selectors into one compact diagnostic label.
@@ -1135,7 +1135,7 @@ text_sensor:
     entity_category: diagnostic
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_hp_diagnostics
     icon: mdi:alert-circle-outline
     lambda: |-
       std::string s;
@@ -1225,4 +1225,4 @@ text_sensor:
       return std::string(buf);
     update_interval: never
     web_server:
-      sorting_group_id: oq_diagnostics_hp
+      sorting_group_id: oq_hp_diagnostics

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -168,7 +168,7 @@ select:
     id: oq_firmware_update_channel
     icon: mdi:source-branch
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
     entity_category: config
     optimistic: true
     restore_value: true
@@ -205,7 +205,7 @@ select:
     disabled_by_default: true
     icon: mdi:lan
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -230,7 +230,7 @@ select:
     disabled_by_default: true
     icon: mdi:lan
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
     entity_category: diagnostic
     optimistic: true
     restore_value: true
@@ -258,14 +258,14 @@ button:
     icon: mdi:restart
     id: restart_switch
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: safe_mode
     name: Safe mode
     icon: mdi:shield-alert
     id: safe_mode_button
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_check_firmware_updates
@@ -273,7 +273,7 @@ button:
     icon: mdi:update
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
     on_press:
       - if:
           condition:
@@ -298,7 +298,7 @@ binary_sensor:
     icon: mdi:check-circle-outline
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
 sensor:
   - platform: template
@@ -312,7 +312,7 @@ sensor:
     lambda: |-
       return id(oq_ota_progress_pct);
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: uptime
     name: Uptime
@@ -324,7 +324,7 @@ sensor:
     unit_of_measurement: s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: internal_temperature
     name: ESP Internal Temperature
@@ -332,7 +332,7 @@ sensor:
     update_interval: 60s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: wifi_signal
     name: WiFi Signal
@@ -340,7 +340,7 @@ sensor:
     update_interval: 300s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
 text_sensor:
   - platform: wifi_info
@@ -349,13 +349,13 @@ text_sensor:
       icon: mdi:ip-network-outline
       entity_category: diagnostic
       web_server:
-        sorting_group_id: oq_diagnostics
+        sorting_group_id: oq_system_diagnostics
     ssid:
       name: WiFi SSID
       icon: mdi:wifi
       entity_category: diagnostic
       web_server:
-        sorting_group_id: oq_diagnostics
+        sorting_group_id: oq_system_diagnostics
   - platform: template
     id: oq_firmware_update_status
     name: Firmware Update Status
@@ -381,7 +381,7 @@ text_sensor:
           return {"Idle"};
       }
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
   - platform: template
     id: oq_project_version_text
     name: OpenQuatt Version
@@ -391,7 +391,7 @@ text_sensor:
     lambda: |-
       return {"${project_version}"};
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
   - platform: template
     id: oq_release_channel_text
     name: OpenQuatt Release Channel
@@ -401,14 +401,14 @@ text_sensor:
     lambda: |-
       return {"${release_channel}"};
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
   - platform: version
     name: ESPHome Version
     icon: mdi:information-outline
     hide_timestamp: true
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
   - platform: template
     id: uptime_readable_text
     name: Uptime
@@ -440,7 +440,7 @@ text_sensor:
       }
       return {buffer};
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
 update:
   - platform: http_request
@@ -451,4 +451,4 @@ update:
     icon: mdi:update
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -160,7 +160,7 @@ binary_sensor:
       }
       return id(oq_cooling_request_latched);
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_permitted
@@ -175,7 +175,7 @@ binary_sensor:
       const bool flow_ok = flow_valid && (id(flow_rate_selected).state >= (float) ${oq_cm_min_flow_lph});
       return core_ok && flow_ok && !id(oq_lowflow_fault_active);
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_dew_point_available
@@ -185,7 +185,7 @@ binary_sensor:
     lambda: |-
       return id(cooling_dew_point_selected).has_state() && !isnan(id(cooling_dew_point_selected).state);
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_cooling
 
 text_sensor:
   - platform: template
@@ -215,7 +215,7 @@ text_sensor:
       }
       return {"Ready"};
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_cooling
 
 sensor:
   - platform: dew_point
@@ -230,7 +230,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: dew_point
     id: cooling_room_2_dew_point_calc
@@ -244,7 +244,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: dew_point
     id: cooling_room_3_dew_point_calc
@@ -258,7 +258,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: dew_point
     id: cooling_room_4_dew_point_calc
@@ -272,7 +272,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: dew_point
     id: cooling_room_5_dew_point_calc
@@ -286,7 +286,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: dew_point
     id: cooling_room_6_dew_point_calc
@@ -300,7 +300,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_room_count_selected
@@ -333,7 +333,7 @@ sensor:
 
       return 0.0f;
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_safety_margin_selected
@@ -348,7 +348,7 @@ sensor:
       if (margin_c > 4.0f) margin_c = 4.0f;
       return margin_c;
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_room_1_dew_point_effective
@@ -369,7 +369,7 @@ sensor:
       }
       return NAN;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_room_2_dew_point_effective
@@ -390,7 +390,7 @@ sensor:
       }
       return NAN;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_room_3_dew_point_effective
@@ -411,7 +411,7 @@ sensor:
       }
       return NAN;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_room_4_dew_point_effective
@@ -432,7 +432,7 @@ sensor:
       }
       return NAN;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_room_5_dew_point_effective
@@ -453,7 +453,7 @@ sensor:
       }
       return NAN;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_room_6_dew_point_effective
@@ -474,7 +474,7 @@ sensor:
       }
       return NAN;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_valid_room_count
@@ -522,7 +522,7 @@ sensor:
 
       return 0.0f;
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_dew_point_selected
@@ -575,7 +575,7 @@ sensor:
 
       return NAN;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: minimum_safe_supply_temp
@@ -592,4 +592,4 @@ sensor:
       if (!id(cooling_safety_margin_selected).has_state() || isnan(id(cooling_safety_margin_selected).state)) return NAN;
       return id(cooling_dew_point_selected).state + id(cooling_safety_margin_selected).state;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -82,7 +82,7 @@ number:
     initial_value: 18.0
     entity_category: config
     web_server:
-      sorting_group_id: oq_control
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_demand_max_f
@@ -98,7 +98,7 @@ number:
     initial_value: 4
     entity_category: config
     web_server:
-      sorting_group_id: oq_control
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_pid_kp
@@ -114,7 +114,7 @@ number:
     initial_value: 3.0
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_pid_ki
@@ -130,7 +130,7 @@ number:
     initial_value: 0.12
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_pid_kd
@@ -146,7 +146,7 @@ number:
     initial_value: 0.0
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_cooling
 
 sensor:
   - platform: template
@@ -166,7 +166,7 @@ sensor:
       }
       return target_c;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_supply_error
@@ -182,7 +182,7 @@ sensor:
       // Positive error means the supply is warmer than target, so more cooling may be requested.
       return id(oq_system_supply_temp).state - id(cooling_supply_target).state;
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_cooling
 
   - platform: template
     id: oq_cooling_demand_raw_sensor
@@ -193,7 +193,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_demand_raw);
 

--- a/openquatt/oq_energy.yaml
+++ b/openquatt/oq_energy.yaml
@@ -12,7 +12,7 @@ button:
     name: "Reset Cumulative Energy Counters"
     icon: mdi:restart
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_performance
     on_press:
       - lambda: |-
           id(oq_electrical_energy_cumulative).reset();

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -243,7 +243,7 @@ binary_sensor:
     device_class: problem
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_hydraulics
     lambda: |-
       static bool state = false;
       static bool mismatch_timer_running = false;

--- a/openquatt/oq_ha_inputs.yaml
+++ b/openquatt/oq_ha_inputs.yaml
@@ -27,7 +27,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: water_supply_temp_ha
@@ -40,7 +40,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: thermostat_setpoint_ha
@@ -53,7 +53,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: thermostat_room_temp_ha
@@ -66,7 +66,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_count_ha
@@ -76,7 +76,7 @@ sensor:
     icon: mdi:counter
     accuracy_decimals: 0
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_1_dew_point_direct_ha
@@ -89,7 +89,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_1_temp_ha
@@ -102,7 +102,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_1_humidity_ha
@@ -115,7 +115,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_2_dew_point_direct_ha
@@ -128,7 +128,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_2_temp_ha
@@ -141,7 +141,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_2_humidity_ha
@@ -154,7 +154,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_3_dew_point_direct_ha
@@ -167,7 +167,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_3_temp_ha
@@ -180,7 +180,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_3_humidity_ha
@@ -193,7 +193,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_4_dew_point_direct_ha
@@ -206,7 +206,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_4_temp_ha
@@ -219,7 +219,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_4_humidity_ha
@@ -232,7 +232,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_5_dew_point_direct_ha
@@ -245,7 +245,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_5_temp_ha
@@ -258,7 +258,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_5_humidity_ha
@@ -271,7 +271,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_6_dew_point_direct_ha
@@ -284,7 +284,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_6_temp_ha
@@ -297,7 +297,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_room_6_humidity_ha
@@ -310,7 +310,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs
 
 binary_sensor:
   - platform: homeassistant
@@ -321,4 +321,4 @@ binary_sensor:
     icon: mdi:snowflake-check
     device_class: cold
     web_server:
-      sorting_group_id: oq_ha
+      sorting_group_id: oq_ha_inputs

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -126,7 +126,7 @@ select:
     initial_option: Balanced
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
     on_value:
       then:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
@@ -175,7 +175,7 @@ number:
     optimistic: true
     initial_value: 55
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_m10
@@ -189,7 +189,7 @@ number:
     optimistic: true
     initial_value: 50
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_0
@@ -203,7 +203,7 @@ number:
     optimistic: true
     initial_value: 45
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_5
@@ -217,7 +217,7 @@ number:
     optimistic: true
     initial_value: 40
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_10
@@ -231,7 +231,7 @@ number:
     optimistic: true
     initial_value: 35
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_15
@@ -245,7 +245,7 @@ number:
     optimistic: true
     initial_value: 30
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: heating_curve_pid_kp
@@ -259,7 +259,7 @@ number:
     optimistic: true
     initial_value: 0.280
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
     on_value:
       then:
         - climate.pid.set_control_parameters:
@@ -281,7 +281,7 @@ number:
     optimistic: true
     initial_value: 0.00060
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
     on_value:
       then:
         - climate.pid.set_control_parameters:
@@ -303,7 +303,7 @@ number:
     optimistic: true
     initial_value: 0.200
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
     on_value:
       then:
         - climate.pid.set_control_parameters:
@@ -325,7 +325,7 @@ number:
     optimistic: true
     initial_value: 40
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
 
 button:
   - platform: template
@@ -334,7 +334,7 @@ button:
     icon: mdi:restart
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
     on_press:
       then:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
@@ -361,7 +361,7 @@ climate:
       min_temperature: 20
       max_temperature: 70
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_curve
 
 output:
   - platform: template
@@ -647,7 +647,7 @@ sensor:
     accuracy_decimals: 1
     update_interval: 10s
     web_server:
-      sorting_group_id: oq_temperatures
+      sorting_group_id: oq_heating_curve
     lambda: |-
       // Generate the curve-mode supply target from outside temperature and room trim.
       const float outside_c = id(oq_curve_outside_temp_filtered).state;
@@ -718,7 +718,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       return id(oq_curve_demand_continuous);
 
@@ -733,7 +733,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       return (float) id(oq_demand_curve);
 
@@ -748,7 +748,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       return (float) id(oq_curve_request_total_level);
 
@@ -763,7 +763,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       return (float) id(oq_curve_dispatch_hp1_level);
 
@@ -778,7 +778,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       return (float) id(oq_curve_dispatch_hp2_level);
 
@@ -791,7 +791,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       return id(oq_curve_restart_inhibit_active) ? 1.0f : 0.0f;
 
@@ -804,7 +804,7 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       if (!id(oq_curve_heat_request_active)) return std::string("OFF");
       return (id(oq_curve_regime_code) == 1) ? std::string("HEAT") : std::string("COAST");
@@ -817,7 +817,7 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       switch (id(oq_curve_regime_code)) {
         case 1: return std::string("RECOVERY");
@@ -833,7 +833,7 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_curve
     lambda: |-
       const char *mode_name = oq_curve::capacity_mode_name(id(oq_curve_capacity_mode_code));
       return std::string(mode_name);

--- a/openquatt/oq_ot_slave.yaml
+++ b/openquatt/oq_ot_slave.yaml
@@ -44,6 +44,8 @@ switch:
       name: "OpenTherm Enabled"
       entity_category: config
       icon: mdi:thermostat-cog
+      web_server:
+        sorting_group_id: oq_opentherm
 
 binary_sensor:
   - platform: openquatt_ot_slave
@@ -52,15 +54,21 @@ binary_sensor:
       id: ot_thermostat_ch_enable
       name: "OT - Thermostat CH Enable"
       icon: mdi:radiator
+      web_server:
+        sorting_group_id: oq_opentherm
     master_cooling_enable:
       id: ot_thermostat_cooling_enable
       name: "OT - Thermostat Cooling Enable"
       icon: mdi:snowflake
+      web_server:
+        sorting_group_id: oq_opentherm
     link_problem:
       id: ot_link_problem
       name: "OT - Link Problem"
       entity_category: diagnostic
       icon: mdi:alert-circle-outline
+      web_server:
+        sorting_group_id: oq_opentherm
 
 sensor:
   - platform: openquatt_ot_slave
@@ -69,14 +77,20 @@ sensor:
       id: ot_thermostat_control_setpoint
       name: "OT - Control Setpoint"
       icon: mdi:thermostat
+      web_server:
+        sorting_group_id: oq_opentherm
     t_roomset:
       id: ot_thermostat_room_setpoint
       name: "OT - Room Setpoint"
       icon: mdi:home-thermometer-outline
+      web_server:
+        sorting_group_id: oq_opentherm
     t_room:
       id: ot_thermostat_room_temp
       name: "OT - Room Temperature"
       icon: mdi:home-thermometer
+      web_server:
+        sorting_group_id: oq_opentherm
 
 interval:
   - interval: 2s

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -90,7 +90,7 @@ select:
     update_interval: 5s
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
     lambda: |-
       const float rise = id(ph_demand_rise_time_min).state;
       const float fall = id(ph_demand_fall_time_min).state;
@@ -137,7 +137,7 @@ number:
     initial_value: -10
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
   - platform: template
     id: house_rated_power_w
@@ -152,7 +152,7 @@ number:
     initial_value: 7020
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
   - platform: template
     id: house_zero_power_temp_c
@@ -167,7 +167,7 @@ number:
     initial_value: 16
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_kp_w_per_k
@@ -182,7 +182,7 @@ number:
     initial_value: 3000
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_comfort_band_below_c
@@ -197,7 +197,7 @@ number:
     initial_value: 0.1
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_comfort_band_above_c
@@ -212,7 +212,7 @@ number:
     initial_value: 0.3
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_demand_rise_time_min
@@ -227,7 +227,7 @@ number:
     initial_value: 8
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_demand_fall_time_min
@@ -242,7 +242,7 @@ number:
     initial_value: 3
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
   - platform: template
     id: oq_demand_filter_ramp_up_step_min
@@ -257,7 +257,7 @@ number:
     optimistic: true
     initial_value: 1
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_power_house
 
 text_sensor:
   # DEBUG-RUNTIME START: Duo Power House request reason
@@ -269,7 +269,7 @@ text_sensor:
     disabled_by_default: true
     update_interval: never
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_power_house
     lambda: |-
       #if OQ_TOPOLOGY_DUO
       return std::string("inactive");
@@ -289,7 +289,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_overview
+      sorting_group_id: oq_power_house
     lambda: |-
       const float Tout = id(outside_temp_selected).state;
       const float Tc = id(house_cold_temp_c).state;
@@ -314,7 +314,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_overview
+      sorting_group_id: oq_power_house
     lambda: |-
       return id(oq_phouse_req_w);
 
@@ -330,7 +330,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_power_house
     lambda: |-
       return id(oq_phouse_comfort_memory_c);
 
@@ -346,7 +346,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_power_house
     lambda: |-
       return id(room_setpoint_selected).state + id(oq_phouse_comfort_memory_c);
 

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -81,7 +81,7 @@ select:
       - HA input
     initial_option: Local
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Flow Source"
@@ -95,7 +95,7 @@ select:
       - CIC
     initial_option: Outdoor unit
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Outdoor Unit Flow Mode"
@@ -111,7 +111,7 @@ select:
       - Local aggregate HP1/HP2
     initial_option: Local aggregate HP1/HP2
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Outside Temperature Source"
@@ -126,7 +126,7 @@ select:
       - HA input
     initial_option: Auto
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Room Temperature Source"
@@ -141,7 +141,7 @@ select:
       - HA input
     initial_option: CIC
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Room Setpoint Source"
@@ -156,7 +156,7 @@ select:
       - HA input
     initial_option: CIC
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Cooling Enable Source"
@@ -171,7 +171,7 @@ select:
       - CIC or HA input
     initial_option: CIC or HA input
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
 binary_sensor:
   - platform: template
@@ -189,7 +189,7 @@ binary_sensor:
       if (source == "CIC or HA input") return cic_enabled || ha_enabled;
       return false;
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
 text_sensor:
   - platform: template
@@ -202,7 +202,7 @@ text_sensor:
       return {id(room_temp_source).current_option().c_str()};
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_room_setpoint_effective_source
@@ -214,7 +214,7 @@ text_sensor:
       return {id(room_setpoint_source).current_option().c_str()};
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_cooling_enable_effective_source
@@ -240,7 +240,7 @@ text_sensor:
       }
       return {"Unknown"};
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_selected_input_hold_active
@@ -268,7 +268,7 @@ text_sensor:
       if (active.empty()) active = "None";
       return {active};
     web_server:
-      sorting_group_id: oq_cic
+      sorting_group_id: oq_sensor_selection
 
 sensor:
   - platform: template

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -85,7 +85,7 @@ select:
       - Water Temperature Control (heating curve)
     initial_option: Power House
     web_server:
-      sorting_group_id: oq_control
+      sorting_group_id: oq_heating_strategy
     on_value:
       then:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
@@ -147,7 +147,7 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return std::string("idle");
 
@@ -159,7 +159,7 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return std::string("init");
 
@@ -231,7 +231,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return (float) id(oq_strategy_active_code);
 
@@ -244,7 +244,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return (float) id(oq_strategy_phase_code);
 
@@ -259,7 +259,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_strategy_requested_power_w);
 
@@ -275,7 +275,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_strategy_supply_target_temp);
 
@@ -288,7 +288,7 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_strategy_water_limit_factor);
 
@@ -302,7 +302,7 @@ binary_sensor:
     lambda: |-
       return id(oq_strategy_heat_request_active);
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
 
   - platform: template
     id: oq_strategy_water_trip_active_sensor
@@ -312,7 +312,7 @@ binary_sensor:
     lambda: |-
       return id(oq_strategy_water_trip_active);
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
 
   - platform: template
     id: oq_strategy_water_hard_trip_active_sensor
@@ -322,7 +322,7 @@ binary_sensor:
     lambda: |-
       return id(oq_strategy_water_hard_trip_active);
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
 
 interval:
   - interval: ${oq_strategy_loop_s}s

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -403,7 +403,7 @@ binary_sensor:
     device_class: problem
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_time_valid
@@ -413,7 +413,7 @@ binary_sensor:
     device_class: connectivity
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
 text_sensor:
   - platform: template
@@ -421,7 +421,7 @@ text_sensor:
     name: "Control Mode"
     icon: mdi:state-machine
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_control_mode_label
@@ -440,7 +440,7 @@ text_sensor:
     update_interval: never
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_silent_window_hhmm
@@ -450,7 +450,7 @@ text_sensor:
     update_interval: never
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_silent_status
@@ -460,7 +460,7 @@ text_sensor:
     update_interval: never
     entity_category: diagnostic
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
 
   # DEBUG-RUNTIME START: Power House low-load diagnostics
   - platform: template
@@ -471,7 +471,7 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_system_diagnostics
     lambda: |-
       // Read the active threshold set from diagnostics.
       const float pmin = id(oq_low_load_pmin_dyn_w);

--- a/openquatt/oq_thermal_limits.yaml
+++ b/openquatt/oq_thermal_limits.yaml
@@ -61,7 +61,7 @@ number:
     initial_value: 60
     entity_category: config
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_strategy
 
 sensor:
   # Shared abstractions and derived telemetry.

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -237,7 +237,7 @@ number:
     optimistic: true
     initial_value: 300
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_strategy
 
   # Dual-HP enable threshold on single-HP compressor level request (1..10).
   # Disable threshold is derived internally as max(1, enable - 1) to keep parameter count low.
@@ -255,7 +255,7 @@ number:
     optimistic: true
     initial_value: 5
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_strategy
 
   # Hold time before enabling dual-HP in curve mode.
   - platform: template
@@ -272,7 +272,7 @@ number:
     optimistic: true
     initial_value: 3
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_strategy
 
   # Hold time before disabling dual-HP in curve mode.
   - platform: template
@@ -289,7 +289,7 @@ number:
     optimistic: true
     initial_value: 5
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_strategy
 
 # ----------------------------
 # BUTTON
@@ -300,7 +300,7 @@ button:
     name: "${hc_runtime_reset_button_name}"
     icon: mdi:restart
     web_server:
-      sorting_group_id: oq_tuning_heat
+      sorting_group_id: oq_heating_strategy
     on_press:
       - lambda: |-
           // Reset accumulated runtime counters and measured-start latches together,
@@ -403,7 +403,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return (float) id(oq_demand_raw);
 
@@ -416,7 +416,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return (float) id(oq_demand_filtered);
 
@@ -429,7 +429,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       if (!id(hp1_compressor_level).has_state()) return NAN;
       auto idx = id(hp1_compressor_level).active_index();
@@ -446,7 +446,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       #if OQ_TOPOLOGY_DUO
       if (!id(${hc_secondary_compressor_level_id}).has_state()) return NAN;
@@ -471,7 +471,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_overview
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_P_hp_cap_w);
 
@@ -485,7 +485,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     web_server:
-      sorting_group_id: oq_overview
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_P_deficit_w);
 
@@ -498,7 +498,7 @@ text_sensor:
     disabled_by_default: true
     update_interval: never
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       return std::string("inactive");
 
@@ -508,7 +508,7 @@ text_sensor:
     icon: mdi:source-branch
     update_interval: 10s
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
     lambda: |-
       #if OQ_TOPOLOGY_DUO
       const bool lead_is_hp1 = (id(hp1_minutes) <= id(${hc_secondary_minutes_id}));
@@ -525,7 +525,7 @@ text_sensor:
     disabled_by_default: true
     update_interval: never
     web_server:
-      sorting_group_id: oq_diagnostics
+      sorting_group_id: oq_heating_strategy
 
 # ----------------------------
 # MAIN LOOP

--- a/openquatt/oq_webserver.yaml
+++ b/openquatt/oq_webserver.yaml
@@ -25,49 +25,61 @@ web_server:
       name: "Overview"
       sorting_weight: 5
     - id: oq_control
-      name: "Control"
+      name: "System Control"
       sorting_weight: 10
-    - id: oq_temperatures
-      name: "Temperatures"
+    - id: oq_heating_strategy
+      name: "Heating Strategy"
       sorting_weight: 20
-    - id: oq_hydraulics
-      name: "Flow & Pump"
+    - id: oq_heating_curve
+      name: "Heating Curve"
+      sorting_weight: 25
+    - id: oq_power_house
+      name: "Power House"
       sorting_weight: 30
-    - id: oq_performance
-      name: "Performance"
+    - id: oq_cooling
+      name: "Cooling"
+      sorting_weight: 35
+    - id: oq_sensor_selection
+      name: "Sensor Selection"
       sorting_weight: 40
-    - id: oq_hp1
-      name: "HP1"
-      sorting_weight: 60
-    - id: oq_hp2
-      name: "HP2"
-      sorting_weight: 65
+    - id: oq_opentherm
+      name: "OpenTherm"
+      sorting_weight: 45
     - id: oq_boiler
       name: "Boiler"
       sorting_weight: 50
     - id: oq_cic
-      name: "CIC"
+      name: "CIC Feed"
       sorting_weight: 55
-    - id: oq_ha
+    - id: oq_ha_inputs
       name: "HA Inputs"
-      sorting_weight: 56
-    - id: oq_tuning_flow
-      name: "Tuning – Flow"
+      sorting_weight: 60
+    - id: oq_temperatures
+      name: "Temperatures"
+      sorting_weight: 70
+    - id: oq_hydraulics
+      name: "Flow & Pump"
       sorting_weight: 80
-    - id: oq_tuning_heat
-      name: "Tuning – Heat"
+    - id: oq_tuning_flow
+      name: "Flow Tuning"
       sorting_weight: 85
-    - id: oq_advanced_levels_hp1
-      name: "Advanced – Levels HP1"
+    - id: oq_performance
+      name: "Performance"
       sorting_weight: 90
-    - id: oq_advanced_levels_hp2
-      name: "Advanced – Levels HP2"
-      sorting_weight: 91
-    - id: oq_diagnostics
-      name: "Diagnostics"
+    - id: oq_hp1
+      name: "HP1"
+      sorting_weight: 100
+    - id: oq_hp2
+      name: "HP2"
+      sorting_weight: 105
+    - id: oq_advanced_hp_levels
+      name: "Advanced - HP Levels"
+      sorting_weight: 110
+    - id: oq_system_diagnostics
+      name: "System Diagnostics"
       sorting_weight: 180
-    - id: oq_diagnostics_hp
-      name: "Diagnostics - Heat Pump"
+    - id: oq_hp_diagnostics
+      name: "HP Diagnostics"
       sorting_weight: 190
     - id: oq_raw
       name: "RAW"


### PR DESCRIPTION
## Summary
- redesign the ESPHome webserver grouping model around system domains such as Heating Strategy, Heating Curve, Power House, Cooling, Sensor Selection, and OpenTherm
- split the old diagnostics buckets into System Diagnostics and HP Diagnostics, and merge the per-HP advanced level groups into a single Advanced - HP Levels category
- remap the existing package entities onto the new categories and update the system overview docs to match

## Validation
- ./scripts/validate_local.sh