### PR TITLE
Add CiC compatibility mode

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -265,6 +265,7 @@ Zie autotune als hulpmiddel, niet als automatische oplossing. Controleer eerst o
 
 Belangrijke instellingen en signalen:
 
+- `CiC Compatibility Mode`
 - `CIC - Enable polling`
 - `CIC - Feed URL`
 - `CIC - JSON Feed OK`
@@ -280,6 +281,8 @@ Belangrijke instellingen en signalen:
 - `Room Setpoint Effective Source`
 
 Dit is vaak de belangrijkste groep bij onverklaarbaar gedrag. Als de geselecteerde bron niet klopt, helpt fijnregelen vrijwel nooit.
+
+`CiC Compatibility Mode` is bedoeld voor de route `ODU -> OpenQuatt -> CiC`. Daarmee kan OpenQuatt read-only warmtepompdata terug aan de CiC aanbieden zodat Quatt Cloud en de app bruikbaar blijven. De modus staat standaard uit en accepteert geen writes vanuit de CiC.
 
 Voor `Outside Temperature Source` is `Auto` de aanbevolen optie. OpenQuatt kiest dan de laagste geldige bron uit de beschikbare buitenmetingen. Daarmee blijft de regeling robuust tegen een bron die tijdelijk te warm uitvalt door zon, stilstand of lokale opwarming.
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -301,6 +301,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_compressor_frequency_demand
     name: "${prefix}Compressor frequency demand"
     icon: mdi:sine-wave
     register_type: holding
@@ -321,6 +322,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_compressor_frequency
     name: "${prefix}Compressor frequency"
     icon: mdi:sine-wave
     register_type: holding
@@ -341,6 +343,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_fan_speed_max
     name: "${prefix}Fan speed max"
     icon: mdi:fan
     register_type: holding
@@ -381,6 +384,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_eev_steps
     name: "${prefix}EEV steps"
     icon: mdi:valve
     register_type: holding
@@ -428,6 +432,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_evaporator_coil_temp
     name: "${prefix}Evaporator coil temperature"
     icon: mdi:thermometer
     register_type: holding
@@ -449,6 +454,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_gas_discharge_temp
     name: "${prefix}Gas discharge temperature"
     icon: mdi:thermometer
     register_type: holding
@@ -470,6 +476,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_gas_return_temp
     name: "${prefix}Gas return temperature"
     icon: mdi:thermometer
     register_type: holding
@@ -492,6 +499,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_evaporator_pressure
     name: "${prefix}Evaporator pressure"
     icon: mdi:gauge
     register_type: holding
@@ -512,6 +520,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_condenser_pressure
     name: "${prefix}Condenser pressure"
     icon: mdi:gauge
     register_type: holding
@@ -566,6 +575,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_condensing_temp
     name: "${prefix}Condensing temperature"
     icon: mdi:thermometer
     register_type: holding
@@ -587,6 +597,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_evaporating_temp
     name: "${prefix}Evaporating temperature"
     icon: mdi:thermometer
     register_type: holding
@@ -652,6 +663,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_inner_coil_temp
     name: "${prefix}Inner coil temperature"
     icon: mdi:thermometer
     register_type: holding
@@ -879,6 +891,7 @@ binary_sensor:
   # At least bits 0,2,4,5,6,11 are used for status in R2108.
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_fan_low_speed_mode
     name: "${prefix}Fan Low Speed Mode"
     disabled_by_default: true
     icon: mdi:fan-speed-1
@@ -918,6 +931,7 @@ binary_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_fan_defrost_mode
     name: "${prefix}Fan Defrost Mode"
     disabled_by_default: true
     icon: mdi:snowflake-melt
@@ -931,6 +945,7 @@ binary_sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_fan_high_speed_mode
     name: "${prefix}Fan High Speed Mode"
     disabled_by_default: true
     icon: mdi:fan-speed-3

