### PR TITLE
Add overview controls and redesign live overview

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -154,8 +154,8 @@ views:
               - `Manual cooling`: adds an extra cooling permission on top of
               CIC and/or HA input.
 
-              - `Manual silent mode`: forces silent mode outside the scheduled
-              window.
+              - `Silent mode override`: sets silent mode to `Schedule`, `On`
+              or `Off`.
 
 
               </details>
@@ -175,12 +175,9 @@ views:
               - type: toggle
             features_position: inline
           - type: tile
-            entity: switch.openquatt_manual_silent_enable
-            name: Manual silent mode
+            entity: select.openquatt_silent_mode_override
+            name: Silent mode override
             vertical: false
-            features:
-              - type: toggle
-            features_position: inline
           - type: heading
             icon: mdi:stethoscope
             heading: Debug

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -135,6 +135,53 @@ views:
             vertical: false
             features_position: bottom
           - type: heading
+            icon: mdi:tune-variant
+            heading: Controls
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Explanation</strong></summary>
+
+
+              Use these switches for direct runtime control:
+
+              - `OpenQuatt enabled`: pauses or resumes normal heating and
+              cooling control. Safety monitoring and freeze protection stay
+              active.
+
+              - `Manual cooling`: adds an extra cooling permission on top of
+              CIC and/or HA input.
+
+              - `Manual silent mode`: forces silent mode outside the scheduled
+              window.
+
+
+              </details>
+            text_only: true
+          - type: tile
+            entity: switch.openquatt_enabled
+            name: OpenQuatt enabled
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
+            entity: switch.openquatt_manual_cooling_enable
+            name: Manual cooling
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
+            entity: switch.openquatt_manual_silent_enable
+            name: Manual silent mode
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: heading
             icon: mdi:stethoscope
             heading: Debug
             heading_style: title
@@ -1092,7 +1139,14 @@ views:
             heading: Cooling state
             heading_style: title
           - type: tile
+            entity: switch.openquatt_manual_cooling_enable
+            name: OpenQuatt manual cooling
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
             entity: input_boolean.koeling_aan
+            name: HA helper cooling
           - type: entities
             show_header_toggle: false
             entities:
@@ -1849,6 +1903,8 @@ views:
                 entities:
                   - entity: select.openquatt_cooling_enable_source
                     name: Cooling enable source
+                  - entity: switch.openquatt_manual_cooling_enable
+                    name: Manual cooling enable (OpenQuatt)
                   - entity: sensor.openquatt_cooling_enable_effective_source
                     name: Effective cooling enable source
                   - entity: binary_sensor.openquatt_cooling_enable_selected

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -140,6 +140,52 @@ views:
             vertical: false
             features_position: bottom
           - type: heading
+            icon: mdi:tune-variant
+            heading: Bediening
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg</strong></summary>
+
+
+              Gebruik deze schakelaars voor directe runtime-bediening:
+
+              - `OpenQuatt actief`: pauzeert of hervat de normale warmte- en
+              koelregeling. Bewaking en vorstbeveiliging blijven actief.
+
+              - `Handmatige koeling`: telt mee als extra koeltoestemming,
+              bovenop CIC en/of HA-invoer.
+
+              - `Handmatige stille modus`: forceert stille modus los van het
+              tijdvenster.
+
+
+              </details>
+            text_only: true
+          - type: tile
+            entity: switch.openquatt_enabled
+            name: OpenQuatt actief
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
+            entity: switch.openquatt_manual_cooling_enable
+            name: Handmatige koeling
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
+            entity: switch.openquatt_manual_silent_enable
+            name: Handmatige stille modus
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: heading
             icon: mdi:stethoscope
             heading: Debug
             heading_style: title
@@ -1168,7 +1214,14 @@ views:
             heading: Koelstatus
             heading_style: title
           - type: tile
+            entity: switch.openquatt_manual_cooling_enable
+            name: OpenQuatt handmatige koeling
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
             entity: input_boolean.koeling_aan
+            name: HA helper koeling
           - type: entities
             show_header_toggle: false
             entities:
@@ -1953,6 +2006,8 @@ views:
                 entities:
                   - entity: select.openquatt_cooling_enable_source
                     name: Koeltoestemming bron
+                  - entity: switch.openquatt_manual_cooling_enable
+                    name: Handmatige koeltoestemming (OpenQuatt)
                   - entity: sensor.openquatt_cooling_enable_effective_source
                     name: Effectieve koeltoestemmingsbron
                   - entity: binary_sensor.openquatt_cooling_enable_selected

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -158,8 +158,8 @@ views:
               - `Handmatige koeling`: telt mee als extra koeltoestemming,
               bovenop CIC en/of HA-invoer.
 
-              - `Handmatige stille modus`: forceert stille modus los van het
-              tijdvenster.
+              - `Stille modus override`: zet stille modus op `Schema`, `Aan`
+              of `Uit`.
 
 
               </details>
@@ -179,12 +179,9 @@ views:
               - type: toggle
             features_position: inline
           - type: tile
-            entity: switch.openquatt_manual_silent_enable
-            name: Handmatige stille modus
+            entity: select.openquatt_silent_mode_override
+            name: Stille modus override
             vertical: false
-            features:
-              - type: toggle
-            features_position: inline
           - type: heading
             icon: mdi:stethoscope
             heading: Debug

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -135,6 +135,53 @@ views:
             vertical: false
             features_position: bottom
           - type: heading
+            icon: mdi:tune-variant
+            heading: Controls
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Explanation</strong></summary>
+
+
+              Use these switches for direct runtime control:
+
+              - `OpenQuatt enabled`: pauses or resumes normal heating and
+              cooling control. Safety monitoring and freeze protection stay
+              active.
+
+              - `Manual cooling`: adds an extra cooling permission on top of
+              CIC and/or HA input.
+
+              - `Manual silent mode`: forces silent mode outside the scheduled
+              window.
+
+
+              </details>
+            text_only: true
+          - type: tile
+            entity: switch.openquatt_enabled
+            name: OpenQuatt enabled
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
+            entity: switch.openquatt_manual_cooling_enable
+            name: Manual cooling
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
+            entity: switch.openquatt_manual_silent_enable
+            name: Manual silent mode
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: heading
             icon: mdi:stethoscope
             heading: Debug
             heading_style: title
@@ -1080,7 +1127,14 @@ views:
             heading: Cooling state
             heading_style: title
           - type: tile
+            entity: switch.openquatt_manual_cooling_enable
+            name: OpenQuatt manual cooling
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
             entity: input_boolean.koeling_aan
+            name: HA helper cooling
           - type: entities
             show_header_toggle: false
             entities:
@@ -1590,6 +1644,8 @@ views:
                 entities:
                   - entity: select.openquatt_cooling_enable_source
                     name: Cooling enable source
+                  - entity: switch.openquatt_manual_cooling_enable
+                    name: Manual cooling enable (OpenQuatt)
                   - entity: sensor.openquatt_cooling_enable_effective_source
                     name: Effective cooling enable source
                   - entity: binary_sensor.openquatt_cooling_enable_selected

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -154,8 +154,8 @@ views:
               - `Manual cooling`: adds an extra cooling permission on top of
               CIC and/or HA input.
 
-              - `Manual silent mode`: forces silent mode outside the scheduled
-              window.
+              - `Silent mode override`: sets silent mode to `Schedule`, `On`
+              or `Off`.
 
 
               </details>
@@ -175,12 +175,9 @@ views:
               - type: toggle
             features_position: inline
           - type: tile
-            entity: switch.openquatt_manual_silent_enable
-            name: Manual silent mode
+            entity: select.openquatt_silent_mode_override
+            name: Silent mode override
             vertical: false
-            features:
-              - type: toggle
-            features_position: inline
           - type: heading
             icon: mdi:stethoscope
             heading: Debug

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -157,8 +157,8 @@ views:
               - `Handmatige koeling`: telt mee als extra koeltoestemming,
               bovenop CIC en/of HA-invoer.
 
-              - `Handmatige stille modus`: forceert stille modus los van het
-              tijdvenster.
+              - `Stille modus override`: zet stille modus op `Schema`, `Aan`
+              of `Uit`.
 
 
               </details>
@@ -178,12 +178,9 @@ views:
               - type: toggle
             features_position: inline
           - type: tile
-            entity: switch.openquatt_manual_silent_enable
-            name: Handmatige stille modus
+            entity: select.openquatt_silent_mode_override
+            name: Stille modus override
             vertical: false
-            features:
-              - type: toggle
-            features_position: inline
           - type: heading
             icon: mdi:stethoscope
             heading: Debug

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -139,6 +139,52 @@ views:
             vertical: false
             features_position: bottom
           - type: heading
+            icon: mdi:tune-variant
+            heading: Bediening
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg</strong></summary>
+
+
+              Gebruik deze schakelaars voor directe runtime-bediening:
+
+              - `OpenQuatt actief`: pauzeert of hervat de normale warmte- en
+              koelregeling. Bewaking en vorstbeveiliging blijven actief.
+
+              - `Handmatige koeling`: telt mee als extra koeltoestemming,
+              bovenop CIC en/of HA-invoer.
+
+              - `Handmatige stille modus`: forceert stille modus los van het
+              tijdvenster.
+
+
+              </details>
+            text_only: true
+          - type: tile
+            entity: switch.openquatt_enabled
+            name: OpenQuatt actief
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
+            entity: switch.openquatt_manual_cooling_enable
+            name: Handmatige koeling
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
+            entity: switch.openquatt_manual_silent_enable
+            name: Handmatige stille modus
+            vertical: false
+            features:
+              - type: toggle
+            features_position: inline
+          - type: heading
             icon: mdi:stethoscope
             heading: Debug
             heading_style: title
@@ -1143,7 +1189,14 @@ views:
             heading: Koelstatus
             heading_style: title
           - type: tile
+            entity: switch.openquatt_manual_cooling_enable
+            name: OpenQuatt handmatige koeling
+            features:
+              - type: toggle
+            features_position: inline
+          - type: tile
             entity: input_boolean.koeling_aan
+            name: HA helper koeling
           - type: entities
             show_header_toggle: false
             entities:
@@ -1656,6 +1709,8 @@ views:
                 entities:
                   - entity: select.openquatt_cooling_enable_source
                     name: Koeltoestemming bron
+                  - entity: switch.openquatt_manual_cooling_enable
+                    name: Handmatige koeltoestemming (OpenQuatt)
                   - entity: sensor.openquatt_cooling_enable_effective_source
                     name: Effectieve koeltoestemmingsbron
                   - entity: binary_sensor.openquatt_cooling_enable_selected

--- a/docs/dashboardoverzicht.md
+++ b/docs/dashboardoverzicht.md
@@ -39,7 +39,7 @@ Je vindt hier nu ook een aparte `Bediening`-sectie met directe runtime-schakelaa
 
 - `OpenQuatt actief`;
 - `Handmatige koeling`;
-- `Handmatige stille modus`.
+- `Stille modus override`.
 
 Die schakelaars zijn bedoeld voor directe bediening. Ze vervangen geen bronconfiguratie of tuning.
 

--- a/docs/dashboardoverzicht.md
+++ b/docs/dashboardoverzicht.md
@@ -24,7 +24,8 @@ Kijk hier als eerste naar:
 - of het systeem online is;
 - welke temperatuurwaarden geselecteerd zijn;
 - hoeveel vermogen en warmte nu geleverd wordt;
-- of het systeem rustig en logisch reageert.
+- of het systeem rustig en logisch reageert;
+- of in `Bediening` een handmatige override actief is.
 
 ### Thermostaat en hoofdstanden
 
@@ -33,6 +34,14 @@ Hier zie je onder meer:
 - welke verwarmingsstrategie actief is;
 - of er een override actief is;
 - of stille uren of niveaubegrenzingen meespelen.
+
+Je vindt hier nu ook een aparte `Bediening`-sectie met directe runtime-schakelaars voor:
+
+- `OpenQuatt actief`;
+- `Handmatige koeling`;
+- `Handmatige stille modus`.
+
+Die schakelaars zijn bedoeld voor directe bediening. Ze vervangen geen bronconfiguratie of tuning.
 
 ### Energie
 
@@ -53,6 +62,7 @@ Als hier de verkeerde bron gekozen is, raken ook andere schermen al snel misleid
 Bij cooling is deze tab extra belangrijk. Daar configureer je ook:
 
 - de cooling enable bron;
+- de handmatige koeltoestemming van OpenQuatt;
 - het aantal koelruimtes;
 - de dauwpunt-, temperatuur- en RH-bronnen die via Home Assistant-proxy's worden ingelezen.
 
@@ -90,6 +100,7 @@ Gebruik deze tab zodra je cooling gebruikt of voorbereidt. Hier zie je onder mee
 
 - of cooling request actief is;
 - of cooling op dit moment toegestaan is;
+- of OpenQuatt handmatig koeltoestemming geeft;
 - waarom cooling eventueel geblokkeerd wordt;
 - welk dauwpunt en welke minimale veilige aanvoer actief zijn;
 - welk cooling-target en welke ruwe cooling demand OpenQuatt nu gebruikt.

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -29,9 +29,18 @@ OpenQuatt is de laag die:
 - bepaalt welke bronwaarden gebruikt worden;
 - beoordeelt hoe terughoudend of actief het systeem moet reageren;
 - extra beveiliging en bewaking toevoegt;
+- directe runtime-bediening mogelijk maakt;
 - de gegevens ontsluit voor Home Assistant.
 
 OpenQuatt vormt daarmee de schakel tussen warmtevraag, beschikbare data en de manier waarop het systeem daarop reageert.
+
+Die runtime-bediening is bewust beperkt tot een paar duidelijke schakelaars:
+
+- `OpenQuatt Enabled`;
+- `Manual Cooling Enable`;
+- `Manual Silent Enable`.
+
+Daarmee kun je de regeling pauzeren, extra koeltoestemming geven of stille modus forceren, zonder onderliggende bronconfiguratie of veiligheidslogica te vervangen.
 
 ### De warmtepomp
 
@@ -102,6 +111,7 @@ Daarom werkt OpenQuatt bij cooling in grote lijnen zo:
 - er is een aparte control mode voor cooling;
 - dauwpuntinformatie is leidend voor de minimale veilige aanvoertemperatuur;
 - flowbewaking blijft net zo belangrijk als bij verwarmen;
+- handmatige koeltoestemming mag cooling vrijgeven, maar vervangt geen koelvraag;
 - zonder bruikbare dauwpuntinformatie hoort normale cooling niet vrijgegeven te worden, tenzij je expliciet een conservatieve fallback inschakelt.
 
 Praktisch betekent dit dat OpenQuatt cooling niet behandelt als "negatief verwarmen". Er is een eigen koelvraag, een eigen veilige aanvoergrens en een aparte bewakingslaag bovenop de warmtepompsturing.

--- a/docs/hoe-openquatt-werkt.md
+++ b/docs/hoe-openquatt-werkt.md
@@ -38,9 +38,9 @@ Die runtime-bediening is bewust beperkt tot een paar duidelijke schakelaars:
 
 - `OpenQuatt Enabled`;
 - `Manual Cooling Enable`;
-- `Manual Silent Enable`.
+- `Silent Mode Override`.
 
-Daarmee kun je de regeling pauzeren, extra koeltoestemming geven of stille modus forceren, zonder onderliggende bronconfiguratie of veiligheidslogica te vervangen.
+Daarmee kun je de regeling pauzeren, extra koeltoestemming geven of stille modus laten volgen, forceren of uitschakelen, zonder onderliggende bronconfiguratie of veiligheidslogica te vervangen.
 
 ### De warmtepomp
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -111,6 +111,9 @@ Belangrijk: `oq_flow_mismatch_threshold_lph` en `oq_flow_mismatch_hyst_lph` zijn
 
 Deze instellingen gebruik je als eerste als je gedrag wilt begrenzen of verklaren:
 
+- `OpenQuatt Enabled`
+- `Manual Cooling Enable`
+- `Manual Silent Enable`
 - `CM Override`
 - `Day max level`
 - `Silent max level`
@@ -124,6 +127,12 @@ Deze instellingen gebruik je als eerste als je gedrag wilt begrenzen of verklare
 - `Low-load CM2 re-entry block`
 
 Praktisch bepaal je hiermee hoeveel ruimte OpenQuatt krijgt, wanneer stille uren gelden en hoe snel het systeem naar ketelhulp of terugschakelen beweegt. De vaste low-load fallbackdrempels zitten intern in substitutions; tijdens runtime tune je vooral de dynamische factoren, hysterese en re-entry block.
