### PR TITLE
Refine cooling control, overview and energy accounting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Gebruik je de standaardfirmware, dan is de web installer uit de README meestal d
 - [Dashboardoverzicht](dashboardoverzicht.md): de belangrijkste dashboardtabs en de volgorde waarin je ze gebruikt.
 - [Diagnose en afstelling](diagnose-en-afstelling.md): diagnose, werkvolgorde en terughoudend afstellen.
 
-Passive cooling wordt nu in hoofdlijnen beschreven in:
+Cooling wordt nu in hoofdlijnen beschreven in:
 
 - [Hoe OpenQuatt werkt](hoe-openquatt-werkt.md): wat koeling wel en niet van OpenQuatt vraagt.
 - [Dashboardoverzicht](dashboardoverzicht.md): waar je de cooling-tab en sensorconfiguratie gebruikt.

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1157,7 +1157,7 @@ views:
         type: markdown
         content: |-
           # <ha-icon icon="mdi:snowflake-thermometer"></ha-icon> Cooling
-          Inspect passive-cooling permission, dew-point safety, and the CM5 control path.
+          Inspect cooling permission, dew-point safety, and the CM5 control path.
   - title: HPs
     path: HPs
     icon: mdi:heat-pump-outline

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1138,6 +1138,8 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
+              - entity: sensor.openquatt_water_supply_temp_selected
+                name: Water supply temperature
               - entity: sensor.openquatt_cooling_supply_target
                 name: Cooling supply target
               - entity: sensor.openquatt_cooling_supply_error

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1214,6 +1214,8 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
+              - entity: sensor.openquatt_water_supply_temp_selected
+                name: Water supply temperature
               - entity: sensor.openquatt_cooling_supply_target
                 name: Cooling supply target
               - entity: sensor.openquatt_cooling_supply_error

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1145,7 +1145,7 @@ views:
         type: markdown
         content: |-
           # <ha-icon icon="mdi:snowflake-thermometer"></ha-icon> Cooling
-          Inspect passive-cooling permission, dew-point safety, and the CM5 control path.
+          Inspect cooling permission, dew-point safety, and the CM5 control path.
   - title: HP1
     path: hp1
     icon: mdi:heat-pump-outline

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1126,6 +1126,8 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
+              - entity: sensor.openquatt_water_supply_temp_selected
+                name: Water supply temperature
               - entity: sensor.openquatt_cooling_supply_target
                 name: Cooling supply target
               - entity: sensor.openquatt_cooling_supply_error

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1189,6 +1189,8 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
+              - entity: sensor.openquatt_water_supply_temp_selected
+                name: Water supply temperature
               - entity: sensor.openquatt_cooling_supply_target
                 name: Cooling supply target
               - entity: sensor.openquatt_cooling_supply_error

--- a/docs/dashboardoverzicht.md
+++ b/docs/dashboardoverzicht.md
@@ -84,7 +84,7 @@ Deze tab is bedoeld voor gedrag dat niet direct verklaarbaar is. Bijvoorbeeld wa
 
 ### Koeling
 
-Gebruik deze tab zodra je passive cooling gebruikt of voorbereidt. Hier zie je onder meer:
+Gebruik deze tab zodra je cooling gebruikt of voorbereidt. Hier zie je onder meer:
 
 - of cooling request actief is;
 - of cooling op dit moment toegestaan is;

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -93,9 +93,9 @@ Die geselecteerde aanvoertemperatuur kan uit de lokale ESP-sensor, uit CIC of ui
 
 Je hoeft daarvoor niet eerst de interne berekening te kennen. Relevanter is welke strategie in jouw installatie het meest stabiele en voorspelbare gedrag geeft.
 
-## Passive cooling
+## Cooling
 
-Passive cooling vraagt een andere veiligheidslogica dan verwarmen. Het belangrijkste verschil is dat bij koelen niet alleen comfort telt, maar vooral het risico op condensvorming.
+Cooling vraagt een andere veiligheidslogica dan verwarmen. Het belangrijkste verschil is dat bij koelen niet alleen comfort telt, maar vooral het risico op condensvorming.
 
 Daarom werkt OpenQuatt bij cooling in grote lijnen zo:
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -795,6 +795,33 @@ sensor:
       return mass_flow_kgps * water_cp_j_per_kgk * delta_t_k;
 
   - platform: template
+    id: ${hp_id}_cooling_power
+    name: "${prefix}Cooling Power"
+    icon: mdi:snowflake
+    unit_of_measurement: "W"
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_performance
+    lambda: |-
+      // Cooling power follows measured HP working mode (1 = Cooling), not supervisory CM.
+      const float working_mode = id(${hp_id}_working_mode).state;
+      if (working_mode != 1.0f) return 0.0f;
+
+      const float t_in_c = id(${hp_id}_water_in_temp).state;
+      const float t_out_c = id(${hp_id}_water_out_temp).state;
+      const float flow_lph = id(flow_rate_selected).state;
+
+      if (isnan(t_in_c) || isnan(t_out_c) || isnan(flow_lph)) return 0.0f;
+
+      const float water_cp_j_per_kgk = ${oq_water_cp_j_per_kgk};  // J/(kg·K)
+      const float mass_flow_kgps = flow_lph / 3600.0f;            // kg/s (≈ L/h)
+      const float delta_t_k = t_in_c - t_out_c;                   // K, positive while cooling
+      return mass_flow_kgps * water_cp_j_per_kgk * delta_t_k;
+
+  - platform: template
     id: ${hp_id}_cop
     name: "${prefix}COP"
     icon: mdi:chart-bell-curve

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -1,5 +1,5 @@
 # ==============================================================================
-# OpenQuatt - Passive Cooling Safety Inputs and Derived Signals
+# OpenQuatt - Cooling Safety Inputs and Derived Signals
 # ==============================================================================
 #
 # Goal:

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -1,14 +1,15 @@
 # ==============================================================================
-# OpenQuatt - Passive Cooling Strategy
+# OpenQuatt - Cooling Strategy
 # ==============================================================================
 #
 # Goal:
-#   Own the complete passive-cooling path on top of the cooling safety signals.
-#   This layer produces a conservative supply target, a cooling demand `f`, and
-#   the downstream cooling compressor requests.
+#   Own the complete cooling path on top of the cooling safety signals.
+#   This layer produces a dynamic supply target, a cooling demand `f`, and the
+#   downstream cooling compressor requests.
 #
 # Scope:
-#   - Derive a safe cooling supply target from dew point + user floor
+#   - Derive a cooling supply target from dew point safety, the configured floor,
+#     and room overshoot
 #   - Run a small water-temperature PI(D) loop for cooling only
 #   - Publish `oq_cooling_demand_raw` (0..20)
 #   - Choose the active cooling owner HP and publish cooling requests
@@ -159,11 +160,29 @@ sensor:
     accuracy_decimals: 1
     update_interval: 5s
     lambda: |-
-      // Cooling may never target below the configured floor or the dew-point-safe floor.
-      float target_c = id(cooling_min_supply_temp).state;
+      // Cooling uses a simple cascade:
+      // - the configured floor and dew-point-safe floor define the lowest allowed target
+      // - room overshoot adds a fixed comfort offset above that floor
+      // This keeps strong cooling possible when the room is clearly too warm,
+      // but favors warmer water and calmer modulation near setpoint.
+      float base_floor_c = id(cooling_min_supply_temp).state;
       if (id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state)) {
-        target_c = fmaxf(target_c, id(minimum_safe_supply_temp).state);
+        base_floor_c = fmaxf(base_floor_c, id(minimum_safe_supply_temp).state);
       }
+
+      float comfort_offset_c = 0.8f;
+      if (id(room_temp_selected).has_state() && !isnan(id(room_temp_selected).state) &&
+          id(room_setpoint_selected).has_state() && !isnan(id(room_setpoint_selected).state)) {
+        const float room_error_c = id(room_temp_selected).state - id(room_setpoint_selected).state;
+        if (room_error_c > 1.2f) comfort_offset_c = 0.0f;
+        else if (room_error_c > 0.8f) comfort_offset_c = 0.4f;
+        else if (room_error_c > 0.4f) comfort_offset_c = 0.8f;
+        else if (room_error_c > 0.2f) comfort_offset_c = 1.2f;
+        else comfort_offset_c = 1.6f;
+      }
+
+      float target_c = base_floor_c + comfort_offset_c;
+      if (target_c < base_floor_c) target_c = base_floor_c;
       return target_c;
     web_server:
       sorting_group_id: oq_cooling
@@ -203,6 +222,8 @@ interval:
       - lambda: |-
           const float near_safe_floor_limit_c = 0.30f;
           const float stop_safe_floor_limit_c = 0.10f;
+          const float simmer_room_error_min_c = 0.20f;
+          const float simmer_supply_error_max_c = 0.45f;
 
           // Resolve loop timing and reset the controller cleanly when cooling is not allowed.
           const uint32_t now_ms = (uint32_t) millis();
@@ -244,9 +265,22 @@ interval:
             derivative = (error_c - id(oq_cooling_pid_last_error_c)) / dt_s;
           }
 
+          float room_error_c = NAN;
+          bool room_error_valid = false;
+          if (id(room_temp_selected).has_state() && !isnan(id(room_temp_selected).state) &&
+              id(room_setpoint_selected).has_state() && !isnan(id(room_setpoint_selected).state)) {
+            room_error_c = id(room_temp_selected).state - id(room_setpoint_selected).state;
+            room_error_valid = true;
+          }
+
           int demand_max = (int) lroundf(id(cooling_demand_max_f).state);
           if (demand_max < 0) demand_max = 0;
           if (demand_max > 20) demand_max = 20;
+          if (room_error_valid) {
+            if (room_error_c < 0.4f) demand_max = std::min(demand_max, 1);
+            else if (room_error_c < 0.8f) demand_max = std::min(demand_max, 2);
+            else if (room_error_c < 1.2f) demand_max = std::min(demand_max, 3);
+          }
 
           // Keep the integrator from "sticking" to level 1 when the supply is already
           // at or below target, and stop winding up while the output is saturated high.
@@ -267,9 +301,10 @@ interval:
           if (demand < 0) demand = 0;
           if (demand > demand_max) demand = demand_max;
 
+          float safe_gap_c = NAN;
           // Add a small explicit approach zone near the dew-point-safe floor.
           if (id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state)) {
-            const float safe_gap_c = id(oq_system_supply_temp).state - id(minimum_safe_supply_temp).state;
+            safe_gap_c = id(oq_system_supply_temp).state - id(minimum_safe_supply_temp).state;
             if (safe_gap_c <= stop_safe_floor_limit_c) {
               demand = 0;
               integral = 0.0f;
@@ -277,6 +312,18 @@ interval:
               if (demand > 1) demand = 1;
               integral = fminf(integral, 1.0f);
             }
+          }
+
+          // When the room still needs a little cooling and supply is already close to target,
+          // prefer a gentle level-1 simmer over dropping to zero immediately.
+          const bool can_simmer =
+              (!room_error_valid || room_error_c > simmer_room_error_min_c) &&
+              error_c > 0.0f && error_c <= simmer_supply_error_max_c &&
+              (isnan(safe_gap_c) || safe_gap_c > (near_safe_floor_limit_c + 0.2f));
+          if (can_simmer) {
+            if (demand < 1) demand = 1;
+            if (demand > 1) demand = 1;
+            integral = fminf(fmaxf(integral, 0.0f), 1.0f);
           }
 
           id(oq_cooling_pid_integral) = integral;

--- a/openquatt/oq_energy.yaml
+++ b/openquatt/oq_energy.yaml
@@ -16,7 +16,10 @@ button:
     on_press:
       - lambda: |-
           id(oq_electrical_energy_cumulative).reset();