--- a/openquatt/oq_cic_compatibility.yaml
+++ b/openquatt/oq_cic_compatibility.yaml
@@ -1,0 +1,32 @@
+# ==============================================================================
+# OpenQuatt - CiC Compatibility Mode
+# ==============================================================================
+#
+# Goal:
+#   Expose a read-only, CiC-facing Modbus compatibility layer so OpenQuatt can
+#   keep Quatt app/cloud telemetry alive via `ODU -> OpenQuatt -> CiC`.
+#
+# Notes:
+#   - This mode is intentionally read-only; no CiC writes are mapped back into
+#     OpenQuatt control entities.
+#   - Default state is OFF. When disabled, the compatibility register map stays
+#     inert and only returns empty/default values.
+#
+# ==============================================================================
+
+globals:
+  - id: cic_compatibility_last_request_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+switch:
+  - platform: template
+    id: cic_compatibility_enable
+    name: "CiC Compatibility Mode"
+    icon: mdi:transit-connection-variant
+    entity_category: config
+    optimistic: true
+    restore_mode: ${oq_cic_compat_restore_mode_default}
+    web_server:
+      sorting_group_id: oq_cic_compatibility

--- a/openquatt/oq_cic_compatibility_server.yaml
+++ b/openquatt/oq_cic_compatibility_server.yaml
@@ -1,0 +1,453 @@
+# ==============================================================================
+# OpenQuatt - CiC Compatibility Server
+# ==============================================================================
+#
+# Goal:
+#   Expose one heat pump's runtime values as a read-only Modbus server for the
+#   CiC on the dedicated compatibility bus.
+#
+# Required vars:
+#   - cic_compat_hp_id
+#   - cic_compat_label
+#   - cic_compat_device_address
+#
+# ==============================================================================
+
+modbus_controller:
+  - id: ${cic_compat_hp_id}_cic_compat_server
+    address: ${cic_compat_device_address}
+    modbus_id: cic_compat_modbus
+    setup_priority: -100
+    update_interval: never
+    server_courtesy_response:
+      enabled: true
+      register_last_address: 5000
+      register_value: 0
+    server_registers:
+      - address: 1999
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state || id(${cic_compat_hp_id}_compressor_level).state.empty()) return 0;
+          return static_cast<uint16_t>(atoi(id(${cic_compat_hp_id}_compressor_level).state.c_str()));
+      - address: 2006
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          return id(${cic_compat_hp_id}_low_noise_mode).state == "On" ? 1 : 0;
+      - address: 2010
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          return id(${cic_compat_hp_id}_set_pump_mode).state == "On" ? 4096 : 0;
+      - address: 2015
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_pump_speed).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+      - address: 3999
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          if (id(${cic_compat_hp_id}_set_working_mode).state == "Cooling") return 1;
+          if (id(${cic_compat_hp_id}_set_working_mode).state == "Heating") return 2;
+          return 0;
+      - address: 2099
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_working_mode).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+      - address: 2100
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_voltage).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+      - address: 2101
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_current).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+      - address: 2102
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_compressor_frequency_demand).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+      - address: 2103
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_compressor_frequency).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+      - address: 2104
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_fan_speed_max).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+      - address: 2105
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_fan_speed).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+      - address: 2106
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0;
+      - address: 2107
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_eev_steps).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+      - address: 2108
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          uint16_t bits = 0;
+          if (id(${cic_compat_hp_id}_fan_low_speed_mode).state) bits |= 0x0001u;
+          if (id(${cic_compat_hp_id}_bottom_plate_heater).state) bits |= 0x0004u;
+          if (id(${cic_compat_hp_id}_crankcase_heater).state) bits |= 0x0008u;
+          if (id(${cic_compat_hp_id}_fan_defrost_mode).state) bits |= 0x0010u;
+          if (id(${cic_compat_hp_id}_fan_high_speed_mode).state) bits |= 0x0020u;
+          if (id(${cic_compat_hp_id}_4_way_valve).state) bits |= 0x0040u;
+          if (id(${cic_compat_hp_id}_pump_relay).state) bits |= 0x0800u;
+          return bits;
+      - address: 2109
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0;
+      - address: 2110
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_outside_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2111
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_evaporator_coil_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2112
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_gas_discharge_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2113
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_gas_return_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2114
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0;
+      - address: 2116
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_evaporator_pressure).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+      - address: 2117
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_condenser_pressure).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+      - address: 2118
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          return id(${cic_compat_hp_id}_defrost).state ? 1 : 0;
+      - address: 2122
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_pcb_firmware_raw).state;
+          return isnan(v) ? 0x011Eu : static_cast<uint16_t>(lroundf(v));
+      - address: 2131
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_condensing_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2132
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_evaporating_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2133
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_water_in_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2134
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_water_out_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2135
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_inner_coil_temp).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+      - address: 2136
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0;
+      - address: 2137
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_pump_power).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+      - address: 2138
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          if (!id(cic_compatibility_enable).state) return 0;
+          const float v = id(${cic_compat_hp_id}_flow).state;
+          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v / 0.618f));
+      - address: 11160
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11161
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11162
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11163
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11164
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11165
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11166
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11167
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11168
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11169
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11170
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11171
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11172
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11173
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11174
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11175
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11176
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11177
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11178
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11179
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11219
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11220
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11221
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11222
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11223
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11224
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11225
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11226
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11227
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11228
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11229
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11230
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11231
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11232
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11233
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11234
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11235
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11236
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11237
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;
+      - address: 11238
+        value_type: U_WORD
+        read_lambda: |-
+          id(cic_compatibility_last_request_ms) = millis();
+          return 0xFFFFu;

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -127,12 +127,26 @@ uart:
     parity: EVEN
     rx_full_threshold: 1
     rx_timeout: 1