+
+De drie runtime-switches hebben elk een andere rol:
+
+- `OpenQuatt Enabled`: pauzeert of hervat de normale warmte- en koelregeling. Bewaking en vorstbeveiliging blijven actief.
+- `Manual Cooling Enable`: telt mee als extra koeltoestemming bovenop CIC en/of HA-invoer.
+- `Manual Silent Enable`: forceert stille modus los van het tijdvenster.
 
 ### Bronselectie
 
@@ -143,6 +152,8 @@ Belangrijke runtime-instellingen en signalen in deze groep zijn:
 - `Cooling Effective Minimum Supply Temp`
 
 Normaal verwacht OpenQuatt bij cooling een geldige dauwpuntbron. Ontbreekt die, dan blijft cooling geblokkeerd.
+
+`Manual Cooling Enable` staat hier los van. Die switch geeft OpenQuatt expliciet extra koeltoestemming, maar vervangt nog steeds geen koelvraag, flowbewaking of dauwpunt-/fallbackbeveiliging.
 
 Met `Cooling Without Dew Point` kun je expliciet een fallback toestaan. Die fallback gebruikt een conservatieve staffel op basis van buitentemperatuur:
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -113,7 +113,7 @@ Deze instellingen gebruik je als eerste als je gedrag wilt begrenzen of verklare
 
 - `OpenQuatt Enabled`
 - `Manual Cooling Enable`
-- `Manual Silent Enable`
+- `Silent Mode Override`
 - `CM Override`
 - `Day max level`
 - `Silent max level`
@@ -128,11 +128,11 @@ Deze instellingen gebruik je als eerste als je gedrag wilt begrenzen of verklare
 
 Praktisch bepaal je hiermee hoeveel ruimte OpenQuatt krijgt, wanneer stille uren gelden en hoe snel het systeem naar ketelhulp of terugschakelen beweegt. De vaste low-load fallbackdrempels zitten intern in substitutions; tijdens runtime tune je vooral de dynamische factoren, hysterese en re-entry block.
 
-De drie runtime-switches hebben elk een andere rol:
+De runtime-bediening heeft drie duidelijke onderdelen:
 
 - `OpenQuatt Enabled`: pauzeert of hervat de normale warmte- en koelregeling. Bewaking en vorstbeveiliging blijven actief.
 - `Manual Cooling Enable`: telt mee als extra koeltoestemming bovenop CIC en/of HA-invoer.
-- `Manual Silent Enable`: forceert stille modus los van het tijdvenster.
+- `Silent Mode Override`: zet stille modus op `Schedule`, `On` of `Off`.
 
 ### Bronselectie
 

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -173,6 +173,16 @@ select:
     web_server:
       sorting_group_id: oq_sensor_selection
 
+switch:
+  - platform: template
+    id: oq_manual_cooling_enable
+    name: "Manual Cooling Enable"
+    icon: mdi:snowflake-check
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    web_server:
+      sorting_group_id: oq_control
+
 binary_sensor:
   - platform: template
     id: cooling_enable_selected
@@ -184,9 +194,10 @@ binary_sensor:
       const auto source = id(cooling_enable_source).current_option();
       const bool cic_enabled = id(cic_cooling_enabled).has_state() && id(cic_cooling_enabled).state;
       const bool ha_enabled = id(cooling_enable_ha).has_state() && id(cooling_enable_ha).state;
-      if (source == "CIC") return cic_enabled;
-      if (source == "HA input") return ha_enabled;
-      if (source == "CIC or HA input") return cic_enabled || ha_enabled;
+      const bool manual_enabled = id(oq_manual_cooling_enable).state;
+      if (source == "CIC") return cic_enabled || manual_enabled;
+      if (source == "HA input") return ha_enabled || manual_enabled;
+      if (source == "CIC or HA input") return cic_enabled || ha_enabled || manual_enabled;
       return false;
     web_server:
       sorting_group_id: oq_sensor_selection
@@ -229,14 +240,21 @@ text_sensor:
       const auto source = id(cooling_enable_source).current_option();
       const bool cic_enabled = id(cic_cooling_enabled).has_state() && id(cic_cooling_enabled).state;
       const bool ha_enabled = id(cooling_enable_ha).has_state() && id(cooling_enable_ha).state;
+      const bool manual_enabled = id(oq_manual_cooling_enable).state;
 
-      if (source == "CIC") return {cic_enabled ? "CIC" : "None"};
-      if (source == "HA input") return {ha_enabled ? "HA input" : "None"};
+      auto with_manual = [&](const std::string &base) -> std::string {
+        if (!manual_enabled) return base;
+        if (base == "None") return "Manual";
+        return base + " + Manual";
+      };
+
+      if (source == "CIC") return {with_manual(cic_enabled ? "CIC" : "None")};
+      if (source == "HA input") return {with_manual(ha_enabled ? "HA input" : "None")};
       if (source == "CIC or HA input") {
-        if (cic_enabled && ha_enabled) return {"CIC + HA input"};
-        if (cic_enabled) return {"CIC"};
-        if (ha_enabled) return {"HA input"};
-        return {"None"};
+        if (cic_enabled && ha_enabled) return {with_manual("CIC + HA input")};
+        if (cic_enabled) return {with_manual("CIC")};
+        if (ha_enabled) return {with_manual("HA input")};
+        return {with_manual("None")};
       }
       return {"Unknown"};
     web_server:

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -211,21 +211,26 @@ select:
     web_server:
       sorting_group_id: oq_control
 
+  - platform: template
+    id: oq_silent_mode_override
+    name: "Silent Mode Override"
+    icon: mdi:weather-night
+    options:
+      - "Schedule"
+      - "On"
+      - "Off"
+    initial_option: "Schedule"
+    restore_value: true
+    optimistic: true
+    web_server:
+      sorting_group_id: oq_control
+
 switch:
   - platform: template
     id: oq_enabled
     name: "OpenQuatt Enabled"
     icon: mdi:power-standby
     restore_mode: RESTORE_DEFAULT_ON
-    optimistic: true
-    web_server:
-      sorting_group_id: oq_control
-
-  - platform: template
-    id: oq_manual_silent_enable
-    name: "Manual Silent Enable"
-    icon: mdi:weather-night
-    restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     web_server:
       sorting_group_id: oq_control
@@ -1238,7 +1243,9 @@ interval:
           auto apply_silent_window = [&]() -> void {
             // Silent window + diagnostics + low-noise mode selection.
             bool silent_active = false;
-            const bool manual_silent_enabled = id(oq_manual_silent_enable).state;
+            const std::string silent_override = id(oq_silent_mode_override).active_index().has_value()
+              ? id(oq_silent_mode_override).at(id(oq_silent_mode_override).active_index().value()).value()
+              : std::string("Schedule");
             auto now_time = id(oq_time).now();
             const bool time_valid = now_time.is_valid();
 
@@ -1289,15 +1296,12 @@ interval:
               }
             }
 
-            if (manual_silent_enabled) {
+            if (silent_override == "On") {
               silent_active = true;
-              if (silent_status == "in_window") {
-                silent_status = "manual + window";
-              } else if (silent_status == "time_invalid") {
-                silent_status = "manual";
-              } else {
-                silent_status = "manual";
-              }
+              silent_status = "forced_on";
+            } else if (silent_override == "Off") {
+              silent_active = false;
+              silent_status = "forced_off";
             }
 
             static std::string last_silent_status;

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -210,6 +210,25 @@ select:
     entity_category: config
     web_server:
       sorting_group_id: oq_control
+
+switch:
+  - platform: template
+    id: oq_enabled
+    name: "OpenQuatt Enabled"
+    icon: mdi:power-standby
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    web_server:
+      sorting_group_id: oq_control
+
+  - platform: template
+    id: oq_manual_silent_enable
+    name: "Manual Silent Enable"
+    icon: mdi:weather-night
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    web_server:
+      sorting_group_id: oq_control
 # ----------------------------
 # TUNING
 # ----------------------------
@@ -675,6 +694,7 @@ interval:
           // -------------------------------------------------
           const char* cur_cm_state = id(oq_control_mode).state.c_str();
           const bool in_cm2 = strcmp(cur_cm_state, "CM2") == 0;
+          const bool openquatt_enabled = id(oq_enabled).state;
           const int strategy_active_code = id(oq_strategy_active_code);
           const bool heating_strategy_active = (strategy_active_code == 2 || strategy_active_code == 3);
           const bool heating_req_raw = heating_strategy_active && id(oq_strategy_heat_request_active);
@@ -682,7 +702,7 @@ interval:
               id(cooling_enable_selected).has_state() && id(cooling_enable_selected).state &&
               id(cooling_request_active).has_state() && id(cooling_request_active).state &&
               id(cooling_permitted_core).has_state() && id(cooling_permitted_core).state;
-          const bool cooling_req = cooling_req_raw;
+          const bool cooling_req = cooling_req_raw && openquatt_enabled;
           const bool power_house_active = (strategy_active_code == 3);
 
           const int hp1_lvl = id(hp1_last_applied_level);
@@ -746,7 +766,7 @@ interval:
           };
           const bool both_units_idle = !any_hp_active_guard;
 
-          bool heating_req = heating_req_raw;
+          bool heating_req = heating_req_raw && openquatt_enabled;
           float p_req_w = NAN;
           float low_load_off_w = NAN;
           float low_load_on_w = NAN;
@@ -1218,6 +1238,7 @@ interval:
           auto apply_silent_window = [&]() -> void {
             // Silent window + diagnostics + low-noise mode selection.
             bool silent_active = false;
+            const bool manual_silent_enabled = id(oq_manual_silent_enable).state;
             auto now_time = id(oq_time).now();
             const bool time_valid = now_time.is_valid();
 
@@ -1265,6 +1286,17 @@ interval:
                 // over midnight
                 silent_active = (cur_min >= start_min) || (cur_min < end_min);
                 silent_status = silent_active ? "in_window" : "out_of_window";
+              }
+            }
+
+            if (manual_silent_enabled) {
+              silent_active = true;
+              if (silent_status == "in_window") {
+                silent_status = "manual + window";
+              } else if (silent_status == "time_invalid") {
+                silent_status = "manual";
+              } else {
+                silent_status = "manual";
               }
             }
 

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -113,6 +113,10 @@
     entity.state = "";
   }
 
+  function isSwitchEnabled(name) {
+    return Boolean(getEntity("switch", name)?.value);
+  }
+
   function clearOtaSimulation() {
     state.otaTimers.forEach((timer) => window.clearTimeout(timer));
     state.otaTimers = [];
@@ -627,7 +631,7 @@
         setBinary("HP2 - Bottom plate heater", true);
         setBinary("HP2 - Crankcase heater", true);
       }
-      syncOverviewTelemetry(single);
+      applyRuntimeControlOverlay(single);
       return;
     }
 
@@ -686,7 +690,7 @@
         setBinary("HP2 - Bottom plate heater", false);
         setBinary("HP2 - Crankcase heater", true);
       }
-      syncOverviewTelemetry(single);
+      applyRuntimeControlOverlay(single);
       return;
     }
 
@@ -743,7 +747,7 @@
       setBinary("HP2 - 4-Way valve", true);
       setBinary("HP2 - Bottom plate heater", true);
       setBinary("HP2 - Crankcase heater", true);
-      syncOverviewTelemetry(single);
+      applyRuntimeControlOverlay(single);
       return;
     }
 
@@ -807,7 +811,7 @@
         setBinary("HP2 - Bottom plate heater", false);
         setBinary("HP2 - Crankcase heater", true);
       }
-      syncOverviewTelemetry(single);
+      applyRuntimeControlOverlay(single);
       return;
     }
 
@@ -876,9 +880,69 @@
         setText("text_sensor", "HP2 - Working Mode Label", "Cooling");
         setBinary("HP2 - 4-Way valve", true);
       }
-      syncOverviewTelemetry(single);
+      applyRuntimeControlOverlay(single);
       return;
     }
+  }
+
+  function applyRuntimeControlOverlay(single) {
+    const openquattEnabled = isSwitchEnabled("OpenQuatt Enabled");
+    const manualCoolingEnabled = isSwitchEnabled("Manual Cooling Enable");
+    const manualSilentEnabled = isSwitchEnabled("Manual Silent Enable");
+
+    if (manualSilentEnabled) {
+      setBinary("Silent active", true);
+    }
+
+    if (manualCoolingEnabled) {
+      setBinary("Cooling Enable (Selected)", true);
+      if (!getEntity("text_sensor", "Cooling Block Reason")?.state || getEntity("text_sensor", "Cooling Block Reason")?.state === "Ready") {
+        setText("text_sensor", "Cooling Block Reason", state.scenario === "cooling" ? "Ready" : "Waiting for room request");
+      }
+    }
+
+    if (!openquattEnabled) {
+      setText("text_sensor", "Control Mode (Label)", "CM0 - Standby");
+      setBinary("Cooling Request Active", false);
+      setBinary("Cooling Permitted", false);
+      setText("text_sensor", "Cooling Block Reason", manualCoolingEnabled ? "OpenQuatt paused" : "Cooling disabled");
+      setText("text_sensor", "Flow Mode", "Paused");
+
+      setNumber("Total Power Input", single ? 5.2 : 10.3, "W");
+      setNumber("Heating Power Input", 0, "W");
+      setNumber("Cooling Power Input", 0, "W");
+      setNumber("Total Heat Power", 0, "W");
+      setNumber("Total Cooling Power", 0, "W");
+      setNumber("Total COP", 0, "");
+      setNumber("Total EER", 0, "");
+      setNumber("Flow average (Selected)", 0, "L/h");
+
+      setNumber("HP1 - Power Input", 5.2, "W");
+      setNumber("HP1 - Heat Power", 0, "W");
+      setNumber("HP1 - Cooling Power", 0, "W");
+      setNumber("HP1 - COP", 0, "");
+      setNumber("HP1 - Compressor frequency", 0, "Hz");
+      setNumber("HP1 - Fan speed", 0, "rpm");
+      setNumber("HP1 - Flow", 0, "L/h");
+      setText("text_sensor", "HP1 - Working Mode Label", "Standby");
+      setBinary("HP1 - Defrost", false);
+      setBinary("HP1 - 4-Way valve", false);
+
+      if (!single) {
+        setNumber("HP2 - Power Input", 5.1, "W");
+        setNumber("HP2 - Heat Power", 0, "W");
+        setNumber("HP2 - Cooling Power", 0, "W");
+        setNumber("HP2 - COP", 0, "");
+        setNumber("HP2 - Compressor frequency", 0, "Hz");
+        setNumber("HP2 - Fan speed", 0, "rpm");
+        setNumber("HP2 - Flow", 0, "L/h");
+        setText("text_sensor", "HP2 - Working Mode Label", "Standby");
+        setBinary("HP2 - Defrost", false);
+        setBinary("HP2 - 4-Way valve", false);
+      }
+    }
+
+    syncOverviewTelemetry(single);
   }
 
   function stepSimulation(force = false) {
@@ -954,6 +1018,7 @@
     }
     entity.value = Boolean(enabled);
     entity.state = Boolean(enabled);
+    applyScenario(state.scenario);
     updateSummary();
     notifyMockUpdated();
   }

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -261,7 +261,11 @@
     });
     setEntity("switch", "OpenQuatt Enabled", { value: true, state: true });
     setEntity("switch", "Manual Cooling Enable", { value: false, state: false });