+          id(oq_heating_electrical_energy_cumulative).reset();
+          id(oq_cooling_electrical_energy_cumulative).reset();
           id(oq_heatpump_thermal_energy_cumulative).reset();
+          id(oq_heatpump_cooling_energy_cumulative).reset();
           id(oq_boiler_thermal_energy_cumulative).reset();
           id(oq_system_thermal_energy_cumulative).reset();
           ESP_LOGW("quatt", "Cumulative energy counters reset.");
@@ -38,11 +41,75 @@ sensor:
     web_server:
       sorting_group_id: oq_performance
 
+  # Heating electrical input energy (daily, kWh). Keeps COP heating-only when cooling is active.
+  - platform: total_daily_energy
+    id: oq_heating_electrical_energy_daily
+    name: "Heating Electrical Energy Daily"
+    power_id: oq_heating_power_input
+    time_id: oq_time
+    unit_of_measurement: "kWh"
+    device_class: energy
+    state_class: total_increasing
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.001
+    restore: true
+    web_server:
+      sorting_group_id: oq_performance
+
+  # Cooling electrical input energy (daily, kWh). Used for cooling-only EER.
+  - platform: total_daily_energy
+    id: oq_cooling_electrical_energy_daily
+    name: "Cooling Electrical Energy Daily"
+    power_id: oq_cooling_power_input
+    time_id: oq_time
+    unit_of_measurement: "kWh"
+    device_class: energy
+    state_class: total_increasing
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.001
+    restore: true
+    web_server:
+      sorting_group_id: oq_performance
+
   # Electrical input energy (cumulative, kWh).
   - platform: integration
     id: oq_electrical_energy_cumulative
     name: "Electrical Energy Cumulative"
     sensor: oq_total_power_input
+    time_unit: h
+    unit_of_measurement: "kWh"
+    device_class: energy
+    state_class: total_increasing
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.001
+    restore: true
+    web_server:
+      sorting_group_id: oq_performance
+
+  # Heating electrical input energy (cumulative, kWh).
+  - platform: integration
+    id: oq_heating_electrical_energy_cumulative
+    name: "Heating Electrical Energy Cumulative"
+    sensor: oq_heating_power_input
+    time_unit: h
+    unit_of_measurement: "kWh"
+    device_class: energy
+    state_class: total_increasing
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.001
+    restore: true
+    web_server:
+      sorting_group_id: oq_performance
+
+  # Cooling electrical input energy (cumulative, kWh).
+  - platform: integration
+    id: oq_cooling_electrical_energy_cumulative
+    name: "Cooling Electrical Energy Cumulative"
+    sensor: oq_cooling_power_input
     time_unit: h
     unit_of_measurement: "kWh"
     device_class: energy
@@ -84,7 +151,7 @@ sensor:
       sorting_group_id: oq_performance
     lambda: |-
       const float heat_kwh = id(oq_heatpump_thermal_energy_daily).state;
-      const float elec_kwh = id(oq_electrical_energy_daily).state;
+      const float elec_kwh = id(oq_heating_electrical_energy_daily).state;
 
       if (isnan(heat_kwh) || isnan(elec_kwh)) return NAN;
       if (elec_kwh < 0.01f) return NAN;
@@ -123,6 +190,38 @@ sensor:
     web_server:
       sorting_group_id: oq_performance
 
+  # HeatPump cooling energy (daily, kWh).
+  - platform: total_daily_energy
+    id: oq_heatpump_cooling_energy_daily
+    name: "HeatPump Cooling Energy Daily"
+    power_id: oq_total_cooling_power
+    time_id: oq_time
+    unit_of_measurement: "kWh"
+    device_class: energy
+    state_class: total_increasing
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.001
+    restore: true
+    web_server:
+      sorting_group_id: oq_performance
+
+  # HeatPump cooling energy (cumulative, kWh).
+  - platform: integration
+    id: oq_heatpump_cooling_energy_cumulative
+    name: "HeatPump Cooling Energy Cumulative"
+    sensor: oq_total_cooling_power
+    time_unit: h
+    unit_of_measurement: "kWh"
+    device_class: energy
+    state_class: total_increasing
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.001
+    restore: true
+    web_server:
+      sorting_group_id: oq_performance
+
   # HeatPump COP based on cumulative thermal/electrical energy (kWh/kWh).
   - platform: template
     id: oq_heatpump_cop_cumulative
@@ -135,12 +234,50 @@ sensor:
       sorting_group_id: oq_performance
     lambda: |-
       const float heat_kwh = id(oq_heatpump_thermal_energy_cumulative).state;
-      const float elec_kwh = id(oq_electrical_energy_cumulative).state;
+      const float elec_kwh = id(oq_heating_electrical_energy_cumulative).state;
 
       if (isnan(heat_kwh) || isnan(elec_kwh)) return NAN;
       if (elec_kwh < 0.01f) return NAN;
 
       return heat_kwh / elec_kwh;
+
+  # HeatPump EER based on daily cooling/electrical energy (kWh/kWh).
+  - platform: template
+    id: oq_heatpump_eer_daily
+    name: "HeatPump EER Daily"
+    icon: mdi:chart-bell-curve-cumulative
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_performance
+    lambda: |-
+      const float cooling_kwh = id(oq_heatpump_cooling_energy_daily).state;
+      const float elec_kwh = id(oq_cooling_electrical_energy_daily).state;
+
+      if (isnan(cooling_kwh) || isnan(elec_kwh)) return NAN;
+      if (elec_kwh < 0.01f) return NAN;
+
+      return cooling_kwh / elec_kwh;
+
+  # HeatPump EER based on cumulative cooling/electrical energy (kWh/kWh).
+  - platform: template
+    id: oq_heatpump_eer_cumulative
+    name: "HeatPump EER Cumulative"
+    icon: mdi:chart-bell-curve-cumulative
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_performance
+    lambda: |-
+      const float cooling_kwh = id(oq_heatpump_cooling_energy_cumulative).state;
+      const float elec_kwh = id(oq_cooling_electrical_energy_cumulative).state;
+
+      if (isnan(cooling_kwh) || isnan(elec_kwh)) return NAN;
+      if (elec_kwh < 0.01f) return NAN;
+
+      return cooling_kwh / elec_kwh;
 
   # Boiler thermal energy (daily, kWh).
   - platform: total_daily_energy

--- a/openquatt/oq_ha_inputs.yaml
+++ b/openquatt/oq_ha_inputs.yaml
@@ -7,7 +7,7 @@
 #
 # Scope:
 #   - Fixed HA-backed temperature and thermostat proxy inputs
-#   - Fixed HA cooling proxy contracts used for passive-cooling safety
+#   - Fixed HA cooling proxy contracts used for cooling safety
 #
 # Notes:
 #   - Entity IDs are compile-time substitutions in oq_substitutions_common.yaml.

--- a/openquatt/oq_packages_common.yaml
+++ b/openquatt/oq_packages_common.yaml
@@ -81,6 +81,7 @@ oq_thermal_request_control: !include
   vars:
     hc_secondary_power_input_id: "${secondary_hp_id}_power_input"
     hc_secondary_heat_power_id: "${secondary_hp_id}_heat_power"
+    hc_secondary_cooling_power_id: "${secondary_hp_id}_cooling_power"
     hc_secondary_compressor_level_id: "${secondary_hp_id}_compressor_level"
     hc_secondary_defrost_id: "${secondary_hp_id}_defrost"
     hc_secondary_last_applied_level_id: "${secondary_hp_id}_last_applied_level"

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -30,7 +30,7 @@
 #   - CM1: holding (heat demand but insufficient flow)
 #   - CM2: heating (HP only)
 #   - CM3: heating (HP + boiler auxiliary heating)
-#   - CM5: passive cooling
+#   - CM5: cooling
 #   - CM98: frost
 #
 # Safety / fail-safe:
@@ -657,7 +657,7 @@ interval:
             if (strcmp(cm_id, "CM1") == 0) return std::string("CM1 - Preflow/Postflow");
             if (strcmp(cm_id, "CM2") == 0) return std::string("CM2 - Heating - Heat Pump Only");
             if (strcmp(cm_id, "CM3") == 0) return std::string("CM3 - Heating - Heat Pump + Boiler");
-            if (strcmp(cm_id, "CM5") == 0) return std::string("CM5 - Passive Cooling");
+            if (strcmp(cm_id, "CM5") == 0) return std::string("CM5 - Cooling");
             if (strcmp(cm_id, "CM98") == 0) return std::string("CM98 - Anti-Freeze Protection - Water Circulation");
             return std::string("Unknown");
           };

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -351,6 +351,52 @@ sensor:
       return (total_input_w < 0.0f) ? 0.0f : total_input_w;
 
   - platform: template
+    id: oq_heating_power_input
+    name: "Heating Power Input"
+    icon: mdi:flash
+    unit_of_measurement: "W"
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_performance
+    lambda: |-
+      auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
+      const float hp1_mode = id(hp1_working_mode).state;
+      const float hp1_power_w = (hp1_mode == 2.0f) ? nz(id(hp1_power_input).state) : 0.0f;
+      #if OQ_TOPOLOGY_DUO
+      const float hp2_mode = id(${hc_secondary_working_mode_id}).state;
+      const float hp2_power_w = (hp2_mode == 2.0f) ? nz(id(${hc_secondary_power_input_id}).state) : 0.0f;
+      return hp1_power_w + hp2_power_w;
+      #else
+      return hp1_power_w;
+      #endif
+
+  - platform: template
+    id: oq_cooling_power_input
+    name: "Cooling Power Input"
+    icon: mdi:flash
+    unit_of_measurement: "W"
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_performance
+    lambda: |-
+      auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
+      const float hp1_mode = id(hp1_working_mode).state;
+      const float hp1_power_w = (hp1_mode == 1.0f) ? nz(id(hp1_power_input).state) : 0.0f;
+      #if OQ_TOPOLOGY_DUO
+      const float hp2_mode = id(${hc_secondary_working_mode_id}).state;
+      const float hp2_power_w = (hp2_mode == 1.0f) ? nz(id(${hc_secondary_power_input_id}).state) : 0.0f;
+      return hp1_power_w + hp2_power_w;
+      #else
+      return hp1_power_w;
+      #endif
+
+  - platform: template
     id: oq_total_heat_power
     name: "Total Heat Power"
     icon: mdi:radiator
@@ -377,6 +423,32 @@ sensor:
       #endif
 
   - platform: template
+    id: oq_total_cooling_power
+    name: "Total Cooling Power"
+    icon: mdi:snowflake
+    unit_of_measurement: "W"
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_performance
+    lambda: |-
+      const float hp1_cooling_w = id(hp1_cooling_power).state;
+      #if OQ_TOPOLOGY_DUO
+      const float hp2_cooling_w = id(${hc_secondary_cooling_power_id}).state;
+
+      if (isnan(hp1_cooling_w) && isnan(hp2_cooling_w)) return NAN;
+      if (isnan(hp1_cooling_w)) return hp2_cooling_w;
+      if (isnan(hp2_cooling_w)) return hp1_cooling_w;
+
+      return hp1_cooling_w + hp2_cooling_w;
+      #else
+      if (isnan(hp1_cooling_w)) return NAN;
+      return hp1_cooling_w;
+      #endif
+
+  - platform: template
     id: oq_total_cop
     name: "Total COP"
     icon: mdi:chart-bell-curve-cumulative
@@ -393,6 +465,24 @@ sensor:
       if (fabsf(total_input_w) < ${oq_cop_min_input_w}) return NAN;
 
       return total_heat_w / total_input_w;