+  - id: cic_compat_uart_bus
+    tx_pin: ${cic_compat_uart_tx_pin}
+    rx_pin: ${cic_compat_uart_rx_pin}
+    baud_rate: 19200
+    data_bits: 8
+    stop_bits: 1
+    parity: EVEN
+    rx_full_threshold: 1
+    rx_timeout: 1
 
 modbus:
   - uart_id: uart_bus
     id: mod_bus
     flow_control_pin: ${uart_rts_pin}
     send_wait_time: 100ms
+  - uart_id: cic_compat_uart_bus
+    id: cic_compat_modbus
+    role: server
+    flow_control_pin: ${cic_compat_uart_rts_pin}
+    send_wait_time: 50ms
 
 # ==============================================================================
 # SHARED RUNTIME STATE

--- a/openquatt/oq_packages_common.yaml
+++ b/openquatt/oq_packages_common.yaml
@@ -11,13 +11,14 @@
 # 7) Flow/boiler and other actuation followers
 # 8) Aggregation/energy telemetry
 # 9) External inputs (CIC)
-# 10) External HA proxy inputs
-# 11) Local sensors
-# 12) Source selection and merged selected-source signals
-# 13) OpenTherm thermostat bridge
-# 14) Setup/status
-# 15) Web UI
-# 16) Per-HP hardware adapters
+# 10) CiC compatibility bridge
+# 11) External HA proxy inputs
+# 12) Local sensors
+# 13) Source selection and merged selected-source signals
+# 14) OpenTherm thermostat bridge
+# 15) Setup/status
+# 16) Web UI
+# 17) Per-HP hardware adapters
 # ==============================================================================
 # Shared modules use `*_secondary_*` template vars so topology wiring stays
 # centralized in topology substitutions and avoids duplicated module files.
@@ -127,6 +128,13 @@ oq_cic: !include
   vars:
     cic_secondary_enabled: "${cic_secondary_enabled}"
     cic_hp2_sensor_internal: "${cic_hp2_sensor_internal}"
+oq_cic_compatibility: !include oq_cic_compatibility.yaml
+oq_cic_compatibility_hp1: !include
+  file: oq_cic_compatibility_server.yaml
+  vars:
+    cic_compat_hp_id: "hp1"
+    cic_compat_label: "HP1"
+    cic_compat_device_address: "${cic_compat_modbus_address_hp1}"
 oq_ha_inputs: !include oq_ha_inputs.yaml
 oq_local_sensors: !include oq_local_sensors.yaml
 oq_sensor_sources: !include

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -138,6 +138,16 @@ cic_feed_error_trip_n: "3"                            # Feed OK becomes false af
 oq_cic_restore_mode_default: "RESTORE_DEFAULT_OFF"    # Default CIC polling state.
 
 # ----------------------------
