### PR TITLE
Add scheduled OpenQuatt pause with auto resume

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -145,11 +145,15 @@ views:
               <summary><strong>Explanation</strong></summary>
 
 
-              Use these switches for direct runtime control:
+              Use these controls for direct runtime interaction:
 
-              - `OpenQuatt enabled`: pauses or resumes normal heating and
-              cooling control. Safety monitoring and freeze protection stay
-              active.
+              - `OpenQuatt regulation`: temporarily disables or re-enables
+              automatic heating and cooling control. Safety monitoring and
+              freeze protection stay active.
+
+              - `Resume automatically`: choose the date and time when the
+              regulation should turn itself back on after being temporarily
+              disabled.
 
               - `Manual cooling`: adds an extra cooling permission on top of
               CIC and/or HA input.
@@ -162,11 +166,20 @@ views:
             text_only: true
           - type: tile
             entity: switch.openquatt_enabled
-            name: OpenQuatt enabled
+            name: OpenQuatt regulation
             vertical: false
             features:
               - type: toggle
             features_position: inline
+          - type: tile
+            visibility:
+              - condition: state
+                entity: switch.openquatt_enabled
+                state: 'off'
+            entity: datetime.openquatt_resume_at
+            name: Resume automatically
+            icon: mdi:calendar-clock
+            vertical: false
           - type: tile
             entity: switch.openquatt_manual_cooling_enable
             name: Manual cooling

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -152,8 +152,13 @@ views:
 
               Gebruik deze schakelaars voor directe runtime-bediening:
 
-              - `OpenQuatt actief`: pauzeert of hervat de normale warmte- en
-              koelregeling. Bewaking en vorstbeveiliging blijven actief.
+              - `OpenQuatt regeling`: schakelt de automatische verwarmings- en
+              koelregeling tijdelijk uit of weer in. Bewaking en
+              vorstbeveiliging blijven actief.
+
+              - `Hervat automatisch`: kies een datum en tijd waarop de
+              regeling vanzelf weer wordt ingeschakeld nadat je haar tijdelijk
+              hebt uitgezet.
 
               - `Handmatige koeling`: telt mee als extra koeltoestemming,
               bovenop CIC en/of HA-invoer.
@@ -166,11 +171,20 @@ views:
             text_only: true
           - type: tile
             entity: switch.openquatt_enabled
-            name: OpenQuatt actief
+            name: OpenQuatt regeling
             vertical: false
             features:
               - type: toggle
             features_position: inline
+          - type: tile
+            visibility:
+              - condition: state
+                entity: switch.openquatt_enabled
+                state: 'off'
+            entity: datetime.openquatt_resume_at
+            name: Hervat automatisch
+            icon: mdi:calendar-clock
+            vertical: false
           - type: tile
             entity: switch.openquatt_manual_cooling_enable
             name: Handmatige koeling

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -145,11 +145,15 @@ views:
               <summary><strong>Explanation</strong></summary>
 
 
-              Use these switches for direct runtime control:
+              Use these controls for direct runtime interaction:
 
-              - `OpenQuatt enabled`: pauses or resumes normal heating and
-              cooling control. Safety monitoring and freeze protection stay
-              active.
+              - `OpenQuatt regulation`: temporarily disables or re-enables
+              automatic heating and cooling control. Safety monitoring and
+              freeze protection stay active.
+
+              - `Resume automatically`: choose the date and time when the
+              regulation should turn itself back on after being temporarily
+              disabled.
 
               - `Manual cooling`: adds an extra cooling permission on top of
               CIC and/or HA input.
@@ -162,11 +166,20 @@ views:
             text_only: true
           - type: tile
             entity: switch.openquatt_enabled
-            name: OpenQuatt enabled
+            name: OpenQuatt regulation
             vertical: false
             features:
               - type: toggle
             features_position: inline
+          - type: tile
+            visibility:
+              - condition: state
+                entity: switch.openquatt_enabled
+                state: 'off'
+            entity: datetime.openquatt_resume_at
+            name: Resume automatically
+            icon: mdi:calendar-clock
+            vertical: false
           - type: tile
             entity: switch.openquatt_manual_cooling_enable
             name: Manual cooling

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -151,8 +151,13 @@ views:
 
               Gebruik deze schakelaars voor directe runtime-bediening:
 
-              - `OpenQuatt actief`: pauzeert of hervat de normale warmte- en
-              koelregeling. Bewaking en vorstbeveiliging blijven actief.
+              - `OpenQuatt regeling`: schakelt de automatische verwarmings- en
+              koelregeling tijdelijk uit of weer in. Bewaking en
+              vorstbeveiliging blijven actief.
+
+              - `Hervat automatisch`: kies een datum en tijd waarop de
+              regeling vanzelf weer wordt ingeschakeld nadat je haar tijdelijk
+              hebt uitgezet.
 
               - `Handmatige koeling`: telt mee als extra koeltoestemming,
               bovenop CIC en/of HA-invoer.
@@ -165,11 +170,20 @@ views:
             text_only: true
           - type: tile
             entity: switch.openquatt_enabled
-            name: OpenQuatt actief
+            name: OpenQuatt regeling
             vertical: false
             features:
               - type: toggle
             features_position: inline
+          - type: tile
+            visibility:
+              - condition: state
+                entity: switch.openquatt_enabled
+                state: 'off'
+            entity: datetime.openquatt_resume_at
+            name: Hervat automatisch
+            icon: mdi:calendar-clock
+            vertical: false
           - type: tile
             entity: switch.openquatt_manual_cooling_enable
             name: Handmatige koeling

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -232,6 +232,11 @@ switch:
     icon: mdi:power-standby
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
+    on_turn_on:
+      then:
+        - datetime.datetime.set:
+            id: oq_openquatt_resume_at
+            datetime: "2000-01-01 00:00:00"
     web_server:
       sorting_group_id: oq_control
 # ----------------------------
@@ -398,6 +403,17 @@ datetime:
     entity_category: config
     web_server:
       sorting_group_id: oq_control
+
+  - platform: template
+    id: oq_openquatt_resume_at
+    name: "OpenQuatt resume at"
+    type: datetime
+    optimistic: true
+    restore_value: true
+    initial_value: "2000-01-01 00:00:00"
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_control
 # ----------------------------
 # DIAGNOSTICS
 # ----------------------------
@@ -554,6 +570,15 @@ interval:
           const uint32_t now_ms = (uint32_t) millis();
           static uint32_t boot_ms = 0;
           if (boot_ms == 0) boot_ms = now_ms;
+          auto now_time = id(oq_time).now();
+          const bool time_valid = now_time.is_valid();
+          const auto openquatt_resume_at = id(oq_openquatt_resume_at).state_as_esptime();
+          const bool openquatt_resume_scheduled =
+              openquatt_resume_at.is_valid() && openquatt_resume_at.year >= 2024;
+
+          if (!id(oq_enabled).state && time_valid && openquatt_resume_scheduled && now_time >= openquatt_resume_at) {
+            id(oq_enabled).turn_on();
+          }
           // -------------------------------------------------
           // -------------------------------------------------
           // Power Limiter (16A guard) - simplified safety net
@@ -1246,8 +1271,6 @@ interval:
             const std::string silent_override = id(oq_silent_mode_override).active_index().has_value()
               ? id(oq_silent_mode_override).at(id(oq_silent_mode_override).active_index().value()).value()
               : std::string("Schedule");
-            auto now_time = id(oq_time).now();
-            const bool time_valid = now_time.is_valid();
 
             static bool last_time_valid_diag = false;
             if (time_valid != last_time_valid_diag) {

--- a/openquatt/web/mock-device.js
+++ b/openquatt/web/mock-device.js
@@ -1,5 +1,6 @@
 (function () {
-  const DOMAINS = new Set(["select", "number", "sensor", "text_sensor", "binary_sensor", "button", "time", "update", "switch"]);
+  const DOMAINS = new Set(["select", "number", "sensor", "text_sensor", "binary_sensor", "button", "time", "datetime", "update", "switch"]);
+  const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
   const entities = new Map();
   const state = {
     scenario: "heating",
@@ -356,6 +357,10 @@
         value,
         state: value,
       });
+    });
+    setEntity("datetime", "OpenQuatt resume at", {
+      value: OPENQUATT_RESUME_CLEAR_VALUE,
+      state: OPENQUATT_RESUME_CLEAR_VALUE,
     });
 
     [
@@ -889,7 +894,65 @@
     }
   }
 