+
+  - platform: template
+    id: oq_total_eer
+    name: "Total EER"
+    icon: mdi:chart-bell-curve-cumulative
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 10s
+    web_server:
+      sorting_group_id: oq_performance
+    lambda: |-
+      const float total_input_w = id(oq_cooling_power_input).state;
+      const float total_cooling_w = id(oq_total_cooling_power).state;
+
+      if (isnan(total_input_w) || isnan(total_cooling_w)) return NAN;
+      if (fabsf(total_input_w) < ${oq_cop_min_input_w}) return NAN;
+
+      return total_cooling_w / total_input_w;
 
   - platform: template
     id: oq_demand_raw_sensor

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -780,7 +780,7 @@ interval:
             const bool hp2_cooling_hold = false;
             #endif
 
-            // Preserve passive-cooling holds across CM5 -> CM1/CM0 transitions.
+            // Preserve cooling holds across CM5 -> CM1/CM0 transitions.
             // Otherwise the generic inactive-CM fallback would reinterpret the hold
             // as Heating and re-arm the compressor in the wrong thermal mode.
             return oq_request::hold_request_mode_code(

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -122,6 +122,7 @@
     const hp1Outside = Number(getEntity("sensor", "HP1 - Outside temperature")?.value);
     const hp2Outside = Number(getEntity("sensor", "HP2 - Outside temperature")?.value);
     const totalHeat = Number(getEntity("sensor", "Total Heat Power")?.value);
+    const totalPower = Number(getEntity("sensor", "Total Power Input")?.value);
     const strategy = String(getEntity("select", "Heating Control Mode")?.value || "");
     const roomTemp = Number(getEntity("sensor", "Room Temperature (Selected)")?.value);
     const roomSetpoint = Number(getEntity("sensor", "Room Setpoint (Selected)")?.value);
@@ -176,23 +177,47 @@
     const systemHeat = Math.max(0, Number((Number(totalHeat || 0) + boilerHeat).toFixed(0)));
     const electricalDaily = state.scenario === "idle" ? 3.1 : state.scenario === "defrost" ? 6.4 : state.scenario === "cooling" ? (single ? 6.8 : 8.1) : single ? 7.2 : 8.6;
     const heatpumpDaily = state.scenario === "idle" ? 9.4 : state.scenario === "defrost" ? 18.2 : state.scenario === "cooling" ? (single ? 24.6 : 31.8) : single ? 28.4 : 36.9;
+    const coolingElectricalDaily = state.scenario === "cooling" ? (single ? 1.8 : 2.4) : 0.0;
+    const coolingDaily = state.scenario === "cooling" ? (single ? 7.1 : 9.3) : 0.0;
     const boilerDaily = state.scenario === "dual" ? 2.7 : 0.0;
     const systemDaily = Number((heatpumpDaily + boilerDaily).toFixed(1));
     const heatpumpCopDaily = electricalDaily > 0 ? Number((heatpumpDaily / electricalDaily).toFixed(2)) : 0;
+    const heatpumpEerDaily = coolingElectricalDaily > 0 ? Number((coolingDaily / coolingElectricalDaily).toFixed(2)) : 0;
     const electricalCumulative = single ? 286.4 : 469.5;
     const heatpumpCumulative = single ? 1208.7 : 2048.6;
+    const coolingElectricalCumulative = state.scenario === "cooling" ? (single ? 28.6 : 41.9) : 0.0;
+    const coolingCumulative = state.scenario === "cooling" ? (single ? 109.4 : 163.7) : 0.0;
     const boilerCumulative = state.scenario === "dual" ? 114.8 : 0.0;
     const systemCumulative = Number((heatpumpCumulative + boilerCumulative).toFixed(1));
     const heatpumpCopCumulative = electricalCumulative > 0 ? Number((heatpumpCumulative / electricalCumulative).toFixed(2)) : 0;
+    const heatpumpEerCumulative = coolingElectricalCumulative > 0 ? Number((coolingCumulative / coolingElectricalCumulative).toFixed(2)) : 0;
+    const heatingElectricalDaily = Math.max(0, Number((electricalDaily - coolingElectricalDaily).toFixed(1)));
+    const heatingElectricalCumulative = Math.max(0, Number((electricalCumulative - coolingElectricalCumulative).toFixed(1)));
+    const totalCoolingPower = state.scenario === "cooling" ? Math.max(0, Number(totalHeat || 0)) : 0;
+    const totalEer = (state.scenario === "cooling" && coolingElectricalDaily > 0)
+      ? Number((coolingDaily / coolingElectricalDaily).toFixed(2))
+      : 0;
 
     setNumber("Boiler Heat Power", boilerHeat, "W");
     setNumber("System Heat Power", systemHeat, "W");
+    setNumber("Heating Power Input", state.scenario === "cooling" ? 0 : (Number.isNaN(totalPower) ? 0 : totalPower), "W");
+    setNumber("Cooling Power Input", state.scenario === "cooling" ? (Number.isNaN(totalPower) ? 0 : totalPower) : 0, "W");
     setNumber("Electrical Energy Daily", electricalDaily, "kWh");
     setNumber("Electrical Energy Cumulative", electricalCumulative, "kWh");
+    setNumber("Heating Electrical Energy Daily", heatingElectricalDaily, "kWh");
+    setNumber("Heating Electrical Energy Cumulative", heatingElectricalCumulative, "kWh");
+    setNumber("Cooling Electrical Energy Daily", coolingElectricalDaily, "kWh");
+    setNumber("Cooling Electrical Energy Cumulative", coolingElectricalCumulative, "kWh");
     setNumber("HeatPump Thermal Energy Daily", heatpumpDaily, "kWh");
     setNumber("HeatPump Thermal Energy Cumulative", heatpumpCumulative, "kWh");
+    setNumber("HeatPump Cooling Energy Daily", coolingDaily, "kWh");
+    setNumber("HeatPump Cooling Energy Cumulative", coolingCumulative, "kWh");
     setNumber("HeatPump COP Daily", heatpumpCopDaily, "");
     setNumber("HeatPump COP Cumulative", heatpumpCopCumulative, "");
+    setNumber("HeatPump EER Daily", heatpumpEerDaily, "");
+    setNumber("HeatPump EER Cumulative", heatpumpEerCumulative, "");
+    setNumber("Total Cooling Power", totalCoolingPower, "W");
+    setNumber("Total EER", totalEer, "");
     setNumber("Boiler Thermal Energy Daily", boilerDaily, "kWh");
     setNumber("Boiler Thermal Energy Cumulative", boilerCumulative, "kWh");
     setNumber("System Thermal Energy Daily", systemDaily, "kWh");
@@ -764,15 +789,19 @@
       setNumber("Cooling Supply Target", wave(18.6, 0.12), "°C");
       setNumber("Cooling Supply Error", wave(1.0, 0.2), "°C");
       setNumber("Cooling Demand (raw)", waveInt(2.2, 0.6), "");
+      setNumber("Cooling Power Input", wave(455, 18), "W");
       setNumber("Total Power Input", wave(455, 18), "W");
-      setNumber("Total Heat Power", wave(1720, 90), "W");
-      setNumber("Total COP", Number((3.9 + Math.sin(t) * 0.08).toFixed(2)));
+      setNumber("Total Heat Power", 0, "W");
+      setNumber("Total Cooling Power", wave(1720, 90), "W");
+      setNumber("Total COP", 0);
+      setNumber("Total EER", Number((3.9 + Math.sin(t) * 0.08).toFixed(2)));
       setNumber("Flow average (Selected)", wave(845, 26), "L/h");
       setNumber("Room Temperature (Selected)", wave(24.2, 0.08), "°C");
       setNumber("Room Setpoint (Selected)", 23.0, "°C");
       setNumber("Water Supply Temp (Selected)", wave(19.6, 0.2), "°C");
       setNumber("HP1 - Power Input", 5.4, "W");
       setNumber("HP1 - Heat Power", 0, "W");
+      setNumber("HP1 - Cooling Power", 0, "W");
       setNumber("HP1 - COP", 0);
       setNumber("HP1 - Compressor frequency", 0, "Hz");
       setNumber("HP1 - Fan speed", 0, "rpm");
@@ -790,7 +819,8 @@
       setText("text_sensor", "HP1 - Working Mode Label", "Standby");
       if (!single) {
         setNumber("HP2 - Power Input", wave(448, 18, 0.3), "W");
-        setNumber("HP2 - Heat Power", wave(1710, 90, 0.3), "W");
+        setNumber("HP2 - Heat Power", 0, "W");
+        setNumber("HP2 - Cooling Power", wave(1710, 90, 0.3), "W");
         setNumber("HP2 - COP", Number((3.82 + Math.sin(t + 0.3) * 0.08).toFixed(2)));
         setNumber("HP2 - Compressor frequency", waveInt(33, 2, 0.3), "Hz");
         setNumber("HP2 - Fan speed", wave(602, 14, 0.3), "rpm");

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -148,7 +148,9 @@
     const roomDelta = Number.isNaN(roomSetpoint) || Number.isNaN(roomTemp) ? 0 : roomSetpoint - roomTemp;
     const roomCorrection = Number.isNaN(kp) ? 0 : Math.round(Math.max(-1500, Math.min(1500, roomDelta * kp)));
     const powerHouseRequested = Math.max(0, Math.round(houseModel + roomCorrection));
-    const strategyRequested = Math.max(0, Math.round(strategy === "Power House" ? powerHouseRequested : totalHeat || 0));
+    const strategyRequested = state.scenario === "cooling"
+      ? 0
+      : Math.max(0, Math.round(strategy === "Power House" ? powerHouseRequested : totalHeat || 0));
 
     let capacity = 0;
     if (state.scenario === "idle") {
@@ -159,19 +161,21 @@
       capacity = 5200;
     } else if (state.scenario === "defrost") {
       capacity = single ? 1800 : 3200;
+    } else if (state.scenario === "cooling") {
+      capacity = single ? 2600 : 4200;
     }
 
     setNumber("Outside Temperature (Selected)", selectedOutside, "°C");
-    setNumber("Power House – P_house", houseModel, "W");
-    setNumber("Power House – P_req", powerHouseRequested, "W");
+    setNumber("Power House – P_house", state.scenario === "cooling" ? 0 : houseModel, "W");
+    setNumber("Power House – P_req", state.scenario === "cooling" ? 0 : powerHouseRequested, "W");
     setNumber("Strategy requested power", strategyRequested, "W");
     setNumber("HP capacity (W)", capacity, "W");
     setNumber("HP deficit (W)", Math.max(0, strategyRequested - capacity), "W");
 
     const boilerHeat = state.scenario === "dual" ? 180 : 0;
     const systemHeat = Math.max(0, Number((Number(totalHeat || 0) + boilerHeat).toFixed(0)));
-    const electricalDaily = state.scenario === "idle" ? 3.1 : state.scenario === "defrost" ? 6.4 : single ? 7.2 : 8.6;
-    const heatpumpDaily = state.scenario === "idle" ? 9.4 : state.scenario === "defrost" ? 18.2 : single ? 28.4 : 36.9;
+    const electricalDaily = state.scenario === "idle" ? 3.1 : state.scenario === "defrost" ? 6.4 : state.scenario === "cooling" ? (single ? 6.8 : 8.1) : single ? 7.2 : 8.6;
+    const heatpumpDaily = state.scenario === "idle" ? 9.4 : state.scenario === "defrost" ? 18.2 : state.scenario === "cooling" ? (single ? 24.6 : 31.8) : single ? 28.4 : 36.9;
     const boilerDaily = state.scenario === "dual" ? 2.7 : 0.0;
     const systemDaily = Number((heatpumpDaily + boilerDaily).toFixed(1));
     const heatpumpCopDaily = electricalDaily > 0 ? Number((heatpumpDaily / electricalDaily).toFixed(2)) : 0;
@@ -224,6 +228,7 @@
       option: ["Flow Setpoint", "Manual PWM"],
     });
     setEntity("text_sensor", "Control Mode (Label)", { state: "CM98" });
