### PR TITLE
Add cooling fallback without dew point input

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1134,8 +1134,9 @@ views:
               - `> 32°C`: minimum water `22°C`
 
               Night correction:
-              - night minimum `< 18°C`: `+0K`
-              - `18–20°C`: `+1K`
+              - night minimum `< 18°C`: `+0°C`
+              - `18–19°C`: `+1°C`
+              - `19–20°C`: `+2°C`
               - `>= 20°C`: fallback off
 
               This table replaces the normal dew-point safety margin, so no extra `+2K` is added on top.

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1106,6 +1106,10 @@ views:
                 name: Cooling request active
               - entity: binary_sensor.openquatt_cooling_permitted
                 name: Cooling permitted
+              - entity: select.openquatt_cooling_without_dew_point
+                name: Allow cooling without dew point
+              - entity: sensor.openquatt_cooling_guard_mode
+                name: Cooling guard mode
               - entity: sensor.openquatt_cooling_block_reason
                 name: Cooling block reason
       - type: grid
@@ -1114,6 +1118,31 @@ views:
             icon: mdi:water-thermometer
             heading: Dew point safety
             heading_style: title
+          - type: markdown
+            content: |-
+              <details>
+              <summary><strong>Fallback without dew point</strong></summary>
+
+              Normally OpenQuatt uses the highest valid dew point plus the configured safety margin.
+
+              Without a dew point source, cooling stays blocked by default. Only when `Cooling without dew point` is explicitly allowed, OpenQuatt uses a conservative fallback:
+
+              - outdoor `< 20°C`: off
+              - `20–24°C`: minimum water `19°C`
+              - `24–28°C`: minimum water `20°C`
+              - `28–32°C`: minimum water `21°C`
+              - `> 32°C`: minimum water `22°C`
+
+              Night correction:
+              - night minimum `< 18°C`: `+0K`
+              - `18–20°C`: `+1K`
+              - `>= 20°C`: fallback off
+
+              This table replaces the normal dew-point safety margin, so no extra `+2K` is added on top.
+              </details>
+            text_only: true
+            grid_options:
+              columns: full
           - type: entities
             show_header_toggle: false
             entities:
@@ -1129,6 +1158,12 @@ views:
                 name: Cooling safety margin
               - entity: sensor.openquatt_cooling_minimum_safe_supply_temp
                 name: Cooling minimum safe supply temp
+              - entity: sensor.openquatt_cooling_effective_min_supply_temp
+                name: Cooling effective minimum supply temp
+              - entity: sensor.openquatt_cooling_fallback_min_supply_temp
+                name: Cooling fallback minimum supply temp
+              - entity: sensor.openquatt_cooling_fallback_night_min_outdoor_temp
+                name: Cooling fallback night minimum outdoor temp
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1210,8 +1210,9 @@ views:
               - `> 32°C`: minimum water `22°C`
 
               Nachtcorrectie:
-              - nachtminimum `< 18°C`: `+0K`
-              - `18–20°C`: `+1K`
+              - nachtminimum `< 18°C`: `+0°C`
+              - `18–19°C`: `+1°C`
+              - `19–20°C`: `+2°C`
               - `>= 20°C`: fallback uit
 
               Deze staffel vervangt de normale dauwpuntmarge; er komt dus niet nog eens extra `+2K` bovenop.

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1179,32 +1179,67 @@ views:
               - entity: binary_sensor.openquatt_cooling_enable_selected
                 name: Geselecteerde koeltoestemming
               - entity: binary_sensor.openquatt_cooling_request_active
-                name: Cooling request active
+                name: Koelvraag actief
               - entity: binary_sensor.openquatt_cooling_permitted
-                name: Cooling permitted
+                name: Koeling toegestaan
+              - entity: select.openquatt_cooling_without_dew_point
+                name: Koeling zonder dauwpunt
+              - entity: sensor.openquatt_cooling_guard_mode
+                name: Actieve koelbeveiliging
               - entity: sensor.openquatt_cooling_block_reason
-                name: Cooling block reason
+                name: Reden koelblokkade
       - type: grid
         cards:
           - type: heading
             icon: mdi:water-thermometer
             heading: Dauwpuntveiligheid
             heading_style: title
+          - type: markdown
+            content: |-
+              <details>
+              <summary><strong>Uitleg fallback zonder dauwpunt</strong></summary>
+
+              Normaal gebruikt OpenQuatt het hoogste geldige dauwpunt plus de ingestelde veiligheidsmarge.
+
+              Zonder dauwpuntbron blijft koeling standaard geblokkeerd. Alleen als `Koeling zonder dauwpunt` expliciet is toegestaan, gebruikt OpenQuatt een conservatieve fallback:
+
+              - `< 20°C` buiten: uit
+              - `20–24°C`: minimum water `19°C`
+              - `24–28°C`: minimum water `20°C`
+              - `28–32°C`: minimum water `21°C`
+              - `> 32°C`: minimum water `22°C`
+
+              Nachtcorrectie:
+              - nachtminimum `< 18°C`: `+0K`
+              - `18–20°C`: `+1K`
+              - `>= 20°C`: fallback uit
+
+              Deze staffel vervangt de normale dauwpuntmarge; er komt dus niet nog eens extra `+2K` bovenop.
+              </details>
+            text_only: true
+            grid_options:
+              columns: full
           - type: entities
             show_header_toggle: false
             entities:
               - entity: sensor.openquatt_cooling_room_count_selected
-                name: Cooling room count
+                name: Aantal koelruimtes
               - entity: sensor.openquatt_cooling_valid_room_count
-                name: Cooling valid room count
+                name: Geldige koelruimtes
               - entity: binary_sensor.openquatt_cooling_dew_point_available
-                name: Cooling dew point available
+                name: Dauwpunt beschikbaar
               - entity: sensor.openquatt_cooling_dew_point_selected
-                name: Cooling dew point (selected)
+                name: Geselecteerd dauwpunt
               - entity: sensor.openquatt_cooling_safety_margin_selected
-                name: Cooling safety margin
+                name: Dauwpunt veiligheidsmarge
               - entity: sensor.openquatt_cooling_minimum_safe_supply_temp
-                name: Cooling minimum safe supply temp
+                name: Minimale veilige aanvoer
+              - entity: sensor.openquatt_cooling_effective_min_supply_temp
+                name: Actieve minimale aanvoer
+              - entity: sensor.openquatt_cooling_fallback_min_supply_temp
+                name: Fallback minimale aanvoer
+              - entity: sensor.openquatt_cooling_fallback_night_min_outdoor_temp
+                name: Nachtminimum buitentemperatuur
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1094,6 +1094,10 @@ views:
                 name: Cooling request active
               - entity: binary_sensor.openquatt_cooling_permitted
                 name: Cooling permitted
+              - entity: select.openquatt_cooling_without_dew_point
+                name: Allow cooling without dew point
+              - entity: sensor.openquatt_cooling_guard_mode
+                name: Cooling guard mode
               - entity: sensor.openquatt_cooling_block_reason
                 name: Cooling block reason
       - type: grid
@@ -1102,6 +1106,31 @@ views:
             icon: mdi:water-thermometer
             heading: Dew point safety
             heading_style: title
+          - type: markdown
+            content: |-
+              <details>
+              <summary><strong>Fallback without dew point</strong></summary>
+
+              Normally OpenQuatt uses the highest valid dew point plus the configured safety margin.
+
+              Without a dew point source, cooling stays blocked by default. Only when `Cooling without dew point` is explicitly allowed, OpenQuatt uses a conservative fallback:
+
+              - outdoor `< 20°C`: off
+              - `20–24°C`: minimum water `19°C`
+              - `24–28°C`: minimum water `20°C`
+              - `28–32°C`: minimum water `21°C`
+              - `> 32°C`: minimum water `22°C`
+
+              Night correction:
+              - night minimum `< 18°C`: `+0K`
+              - `18–20°C`: `+1K`
+              - `>= 20°C`: fallback off
+
+              This table replaces the normal dew-point safety margin, so no extra `+2K` is added on top.
+              </details>
+            text_only: true
+            grid_options:
+              columns: full
           - type: entities
             show_header_toggle: false
             entities:
@@ -1117,6 +1146,12 @@ views:
                 name: Cooling safety margin
               - entity: sensor.openquatt_cooling_minimum_safe_supply_temp
                 name: Cooling minimum safe supply temp