+# CIC COMPATIBILITY
+# ----------------------------
+cic_compat_uart_tx_pin: "GPIO15"                      # Placeholder TX pin for the secondary CiC Modbus port.
+cic_compat_uart_rx_pin: "GPIO16"                      # Placeholder RX pin for the secondary CiC Modbus port.
+cic_compat_uart_rts_pin: "GPIO4"                      # Placeholder DE/RE pin for the secondary CiC Modbus port.
+cic_compat_modbus_address_hp1: "0x01"                 # CiC-facing Modbus address for HP1 compatibility data.
+cic_compat_modbus_address_hp2: "0x02"                 # CiC-facing Modbus address for HP2 compatibility data.
+oq_cic_compat_restore_mode_default: "RESTORE_DEFAULT_OFF" # Default CiC compatibility mode state.
+
+# ----------------------------
 # HA INPUT ENTITY MAPPING
 # ----------------------------
 ha_outside_temp_entity_id: "sensor.openquatt_ext_outdoor_temperature"      # HA proxy entity for outside temperature [degC].

--- a/openquatt/oq_webserver.yaml
+++ b/openquatt/oq_webserver.yaml
@@ -42,6 +42,9 @@ web_server:
     - id: oq_boiler
       name: "Boiler"
       sorting_weight: 50
+    - id: oq_cic_compatibility
+      name: "CiC Compatibility"
+      sorting_weight: 52
     - id: oq_cic
       name: "CIC Feed"
       sorting_weight: 55

--- a/openquatt/topology/oq_topology_packages_duo.yaml
+++ b/openquatt/topology/oq_topology_packages_duo.yaml
@@ -4,3 +4,9 @@ heatpump2: !include
     hp_id: "hp2"
     prefix: "HP2 - "
     device_address: 0x02
+oq_cic_compatibility_hp2: !include
+  file: ../oq_cic_compatibility_server.yaml
+  vars:
+    cic_compat_hp_id: "hp2"
+    cic_compat_label: "HP2"
+    cic_compat_device_address: "${cic_compat_modbus_address_hp2}"

--- a/openquatt/web/css/openquatt-app.css
+++ b/openquatt/web/css/openquatt-app.css
@@ -2061,6 +2061,7 @@ body.oq-page-light {
   min-width: 0;
   text-align: left;
   display: grid;
+  align-content: start;
   gap: 10px;
   padding: 16px;
   border-radius: var(--oq-helper-radius-lg);

--- a/openquatt/web/css/src/10-settings.css
+++ b/openquatt/web/css/src/10-settings.css
@@ -296,6 +296,7 @@
   min-width: 0;
   text-align: left;
   display: grid;
+  align-content: start;
   gap: 10px;
   padding: 16px;
   border-radius: var(--oq-helper-radius-lg);
@@ -1125,4 +1126,3 @@
 .oq-settings-hp-group header {
   margin-bottom: 12px;
 }
-

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -32,7 +32,7 @@
     <div class="oq-dev-page">
       <esp-app></esp-app>
     </div>
-    <script src="./js/mock-device.js?v=quick-start-single-toggle-1"></script>
-    <script src="./js/openquatt-app.js?v=quick-start-single-toggle-1"></script>
+    <script src="./js/mock-device.js?v=cic-compatibility-mode-1"></script>
+    <script src="./js/openquatt-app.js?v=cic-compatibility-mode-1"></script>
   </body>
 </html>

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -262,6 +262,7 @@
     });
     setEntity("switch", "OpenQuatt Enabled", { value: true, state: true });
     setEntity("switch", "Manual Cooling Enable", { value: false, state: false });