+    setEntity("text_sensor", "Cooling Block Reason", { state: "Ready", value: "Ready" });
     setEntity("text_sensor", "Flow Mode", { state: "Adaptive" });
     setEntity("select", "Behavior", {
       value: "Balanced",
@@ -330,6 +335,11 @@
       ["Heating Curve Supply Target", 33.0, "°C"],
       ["Power House – P_house", 2500, "W"],
       ["Power House – P_req", 2800, "W"],
+      ["Cooling Dew Point (Selected)", 16.1, "°C"],
+      ["Cooling Minimum Safe Supply Temp", 18.1, "°C"],
+      ["Cooling Supply Target", 18.6, "°C"],
+      ["Cooling Supply Error", 0.9, "°C"],
+      ["Cooling Demand (raw)", 2, ""],
       ["HP1 - Power Input", 0, "W"],
       ["HP1 - Heat Power", 0, "W"],
       ["HP1 - COP", 0, ""],
@@ -360,6 +370,9 @@
     [
       ["Silent active", false],
       ["Sticky pump active", false],
+      ["Cooling Enable (Selected)", false],
+      ["Cooling Request Active", false],
+      ["Cooling Permitted", false],
       ["HP1 - Defrost", false],
       ["HP1 - 4-Way valve", false],
       ["HP1 - Bottom plate heater", false],
@@ -505,6 +518,10 @@
 
     if (name === "idle") {
       setText("text_sensor", "Control Mode (Label)", "CM98");
+      setBinary("Cooling Enable (Selected)", false);
+      setBinary("Cooling Request Active", false);
+      setBinary("Cooling Permitted", false);
+      setText("text_sensor", "Cooling Block Reason", "Ready");
       setText("text_sensor", "Flow Mode", "Adaptive");
       setNumber("Total Power Input", single ? 5.2 : 10.3, "W");
       setNumber("Total Heat Power", 0, "W");
@@ -557,6 +574,10 @@
 
     if (name === "heating") {
       setText("text_sensor", "Control Mode (Label)", "CM98");
+      setBinary("Cooling Enable (Selected)", false);
+      setBinary("Cooling Request Active", false);
+      setBinary("Cooling Permitted", false);
+      setText("text_sensor", "Cooling Block Reason", "Ready");
       setText("text_sensor", "Flow Mode", "Adaptive");
       const hp1Power = wave(418, 22);
       const hp1Heat = wave(1880, 120);
@@ -612,6 +633,10 @@
 
     if (name === "dual") {
       setText("text_sensor", "Control Mode (Label)", "CM99");
+      setBinary("Cooling Enable (Selected)", false);
+      setBinary("Cooling Request Active", false);
+      setBinary("Cooling Permitted", false);
+      setText("text_sensor", "Cooling Block Reason", "Ready");
       setText("text_sensor", "Flow Mode", "Mixed test");
       setBinary("Silent active", true);
       setText("text_sensor", "HP2 - Active Failures List", "Compressor oil return");
@@ -665,6 +690,10 @@
 
     if (name === "defrost") {
       setText("text_sensor", "Control Mode (Label)", "CM99");
+      setBinary("Cooling Enable (Selected)", false);
+      setBinary("Cooling Request Active", false);
+      setBinary("Cooling Permitted", false);
+      setText("text_sensor", "Cooling Block Reason", "Ready");
       setText("text_sensor", "Flow Mode", "Defrost recovery");
       setBinary("Sticky pump active", true);
       setBinary("HP1 - Defrost", true);
@@ -718,6 +747,66 @@
         setText("text_sensor", "HP2 - Working Mode Label", "Standby");
         setBinary("HP2 - Bottom plate heater", false);
         setBinary("HP2 - Crankcase heater", true);
+      }
+      syncOverviewTelemetry(single);
+      return;
+    }
+
+    if (name === "cooling") {
+      setText("text_sensor", "Control Mode (Label)", "CM5 - Cooling");
+      setText("text_sensor", "Flow Mode", "Adaptive");
+      setBinary("Cooling Enable (Selected)", true);
+      setBinary("Cooling Request Active", true);
+      setBinary("Cooling Permitted", true);
+      setText("text_sensor", "Cooling Block Reason", "Ready");
+      setNumber("Cooling Dew Point (Selected)", wave(16.0, 0.15), "°C");
+      setNumber("Cooling Minimum Safe Supply Temp", wave(18.0, 0.15), "°C");
+      setNumber("Cooling Supply Target", wave(18.6, 0.12), "°C");
+      setNumber("Cooling Supply Error", wave(1.0, 0.2), "°C");
+      setNumber("Cooling Demand (raw)", waveInt(2.2, 0.6), "");
+      setNumber("Total Power Input", wave(455, 18), "W");
+      setNumber("Total Heat Power", wave(1720, 90), "W");
+      setNumber("Total COP", Number((3.9 + Math.sin(t) * 0.08).toFixed(2)));
+      setNumber("Flow average (Selected)", wave(845, 26), "L/h");
+      setNumber("Room Temperature (Selected)", wave(24.2, 0.08), "°C");
+      setNumber("Room Setpoint (Selected)", 23.0, "°C");
+      setNumber("Water Supply Temp (Selected)", wave(19.6, 0.2), "°C");
+      setNumber("HP1 - Power Input", 5.4, "W");
+      setNumber("HP1 - Heat Power", 0, "W");
+      setNumber("HP1 - COP", 0);
+      setNumber("HP1 - Compressor frequency", 0, "Hz");
+      setNumber("HP1 - Fan speed", 0, "rpm");
+      setNumber("HP1 - Flow", 0, "L/h");
+      setNumber("HP1 - Evaporator coil temperature", wave(24.8, 0.2), "\u00B0C");
+      setNumber("HP1 - Inner coil temperature", wave(25.7, 0.2), "\u00B0C");
+      setNumber("HP1 - Outside temperature", wave(26.1, 0.2), "\u00B0C");
+      setNumber("HP1 - Condenser pressure", wave(8.0, 0.1), "bar");
+      setNumber("HP1 - Gas discharge temperature", wave(27.6, 0.2), "\u00B0C");
+      setNumber("HP1 - Evaporator pressure", wave(7.8, 0.1), "bar");
+      setNumber("HP1 - Gas return temperature", wave(25.3, 0.2), "\u00B0C");
+      setNumber("HP1 - EEV steps", 0, "p");
+      setNumber("HP1 - Water in temperature", wave(20.8, 0.2), "°C");
+      setNumber("HP1 - Water out temperature", wave(20.1, 0.2), "°C");
+      setText("text_sensor", "HP1 - Working Mode Label", "Standby");
+      if (!single) {
+        setNumber("HP2 - Power Input", wave(448, 18, 0.3), "W");
+        setNumber("HP2 - Heat Power", wave(1710, 90, 0.3), "W");
+        setNumber("HP2 - COP", Number((3.82 + Math.sin(t + 0.3) * 0.08).toFixed(2)));
+        setNumber("HP2 - Compressor frequency", waveInt(33, 2, 0.3), "Hz");
+        setNumber("HP2 - Fan speed", wave(602, 14, 0.3), "rpm");
+        setNumber("HP2 - Flow", wave(842, 18, 0.3), "L/h");
+        setNumber("HP2 - Evaporator coil temperature", wave(8.2, 0.3, 0.3), "\u00B0C");
+        setNumber("HP2 - Inner coil temperature", wave(12.0, 0.3, 0.2), "\u00B0C");
+        setNumber("HP2 - Outside temperature", wave(25.9, 0.2, 0.2), "\u00B0C");
+        setNumber("HP2 - Condenser pressure", wave(17.8, 0.3, 0.3), "bar");
+        setNumber("HP2 - Gas discharge temperature", wave(47.0, 0.8, 0.3), "\u00B0C");
+        setNumber("HP2 - Evaporator pressure", wave(6.0, 0.15, 0.3), "bar");
+        setNumber("HP2 - Gas return temperature", wave(10.4, 0.2, 0.3), "\u00B0C");
+        setNumber("HP2 - EEV steps", waveInt(268, 12, 0.3), "p");
+        setNumber("HP2 - Water in temperature", wave(21.0, 0.2, 0.3), "°C");
+        setNumber("HP2 - Water out temperature", wave(19.3, 0.2, 0.3), "°C");
+        setText("text_sensor", "HP2 - Working Mode Label", "Cooling");
+        setBinary("HP2 - 4-Way valve", true);
       }
       syncOverviewTelemetry(single);
       return;
@@ -959,6 +1048,7 @@
               <option value="idle">Idle</option>
               <option value="heating">HP1 heating</option>
               ${state.installation === "duo" ? '<option value="dual">HP1 heat + HP2 cool</option>' : ""}
+              ${state.installation === "duo" ? '<option value="cooling">HP1 standby + HP2 cooling</option>' : ""}
               <option value="defrost">Defrost</option>
             </select>
           </label>

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -3861,7 +3861,7 @@ body.oq-page-light {
   text-align: right;
 }
 
-.oq-hp-schematic-board.is-running .oq-hp-schematic-fan-blades {
+.oq-hp-schematic-board.is-fan-running .oq-hp-schematic-fan-blades {
   animation: oq-hp-spin 3.2s linear infinite;
 }
 

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -354,9 +354,13 @@
     "hp1Power",
     "hp1Heat",
     "hp1Cop",
+    "hp1Compressor",
     "hp1Freq",
+    "hp1FanSpeed",
     "hp1Flow",
     "hp1EvaporatorCoilTemp",
+    "hp1InnerCoilTemp",
+    "hp1OutsideTemp",
     "hp1CondenserPressure",
     "hp1DischargeTemp",
     "hp1EvaporatorPressure",
@@ -373,9 +377,13 @@
     "hp2Power",
     "hp2Heat",
     "hp2Cop",
+    "hp2Compressor",
     "hp2Freq",
+    "hp2FanSpeed",
     "hp2Flow",
     "hp2EvaporatorCoilTemp",
+    "hp2InnerCoilTemp",
+    "hp2OutsideTemp",
     "hp2CondenserPressure",
     "hp2DischargeTemp",
     "hp2EvaporatorPressure",
@@ -857,11 +865,15 @@
       return;
     }
 
-    const boards = state.root.querySelectorAll(".oq-hp-schematic-board.is-running");
-    boards.forEach((board) => {
+    const runningBoards = state.root.querySelectorAll(".oq-hp-schematic-board.is-running");
+    runningBoards.forEach((board) => {
       board.querySelectorAll(".oq-hp-tech-pipe-flow").forEach((node) => {
         state.motionTargets.pipeFlows.push(node);
       });
+    });
+
+    const fanBoards = state.root.querySelectorAll(".oq-hp-schematic-board.is-fan-running");
+    fanBoards.forEach((board) => {
       board.querySelectorAll(".oq-hp-tech-fan-blades").forEach((node) => {
         state.motionTargets.fanBlades.push(node);
       });
@@ -4292,7 +4304,7 @@
 
   function isCoolingOverviewActive() {
     const modeLabel = getEntityStateText("controlModeLabel", "").toLowerCase();
-    if (modeLabel.includes("cm5") || modeLabel.includes("cooling")) {
+    if (modeLabel.includes("cm5") || modeLabel.includes("cooling") || modeLabel.includes("koeling")) {
       return true;
     }
     return isEntityActive("coolingRequestActive") || isEntityActive("coolingEnableSelected");
@@ -4300,7 +4312,7 @@
 
   function getOverviewStrategyLabel() {
     if (isCoolingOverviewActive()) {
-      return "Cooling";
+      return "Koeling";
     }
     return isCurveMode() ? "Stooklijn" : "Power House";
   }
@@ -4406,7 +4418,7 @@
       statusTitle = "Koeling gereed";
       statusCopy = "Koeling is toegestaan, maar wacht nog op actieve koelvraag vanuit de kamerregeling.";
     } else if (!Number.isNaN(rawDemand) && rawDemand <= 0.0) {
-      statusTitle = "Houdt temperatuur vast";
+      statusTitle = "Houdt doel vast";
       statusCopy = "De koelvraag loopt nog, maar de compressor hoeft nu niet harder te werken.";
     } else if (!Number.isNaN(supplyError) && supplyError > 1.0) {
       statusTitle = "Trekt aanvoer omlaag";
@@ -4491,7 +4503,7 @@
       <section class="oq-overview-system">
         <div class="oq-overview-system-copy">
           <h3>Koelregeling</h3>
-          <p>Cooling laat zien op welke aanvoertemperatuur de regeling nu mikt en hoe dicht die bij de veilige grens zit.</p>
+          <p>Koeling laat zien op welke aanvoertemperatuur de regeling nu mikt en hoe dicht die bij de veilige grens zit.</p>
         </div>
         <div class="oq-overview-hero">
           <div class="oq-overview-hero-main">
@@ -4503,7 +4515,7 @@
         <div class="oq-overview-metrics oq-overview-metrics--three-column">
           ${renderOverviewMetricCard("Actuele aanvoertemperatuur", model.supplyText, "orange", "Wat nu door het systeem loopt.")}
           ${renderOverviewMetricCard("Veilige aanvoergrens", model.safeFloorText, "blue", "Dauwpunt plus veiligheidsmarge.")}
-          ${renderOverviewMetricCard("Cooling demand", model.demandText, "sky", "De huidige koelvraag van de regelaar.")}
+          ${renderOverviewMetricCard("Koelvraag", model.demandText, "sky", "De huidige koelvraag van de regelaar.")}
         </div>
       </section>
     `;
@@ -4567,7 +4579,7 @@
         ? "Koelvraag actief"
         : rawDemand <= 0
           ? "Koelvraag actief, compressor rust"
-          : `Cooling demand ${Math.round(rawDemand)}`;
+          : `Koelvraag ${Math.round(rawDemand)}`;
       return {
         label: "Koelvraag",
         value,
@@ -5181,6 +5193,7 @@
     const heatText = formatNumericState(heatValue, 0, "W");
     const copText = formatNumericState(getEntityNumericValue(keys.cop), 1);
     const fanRpmValue = getEntityNumericValue(keys.fanSpeed);
+    const fanRunning = !Number.isNaN(fanRpmValue) && fanRpmValue > 0;
     const fanRpmText = Number.isNaN(fanRpmValue)
       ? "—"
       : `${Math.round(fanRpmValue)} rpm`;
@@ -5210,6 +5223,7 @@
       "oq-hp-schematic-board",
       `oq-hp-schematic-board--${accent}`,
       animated ? "is-running" : "",
+      fanRunning ? "is-fan-running" : "",
       reverseCycle ? "is-reversed" : "",
       defrostActive ? "is-defrost" : "",
     ].filter(Boolean).join(" ");

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -5192,6 +5192,8 @@
     const powerText = formatNumericState(powerValue, 0, "W");
     const heatText = formatNumericState(heatValue, 0, "W");
     const copText = formatNumericState(getEntityNumericValue(keys.cop), 1);
+    const heatLabel = mode === "Koelen" ? "Koelafgifte" : "Warmteafgifte";
+    const heatDescription = mode === "Koelen" ? "afgegeven koeling" : "afgegeven warmte";
     const fanRpmValue = getEntityNumericValue(keys.fanSpeed);
     const fanRunning = !Number.isNaN(fanRpmValue) && fanRpmValue > 0;
     const fanRpmText = Number.isNaN(fanRpmValue)
@@ -5259,6 +5261,8 @@
       fourWayPositionText,
       powerText,
       heatText,
+      heatLabel,
+      heatDescription,
       copText,
       fanRpmText,
       hotgasValveHeat,
@@ -5789,7 +5793,7 @@
               <strong data-oq-bind="footer-power">${escapeHtml(model.powerText)}</strong>
             </div>
             <div class="oq-hp-tech-footer-item">
-              <span aria-label="Warmteafgifte">Warmte<br>afgifte</span>
+              <span aria-label="${escapeHtml(model.heatLabel)}" data-oq-bind="footer-heat-label">${model.heatLabel === "Koelafgifte" ? "Koel<br>afgifte" : "Warmte<br>afgifte"}</span>
               <strong data-oq-bind="footer-heat">${escapeHtml(model.heatText)}</strong>
             </div>
             <div class="oq-hp-tech-footer-item">
@@ -5918,7 +5922,7 @@
         </div>
         <div class="oq-overview-hp-stats">
           ${renderOverviewStatCard(keys.power, "Stroomverbruik", "blue", "elektrisch verbruik")}
-          ${renderOverviewStatCard(keys.heat, "Warmteafgifte", "orange", "afgegeven warmte")}
+          ${renderOverviewStatCard(keys.heat, schematicModel.heatLabel, "orange", schematicModel.heatDescription)}
           ${renderOverviewStatCard(keys.cop, "COP", "green", "actueel")}
         </div>
         <div class="oq-overview-hp-meta">
@@ -6256,6 +6260,14 @@
     setTextContent(board, '[data-oq-bind="return-value"]', model.waterInText);
     setTextContent(board, '[data-oq-bind="footer-mode"]', model.mode);
     setTextContent(board, '[data-oq-bind="footer-power"]', model.powerText);
+    const footerHeatLabel = board.querySelector('[data-oq-bind="footer-heat-label"]');
+    if (footerHeatLabel) {
+      footerHeatLabel.setAttribute("aria-label", model.heatLabel);
+      const nextHeatLabelMarkup = model.heatLabel === "Koelafgifte" ? "Koel<br>afgifte" : "Warmte<br>afgifte";
+      if (footerHeatLabel.innerHTML !== nextHeatLabelMarkup) {
+        footerHeatLabel.innerHTML = nextHeatLabelMarkup;
+      }
+    }
     setTextContent(board, '[data-oq-bind="footer-heat"]', model.heatText);
     setTextContent(board, '[data-oq-bind="footer-cop"]', model.copText);
     setTextContent(board, '[data-oq-bind="fan-speed-value"]', model.fanRpmText);

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -4579,7 +4579,7 @@
         ? "Koelvraag actief"
         : rawDemand <= 0
           ? "Koelvraag actief, compressor rust"
-          : `Koelvraag ${Math.round(rawDemand)}`;
+          : "Koelvraag actief";
       return {
         label: "Koelvraag",
         value,

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -119,17 +119,29 @@
     maxWater: { domain: "number", name: "Maximum water temperature" },
     minRuntime: { domain: "number", name: "Minimum runtime" },
     totalPower: { domain: "sensor", name: "Total Power Input" },
+    heatingPowerInput: { domain: "sensor", name: "Heating Power Input", optional: true },
+    coolingPowerInput: { domain: "sensor", name: "Cooling Power Input", optional: true },
     totalCop: { domain: "sensor", name: "Total COP" },
+    totalEer: { domain: "sensor", name: "Total EER", optional: true },
     totalHeat: { domain: "sensor", name: "Total Heat Power" },
+    totalCoolingPower: { domain: "sensor", name: "Total Cooling Power", optional: true },
     boilerHeatPower: { domain: "sensor", name: "Boiler Heat Power", optional: true },
     systemHeatPower: { domain: "sensor", name: "System Heat Power", optional: true },
     flowSelected: { domain: "sensor", name: "Flow average (Selected)" },
     electricalEnergyDaily: { domain: "sensor", name: "Electrical Energy Daily", optional: true },
     electricalEnergyCumulative: { domain: "sensor", name: "Electrical Energy Cumulative", optional: true },
+    heatingElectricalEnergyDaily: { domain: "sensor", name: "Heating Electrical Energy Daily", optional: true },
+    heatingElectricalEnergyCumulative: { domain: "sensor", name: "Heating Electrical Energy Cumulative", optional: true },
+    coolingElectricalEnergyDaily: { domain: "sensor", name: "Cooling Electrical Energy Daily", optional: true },
+    coolingElectricalEnergyCumulative: { domain: "sensor", name: "Cooling Electrical Energy Cumulative", optional: true },
     heatpumpThermalEnergyDaily: { domain: "sensor", name: "HeatPump Thermal Energy Daily", optional: true },
     heatpumpThermalEnergyCumulative: { domain: "sensor", name: "HeatPump Thermal Energy Cumulative", optional: true },
+    heatpumpCoolingEnergyDaily: { domain: "sensor", name: "HeatPump Cooling Energy Daily", optional: true },
+    heatpumpCoolingEnergyCumulative: { domain: "sensor", name: "HeatPump Cooling Energy Cumulative", optional: true },
     heatpumpCopDaily: { domain: "sensor", name: "HeatPump COP Daily", optional: true },
     heatpumpCopCumulative: { domain: "sensor", name: "HeatPump COP Cumulative", optional: true },
+    heatpumpEerDaily: { domain: "sensor", name: "HeatPump EER Daily", optional: true },
+    heatpumpEerCumulative: { domain: "sensor", name: "HeatPump EER Cumulative", optional: true },
     boilerThermalEnergyDaily: { domain: "sensor", name: "Boiler Thermal Energy Daily", optional: true },
     boilerThermalEnergyCumulative: { domain: "sensor", name: "Boiler Thermal Energy Cumulative", optional: true },
     systemThermalEnergyDaily: { domain: "sensor", name: "System Thermal Energy Daily", optional: true },
@@ -167,6 +179,7 @@
     hp1ExcludedB: { domain: "select", name: "HP1 - Excluded compressor level B" },
     hp1Power: { domain: "sensor", name: "HP1 - Power Input" },
     hp1Heat: { domain: "sensor", name: "HP1 - Heat Power" },
+    hp1Cooling: { domain: "sensor", name: "HP1 - Cooling Power" },
     hp1Cop: { domain: "sensor", name: "HP1 - COP" },
     hp1Compressor: { domain: "sensor", name: "HP1 compressor level" },
     hp1Freq: { domain: "sensor", name: "HP1 - Compressor frequency" },
@@ -192,6 +205,7 @@
     hp2ExcludedB: { domain: "select", name: "HP2 - Excluded compressor level B", optional: true },
     hp2Power: { domain: "sensor", name: "HP2 - Power Input", optional: true },
     hp2Heat: { domain: "sensor", name: "HP2 - Heat Power", optional: true },
+    hp2Cooling: { domain: "sensor", name: "HP2 - Cooling Power", optional: true },
     hp2Cop: { domain: "sensor", name: "HP2 - COP", optional: true },
     hp2Compressor: { domain: "sensor", name: "HP2 compressor level", optional: true },
     hp2Freq: { domain: "sensor", name: "HP2 - Compressor frequency", optional: true },
@@ -232,6 +246,7 @@
       keys: {
         power: "hp1Power",
         heat: "hp1Heat",
+        cooling: "hp1Cooling",
         cop: "hp1Cop",
         freq: "hp1Freq",
         fanSpeed: "hp1FanSpeed",
@@ -260,6 +275,7 @@
       keys: {
         power: "hp2Power",
         heat: "hp2Heat",
+        cooling: "hp2Cooling",
         cop: "hp2Cop",
         freq: "hp2Freq",
         fanSpeed: "hp2FanSpeed",
@@ -326,8 +342,12 @@
     "controlModeLabel",
     "flowMode",
     "totalPower",
+    "heatingPowerInput",
+    "coolingPowerInput",
     "totalCop",
+    "totalEer",
     "totalHeat",
+    "totalCoolingPower",
     "strategyRequestedPower",
     "phouseHouse",
     "phouseReq",
@@ -336,10 +356,18 @@
     "systemHeatPower",
     "electricalEnergyDaily",
     "electricalEnergyCumulative",
+    "heatingElectricalEnergyDaily",
+    "heatingElectricalEnergyCumulative",
+    "coolingElectricalEnergyDaily",
+    "coolingElectricalEnergyCumulative",
     "heatpumpThermalEnergyDaily",
     "heatpumpThermalEnergyCumulative",
+    "heatpumpCoolingEnergyDaily",
+    "heatpumpCoolingEnergyCumulative",
     "heatpumpCopDaily",
     "heatpumpCopCumulative",
+    "heatpumpEerDaily",
+    "heatpumpEerCumulative",
     "boilerThermalEnergyDaily",
     "boilerThermalEnergyCumulative",
     "systemThermalEnergyDaily",
@@ -353,6 +381,7 @@
     "stickyActive",
     "hp1Power",
     "hp1Heat",
+    "hp1Cooling",
     "hp1Cop",
     "hp1Compressor",
     "hp1Freq",
@@ -376,6 +405,7 @@
     "hp1FourWay",
     "hp2Power",
     "hp2Heat",
+    "hp2Cooling",
     "hp2Cop",
     "hp2Compressor",
     "hp2Freq",
@@ -4142,6 +4172,16 @@
     `;
   }
 
+  function renderOverviewStatCardValue(label, value, tone, note) {
+    return `
+      <article class="oq-overview-stat oq-overview-stat--${escapeHtml(tone)}">
+        <p>${escapeHtml(label)}</p>
+        <strong>${escapeHtml(value)}</strong>
+        <span>${escapeHtml(note)}</span>
+      </article>
+    `;
+  }
+
   function renderOverviewStatusChip(label, value, tone = "neutral") {
     return `<span class="oq-overview-chip oq-overview-chip--${escapeHtml(tone)}"><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}</span>`;
   }
@@ -4682,11 +4722,15 @@
   }
 
   function renderOverviewTopCards() {
-    const heatLabel = isCoolingOverviewActive() ? "Koelafgifte" : "Warmteafgifte";
+    const coolingActive = isCoolingOverviewActive();
+    const thermalLabel = coolingActive ? "Koelafgifte" : "Warmteafgifte";
+    const thermalKey = coolingActive ? "totalCoolingPower" : "totalHeat";
+    const efficiencyKey = coolingActive ? "totalEer" : "totalCop";
+    const efficiencyLabel = coolingActive ? "EER" : "COP";
     return `
       ${renderOverviewStatCard("totalPower", "Stroomverbruik", "blue", "hele systeem")}
-      ${renderOverviewStatCard("totalHeat", heatLabel, "orange", "thermisch vermogen")}
-      ${renderOverviewStatCard("totalCop", "COP", "green", "rendement")}
+      ${renderOverviewStatCard(thermalKey, thermalLabel, "orange", "thermisch vermogen")}
+      ${renderOverviewStatCard(efficiencyKey, efficiencyLabel, "green", "rendement")}
       ${renderOverviewStatCard("flowSelected", "Flow", "sky", "watercircuit")}
     `;
   }
@@ -4805,8 +4849,8 @@
 
   function renderOverviewEnergySection() {
     const currentColumn = renderOverviewEnergyColumn("Nu", "Live energie", [
-      renderOverviewEnergyGroup("Warmtepomp", [
-        renderOverviewEnergyRow("Elektrisch vermogen", "totalPower"),
+      renderOverviewEnergyGroup("Warmtepomp verwarmen", [
+        renderOverviewEnergyRow("Elektrisch vermogen", "heatingPowerInput"),
         renderOverviewEnergyRow("Warmteafgifte", "totalHeat"),
         renderOverviewEnergyRow("COP", "totalCop"),
       ]),
@@ -4816,11 +4860,16 @@
       renderOverviewEnergyGroup("Systeem", [
         renderOverviewEnergyRow("Warmteafgifte", "systemHeatPower"),
       ]),
+      renderOverviewEnergyGroup("Warmtepomp koelen", [
+        renderOverviewEnergyRow("Elektrisch vermogen", "coolingPowerInput"),
+        renderOverviewEnergyRow("Koelafgifte", "totalCoolingPower"),
+        renderOverviewEnergyRow("EER", "totalEer"),
+      ]),
     ], "blue");
 
     const dailyColumn = renderOverviewEnergyColumn("Vandaag", "Energie vandaag", [
-      renderOverviewEnergyGroup("Warmtepomp", [
-        renderOverviewEnergyRow("Elektriciteit", "electricalEnergyDaily"),
+      renderOverviewEnergyGroup("Warmtepomp verwarmen", [
+        renderOverviewEnergyRow("Elektriciteit", "heatingElectricalEnergyDaily"),
         renderOverviewEnergyRow("Warmte", "heatpumpThermalEnergyDaily"),
         renderOverviewEnergyRow("COP", "heatpumpCopDaily"),
       ]),
@@ -4830,11 +4879,16 @@
       renderOverviewEnergyGroup("Systeem", [
         renderOverviewEnergyRow("Warmte", "systemThermalEnergyDaily"),
       ]),
+      renderOverviewEnergyGroup("Warmtepomp koelen", [
+        renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyDaily"),
+        renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyDaily"),
+        renderOverviewEnergyRow("EER", "heatpumpEerDaily"),
+      ]),
     ], "orange");
 
     const cumulativeColumn = renderOverviewEnergyColumn("Cumulatief", "Tot nu toe", [
-      renderOverviewEnergyGroup("Warmtepomp", [
-        renderOverviewEnergyRow("Elektriciteit", "electricalEnergyCumulative"),
+      renderOverviewEnergyGroup("Warmtepomp verwarmen", [
+        renderOverviewEnergyRow("Elektriciteit", "heatingElectricalEnergyCumulative"),
         renderOverviewEnergyRow("Warmte", "heatpumpThermalEnergyCumulative"),
         renderOverviewEnergyRow("COP", "heatpumpCopCumulative"),
       ]),
@@ -4843,6 +4897,11 @@
       ]),
       renderOverviewEnergyGroup("Systeem", [
         renderOverviewEnergyRow("Warmte", "systemThermalEnergyCumulative"),
+      ]),
+      renderOverviewEnergyGroup("Warmtepomp koelen", [
+        renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyCumulative"),
+        renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyCumulative"),
+        renderOverviewEnergyRow("EER", "heatpumpEerCumulative"),
       ]),
     ], "green");
 
@@ -4855,7 +4914,7 @@
       <section class="oq-overview-energy">
         <div class="oq-overview-system-copy">
           <h3>Energie</h3>
-          <p>Bekijk hier verbruik, warmte en rendement voor nu, vandaag en cumulatief.</p>
+          <p>Bekijk hier verbruik, warmte of koeling en rendement voor nu, vandaag en cumulatief.</p>
         </div>
         <div class="oq-overview-energy-grid">
           ${columns.join("")}
@@ -4866,8 +4925,8 @@
 
   function renderEnergyView() {
     const currentColumn = renderOverviewEnergyColumn("Nu", "Nu", [
-      renderOverviewEnergyGroup("Warmtepomp", [
-        renderOverviewEnergyRow("Elektrisch vermogen", "totalPower"),
+      renderOverviewEnergyGroup("Warmtepomp verwarmen", [
+        renderOverviewEnergyRow("Elektrisch vermogen", "heatingPowerInput"),
         renderOverviewEnergyRow("Warmteafgifte", "totalHeat"),
         renderOverviewEnergyRow("COP", "totalCop"),
       ]),
@@ -4877,11 +4936,16 @@
       renderOverviewEnergyGroup("Systeem", [
         renderOverviewEnergyRow("Warmteafgifte", "systemHeatPower"),
       ]),
+      renderOverviewEnergyGroup("Warmtepomp koelen", [
+        renderOverviewEnergyRow("Elektrisch vermogen", "coolingPowerInput"),
+        renderOverviewEnergyRow("Koelafgifte", "totalCoolingPower"),
+        renderOverviewEnergyRow("EER", "totalEer"),
+      ]),
     ], "blue");
 
     const dailyColumn = renderOverviewEnergyColumn("Vandaag", "Vandaag", [
-      renderOverviewEnergyGroup("Warmtepomp", [
-        renderOverviewEnergyRow("Elektriciteit", "electricalEnergyDaily"),
+      renderOverviewEnergyGroup("Warmtepomp verwarmen", [
+        renderOverviewEnergyRow("Elektriciteit", "heatingElectricalEnergyDaily"),
         renderOverviewEnergyRow("Warmte", "heatpumpThermalEnergyDaily"),
         renderOverviewEnergyRow("COP", "heatpumpCopDaily"),
       ]),
@@ -4891,11 +4955,16 @@
       renderOverviewEnergyGroup("Systeem", [
         renderOverviewEnergyRow("Warmte", "systemThermalEnergyDaily"),
       ]),
+      renderOverviewEnergyGroup("Warmtepomp koelen", [
+        renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyDaily"),
+        renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyDaily"),
+        renderOverviewEnergyRow("EER", "heatpumpEerDaily"),
+      ]),
     ], "orange");
 
     const cumulativeColumn = renderOverviewEnergyColumn("Cumulatief", "Cumulatief", [
-      renderOverviewEnergyGroup("Warmtepomp", [
-        renderOverviewEnergyRow("Elektriciteit", "electricalEnergyCumulative"),
+      renderOverviewEnergyGroup("Warmtepomp verwarmen", [
+        renderOverviewEnergyRow("Elektriciteit", "heatingElectricalEnergyCumulative"),
         renderOverviewEnergyRow("Warmte", "heatpumpThermalEnergyCumulative"),
         renderOverviewEnergyRow("COP", "heatpumpCopCumulative"),
       ]),
@@ -4905,6 +4974,11 @@
       renderOverviewEnergyGroup("Systeem", [
         renderOverviewEnergyRow("Warmte", "systemThermalEnergyCumulative"),
       ]),
+      renderOverviewEnergyGroup("Warmtepomp koelen", [
+        renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyCumulative"),
+        renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyCumulative"),
+        renderOverviewEnergyRow("EER", "heatpumpEerCumulative"),
+      ]),
     ], "green");
 
     const columns = [currentColumn, dailyColumn, cumulativeColumn].filter(Boolean).join("");
@@ -4913,11 +4987,11 @@
       <section class="oq-helper-panel oq-helper-panel--flush">
         <div class="oq-overview-board oq-overview-board--${escapeHtml(state.overviewTheme)}">
           <div class="oq-overview-head">
-            <div>
-              <p class="oq-helper-label">Energie</p>
-              <h2 class="oq-helper-section-title">Verbruik en rendement</h2>
-              <p class="oq-helper-section-copy">Bekijk hier verbruik, warmte en rendement voor nu, vandaag en cumulatief.</p>
-            </div>
+          <div>
+            <p class="oq-helper-label">Energie</p>
+            <h2 class="oq-helper-section-title">Verbruik en rendement</h2>
+            <p class="oq-helper-section-copy">Bekijk hier verbruik, warmte of koeling en rendement voor nu, vandaag en cumulatief.</p>
+          </div>
           </div>
           <section class="oq-overview-energy oq-overview-energy--solo">
             <div class="oq-overview-energy-grid">
@@ -5170,6 +5244,8 @@
     const freqText = Number.isNaN(freqValue) ? "—" : String(Math.round(freqValue));
     const powerValue = getEntityNumericValue(keys.power);
     const heatValue = getEntityNumericValue(keys.heat);
+    const coolingValue = getEntityNumericValue(keys.cooling);
+    const thermalValue = mode === "Koelen" ? coolingValue : heatValue;
     const animated = running || (!Number.isNaN(freqValue) && freqValue > 0) || (!Number.isNaN(powerValue) && powerValue > 80) || (!Number.isNaN(heatValue) && heatValue > 150);
     const statusText = getHeatPumpPanelStatusLabel(mode, animated);
     const failureText = failures === "Geen actieve storingen" ? "Geen storingen" : failures;
@@ -5190,8 +5266,12 @@
     const eevPositionText = formatComponentPositionLabel(keys.eev);
     const fourWayPositionText = formatFourWayPositionLabel(keys.fourWay);
     const powerText = formatNumericState(powerValue, 0, "W");
-    const heatText = formatNumericState(heatValue, 0, "W");
-    const copText = formatNumericState(getEntityNumericValue(keys.cop), 1);
+    const heatText = formatNumericState(thermalValue, 0, "W");
+    const efficiencyValue = mode === "Koelen"
+      ? ((!Number.isNaN(powerValue) && powerValue >= 5.0 && !Number.isNaN(coolingValue)) ? (coolingValue / powerValue) : Number.NaN)
+      : getEntityNumericValue(keys.cop);
+    const efficiencyText = formatNumericState(efficiencyValue, 1);
+    const efficiencyLabel = mode === "Koelen" ? "EER" : "COP";
     const heatLabel = mode === "Koelen" ? "Koelafgifte" : "Warmteafgifte";
     const heatDescription = mode === "Koelen" ? "afgegeven koeling" : "afgegeven warmte";
     const fanRpmValue = getEntityNumericValue(keys.fanSpeed);
@@ -5263,7 +5343,8 @@
       heatText,
       heatLabel,
       heatDescription,
-      copText,
+      efficiencyText,
+      efficiencyLabel,
       fanRpmText,
       hotgasValveHeat,
       hotgasValveCool,
@@ -5797,8 +5878,8 @@
               <strong data-oq-bind="footer-heat">${escapeHtml(model.heatText)}</strong>
             </div>
             <div class="oq-hp-tech-footer-item">
-              <span>COP</span>
-              <strong data-oq-bind="footer-cop">${escapeHtml(model.copText)}</strong>
+              <span data-oq-bind="footer-efficiency-label">${escapeHtml(model.efficiencyLabel)}</span>
+              <strong data-oq-bind="footer-efficiency">${escapeHtml(model.efficiencyText)}</strong>
             </div>
           </div>
         </div>
@@ -5890,6 +5971,7 @@
     const failures = formatFailures(getEntityStateText(keys.failures, "None"));
     const running = mode === "Verwarmen" || mode === "Koelen" || defrostActive;
     const schematicModel = buildHeatPumpSchematicModel(title, keys, accent, mode, defrostActive, failures, running);
+    const thermalKey = mode === "Koelen" ? keys.cooling : keys.heat;
 
     if (state.hpVisualMode === "schematic") {
       return `
@@ -5922,8 +6004,8 @@
         </div>
         <div class="oq-overview-hp-stats">
           ${renderOverviewStatCard(keys.power, "Stroomverbruik", "blue", "elektrisch verbruik")}
-          ${renderOverviewStatCard(keys.heat, schematicModel.heatLabel, "orange", schematicModel.heatDescription)}
-          ${renderOverviewStatCard(keys.cop, "COP", "green", "actueel")}
+          ${renderOverviewStatCard(thermalKey, schematicModel.heatLabel, "orange", schematicModel.heatDescription)}
+          ${renderOverviewStatCardValue(schematicModel.efficiencyLabel, schematicModel.efficiencyText, "green", "actueel")}
         </div>
         <div class="oq-overview-hp-meta">
           <div class="oq-overview-hp-meta-chip">
@@ -6269,7 +6351,8 @@
       }
     }
     setTextContent(board, '[data-oq-bind="footer-heat"]', model.heatText);
-    setTextContent(board, '[data-oq-bind="footer-cop"]', model.copText);
+    setTextContent(board, '[data-oq-bind="footer-efficiency-label"]', model.efficiencyLabel);
+    setTextContent(board, '[data-oq-bind="footer-efficiency"]', model.efficiencyText);
     setTextContent(board, '[data-oq-bind="fan-speed-value"]', model.fanRpmText);
     setTextContent(board, '[data-oq-bind="fourway-detail"]', model.fourWayPositionText);
     setTextContent(board, '[data-oq-bind="eev-detail"]', model.eevPositionText);

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -98,6 +98,15 @@
     projectVersionText: { domain: "text_sensor", name: "OpenQuatt Version", optional: true },
     releaseChannelText: { domain: "text_sensor", name: "OpenQuatt Release Channel", optional: true },
     strategy: { domain: "select", name: "Heating Control Mode" },
+    coolingEnableSelected: { domain: "binary_sensor", name: "Cooling Enable (Selected)", optional: true },
+    coolingRequestActive: { domain: "binary_sensor", name: "Cooling Request Active", optional: true },
+    coolingPermitted: { domain: "binary_sensor", name: "Cooling Permitted", optional: true },
+    coolingBlockReason: { domain: "text_sensor", name: "Cooling Block Reason", optional: true },
+    coolingDewPointSelected: { domain: "sensor", name: "Cooling Dew Point (Selected)", optional: true },
+    coolingMinimumSafeSupplyTemp: { domain: "sensor", name: "Cooling Minimum Safe Supply Temp", optional: true },
+    coolingSupplyTarget: { domain: "sensor", name: "Cooling Supply Target", optional: true },
+    coolingSupplyError: { domain: "sensor", name: "Cooling Supply Error", optional: true },
+    coolingDemandRaw: { domain: "sensor", name: "Cooling Demand (raw)", optional: true },
     flowControlMode: { domain: "select", name: "Flow Control Mode" },
     flowSetpoint: { domain: "number", name: "Flow Setpoint" },
     manualIpwm: { domain: "number", name: "Manual iPWM" },
@@ -305,6 +314,15 @@
   const HEADER_ENTITY_KEYS = ["uptimeReadable", "ipAddress", "projectVersionText", "releaseChannelText"];
   const OVERVIEW_KEYS = [
     "strategy",
+    "coolingEnableSelected",
+    "coolingRequestActive",
+    "coolingPermitted",
+    "coolingBlockReason",
+    "coolingDewPointSelected",
+    "coolingMinimumSafeSupplyTemp",
+    "coolingSupplyTarget",
+    "coolingSupplyError",
+    "coolingDemandRaw",
     "controlModeLabel",
     "flowMode",
     "totalPower",
@@ -4272,6 +4290,21 @@
     return "";
   }
 
+  function isCoolingOverviewActive() {
+    const modeLabel = getEntityStateText("controlModeLabel", "").toLowerCase();
+    if (modeLabel.includes("cm5") || modeLabel.includes("cooling")) {
+      return true;
+    }
+    return isEntityActive("coolingRequestActive") || isEntityActive("coolingEnableSelected");
+  }
+
+  function getOverviewStrategyLabel() {
+    if (isCoolingOverviewActive()) {
+      return "Cooling";
+    }
+    return isCurveMode() ? "Stooklijn" : "Power House";
+  }
+
   function getPowerHouseRequestedPower() {
     const keys = ["phouseReq", "strategyRequestedPower"];
     for (const key of keys) {
@@ -4352,6 +4385,55 @@
     };
   }
 
+  function getCoolingOverviewModel() {
+    const target = getEntityNumericValue("coolingSupplyTarget");
+    const supply = getEntityNumericValue("supplyTemp");
+    const safeFloor = getEntityNumericValue("coolingMinimumSafeSupplyTemp");
+    const dewPoint = getEntityNumericValue("coolingDewPointSelected");
+    const supplyError = getEntityNumericValue("coolingSupplyError");
+    const rawDemand = getEntityNumericValue("coolingDemandRaw");
+    const permitted = isEntityActive("coolingPermitted");
+    const requestActive = isEntityActive("coolingRequestActive");
+    const blockReason = getEntityStateText("coolingBlockReason", "Onbekend");
+
+    let statusTitle = "Wacht op koelvraag";
+    let statusCopy = "Zodra er koelvraag is, zie je hier hoe de regeling de aanvoer richting het koeldoel stuurt.";
+
+    if (!permitted) {
+      statusTitle = "Koeling geblokkeerd";
+      statusCopy = `Blokkade: ${blockReason}.`;
+    } else if (!requestActive) {
+      statusTitle = "Koeling gereed";
+      statusCopy = "Koeling is toegestaan, maar wacht nog op actieve koelvraag vanuit de kamerregeling.";
+    } else if (!Number.isNaN(rawDemand) && rawDemand <= 0.0) {
+      statusTitle = "Houdt temperatuur vast";
+      statusCopy = "De koelvraag loopt nog, maar de compressor hoeft nu niet harder te werken.";
+    } else if (!Number.isNaN(supplyError) && supplyError > 1.0) {
+      statusTitle = "Trekt aanvoer omlaag";
+      statusCopy = "De actuele aanvoertemperatuur ligt nog ruim boven het koeldoel.";
+    } else if (!Number.isNaN(supplyError) && supplyError > 0.2) {
+      statusTitle = "Benadert koeldoel";
+      statusCopy = "De regeling koelt nog door, maar zit al dicht bij de gewenste aanvoertemperatuur.";
+    } else if (!Number.isNaN(supplyError)) {
+      statusTitle = "Koelt rustig door";
+      statusCopy = "De aanvoertemperatuur zit dicht bij het koeldoel en de regeling werkt nu op laag pitje.";
+    }
+
+    return {
+      targetText: formatOverviewStatValue("coolingSupplyTarget"),
+      supplyText: formatOverviewStatValue("supplyTemp"),
+      safeFloorText: formatOverviewStatValue("coolingMinimumSafeSupplyTemp"),
+      dewPointText: formatOverviewStatValue("coolingDewPointSelected"),
+      demandText: formatOverviewStatValue("coolingDemandRaw"),
+      deltaText: formatSignedTemperature(supplyError),
+      statusTitle,
+      statusCopy,
+      permitted,
+      requestActive,
+      blockReason,
+    };
+  }
+
   function renderPowerHouseOverviewCard() {
     const model = getPowerHouseOverviewModel();
 
@@ -4402,11 +4484,54 @@
     `;
   }
 
+  function renderCoolingOverviewCard() {
+    const model = getCoolingOverviewModel();
+
+    return `
+      <section class="oq-overview-system">
+        <div class="oq-overview-system-copy">
+          <h3>Koelregeling</h3>
+          <p>Cooling laat zien op welke aanvoertemperatuur de regeling nu mikt en hoe dicht die bij de veilige grens zit.</p>
+        </div>
+        <div class="oq-overview-hero">
+          <div class="oq-overview-hero-main">
+            <span class="oq-overview-focus-label">Koeldoel</span>
+            <strong>${escapeHtml(model.targetText)}</strong>
+            <p>${escapeHtml(model.statusCopy)}</p>
+          </div>
+        </div>
+        <div class="oq-overview-metrics oq-overview-metrics--three-column">
+          ${renderOverviewMetricCard("Actuele aanvoertemperatuur", model.supplyText, "orange", "Wat nu door het systeem loopt.")}
+          ${renderOverviewMetricCard("Veilige aanvoergrens", model.safeFloorText, "blue", "Dauwpunt plus veiligheidsmarge.")}
+          ${renderOverviewMetricCard("Cooling demand", model.demandText, "sky", "De huidige koelvraag van de regelaar.")}
+        </div>
+      </section>
+    `;
+  }
+
   function renderOverviewStrategyPanel() {
+    if (isCoolingOverviewActive()) {
+      return renderCoolingOverviewCard();
+    }
     return isCurveMode() ? renderCurveOverviewCard() : renderPowerHouseOverviewCard();
   }
 
   function getOverviewPrimarySignal() {
+    if (isCoolingOverviewActive()) {
+      const model = getCoolingOverviewModel();
+      const tone = !model.permitted
+        ? "orange"
+        : model.statusTitle === "Koelt rustig door" || model.statusTitle === "Houdt temperatuur vast"
+          ? "green"
+          : model.statusTitle === "Koeling gereed"
+            ? "neutral"
+            : "sky";
+      return {
+        label: "Regeling nu",
+        value: model.statusTitle,
+        tone,
+      };
+    }
     if (isSystemInStandby()) {
       return {
         label: "Regeling nu",
@@ -4429,6 +4554,26 @@
   }
 
   function getOverviewDemandSignal() {
+    if (isCoolingOverviewActive()) {
+      if (!isEntityActive("coolingRequestActive")) {
+        return {
+          label: "Koelvraag",
+          value: "Geen koelvraag",
+          tone: "neutral",
+        };
+      }
+      const rawDemand = getEntityNumericValue("coolingDemandRaw");
+      const value = Number.isNaN(rawDemand)
+        ? "Koelvraag actief"
+        : rawDemand <= 0
+          ? "Koelvraag actief, compressor rust"
+          : `Cooling demand ${Math.round(rawDemand)}`;
+      return {
+        label: "Koelvraag",
+        value,
+        tone: rawDemand > 0 ? "sky" : "neutral",
+      };
+    }
     if (isSystemInStandby()) {
       return {
         label: "Warmtevraag",
@@ -4450,6 +4595,27 @@
   }
 
   function getOverviewSystemSignal() {
+    if (isCoolingOverviewActive()) {
+      if (!isEntityActive("coolingPermitted")) {
+        return {
+          label: "Systeem",
+          value: getEntityStateText("coolingBlockReason", "Koeling geblokkeerd"),
+          tone: "orange",
+        };
+      }
+      if (isEntityActive("silentActive")) {
+        return {
+          label: "Systeem",
+          value: "Stille uren actief",
+          tone: "neutral",
+        };
+      }
+      return {
+        label: "Systeem",
+        value: "Koeling toegestaan",
+        tone: "green",
+      };
+    }
     if (isFirmwareUpdateAvailable()) {
       return {
         label: "Systeem",
@@ -4500,6 +4666,50 @@
           </article>
         `).join("")}
       </section>
+    `;
+  }
+
+  function renderOverviewTopCards() {
+    const heatLabel = isCoolingOverviewActive() ? "Koelafgifte" : "Warmteafgifte";
+    return `
+      ${renderOverviewStatCard("totalPower", "Stroomverbruik", "blue", "hele systeem")}
+      ${renderOverviewStatCard("totalHeat", heatLabel, "orange", "thermisch vermogen")}
+      ${renderOverviewStatCard("totalCop", "COP", "green", "rendement")}
+      ${renderOverviewStatCard("flowSelected", "Flow", "sky", "watercircuit")}
+    `;
+  }
+
+  function renderOverviewTempsSection() {
+    const outsideTempKey = getOverviewOutsideTempKey();
+    const returnTempKey = getOverviewReturnTempKey();
+    if (isCoolingOverviewActive()) {
+      return `
+        <div class="oq-overview-system-copy">
+          <h3>Koeltemperaturen</h3>
+          <p>De belangrijkste temperaturen voor koeldoel, dauwpuntveiligheid en comfort.</p>
+        </div>
+        <div class="oq-overview-temps-list">
+          ${renderTempRow("Kamertemperatuur", "roomTemp")}
+          ${renderTempRow("Kamer setpoint", "roomSetpoint")}
+          ${renderTempRow("Aanvoertemperatuur", "supplyTemp")}
+          ${renderTempRow("Koeldoel", "coolingSupplyTarget")}
+          ${renderTempRow("Veilige aanvoergrens", "coolingMinimumSafeSupplyTemp")}
+          ${renderTempRow("Dauwpunt", "coolingDewPointSelected")}
+        </div>
+      `;
+    }
+    return `
+      <div class="oq-overview-system-copy">
+        <h3>Temperaturen</h3>
+        <p>De belangrijkste temperaturen voor comfort en regeling.</p>
+      </div>
+      <div class="oq-overview-temps-list">
+        ${renderTempRow("Kamertemperatuur", "roomTemp")}
+        ${renderTempRow("Kamer setpoint", "roomSetpoint")}
+        ${renderTempRow("Aanvoertemperatuur", "supplyTemp")}
+        ${returnTempKey ? renderTempRow("Retourtemperatuur", returnTempKey) : ""}
+        ${outsideTempKey ? renderTempRow("Buitentemperatuur", outsideTempKey) : renderTempRow("Buitentemperatuur", "", "—")}
+      </div>
     `;
   }
 
@@ -5822,11 +6032,9 @@
   }
 
   function renderOverviewView() {
-    const strategyLabel = isCurveMode() ? "Stooklijn" : "Power House";
+    const strategyLabel = getOverviewStrategyLabel();
     const heatPumpPanels = getHeatPumpPanels();
     const hpLayoutMode = getEffectiveHpLayoutMode(heatPumpPanels);
-    const outsideTempKey = getOverviewOutsideTempKey();
-    const returnTempKey = getOverviewReturnTempKey();
 
     return `
       <section class="oq-helper-panel oq-helper-panel--flush">
@@ -5840,31 +6048,18 @@
             <div class="oq-overview-head-actions">
               <div class="oq-overview-status">
                 ${renderOverviewStatusChip("Strategie", strategyLabel, "blue")}
-                ${renderOverviewStatusChip("Regelmodus", getEntityStateText("controlModeLabel"), "neutral")}
+                ${renderOverviewStatusChip("Controlmode", getEntityStateText("controlModeLabel"), "neutral")}
               </div>
             </div>
           </div>
           <div class="oq-overview-top">
-            ${renderOverviewStatCard("totalPower", "Stroomverbruik", "blue", "hele systeem")}
-            ${renderOverviewStatCard("totalHeat", "Warmteafgifte", "orange", "thermisch vermogen")}
-            ${renderOverviewStatCard("totalCop", "COP", "green", "rendement")}
-            ${renderOverviewStatCard("flowSelected", "Flow", "sky", "watercircuit")}
+            ${renderOverviewTopCards()}
           </div>
           ${renderOverviewSignals()}
           <div class="oq-overview-main">
             ${renderOverviewStrategyPanel()}
             <section class="oq-overview-temps">
-              <div class="oq-overview-system-copy">
-                <h3>Temperaturen</h3>
-                <p>De belangrijkste temperaturen voor comfort en regeling.</p>
-              </div>
-              <div class="oq-overview-temps-list">
-                ${renderTempRow("Kamertemperatuur", "roomTemp")}
-                ${renderTempRow("Kamer setpoint", "roomSetpoint")}
-                ${renderTempRow("Aanvoertemperatuur", "supplyTemp")}
-                ${returnTempKey ? renderTempRow("Retourtemperatuur", returnTempKey) : ""}
-                ${outsideTempKey ? renderTempRow("Buitentemperatuur", outsideTempKey) : renderTempRow("Buitentemperatuur", "", "—")}
-              </div>
+              ${renderOverviewTempsSection()}
             </section>
           </div>
           ${renderHeatPumpControls(heatPumpPanels)}
@@ -6163,7 +6358,7 @@
       return false;
     }
 
-    const strategyLabel = isCurveMode() ? "Stooklijn" : "Power House";
+    const strategyLabel = getOverviewStrategyLabel();
     const status = board.querySelector(".oq-overview-status");
     const top = board.querySelector(".oq-overview-top");
     const signals = board.querySelector(".oq-overview-signals");
@@ -6172,23 +6367,16 @@
     const hpTools = board.querySelector(".oq-overview-hp-tools");
     const hpGrid = board.querySelector(".oq-overview-hp-grid");
     const heatPumpPanels = getHeatPumpPanels();
-    const outsideTempKey = getOverviewOutsideTempKey();
-    const returnTempKey = getOverviewReturnTempKey();
 
     if (status) {
       setInnerHtmlIfChanged(status, `
         ${renderOverviewStatusChip("Strategie", strategyLabel, "blue")}
-        ${renderOverviewStatusChip("Regelmodus", getEntityStateText("controlModeLabel"), "neutral")}
+        ${renderOverviewStatusChip("Controlmode", getEntityStateText("controlModeLabel"), "neutral")}
       `);
     }
 
     if (top) {
-      setInnerHtmlIfChanged(top, `
-        ${renderOverviewStatCard("totalPower", "Stroomverbruik", "blue", "hele systeem")}
-        ${renderOverviewStatCard("totalHeat", "Warmteafgifte", "orange", "thermisch vermogen")}
-        ${renderOverviewStatCard("totalCop", "COP", "green", "rendement")}
-        ${renderOverviewStatCard("flowSelected", "Flow", "sky", "watercircuit")}
-      `);
+      setInnerHtmlIfChanged(top, renderOverviewTopCards());
     }
 
     if (signals) {
@@ -6203,19 +6391,7 @@
     }
 
     if (temps) {
-      temps.innerHTML = `
-        <div class="oq-overview-system-copy">
-          <h3>Temperaturen</h3>
-          <p>De belangrijkste temperaturen voor comfort en regeling.</p>
-        </div>
-        <div class="oq-overview-temps-list">
-          ${renderTempRow("Kamertemperatuur", "roomTemp")}
-          ${renderTempRow("Kamer setpoint", "roomSetpoint")}
-          ${renderTempRow("Aanvoertemperatuur", "supplyTemp")}
-          ${returnTempKey ? renderTempRow("Retourtemperatuur", returnTempKey) : ""}
-          ${outsideTempKey ? renderTempRow("Buitentemperatuur", outsideTempKey) : renderTempRow("Buitentemperatuur", "", "—")}
-        </div>
-      `;
+      temps.innerHTML = renderOverviewTempsSection();
     }
 
     if (!hpTools || !hpGrid) {


### PR DESCRIPTION
## Summary
- rename CM5 and related user-facing references from passive cooling to cooling
- make the cooling controller calmer and more room-aware without adding new user parameters
- add separate cooling power, cooling energy and EER accounting so cooling no longer pollutes heating COP metrics
- align the HA dashboards and web overview with the cooling runtime, labels and heat-pump visuals

## What changed
- cooling now uses a room-aware supply-target cascade instead of behaving mostly like a fixed water-temperature thermostat
- near target, the controller prefers a gentle low-level cooling phase instead of dropping straight from high demand to zero
- the cooling approach to the dew-point-safe floor is tightened so demand and minimum-runtime behavior back off earlier near the safety boundary
- strategy and control labels now consistently use Cooling / Koeling and Controlmode
- the HA dashboards now show the relevant cooling targets and supply temperature
- the web app overview now switches more cleanly into cooling context, including updated labels, fan handling and HP panel wording
- the energy model is now split cleanly between heating and cooling:
  - heating keeps using heat power, thermal energy and COP
  - cooling gets its own cooling power, cooling energy and EER track
  - heating COP no longer gets diluted by cooling electricity

## Why
The first cooling path worked, but still felt too binary in practice. Room temperature mainly decided whether cooling was active at all, while the inner loop often chased an almost fixed supply target. That produced more 0/4 cycling than desired.

On top of that, the existing energy bookkeeping was still heating-centric. During cooling, electrical input would continue to accumulate while the thermal counters stayed on the heating side, which would skew COP-style reporting and make the energy page semantically confusing.

This PR keeps the existing safety model and keeps configuration simple, but makes the cooling loop behave more like a calmer cascade, while also giving cooling its own bookkeeping lane with dedicated power, energy and EER metrics.

## Validation
- python3 scripts/dev.py validate --config-only
- esphome compile openquatt_duo_waveshare.yaml
- node --check openquatt/web/openquatt-app.js
- node --check openquatt/web/mock-device.js

## Notes
- the branch also includes multiple web-app wording and visualization fixes discovered during live cooling tests, such as fan RPM syncing and cooling-specific HP labels
- the energy view now shows both heating and cooling blocks so historical heating and cooling figures stay visible side by side