+              - entity: sensor.openquatt_cooling_effective_min_supply_temp
+                name: Cooling effective minimum supply temp
+              - entity: sensor.openquatt_cooling_fallback_min_supply_temp
+                name: Cooling fallback minimum supply temp
+              - entity: sensor.openquatt_cooling_fallback_night_min_outdoor_temp
+                name: Cooling fallback night minimum outdoor temp
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1122,8 +1122,9 @@ views:
               - `> 32°C`: minimum water `22°C`
 
               Night correction:
-              - night minimum `< 18°C`: `+0K`
-              - `18–20°C`: `+1K`
+              - night minimum `< 18°C`: `+0°C`
+              - `18–19°C`: `+1°C`
+              - `19–20°C`: `+2°C`
               - `>= 20°C`: fallback off
 
               This table replaces the normal dew-point safety margin, so no extra `+2K` is added on top.

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1154,32 +1154,67 @@ views:
               - entity: binary_sensor.openquatt_cooling_enable_selected
                 name: Geselecteerde koeltoestemming
               - entity: binary_sensor.openquatt_cooling_request_active
-                name: Cooling request active
+                name: Koelvraag actief
               - entity: binary_sensor.openquatt_cooling_permitted
-                name: Cooling permitted
+                name: Koeling toegestaan
+              - entity: select.openquatt_cooling_without_dew_point
+                name: Koeling zonder dauwpunt
+              - entity: sensor.openquatt_cooling_guard_mode
+                name: Actieve koelbeveiliging
               - entity: sensor.openquatt_cooling_block_reason
-                name: Cooling block reason
+                name: Reden koelblokkade
       - type: grid
         cards:
           - type: heading
             icon: mdi:water-thermometer
             heading: Dauwpuntveiligheid
             heading_style: title
+          - type: markdown
+            content: |-
+              <details>
+              <summary><strong>Uitleg fallback zonder dauwpunt</strong></summary>
+
+              Normaal gebruikt OpenQuatt het hoogste geldige dauwpunt plus de ingestelde veiligheidsmarge.
+
+              Zonder dauwpuntbron blijft koeling standaard geblokkeerd. Alleen als `Koeling zonder dauwpunt` expliciet is toegestaan, gebruikt OpenQuatt een conservatieve fallback:
+
+              - `< 20°C` buiten: uit
+              - `20–24°C`: minimum water `19°C`
+              - `24–28°C`: minimum water `20°C`
+              - `28–32°C`: minimum water `21°C`
+              - `> 32°C`: minimum water `22°C`
+
+              Nachtcorrectie:
+              - nachtminimum `< 18°C`: `+0K`
+              - `18–20°C`: `+1K`
+              - `>= 20°C`: fallback uit
+
+              Deze staffel vervangt de normale dauwpuntmarge; er komt dus niet nog eens extra `+2K` bovenop.
+              </details>
+            text_only: true
+            grid_options:
+              columns: full
           - type: entities
             show_header_toggle: false
             entities:
               - entity: sensor.openquatt_cooling_room_count_selected
-                name: Cooling room count
+                name: Aantal koelruimtes
               - entity: sensor.openquatt_cooling_valid_room_count
-                name: Cooling valid room count
+                name: Geldige koelruimtes
               - entity: binary_sensor.openquatt_cooling_dew_point_available
-                name: Cooling dew point available
+                name: Dauwpunt beschikbaar
               - entity: sensor.openquatt_cooling_dew_point_selected
-                name: Cooling dew point (selected)
+                name: Geselecteerd dauwpunt
               - entity: sensor.openquatt_cooling_safety_margin_selected
-                name: Cooling safety margin
+                name: Dauwpunt veiligheidsmarge
               - entity: sensor.openquatt_cooling_minimum_safe_supply_temp
-                name: Cooling minimum safe supply temp
+                name: Minimale veilige aanvoer
+              - entity: sensor.openquatt_cooling_effective_min_supply_temp
+                name: Actieve minimale aanvoer
+              - entity: sensor.openquatt_cooling_fallback_min_supply_temp
+                name: Fallback minimale aanvoer
+              - entity: sensor.openquatt_cooling_fallback_night_min_outdoor_temp
+                name: Nachtminimum buitentemperatuur
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1185,8 +1185,9 @@ views:
               - `> 32°C`: minimum water `22°C`
 
               Nachtcorrectie:
-              - nachtminimum `< 18°C`: `+0K`
-              - `18–20°C`: `+1K`
+              - nachtminimum `< 18°C`: `+0°C`
+              - `18–19°C`: `+1°C`
+              - `19–20°C`: `+2°C`
               - `>= 20°C`: fallback uit
 
               Deze staffel vervangt de normale dauwpuntmarge; er komt dus niet nog eens extra `+2K` bovenop.

--- a/docs/dashboardoverzicht.md
+++ b/docs/dashboardoverzicht.md
@@ -109,7 +109,8 @@ De fallback werkt bewust simpel:
 - `24–28°C`: minimum water `20°C`;
 - `28–32°C`: minimum water `21°C`;
 - `> 32°C`: minimum water `22°C`;
-- nachtminimum `18–20°C`: `+1K`;
+- nachtminimum `18–19°C`: `+1°C`;
+- nachtminimum `19–20°C`: `+2°C`;
 - nachtminimum `>= 20°C`: fallback uit.
 
 De gewone dauwpuntmarge komt daar niet nog eens extra bovenop. Die conservatieve staffel is in de fallbackmodus zelf al de veiligheidsmarge.

--- a/docs/dashboardoverzicht.md
+++ b/docs/dashboardoverzicht.md
@@ -56,6 +56,8 @@ Bij cooling is deze tab extra belangrijk. Daar configureer je ook:
 - het aantal koelruimtes;
 - de dauwpunt-, temperatuur- en RH-bronnen die via Home Assistant-proxy's worden ingelezen.
 
+Gebruik je bewust de fallback zonder dauwpunt, dan configureer je die niet hier maar via `Instellingen`. De sensorconfiguratie-tab blijft dan leeg voor koelruimtes, en OpenQuatt schakelt over op de conservatieve fallback-route.
+
 Als deze bronlaag niet klopt, is ook de cooling-tab niet betrouwbaar.
 
 ### Flow
@@ -93,6 +95,24 @@ Gebruik deze tab zodra je cooling gebruikt of voorbereidt. Hier zie je onder mee
 - welk cooling-target en welke ruwe cooling demand OpenQuatt nu gebruikt.
 
 De cooling-tab is dus vooral een runtime- en veiligheidsweergave. De bronkeuze zelf doe je op `Sensorconfiguratie`.
+
+Gebruik je de fallback zonder dauwpunt, dan zie je hier ook:
+
+- welke beveiligingsroute actief is (`Dew point`, `Fallback` of `Blocked`);
+- wat het nachtminimum van de afgelopen nacht was;
+- welke fallback minimale aanvoer OpenQuatt daaruit heeft afgeleid.
+
+De fallback werkt bewust simpel:
+
+- buiten `< 20°C`: cooling uit;
+- `20–24°C`: minimum water `19°C`;
+- `24–28°C`: minimum water `20°C`;
+- `28–32°C`: minimum water `21°C`;
+- `> 32°C`: minimum water `22°C`;
+- nachtminimum `18–20°C`: `+1K`;
+- nachtminimum `>= 20°C`: fallback uit.
+
+De gewone dauwpuntmarge komt daar niet nog eens extra bovenop. Die conservatieve staffel is in de fallbackmodus zelf al de veiligheidsmarge.
 
 ## Tabs voor gevorderden
 

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -102,7 +102,7 @@ Daarom werkt OpenQuatt bij cooling in grote lijnen zo:
 - er is een aparte control mode voor cooling;
 - dauwpuntinformatie is leidend voor de minimale veilige aanvoertemperatuur;
 - flowbewaking blijft net zo belangrijk als bij verwarmen;
-- zonder bruikbare dauwpuntinformatie hoort normale cooling niet vrijgegeven te worden.
+- zonder bruikbare dauwpuntinformatie hoort normale cooling niet vrijgegeven te worden, tenzij je expliciet een conservatieve fallback inschakelt.
 
 Praktisch betekent dit dat OpenQuatt cooling niet behandelt als "negatief verwarmen". Er is een eigen koelvraag, een eigen veilige aanvoergrens en een aparte bewakingslaag bovenop de warmtepompsturing.
 