+    setEntity("switch", "CiC Compatibility Mode", { value: false, state: false });
     setEntity("select", "Silent Mode Override", {
       value: "Schedule",
       state: "Schedule",

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -111,6 +111,7 @@
     strategy: { domain: "select", name: "Heating Control Mode" },
     openquattEnabled: { domain: "switch", name: "OpenQuatt Enabled", optional: true },
     manualCoolingEnable: { domain: "switch", name: "Manual Cooling Enable", optional: true },
+    cicCompatibilityMode: { domain: "switch", name: "CiC Compatibility Mode", optional: true },
     silentModeOverride: { domain: "select", name: "Silent Mode Override", optional: true },
     coolingEnableSelected: { domain: "binary_sensor", name: "Cooling Enable (Selected)", optional: true },
     coolingRequestActive: { domain: "binary_sensor", name: "Cooling Request Active", optional: true },
@@ -342,6 +343,7 @@
   ];
   const LIMIT_KEYS = ["dayMax", "silentMax", "maxWater"];
   const FLOW_SETTING_KEYS = ["flowControlMode", "flowSetpoint", "manualIpwm"];
+  const CIC_COMPATIBILITY_KEYS = ["cicCompatibilityMode"];
   const COOLING_SETTING_KEYS = [
     "coolingWithoutDewPointMode",
     "coolingGuardMode",
@@ -547,6 +549,7 @@
     "openquattEnabled",
     "manualCoolingEnable",
     "silentModeOverride",
+    ...CIC_COMPATIBILITY_KEYS,
     ...FLOW_SETTING_KEYS,
     ...COOLING_SETTING_KEYS,
     ...LIMIT_KEYS,
@@ -3816,6 +3819,42 @@
     return renderSettingsFieldCard(key, title, copy, `<label class="oq-settings-control oq-settings-control--select"><select class="oq-helper-select" data-oq-field="${escapeHtml(key)}" ${state.loadingEntities ? "disabled" : ""}>${options.map((option) => `<option value="${escapeHtml(option)}" ${option === value ? "selected" : ""}>${escapeHtml(formatSettingsOptionLabel(option))}</option>`).join("")}</select><span class="oq-settings-select-caret" aria-hidden="true"></span></label>`, className);
   }
 
+  function renderSettingsSwitchField(key, title, copy, enabledCopy = "", disabledCopy = "", className = "") {
+    if (!hasEntity(key)) {
+      return "";
+    }
+
+    const enabled = Boolean(getEntityValue(key));
+    const busy = state.loadingEntities || state.busyAction === `switch-${key}`;
+    const renderToggleCard = (label, active, targetState, detail) => `
+      <button
+        class="oq-settings-choice-card${active ? " is-active" : ""}"
+        type="button"
+        data-oq-action="toggle-overview-control"
+        data-control-key="${escapeHtml(key)}"
+        data-control-state="${escapeHtml(targetState)}"
+        aria-pressed="${active ? "true" : "false"}"
+        ${busy ? "disabled" : ""}
+      >
+        <span class="oq-settings-choice-title">${escapeHtml(label)}</span>
+        ${detail ? `<span class="oq-settings-choice-copy">${escapeHtml(detail)}</span>` : ""}
+      </button>
+    `;
+
+    return renderSettingsFieldCard(
+      key,
+      title,
+      copy,
+      `
+        <div class="oq-settings-choice-grid">
+          ${renderToggleCard("Uit", !enabled, "off", disabledCopy)}
+          ${renderToggleCard("Aan", enabled, "on", enabledCopy)}
+        </div>
+      `,
+      className,
+    );
+  }
+
   function renderSettingsOptionCardsField(key, title, copy, descriptions, className = "") {
     if (!hasEntity(key)) {
       return "";
@@ -4397,6 +4436,29 @@
       "Watertemperatuur",
       "Beschermt het systeem tegen te hoge aanvoertemperaturen. OpenQuatt regelt richting deze grens terug en grijpt 5°C erboven hard in.",
       renderWaterSettingsFields(),
+    );
+  }
+
+  function renderSettingsCiCCompatibilitySection() {
+    if (!hasEntity("cicCompatibilityMode")) {
+      return "";
+    }
+
+    return renderSettingsSection(
+      "Integratie",
+      "CiC Compatibility Mode",
+      "Zet dit aan als je de Quatt app wilt blijven gebruiken terwijl OpenQuatt tussen de warmtepomp en de CiC zit.",
+      `
+        <div class="oq-settings-grid">
+          ${renderSettingsSwitchField(
+            "cicCompatibilityMode",
+            "Quatt app-verbinding via CiC",
+            "Zet dit aan als je wilt dat OpenQuatt gegevens blijft doorgeven aan de CiC voor de Quatt app. Standaard staat dit uit.",
+            "OpenQuatt houdt de gegevensstroom naar de CiC in stand, zodat de Quatt app kan blijven werken.",
+            "OpenQuatt geeft geen gegevens door aan de CiC voor de Quatt app."
+          )}
+        </div>
+      `,
     );
   }
 
@@ -6871,6 +6933,7 @@
           ${renderSettingsFlowSection()}
           ${renderSettingsHeatingSection()}
           ${renderSettingsCoolingSection()}
+          ${renderSettingsCiCCompatibilitySection()}
           ${renderSettingsWaterSection()}
           ${renderSettingsCompressorSection()}
           ${renderSettingsSilentSection()}

--- a/openquatt/web/js/src/00-config.js
+++ b/openquatt/web/js/src/00-config.js
@@ -107,6 +107,7 @@
     strategy: { domain: "select", name: "Heating Control Mode" },
     openquattEnabled: { domain: "switch", name: "OpenQuatt Enabled", optional: true },
     manualCoolingEnable: { domain: "switch", name: "Manual Cooling Enable", optional: true },
+    cicCompatibilityMode: { domain: "switch", name: "CiC Compatibility Mode", optional: true },
     silentModeOverride: { domain: "select", name: "Silent Mode Override", optional: true },
     coolingEnableSelected: { domain: "binary_sensor", name: "Cooling Enable (Selected)", optional: true },
     coolingRequestActive: { domain: "binary_sensor", name: "Cooling Request Active", optional: true },
@@ -338,6 +339,7 @@
   ];
   const LIMIT_KEYS = ["dayMax", "silentMax", "maxWater"];
   const FLOW_SETTING_KEYS = ["flowControlMode", "flowSetpoint", "manualIpwm"];