-    setEntity("switch", "Manual Silent Enable", { value: false, state: false });
+    setEntity("select", "Silent Mode Override", {
+      value: "Schedule",
+      state: "Schedule",
+      option: ["Schedule", "On", "Off"],
+    });
     setEntity("select", "Flow Control Mode", {
       value: "Flow Setpoint",
       state: "Flow Setpoint",
@@ -888,10 +892,12 @@
   function applyRuntimeControlOverlay(single) {
     const openquattEnabled = isSwitchEnabled("OpenQuatt Enabled");
     const manualCoolingEnabled = isSwitchEnabled("Manual Cooling Enable");
-    const manualSilentEnabled = isSwitchEnabled("Manual Silent Enable");
+    const silentModeOverride = String(getEntity("select", "Silent Mode Override")?.value || "Schedule");
 
-    if (manualSilentEnabled) {
+    if (silentModeOverride === "On") {
       setBinary("Silent active", true);
+    } else if (silentModeOverride === "Off") {
+      setBinary("Silent active", false);
     }
 
     if (manualCoolingEnabled) {
@@ -992,7 +998,7 @@
         setNumber("Power House demand fall time", 2);
       }
     }
-    syncOverviewTelemetry(state.installation === "single");
+    applyScenario(state.scenario);
     updateSummary();
     notifyMockUpdated();
   }

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -897,7 +897,7 @@
     if (manualCoolingEnabled) {
       setBinary("Cooling Enable (Selected)", true);
       if (!getEntity("text_sensor", "Cooling Block Reason")?.state || getEntity("text_sensor", "Cooling Block Reason")?.state === "Ready") {
-        setText("text_sensor", "Cooling Block Reason", state.scenario === "cooling" ? "Ready" : "Waiting for room request");
+        setText("text_sensor", "Cooling Block Reason", state.scenario === "cooling" ? "Ready" : "Wacht op kamervraag");
       }
     }
 
@@ -905,8 +905,8 @@
       setText("text_sensor", "Control Mode (Label)", "CM0 - Standby");
       setBinary("Cooling Request Active", false);
       setBinary("Cooling Permitted", false);
-      setText("text_sensor", "Cooling Block Reason", manualCoolingEnabled ? "OpenQuatt paused" : "Cooling disabled");
-      setText("text_sensor", "Flow Mode", "Paused");
+      setText("text_sensor", "Cooling Block Reason", manualCoolingEnabled ? "OpenQuatt gepauzeerd" : "Koeling uitgeschakeld");
+      setText("text_sensor", "Flow Mode", "Gepauzeerd");
 
       setNumber("Total Power Input", single ? 5.2 : 10.3, "W");
       setNumber("Heating Power Input", 0, "W");

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -1,5 +1,5 @@
 (function () {
-  const DOMAINS = new Set(["select", "number", "sensor", "text_sensor", "binary_sensor", "button", "time", "update"]);
+  const DOMAINS = new Set(["select", "number", "sensor", "text_sensor", "binary_sensor", "button", "time", "update", "switch"]);
   const entities = new Map();
   const state = {
     scenario: "dual",
@@ -255,6 +255,9 @@
       state: "Power House",
       option: ["Power House", "Water Temperature Control (heating curve)"],
     });
+    setEntity("switch", "OpenQuatt Enabled", { value: true, state: true });
+    setEntity("switch", "Manual Cooling Enable", { value: false, state: false });
+    setEntity("switch", "Manual Silent Enable", { value: false, state: false });
     setEntity("select", "Flow Control Mode", {
       value: "Flow Setpoint",
       state: "Flow Setpoint",
@@ -944,6 +947,17 @@
     notifyMockUpdated();
   }
 
+  function handleSwitchSet(name, enabled) {
+    const entity = getEntity("switch", name);
+    if (!entity) {
+      return;
+    }
+    entity.value = Boolean(enabled);
+    entity.state = Boolean(enabled);
+    updateSummary();
+    notifyMockUpdated();
+  }
+
   function handleButtonPress(name) {
     if (name === "Complete setup") {
       state.complete = true;
@@ -1034,7 +1048,7 @@
     const url = new URL(String(typeof input === "string" ? input : input.url), window.location.href);
     const parts = url.pathname.split("/").filter(Boolean);
     const maybeAction = parts.at(-1);
-    const action = maybeAction === "set" || maybeAction === "press" || maybeAction === "install" ? parts.pop() : "";
+    const action = ["set", "press", "install", "turn_on", "turn_off"].includes(maybeAction) ? parts.pop() : "";
     const name = decodeURIComponent(parts.pop() || "");
     const domain = parts.pop() || "";
     if (!DOMAINS.has(domain)) {
@@ -1079,6 +1093,13 @@
           handleTimeSet(request.name, rawValue || "");
         }
         return mockResponse(200, entity);
+      }
+
+      if (request.action === "turn_on" || request.action === "turn_off") {
+        if (request.domain === "switch") {
+          handleSwitchSet(request.name, request.action === "turn_on");
+        }
+        return mockResponse(200, { ok: true });
       }
 
       if (request.action === "press") {

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -3015,6 +3015,11 @@ body.oq-page-light {
   border-color: rgba(249, 115, 22, 0.32);
 }
 
+.oq-overview-control-state--violet {
+  border-color: rgba(139, 92, 246, 0.30);
+  background: rgba(139, 92, 246, 0.08);
+}
+
 .oq-overview-control p {
   margin: 10px 0 16px;
   color: var(--oq-overview-soft);
@@ -3026,6 +3031,47 @@ body.oq-page-light {
 .oq-overview-control-actions {
   display: flex;
   justify-content: flex-start;
+}
+
+.oq-overview-control-segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.oq-overview-control-segment {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 36px;
+  padding: 0 14px;
+  border-radius: 999px;
+  border: 1px solid var(--oq-overview-chip-border);
+  background: var(--oq-overview-chip-bg);
+  color: var(--oq-overview-title);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 700;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, color 160ms ease;
+}
+
+.oq-overview-control-segment:hover {
+  transform: translateY(-1px);
+}
+
+.oq-overview-control-segment.is-selected {
+  border-color: rgba(37, 99, 235, 0.28);
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.oq-overview-control-segment:disabled,
+.oq-overview-control-segment.is-busy {
+  cursor: wait;
+  opacity: 0.75;
+  transform: none;
 }
 
 .oq-overview-control-toggle {
@@ -3075,6 +3121,10 @@ body.oq-page-light {
 
 .oq-overview-control--orange {
   box-shadow: inset 0 4px 0 0 rgba(249, 115, 22, 0.9);
+}
+
+.oq-overview-control--violet {
+  box-shadow: inset 0 4px 0 0 rgba(139, 92, 246, 0.9);
 }
 
 .oq-overview-stat {

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -2903,21 +2903,11 @@ body.oq-page-light {
 }
 
 .oq-overview-head {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: 16px;
+  display: grid;
+  gap: 12px;
 }
 
 .oq-overview-head > :first-child {
-  min-width: 0;
-}
-
-.oq-overview-head-actions {
-  display: grid;
-  justify-items: end;
-  align-content: start;
-  gap: 8px;
   min-width: 0;
 }
 
@@ -2940,9 +2930,9 @@ body.oq-page-light {
 
 .oq-overview-summary-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(340px, 380px);
+  grid-template-columns: minmax(0, 1fr) minmax(380px, 430px);
   gap: 16px;
-  margin-top: 16px;
+  margin-top: 12px;
   align-items: start;
 }
 
@@ -2952,205 +2942,453 @@ body.oq-page-light {
   min-width: 0;
 }
 
+.oq-overview-kpis {
+  display: grid;
+  gap: 8px;
+}
+
 .oq-overview-summary-side {
   display: grid;
   align-content: start;
   gap: 10px;
   min-width: 0;
+  padding-top: 0;
 }
 
 .oq-overview-top {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0;
-  border-radius: 20px;
-  background: var(--oq-overview-lane-bg);
-  border: 1px solid var(--oq-overview-panel-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
-  overflow: hidden;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 0;
+  align-items: stretch;
 }
 
-.oq-overview-controlstrip {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0;
-  border-radius: 20px;
-  background: var(--oq-overview-lane-bg);
-  border: 1px solid var(--oq-overview-panel-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
-  overflow: hidden;
-}
-
-.oq-overview-controlstrip--stacked {
-  grid-template-columns: 1fr;
-}
-
-.oq-overview-controlstrip-item {
-  position: relative;
-  display: grid;
-  gap: 7px;
-  align-content: start;
-  padding: 12px 14px 13px;
-  min-height: 92px;
-}
-
-.oq-overview-controlstrip-item + .oq-overview-controlstrip-item {
-  border-left: 1px solid var(--oq-overview-row-border);
-}
-
-.oq-overview-controlstrip--stacked .oq-overview-controlstrip-item + .oq-overview-controlstrip-item {
-  border-left: none;
-  border-top: 1px solid var(--oq-overview-row-border);
-}
-
-.oq-overview-controlstrip-item::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto auto 0;
-  width: 100%;
-  height: 4px;
-}
-
-.oq-overview-controlstrip-item--neutral::before {
-  background: rgba(148, 163, 184, 0.85);
-}
-
-.oq-overview-controlstrip-item--green::before {
-  background: rgba(34, 197, 94, 0.9);
-}
-
-.oq-overview-controlstrip-item--blue::before,
-.oq-overview-controlstrip-item--sky::before {
-  background: rgba(59, 130, 246, 0.9);
-}
-
-.oq-overview-controlstrip-item--orange::before {
-  background: rgba(249, 115, 22, 0.9);
-}
-
-.oq-overview-controlstrip-item--violet::before {
-  background: rgba(139, 92, 246, 0.9);
-}
-
-.oq-overview-controlstrip-head {
+.oq-overview-stat {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  flex-direction: column;
+  justify-content: flex-start;
+  padding: 12px 16px;
+  min-height: 0;
+  border-radius: 16px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025), 0 6px 14px rgba(2, 6, 23, 0.035);
 }
 
-.oq-overview-controlstrip-head span {
-  color: var(--oq-overview-muted);
-  font-size: 0.74rem;
+.oq-overview-stat p,
+.oq-overview-stat span {
+  margin: 0;
+}
+
+.oq-overview-stat p {
+  font-size: 0.72rem;
   font-weight: 700;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.oq-overview-controlstrip-state {
+.oq-overview-stat strong {
+  display: block;
+  margin-top: 6px;
+  color: var(--oq-overview-title);
+  font-size: clamp(1.18rem, 1.05vw, 1.55rem);
+  line-height: 1;
+}
+
+.oq-overview-stat span {
+  display: block;
+  margin-top: 5px;
+  color: var(--oq-overview-soft);
+  font-size: 0.78rem;
+}
+
+.oq-overview-stat--blue p {
+  color: #2563eb;
+}
+
+.oq-overview-stat--orange p {
+  color: #ea580c;
+}
+
+.oq-overview-stat--green p {
+  color: #16a34a;
+}
+
+.oq-overview-stat--sky p {
+  color: #0284c7;
+}
+
+.oq-overview-stat--status {
+  min-height: 0;
+}
+
+.oq-overview-stat--status strong {
+  font-size: 0.86rem;
+  line-height: 1.2;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.oq-overview-stat--status span {
+  font-size: 0.74rem;
+}
+
+.oq-overview-stat--system p {
+  color: var(--oq-overview-muted);
+}
+
+.oq-overview-sectionhead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 28px;
+}
+
+.oq-overview-sectionhead h3 {
+  margin: 0;
+  color: var(--oq-overview-title);
+  font-size: 0.92rem;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+}
+
+.oq-overview-statuspanel,
+.oq-overview-controlpanel-stack {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+}
+
+.oq-overview-statusgrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  align-items: stretch;
+}
+
+.oq-overview-statusmeta-card {
+  width: 100%;
+  max-width: none;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025), 0 3px 8px rgba(2, 6, 23, 0.025);
+}
+
+.oq-overview-statusmeta-item {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.oq-overview-statusmeta-item span {
+  color: var(--oq-overview-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-statusmeta-item strong {
+  color: var(--oq-overview-title);
+  font-size: 0.84rem;
+  line-height: 1.22;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.oq-overview-statuscard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 4px;
+  padding: 12px 14px;
+  min-height: 0;
+  border-radius: 14px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025), 0 3px 8px rgba(2, 6, 23, 0.025);
+}
+
+.oq-overview-statuscard--primary {
+  padding: 13px 15px;
+  min-height: 86px;
+}
+
+.oq-overview-statuscard--compact {
+  padding: 12px 14px;
+  min-height: 86px;
+}
+
+.oq-overview-statuscard::before {
+  content: "";
+  position: absolute;
+  left: 14px;
+  top: 14px;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+}
+
+.oq-overview-statuscard span {
+  padding-left: 15px;
+  color: var(--oq-overview-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-statuscard strong {
+  color: var(--oq-overview-title);
+  font-size: 0.9rem;
+  line-height: 1.22;
+  max-width: 30ch;
+}
+
+.oq-overview-statuscard--primary strong {
+  font-size: 1rem;
+  max-width: 18ch;
+}
+
+.oq-overview-statuscard--blue::before {
+  background: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.12);
+}
+
+.oq-overview-statuscard--orange::before {
+  background: #f97316;
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.12);
+}
+
+.oq-overview-statuscard--green::before {
+  background: #22c55e;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.12);
+}
+
+.oq-overview-statuscard--neutral::before {
+  background: #94a3b8;
+  box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.12);
+}
+
+.oq-overview-controlpanel {
+  display: grid;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025), 0 4px 10px rgba(2, 6, 23, 0.03);
+}
+
+.oq-overview-controlpanel p {
+  margin: 0;
+  color: var(--oq-overview-soft);
+  font-size: 0.83rem;
+  line-height: 1.38;
+}
+
+.oq-overview-controlpanel-meta-item,
+.oq-overview-controlpanel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.oq-overview-controlpanel-meta-item {
+  flex-direction: column;
+  align-items: flex-start;
+  flex: 1 1 120px;
+  min-width: 0;
+}
+
+.oq-overview-controlpanel-meta-item span,
+.oq-overview-controlpanel-head span {
+  color: #667085;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.oq-overview-controlpanel-head span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.oq-overview-controlpanel-head span::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #cbd5e1;
+  box-shadow: 0 0 0 4px rgba(203, 213, 225, 0.16);
+  flex: 0 0 auto;
+}
+
+.oq-overview-controlpanel-meta-item strong,
+.oq-overview-controlpanel-head strong {
+  color: var(--oq-overview-title);
+  font-size: 0.9rem;
+  line-height: 1.2;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.oq-overview-controlpanel-meta-item--blue strong {
+  color: #2563eb;
+}
+
+.oq-overview-controlpanel-meta-item--green strong {
+  color: #16a34a;
+}
+
+.oq-overview-controlpanel--green .oq-overview-controlpanel-head span {
+  color: #3f6f55;
+}
+
+.oq-overview-controlpanel--green .oq-overview-controlpanel-head span::before {
+  background: #22c55e;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.14);
+}
+
+.oq-overview-controlpanel--blue .oq-overview-controlpanel-head span,
+.oq-overview-controlpanel--sky .oq-overview-controlpanel-head span {
+  color: #46678e;
+}
+
+.oq-overview-controlpanel--blue .oq-overview-controlpanel-head span::before,
+.oq-overview-controlpanel--sky .oq-overview-controlpanel-head span::before {
+  background: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.14);
+}
+
+.oq-overview-controlpanel--orange .oq-overview-controlpanel-head span {
+  color: #9a5a35;
+}
+
+.oq-overview-controlpanel--orange .oq-overview-controlpanel-head span::before {
+  background: #f97316;
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.14);
+}
+
+.oq-overview-controlpanel--violet .oq-overview-controlpanel-head span {
+  color: #74638f;
+}
+
+.oq-overview-controlpanel--violet .oq-overview-controlpanel-head span::before {
+  background: #a855f7;
+  box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.14);
+}
+
+.oq-overview-controlpanel-state {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 30px;
-  padding: 0 11px;
+  min-height: 24px;
+  padding: 0 10px;
   border-radius: 999px;
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
   color: var(--oq-overview-title);
-  font-size: 0.82rem;
+  font-size: 0.76rem;
 }
 
-.oq-overview-controlstrip-state--green {
+.oq-overview-controlpanel-state--green {
   border-color: rgba(34, 197, 94, 0.34);
 }
 
-.oq-overview-controlstrip-state--blue,
-.oq-overview-controlstrip-state--sky {
+.oq-overview-controlpanel-state--blue,
+.oq-overview-controlpanel-state--sky {
   border-color: rgba(59, 130, 246, 0.28);
 }
 
-.oq-overview-controlstrip-state--orange {
+.oq-overview-controlpanel-state--orange {
   border-color: rgba(249, 115, 22, 0.32);
 }
 
-.oq-overview-controlstrip-state--violet {
-  border-color: rgba(139, 92, 246, 0.30);
+.oq-overview-controlpanel-state--violet {
+  border-color: rgba(139, 92, 246, 0.3);
   background: rgba(139, 92, 246, 0.08);
 }
 
-.oq-overview-controlstrip-item p {
-  margin: 0;
-  color: var(--oq-overview-soft);
-  font-size: 0.82rem;
-  line-height: 1.3;
-  max-width: 28ch;
-}
-
-.oq-overview-controlstrip-actions {
+.oq-overview-controlpanel-actions {
   display: flex;
-  justify-content: flex-start;
   align-items: center;
-  gap: 8px;
-  margin-top: auto;
+  gap: 10px;
 }
 
-.oq-overview-controlstrip-actions--split {
+.oq-overview-controlpanel-actions--split {
   justify-content: space-between;
 }
 
-.oq-overview-controlstrip-segmented {
+.oq-overview-controlpanel-segmented {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
-.oq-overview-controlstrip-segment,
-.oq-overview-controlstrip-toggle {
+.oq-overview-controlpanel-segment,
+.oq-overview-controlpanel-toggle {
   appearance: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 34px;
-  padding: 0 13px;
-  border-radius: 999px;
+  min-height: 40px;
+  padding: 0 15px;
+  border-radius: 13px;
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
   color: var(--oq-overview-title);
   cursor: pointer;
   font: inherit;
-  font-size: 0.86rem;
+  font-size: 0.85rem;
   font-weight: 700;
   transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, color 160ms ease;
 }
 
-.oq-overview-controlstrip-segment:hover,
-.oq-overview-controlstrip-toggle:hover,
-.oq-overview-controlstrip-icon:hover {
+.oq-overview-controlpanel-segment:hover,
+.oq-overview-controlpanel-toggle:hover,
+.oq-overview-controlpanel-icon:hover {
   transform: translateY(-1px);
 }
 
-.oq-overview-controlstrip-segment.is-selected {
+.oq-overview-controlpanel-segment.is-selected {
   border-color: rgba(37, 99, 235, 0.28);
   background: rgba(37, 99, 235, 0.12);
 }
 
-.oq-overview-controlstrip-segment:disabled,
-.oq-overview-controlstrip-segment.is-busy,
-.oq-overview-controlstrip-toggle:disabled,
-.oq-overview-controlstrip-toggle.is-busy {
+.oq-overview-controlpanel-segment:disabled,
+.oq-overview-controlpanel-segment.is-busy,
+.oq-overview-controlpanel-toggle:disabled,
+.oq-overview-controlpanel-toggle.is-busy {
   cursor: wait;
   opacity: 0.75;
   transform: none;
 }
 
-.oq-overview-controlstrip-icon {
+.oq-overview-controlpanel-toggle {
+  min-width: 160px;
+}
+
+.oq-overview-controlpanel-actions:not(.oq-overview-controlpanel-actions--split) .oq-overview-controlpanel-toggle {
+  width: 100%;
+}
+
+.oq-overview-controlpanel-icon {
   appearance: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  width: 42px;
+  height: 42px;
   border-radius: 999px;
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
@@ -3162,62 +3400,9 @@ body.oq-page-light {
   transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
 }
 
-.oq-overview-controlstrip-icon:hover {
+.oq-overview-controlpanel-icon:hover {
   border-color: rgba(37, 99, 235, 0.28);
   background: rgba(37, 99, 235, 0.08);
-}
-
-.oq-overview-stat {
-  padding: 14px 18px 16px;
-  background: transparent;
-  min-height: 120px;
-}
-
-.oq-overview-stat + .oq-overview-stat {
-  border-left: 1px solid var(--oq-overview-row-border);
-}
-
-.oq-overview-stat p,
-.oq-overview-stat span {
-  margin: 0;
-  color: var(--oq-overview-muted);
-}
-
-.oq-overview-stat p {
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.oq-overview-stat strong {
-  display: block;
-  margin-top: 8px;
-  color: var(--oq-overview-title);
-  font-size: clamp(1.32rem, 1.58vw, 1.88rem);
-  line-height: 1;
-}
-
-.oq-overview-stat span {
-  display: block;
-  margin-top: 6px;
-  font-size: 0.88rem;
-}
-
-.oq-overview-stat--blue {
-  box-shadow: inset 0 6px 0 0 rgba(59, 130, 246, 0.9);
-}
-
-.oq-overview-stat--green {
-  box-shadow: inset 0 6px 0 0 rgba(34, 197, 94, 0.9);
-}
-
-.oq-overview-stat--orange {
-  box-shadow: inset 0 6px 0 0 rgba(249, 115, 22, 0.9);
-}
-
-.oq-overview-stat--sky {
-  box-shadow: inset 0 6px 0 0 rgba(56, 189, 248, 0.9);
 }
 
 .oq-overview-main {
@@ -3235,13 +3420,6 @@ body.oq-page-light {
   background: var(--oq-overview-panel-bg);
   border: 1px solid var(--oq-overview-panel-border);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035), 0 14px 30px rgba(2, 6, 23, 0.08);
-}
-
-.oq-overview-status {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
 }
 
 .oq-overview-chip {
@@ -3277,82 +3455,6 @@ body.oq-page-light {
   border-color: rgba(249, 115, 22, 0.32);
   background: rgba(249, 115, 22, 0.1);
   color: var(--oq-overview-title);
-}
-
-.oq-overview-signals {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0;
-  border-radius: 18px;
-  background: var(--oq-overview-lane-bg);
-  border: 1px solid var(--oq-overview-panel-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
-  overflow: hidden;
-}
-
-.oq-overview-signal {
-  position: relative;
-  padding: 12px 16px 13px;
-  min-width: 0;
-}
-
-.oq-overview-signal + .oq-overview-signal {
-  border-left: 1px solid var(--oq-overview-row-border);
-}
-
-.oq-overview-signal::before {
-  content: "";
-  position: absolute;
-  left: 20px;
-  top: 18px;
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: #60a5fa;
-  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.12);
-}
-
-.oq-overview-signal span {
-  display: block;
-  padding-left: 18px;
-  color: var(--oq-overview-muted);
-  font-size: 0.76rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.oq-overview-signal strong {
-  display: block;
-  margin-top: 4px;
-  color: var(--oq-overview-title);
-  font-size: 0.95rem;
-  line-height: 1.25;
-}
-
-.oq-overview-signal--blue::before {
-  background: linear-gradient(180deg, #1d4ed8, #60a5fa);
-  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.12);
-}
-
-.oq-overview-signal--green::before {
-  background: linear-gradient(180deg, #16a34a, #4ade80);
-  box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.12);
-}
-
-.oq-overview-signal--neutral::before {
-  background: linear-gradient(180deg, #94a3b8, #cbd5e1);
-  box-shadow: 0 0 0 4px rgba(203, 213, 225, 0.08);
-}
-
-.oq-overview-signal--orange::before {
-  background: linear-gradient(180deg, #f59e0b, #ef4444);
-  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.12);
-}
-
-.oq-overview-signal--sky::before {
-  background: linear-gradient(180deg, #0ea5e9, #67e8f9);
-  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.12);
 }
 
 .oq-overview-home-demand {
@@ -5437,7 +5539,6 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     grid-template-columns: 1fr;
   }
 
-  .oq-overview-controlstrip,
   .oq-overview-top,
   .oq-overview-main,
   .oq-overview-hp-grid,
@@ -5446,13 +5547,16 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     grid-template-columns: 1fr;
   }
 
+  .oq-overview-statusgrid {
+    grid-template-columns: 1fr;
+  }
+
   .oq-overview-summary-layout {
     grid-template-columns: 1fr;
   }
 
   .oq-overview-head {
-    flex-direction: column;
-    align-items: stretch;
+    gap: 10px;
   }
 
   .oq-overview-hp {
@@ -5477,14 +5581,16 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     grid-template-columns: 1fr;
   }
 
-  .oq-overview-signals,
   .oq-overview-energy-grid {
     grid-template-columns: 1fr;
   }
 
-  .oq-overview-signal + .oq-overview-signal {
-    border-left: none;
-    border-top: 1px solid var(--oq-overview-row-border);
+  .oq-overview-statusmeta {
+    grid-template-columns: 1fr;
+  }
+
+  .oq-overview-statuscards {
+    grid-template-columns: 1fr;
   }
 
   .oq-overview-metrics--two-column,
@@ -5526,21 +5632,6 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-hp-schematic-footer-grid {
     grid-template-columns: 1fr;
-  }
-
-  .oq-overview-head-actions {
-    justify-items: stretch;
-    min-width: 0;
-  }
-
-  .oq-overview-controlstrip-item + .oq-overview-controlstrip-item {
-    border-left: none;
-    border-top: 1px solid var(--oq-overview-row-border);
-  }
-
-  .oq-overview-stat + .oq-overview-stat {
-    border-left: none;
-    border-top: 1px solid var(--oq-overview-row-border);
   }
 
   .oq-overview-energy {
@@ -5815,10 +5906,6 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-overview-energy-row strong {
     text-align: left;
-  }
-
-  .oq-overview-signal {
-    padding: 16px;
   }
 
   .oq-overview-top {

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -777,6 +777,10 @@ body.oq-page-light {
   padding: 22px;
 }
 
+.oq-helper-modal--wide {
+  width: min(100%, 1120px);
+}
+
 .oq-helper-shell--dark .oq-helper-modal,
 .oq-helper-modal-backdrop--dark .oq-helper-modal {
   border-color: rgba(71, 85, 105, 0.5);
@@ -1015,6 +1019,10 @@ body.oq-page-light {
   flex-wrap: wrap;
   gap: 10px;
   margin-top: 18px;
+}
+
+.oq-helper-modal-body {
+  min-width: 0;
 }
 
 .oq-helper-modal-link {
@@ -2886,17 +2894,31 @@ body.oq-page-light {
   border-color: #dbe3ee;
 }
 
+.oq-overview-summary-shell {
+  padding: 16px;
+  border-radius: 26px;
+  background: var(--oq-overview-panel-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035), 0 12px 24px rgba(2, 6, 23, 0.07);
+}
+
 .oq-overview-head {
   display: flex;
+  align-items: start;
   justify-content: space-between;
-  gap: 18px;
-  align-items: flex-start;
+  gap: 16px;
+}
+
+.oq-overview-head > :first-child {
+  min-width: 0;
 }
 
 .oq-overview-head-actions {
   display: grid;
-  gap: 12px;
   justify-items: end;
+  align-content: start;
+  gap: 8px;
+  min-width: 0;
 }
 
 .oq-overview-theme-toggle {
@@ -2916,223 +2938,243 @@ body.oq-page-light {
   color: var(--oq-overview-soft);
 }
 
+.oq-overview-summary-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(340px, 380px);
+  gap: 16px;
+  margin-top: 16px;
+  align-items: start;
+}
+
+.oq-overview-summary-main {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.oq-overview-summary-side {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  min-width: 0;
+}
+
 .oq-overview-top {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 18px;
-}
-
-.oq-overview-controls {
-  display: block;
-  margin-top: 14px;
-  padding: 18px;
-  border-radius: 22px;
-  background: var(--oq-overview-panel-bg);
+  gap: 0;
+  border-radius: 20px;
+  background: var(--oq-overview-lane-bg);
   border: 1px solid var(--oq-overview-panel-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 12px 26px rgba(2, 6, 23, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+  overflow: hidden;
 }
 
-.oq-overview-controls-head {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.oq-overview-controls-copy h3 {
-  margin: 0;
-  color: var(--oq-overview-title);
-  font-size: 1.05rem;
-}
-
-.oq-overview-controls-copy p {
-  margin: 6px 0 0;
-  color: var(--oq-overview-soft);
-  line-height: 1.5;
-  font-size: 0.94rem;
-}
-
-.oq-overview-controls-grid {
+.oq-overview-controlstrip {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 14px;
+  gap: 0;
+  border-radius: 20px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+  overflow: hidden;
 }
 
-.oq-overview-control {
-  padding: 16px;
-  border-radius: 18px;
-  background: var(--oq-overview-surface);
-  border: 1px solid var(--oq-overview-surface-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
-  min-height: 160px;
-  display: flex;
-  flex-direction: column;
+.oq-overview-controlstrip--stacked {
+  grid-template-columns: 1fr;
 }
 
-.oq-overview-control-head {
+.oq-overview-controlstrip-item {
+  position: relative;
+  display: grid;
+  gap: 7px;
+  align-content: start;
+  padding: 12px 14px 13px;
+  min-height: 92px;
+}
+
+.oq-overview-controlstrip-item + .oq-overview-controlstrip-item {
+  border-left: 1px solid var(--oq-overview-row-border);
+}
+
+.oq-overview-controlstrip--stacked .oq-overview-controlstrip-item + .oq-overview-controlstrip-item {
+  border-left: none;
+  border-top: 1px solid var(--oq-overview-row-border);
+}
+
+.oq-overview-controlstrip-item::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 4px;
+}
+
+.oq-overview-controlstrip-item--neutral::before {
+  background: rgba(148, 163, 184, 0.85);
+}
+
+.oq-overview-controlstrip-item--green::before {
+  background: rgba(34, 197, 94, 0.9);
+}
+
+.oq-overview-controlstrip-item--blue::before,
+.oq-overview-controlstrip-item--sky::before {
+  background: rgba(59, 130, 246, 0.9);
+}
+
+.oq-overview-controlstrip-item--orange::before {
+  background: rgba(249, 115, 22, 0.9);
+}
+
+.oq-overview-controlstrip-item--violet::before {
+  background: rgba(139, 92, 246, 0.9);
+}
+
+.oq-overview-controlstrip-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
 }
 
-.oq-overview-control-head span {
+.oq-overview-controlstrip-head span {
   color: var(--oq-overview-muted);
-  font-size: 0.76rem;
+  font-size: 0.74rem;
   font-weight: 700;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
 }
 
-.oq-overview-control-head strong {
-  color: var(--oq-overview-title);
-  font-size: 0.86rem;
-}
-
-.oq-overview-control-state {
+.oq-overview-controlstrip-state {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 28px;
-  padding: 0 10px;
+  min-height: 30px;
+  padding: 0 11px;
   border-radius: 999px;
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
+  color: var(--oq-overview-title);
+  font-size: 0.82rem;
 }
 
-.oq-overview-control-state--green {
+.oq-overview-controlstrip-state--green {
   border-color: rgba(34, 197, 94, 0.34);
 }
 
-.oq-overview-control-state--blue,
-.oq-overview-control-state--sky {
+.oq-overview-controlstrip-state--blue,
+.oq-overview-controlstrip-state--sky {
   border-color: rgba(59, 130, 246, 0.28);
 }
 
-.oq-overview-control-state--orange {
+.oq-overview-controlstrip-state--orange {
   border-color: rgba(249, 115, 22, 0.32);
 }
 
-.oq-overview-control-state--violet {
+.oq-overview-controlstrip-state--violet {
   border-color: rgba(139, 92, 246, 0.30);
   background: rgba(139, 92, 246, 0.08);
 }
 
-.oq-overview-control p {
-  margin: 10px 0 16px;
+.oq-overview-controlstrip-item p {
+  margin: 0;
   color: var(--oq-overview-soft);
-  font-size: 0.92rem;
-  line-height: 1.45;
-  flex: 1;
+  font-size: 0.82rem;
+  line-height: 1.3;
+  max-width: 28ch;
 }
 
-.oq-overview-control-actions {
+.oq-overview-controlstrip-actions {
   display: flex;
   justify-content: flex-start;
-}
-
-.oq-overview-control-segmented {
-  display: inline-flex;
   align-items: center;
   gap: 8px;
+  margin-top: auto;
+}
+
+.oq-overview-controlstrip-actions--split {
+  justify-content: space-between;
+}
+
+.oq-overview-controlstrip-segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
-.oq-overview-control-segment {
+.oq-overview-controlstrip-segment,
+.oq-overview-controlstrip-toggle {
   appearance: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 36px;
-  padding: 0 14px;
+  min-height: 34px;
+  padding: 0 13px;
   border-radius: 999px;
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
   color: var(--oq-overview-title);
   cursor: pointer;
   font: inherit;
-  font-size: 0.88rem;
+  font-size: 0.86rem;
   font-weight: 700;
   transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, color 160ms ease;
 }
 
-.oq-overview-control-segment:hover {
+.oq-overview-controlstrip-segment:hover,
+.oq-overview-controlstrip-toggle:hover,
+.oq-overview-controlstrip-icon:hover {
   transform: translateY(-1px);
 }
 
-.oq-overview-control-segment.is-selected {
+.oq-overview-controlstrip-segment.is-selected {
   border-color: rgba(37, 99, 235, 0.28);
   background: rgba(37, 99, 235, 0.12);
 }
 
-.oq-overview-control-segment:disabled,
-.oq-overview-control-segment.is-busy {
+.oq-overview-controlstrip-segment:disabled,
+.oq-overview-controlstrip-segment.is-busy,
+.oq-overview-controlstrip-toggle:disabled,
+.oq-overview-controlstrip-toggle.is-busy {
   cursor: wait;
   opacity: 0.75;
   transform: none;
 }
 
-.oq-overview-control-toggle {
+.oq-overview-controlstrip-icon {
   appearance: none;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 36px;
-  padding: 0 14px;
+  width: 34px;
+  height: 34px;
   border-radius: 999px;
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
   color: var(--oq-overview-title);
   cursor: pointer;
   font: inherit;
-  font-size: 0.88rem;
-  font-weight: 700;
+  font-size: 0.95rem;
+  line-height: 1;
   transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
 }
 
-.oq-overview-control-toggle:hover {
-  transform: translateY(-1px);
-}
-
-.oq-overview-control-toggle:disabled,
-.oq-overview-control-toggle.is-busy {
-  cursor: wait;
-  opacity: 0.75;
-  transform: none;
-}
-
-.oq-overview-control--neutral {
-  box-shadow: inset 0 4px 0 0 rgba(148, 163, 184, 0.85);
-}
-
-.oq-overview-control--green {
-  box-shadow: inset 0 4px 0 0 rgba(34, 197, 94, 0.9);
-}
-
-.oq-overview-control--blue {
-  box-shadow: inset 0 4px 0 0 rgba(59, 130, 246, 0.9);
-}
-
-.oq-overview-control--sky {
-  box-shadow: inset 0 4px 0 0 rgba(14, 165, 233, 0.9);
-}
-
-.oq-overview-control--orange {
-  box-shadow: inset 0 4px 0 0 rgba(249, 115, 22, 0.9);
-}
-
-.oq-overview-control--violet {
-  box-shadow: inset 0 4px 0 0 rgba(139, 92, 246, 0.9);
+.oq-overview-controlstrip-icon:hover {
+  border-color: rgba(37, 99, 235, 0.28);
+  background: rgba(37, 99, 235, 0.08);
 }
 
 .oq-overview-stat {
-  padding: 16px 18px;
-  border-radius: 18px;
-  background: var(--oq-overview-surface);
-  border: 1px solid var(--oq-overview-surface-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 10px 24px rgba(2, 6, 23, 0.08);
+  padding: 14px 18px 16px;
+  background: transparent;
+  min-height: 120px;
+}
+
+.oq-overview-stat + .oq-overview-stat {
+  border-left: 1px solid var(--oq-overview-row-border);
 }
 
 .oq-overview-stat p,
@@ -3152,7 +3194,7 @@ body.oq-page-light {
   display: block;
   margin-top: 8px;
   color: var(--oq-overview-title);
-  font-size: clamp(1.35rem, 1.7vw, 1.95rem);
+  font-size: clamp(1.32rem, 1.58vw, 1.88rem);
   line-height: 1;
 }
 
@@ -3211,7 +3253,7 @@ body.oq-page-light {
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
   color: var(--oq-overview-chip-ink);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
 }
 
 .oq-overview-chip strong {
@@ -3241,7 +3283,6 @@ body.oq-page-light {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0;
-  margin-top: 14px;
   border-radius: 18px;
   background: var(--oq-overview-lane-bg);
   border: 1px solid var(--oq-overview-panel-border);
@@ -5285,7 +5326,6 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
 @media (max-width: 860px) {
   .oq-helper-head,
-  .oq-overview-head,
   .oq-native-surface-head {
     grid-template-columns: 1fr;
   }
@@ -5397,12 +5437,22 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     grid-template-columns: 1fr;
   }
 
+  .oq-overview-controlstrip,
   .oq-overview-top,
   .oq-overview-main,
   .oq-overview-hp-grid,
   .oq-overview-hp-stats,
   .oq-overview-hp-meta {
     grid-template-columns: 1fr;
+  }
+
+  .oq-overview-summary-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .oq-overview-head {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .oq-overview-hp {
@@ -5421,17 +5471,6 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-overview-home-demand {
     grid-template-columns: 1fr;
-  }
-
-  .oq-overview-hero {
-    grid-template-columns: 1fr;
-  }
-
-  .oq-overview-hero-side {
-    padding-left: 0;
-    padding-top: 12px;
-    border-left: none;
-    border-top: 1px solid var(--oq-overview-row-border);
   }
 
   .oq-overview-lanes--two-column {
@@ -5489,12 +5528,19 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     grid-template-columns: 1fr;
   }
 
-  .oq-overview-status {
-    justify-content: flex-start;
-  }
-
   .oq-overview-head-actions {
     justify-items: stretch;
+    min-width: 0;
+  }
+
+  .oq-overview-controlstrip-item + .oq-overview-controlstrip-item {
+    border-left: none;
+    border-top: 1px solid var(--oq-overview-row-border);
+  }
+
+  .oq-overview-stat + .oq-overview-stat {
+    border-left: none;
+    border-top: 1px solid var(--oq-overview-row-border);
   }
 
   .oq-overview-energy {
@@ -5562,6 +5608,11 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   .oq-helper-card,
   .oq-helper-panel {
     padding: 10px;
+  }
+
+  .oq-overview-summary-shell {
+    padding: 12px;
+    border-radius: 22px;
   }
 
   .oq-helper-head {
@@ -5773,22 +5824,6 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   .oq-overview-top {
     gap: 10px;
     margin-top: 14px;
-  }
-
-  .oq-overview-controls {
-    padding: 16px;
-  }
-
-  .oq-overview-controls-head {
-    align-items: flex-start;
-  }
-
-  .oq-overview-controls-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .oq-overview-control {
-    min-height: 0;
   }
 
   .oq-overview-hp-tools {

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -2924,15 +2924,20 @@ body.oq-page-light {
 }
 
 .oq-overview-controls {
-  display: grid;
-  grid-template-columns: minmax(220px, 0.42fr) minmax(0, 1fr);
-  gap: 14px;
+  display: block;
   margin-top: 14px;
   padding: 18px;
   border-radius: 22px;
   background: var(--oq-overview-panel-bg);
   border: 1px solid var(--oq-overview-panel-border);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 12px 26px rgba(2, 6, 23, 0.08);
+}
+
+.oq-overview-controls-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .oq-overview-controls-copy h3 {
@@ -2942,15 +2947,17 @@ body.oq-page-light {
 }
 
 .oq-overview-controls-copy p {
-  margin: 8px 0 0;
+  margin: 6px 0 0;
   color: var(--oq-overview-soft);
   line-height: 1.5;
+  font-size: 0.94rem;
 }
 
 .oq-overview-controls-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
+  margin-top: 14px;
 }
 
 .oq-overview-control {
@@ -2959,11 +2966,14 @@ body.oq-page-light {
   background: var(--oq-overview-surface);
   border: 1px solid var(--oq-overview-surface-border);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
 }
 
 .oq-overview-control-head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 10px;
 }
@@ -2978,14 +2988,44 @@ body.oq-page-light {
 
 .oq-overview-control-head strong {
   color: var(--oq-overview-title);
-  font-size: 1rem;
+  font-size: 0.86rem;
+}
+
+.oq-overview-control-state {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid var(--oq-overview-chip-border);
+  background: var(--oq-overview-chip-bg);
+}
+
+.oq-overview-control-state--green {
+  border-color: rgba(34, 197, 94, 0.34);
+}
+
+.oq-overview-control-state--blue,
+.oq-overview-control-state--sky {
+  border-color: rgba(59, 130, 246, 0.28);
+}
+
+.oq-overview-control-state--orange {
+  border-color: rgba(249, 115, 22, 0.32);
 }
 
 .oq-overview-control p {
-  margin: 10px 0 14px;
+  margin: 10px 0 16px;
   color: var(--oq-overview-soft);
   font-size: 0.92rem;
   line-height: 1.45;
+  flex: 1;
+}
+
+.oq-overview-control-actions {
+  display: flex;
+  justify-content: flex-start;
 }
 
 .oq-overview-control-toggle {
@@ -2993,7 +3033,7 @@ body.oq-page-light {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 38px;
+  min-height: 36px;
   padding: 0 14px;
   border-radius: 999px;
   border: 1px solid var(--oq-overview-chip-border);
@@ -5686,12 +5726,19 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   }
 
   .oq-overview-controls {
-    grid-template-columns: 1fr;
     padding: 16px;
+  }
+
+  .oq-overview-controls-head {
+    align-items: flex-start;
   }
 
   .oq-overview-controls-grid {
     grid-template-columns: 1fr;
+  }
+
+  .oq-overview-control {
+    min-height: 0;
   }
 
   .oq-overview-hp-tools {

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -2923,6 +2923,120 @@ body.oq-page-light {
   margin-top: 18px;
 }
 
+.oq-overview-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.42fr) minmax(0, 1fr);
+  gap: 14px;
+  margin-top: 14px;
+  padding: 18px;
+  border-radius: 22px;
+  background: var(--oq-overview-panel-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 12px 26px rgba(2, 6, 23, 0.08);
+}
+
+.oq-overview-controls-copy h3 {
+  margin: 0;
+  color: var(--oq-overview-title);
+  font-size: 1.05rem;
+}
+
+.oq-overview-controls-copy p {
+  margin: 8px 0 0;
+  color: var(--oq-overview-soft);
+  line-height: 1.5;
+}
+
+.oq-overview-controls-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.oq-overview-control {
+  padding: 16px;
+  border-radius: 18px;
+  background: var(--oq-overview-surface);
+  border: 1px solid var(--oq-overview-surface-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+.oq-overview-control-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.oq-overview-control-head span {
+  color: var(--oq-overview-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.oq-overview-control-head strong {
+  color: var(--oq-overview-title);
+  font-size: 1rem;
+}
+
+.oq-overview-control p {
+  margin: 10px 0 14px;
+  color: var(--oq-overview-soft);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.oq-overview-control-toggle {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 999px;
+  border: 1px solid var(--oq-overview-chip-border);
+  background: var(--oq-overview-chip-bg);
+  color: var(--oq-overview-title);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 700;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.oq-overview-control-toggle:hover {
+  transform: translateY(-1px);
+}
+
+.oq-overview-control-toggle:disabled,
+.oq-overview-control-toggle.is-busy {
+  cursor: wait;
+  opacity: 0.75;
+  transform: none;
+}
+
+.oq-overview-control--neutral {
+  box-shadow: inset 0 4px 0 0 rgba(148, 163, 184, 0.85);
+}
+
+.oq-overview-control--green {
+  box-shadow: inset 0 4px 0 0 rgba(34, 197, 94, 0.9);
+}
+
+.oq-overview-control--blue {
+  box-shadow: inset 0 4px 0 0 rgba(59, 130, 246, 0.9);
+}
+
+.oq-overview-control--sky {
+  box-shadow: inset 0 4px 0 0 rgba(14, 165, 233, 0.9);
+}
+
+.oq-overview-control--orange {
+  box-shadow: inset 0 4px 0 0 rgba(249, 115, 22, 0.9);
+}
+
 .oq-overview-stat {
   padding: 16px 18px;
   border-radius: 18px;
@@ -5569,6 +5683,15 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   .oq-overview-top {
     gap: 10px;
     margin-top: 14px;
+  }
+
+  .oq-overview-controls {
+    grid-template-columns: 1fr;
+    padding: 16px;
+  }
+
+  .oq-overview-controls-grid {
+    grid-template-columns: 1fr;
   }
 
   .oq-overview-hp-tools {

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -363,6 +363,9 @@
   ];
   const OVERVIEW_KEYS = [
     "strategy",
+    "openquattEnabled",
+    "manualCoolingEnable",
+    "manualSilentEnable",
     "coolingEnableSelected",
     "coolingRequestActive",
     "coolingPermitted",
@@ -467,6 +470,9 @@
   ];
   const SETTINGS_KEYS = [
     "strategy",
+    "openquattEnabled",
+    "manualCoolingEnable",
+    "manualSilentEnable",
     ...FLOW_SETTING_KEYS,
     ...COOLING_SETTING_KEYS,
     ...LIMIT_KEYS,
@@ -2808,8 +2814,20 @@
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
+      state.entities[key] = {
+        ...(state.entities[key] || {}),
+        value: enabled,
+        state: enabled,
+      };
       state.controlNotice = `${entity.name} ${enabled ? "ingeschakeld" : "uitgeschakeld"}.`;
-      await syncEntities();
+      state.busyAction = "";
+      if (state.appView === "overview") {
+        await refreshEntities([...OVERVIEW_KEYS, ...HEADER_ENTITY_KEYS, "setupComplete", ...FIRMWARE_ENTITY_KEYS], "state");
+      } else if (state.appView === "settings") {
+        await refreshEntities(getSettingsRefreshKeys(), "state");
+      } else {
+        await refreshEntities(["setupComplete", "strategy", "openquattEnabled", "manualCoolingEnable", "manualSilentEnable", ...FLOW_SETTING_KEYS, ...LIMIT_KEYS], "state");
+      }
       render();
     } catch (error) {
       state.controlError = `${entity.name} aanpassen mislukt (${error.message}).`;

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -107,7 +107,7 @@
     strategy: { domain: "select", name: "Heating Control Mode" },
     openquattEnabled: { domain: "switch", name: "OpenQuatt Enabled", optional: true },
     manualCoolingEnable: { domain: "switch", name: "Manual Cooling Enable", optional: true },
-    manualSilentEnable: { domain: "switch", name: "Manual Silent Enable", optional: true },
+    silentModeOverride: { domain: "select", name: "Silent Mode Override", optional: true },
     coolingEnableSelected: { domain: "binary_sensor", name: "Cooling Enable (Selected)", optional: true },
     coolingRequestActive: { domain: "binary_sensor", name: "Cooling Request Active", optional: true },
     coolingPermitted: { domain: "binary_sensor", name: "Cooling Permitted", optional: true },
@@ -365,7 +365,7 @@
     "strategy",
     "openquattEnabled",
     "manualCoolingEnable",
-    "manualSilentEnable",
+    "silentModeOverride",
     "coolingEnableSelected",
     "coolingRequestActive",
     "coolingPermitted",
@@ -472,7 +472,7 @@
     "strategy",
     "openquattEnabled",
     "manualCoolingEnable",
-    "manualSilentEnable",
+    "silentModeOverride",
     ...FLOW_SETTING_KEYS,
     ...COOLING_SETTING_KEYS,
     ...LIMIT_KEYS,
@@ -2698,6 +2698,15 @@
       return;
     }
 
+    if (action === "select-overview-control-option") {
+      const key = button.dataset.controlKey || "";
+      const option = button.dataset.controlOption || "";
+      if (key && option && String(getEntityValue(key) || "") !== option) {
+        commitSelect(key, option);
+      }
+      return;
+    }
+
     if (action === "suggest-curve-fallback") {
       const suggestion = getCurveFallbackSuggestion();
       if (suggestion) {
@@ -2784,7 +2793,7 @@
       } else if (state.appView === "settings") {
         await refreshEntities(getSettingsRefreshKeys(), "state");
       } else {
-        await refreshEntities(["setupComplete", "strategy", ...FLOW_SETTING_KEYS, ...LIMIT_KEYS], "state");
+        await refreshEntities(["setupComplete", "strategy", "openquattEnabled", "manualCoolingEnable", "silentModeOverride", ...FLOW_SETTING_KEYS, ...LIMIT_KEYS], "state");
       }
       if (key === "strategy" && state.appView !== "settings") {
         await refreshEntities(isCurveMode(option) ? CURVE_POINTS.map((point) => point.key) : POWER_HOUSE_KEYS, "state");
@@ -2826,7 +2835,7 @@
       } else if (state.appView === "settings") {
         await refreshEntities(getSettingsRefreshKeys(), "state");
       } else {
-        await refreshEntities(["setupComplete", "strategy", "openquattEnabled", "manualCoolingEnable", "manualSilentEnable", ...FLOW_SETTING_KEYS, ...LIMIT_KEYS], "state");
+        await refreshEntities(["setupComplete", "strategy", "openquattEnabled", "manualCoolingEnable", "silentModeOverride", ...FLOW_SETTING_KEYS, ...LIMIT_KEYS], "state");
       }
       render();
     } catch (error) {
@@ -5212,7 +5221,7 @@
   function getOverviewControlCards() {
     const openquattEnabled = isEntityActive("openquattEnabled");
     const manualCoolingEnabled = isEntityActive("manualCoolingEnable");
-    const manualSilentEnabled = isEntityActive("manualSilentEnable");
+    const silentModeOverride = String(getEntityValue("silentModeOverride") || "Schedule");
     const coolingBlocked = !isEntityActive("coolingPermitted");
     const coolingRequestActive = isEntityActive("coolingRequestActive");
     const coolingModeActive = getEntityStateText("controlModeLabel", "").toLowerCase().includes("cm5");
@@ -5235,12 +5244,19 @@
 
     let silentStatus = "Uit";
     let silentCopy = "Stille modus staat uit.";
-    if (manualSilentEnabled) {
+    let silentTone = "neutral";
+    if (silentModeOverride === "On") {
       silentStatus = "Aan";
-      silentCopy = "Stille modus staat aan, ook buiten het tijdvenster.";
-    } else if (isEntityActive("silentActive")) {
-      silentStatus = "Actief";
-      silentCopy = "Stille modus staat nu aan via het tijdvenster.";
+      silentCopy = "Stille modus staat geforceerd aan, ook buiten het tijdvenster.";
+      silentTone = "orange";
+    } else if (silentModeOverride === "Schedule") {
+      silentStatus = "Schema";
+      if (isEntityActive("silentActive")) {
+        silentCopy = "Stille modus staat nu aan via het tijdvenster.";
+        silentTone = "violet";
+      } else {
+        silentCopy = "Stille modus volgt het tijdvenster.";
+      }
     }
 
     return [
@@ -5265,13 +5281,18 @@
         tone: manualCoolingEnabled ? (coolingModeActive ? "blue" : "sky") : "neutral",
       },
       {
-        key: "manualSilentEnable",
+        key: "silentModeOverride",
         label: "Stille modus",
         status: silentStatus,
         copy: silentCopy,
-        buttonLabel: manualSilentEnabled ? "Zet uit" : "Zet aan",
-        nextState: manualSilentEnabled ? "off" : "on",
-        tone: manualSilentEnabled ? "orange" : "neutral",
+        tone: silentTone,
+        kind: "select",
+        selectedOption: silentModeOverride,
+        options: [
+          { value: "Off", label: "Uit" },
+          { value: "On", label: "Aan" },
+          { value: "Schedule", label: "Schema" },
+        ],
       },
     ].filter((card) => hasEntity(card.key));
   }
@@ -5298,14 +5319,28 @@
               </div>
               <p>${escapeHtml(card.copy)}</p>
               <div class="oq-overview-control-actions">
-                <button
-                  class="oq-overview-control-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
-                  type="button"
-                  data-oq-action="toggle-overview-control"
-                  data-control-key="${escapeHtml(card.key)}"
-                  data-control-state="${escapeHtml(card.nextState)}"
-                  ${state.busyAction ? "disabled" : ""}
-                >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>
+                ${card.kind === "select"
+                  ? `<div class="oq-overview-control-segmented">
+                      ${card.options.map((option) => `
+                        <button
+                          class="oq-overview-control-segment${card.selectedOption === option.value ? " is-selected" : ""}${state.busyAction === `save-${card.key}` ? " is-busy" : ""}"
+                          type="button"
+                          data-oq-action="select-overview-control-option"
+                          data-control-key="${escapeHtml(card.key)}"
+                          data-control-option="${escapeHtml(option.value)}"
+                          ${state.busyAction ? "disabled" : ""}
+                        >${escapeHtml(option.label)}</button>
+                      `).join("")}
+                    </div>`
+                  : `<button
+                      class="oq-overview-control-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
+                      type="button"
+                      data-oq-action="toggle-overview-control"
+                      data-control-key="${escapeHtml(card.key)}"
+                      data-control-state="${escapeHtml(card.nextState)}"
+                      ${state.busyAction ? "disabled" : ""}
+                    >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>`
+                }
               </div>
             </article>
           `).join("")}

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -5218,40 +5218,40 @@
     const coolingModeActive = getEntityStateText("controlModeLabel", "").toLowerCase().includes("cm5");
 
     let coolingStatus = "Uit";
-    let coolingCopy = "Handmatige koeltoestemming staat uit.";
+    let coolingCopy = "Koeling staat uit.";
     if (manualCoolingEnabled && coolingModeActive) {
       coolingStatus = "Actief";
-      coolingCopy = "Koeling draait nu en blijft verder door safety en koelvraag begrensd.";
+      coolingCopy = "Koeling draait nu.";
     } else if (manualCoolingEnabled && coolingBlocked) {
       coolingStatus = "Geblokkeerd";
       coolingCopy = formatCoolingBlockReason(getEntityStateText("coolingBlockReason", "Koeling wacht nog op veilige condities."));
     } else if (manualCoolingEnabled && coolingRequestActive) {
-      coolingStatus = "Wacht op start";
-      coolingCopy = "Koelvraag is actief; de compressor start zodra de regeling ruimte ziet.";
+      coolingStatus = "Start bijna";
+      coolingCopy = "Er is koelvraag. Koeling start zodra dat kan.";
     } else if (manualCoolingEnabled) {
-      coolingStatus = "Toegestaan";
-      coolingCopy = "Koeling is handmatig toegestaan en wacht op koelvraag vanuit de kamerregeling.";
+      coolingStatus = "Aan";
+      coolingCopy = "Koeling staat aan en wacht op koelvraag.";
     }
 
     let silentStatus = "Uit";
-    let silentCopy = "Normale compressorlimieten zijn actief.";
+    let silentCopy = "Stille modus staat uit.";
     if (manualSilentEnabled) {
-      silentStatus = "Geforceerd";
-      silentCopy = "Handmatige override houdt stille modus actief, los van het tijdvenster.";
+      silentStatus = "Aan";
+      silentCopy = "Stille modus staat aan, ook buiten het tijdvenster.";
     } else if (isEntityActive("silentActive")) {
       silentStatus = "Actief";
-      silentCopy = "Stille modus is nu actief via het ingestelde tijdvenster.";
+      silentCopy = "Stille modus staat nu aan via het tijdvenster.";
     }
 
     return [
       {
         key: "openquattEnabled",
         label: "OpenQuatt",
-        status: openquattEnabled ? "Actief" : "Gepauzeerd",
+        status: openquattEnabled ? "Aan" : "Gepauzeerd",
         copy: openquattEnabled
-          ? "Warmte- en koelregeling mogen normaal doorlopen."
-          : "Nieuwe warmte- en koelvraag staan uit; bewaking en vorstbeveiliging blijven actief.",
-        buttonLabel: openquattEnabled ? "Pauzeer" : "Hervat",
+          ? "Verwarmen en koelen mogen gewoon werken."
+          : "Verwarmen en koelen staan uit. Bescherming blijft actief.",
+        buttonLabel: openquattEnabled ? "Pauzeer" : "Zet aan",
         nextState: openquattEnabled ? "off" : "on",
         tone: openquattEnabled ? "green" : "neutral",
       },
@@ -5260,7 +5260,7 @@
         label: "Koeling",
         status: coolingStatus,
         copy: coolingCopy,
-        buttonLabel: manualCoolingEnabled ? "Stop" : "Sta toe",
+        buttonLabel: manualCoolingEnabled ? "Zet uit" : "Zet aan",
         nextState: manualCoolingEnabled ? "off" : "on",
         tone: manualCoolingEnabled ? (coolingModeActive ? "blue" : "sky") : "neutral",
       },
@@ -5269,7 +5269,7 @@
         label: "Stille modus",
         status: silentStatus,
         copy: silentCopy,
-        buttonLabel: manualSilentEnabled ? "Normaal" : "Forceer",
+        buttonLabel: manualSilentEnabled ? "Zet uit" : "Zet aan",
         nextState: manualSilentEnabled ? "off" : "on",
         tone: manualSilentEnabled ? "orange" : "neutral",
       },

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -3212,6 +3212,27 @@
     return labels[value] || value;
   }
 
+  function formatCoolingBlockReason(reason) {
+    const value = String(reason || "").trim();
+    if (!value) {
+      return "";
+    }
+
+    const labels = {
+      Ready: "Gereed",
+      "Waiting for room request": "Wacht op kamervraag",
+      "No dew point source": "Geen dauwpuntbron",
+      "OpenQuatt paused": "OpenQuatt gepauzeerd",
+      "Cooling disabled": "Koeling uitgeschakeld",
+      "Flow too low": "Flow te laag",
+      "Fallback cooling active": "Fallback-koeling actief",
+      "Fallback corrected by warm night": "Fallback gecorrigeerd door warme nacht",
+      "Fallback blocked by tropical night": "Fallback geblokkeerd door tropische nacht",
+    };
+
+    return labels[value] || value;
+  }
+
   function renderSettingsSelectField(key, title, copy, className = "") {
     if (!hasEntity(key)) {
       return "";
@@ -4872,7 +4893,7 @@
     const rawDemand = getEntityNumericValue("coolingDemandRaw");
     const permitted = isEntityActive("coolingPermitted");
     const requestActive = isEntityActive("coolingRequestActive");
-    const blockReason = getEntityStateText("coolingBlockReason", "Onbekend");
+    const blockReason = formatCoolingBlockReason(getEntityStateText("coolingBlockReason", "Onbekend"));
 
     let statusTitle = "Wacht op koelvraag";
     let statusCopy = "Zodra er koelvraag is, zie je hier hoe de regeling de aanvoer richting het koeldoel stuurt.";
@@ -5203,7 +5224,7 @@
       coolingCopy = "Koeling draait nu en blijft verder door safety en koelvraag begrensd.";
     } else if (manualCoolingEnabled && coolingBlocked) {
       coolingStatus = "Geblokkeerd";
-      coolingCopy = getEntityStateText("coolingBlockReason", "Koeling wacht nog op veilige condities.");
+      coolingCopy = formatCoolingBlockReason(getEntityStateText("coolingBlockReason", "Koeling wacht nog op veilige condities."));
     } else if (manualCoolingEnabled && coolingRequestActive) {
       coolingStatus = "Wacht op start";
       coolingCopy = "Koelvraag is actief; de compressor start zodra de regeling ruimte ziet.";

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -105,6 +105,9 @@
     wifiSignal: { domain: "sensor", name: "WiFi Signal", optional: true },
     espInternalTemp: { domain: "sensor", name: "ESP Internal Temperature", optional: true },
     strategy: { domain: "select", name: "Heating Control Mode" },
+    openquattEnabled: { domain: "switch", name: "OpenQuatt Enabled", optional: true },
+    manualCoolingEnable: { domain: "switch", name: "Manual Cooling Enable", optional: true },
+    manualSilentEnable: { domain: "switch", name: "Manual Silent Enable", optional: true },
     coolingEnableSelected: { domain: "binary_sensor", name: "Cooling Enable (Selected)", optional: true },
     coolingRequestActive: { domain: "binary_sensor", name: "Cooling Request Active", optional: true },
     coolingPermitted: { domain: "binary_sensor", name: "Cooling Permitted", optional: true },
@@ -2680,6 +2683,15 @@
       return;
     }
 
+    if (action === "toggle-overview-control") {
+      const key = button.dataset.controlKey || "";
+      const nextState = (button.dataset.controlState || "").toLowerCase();
+      if (key && (nextState === "on" || nextState === "off")) {
+        commitSwitch(key, nextState === "on");
+      }
+      return;
+    }
+
     if (action === "suggest-curve-fallback") {
       const suggestion = getCurveFallbackSuggestion();
       if (suggestion) {
@@ -2773,6 +2785,35 @@
       }
     } catch (error) {
       state.controlError = `${entity.name} kon niet worden bijgewerkt. ${error.message}`;
+    } finally {
+      state.busyAction = "";
+      render();
+    }
+  }
+
+  async function commitSwitch(key, enabled) {
+    const entity = ENTITY_DEFS[key];
+    if (!entity) {
+      return;
+    }
+
+    state.busyAction = `switch-${key}`;
+    state.controlNotice = "";
+    state.controlError = "";
+    render();
+
+    try {
+      const action = enabled ? "turn_on" : "turn_off";
+      const response = await fetch(buildEntityPath(entity.domain, entity.name, action), { method: "POST" });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      state.controlNotice = `${entity.name} ${enabled ? "ingeschakeld" : "uitgeschakeld"}.`;
+      await syncEntities();
+      render();
+    } catch (error) {
+      state.controlError = `${entity.name} aanpassen mislukt (${error.message}).`;
+      render();
     } finally {
       state.busyAction = "";
       render();
@@ -4712,7 +4753,7 @@
     if (modeLabel.includes("cm5") || modeLabel.includes("cooling") || modeLabel.includes("koeling")) {
       return true;
     }
-    return isEntityActive("coolingRequestActive") || isEntityActive("coolingEnableSelected");
+    return isEntityActive("coolingRequestActive");
   }
 
   function getOverviewStrategyLabel() {
@@ -4942,6 +4983,13 @@
   }
 
   function getOverviewPrimarySignal() {
+    if (!isEntityActive("openquattEnabled")) {
+      return {
+        label: "Regeling nu",
+        value: "OpenQuatt gepauzeerd",
+        tone: "neutral",
+      };
+    }
     if (isCoolingOverviewActive()) {
       const model = getCoolingOverviewModel();
       const tone = !model.permitted
@@ -4979,6 +5027,13 @@
   }
 
   function getOverviewDemandSignal() {
+    if (!isEntityActive("openquattEnabled")) {
+      return {
+        label: "Warmte/koelvraag",
+        value: "Handmatig uitgezet",
+        tone: "neutral",
+      };
+    }
     if (isCoolingOverviewActive()) {
       if (!isEntityActive("coolingRequestActive")) {
         return {
@@ -5020,6 +5075,13 @@
   }
 
   function getOverviewSystemSignal() {
+    if (!isEntityActive("openquattEnabled")) {
+      return {
+        label: "Systeem",
+        value: "Vorstbeveiliging blijft actief",
+        tone: "neutral",
+      };
+    }
     if (isCoolingOverviewActive()) {
       if (!isEntityActive("coolingPermitted")) {
         return {
@@ -5105,6 +5167,107 @@
       ${renderOverviewStatCard(thermalKey, thermalLabel, "orange", "thermisch vermogen")}
       ${renderOverviewStatCard(efficiencyKey, efficiencyLabel, "green", "rendement")}
       ${renderOverviewStatCard("flowSelected", "Flow", "sky", "watercircuit")}
+    `;
+  }
+
+  function getOverviewControlCards() {
+    const openquattEnabled = isEntityActive("openquattEnabled");
+    const manualCoolingEnabled = isEntityActive("manualCoolingEnable");
+    const manualSilentEnabled = isEntityActive("manualSilentEnable");
+    const coolingBlocked = !isEntityActive("coolingPermitted");
+    const coolingRequestActive = isEntityActive("coolingRequestActive");
+    const coolingModeActive = getEntityStateText("controlModeLabel", "").toLowerCase().includes("cm5");
+
+    let coolingStatus = "Uit";
+    let coolingCopy = "Handmatige koeltoestemming staat uit.";
+    if (manualCoolingEnabled && coolingModeActive) {
+      coolingStatus = "Actief";
+      coolingCopy = "Koeling draait nu en blijft verder door safety en koelvraag begrensd.";
+    } else if (manualCoolingEnabled && coolingBlocked) {
+      coolingStatus = "Geblokkeerd";
+      coolingCopy = getEntityStateText("coolingBlockReason", "Koeling wacht nog op veilige condities.");
+    } else if (manualCoolingEnabled && coolingRequestActive) {
+      coolingStatus = "Wacht op start";
+      coolingCopy = "Koelvraag is actief; de compressor start zodra de regeling ruimte ziet.";
+    } else if (manualCoolingEnabled) {
+      coolingStatus = "Toegestaan";
+      coolingCopy = "Koeling is handmatig toegestaan en wacht op koelvraag vanuit de kamerregeling.";
+    }
+
+    let silentStatus = "Uit";
+    let silentCopy = "Normale compressorlimieten zijn actief.";
+    if (manualSilentEnabled) {
+      silentStatus = "Geforceerd";
+      silentCopy = "Handmatige override houdt stille modus actief, los van het tijdvenster.";
+    } else if (isEntityActive("silentActive")) {
+      silentStatus = "Actief";
+      silentCopy = "Stille modus is nu actief via het ingestelde tijdvenster.";
+    }
+
+    return [
+      {
+        key: "openquattEnabled",
+        label: "OpenQuatt",
+        status: openquattEnabled ? "Actief" : "Gepauzeerd",
+        copy: openquattEnabled
+          ? "Warmte- en koelregeling mogen normaal doorlopen."
+          : "Nieuwe warmte- en koelvraag staan uit; bewaking en vorstbeveiliging blijven actief.",
+        buttonLabel: openquattEnabled ? "Uitzetten" : "Aanzetten",
+        nextState: openquattEnabled ? "off" : "on",
+        tone: openquattEnabled ? "green" : "neutral",
+      },
+      {
+        key: "manualCoolingEnable",
+        label: "Koeling",
+        status: coolingStatus,
+        copy: coolingCopy,
+        buttonLabel: manualCoolingEnabled ? "Uitzetten" : "Aanzetten",
+        nextState: manualCoolingEnabled ? "off" : "on",
+        tone: manualCoolingEnabled ? (coolingModeActive ? "blue" : "sky") : "neutral",
+      },
+      {
+        key: "manualSilentEnable",
+        label: "Stille modus",
+        status: silentStatus,
+        copy: silentCopy,
+        buttonLabel: manualSilentEnabled ? "Opheffen" : "Forceren",
+        nextState: manualSilentEnabled ? "off" : "on",
+        tone: manualSilentEnabled ? "orange" : "neutral",
+      },
+    ].filter((card) => hasEntity(card.key));
+  }
+
+  function renderOverviewControls() {
+    const cards = getOverviewControlCards();
+    if (!cards.length) {
+      return "";
+    }
+    return `
+      <section class="oq-overview-controls">
+        <div class="oq-overview-controls-copy">
+          <h3>Bediening</h3>
+          <p>Directe schakelaars voor regeling, koeling en stille modus.</p>
+        </div>
+        <div class="oq-overview-controls-grid">
+          ${cards.map((card) => `
+            <article class="oq-overview-control oq-overview-control--${escapeHtml(card.tone)}">
+              <div class="oq-overview-control-head">
+                <span>${escapeHtml(card.label)}</span>
+                <strong>${escapeHtml(card.status)}</strong>
+              </div>
+              <p>${escapeHtml(card.copy)}</p>
+              <button
+                class="oq-overview-control-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
+                type="button"
+                data-oq-action="toggle-overview-control"
+                data-control-key="${escapeHtml(card.key)}"
+                data-control-state="${escapeHtml(card.nextState)}"
+                ${state.busyAction ? "disabled" : ""}
+              >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>
+            </article>
+          `).join("")}
+        </div>
+      </section>
     `;
   }
 
@@ -6569,6 +6732,7 @@
           <div class="oq-overview-top">
             ${renderOverviewTopCards()}
           </div>
+          ${renderOverviewControls()}
           ${renderOverviewSignals()}
           <div class="oq-overview-main">
             ${renderOverviewStrategyPanel()}

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -2794,6 +2794,11 @@
     state.busyAction = `save-${key}`;
     state.controlNotice = "";
     state.controlError = "";
+    state.entities[key] = {
+      ...(state.entities[key] || {}),
+      state: option,
+      value: option,
+    };
     render();
 
     try {
@@ -4678,8 +4683,14 @@
     `;
   }
 
-  function renderOverviewStatusChip(label, value, tone = "neutral") {
-    return `<span class="oq-overview-chip oq-overview-chip--${escapeHtml(tone)}"><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}</span>`;
+  function renderOverviewStatusStatCard(label, value, tone, note) {
+    return `
+      <article class="oq-overview-stat oq-overview-stat--${escapeHtml(tone)} oq-overview-stat--status${label === "Systeem" ? " oq-overview-stat--system" : ""}">
+        <p>${escapeHtml(label)}</p>
+        <strong>${escapeHtml(value)}</strong>
+        <span>${escapeHtml(note)}</span>
+      </article>
+    `;
   }
 
   function getHeatPumpPanelStatusLabel(mode, running) {
@@ -5116,54 +5127,6 @@
     };
   }
 
-  function getOverviewDemandSignal() {
-    if (!isEntityActive("openquattEnabled")) {
-      return {
-        label: "Warmte/koelvraag",
-        value: "Handmatig uitgezet",
-        tone: "neutral",
-      };
-    }
-    if (isCoolingOverviewActive()) {
-      if (!isEntityActive("coolingRequestActive")) {
-        return {
-          label: "Koelvraag",
-          value: "Geen koelvraag",
-          tone: "neutral",
-        };
-      }
-      const rawDemand = getEntityNumericValue("coolingDemandRaw");
-      const value = Number.isNaN(rawDemand)
-        ? "Koelvraag actief"
-        : rawDemand <= 0
-          ? "Koelvraag actief, compressor rust"
-          : "Koelvraag actief";
-      return {
-        label: "Koelvraag",
-        value,
-        tone: rawDemand > 0 ? "sky" : "neutral",
-      };
-    }
-    if (isSystemInStandby()) {
-      return {
-        label: "Warmtevraag",
-        value: "Geen warmtevraag",
-        tone: "neutral",
-      };
-    }
-    const demand = getHomeDemandState();
-    const tone = demand.tone === "high" || demand.tone === "active"
-      ? "orange"
-      : demand.tone === "steady"
-        ? "green"
-        : "neutral";
-    return {
-      label: "Warmtevraag",
-      value: demand.level,
-      tone,
-    };
-  }
-
   function getOverviewSystemSignal() {
     if (!isEntityActive("openquattEnabled")) {
       return {
@@ -5189,22 +5152,8 @@
       }
       return {
         label: "Systeem",
-        value: "Koeling toegestaan",
+        value: "Normaal",
         tone: "green",
-      };
-    }
-    if (isFirmwareUpdateAvailable()) {
-      return {
-        label: "Systeem",
-        value: "Update beschikbaar",
-        tone: "orange",
-      };
-    }
-    if (isSystemInStandby()) {
-      return {
-        label: "Systeem",
-        value: "Stand-by, gereed om te starten",
-        tone: "sky",
       };
     }
     if (isEntityActive("silentActive")) {
@@ -5223,25 +5172,25 @@
     }
     return {
       label: "Systeem",
-      value: "Alles draait normaal",
+      value: "Normaal",
       tone: "green",
     };
   }
 
-  function renderOverviewSignals() {
-    const items = [
-      getOverviewPrimarySignal(),
-      getOverviewDemandSignal(),
-      getOverviewSystemSignal(),
-    ];
+  function renderOverviewStatusStack(strategyLabel, controlModeLabel) {
+    const primary = getOverviewPrimarySignal();
+    const system = getOverviewSystemSignal();
     return `
-      <section class="oq-overview-signals">
-        ${items.map((item) => `
-          <article class="oq-overview-signal oq-overview-signal--${escapeHtml(item.tone)}">
-            <span>${escapeHtml(item.label)}</span>
-            <strong>${escapeHtml(item.value)}</strong>
-          </article>
-        `).join("")}
+      <section class="oq-overview-statuspanel" aria-label="Systeemstatus">
+        <div class="oq-overview-sectionhead">
+          <h3>Systeemstatus</h3>
+        </div>
+        <div class="oq-overview-statusgrid">
+          ${renderOverviewStatusStatCard("Strategie", strategyLabel, "blue", "regelstrategie")}
+          ${renderOverviewStatusStatCard("Controlmode", controlModeLabel, "sky", "actieve modus")}
+          ${renderOverviewStatusStatCard("Regeling", primary.value, primary.tone, "wat OpenQuatt nu doet")}
+          ${renderOverviewStatusStatCard("Systeem", system.value, system.tone, "actieve randvoorwaarde")}
+        </div>
       </section>
     `;
   }
@@ -5340,56 +5289,86 @@
     ].filter((card) => hasEntity(card.key));
   }
 
-  function renderOverviewControlStrip(options = {}) {
-    const { stacked = false } = options;
+  function renderOverviewControlBody(card) {
+    if (card.kind === "select") {
+      return `
+        <div class="oq-overview-controlpanel-actions oq-overview-controlpanel-actions--split">
+          <div class="oq-overview-controlpanel-segmented">
+            ${card.options.map((option) => `
+              <button
+                class="oq-overview-controlpanel-segment${card.selectedOption === option.value ? " is-selected" : ""}${state.busyAction === `save-${card.key}` ? " is-busy" : ""}"
+                type="button"
+                data-oq-action="select-overview-control-option"
+                data-control-key="${escapeHtml(card.key)}"
+                data-control-option="${escapeHtml(option.value)}"
+                ${state.busyAction ? "disabled" : ""}
+              >${escapeHtml(option.label)}</button>
+            `).join("")}
+          </div>
+          ${card.settingsAction
+            ? `<button
+                class="oq-overview-controlpanel-icon"
+                type="button"
+                data-oq-action="open-silent-settings-modal"
+                aria-label="Open instellingen voor stille uren"
+                title="Stille uren instellen"
+              >⚙</button>`
+            : ""
+          }
+        </div>
+      `;
+    }
+
+    return `
+      <div class="oq-overview-controlpanel-actions">
+        <button
+          class="oq-overview-controlpanel-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
+          type="button"
+          data-oq-action="toggle-overview-control"
+          data-control-key="${escapeHtml(card.key)}"
+          data-control-state="${escapeHtml(card.nextState)}"
+          ${state.busyAction ? "disabled" : ""}
+        >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>
+      </div>
+    `;
+  }
+
+  function renderOverviewControlPanels() {
     const cards = getOverviewControlCards();
     if (!cards.length) {
       return "";
     }
 
+    const openquattCard = cards.find((card) => card.key === "openquattEnabled");
+    const coolingCard = cards.find((card) => card.key === "manualCoolingEnable");
+    const silentCard = cards.find((card) => card.key === "silentModeOverride");
+
     return `
-      <section class="oq-overview-controlstrip${stacked ? " oq-overview-controlstrip--stacked" : ""}" aria-label="Bediening">
-        ${cards.map((card) => `
-          <article class="oq-overview-controlstrip-item oq-overview-controlstrip-item--${escapeHtml(card.tone)}">
-            <div class="oq-overview-controlstrip-head">
+      <section class="oq-overview-controlpanel-stack" aria-label="Bediening">
+        <div class="oq-overview-sectionhead">
+          <h3>Bediening</h3>
+        </div>
+        ${openquattCard
+          ? `
+            <article class="oq-overview-controlpanel oq-overview-controlpanel--${escapeHtml(openquattCard.tone)}">
+              <div class="oq-overview-controlpanel-head">
+                <span>${escapeHtml(openquattCard.label)}</span>
+                <strong class="oq-overview-controlpanel-state oq-overview-controlpanel-state--${escapeHtml(openquattCard.tone)}">${escapeHtml(openquattCard.status)}</strong>
+              </div>
+              <p>${escapeHtml(openquattCard.copy)}</p>
+              ${renderOverviewControlBody(openquattCard)}
+            </article>
+          `
+          : ""
+        }
+        ${[coolingCard, silentCard].filter(Boolean).map((card) => `
+          <article class="oq-overview-controlpanel oq-overview-controlpanel--${escapeHtml(card.tone)}">
+            <div class="oq-overview-controlpanel-head">
               <span>${escapeHtml(card.label)}</span>
-              <strong class="oq-overview-controlstrip-state oq-overview-controlstrip-state--${escapeHtml(card.tone)}">${escapeHtml(card.status)}</strong>
+              <strong class="oq-overview-controlpanel-state oq-overview-controlpanel-state--${escapeHtml(card.tone)}">${escapeHtml(card.status)}</strong>
             </div>
             <p>${escapeHtml(card.copy)}</p>
-            <div class="oq-overview-controlstrip-actions${card.settingsAction ? " oq-overview-controlstrip-actions--split" : ""}">
-              ${card.kind === "select"
-                ? `<div class="oq-overview-controlstrip-segmented">
-                    ${card.options.map((option) => `
-                      <button
-                        class="oq-overview-controlstrip-segment${card.selectedOption === option.value ? " is-selected" : ""}${state.busyAction === `save-${card.key}` ? " is-busy" : ""}"
-                        type="button"
-                        data-oq-action="select-overview-control-option"
-                        data-control-key="${escapeHtml(card.key)}"
-                        data-control-option="${escapeHtml(option.value)}"
-                        ${state.busyAction ? "disabled" : ""}
-                      >${escapeHtml(option.label)}</button>
-                    `).join("")}
-                  </div>`
-                : `<button
-                    class="oq-overview-controlstrip-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
-                    type="button"
-                    data-oq-action="toggle-overview-control"
-                    data-control-key="${escapeHtml(card.key)}"
-                    data-control-state="${escapeHtml(card.nextState)}"
-                    ${state.busyAction ? "disabled" : ""}
-                  >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>`
-              }
-              ${card.settingsAction
-                ? `<button
-                    class="oq-overview-controlstrip-icon"
-                    type="button"
-                    data-oq-action="open-silent-settings-modal"
-                    aria-label="Open instellingen voor stille uren"
-                    title="Stille uren instellen"
-                  >⚙</button>`
-                : ""
-              }
-            </div>
+            ${renderOverviewControlBody(card)}
           </article>
         `).join("")}
       </section>
@@ -5397,6 +5376,7 @@
   }
 
   function renderOverviewSummaryShell(strategyLabel) {
+    const controlModeLabel = getEntityStateText("controlModeLabel");
     return `
       <section class="oq-overview-summary-shell">
         <div class="oq-overview-head">
@@ -5405,22 +5385,21 @@
             <h2 class="oq-helper-section-title">Live regeling</h2>
             <p class="oq-helper-section-copy">Hier zie je in één oogopslag hoe OpenQuatt nu werkt.</p>
           </div>
-          <div class="oq-overview-head-actions">
-            <div class="oq-overview-status">
-              ${renderOverviewStatusChip("Strategie", strategyLabel, "blue")}
-              ${renderOverviewStatusChip("Controlmode", getEntityStateText("controlModeLabel"), "neutral")}
-            </div>
-          </div>
         </div>
         <div class="oq-overview-summary-layout">
           <div class="oq-overview-summary-main">
-            <div class="oq-overview-top">
-              ${renderOverviewTopCards()}
-            </div>
-            ${renderOverviewSignals()}
+            <section class="oq-overview-kpis" aria-label="Kerncijfers">
+              <div class="oq-overview-sectionhead">
+                <h3>Kerncijfers</h3>
+              </div>
+              <div class="oq-overview-top">
+                ${renderOverviewTopCards()}
+              </div>
+            </section>
+            ${renderOverviewStatusStack(strategyLabel, controlModeLabel)}
           </div>
           <aside class="oq-overview-summary-side">
-            ${renderOverviewControlStrip({ stacked: true })}
+            ${renderOverviewControlPanels()}
           </aside>
         </div>
       </section>

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -5212,7 +5212,7 @@
         copy: openquattEnabled
           ? "Warmte- en koelregeling mogen normaal doorlopen."
           : "Nieuwe warmte- en koelvraag staan uit; bewaking en vorstbeveiliging blijven actief.",
-        buttonLabel: openquattEnabled ? "Uitzetten" : "Aanzetten",
+        buttonLabel: openquattEnabled ? "Pauzeer" : "Hervat",
         nextState: openquattEnabled ? "off" : "on",
         tone: openquattEnabled ? "green" : "neutral",
       },
@@ -5221,7 +5221,7 @@
         label: "Koeling",
         status: coolingStatus,
         copy: coolingCopy,
-        buttonLabel: manualCoolingEnabled ? "Uitzetten" : "Aanzetten",
+        buttonLabel: manualCoolingEnabled ? "Stop" : "Sta toe",
         nextState: manualCoolingEnabled ? "off" : "on",
         tone: manualCoolingEnabled ? (coolingModeActive ? "blue" : "sky") : "neutral",
       },
@@ -5230,7 +5230,7 @@
         label: "Stille modus",
         status: silentStatus,
         copy: silentCopy,
-        buttonLabel: manualSilentEnabled ? "Opheffen" : "Forceren",
+        buttonLabel: manualSilentEnabled ? "Normaal" : "Forceer",
         nextState: manualSilentEnabled ? "off" : "on",
         tone: manualSilentEnabled ? "orange" : "neutral",
       },
@@ -5244,26 +5244,30 @@
     }
     return `
       <section class="oq-overview-controls">
-        <div class="oq-overview-controls-copy">
-          <h3>Bediening</h3>
-          <p>Directe schakelaars voor regeling, koeling en stille modus.</p>
+        <div class="oq-overview-controls-head">
+          <div class="oq-overview-controls-copy">
+            <h3>Bediening</h3>
+            <p>Directe runtime-schakelaars voor regeling, koeling en stille modus.</p>
+          </div>
         </div>
         <div class="oq-overview-controls-grid">
           ${cards.map((card) => `
             <article class="oq-overview-control oq-overview-control--${escapeHtml(card.tone)}">
               <div class="oq-overview-control-head">
                 <span>${escapeHtml(card.label)}</span>
-                <strong>${escapeHtml(card.status)}</strong>
+                <strong class="oq-overview-control-state oq-overview-control-state--${escapeHtml(card.tone)}">${escapeHtml(card.status)}</strong>
               </div>
               <p>${escapeHtml(card.copy)}</p>
-              <button
-                class="oq-overview-control-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
-                type="button"
-                data-oq-action="toggle-overview-control"
-                data-control-key="${escapeHtml(card.key)}"
-                data-control-state="${escapeHtml(card.nextState)}"
-                ${state.busyAction ? "disabled" : ""}
-              >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>
+              <div class="oq-overview-control-actions">
+                <button
+                  class="oq-overview-control-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
+                  type="button"
+                  data-oq-action="toggle-overview-control"
+                  data-control-key="${escapeHtml(card.key)}"
+                  data-control-state="${escapeHtml(card.nextState)}"
+                  ${state.busyAction ? "disabled" : ""}
+                >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>
+              </div>
             </article>
           `).join("")}
         </div>

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -2111,6 +2111,29 @@
       `;
     }
 
+    if (state.systemModal === "silent-settings") {
+      return `
+        <div class="oq-helper-modal-backdrop${state.overviewTheme === "dark" ? " oq-helper-modal-backdrop--dark" : ""}" data-oq-modal="system">
+          <section class="oq-helper-modal oq-helper-modal--wide" role="dialog" aria-modal="true" aria-labelledby="oq-silent-settings-modal-title">
+            <div class="oq-helper-modal-head">
+              <div>
+                <p class="oq-helper-modal-kicker">Stille uren</p>
+                <h2 class="oq-helper-modal-title" id="oq-silent-settings-modal-title">Stille uren instellen</h2>
+              </div>
+              <button class="oq-helper-modal-close" type="button" data-oq-action="close-system-modal" aria-label="Sluit stille-uren-popup">×</button>
+            </div>
+            <p class="oq-helper-modal-copy">Kies wanneer het systeem stiller moet werken, en hoe ver het dan nog mag opschalen. Wijzigingen worden direct toegepast.</p>
+            <div class="oq-helper-modal-body">
+              ${renderSilentSettingsFields()}
+            </div>
+            <div class="oq-helper-modal-actions">
+              <button class="oq-helper-button oq-helper-button--primary" type="button" data-oq-action="close-system-modal">Gereed</button>
+            </div>
+          </section>
+        </div>
+      `;
+    }
+
     return "";
   }
 
@@ -2586,6 +2609,12 @@
 
     if (action === "open-restart-confirm") {
       state.systemModal = "restart-confirm";
+      render();
+      return;
+    }
+
+    if (action === "open-silent-settings-modal") {
+      state.systemModal = "silent-settings";
       render();
       return;
     }
@@ -3944,19 +3973,32 @@
   }
 
   function renderSettingsSilentSection() {
+    const silentFields = `
+      <div class="oq-settings-grid">
+        ${renderSettingsTimeField("silentStartTime", "Start stille uren", "Vanaf dit tijdstip werkt het systeem in stille modus.")}
+        ${renderSettingsTimeField("silentEndTime", "Einde stille uren", "Vanaf dit tijdstip stopt de stille modus weer.")}
+        ${renderSettingsSliderField("silentMax", "Maximaal niveau tijdens stille uren", "Zo ver mag het systeem nog opschalen tijdens stille uren.")}
+        ${renderSettingsSliderField("dayMax", "Maximaal niveau overdag", "Zo ver mag het systeem overdag opschalen.")}
+      </div>
+    `;
+
     return renderSettingsSection(
       "Stille uren",
       "Stille uren",
       "Kies wanneer het systeem stiller moet werken, en hoe ver het dan nog mag opschalen.",
-      `
-        <div class="oq-settings-grid">
-          ${renderSettingsTimeField("silentStartTime", "Start stille uren", "Vanaf dit tijdstip werkt het systeem in stille modus.")}
-          ${renderSettingsTimeField("silentEndTime", "Einde stille uren", "Vanaf dit tijdstip stopt de stille modus weer.")}
-          ${renderSettingsSliderField("silentMax", "Maximaal niveau tijdens stille uren", "Zo ver mag het systeem nog opschalen tijdens stille uren.")}
-          ${renderSettingsSliderField("dayMax", "Maximaal niveau overdag", "Zo ver mag het systeem overdag opschalen.")}
-        </div>
-      `,
+      silentFields,
     );
+  }
+
+  function renderSilentSettingsFields() {
+    return `
+      <div class="oq-settings-grid oq-settings-grid--modal">
+        ${renderSettingsTimeField("silentStartTime", "Start stille uren", "Vanaf dit tijdstip werkt het systeem in stille modus.")}
+        ${renderSettingsTimeField("silentEndTime", "Einde stille uren", "Vanaf dit tijdstip stopt de stille modus weer.")}
+        ${renderSettingsSliderField("silentMax", "Maximaal niveau tijdens stille uren", "Zo ver mag het systeem nog opschalen tijdens stille uren.")}
+        ${renderSettingsSliderField("dayMax", "Maximaal niveau overdag", "Zo ver mag het systeem overdag opschalen.")}
+      </div>
+    `;
   }
 
   function renderSettingsCoolingSection() {
@@ -5288,6 +5330,7 @@
         tone: silentTone,
         kind: "select",
         selectedOption: silentModeOverride,
+        settingsAction: true,
         options: [
           { value: "Off", label: "Uit" },
           { value: "On", label: "Aan" },
@@ -5297,53 +5340,88 @@
     ].filter((card) => hasEntity(card.key));
   }
 
-  function renderOverviewControls() {
+  function renderOverviewControlStrip(options = {}) {
+    const { stacked = false } = options;
     const cards = getOverviewControlCards();
     if (!cards.length) {
       return "";
     }
+
     return `
-      <section class="oq-overview-controls">
-        <div class="oq-overview-controls-head">
-          <div class="oq-overview-controls-copy">
-            <h3>Bediening</h3>
-            <p>Directe runtime-schakelaars voor regeling, koeling en stille modus.</p>
+      <section class="oq-overview-controlstrip${stacked ? " oq-overview-controlstrip--stacked" : ""}" aria-label="Bediening">
+        ${cards.map((card) => `
+          <article class="oq-overview-controlstrip-item oq-overview-controlstrip-item--${escapeHtml(card.tone)}">
+            <div class="oq-overview-controlstrip-head">
+              <span>${escapeHtml(card.label)}</span>
+              <strong class="oq-overview-controlstrip-state oq-overview-controlstrip-state--${escapeHtml(card.tone)}">${escapeHtml(card.status)}</strong>
+            </div>
+            <p>${escapeHtml(card.copy)}</p>
+            <div class="oq-overview-controlstrip-actions${card.settingsAction ? " oq-overview-controlstrip-actions--split" : ""}">
+              ${card.kind === "select"
+                ? `<div class="oq-overview-controlstrip-segmented">
+                    ${card.options.map((option) => `
+                      <button
+                        class="oq-overview-controlstrip-segment${card.selectedOption === option.value ? " is-selected" : ""}${state.busyAction === `save-${card.key}` ? " is-busy" : ""}"
+                        type="button"
+                        data-oq-action="select-overview-control-option"
+                        data-control-key="${escapeHtml(card.key)}"
+                        data-control-option="${escapeHtml(option.value)}"
+                        ${state.busyAction ? "disabled" : ""}
+                      >${escapeHtml(option.label)}</button>
+                    `).join("")}
+                  </div>`
+                : `<button
+                    class="oq-overview-controlstrip-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
+                    type="button"
+                    data-oq-action="toggle-overview-control"
+                    data-control-key="${escapeHtml(card.key)}"
+                    data-control-state="${escapeHtml(card.nextState)}"
+                    ${state.busyAction ? "disabled" : ""}
+                  >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>`
+              }
+              ${card.settingsAction
+                ? `<button
+                    class="oq-overview-controlstrip-icon"
+                    type="button"
+                    data-oq-action="open-silent-settings-modal"
+                    aria-label="Open instellingen voor stille uren"
+                    title="Stille uren instellen"
+                  >⚙</button>`
+                : ""
+              }
+            </div>
+          </article>
+        `).join("")}
+      </section>
+    `;
+  }
+
+  function renderOverviewSummaryShell(strategyLabel) {
+    return `
+      <section class="oq-overview-summary-shell">
+        <div class="oq-overview-head">
+          <div>
+            <p class="oq-helper-label">Overzicht</p>
+            <h2 class="oq-helper-section-title">Live regeling</h2>
+            <p class="oq-helper-section-copy">Hier zie je in één oogopslag hoe OpenQuatt nu werkt.</p>
+          </div>
+          <div class="oq-overview-head-actions">
+            <div class="oq-overview-status">
+              ${renderOverviewStatusChip("Strategie", strategyLabel, "blue")}
+              ${renderOverviewStatusChip("Controlmode", getEntityStateText("controlModeLabel"), "neutral")}
+            </div>
           </div>
         </div>
-        <div class="oq-overview-controls-grid">
-          ${cards.map((card) => `
-            <article class="oq-overview-control oq-overview-control--${escapeHtml(card.tone)}">
-              <div class="oq-overview-control-head">
-                <span>${escapeHtml(card.label)}</span>
-                <strong class="oq-overview-control-state oq-overview-control-state--${escapeHtml(card.tone)}">${escapeHtml(card.status)}</strong>
-              </div>
-              <p>${escapeHtml(card.copy)}</p>
-              <div class="oq-overview-control-actions">
-                ${card.kind === "select"
-                  ? `<div class="oq-overview-control-segmented">
-                      ${card.options.map((option) => `
-                        <button
-                          class="oq-overview-control-segment${card.selectedOption === option.value ? " is-selected" : ""}${state.busyAction === `save-${card.key}` ? " is-busy" : ""}"
-                          type="button"
-                          data-oq-action="select-overview-control-option"
-                          data-control-key="${escapeHtml(card.key)}"
-                          data-control-option="${escapeHtml(option.value)}"
-                          ${state.busyAction ? "disabled" : ""}
-                        >${escapeHtml(option.label)}</button>
-                      `).join("")}
-                    </div>`
-                  : `<button
-                      class="oq-overview-control-toggle${state.busyAction === `switch-${card.key}` ? " is-busy" : ""}"
-                      type="button"
-                      data-oq-action="toggle-overview-control"
-                      data-control-key="${escapeHtml(card.key)}"
-                      data-control-state="${escapeHtml(card.nextState)}"
-                      ${state.busyAction ? "disabled" : ""}
-                    >${escapeHtml(state.busyAction === `switch-${card.key}` ? "Bezig..." : card.buttonLabel)}</button>`
-                }
-              </div>
-            </article>
-          `).join("")}
+        <div class="oq-overview-summary-layout">
+          <div class="oq-overview-summary-main">
+            <div class="oq-overview-top">
+              ${renderOverviewTopCards()}
+            </div>
+            ${renderOverviewSignals()}
+          </div>
+          <aside class="oq-overview-summary-side">
+            ${renderOverviewControlStrip({ stacked: true })}
+          </aside>
         </div>
       </section>
     `;
@@ -5497,7 +5575,7 @@
         renderOverviewEnergyGroup("Warmtepomp", [
           renderOverviewEnergyRow("Elektrisch vermogen", "coolingPowerInput"),
           renderOverviewEnergyRow("Koelafgifte", "totalCoolingPower"),
-          renderOverviewEnergyRow("EER", "totalEer"),
+          renderOverviewEnergyRow("COP (EER)", "totalEer"),
         ]),
       ]),
     ], "blue");
@@ -5520,7 +5598,7 @@
         renderOverviewEnergyGroup("Warmtepomp", [
           renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyDaily"),
           renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyDaily"),
-          renderOverviewEnergyRow("EER", "heatpumpEerDaily"),
+          renderOverviewEnergyRow("COP (EER)", "heatpumpEerDaily"),
         ]),
       ]),
     ], "orange");
@@ -5543,7 +5621,7 @@
         renderOverviewEnergyGroup("Warmtepomp", [
           renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyCumulative"),
           renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyCumulative"),
-          renderOverviewEnergyRow("EER", "heatpumpEerCumulative"),
+          renderOverviewEnergyRow("COP (EER)", "heatpumpEerCumulative"),
         ]),
       ]),
     ], "green");
@@ -5585,7 +5663,7 @@
         renderOverviewEnergyGroup("Warmtepomp", [
           renderOverviewEnergyRow("Elektrisch vermogen", "coolingPowerInput"),
           renderOverviewEnergyRow("Koelafgifte", "totalCoolingPower"),
-          renderOverviewEnergyRow("EER", "totalEer"),
+          renderOverviewEnergyRow("COP (EER)", "totalEer"),
         ]),
       ]),
     ], "blue");
@@ -5608,7 +5686,7 @@
         renderOverviewEnergyGroup("Warmtepomp", [
           renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyDaily"),
           renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyDaily"),
-          renderOverviewEnergyRow("EER", "heatpumpEerDaily"),
+          renderOverviewEnergyRow("COP (EER)", "heatpumpEerDaily"),
         ]),
       ]),
     ], "orange");
@@ -5631,7 +5709,7 @@
         renderOverviewEnergyGroup("Warmtepomp", [
           renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyCumulative"),
           renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyCumulative"),
-          renderOverviewEnergyRow("EER", "heatpumpEerCumulative"),
+          renderOverviewEnergyRow("COP (EER)", "heatpumpEerCumulative"),
         ]),
       ]),
     ], "green");
@@ -6794,24 +6872,7 @@
     return `
       <section class="oq-helper-panel oq-helper-panel--flush">
         <div class="oq-overview-board oq-overview-board--${escapeHtml(state.overviewTheme)}">
-          <div class="oq-overview-head">
-            <div>
-              <p class="oq-helper-label">Overzicht</p>
-              <h2 class="oq-helper-section-title">Live regeling</h2>
-              <p class="oq-helper-section-copy">Hier zie je in één oogopslag hoe OpenQuatt nu werkt.</p>
-            </div>
-            <div class="oq-overview-head-actions">
-              <div class="oq-overview-status">
-                ${renderOverviewStatusChip("Strategie", strategyLabel, "blue")}
-                ${renderOverviewStatusChip("Controlmode", getEntityStateText("controlModeLabel"), "neutral")}
-              </div>
-            </div>
-          </div>
-          <div class="oq-overview-top">
-            ${renderOverviewTopCards()}
-          </div>
-          ${renderOverviewControls()}
-          ${renderOverviewSignals()}
+          ${renderOverviewSummaryShell(strategyLabel)}
           <div class="oq-overview-main">
             ${renderOverviewStrategyPanel()}
             <section class="oq-overview-temps">
@@ -7124,30 +7185,17 @@
     }
 
     const strategyLabel = getOverviewStrategyLabel();
-    const status = board.querySelector(".oq-overview-status");
-    const top = board.querySelector(".oq-overview-top");
-    const signals = board.querySelector(".oq-overview-signals");
+    const summaryShell = board.querySelector(".oq-overview-summary-shell");
     const system = board.querySelector(".oq-overview-system");
     const temps = board.querySelector(".oq-overview-temps");
     const hpTools = board.querySelector(".oq-overview-hp-tools");
     const hpGrid = board.querySelector(".oq-overview-hp-grid");
     const heatPumpPanels = getHeatPumpPanels();
 
-    if (status) {
-      setInnerHtmlIfChanged(status, `
-        ${renderOverviewStatusChip("Strategie", strategyLabel, "blue")}
-        ${renderOverviewStatusChip("Controlmode", getEntityStateText("controlModeLabel"), "neutral")}
-      `);
-    }
-
-    if (top) {
-      setInnerHtmlIfChanged(top, renderOverviewTopCards());
-    }
-
-    if (signals) {
-      const nextSignals = renderOverviewSignals();
-      if (signals.outerHTML !== nextSignals) {
-        signals.outerHTML = nextSignals;
+    if (summaryShell) {
+      const nextSummaryShell = renderOverviewSummaryShell(strategyLabel);
+      if (summaryShell.outerHTML !== nextSummaryShell) {
+        summaryShell.outerHTML = nextSummaryShell;
       }
     }
 


### PR DESCRIPTION
## Summary
- add native OpenQuatt runtime controls for OpenQuatt enable, manual cooling enable, and silent mode override
- redesign the web-app live overview with a clearer split between kerncijfers, systeemstatus, and bediening
- expose the same controls in the HA dashboards and document how they behave

## Details
- `OpenQuatt Enabled` now pauses normal heating and cooling regulation while leaving supervision, safety, sticky pump protection, and freeze protection active
- `Manual Cooling Enable` acts as an extra cooling permission on top of CIC and/or HA input and is reflected in the cooling diagnostics
- silent mode now uses a real three-state override: `Uit`, `Aan`, or `Schema`
- the web overview has been rebuilt into a calmer dashboard layout:
  - `Kerncijfers` as a compact 2x2 metrics grid
  - `Systeemstatus` as a matching 2x2 status grid with `Strategie`, `Controlmode`, `Regeling`, and `Systeem`
  - `Bediening` as a dedicated right-hand control column for OpenQuatt, cooling, and silent mode
- the silent-mode card now includes a settings shortcut that opens the silent-hours popup directly from the overview
- mock support has been updated so the overview controls and silent-mode states behave realistically in `dev.html`
- all four HA dashboards now expose the same runtime controls and show the OpenQuatt manual cooling path alongside the existing HA helper route
- the docs describe the new runtime controls and their intended behavior

## Validation
- `node --check openquatt/web/openquatt-app.js`
- `node --check openquatt/web/mock-device.js`
- `python3 scripts/dev.py validate --config-only`
- `python3 scripts/dev.py preview-pages --no-serve`
- `esphome compile openquatt_duo_waveshare.yaml`