@@ -115,6 +115,38 @@ OpenQuatt kan voor cooling gebruikmaken van:
 - meerdere ruimtes, waarbij de hoogste geldige dauwpuntwaarde leidend mag zijn.
 
 Voor centrale vloerkoeling is dat laatste belangrijk: de vochtigste relevante ruimte is maatgevend voor het condensrisico.
+
+### Fallback zonder dauwpunt
+
+OpenQuatt kan ook een expliciete fallback gebruiken als er geen bruikbare dauwpuntbron is. Die fallback staat standaard uit en moet je bewust inschakelen via `Koeling zonder dauwpuntbeveiliging`.
+
+Belangrijk:
+
+- dit is geen echte condensgarantie;
+- OpenQuatt gebruikt dan geen gemeten binnendauwpunt, maar een conservatieve benadering voor Nederland;
+- de fallback is bedoeld als pragmatische noodroute, niet als vervanging van echte dauwpuntbewaking.
+
+De fallback gebruikt deze basistabel voor de minimale watertemperatuur:
+
+- buitentemperatuur `< 20°C`: cooling uit;
+- `20–24°C`: minimum water `19°C`;
+- `24–28°C`: minimum water `20°C`;
+- `28–32°C`: minimum water `21°C`;
+- `> 32°C`: minimum water `22°C`.
+
+Daarbovenop kijkt OpenQuatt naar de minimum buitentemperatuur van de afgelopen nacht:
+
+- nachtminimum `< 18°C`: geen correctie;
+- nachtminimum `18–20°C`: `+1K` op de fallback-ondergrens;
+- nachtminimum `>= 20°C`: fallback-cooling geblokkeerd.
+
+Die warme-nachtcorrectie werkt als een eenvoudige risicovlag voor benauwde of tropische luchtmassa's. Juist op zulke dagen is de kans groter dat de woning al met een hoger intern dauwpunt aan de dag begint.
+
+### Waarom geen extra `+2K` erbovenop?
+
+Bij normale dauwpuntregeling gebruikt OpenQuatt wel een aparte veiligheidsmarge boven het gemeten of berekende dauwpunt. In de fallback-route gebeurt dat niet nog eens.
+
+De reden is simpel: de conservatieve staffel en de nachtcorrectie vormen hier samen al de veiligheidsmarge. Nog eens een extra generieke `+2K` zou de fallback onnodig dubbel-conservatief maken en in veel gevallen praktisch onbruikbaar.
 
 ### Wat blijft gedeeld met heating?
 

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -137,7 +137,8 @@ De fallback gebruikt deze basistabel voor de minimale watertemperatuur:
 Daarbovenop kijkt OpenQuatt naar de minimum buitentemperatuur van de afgelopen nacht:
 
 - nachtminimum `< 18°C`: geen correctie;
-- nachtminimum `18–20°C`: `+1K` op de fallback-ondergrens;
+- nachtminimum `18–19°C`: `+1°C` op de fallback-ondergrens;
+- nachtminimum `19–20°C`: `+2°C` op de fallback-ondergrens;
 - nachtminimum `>= 20°C`: fallback-cooling geblokkeerd.
 
 Die warme-nachtcorrectie werkt als een eenvoudige risicovlag voor benauwde of tropische luchtmassa's. Juist op zulke dagen is de kans groter dat de woning al met een hoger intern dauwpunt aan de dag begint.

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -154,8 +154,9 @@ Met `Cooling Without Dew Point` kun je expliciet een fallback toestaan. Die fall
 
 Daarbovenop telt de minimum buitentemperatuur van de afgelopen nacht mee:
 
-- `< 18°C`: `+0K`
-- `18–20°C`: `+1K`
+- `< 18°C`: `+0°C`
+- `18–19°C`: `+1°C`
+- `19–20°C`: `+2°C`
 - `>= 20°C`: fallback uit
 
 Belangrijk: in deze fallback-route wordt de gewone dauwpuntmarge niet nog eens extra bovenop de staffel gezet. De staffel zelf ís hier de conservatieve marge.

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -132,6 +132,34 @@ Belangrijke runtime-instellingen in deze groep zijn:
 - `Room Temperature Source`
 - `Room Setpoint Source`
 
+### Cooling en fallback zonder dauwpunt
+
+Belangrijke runtime-instellingen en signalen in deze groep zijn:
+
+- `Cooling Without Dew Point`
+- `Cooling Guard Mode`
+- `Cooling Fallback Night Minimum Outdoor Temp`
+- `Cooling Fallback Minimum Supply Temp`
+- `Cooling Effective Minimum Supply Temp`
+
+Normaal verwacht OpenQuatt bij cooling een geldige dauwpuntbron. Ontbreekt die, dan blijft cooling geblokkeerd.
+
+Met `Cooling Without Dew Point` kun je expliciet een fallback toestaan. Die fallback gebruikt een conservatieve staffel op basis van buitentemperatuur:
+
+- `< 20°C`: cooling uit
+- `20–24°C`: minimum water `19°C`
+- `24–28°C`: minimum water `20°C`
+- `28–32°C`: minimum water `21°C`
+- `> 32°C`: minimum water `22°C`
+
+Daarbovenop telt de minimum buitentemperatuur van de afgelopen nacht mee:
+
+- `< 18°C`: `+0K`
+- `18–20°C`: `+1K`
+- `>= 20°C`: fallback uit
+
+Belangrijk: in deze fallback-route wordt de gewone dauwpuntmarge niet nog eens extra bovenop de staffel gezet. De staffel zelf ís hier de conservatieve marge.
+
 ### Verwarmingsstrategie
 
 Belangrijke runtime-instellingen in deze groep zijn:
@@ -283,6 +311,8 @@ Gebruik deze groep vooral voor onderhoud en diagnose, niet voor dagelijks gebrui
 - `Demand filtered`
 - `Heating Curve Supply Target`
 - `Water Supply Temp (Selected)`
+- `Cooling Supply Target`
+- `Cooling Demand (raw)`
 
 ### Voor flow en veiligheid
 
@@ -290,6 +320,11 @@ Gebruik deze groep vooral voor onderhoud en diagnose, niet voor dagelijks gebrui
 - `Flow average (Selected)`
 - `Flow mismatch (HP1 vs HP2)`
 - `Flow Mode`
+- `Cooling Block Reason`
+- `Cooling Guard Mode`
+- `Cooling Effective Minimum Supply Temp`
+- `Cooling Fallback Night Minimum Outdoor Temp`
+- `Cooling Fallback Minimum Supply Temp`
 
 ### Voor vermogen en prestaties
 

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -20,6 +20,23 @@ globals:
     restore_value: false
     initial_value: 'false'
 
+  - id: oq_cooling_fallback_night_min_current_c
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_cooling_fallback_night_window_day_key
+    type: int
+    restore_value: false
+    initial_value: '-1'
+  - id: oq_cooling_fallback_night_min_last_c
+    type: float
+    restore_value: true
+    initial_value: 'NAN'
+  - id: oq_cooling_fallback_night_min_last_day_key
+    type: int
+    restore_value: true
+    initial_value: '-1'
+
   - id: oq_cooling_room_count_selected_last_valid
     type: float
     restore_value: false
@@ -110,7 +127,47 @@ number:
     web_server:
       sorting_group_id: oq_control
 
+select:
+  - platform: template
+    id: cooling_without_dew_point_mode
+    name: "Cooling Without Dew Point"
+    icon: mdi:water-alert
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - Dew point required
+      - Allow without dew point
+    initial_option: Dew point required
+    web_server:
+      sorting_group_id: oq_cooling
+
 binary_sensor:
+  - platform: template
+    id: cooling_without_dew_point_enabled
+    name: "Cooling Without Dew Point Enabled"
+    internal: true
+    lambda: |-
+      return id(cooling_without_dew_point_mode).has_state() &&
+             id(cooling_without_dew_point_mode).current_option() == "Allow without dew point";
+
+  - platform: template
+    id: cooling_fallback_active
+    name: "Cooling Fallback Active"
+    icon: mdi:water-alert
+    device_class: running
+    lambda: |-
+      const bool no_rooms_configured =
+          !id(cooling_room_count_selected).has_state() || isnan(id(cooling_room_count_selected).state) ||
+          id(cooling_room_count_selected).state < 1.0f;
+      const bool fallback_floor_ok =
+          id(cooling_fallback_min_supply_temp).has_state() && !isnan(id(cooling_fallback_min_supply_temp).state);
+      return no_rooms_configured &&
+             id(cooling_without_dew_point_enabled).state &&
+             fallback_floor_ok;
+    web_server:
+      sorting_group_id: oq_cooling
+
   - platform: template
     id: cooling_permitted_core
     name: "Cooling Permitted Core"