+  const CIC_COMPATIBILITY_KEYS = ["cicCompatibilityMode"];
   const COOLING_SETTING_KEYS = [
     "coolingWithoutDewPointMode",
     "coolingGuardMode",
@@ -543,6 +545,7 @@
     "openquattEnabled",
     "manualCoolingEnable",
     "silentModeOverride",
+    ...CIC_COMPATIBILITY_KEYS,
     ...FLOW_SETTING_KEYS,
     ...COOLING_SETTING_KEYS,
     ...LIMIT_KEYS,
@@ -556,4 +559,3 @@
   const FLOW_OFFSET_PX_PER_SEC = FLOW_DASH_CYCLE_PX / 1.7;
   const FAN_ROTATION_DEG_PER_SEC = 360 / 3.2;
   const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
-

--- a/openquatt/web/js/src/10-settings.js
+++ b/openquatt/web/js/src/10-settings.js
@@ -87,6 +87,42 @@
     return renderSettingsFieldCard(key, title, copy, `<label class="oq-settings-control oq-settings-control--select"><select class="oq-helper-select" data-oq-field="${escapeHtml(key)}" ${state.loadingEntities ? "disabled" : ""}>${options.map((option) => `<option value="${escapeHtml(option)}" ${option === value ? "selected" : ""}>${escapeHtml(formatSettingsOptionLabel(option))}</option>`).join("")}</select><span class="oq-settings-select-caret" aria-hidden="true"></span></label>`, className);
   }
 
+  function renderSettingsSwitchField(key, title, copy, enabledCopy = "", disabledCopy = "", className = "") {
+    if (!hasEntity(key)) {
+      return "";
+    }
+
+    const enabled = Boolean(getEntityValue(key));
+    const busy = state.loadingEntities || state.busyAction === `switch-${key}`;
+    const renderToggleCard = (label, active, targetState, detail) => `
+      <button
+        class="oq-settings-choice-card${active ? " is-active" : ""}"
+        type="button"
+        data-oq-action="toggle-overview-control"
+        data-control-key="${escapeHtml(key)}"
+        data-control-state="${escapeHtml(targetState)}"
+        aria-pressed="${active ? "true" : "false"}"
+        ${busy ? "disabled" : ""}
+      >
+        <span class="oq-settings-choice-title">${escapeHtml(label)}</span>
+        ${detail ? `<span class="oq-settings-choice-copy">${escapeHtml(detail)}</span>` : ""}
+      </button>
+    `;
+
+    return renderSettingsFieldCard(
+      key,
+      title,
+      copy,
+      `
+        <div class="oq-settings-choice-grid">
+          ${renderToggleCard("Uit", !enabled, "off", disabledCopy)}
+          ${renderToggleCard("Aan", enabled, "on", enabledCopy)}
+        </div>
+      `,
+      className,
+    );
+  }
+
   function renderSettingsOptionCardsField(key, title, copy, descriptions, className = "") {
     if (!hasEntity(key)) {
       return "";
@@ -671,6 +707,29 @@
     );
   }
 