+  function normalizeDateTimeValue(rawValue) {
+    const value = String(rawValue || "").trim();
+    if (!value) {
+      return "";
+    }
+    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2})(?::(\d{2}))?)$/);
+    if (!match) {
+      return "";
+    }
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const hour = Number(match[4]);
+    const minute = Number(match[5]);
+    const second = Number(match[6] || "0");
+    if ([year, month, day, hour, minute, second].some((part) => Number.isNaN(part))) {
+      return "";
+    }
+    return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")} ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}:${String(second).padStart(2, "0")}`;
+  }
+
+  function parseDateTimeValue(rawValue) {
+    const normalized = normalizeDateTimeValue(rawValue);
+    if (!normalized || normalized === OPENQUATT_RESUME_CLEAR_VALUE) {
+      return null;
+    }
+    const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/);
+    if (!match) {
+      return null;
+    }
+    const date = new Date(
+      Number(match[1]),
+      Number(match[2]) - 1,
+      Number(match[3]),
+      Number(match[4]),
+      Number(match[5]),
+      Number(match[6]),
+      0
+    );
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  function applyOpenQuattResumeSchedule() {
+    const resumeAt = parseDateTimeValue(getEntity("datetime", "OpenQuatt resume at")?.value || "");
+    if (!resumeAt || isSwitchEnabled("OpenQuatt Enabled")) {
+      return;
+    }
+    if (Date.now() >= resumeAt.getTime()) {
+      const enabledEntity = getEntity("switch", "OpenQuatt Enabled");
+      if (enabledEntity) {
+        enabledEntity.value = true;
+        enabledEntity.state = true;
+      }
+      setText("datetime", "OpenQuatt resume at", OPENQUATT_RESUME_CLEAR_VALUE);
+    }
+  }
+
   function applyRuntimeControlOverlay(single) {
+    applyOpenQuattResumeSchedule();
     const openquattEnabled = isSwitchEnabled("OpenQuatt Enabled");
     const manualCoolingEnabled = isSwitchEnabled("Manual Cooling Enable");
     const silentModeOverride = String(getEntity("select", "Silent Mode Override")?.value || "Schedule");
@@ -1017,6 +1080,13 @@
     notifyMockUpdated();
   }
 
+  function handleDateTimeSet(name, value) {
+    const normalized = normalizeDateTimeValue(value) || OPENQUATT_RESUME_CLEAR_VALUE;
+    setText("datetime", name, normalized);
+    updateSummary();
+    notifyMockUpdated();
+  }
+
   function handleSwitchSet(name, enabled) {
     const entity = getEntity("switch", name);
     if (!entity) {
@@ -1024,6 +1094,9 @@
     }
     entity.value = Boolean(enabled);
     entity.state = Boolean(enabled);
+    if (name === "OpenQuatt Enabled" && enabled && getEntity("datetime", "OpenQuatt resume at")) {
+      setText("datetime", "OpenQuatt resume at", OPENQUATT_RESUME_CLEAR_VALUE);
+    }
     applyScenario(state.scenario);
     updateSummary();
     notifyMockUpdated();
@@ -1162,6 +1235,8 @@
           handleNumberSet(request.name, rawValue || "0");
         } else if (request.domain === "time") {
           handleTimeSet(request.name, rawValue || "");
+        } else if (request.domain === "datetime") {
+          handleDateTimeSet(request.name, rawValue || "");
         }
         return mockResponse(200, entity);
       }

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -2936,11 +2936,6 @@ body.oq-page-light {
   --oq-overview-meter-track: #e5e7eb;
 }
 