@@ -127,7 +184,14 @@ binary_sensor:
           id(cooling_dew_point_available).state &&
           id(cooling_dew_point_selected).has_state() && !isnan(id(cooling_dew_point_selected).state) &&
           id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state);
-      return rooms_configured && valid_rooms && dew_point_ok;
+      const bool fallback_ok =
+          !rooms_configured &&
+          id(cooling_without_dew_point_enabled).state &&
+          id(cooling_fallback_min_supply_temp).has_state() && !isnan(id(cooling_fallback_min_supply_temp).state);
+      if (rooms_configured) {
+        return valid_rooms && dew_point_ok;
+      }
+      return fallback_ok;
 
   - platform: template
     id: cooling_request_active
@@ -189,6 +253,26 @@ binary_sensor:
 
 text_sensor:
   - platform: template
+    id: cooling_guard_mode
+    name: "Cooling Guard Mode"
+    icon: mdi:shield-half-full
+    entity_category: diagnostic
+    update_interval: 10s
+    lambda: |-
+      const bool rooms_configured =
+          id(cooling_room_count_selected).has_state() && !isnan(id(cooling_room_count_selected).state) &&
+          id(cooling_room_count_selected).state >= 1.0f;
+      if (rooms_configured) {
+        return {"Dew point"};
+      }
+      if (id(cooling_without_dew_point_enabled).state) {
+        return {"Fallback"};
+      }
+      return {"Blocked"};
+    web_server:
+      sorting_group_id: oq_cooling
+
+  - platform: template
     id: cooling_block_reason
     name: "Cooling Block Reason"
     icon: mdi:information-outline
@@ -196,9 +280,33 @@ text_sensor:
     update_interval: 5s
     lambda: |-
       // Report the first blocking condition in operator-friendly terms.
-      if (!id(cooling_room_count_selected).has_state() || isnan(id(cooling_room_count_selected).state) ||
-          id(cooling_room_count_selected).state < 1.0f) {
-        return {"No cooling rooms configured"};
+      if (!id(cooling_room_count_selected).has_state() || isnan(id(cooling_room_count_selected).state)) {
+        return {"Cooling room count unavailable"};
+      }
+      if (id(cooling_room_count_selected).state < 1.0f) {
+        if (!id(cooling_without_dew_point_enabled).state) {
+          return {"No dew point source"};
+        }
+        if (!id(outside_temp_selected).has_state() || isnan(id(outside_temp_selected).state)) {
+          return {"Fallback outside temperature unavailable"};
+        }
+        if (id(outside_temp_selected).state < 20.0f) {
+          return {"Fallback blocked below 20°C outdoor"};
+        }
+        if (id(cooling_fallback_night_min_outdoor_temp).has_state() &&
+            !isnan(id(cooling_fallback_night_min_outdoor_temp).state) &&
+            id(cooling_fallback_night_min_outdoor_temp).state >= 20.0f) {
+          return {"Fallback blocked by tropical night"};
+        }
+        if (!id(cooling_fallback_min_supply_temp).has_state() || isnan(id(cooling_fallback_min_supply_temp).state)) {
+          return {"Fallback minimum unavailable"};
+        }
+        if (id(cooling_fallback_night_min_outdoor_temp).has_state() &&
+            !isnan(id(cooling_fallback_night_min_outdoor_temp).state) &&
+            id(cooling_fallback_night_min_outdoor_temp).state >= 18.0f) {
+          return {"Fallback active (+1K warm night)"};
+        }
+        return {"Fallback active"};
       }
       if (!id(cooling_valid_room_count).has_state() || isnan(id(cooling_valid_room_count).state) ||
           id(cooling_valid_room_count).state < 1.0f) {
@@ -593,3 +701,114 @@ sensor:
       return id(cooling_dew_point_selected).state + id(cooling_safety_margin_selected).state;
     web_server:
       sorting_group_id: oq_cooling
+
+  - platform: template
+    id: cooling_fallback_night_min_outdoor_temp
+    name: "Cooling Fallback Night Minimum Outdoor Temp"
+    icon: mdi:weather-night
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 1
+    update_interval: 60s
+    lambda: |-
+      if (!id(oq_time).now().is_valid()) return NAN;
+      const auto now = id(oq_time).now();
+      if (now.hour < 6 &&
+          id(oq_cooling_fallback_night_window_day_key) >= 0 &&
+          !isnan(id(oq_cooling_fallback_night_min_current_c))) {
+        return id(oq_cooling_fallback_night_min_current_c);
+      }
+      if (!isnan(id(oq_cooling_fallback_night_min_last_c))) {
+        return id(oq_cooling_fallback_night_min_last_c);
+      }
+      return NAN;
+    web_server:
+      sorting_group_id: oq_cooling
+
+  - platform: template
+    id: cooling_fallback_min_supply_temp
+    name: "Cooling Fallback Minimum Supply Temp"
+    icon: mdi:thermometer-chevron-down
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 1
+    update_interval: 10s
+    lambda: |-
+      // Conservative fallback floor for systems without a dew-point source.
+      if (!id(outside_temp_selected).has_state() || isnan(id(outside_temp_selected).state)) return NAN;
+      const float outside_c = id(outside_temp_selected).state;
+      if (outside_c < 20.0f) return NAN;
+
+      float base_floor_c = 19.0f;
+      if (outside_c >= 32.0f) base_floor_c = 22.0f;
+      else if (outside_c >= 28.0f) base_floor_c = 21.0f;
+      else if (outside_c >= 24.0f) base_floor_c = 20.0f;
+
+      float correction_c = 0.0f;
+      if (id(cooling_fallback_night_min_outdoor_temp).has_state() &&
+          !isnan(id(cooling_fallback_night_min_outdoor_temp).state)) {
+        const float night_min_c = id(cooling_fallback_night_min_outdoor_temp).state;
+        if (night_min_c >= 20.0f) return NAN;
+        if (night_min_c >= 18.0f) correction_c = 1.0f;
+      }
+
+      return base_floor_c + correction_c;
+    web_server:
+      sorting_group_id: oq_cooling
+
+  - platform: template
+    id: cooling_effective_min_supply_temp
+    name: "Cooling Effective Minimum Supply Temp"
+    icon: mdi:shield-thermometer
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 1
+    update_interval: 10s
+    lambda: |-
+      if (id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state)) {
+        return id(minimum_safe_supply_temp).state;
+      }
+      if (id(cooling_fallback_active).state &&
+          id(cooling_fallback_min_supply_temp).has_state() &&
+          !isnan(id(cooling_fallback_min_supply_temp).state)) {
+        return id(cooling_fallback_min_supply_temp).state;
+      }
+      return NAN;
+    web_server:
+      sorting_group_id: oq_cooling
+
+interval:
+  - interval: 60s
+    then:
+      - lambda: |-
+          // Track the minimum selected outside temperature during the local 00:00-06:00 window.
+          if (!id(oq_time).now().is_valid()) return;
+          if (!id(outside_temp_selected).has_state() || isnan(id(outside_temp_selected).state)) return;
+
+          const auto now = id(oq_time).now();
+          const int day_key = (now.year * 10000) + (now.month * 100) + now.day_of_month;
+          const bool in_night_window = now.hour < 6;
+          const float outside_c = id(outside_temp_selected).state;
+
+          if (in_night_window) {
+            if (id(oq_cooling_fallback_night_window_day_key) != day_key) {
+              id(oq_cooling_fallback_night_window_day_key) = day_key;
+              id(oq_cooling_fallback_night_min_current_c) = outside_c;
+            } else if (isnan(id(oq_cooling_fallback_night_min_current_c))) {
+              id(oq_cooling_fallback_night_min_current_c) = outside_c;
+            } else {
+              id(oq_cooling_fallback_night_min_current_c) =
+                  fminf(id(oq_cooling_fallback_night_min_current_c), outside_c);
+            }
+            return;
+          }
+
+          if (id(oq_cooling_fallback_night_window_day_key) >= 0 &&
+              id(oq_cooling_fallback_night_window_day_key) != id(oq_cooling_fallback_night_min_last_day_key) &&
+              !isnan(id(oq_cooling_fallback_night_min_current_c))) {
+            id(oq_cooling_fallback_night_min_last_c) = id(oq_cooling_fallback_night_min_current_c);
+            id(oq_cooling_fallback_night_min_last_day_key) = id(oq_cooling_fallback_night_window_day_key);
+          }

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -303,8 +303,13 @@ text_sensor:
         }
         if (id(cooling_fallback_night_min_outdoor_temp).has_state() &&
             !isnan(id(cooling_fallback_night_min_outdoor_temp).state) &&
+            id(cooling_fallback_night_min_outdoor_temp).state >= 19.0f) {
+          return {"Fallback active (+2°C very warm night)"};
+        }
+        if (id(cooling_fallback_night_min_outdoor_temp).has_state() &&
+            !isnan(id(cooling_fallback_night_min_outdoor_temp).state) &&
             id(cooling_fallback_night_min_outdoor_temp).state >= 18.0f) {
-          return {"Fallback active (+1K warm night)"};
+          return {"Fallback active (+1°C warm night)"};
         }
         return {"Fallback active"};
       }