+  function renderSettingsCiCCompatibilitySection() {
+    if (!hasEntity("cicCompatibilityMode")) {
+      return "";
+    }
+
+    return renderSettingsSection(
+      "Integratie",
+      "CiC Compatibility Mode",
+      "Zet dit aan als je de Quatt app wilt blijven gebruiken terwijl OpenQuatt tussen de warmtepomp en de CiC zit.",
+      `
+        <div class="oq-settings-grid">
+          ${renderSettingsSwitchField(
+            "cicCompatibilityMode",
+            "Quatt app-verbinding via CiC",
+            "Zet dit aan als je wilt dat OpenQuatt gegevens blijft doorgeven aan de CiC voor de Quatt app. Standaard staat dit uit.",
+            "OpenQuatt houdt de gegevensstroom naar de CiC in stand, zodat de Quatt app kan blijven werken.",
+            "OpenQuatt geeft geen gegevens door aan de CiC voor de Quatt app."
+          )}
+        </div>
+      `,
+    );
+  }
+
   function renderSettingsCompressorSection() {
     const hpGroups = [
       renderSettingsHeatPumpLimiterCard("HP1", "hp1ExcludedA", "hp1ExcludedB"),
@@ -864,4 +923,3 @@
       </div>
     `;
   }
-

--- a/openquatt/web/js/src/90-shell.js
+++ b/openquatt/web/js/src/90-shell.js
@@ -8,6 +8,7 @@
           ${renderSettingsFlowSection()}
           ${renderSettingsHeatingSection()}
           ${renderSettingsCoolingSection()}
+          ${renderSettingsCiCCompatibilitySection()}
           ${renderSettingsWaterSection()}
           ${renderSettingsCompressorSection()}
           ${renderSettingsSilentSection()}

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -83,6 +83,8 @@ STRICT_TOP_LEVEL_ORDER_RULES = {
         "oq_boiler_control",
         "oq_energy",
         "oq_cic",
+        "oq_cic_compatibility",
+        "oq_cic_compatibility_hp1",
         "oq_ha_inputs",
         "oq_local_sensors",
         "oq_sensor_sources",
@@ -106,6 +108,7 @@ STRICT_TOP_LEVEL_ORDER_RULES = {
     ),
     "openquatt/topology/oq_topology_packages_duo.yaml": (
         "heatpump2",
+        "oq_cic_compatibility_hp2",
     ),
     "openquatt/topology/oq_topology_single.yaml": (
         "secondary_hp_id",
@@ -158,6 +161,7 @@ SUBSTITUTION_SECTION_ORDER_RULES = {
         "FLOW AUTOTUNE",
         "BOILER CONTROL",
         "CIC FEED",
+        "CIC COMPATIBILITY",
         "HA INPUT ENTITY MAPPING",
         "HP IO (MODBUS POLLING)",
     ),


### PR DESCRIPTION
## Summary
- add a read-only CiC compatibility Modbus bridge on a second bus with a default-off enable switch
- surface the switch in the custom web app and dev mock preview with simpler Dutch copy
- document the setting and update style-consistency rules for the new packages

## Validation
- `python3 scripts/dev.py validate --config-only`
- `python3 scripts/dev.py validate --config openquatt_duo_heatpump_listener.yaml --config openquatt_single_heatpump_listener.yaml`
- `python3 scripts/dev.py validate` *(heatpump_listener builds passed; Waveshare builds still hit the known ESP-IDF efuse duplicate-target cache issue)*