-.oq-overview-board--light .oq-overview-home-badge {
-  background: #ffffff;
-  border-color: #dbe3ee;
-}
-
 .oq-overview-summary-shell {
   padding: 16px;
   border-radius: 26px;
@@ -2964,14 +2959,12 @@ body.oq-page-light {
 
 .oq-overview-head .oq-helper-section-title,
 .oq-overview-system-copy h3,
-.oq-overview-hp h3,
-.oq-overview-home-demand h4 {
+.oq-overview-hp h3 {
   color: var(--oq-overview-title);
 }
 
 .oq-overview-head .oq-helper-section-copy,
-.oq-overview-system-copy p,
-.oq-overview-home-demand p {
+.oq-overview-system-copy p {
   color: var(--oq-overview-soft);
 }
 
@@ -3112,114 +3105,6 @@ body.oq-page-light {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
   align-items: stretch;
-}
-
-.oq-overview-statusmeta-card {
-  width: 100%;
-  max-width: none;
-  padding: 8px 10px;
-  border-radius: 12px;
-  background: var(--oq-overview-lane-bg);
-  border: 1px solid var(--oq-overview-panel-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025), 0 3px 8px rgba(2, 6, 23, 0.025);
-}
-
-.oq-overview-statusmeta-item {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-}
-
-.oq-overview-statusmeta-item span {
-  color: var(--oq-overview-muted);
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.oq-overview-statusmeta-item strong {
-  color: var(--oq-overview-title);
-  font-size: 0.84rem;
-  line-height: 1.22;
-  white-space: normal;
-  overflow-wrap: anywhere;
-}
-
-.oq-overview-statuscard {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-  gap: 4px;
-  padding: 12px 14px;
-  min-height: 0;
-  border-radius: 14px;
-  background: var(--oq-overview-lane-bg);
-  border: 1px solid var(--oq-overview-panel-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025), 0 3px 8px rgba(2, 6, 23, 0.025);
-}
-
-.oq-overview-statuscard--primary {
-  padding: 13px 15px;
-  min-height: 86px;
-}
-
-.oq-overview-statuscard--compact {
-  padding: 12px 14px;
-  min-height: 86px;
-}
-
-.oq-overview-statuscard::before {
-  content: "";
-  position: absolute;
-  left: 14px;
-  top: 14px;
-  width: 9px;
-  height: 9px;
-  border-radius: 999px;
-}
-
-.oq-overview-statuscard span {
-  padding-left: 15px;
-  color: var(--oq-overview-muted);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.oq-overview-statuscard strong {
-  color: var(--oq-overview-title);
-  font-size: 0.9rem;
-  line-height: 1.22;
-  max-width: 30ch;
-}
-
-.oq-overview-statuscard--primary strong {
-  font-size: 1rem;
-  max-width: 18ch;
-}
-
-.oq-overview-statuscard--blue::before {
-  background: #3b82f6;
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.12);
-}
-
-.oq-overview-statuscard--orange::before {
-  background: #f97316;
-  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.12);
-}
-
-.oq-overview-statuscard--green::before {
-  background: #22c55e;
-  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.12);
-}
-
-.oq-overview-statuscard--neutral::before {
-  background: #94a3b8;
-  box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.12);
 }
 
 .oq-overview-controlpanel {
@@ -3512,73 +3397,6 @@ body.oq-page-light {
   border-color: rgba(249, 115, 22, 0.32);
   background: rgba(249, 115, 22, 0.1);
   color: var(--oq-overview-title);
-}
-
-.oq-overview-home-demand {
-  display: grid;
-  grid-template-columns: minmax(180px, 0.34fr) minmax(0, 1fr);
-  align-items: stretch;
-  gap: 16px;
-  margin-top: 16px;
-  padding: 18px;
-  border-radius: 20px;
-  background: var(--oq-overview-chip-bg);
-  border: 1px solid var(--oq-overview-panel-border);
-}
-
-.oq-overview-home-badge {
-  display: grid;
-  align-content: center;
-  gap: 10px;
-  padding: 18px;
-  border-radius: 18px;
-  border: 1px solid var(--oq-overview-panel-border);
-  background: var(--oq-overview-surface);
-}
-
-.oq-overview-home-badge span {
-  color: var(--oq-overview-muted);
-  font-size: 0.82rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.oq-overview-home-badge strong {
-  color: var(--oq-overview-title);
-  font-size: 1.25rem;
-  line-height: 1.15;
-}
-
-.oq-overview-home-badge--high {
-  box-shadow: inset 0 0 0 2px rgba(249, 115, 22, 0.18);
-}
-
-.oq-overview-home-badge--active {
-  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.18);
-}
-
-.oq-overview-home-badge--steady {
-  box-shadow: inset 0 0 0 2px rgba(34, 197, 94, 0.16);
-}
-
-.oq-overview-home-badge--low,
-.oq-overview-home-badge--unknown {
-  box-shadow: inset 0 0 0 2px rgba(148, 163, 184, 0.18);
-}
-
-.oq-overview-home-copy {
-  display: grid;
-  gap: 12px;
-}
-
-.oq-overview-home-copy h4 {
-  margin: 0;
-  color: var(--oq-overview-title);
-}
-
-.oq-overview-home-copy p {
-  margin: 0;
 }
 
 .oq-overview-hero {
@@ -3884,50 +3702,6 @@ body.oq-page-light {
   color: var(--oq-overview-title);
   font-size: 0.98rem;
   text-align: right;
-}
-
-.oq-overview-home-meter {
-  display: grid;
-  gap: 8px;
-}
-
-.oq-overview-home-meter-track {
-  height: 12px;
-  overflow: hidden;
-  border-radius: 999px;
-  background: var(--oq-overview-meter-track);
-}
-
-.oq-overview-home-meter-fill {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-}
-
-.oq-overview-home-meter-fill--high {
-  background: linear-gradient(90deg, #f97316, #ef4444);
-}
-
-.oq-overview-home-meter-fill--active {
-  background: linear-gradient(90deg, #2563eb, #60a5fa);
-}
-
-.oq-overview-home-meter-fill--steady {
-  background: linear-gradient(90deg, #22c55e, #86efac);
-}
-
-.oq-overview-home-meter-fill--low,
-.oq-overview-home-meter-fill--unknown {
-  background: linear-gradient(90deg, #94a3b8, #cbd5e1);
-}
-
-.oq-overview-home-meter-labels {
-  display: flex;
-  justify-content: space-between;
-  color: var(--oq-overview-muted);
-  font-size: 0.82rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
 }
 
 .oq-overview-temps-list {
@@ -5630,23 +5404,7 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     justify-items: flex-start;
   }
 
-  .oq-overview-home-demand {
-    grid-template-columns: 1fr;
-  }
-
-  .oq-overview-lanes--two-column {
-    grid-template-columns: 1fr;
-  }
-
   .oq-overview-energy-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .oq-overview-statusmeta {
-    grid-template-columns: 1fr;
-  }
-
-  .oq-overview-statuscards {
     grid-template-columns: 1fr;
   }
 

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -3085,10 +3085,6 @@ body.oq-page-light {
   font-size: 0.74rem;
 }
 
-.oq-overview-stat--system p {
-  color: var(--oq-overview-muted);
-}
-
 .oq-overview-sectionhead {
   display: flex;
   align-items: center;

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -2987,16 +2987,20 @@ body.oq-page-light {
   display: grid;
   gap: 10px;
   min-width: 0;
+  align-content: start;
+  align-self: start;
 }
 
 .oq-overview-kpis {
   display: grid;
   gap: 8px;
+  align-content: start;
 }
 
 .oq-overview-summary-side {
   display: grid;
   align-content: start;
+  align-self: start;
   gap: 10px;
   min-width: 0;
   padding-top: 0;

--- a/openquatt/web/openquatt-app.css
+++ b/openquatt/web/openquatt-app.css
@@ -922,6 +922,11 @@ body.oq-page-light {
   line-height: 1.5;
 }
 
+.oq-helper-modal-success--compact {
+  margin-top: 6px;
+  margin-bottom: 0;
+}
+
 .oq-helper-shell--dark .oq-helper-modal-success,
 .oq-helper-modal-backdrop--dark .oq-helper-modal-success {
   border-color: rgba(74, 222, 128, 0.24);
@@ -1023,6 +1028,38 @@ body.oq-page-light {
 
 .oq-helper-modal-body {
   min-width: 0;
+}
+
+.oq-helper-modal-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.oq-helper-modal-channel--datetime {
+  margin-top: 16px;
+}
+
+.oq-helper-modal-inline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.oq-helper-modal-inline .oq-helper-button {
+  min-width: 128px;
+}
+
+@media (max-width: 640px) {
+  .oq-helper-modal-inline {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .oq-helper-modal-inline .oq-helper-button {
+    width: 100%;
+  }
 }
 
 .oq-helper-modal-link {
@@ -2669,45 +2706,54 @@ body.oq-page-light {
   align-content: start;
 }
 
-.oq-settings-control--time {
+.oq-settings-control--time,
+.oq-settings-control--datetime {
   position: relative;
   display: block;
   min-width: 0;
 }
 
-.oq-settings-control--time .oq-helper-input {
+.oq-settings-control--time .oq-helper-input,
+.oq-settings-control--datetime .oq-helper-input {
   min-height: 54px;
   padding: 0 50px 0 16px;
   font-variant-numeric: tabular-nums;
   color-scheme: light;
 }
 
-.oq-helper-shell--dark .oq-settings-control--time .oq-helper-input {
+.oq-helper-shell--dark .oq-settings-control--time .oq-helper-input,
+.oq-helper-shell--dark .oq-settings-control--datetime .oq-helper-input {
   color-scheme: dark;
 }
 
-.oq-settings-control--time .oq-helper-input::-webkit-date-and-time-value {
+.oq-settings-control--time .oq-helper-input::-webkit-date-and-time-value,
+.oq-settings-control--datetime .oq-helper-input::-webkit-date-and-time-value {
   text-align: left;
 }
 
-.oq-settings-control--time .oq-helper-input::-webkit-datetime-edit {
+.oq-settings-control--time .oq-helper-input::-webkit-datetime-edit,
+.oq-settings-control--datetime .oq-helper-input::-webkit-datetime-edit {
   display: inline-flex;
   align-items: center;
   min-height: 100%;
   padding: 0;
 }
 
-.oq-settings-control--time .oq-helper-input::-webkit-datetime-edit-fields-wrapper {
+.oq-settings-control--time .oq-helper-input::-webkit-datetime-edit-fields-wrapper,
+.oq-settings-control--datetime .oq-helper-input::-webkit-datetime-edit-fields-wrapper {
   display: inline-flex;
   align-items: center;
 }
 
 .oq-settings-control--time .oq-helper-input::-webkit-clear-button,
-.oq-settings-control--time .oq-helper-input::-webkit-inner-spin-button {
+.oq-settings-control--time .oq-helper-input::-webkit-inner-spin-button,
+.oq-settings-control--datetime .oq-helper-input::-webkit-clear-button,
+.oq-settings-control--datetime .oq-helper-input::-webkit-inner-spin-button {
   display: none;
 }
 
-.oq-settings-control--time .oq-helper-input::-webkit-calendar-picker-indicator {
+.oq-settings-control--time .oq-helper-input::-webkit-calendar-picker-indicator,
+.oq-settings-control--datetime .oq-helper-input::-webkit-calendar-picker-indicator {
   opacity: 0;
   width: 22px;
   height: 22px;
@@ -2736,7 +2782,8 @@ body.oq-page-light {
   transition: color 160ms ease;
 }
 
-.oq-settings-control--time:focus-within .oq-settings-time-icon {
+.oq-settings-control--time:focus-within .oq-settings-time-icon,
+.oq-settings-control--datetime:focus-within .oq-settings-time-icon {
   color: var(--oq-helper-accent-deep);
 }
 
@@ -3192,6 +3239,12 @@ body.oq-page-light {
   line-height: 1.38;
 }
 
+.oq-overview-controlpanel-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .oq-overview-controlpanel-meta-item,
 .oq-overview-controlpanel-head {
   display: flex;
@@ -3247,6 +3300,10 @@ body.oq-page-light {
 
 .oq-overview-controlpanel-meta-item--green strong {
   color: #16a34a;
+}
+
+.oq-overview-controlpanel-meta-item--orange strong {
+  color: #c2410c;
 }
 
 .oq-overview-controlpanel--green .oq-overview-controlpanel-head span {

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -131,6 +131,7 @@
     silentMax: { domain: "number", name: "Silent max level" },
     silentStartTime: { domain: "time", name: "Silent start time" },
     silentEndTime: { domain: "time", name: "Silent end time" },
+    openquattResumeAt: { domain: "datetime", name: "OpenQuatt resume at", optional: true },
     maxWater: { domain: "number", name: "Maximum water temperature" },
     minRuntime: { domain: "number", name: "Minimum runtime" },
     totalPower: { domain: "sensor", name: "Total Power Input" },
@@ -364,6 +365,7 @@
   const OVERVIEW_KEYS = [
     "strategy",
     "openquattEnabled",
+    "openquattResumeAt",
     "manualCoolingEnable",
     "silentModeOverride",
     "coolingEnableSelected",
@@ -485,6 +487,7 @@
   const FLOW_DASH_CYCLE_PX = 22;
   const FLOW_OFFSET_PX_PER_SEC = FLOW_DASH_CYCLE_PX / 1.7;
   const FAN_ROTATION_DEG_PER_SEC = 360 / 3.2;
+  const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
 
   const state = {
     mounted: false,
@@ -526,6 +529,7 @@
     updateInstallProgressHint: Number.NaN,
     updateInstallCompleted: false,
     updateInstallCompletedVersion: "",
+    pauseResumeDraft: "",
     draggingCurveKey: "",
     motionFrame: 0,
     motionStartedAt: 0,
@@ -2134,6 +2138,81 @@
       `;
     }
 
+    if (state.systemModal === "openquatt-pause") {
+      const enabled = isEntityActive("openquattEnabled");
+      const busy = state.busyAction === "openquatt-regulation";
+      const hasResumeEntity = hasEntity("openquattResumeAt");
+      const resumeScheduled = hasOpenQuattResumeSchedule();
+      const resumeLabel = formatOpenQuattResumeDateTime(getEntityValue("openquattResumeAt"));
+      const draftValue = getOpenQuattPauseDraftValue();
+      return `
+        <div class="oq-helper-modal-backdrop${state.overviewTheme === "dark" ? " oq-helper-modal-backdrop--dark" : ""}" data-oq-modal="system">
+          <section class="oq-helper-modal oq-helper-modal--wide" role="dialog" aria-modal="true" aria-labelledby="oq-openquatt-pause-modal-title">
+            <div class="oq-helper-modal-head">
+              <div>
+                <p class="oq-helper-modal-kicker">Bediening</p>
+                <h2 class="oq-helper-modal-title" id="oq-openquatt-pause-modal-title">Openquatt regeling</h2>
+              </div>
+              <button class="oq-helper-modal-close" type="button" data-oq-action="close-system-modal" aria-label="Sluit regeling-popup">×</button>
+            </div>
+            <p class="oq-helper-modal-copy">${enabled
+              ? "Kies hoe lang de regeling uit moet blijven. Verwarmen en koelen stoppen dan, maar beveiligingen blijven actief."
+              : "De regeling staat nu tijdelijk uit. Je kunt meteen weer inschakelen of een nieuw hervatmoment plannen."
+            }</p>
+            ${resumeScheduled
+              ? `<div class="oq-helper-modal-success oq-helper-modal-success--compact">
+                  <strong>Hervat nu automatisch</strong>
+                  <span>${escapeHtml(resumeLabel)}</span>
+                </div>`
+              : ""
+            }
+            ${hasResumeEntity
+              ? `
+                <div class="oq-helper-modal-presets">
+                  <button class="oq-helper-button" type="button" data-oq-action="apply-openquatt-preset" data-pause-preset="2h" ${busy ? "disabled" : ""}>2 uur</button>
+                  <button class="oq-helper-button" type="button" data-oq-action="apply-openquatt-preset" data-pause-preset="8h" ${busy ? "disabled" : ""}>8 uur</button>
+                  <button class="oq-helper-button" type="button" data-oq-action="apply-openquatt-preset" data-pause-preset="tomorrow-morning" ${busy ? "disabled" : ""}>Tot morgenochtend</button>
+                </div>
+                <div class="oq-helper-modal-channel oq-helper-modal-channel--datetime">
+                  <span class="oq-helper-modal-label">Hervatten op</span>
+                  <div class="oq-helper-modal-inline">
+                    <label class="oq-settings-control oq-settings-control--datetime">
+                      <input
+                        class="oq-helper-input"
+                        type="datetime-local"
+                        step="60"
+                        lang="nl-NL"
+                        data-oq-field="openquattPauseDraft"
+                        data-oq-pause-draft="resume"
+                        value="${escapeHtml(draftValue)}"
+                        ${busy ? "disabled" : ""}
+                      >
+                      <span class="oq-settings-time-icon" aria-hidden="true">
+                        <svg viewBox="0 0 20 20" focusable="false">
+                          <rect x="3.2" y="4.2" width="13.6" height="12.6" rx="2.4" fill="none" stroke="currentColor" stroke-width="1.5" />
+                          <path d="M6.2 2.9V5.4M13.8 2.9V5.4M3.8 8.1H16.2M10 10.3V13.1L12.3 14.4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                        </svg>
+                      </span>
+                    </label>
+                    <button class="oq-helper-button oq-helper-button--primary" type="button" data-oq-action="apply-openquatt-custom-pause" ${busy ? "disabled" : ""}>Plan moment</button>
+                  </div>
+                </div>
+              `
+              : `<p class="oq-helper-modal-note">Automatisch hervatten is nog niet beschikbaar op deze firmware. Je kunt de regeling wel zonder eindtijd uitschakelen.</p>`
+            }
+            <div class="oq-helper-modal-actions">
+              <button class="oq-helper-button oq-helper-button--ghost" type="button" data-oq-action="close-system-modal" ${busy ? "disabled" : ""}>Annuleren</button>
+              ${!enabled
+                ? `<button class="oq-helper-button" type="button" data-oq-action="enable-openquatt-now" ${busy ? "disabled" : ""}>Nu inschakelen</button>`
+                : ""
+              }
+              <button class="oq-helper-button" type="button" data-oq-action="apply-openquatt-indefinite" ${busy ? "disabled" : ""}>${enabled ? "Zonder eindtijd uitschakelen" : "Zonder eindtijd"}</button>
+            </div>
+          </section>
+        </div>
+      `;
+    }
+
     return "";
   }
 
@@ -2208,6 +2287,130 @@
   function toTimeInputValue(rawValue) {
     const normalized = normalizeTimeValue(rawValue);
     return normalized ? normalized.slice(0, 5) : "";
+  }
+
+  function normalizeDateTimeValue(rawValue) {
+    const value = String(rawValue || "").trim();
+    if (!value) {
+      return "";
+    }
+
+    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2})(?::(\d{2}))?)$/);
+    if (!match) {
+      return "";
+    }
+
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const hour = Number(match[4]);
+    const minute = Number(match[5]);
+    const second = Number(match[6] || "0");
+    if ([year, month, day, hour, minute, second].some((part) => Number.isNaN(part))) {
+      return "";
+    }
+    if (
+      year < 2000
+      || month < 1
+      || month > 12
+      || day < 1
+      || day > 31
+      || hour < 0
+      || hour > 23
+      || minute < 0
+      || minute > 59
+      || second < 0
+      || second > 59
+    ) {
+      return "";
+    }
+
+    return `${String(year).padStart(4, "0")}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")} ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}:${String(second).padStart(2, "0")}`;
+  }
+
+  function toDateTimeInputValue(rawValue) {
+    const normalized = normalizeDateTimeValue(rawValue);
+    return normalized ? normalized.slice(0, 16).replace(" ", "T") : "";
+  }
+
+  function parseDateTimeValue(rawValue) {
+    const normalized = normalizeDateTimeValue(rawValue);
+    if (!normalized || normalized === OPENQUATT_RESUME_CLEAR_VALUE) {
+      return null;
+    }
+
+    const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/);
+    if (!match) {
+      return null;
+    }
+
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const hour = Number(match[4]);
+    const minute = Number(match[5]);
+    const second = Number(match[6]);
+    const date = new Date(year, month - 1, day, hour, minute, second, 0);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  function hasOpenQuattResumeSchedule(rawValue = getEntityValue("openquattResumeAt")) {
+    return Boolean(parseDateTimeValue(rawValue));
+  }
+
+  function formatOpenQuattResumeDateTime(rawValue, short = false) {
+    const date = parseDateTimeValue(rawValue);
+    if (!date) {
+      return "";
+    }
+    return new Intl.DateTimeFormat("nl-NL", short
+      ? { weekday: "short", day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" }
+      : { weekday: "long", day: "numeric", month: "long", hour: "2-digit", minute: "2-digit" }
+    ).format(date);
+  }
+
+  function formatDateTimeForInput(date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hour = String(date.getHours()).padStart(2, "0");
+    const minute = String(date.getMinutes()).padStart(2, "0");
+    return `${year}-${month}-${day}T${hour}:${minute}`;
+  }
+
+  function roundDateToNextQuarter(date) {
+    const rounded = new Date(date.getTime());
+    rounded.setSeconds(0, 0);
+    const minutes = rounded.getMinutes();
+    const remainder = minutes % 15;
+    if (remainder !== 0) {
+      rounded.setMinutes(minutes + (15 - remainder));
+    }
+    return rounded;
+  }
+
+  function getOpenQuattPausePresetValue(preset) {
+    const now = new Date();
+    if (preset === "2h" || preset === "8h") {
+      const hours = preset === "2h" ? 2 : 8;
+      const target = roundDateToNextQuarter(new Date(now.getTime() + (hours * 3600 * 1000)));
+      return formatDateTimeForInput(target);
+    }
+    if (preset === "tomorrow-morning") {
+      const target = new Date(now);
+      target.setDate(target.getDate() + 1);
+      target.setHours(7, 0, 0, 0);
+      return formatDateTimeForInput(target);
+    }
+    return "";
+  }
+
+  function getOpenQuattPauseDraftValue() {
+    if (state.pauseResumeDraft) {
+      return state.pauseResumeDraft;
+    }
+    const scheduledValue = toDateTimeInputValue(getEntityValue("openquattResumeAt"));
+    return scheduledValue || getOpenQuattPausePresetValue("8h");
   }
 
   function getSettingsRefreshKeys() {
@@ -2472,6 +2675,11 @@
       return;
     }
 
+    if (event.target.dataset.oqPauseDraft) {
+      state.pauseResumeDraft = String(event.target.value || "");
+      return;
+    }
+
     if (event.target.type === "range" || event.target.type === "number") {
       if (event.target.type === "number") {
         state.inputDrafts[field] = event.target.value;
@@ -2514,16 +2722,27 @@
         return;
       }
       commitTime(field, normalized);
+      return;
+    }
+
+    if (entity.domain === "datetime") {
+      const normalized = normalizeDateTimeValue(event.target.value);
+      if (!normalized) {
+        state.controlError = `${entity.name} verwacht datum en tijd.`;
+        render();
+        return;
+      }
+      commitDateTime(field, normalized);
     }
   }
 
   function handleClick(event) {
-    const timeControl = event.target.closest(".oq-settings-control--time");
-    if (timeControl) {
-      const timeInput = timeControl.querySelector('input[data-oq-field]');
-      if (timeInput && timeInput.type === "time" && typeof timeInput.showPicker === "function") {
+    const dateTimeControl = event.target.closest(".oq-settings-control--time, .oq-settings-control--datetime");
+    if (dateTimeControl) {
+      const pickerInput = dateTimeControl.querySelector('input[data-oq-field]');
+      if (pickerInput && (pickerInput.type === "time" || pickerInput.type === "datetime-local") && typeof pickerInput.showPicker === "function") {
         try {
-          timeInput.showPicker();
+          pickerInput.showPicker();
         } catch (_error) {
           // Ignore browsers that block this call.
         }
@@ -2616,6 +2835,40 @@
     if (action === "open-silent-settings-modal") {
       state.systemModal = "silent-settings";
       render();
+      return;
+    }
+
+    if (action === "open-openquatt-pause-modal") {
+      state.pauseResumeDraft = getOpenQuattPauseDraftValue();
+      state.systemModal = "openquatt-pause";
+      render();
+      return;
+    }
+
+    if (action === "enable-openquatt-now") {
+      commitOpenQuattRegulationResumeNow();
+      return;
+    }
+
+    if (action === "apply-openquatt-preset") {
+      const presetValue = getOpenQuattPausePresetValue(button.dataset.pausePreset || "");
+      state.pauseResumeDraft = presetValue;
+      commitOpenQuattRegulationPause(presetValue);
+      return;
+    }
+
+    if (action === "apply-openquatt-indefinite") {
+      commitOpenQuattRegulationPause("");
+      return;
+    }
+
+    if (action === "apply-openquatt-custom-pause") {
+      if (!String(state.pauseResumeDraft || "").trim()) {
+        state.controlError = "Kies eerst een datum en tijd om automatisch te hervatten.";
+        render();
+        return;
+      }
+      commitOpenQuattRegulationPause(state.pauseResumeDraft || "");
       return;
     }
 
@@ -3013,6 +3266,137 @@
       );
     } catch (error) {
       state.controlError = `${entity.name} kon niet worden bijgewerkt. ${error.message}`;
+    } finally {
+      state.busyAction = "";
+      render();
+    }
+  }
+
+  async function postDateTimeValue(key, value) {
+    const entity = ENTITY_DEFS[key];
+    const normalized = normalizeDateTimeValue(value) || OPENQUATT_RESUME_CLEAR_VALUE;
+    const response = await fetch(
+      `${buildEntityPath(entity.domain, entity.name, "set")}?value=${encodeURIComponent(normalized)}`,
+      { method: "POST" }
+    );
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    state.entities[key] = {
+      ...(state.entities[key] || {}),
+      value: normalized,
+      state: normalized,
+    };
+    return normalized;
+  }
+
+  async function postSwitchState(key, enabled) {
+    const entity = ENTITY_DEFS[key];
+    const action = enabled ? "turn_on" : "turn_off";
+    const response = await fetch(buildEntityPath(entity.domain, entity.name, action), { method: "POST" });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    state.entities[key] = {
+      ...(state.entities[key] || {}),
+      value: enabled,
+      state: enabled,
+    };
+    return enabled;
+  }
+
+  async function refreshOpenQuattControlState() {
+    await refreshEntities(
+      [...new Set([...OVERVIEW_KEYS, ...HEADER_ENTITY_KEYS, "setupComplete", ...FIRMWARE_ENTITY_KEYS])],
+      "state"
+    );
+  }
+
+  async function commitDateTime(key, value) {
+    const entity = ENTITY_DEFS[key];
+    const normalized = normalizeDateTimeValue(value);
+    state.busyAction = `save-${key}`;
+    state.controlNotice = "";
+    state.controlError = "";
+    render();
+
+    try {
+      await postDateTimeValue(key, normalized);
+      state.controlNotice = `${entity.name} bijgewerkt.`;
+      await refreshEntities(
+        state.appView === "settings"
+          ? getSettingsRefreshKeys()
+          : [key, "setupComplete", "openquattEnabled"],
+        "state"
+      );
+    } catch (error) {
+      state.controlError = `${entity.name} kon niet worden bijgewerkt. ${error.message}`;
+    } finally {
+      state.busyAction = "";
+      render();
+    }
+  }
+
+  async function commitOpenQuattRegulationPause(rawResumeValue) {
+    const scheduledValue = normalizeDateTimeValue(rawResumeValue);
+    if (rawResumeValue && !scheduledValue) {
+      state.controlError = "Kies een geldig hervatmoment om automatisch weer in te schakelen.";
+      render();
+      return;
+    }
+    if (scheduledValue && !hasEntity("openquattResumeAt")) {
+      state.controlError = "Automatisch hervatten is op deze firmware nog niet beschikbaar.";
+      render();
+      return;
+    }
+
+    state.busyAction = "openquatt-regulation";
+    state.controlNotice = "";
+    state.controlError = "";
+    render();
+
+    let resumeScheduled = false;
+    try {
+      if (hasEntity("openquattResumeAt")) {
+        await postDateTimeValue("openquattResumeAt", scheduledValue || OPENQUATT_RESUME_CLEAR_VALUE);
+        resumeScheduled = Boolean(scheduledValue);
+      }
+      await postSwitchState("openquattEnabled", false);
+      state.pauseResumeDraft = scheduledValue ? toDateTimeInputValue(scheduledValue) : "";
+      state.systemModal = "";
+      state.controlNotice = scheduledValue
+        ? `Openquatt regeling is tijdelijk uitgeschakeld tot ${formatOpenQuattResumeDateTime(scheduledValue)}.`
+        : "Openquatt regeling is uitgeschakeld zonder eindmoment.";
+      await refreshOpenQuattControlState();
+    } catch (error) {
+      if (resumeScheduled && hasEntity("openquattResumeAt")) {
+        try {
+          await postDateTimeValue("openquattResumeAt", OPENQUATT_RESUME_CLEAR_VALUE);
+        } catch (_rollbackError) {
+          // Best effort rollback to avoid leaving a stray resume moment behind.
+        }
+      }
+      state.controlError = `Openquatt regeling kon niet worden bijgewerkt. ${error.message}`;
+    } finally {
+      state.busyAction = "";
+      render();
+    }
+  }
+
+  async function commitOpenQuattRegulationResumeNow() {
+    state.busyAction = "openquatt-regulation";
+    state.controlNotice = "";
+    state.controlError = "";
+    render();
+
+    try {
+      await postSwitchState("openquattEnabled", true);
+      state.pauseResumeDraft = "";
+      state.systemModal = "";
+      state.controlNotice = "Openquatt regeling is weer actief.";
+      await refreshOpenQuattControlState();
+    } catch (error) {
+      state.controlError = `Openquatt regeling kon niet worden ingeschakeld. ${error.message}`;
     } finally {
       state.busyAction = "";
       render();
@@ -5087,8 +5471,8 @@
     if (!isEntityActive("openquattEnabled")) {
       return {
         label: "Regeling nu",
-        value: "OpenQuatt gepauzeerd",
-        tone: "neutral",
+        value: "Regeling tijdelijk uit",
+        tone: "orange",
       };
     }
     if (isCoolingOverviewActive()) {
@@ -5211,6 +5595,8 @@
 
   function getOverviewControlCards() {
     const openquattEnabled = isEntityActive("openquattEnabled");
+    const openquattResumeAt = getEntityValue("openquattResumeAt");
+    const openquattResumeScheduled = hasOpenQuattResumeSchedule(openquattResumeAt);
     const manualCoolingEnabled = isEntityActive("manualCoolingEnable");
     const silentModeOverride = String(getEntityValue("silentModeOverride") || "Schedule");
     const coolingBlocked = !isEntityActive("coolingPermitted");
@@ -5253,14 +5639,24 @@
     return [
       {
         key: "openquattEnabled",
-        label: "OpenQuatt",
-        status: openquattEnabled ? "Aan" : "Gepauzeerd",
+        label: "Openquatt regeling",
+        status: openquattEnabled ? "Actief" : "Tijdelijk uit",
         copy: openquattEnabled
-          ? "Verwarmen en koelen mogen gewoon werken."
-          : "Verwarmen en koelen staan uit. Bescherming blijft actief.",
-        buttonLabel: openquattEnabled ? "Pauzeer" : "Zet aan",
-        nextState: openquattEnabled ? "off" : "on",
-        tone: openquattEnabled ? "green" : "neutral",
+          ? "Verwarmen en koelen worden automatisch geregeld."
+          : openquattResumeScheduled
+            ? "Verwarming en koeling zijn tijdelijk uitgeschakeld. Beveiligingen blijven actief."
+            : "Verwarming en koeling zijn uitgeschakeld. Beveiligingen blijven actief.",
+        tone: openquattEnabled ? "green" : "orange",
+        kind: "openquatt-control",
+        meta: openquattEnabled
+          ? []
+          : [
+              {
+                label: openquattResumeScheduled ? "Hervat automatisch" : "Hervatten",
+                value: openquattResumeScheduled ? formatOpenQuattResumeDateTime(openquattResumeAt, true) : "Handmatig",
+                tone: openquattResumeScheduled ? "orange" : "neutral",
+              },
+            ],
       },
       {
         key: "manualCoolingEnable",
@@ -5289,7 +5685,57 @@
     ].filter((card) => hasEntity(card.key));
   }
 
+  function renderOverviewControlMeta(card) {
+    if (!Array.isArray(card.meta) || !card.meta.length) {
+      return "";
+    }
+
+    return `
+      <div class="oq-overview-controlpanel-meta">
+        ${card.meta.map((item) => `
+          <div class="oq-overview-controlpanel-meta-item oq-overview-controlpanel-meta-item--${escapeHtml(item.tone || "neutral")}">
+            <span>${escapeHtml(item.label)}</span>
+            <strong>${escapeHtml(item.value)}</strong>
+          </div>
+        `).join("")}
+      </div>
+    `;
+  }
+
   function renderOverviewControlBody(card) {
+    if (card.kind === "openquatt-control") {
+      const busy = state.busyAction === "openquatt-regulation";
+      if (isEntityActive("openquattEnabled")) {
+        return `
+          <div class="oq-overview-controlpanel-actions">
+            <button
+              class="oq-overview-controlpanel-toggle${busy ? " is-busy" : ""}"
+              type="button"
+              data-oq-action="open-openquatt-pause-modal"
+              ${state.busyAction ? "disabled" : ""}
+            >${escapeHtml(busy ? "Bezig..." : "Tijdelijk uitschakelen")}</button>
+          </div>
+        `;
+      }
+
+      return `
+        <div class="oq-overview-controlpanel-actions oq-overview-controlpanel-actions--split">
+          <button
+            class="oq-overview-controlpanel-toggle${busy ? " is-busy" : ""}"
+            type="button"
+            data-oq-action="enable-openquatt-now"
+            ${state.busyAction ? "disabled" : ""}
+          >${escapeHtml(busy ? "Bezig..." : "Nu inschakelen")}</button>
+          <button
+            class="oq-overview-controlpanel-segment"
+            type="button"
+            data-oq-action="open-openquatt-pause-modal"
+            ${state.busyAction ? "disabled" : ""}
+          >${escapeHtml(hasOpenQuattResumeSchedule() ? "Moment wijzigen" : "Automatisch hervatten")}</button>
+        </div>
+      `;
+    }
+
     if (card.kind === "select") {
       return `
         <div class="oq-overview-controlpanel-actions oq-overview-controlpanel-actions--split">
@@ -5356,6 +5802,7 @@
                 <strong class="oq-overview-controlpanel-state oq-overview-controlpanel-state--${escapeHtml(openquattCard.tone)}">${escapeHtml(openquattCard.status)}</strong>
               </div>
               <p>${escapeHtml(openquattCard.copy)}</p>
+              ${renderOverviewControlMeta(openquattCard)}
               ${renderOverviewControlBody(openquattCard)}
             </article>
           `
@@ -5368,6 +5815,7 @@
               <strong class="oq-overview-controlpanel-state oq-overview-controlpanel-state--${escapeHtml(card.tone)}">${escapeHtml(card.status)}</strong>
             </div>
             <p>${escapeHtml(card.copy)}</p>
+            ${renderOverviewControlMeta(card)}
             ${renderOverviewControlBody(card)}
           </article>
         `).join("")}

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -5085,7 +5085,7 @@
 
   function renderOverviewStatusStatCard(label, value, tone, note) {
     return `
-      <article class="oq-overview-stat oq-overview-stat--${escapeHtml(tone)} oq-overview-stat--status${label === "Systeem" ? " oq-overview-stat--system" : ""}">
+      <article class="oq-overview-stat oq-overview-stat--${escapeHtml(tone)} oq-overview-stat--status">
         <p>${escapeHtml(label)}</p>
         <strong>${escapeHtml(value)}</strong>
         <span>${escapeHtml(note)}</span>
@@ -5553,7 +5553,7 @@
       return {
         label: "Systeem",
         value: "Normaal",
-        tone: "green",
+        tone: "neutral",
       };
     }
     if (isEntityActive("silentActive")) {
@@ -5573,7 +5573,7 @@
     return {
       label: "Systeem",
       value: "Normaal",
-      tone: "green",
+      tone: "neutral",
     };
   }
 
@@ -5586,10 +5586,10 @@
           <h3>Systeemstatus</h3>
         </div>
         <div class="oq-overview-statusgrid">
-          ${renderOverviewStatusStatCard("Strategie", strategyLabel, "blue", "regelstrategie")}
-          ${renderOverviewStatusStatCard("Controlmode", controlModeLabel, "sky", "actieve modus")}
-          ${renderOverviewStatusStatCard("Regeling", primary.value, primary.tone, "wat OpenQuatt nu doet")}
-          ${renderOverviewStatusStatCard("Systeem", system.value, system.tone, "actieve randvoorwaarde")}
+          ${renderOverviewStatusStatCard("Strategie", strategyLabel, "orange", "regelstrategie")}
+          ${renderOverviewStatusStatCard("Controlmode", controlModeLabel, "orange", "actieve modus")}
+          ${renderOverviewStatusStatCard("Regeling", primary.value, "orange", "wat OpenQuatt nu doet")}
+          ${renderOverviewStatusStatCard("Systeem", system.value, "orange", "actieve randvoorwaarde")}
         </div>
       </section>
     `;

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -1122,10 +1122,6 @@
     return formatDurationFromMinutes((Date.now() - bootedAt) / 60000);
   }
 
-  function formatDeviceUptime() {
-    return formatUptimeFromMeta();
-  }
-
   function getDeviceIpAddress() {
     const entityText = String(state.entities.ipAddress?.state ?? state.entities.ipAddress?.value ?? "").trim();
     if (entityText) {
@@ -1539,10 +1535,6 @@
       return fallbackUrl;
     }
     return entityUrl;
-  }
-
-  function getFirmwareSummary() {
-    return String((getFirmwareUpdateEntity() || {}).summary || "").trim();
   }
 
   function getFirmwareTitle() {
@@ -3499,35 +3491,6 @@
     }
   }
 
-  function renderFieldList(fields) {
-    return fields.map((field) => `
-      <article class="oq-helper-field">
-        <h3>${escapeHtml(field.title)}</h3>
-        <p>${escapeHtml(field.copy)}</p>
-      </article>
-    `).join("");
-  }
-
-  function renderSelectField(key, title, copy) {
-    const entity = state.entities[key] || {};
-    const value = String(getEntityValue(key) || "");
-    const options = Array.isArray(entity.option) ? entity.option : [];
-
-    return `
-      <article class="oq-helper-control-card">
-        <div class="oq-helper-control-copy">
-          <h3>${escapeHtml(title)}</h3>
-          <p>${escapeHtml(copy)}</p>
-        </div>
-        <label class="oq-helper-control">
-          <select class="oq-helper-select" data-oq-field="${escapeHtml(key)}" ${state.loadingEntities ? "disabled" : ""}>
-            ${options.map((option) => `<option value="${escapeHtml(option)}" ${option === value ? "selected" : ""}>${escapeHtml(option)}</option>`).join("")}
-          </select>
-        </label>
-      </article>
-    `;
-  }
-
   function renderNumberInputField(key, title, copy, options = {}) {
     const meta = getNumberMeta(key);
     const value = getInputDraftValue(key);
@@ -3551,36 +3514,6 @@
           <span class="oq-helper-unit">${escapeHtml(meta.uom || "")}</span>
         </label>
         ${options.footerMarkup || ""}
-      </article>
-    `;
-  }
-
-  function renderSliderField(key, title, copy) {
-    const meta = getNumberMeta(key);
-    const value = normalizeNumber(key, getEntityValue(key));
-    return `
-      <article class="oq-helper-control-card">
-        <div class="oq-helper-control-copy">
-          <h3>${escapeHtml(title)}</h3>
-          <p>${escapeHtml(copy)}</p>
-        </div>
-        <label class="oq-helper-slider-field">
-          <div class="oq-helper-slider-meta">
-            <span>${escapeHtml(meta.min)}${escapeHtml(meta.uom || "")}</span>
-            <strong>${escapeHtml(formatValue(key, value))}</strong>
-            <span>${escapeHtml(meta.max)}${escapeHtml(meta.uom || "")}</span>
-          </div>
-          <input
-            class="oq-helper-range"
-            type="range"
-            data-oq-field="${escapeHtml(key)}"
-            min="${meta.min}"
-            max="${meta.max}"
-            step="${meta.step}"
-            value="${value}"
-            ${state.loadingEntities ? "disabled" : ""}
-          >
-        </label>
       </article>
     `;
   }
@@ -4491,21 +4424,6 @@
     );
   }
 
-  function renderPowerHouseWorkspace() {
-    return `
-      <section class="oq-helper-mode-panel">
-        <div class="oq-helper-mode-head">
-          <p class="oq-helper-label">Verplicht Voor Power House</p>
-          <p class="oq-helper-section-copy">Met deze waarden schat OpenQuatt hoeveel warmte je woning nodig heeft. Heb je deze gegevens van Quatt, dan kun je ze hier gebruiken.</p>
-        </div>
-        <div class="oq-helper-control-grid">
-          ${renderNumberInputField("housePower", "Rated maximum house power", "Hoeveel warmte je woning ongeveer nodig heeft op een koude dag.")}
-          ${renderNumberInputField("houseOutdoorMax", "Maximum heating outdoor temperature", "Bij deze buitentemperatuur is verwarmen meestal niet meer nodig.")}
-        </div>
-      </section>
-    `;
-  }
-
   function renderCurveGraph() {
     const width = 560;
     const height = 240;
@@ -4595,19 +4513,6 @@
         ${CURVE_POINTS.map((point) => renderNumberInputField(point.key, `Aanvoertemp. bij ${point.label}`, `Doelaanvoertemperatuur bij ${point.label} buitentemperatuur.`)).join("")}
         ${renderNumberInputField("curveFallbackSupply", "Fallback-aanvoertemperatuur zonder buitentemperatuur", "Aanvoertemperatuur die gebruikt wordt als de buitentemperatuursensor niet beschikbaar is.", { footerMarkup: suggestionMarkup })}
       </div>
-    `;
-  }
-
-  function renderCurveWorkspace() {
-    return `
-      <section class="oq-helper-mode-panel">
-        <div class="oq-helper-mode-head">
-          <p class="oq-helper-label">Verplicht voor Stooklijn</p>
-          <p class="oq-helper-section-copy">Deze zes punten vormen samen je stooklijn. Zo bepaal je welke aanvoertemperatuur hoort bij welke buitentemperatuur.</p>
-        </div>
-        ${renderCurveGraph()}
-        ${renderCurveInputs()}
-      </section>
     `;
   }
 
@@ -5179,16 +5084,6 @@
         <span>${escapeHtml(label)}</span>
         <strong>${escapeHtml(explicitValue || getEntityStateText(key))}</strong>
       </div>
-    `;
-  }
-
-  function renderOverviewLane(label, value, tone = "blue", note = "") {
-    return `
-      <article class="oq-overview-lane oq-overview-lane--${escapeHtml(tone)}">
-        <span>${escapeHtml(label)}</span>
-        <strong>${escapeHtml(value)}</strong>
-        ${note ? `<p>${escapeHtml(note)}</p>` : ""}
-      </article>
     `;
   }
 
@@ -5996,94 +5891,6 @@
           ${filledGroups}
         </div>
       </article>
-    `;
-  }
-
-  function renderOverviewEnergySection() {
-    const currentColumn = renderOverviewEnergyColumn("Nu", "Live energie", [
-      renderOverviewEnergyCategory("Verwarmen", "orange", [
-        renderOverviewEnergyGroup("Warmtepomp", [
-          renderOverviewEnergyRow("Elektrisch vermogen", "heatingPowerInput"),
-          renderOverviewEnergyRow("Warmteafgifte", "totalHeat"),
-          renderOverviewEnergyRow("COP", "totalCop"),
-        ]),
-        renderOverviewEnergyGroup("CV-ketel", [
-          renderOverviewEnergyRow("Warmteafgifte", "boilerHeatPower"),
-        ]),
-        renderOverviewEnergyGroup("Systeem", [
-          renderOverviewEnergyRow("Warmteafgifte", "systemHeatPower"),
-        ]),
-      ]),
-      renderOverviewEnergyCategory("Koelen", "blue", [
-        renderOverviewEnergyGroup("Warmtepomp", [
-          renderOverviewEnergyRow("Elektrisch vermogen", "coolingPowerInput"),
-          renderOverviewEnergyRow("Koelafgifte", "totalCoolingPower"),
-          renderOverviewEnergyRow("COP (EER)", "totalEer"),
-        ]),
-      ]),
-    ], "blue");
-
-    const dailyColumn = renderOverviewEnergyColumn("Vandaag", "Energie vandaag", [
-      renderOverviewEnergyCategory("Verwarmen", "orange", [
-        renderOverviewEnergyGroup("Warmtepomp", [
-          renderOverviewEnergyRow("Elektriciteit", "heatingElectricalEnergyDaily"),
-          renderOverviewEnergyRow("Warmte", "heatpumpThermalEnergyDaily"),
-          renderOverviewEnergyRow("COP", "heatpumpCopDaily"),
-        ]),
-        renderOverviewEnergyGroup("CV-ketel", [
-          renderOverviewEnergyRow("Warmte", "boilerThermalEnergyDaily"),
-        ]),
-        renderOverviewEnergyGroup("Systeem", [
-          renderOverviewEnergyRow("Warmte", "systemThermalEnergyDaily"),
-        ]),
-      ]),
-      renderOverviewEnergyCategory("Koelen", "blue", [
-        renderOverviewEnergyGroup("Warmtepomp", [
-          renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyDaily"),
-          renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyDaily"),
-          renderOverviewEnergyRow("COP (EER)", "heatpumpEerDaily"),
-        ]),
-      ]),
-    ], "orange");
-
-    const cumulativeColumn = renderOverviewEnergyColumn("Cumulatief", "Tot nu toe", [
-      renderOverviewEnergyCategory("Verwarmen", "orange", [
-        renderOverviewEnergyGroup("Warmtepomp", [
-          renderOverviewEnergyRow("Elektriciteit", "heatingElectricalEnergyCumulative"),
-          renderOverviewEnergyRow("Warmte", "heatpumpThermalEnergyCumulative"),
-          renderOverviewEnergyRow("COP", "heatpumpCopCumulative"),
-        ]),
-        renderOverviewEnergyGroup("CV-ketel", [
-          renderOverviewEnergyRow("Warmte", "boilerThermalEnergyCumulative"),
-        ]),
-        renderOverviewEnergyGroup("Systeem", [
-          renderOverviewEnergyRow("Warmte", "systemThermalEnergyCumulative"),
-        ]),
-      ]),
-      renderOverviewEnergyCategory("Koelen", "blue", [
-        renderOverviewEnergyGroup("Warmtepomp", [
-          renderOverviewEnergyRow("Elektriciteit", "coolingElectricalEnergyCumulative"),
-          renderOverviewEnergyRow("Koeling", "heatpumpCoolingEnergyCumulative"),
-          renderOverviewEnergyRow("COP (EER)", "heatpumpEerCumulative"),
-        ]),
-      ]),
-    ], "green");
-
-    const columns = [currentColumn, dailyColumn, cumulativeColumn].filter(Boolean);
-    if (!columns.length) {
-      return "";
-    }
-
-    return `
-      <section class="oq-overview-energy">
-        <div class="oq-overview-system-copy">
-          <h3>Energie</h3>
-          <p>Bekijk hier verbruik, warmte of koeling en rendement voor nu, vandaag en cumulatief.</p>
-        </div>
-        <div class="oq-overview-energy-grid">
-          ${columns.join("")}
-        </div>
-      </section>
     `;
   }
 
@@ -7056,81 +6863,6 @@
             <div class="oq-hp-tech-footer-item">
               <span data-oq-bind="footer-efficiency-label">${escapeHtml(model.efficiencyLabel)}</span>
               <strong data-oq-bind="footer-efficiency">${escapeHtml(model.efficiencyText)}</strong>
-            </div>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  function getHomeDemandState() {
-    const roomTemp = getEntityNumericValue("roomTemp");
-    const roomSetpoint = getEntityNumericValue("roomSetpoint");
-    const delta = roomSetpoint - roomTemp;
-
-    if (Number.isNaN(delta)) {
-      return {
-        tone: "unknown",
-        level: "Onbekend",
-        score: 0,
-        description: "Nog niet genoeg ruimtegegevens om de warmtevraag betrouwbaar te duiden.",
-      };
-    }
-
-    if (delta >= 1.0) {
-      return {
-        tone: "high",
-        level: "Hoge warmtevraag",
-        score: Math.min(100, Math.round((delta / 2) * 100)),
-        description: "De woning zit merkbaar onder setpoint. Het systeem mag nu duidelijk doorverwarmen richting comfort.",
-      };
-    }
-
-    if (delta >= 0.3) {
-      return {
-        tone: "active",
-        level: "Warmtevraag actief",
-        score: Math.min(100, Math.round((delta / 2) * 100)),
-        description: "Er is nog warmtevraag, maar minder agressief dan bij een grote achterstand.",
-      };
-    }
-
-    if (delta >= -0.2) {
-      return {
-        tone: "steady",
-        level: "Bijna op setpoint",
-        score: Math.max(8, Math.round(((delta + 0.2) / 0.5) * 35)),
-        description: "De woning zit dicht bij setpoint. Het systeem hoeft vooral vast te houden en rustig bij te sturen.",
-      };
-    }
-
-    return {
-      tone: "low",
-      level: "Lage warmtevraag",
-      score: 6,
-      description: "De woning zit boven setpoint. De installatie kan terugmoduleren of afbouwen.",
-    };
-  }
-
-  function renderHomeDemandCard() {
-    const demand = getHomeDemandState();
-
-    return `
-      <div class="oq-overview-home-demand">
-        <div class="oq-overview-home-badge oq-overview-home-badge--${escapeHtml(demand.tone)}">
-          <span>Vraag</span>
-          <strong>${escapeHtml(demand.level)}</strong>
-        </div>
-        <div class="oq-overview-home-copy">
-          <h4>Warmtevraag woning</h4>
-          <p>${escapeHtml(demand.description)}</p>
-          <div class="oq-overview-home-meter">
-            <div class="oq-overview-home-meter-track">
-              <span class="oq-overview-home-meter-fill oq-overview-home-meter-fill--${escapeHtml(demand.tone)}" style="width:${demand.score}%"></span>
-            </div>
-            <div class="oq-overview-home-meter-labels">
-              <span>laag</span>
-              <span>hoog</span>
             </div>
           </div>
         </div>

--- a/openquatt/web/openquatt-app.js
+++ b/openquatt/web/openquatt-app.js
@@ -2652,6 +2652,22 @@
     ].join("|");
   }
 
+  function getOverviewControlsRenderSignature() {
+    return [
+      state.appView,
+      state.busyAction,
+      getEntitySignatureFragment("openquattEnabled"),
+      getEntitySignatureFragment("openquattResumeAt"),
+      getEntitySignatureFragment("manualCoolingEnable"),
+      getEntitySignatureFragment("silentModeOverride"),
+      getEntitySignatureFragment("controlModeLabel"),
+      getEntitySignatureFragment("coolingPermitted"),
+      getEntitySignatureFragment("coolingRequestActive"),
+      getEntitySignatureFragment("coolingBlockReason"),
+      getEntitySignatureFragment("silentActive"),
+    ].join("|");
+  }
+
   function getQuickStartRenderSignature() {
     return [
       state.appView,
@@ -7620,9 +7636,27 @@
     const heatPumpPanels = getHeatPumpPanels();
 
     if (summaryShell) {
-      const nextSummaryShell = renderOverviewSummaryShell(strategyLabel);
-      if (summaryShell.outerHTML !== nextSummaryShell) {
-        summaryShell.outerHTML = nextSummaryShell;
+      const top = summaryShell.querySelector(".oq-overview-top");
+      if (top) {
+        setInnerHtmlIfChanged(top, renderOverviewTopCards());
+      }
+
+      const statusPanel = summaryShell.querySelector(".oq-overview-statuspanel");
+      if (statusPanel) {
+        const controlModeLabel = getEntityStateText("controlModeLabel");
+        const nextStatusPanel = renderOverviewStatusStack(strategyLabel, controlModeLabel);
+        if (statusPanel.outerHTML !== nextStatusPanel) {
+          statusPanel.outerHTML = nextStatusPanel;
+        }
+      }
+
+      const summarySide = summaryShell.querySelector(".oq-overview-summary-side");
+      if (summarySide) {
+        const nextControlsSignature = getOverviewControlsRenderSignature();
+        if (summarySide.dataset.renderSignature !== nextControlsSignature) {
+          setInnerHtmlIfChanged(summarySide, renderOverviewControlPanels());
+          summarySide.dataset.renderSignature = nextControlsSignature;
+        }
       }
     }
 


### PR DESCRIPTION
## What changed

This PR fully implements temporary OpenQuatt regulation disablement with optional automatic resume.

- adds device-side `OpenQuatt resume at` scheduling in supervisory control mode
- automatically re-enables regulation once the scheduled resume time is reached
- replaces the old `Pause` interaction in the web app with `OpenQuatt regulation` and explicit `Active` / `Temporarily off` states
- adds a scheduling modal with quick presets such as `2 hours`, `8 hours`, `Tomorrow morning`, `No end time`, and an exact date/time option
- mirrors the same flow in the local mock preview so the UX can be iterated locally
- updates the Home Assistant dashboards (single/duo, NL/EN) with the new regulation naming and a conditional `resume automatically` datetime control

## Why

`Pause` was too vague for the real use case. The actual need is to temporarily disable heating and cooling regulation, for example during a holiday, while keeping safety monitoring and freeze protection active and optionally resuming automatically at a chosen time.

## Impact

- clearer user-facing terminology around temporarily disabling regulation
- scheduled resume now lives on the device itself instead of only in the UI session
- the web app, mock preview, and HA dashboards now all expose the same concept



## Validation

- `node --check openquatt/web/openquatt-app.js`
- `node --check openquatt/web/mock-device.js`
- upgraded the repo-local ESPHome environment to `2026.4.0`
- `py -3 scripts\\dev.py validate --jobs 1`
  - style consistency: OK
  - docs consistency: OK
  - config validation: OK for all four default profiles
  - compile: OK for `openquatt_duo_heatpump_listener.yaml`
  - compile: OK for `openquatt_single_heatpump_listener.yaml`
  - compile: local Windows limitation remains for `openquatt_duo_waveshare.yaml` and `openquatt_single_waveshare.yaml` with `The command line is too long`