@@ -751,7 +756,8 @@ sensor:
           !isnan(id(cooling_fallback_night_min_outdoor_temp).state)) {
         const float night_min_c = id(cooling_fallback_night_min_outdoor_temp).state;
         if (night_min_c >= 20.0f) return NAN;
-        if (night_min_c >= 18.0f) correction_c = 1.0f;
+        if (night_min_c >= 19.0f) correction_c = 2.0f;
+        else if (night_min_c >= 18.0f) correction_c = 1.0f;
       }
 
       return base_floor_c + correction_c;

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -166,8 +166,8 @@ sensor:
       // This keeps strong cooling possible when the room is clearly too warm,
       // but favors warmer water and calmer modulation near setpoint.
       float base_floor_c = id(cooling_min_supply_temp).state;
-      if (id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state)) {
-        base_floor_c = fmaxf(base_floor_c, id(minimum_safe_supply_temp).state);
+      if (id(cooling_effective_min_supply_temp).has_state() && !isnan(id(cooling_effective_min_supply_temp).state)) {
+        base_floor_c = fmaxf(base_floor_c, id(cooling_effective_min_supply_temp).state);
       }
 
       float comfort_offset_c = 0.8f;
@@ -303,8 +303,8 @@ interval:
 
           float safe_gap_c = NAN;
           // Add a small explicit approach zone near the dew-point-safe floor.
-          if (id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state)) {
-            safe_gap_c = id(oq_system_supply_temp).state - id(minimum_safe_supply_temp).state;
+          if (id(cooling_effective_min_supply_temp).has_state() && !isnan(id(cooling_effective_min_supply_temp).state)) {
+            safe_gap_c = id(oq_system_supply_temp).state - id(cooling_effective_min_supply_temp).state;
             if (safe_gap_c <= stop_safe_floor_limit_c) {
               demand = 0;
               integral = 0.0f;

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -1266,9 +1266,9 @@ interval:
           if (!id(oq_water_temp_hard_trip_active) && min_rt_s > 0) {
             const bool cooling_floor_trip =
                 is_cooling_mode &&
-                id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state) &&
+                id(cooling_effective_min_supply_temp).has_state() && !isnan(id(cooling_effective_min_supply_temp).state) &&
                 id(oq_system_supply_temp).has_state() && !isnan(id(oq_system_supply_temp).state) &&
-                (id(oq_system_supply_temp).state <= (id(minimum_safe_supply_temp).state + 0.10f));
+                (id(oq_system_supply_temp).state <= (id(cooling_effective_min_supply_temp).state + 0.10f));
             // HP1/HP2: if request is 0 but measured heating start is still within
             // the minimum runtime window, keep that compressor alive at >=1.
             // This guard intentionally keys off real heating start instead of the

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -255,6 +255,7 @@
     });
     setEntity("text_sensor", "Control Mode (Label)", { state: "CM98" });
     setEntity("text_sensor", "Cooling Block Reason", { state: "Ready", value: "Ready" });
+    setEntity("text_sensor", "Cooling Guard Mode", { state: "Dew point", value: "Dew point" });
     setEntity("text_sensor", "Flow Mode", { state: "Adaptive" });
     setEntity("select", "Behavior", {
       value: "Balanced",
@@ -270,6 +271,11 @@
       value: "Balanced",
       state: "Balanced",
       option: ["Comfort", "Balanced", "Stable"],
+    });
+    setEntity("select", "Cooling Without Dew Point", {
+      value: "Dew point required",
+      state: "Dew point required",
+      option: ["Dew point required", "Allow without dew point"],
     });
     setEntity("select", "Firmware Update Channel", {
       value: "dev",
@@ -375,6 +381,9 @@
       ["Power House – P_req", 2800, "W"],
       ["Cooling Dew Point (Selected)", 16.1, "°C"],
       ["Cooling Minimum Safe Supply Temp", 18.1, "°C"],
+      ["Cooling Effective Minimum Supply Temp", 18.1, "°C"],
+      ["Cooling Fallback Night Minimum Outdoor Temp", 14.3, "°C"],
+      ["Cooling Fallback Minimum Supply Temp", 19.0, "°C"],
       ["Cooling Supply Target", 18.6, "°C"],
       ["Cooling Supply Error", 0.9, "°C"],
       ["Cooling Demand (raw)", 2, ""],
@@ -798,8 +807,12 @@
       setBinary("Cooling Request Active", true);
       setBinary("Cooling Permitted", true);
       setText("text_sensor", "Cooling Block Reason", "Ready");
+      setText("text_sensor", "Cooling Guard Mode", "Dew point");
       setNumber("Cooling Dew Point (Selected)", wave(16.0, 0.15), "°C");
       setNumber("Cooling Minimum Safe Supply Temp", wave(18.0, 0.15), "°C");
+      setNumber("Cooling Effective Minimum Supply Temp", wave(18.0, 0.15), "°C");
+      setNumber("Cooling Fallback Night Minimum Outdoor Temp", wave(15.4, 0.1), "°C");
+      setNumber("Cooling Fallback Minimum Supply Temp", wave(19.0, 0.1), "°C");
       setNumber("Cooling Supply Target", wave(18.6, 0.12), "°C");
       setNumber("Cooling Supply Error", wave(1.0, 0.2), "°C");
       setNumber("Cooling Demand (raw)", waveInt(2.2, 0.6), "");

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -1715,6 +1715,37 @@ body.oq-page-light {
   line-height: 1.6;
 }
 
+.oq-settings-callout {
+  margin-top: 16px;
+  padding: 16px 18px;
+  border-radius: var(--oq-helper-radius-lg);
+  border: 1px solid var(--oq-helper-line);
+  background: linear-gradient(180deg, rgba(255, 247, 237, 0.72), rgba(255, 255, 255, 0.98));
+}
+
+.oq-helper-shell--dark .oq-settings-callout {
+  background: linear-gradient(180deg, rgba(66, 32, 14, 0.34), rgba(22, 33, 49, 0.94));
+}
+
+.oq-settings-callout strong {
+  display: block;
+  margin: 0 0 10px;
+  color: var(--oq-helper-ink);
+  font-size: 0.98rem;
+  line-height: 1.3;
+}
+
+.oq-settings-callout ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--oq-helper-soft);
+  line-height: 1.6;
+}
+
+.oq-settings-callout li + li {
+  margin-top: 4px;
+}
+
 .oq-settings-grid,
 .oq-settings-hp-group-grid,
 .oq-settings-curve-grid {
@@ -5258,6 +5289,23 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     margin-top: 14px;
   }
 
+  .oq-overview-hp-tools {
+    margin-top: 14px;
+  }
+
+  .oq-overview-hp-tools-head {
+    gap: 10px;
+  }
+
+  .oq-overview-hp-tool-switches {
+    gap: 6px;
+  }
+
+  .oq-overview-hp-tool-chip {
+    min-height: 36px;
+    padding: 0 12px;
+  }
+
   .oq-overview-main,
   .oq-overview-hp-grid {
     gap: 6px;
@@ -5267,6 +5315,22 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   .oq-overview-hp-head,
   .oq-overview-hp-head-title {
     gap: 10px;
+  }
+
+  .oq-overview-hp-head {
+    align-items: center;
+  }
+
+  .oq-overview-hp-head h3 {
+    margin-top: 0;
+  }
+
+  .oq-overview-hp-head-side {
+    gap: 6px;
+  }
+
+  .oq-overview-hp-status {
+    gap: 6px;
   }
 
   .oq-overview-hp {
@@ -5314,14 +5378,14 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-hp-tech-footer-item span {
     font-size: 0.72rem;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.05em;
     line-height: 1.04;
   }
 
   .oq-hp-tech-footer-item strong {
     margin-top: 0;
-    font-size: 0.88rem;
-    line-height: 1.04;
+    font-size: 0.9rem;
+    line-height: 1.02;
   }
 
   esp-app.oq-native-app {

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -1735,6 +1735,47 @@ body.oq-page-light {
   line-height: 1.3;
 }
 
+.oq-settings-callout summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  list-style: none;
+  color: var(--oq-helper-ink);
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.oq-settings-callout summary::-webkit-details-marker {
+  display: none;
+}
+
+.oq-settings-callout summary::before {
+  content: "i";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: rgb(37, 99, 235);
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.oq-settings-callout[open] summary {
+  margin-bottom: 10px;
+}
+
+.oq-settings-callout-body p {
+  margin: 0 0 10px;
+  color: var(--oq-helper-soft);
+  line-height: 1.6;
+}
+
 .oq-settings-callout ul {
   margin: 0;
   padding-left: 18px;

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -1776,15 +1776,62 @@ body.oq-page-light {
   line-height: 1.6;
 }
 
-.oq-settings-callout ul {
-  margin: 0;
-  padding-left: 18px;
-  color: var(--oq-helper-soft);
-  line-height: 1.6;
+.oq-settings-rule-groups {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
 }
 
-.oq-settings-callout li + li {
-  margin-top: 4px;
+.oq-settings-rule-group {
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.oq-helper-shell--dark .oq-settings-rule-group {
+  border-color: rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.24);
+}
+
+.oq-settings-rule-group h4 {
+  margin: 0 0 10px;
+  color: var(--oq-helper-ink);
+  font-size: 0.92rem;
+  line-height: 1.3;
+}
+
+.oq-settings-rule-table {
+  display: grid;
+  gap: 8px;
+}
+
+.oq-settings-rule-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.oq-helper-shell--dark .oq-settings-rule-row {
+  background: rgba(15, 23, 42, 0.36);
+}
+
+.oq-settings-rule-key {
+  color: var(--oq-helper-soft);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.oq-settings-rule-value {
+  flex: 0 0 auto;
+  color: var(--oq-helper-ink);
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.4;
 }
 
 .oq-settings-grid,
@@ -5211,6 +5258,7 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   .oq-settings-choice-grid,
   .oq-settings-response-grid,
   .oq-settings-choice-inline-grid,
+  .oq-settings-rule-groups,
   .oq-settings-curve-grid,
   .oq-settings-hp-columns,
   .oq-settings-hp-group-grid {

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -3633,16 +3633,54 @@
           <summary>Fallback-regel bekijken</summary>
           <div class="oq-settings-callout-body">
             <p>Onder de 20°C buiten blijft fallback-cooling uit. Daarboven gebruikt OpenQuatt 19/20/21/22°C als minimum water, met extra correctie voor warme nachten.</p>
-            <ul>
-              <li>Buiten &lt; 20°C: uit</li>
-              <li>20-24°C: minimum water 19°C</li>
-              <li>24-28°C: minimum water 20°C</li>
-              <li>28-32°C: minimum water 21°C</li>
-              <li>Boven 32°C: minimum water 22°C</li>
-              <li>Warme nacht 18-19°C: +1°C</li>
-              <li>Zeer warme nacht 19-20°C: +2°C</li>
-              <li>Tropische nacht vanaf 20°C: fallback uit</li>
-            </ul>
+            <div class="oq-settings-rule-groups">
+              <section class="oq-settings-rule-group">
+                <h4>Buitentemperatuur</h4>
+                <div class="oq-settings-rule-table">
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">Onder 20°C</span>
+                    <span class="oq-settings-rule-value">Uit</span>
+                  </div>
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">20-24°C</span>
+                    <span class="oq-settings-rule-value">Min. water 19°C</span>
+                  </div>
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">24-28°C</span>
+                    <span class="oq-settings-rule-value">Min. water 20°C</span>
+                  </div>
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">28-32°C</span>
+                    <span class="oq-settings-rule-value">Min. water 21°C</span>
+                  </div>
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">Boven 32°C</span>
+                    <span class="oq-settings-rule-value">Min. water 22°C</span>
+                  </div>
+                </div>
+              </section>
+              <section class="oq-settings-rule-group">
+                <h4>Nachtcorrectie</h4>
+                <div class="oq-settings-rule-table">
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">Onder 18°C</span>
+                    <span class="oq-settings-rule-value">+0°C</span>
+                  </div>
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">18-19°C</span>
+                    <span class="oq-settings-rule-value">+1°C</span>
+                  </div>
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">19-20°C</span>
+                    <span class="oq-settings-rule-value">+2°C</span>
+                  </div>
+                  <div class="oq-settings-rule-row">
+                    <span class="oq-settings-rule-key">Vanaf 20°C</span>
+                    <span class="oq-settings-rule-value">Fallback uit</span>
+                  </div>
+                </div>
+              </section>
+            </div>
           </div>
         </details>
         <div class="oq-settings-grid">

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -3629,19 +3629,22 @@
       "Koeling zonder dauwpunt",
       "Standaard blijft koeling zonder dauwpuntbron geblokkeerd. Met deze opt-in mag OpenQuatt een conservatieve fallback gebruiken op basis van buitentemperatuur en de afgelopen nacht.",
       `
-        <div class="oq-settings-callout oq-settings-callout--cooling">
-          <strong>Fallback-regel</strong>
-          <ul>
-            <li>Buiten &lt; 20°C: uit</li>
-            <li>20-24°C: minimum water 19°C</li>
-            <li>24-28°C: minimum water 20°C</li>
-            <li>28-32°C: minimum water 21°C</li>
-            <li>Boven 32°C: minimum water 22°C</li>
-            <li>Warme nacht 18-19°C: +1°C</li>
-            <li>Zeer warme nacht 19-20°C: +2°C</li>
-            <li>Tropische nacht vanaf 20°C: fallback uit</li>
-          </ul>
-        </div>
+        <details class="oq-settings-callout oq-settings-callout--cooling">
+          <summary>Fallback-regel bekijken</summary>
+          <div class="oq-settings-callout-body">
+            <p>Onder de 20°C buiten blijft fallback-cooling uit. Daarboven gebruikt OpenQuatt 19/20/21/22°C als minimum water, met extra correctie voor warme nachten.</p>
+            <ul>
+              <li>Buiten &lt; 20°C: uit</li>
+              <li>20-24°C: minimum water 19°C</li>
+              <li>24-28°C: minimum water 20°C</li>
+              <li>28-32°C: minimum water 21°C</li>
+              <li>Boven 32°C: minimum water 22°C</li>
+              <li>Warme nacht 18-19°C: +1°C</li>
+              <li>Zeer warme nacht 19-20°C: +2°C</li>
+              <li>Tropische nacht vanaf 20°C: fallback uit</li>
+            </ul>
+          </div>
+        </details>
         <div class="oq-settings-grid">
           ${renderSettingsOptionCardsField("coolingWithoutDewPointMode", "Koeling zonder dauwpuntbeveiliging", "Kies of OpenQuatt zonder dauwpuntbron volledig moet blokkeren, of een conservatieve fallback mag gebruiken.", fallbackModeCopy, "oq-settings-field--span-2")}
           ${renderSettingsStaticField("coolingGuardMode", "Actieve beveiligingsroute", "Laat zien of koeling nu via dauwpunt of via de fallback wordt begrensd.", guardMode)}

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -3637,7 +3637,8 @@
             <li>24-28°C: minimum water 20°C</li>
             <li>28-32°C: minimum water 21°C</li>
             <li>Boven 32°C: minimum water 22°C</li>
-            <li>Warme nacht 18-20°C: +1°C</li>
+            <li>Warme nacht 18-19°C: +1°C</li>
+            <li>Zeer warme nacht 19-20°C: +2°C</li>
             <li>Tropische nacht vanaf 20°C: fallback uit</li>
           </ul>
         </div>

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -102,11 +102,16 @@
     coolingRequestActive: { domain: "binary_sensor", name: "Cooling Request Active", optional: true },
     coolingPermitted: { domain: "binary_sensor", name: "Cooling Permitted", optional: true },
     coolingBlockReason: { domain: "text_sensor", name: "Cooling Block Reason", optional: true },
+    coolingGuardMode: { domain: "text_sensor", name: "Cooling Guard Mode", optional: true },
     coolingDewPointSelected: { domain: "sensor", name: "Cooling Dew Point (Selected)", optional: true },
     coolingMinimumSafeSupplyTemp: { domain: "sensor", name: "Cooling Minimum Safe Supply Temp", optional: true },
+    coolingEffectiveMinSupplyTemp: { domain: "sensor", name: "Cooling Effective Minimum Supply Temp", optional: true },
+    coolingFallbackNightMinOutdoorTemp: { domain: "sensor", name: "Cooling Fallback Night Minimum Outdoor Temp", optional: true },
+    coolingFallbackMinSupplyTemp: { domain: "sensor", name: "Cooling Fallback Minimum Supply Temp", optional: true },
     coolingSupplyTarget: { domain: "sensor", name: "Cooling Supply Target", optional: true },
     coolingSupplyError: { domain: "sensor", name: "Cooling Supply Error", optional: true },
     coolingDemandRaw: { domain: "sensor", name: "Cooling Demand (raw)", optional: true },
+    coolingWithoutDewPointMode: { domain: "select", name: "Cooling Without Dew Point", optional: true },
     flowControlMode: { domain: "select", name: "Flow Control Mode" },
     flowSetpoint: { domain: "number", name: "Flow Setpoint" },
     manualIpwm: { domain: "number", name: "Manual iPWM" },
@@ -322,6 +327,13 @@
   ];
   const LIMIT_KEYS = ["dayMax", "silentMax", "maxWater"];
   const FLOW_SETTING_KEYS = ["flowControlMode", "flowSetpoint", "manualIpwm"];
+  const COOLING_SETTING_KEYS = [
+    "coolingWithoutDewPointMode",
+    "coolingGuardMode",
+    "coolingFallbackNightMinOutdoorTemp",
+    "coolingFallbackMinSupplyTemp",
+    "coolingEffectiveMinSupplyTemp",
+  ];
   const CURVE_SETTING_KEYS = [...CURVE_POINTS.map((point) => point.key), "curveFallbackSupply", "curveControlProfile"];
   const COMPRESSOR_SETTING_KEYS = ["minRuntime", "hp1ExcludedA", "hp1ExcludedB", "hp2ExcludedA", "hp2ExcludedB"];
   const SILENT_SETTING_KEYS = ["silentStartTime", "silentEndTime", "silentMax", "dayMax"];
@@ -334,8 +346,12 @@
     "coolingRequestActive",
     "coolingPermitted",
     "coolingBlockReason",
+    "coolingGuardMode",
     "coolingDewPointSelected",
     "coolingMinimumSafeSupplyTemp",
+    "coolingEffectiveMinSupplyTemp",
+    "coolingFallbackNightMinOutdoorTemp",
+    "coolingFallbackMinSupplyTemp",
     "coolingSupplyTarget",
     "coolingSupplyError",
     "coolingDemandRaw",
@@ -431,6 +447,7 @@
   const SETTINGS_KEYS = [
     "strategy",
     ...FLOW_SETTING_KEYS,
+    ...COOLING_SETTING_KEYS,
     ...LIMIT_KEYS,
     ...POWER_HOUSE_KEYS,
     ...CURVE_SETTING_KEYS,
@@ -2868,6 +2885,8 @@
       Custom: "Aangepast",
       [STRATEGY_OPTION_CURVE]: "Stooklijn",
       [STRATEGY_OPTION_POWER_HOUSE]: "Power House",
+      "Dew point required": "Dauwpunt verplicht",
+      "Allow without dew point": "Toestaan zonder dauwpunt",
     };
 
     return labels[value] || value;
@@ -2916,7 +2935,7 @@
               aria-pressed="${option === currentValue ? "true" : "false"}"
               ${busy ? "disabled" : ""}
             >
-              <span class="oq-settings-choice-title">${escapeHtml(option)}</span>
+              <span class="oq-settings-choice-title">${escapeHtml(formatSettingsOptionLabel(option))}</span>
               ${optionCopy ? `<span class="oq-settings-choice-copy">${escapeHtml(optionCopy)}</span>` : ""}
             </button>
           `;
@@ -3585,6 +3604,37 @@
           ${renderSettingsTimeField("silentEndTime", "Einde stille uren", "Vanaf dit tijdstip stopt de stille modus weer.")}
           ${renderSettingsSliderField("silentMax", "Maximaal niveau tijdens stille uren", "Zo ver mag het systeem nog opschalen tijdens stille uren.")}
           ${renderSettingsSliderField("dayMax", "Maximaal niveau overdag", "Zo ver mag het systeem overdag opschalen.")}
+        </div>
+      `,
+    );
+  }
+
+  function renderSettingsCoolingSection() {
+    if (!hasEntity("coolingWithoutDewPointMode")) {
+      return "";
+    }
+
+    const fallbackModeCopy = {
+      "Dew point required": "Blokkeer koeling zodra er geen dauwpuntbron beschikbaar is.",
+      "Allow without dew point": "Sta een conservatieve fallback toe op basis van buitentemperatuur en de minimum buitentemperatuur van de afgelopen nacht.",
+    };
+
+    const guardMode = getEntityStateText("coolingGuardMode", "Onbekend");
+    const fallbackFloor = getEntityStateText("coolingFallbackMinSupplyTemp", "—");
+    const nightMin = getEntityStateText("coolingFallbackNightMinOutdoorTemp", "—");
+    const effectiveFloor = getEntityStateText("coolingEffectiveMinSupplyTemp", "—");
+
+    return renderSettingsSection(
+      "Koeling",
+      "Koeling zonder dauwpunt",
+      "Standaard blijft koeling zonder dauwpuntbron geblokkeerd. Met deze opt-in mag OpenQuatt een conservatieve fallback gebruiken op basis van buitentemperatuur en de afgelopen nacht. Basisstaffel: onder 20°C buiten uit, daarna 19/20/21/22°C minimum water. Warme nachten tellen daar +1K bovenop, tropische nachten blokkeren fallback helemaal.",
+      `
+        <div class="oq-settings-grid">
+          ${renderSettingsOptionCardsField("coolingWithoutDewPointMode", "Koeling zonder dauwpuntbeveiliging", "Kies of OpenQuatt zonder dauwpuntbron volledig moet blokkeren, of een conservatieve fallback mag gebruiken.", fallbackModeCopy, "oq-settings-field--span-2")}
+          ${renderSettingsStaticField("coolingGuardMode", "Actieve beveiligingsroute", "Laat zien of koeling nu via dauwpunt of via de fallback wordt begrensd.", guardMode)}
+          ${renderSettingsStaticField("coolingFallbackNightMinOutdoorTemp", "Nachtminimum buitentemperatuur", "Minimum buitentemperatuur van de afgelopen nacht. Warme nachten maken fallback-cooling conservatiever of blokkeren die helemaal.", nightMin)}
+          ${renderSettingsStaticField("coolingFallbackMinSupplyTemp", "Fallback minimum watertemperatuur", "De conservatieve ondergrens die OpenQuatt gebruikt als er geen dauwpuntbron beschikbaar is en fallback is toegestaan.", fallbackFloor)}
+          ${renderSettingsStaticField("coolingEffectiveMinSupplyTemp", "Actieve minimum ondergrens", "De ondergrens die de koeling nu daadwerkelijk gebruikt: dauwpunt plus marge, of de fallback-ondergrens.", effectiveFloor)}
         </div>
       `,
     );
@@ -4440,8 +4490,10 @@
   function getCoolingOverviewModel() {
     const target = getEntityNumericValue("coolingSupplyTarget");
     const supply = getEntityNumericValue("supplyTemp");
-    const safeFloor = getEntityNumericValue("coolingMinimumSafeSupplyTemp");
+    const safeFloor = getEntityNumericValue("coolingEffectiveMinSupplyTemp");
     const dewPoint = getEntityNumericValue("coolingDewPointSelected");
+    const guardMode = getEntityStateText("coolingGuardMode", "");
+    const fallbackNightMin = getEntityStateText("coolingFallbackNightMinOutdoorTemp", "—");
     const supplyError = getEntityNumericValue("coolingSupplyError");
     const rawDemand = getEntityNumericValue("coolingDemandRaw");
     const permitted = isEntityActive("coolingPermitted");
@@ -4474,8 +4526,10 @@
     return {
       targetText: formatOverviewStatValue("coolingSupplyTarget"),
       supplyText: formatOverviewStatValue("supplyTemp"),
-      safeFloorText: formatOverviewStatValue("coolingMinimumSafeSupplyTemp"),
+      safeFloorText: formatOverviewStatValue("coolingEffectiveMinSupplyTemp"),
       dewPointText: formatOverviewStatValue("coolingDewPointSelected"),
+      guardMode,
+      fallbackNightMin,
       demandText: formatOverviewStatValue("coolingDemandRaw"),
       deltaText: formatSignedTemperature(supplyError),
       statusTitle,
@@ -4538,6 +4592,10 @@
 
   function renderCoolingOverviewCard() {
     const model = getCoolingOverviewModel();
+    const floorLabel = model.guardMode.toLowerCase().includes("fallback") ? "Fallback ondergrens" : "Veilige aanvoergrens";
+    const floorCopy = model.guardMode.toLowerCase().includes("fallback")
+      ? `Conservatieve ondergrens zonder dauwpuntmeting. Nachtminimum: ${model.fallbackNightMin}.`
+      : "Dauwpunt plus veiligheidsmarge.";
 
     return `
       <section class="oq-overview-system">
@@ -4554,7 +4612,7 @@
         </div>
         <div class="oq-overview-metrics oq-overview-metrics--three-column">
           ${renderOverviewMetricCard("Actuele aanvoertemperatuur", model.supplyText, "orange", "Wat nu door het systeem loopt.")}
-          ${renderOverviewMetricCard("Veilige aanvoergrens", model.safeFloorText, "blue", "Dauwpunt plus veiligheidsmarge.")}
+          ${renderOverviewMetricCard(floorLabel, model.safeFloorText, "blue", floorCopy)}
           ${renderOverviewMetricCard("Koelvraag", model.demandText, "sky", "De huidige koelvraag van de regelaar.")}
         </div>
       </section>
@@ -6611,6 +6669,7 @@
         <div class="oq-helper-settings-stack">
           ${renderSettingsFlowSection()}
           ${renderSettingsHeatingSection()}
+          ${renderSettingsCoolingSection()}
           ${renderSettingsWaterSection()}
           ${renderSettingsCompressorSection()}
           ${renderSettingsSilentSection()}

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -3563,7 +3563,7 @@
     return renderSettingsSection(
       "Maximale watertemperatuur",
       "Watertemperatuur",
-      "Beschermt het systeem tegen te hoge aanvoertemperaturen. OpenQuatt leidt daar intern zelf de terugregelband en een harde trip op 5°C boven deze grens uit af.",
+      "Beschermt het systeem tegen te hoge aanvoertemperaturen. OpenQuatt regelt richting deze grens terug en grijpt 5°C erboven hard in.",
       `
         <div class="oq-settings-grid">
           ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf. OpenQuatt begint enkele graden eerder al terug te regelen en bewaakt een harde trip op 5°C boven deze grens.")}
@@ -3846,7 +3846,7 @@
       <section class="oq-helper-panel">
         <p class="oq-helper-label">Stap 4</p>
         <h2 class="oq-helper-section-title">Watertemperatuur beveiligen</h2>
-        <p class="oq-helper-section-copy">Hier stel je de veilige bovengrens voor de watertemperatuur in. OpenQuatt leidt daar zelf de terugregelband en een harde trip op 5°C boven af.</p>
+        <p class="oq-helper-section-copy">Hier stel je de veilige bovengrens voor de watertemperatuur in. OpenQuatt regelt richting deze grens terug en grijpt 5°C erboven hard in.</p>
         <div class="oq-settings-grid oq-settings-grid--quickstart">
           ${renderSettingsNumberField("maxWater", "Maximale watertemperatuur", "Normale bovengrens voor de watertemperatuur tijdens bedrijf. OpenQuatt begint enkele graden eerder al terug te regelen en bewaakt een harde trip op 5°C boven deze grens.")}
         </div>

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -3627,8 +3627,20 @@
     return renderSettingsSection(
       "Koeling",
       "Koeling zonder dauwpunt",
-      "Standaard blijft koeling zonder dauwpuntbron geblokkeerd. Met deze opt-in mag OpenQuatt een conservatieve fallback gebruiken op basis van buitentemperatuur en de afgelopen nacht. Basisstaffel: onder 20°C buiten uit, daarna 19/20/21/22°C minimum water. Warme nachten tellen daar +1K bovenop, tropische nachten blokkeren fallback helemaal.",
+      "Standaard blijft koeling zonder dauwpuntbron geblokkeerd. Met deze opt-in mag OpenQuatt een conservatieve fallback gebruiken op basis van buitentemperatuur en de afgelopen nacht.",
       `
+        <div class="oq-settings-callout oq-settings-callout--cooling">
+          <strong>Fallback-regel</strong>
+          <ul>
+            <li>Buiten &lt; 20°C: uit</li>
+            <li>20-24°C: minimum water 19°C</li>
+            <li>24-28°C: minimum water 20°C</li>
+            <li>28-32°C: minimum water 21°C</li>
+            <li>Boven 32°C: minimum water 22°C</li>
+            <li>Warme nacht 18-20°C: +1°C</li>
+            <li>Tropische nacht vanaf 20°C: fallback uit</li>
+          </ul>
+        </div>
         <div class="oq-settings-grid">
           ${renderSettingsOptionCardsField("coolingWithoutDewPointMode", "Koeling zonder dauwpuntbeveiliging", "Kies of OpenQuatt zonder dauwpuntbron volledig moet blokkeren, of een conservatieve fallback mag gebruiken.", fallbackModeCopy, "oq-settings-field--span-2")}
           ${renderSettingsStaticField("coolingGuardMode", "Actieve beveiligingsroute", "Laat zien of koeling nu via dauwpunt of via de fallback wordt begrensd.", guardMode)}


### PR DESCRIPTION
## Summary

- add an explicit opt-in fallback for cooling without a dew point source
- derive a conservative fallback minimum water temperature from outdoor temperature plus the previous night's minimum
- expose the new fallback route in the web app settings, HA dashboards, and docs

## What changed

- adds a new `Cooling Without Dew Point` select that defaults to `Dew point required`
- keeps normal cooling unchanged when valid dew point inputs are available
- allows fallback cooling only when no cooling rooms are configured and the opt-in is enabled
- applies this conservative fallback table:
  - `< 20°C` outdoor: cooling off
  - `20–24°C`: minimum water `19°C`
  - `24–28°C`: minimum water `20°C`
  - `28–32°C`: minimum water `21°C`
  - `> 32°C`: minimum water `22°C`
- applies a stricter night correction using the previous night's minimum outdoor temperature:
  - `< 18°C`: `+0°C`
  - `18–19°C`: `+1°C`
  - `19–20°C`: `+2°C`
  - `>= 20°C`: fallback blocked
- uses the fallback floor as the effective cooling floor whenever dew point protection is unavailable but fallback is explicitly allowed
- adds fallback visibility to the native web app settings and cooling overview
- refines the web settings UI so the fallback rule is shown as a compact, collapsible rule card instead of a long bullet list
- updates all four HA dashboards with the new switch, diagnostics, and explanation block
- documents how the fallback works, including why the normal dew-point `+2K` safety margin is not added on top of the fallback table

## Validation

- `node --check openquatt/web/openquatt-app.js`
- `node --check openquatt/web/mock-device.js`
- `python3 scripts/dev.py validate --config-only`
- `python3 scripts/dev.py preview-pages --no-serve`
- `esphome compile openquatt_duo_waveshare.yaml`

## Notes

- the fallback is intentionally an explicit opt-in and remains more conservative than the regular dew-point-protected route
- the warmer-night guard was tightened after review to be more cautious in the `19–20°C` night range
