### PR TITLE
Introduce trends tab and trend storage

### DIFF
--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -172,6 +172,22 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+  - id: oq_overview_trend_rows
+    type: std::string
+    restore_value: false
+    initial_value: '""'
+  - id: oq_trend_history_enabled
+    type: bool
+    restore_value: true
+    initial_value: 'true'
+  - id: oq_overview_trend_row_count
+    type: uint16_t
+    restore_value: false
+    initial_value: '0'
+  - id: oq_overview_trend_last_bucket
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
 
 # ==============================================================================
 # DIAGNOSTIC ENTITIES
@@ -199,6 +215,7 @@ select:
         - if:
             condition:
               lambda: |-
+                // Prevent duplicate update checks when the channel changes repeatedly.
                 constexpr uint32_t fw_check_cooldown_ms = 1000UL;
                 const uint32_t now_ms = (uint32_t) millis();
                 const uint32_t last_request_ms = id(oq_fw_check_last_request_ms);
@@ -317,6 +334,28 @@ button:
           then:
             - update.check:
                 id: oq_firmware_update
+
+switch:
+  - platform: template
+    id: oq_trend_history_enabled_switch
+    name: Trendopslag
+    icon: mdi:chart-line
+    entity_category: config
+    optimistic: true
+    lambda: |-
+      return id(oq_trend_history_enabled);
+    turn_on_action:
+      - lambda: |-
+          id(oq_trend_history_enabled) = true;
+    turn_off_action:
+      - lambda: |-
+          id(oq_trend_history_enabled) = false;
+          id(oq_overview_trend_rows).clear();
+          id(oq_overview_trend_row_count) = 0;
+          id(oq_overview_trend_last_bucket) = 0;
+          id(oq_overview_trend_history).publish_state("");
+    web_server:
+      sorting_group_id: oq_system_diagnostics
 
 binary_sensor:
   - platform: status
@@ -453,6 +492,18 @@ text_sensor:
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_system_diagnostics
+
+  - platform: template
+    id: oq_overview_trend_history
+    name: "Overview Trend History"
+    icon: mdi:chart-line
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5min
+    lambda: |-
+      return id(oq_overview_trend_rows);
+    web_server:
+      sorting_group_id: oq_overview
   - platform: template
     id: uptime_readable_text
     name: Uptime readable
@@ -497,3 +548,89 @@ update:
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_system_diagnostics
+
+# ==============================================================================
+# OVERVIEW TRENDS
+# ==============================================================================
+interval:
+  - interval: 5min
+    startup_delay: 45s
+    then:
+      - lambda: |-
+          // Sample the live telemetry every 5 minutes and keep the last 24 hours.
+          if (!id(oq_trend_history_enabled)) {
+            return;
+          }
+          constexpr uint32_t trend_bucket_ms = 5UL * 60UL * 1000UL;
+          constexpr uint16_t trend_capacity = 288;
+
+          const uint32_t now_ms = (uint32_t) millis();
+          const uint32_t bucket = now_ms / trend_bucket_ms;
+          if (id(oq_overview_trend_last_bucket) == bucket) {
+            return;
+          }
+
+          const float outside_c = id(outside_temp_selected).has_state() ? id(outside_temp_selected).state : NAN;
+          const float room_c = id(room_temp_selected).has_state() ? id(room_temp_selected).state : NAN;
+          const float room_sp_c = id(room_setpoint_selected).has_state() ? id(room_setpoint_selected).state : NAN;
+          const float supply_c = id(water_supply_temp_selected).has_state() ? id(water_supply_temp_selected).state : NAN;
+          const float flow_lph = id(flow_rate_selected).has_state() ? id(flow_rate_selected).state : NAN;
+          const float input_w = id(oq_total_power_input).has_state() ? id(oq_total_power_input).state : NAN;
+
+          float output_w = NAN;
+          bool cooling_mode = false;
+          if (id(oq_control_mode_label).has_state()) {
+            std::string mode_label = id(oq_control_mode_label).state;
+            for (char &ch : mode_label) {
+              ch = static_cast<char>(tolower(static_cast<unsigned char>(ch)));
+            }
+            cooling_mode = mode_label.find("koel") != std::string::npos || mode_label.find("cool") != std::string::npos;
+          }
+          if (cooling_mode) {
+            output_w = id(oq_total_cooling_power).has_state() ? id(oq_total_cooling_power).state : NAN;
+          } else {
+            output_w = id(oq_total_heat_power).has_state() ? id(oq_total_heat_power).state : NAN;
+          }
+
+          if (isnan(outside_c) && isnan(room_c) && isnan(room_sp_c) && isnan(supply_c) && isnan(flow_lph) && isnan(input_w) && isnan(output_w)) {
+            return;
+          }
+
+          auto &rows = id(oq_overview_trend_rows);
+          if (rows.capacity() < 24576) {
+            rows.reserve(24576);
+          }
+
+          char row[128];
+          snprintf(
+            row,
+            sizeof(row),
+            "%lu|%.2f|%.2f|%.2f|%.2f|%.0f|%.0f|%.0f",
+            (unsigned long) now_ms,
+            outside_c,
+            supply_c,
+            room_c,
+            room_sp_c,
+            flow_lph,
+            input_w,
+            output_w
+          );
+
+          if (!rows.empty()) {
+            rows.push_back('\n');
+          }
+          rows += row;
+
+          if (id(oq_overview_trend_row_count) >= trend_capacity) {
+            const size_t cut = rows.find('\n');
+            if (cut != std::string::npos) {
+              rows.erase(0, cut + 1);
+            } else {
+              rows.clear();
+              id(oq_overview_trend_row_count) = 0;
+            }
+          } else {
+            id(oq_overview_trend_row_count)++;
+          }
+
+          id(oq_overview_trend_last_bucket) = bucket;

--- a/openquatt/web/css/openquatt-app.css
+++ b/openquatt/web/css/openquatt-app.css
@@ -3937,11 +3937,15 @@ body.oq-page-light {
   box-shadow: var(--oq-overview-shell-shadow);
 }
 
+.oq-overview-trends-head {
+  margin: 0;
+}
+
 .oq-overview-trends-toolbar {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
   gap: 12px;
-  align-items: start;
+  align-items: stretch;
   margin-top: 14px;
 }
 
@@ -3954,6 +3958,7 @@ body.oq-page-light {
   background: var(--oq-overview-lane-bg);
   border: 1px solid var(--oq-overview-lane-border);
   box-shadow: var(--oq-overview-lane-shadow);
+  align-content: start;
 }
 
 .oq-overview-trends-note span,
@@ -4040,35 +4045,22 @@ body.oq-page-light {
 }
 
 .oq-overview-trendcard::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 5px;
-}
-
-.oq-overview-trendcard--orange::before {
-  background: linear-gradient(180deg, #f59e0b, #ef4444);
-}
-
-.oq-overview-trendcard--green::before {
-  background: linear-gradient(180deg, #22c55e, #16a34a);
-}
-
-.oq-overview-trendcard--slate::before {
-  background: linear-gradient(180deg, #94a3b8, #475569);
+  content: none;
 }
 
 .oq-overview-trendcard-head {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(250px, 300px);
   gap: 14px;
-  align-items: flex-start;
+  align-items: start;
 }
 
 .oq-overview-trendcard-copy {
   min-width: 0;
   display: grid;
   gap: 4px;
+  align-content: start;
+  min-height: 88px;
 }
 
 .oq-overview-trendcard-kicker {
@@ -4083,15 +4075,29 @@ body.oq-page-light {
 .oq-overview-trendcard-copy h4 {
   margin: 0;
   color: var(--oq-overview-title);
-  font-size: 1rem;
-  line-height: 1.1;
+  font-size: 0.96rem;
+  line-height: 1.06;
 }
 
 .oq-overview-trendcard-copy p {
   margin: 0;
   color: var(--oq-overview-soft);
-  font-size: 0.84rem;
+  font-size: 0.81rem;
   line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.7em;
+}
+
+.oq-overview-trendcard-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-content: flex-start;
+  gap: 8px;
+  min-width: 0;
 }
 
 .oq-overview-trendcard-latest {
@@ -4099,22 +4105,6 @@ body.oq-page-light {
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px;
-  flex: 0 0 auto;
-}
-
-.oq-overview-trendcard-badge {
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  padding: 0 10px;
-  border-radius: 999px;
-  border: 1px solid rgba(249, 115, 22, 0.22);
-  background: rgba(249, 115, 22, 0.08);
-  color: #b45309;
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
 }
 
 .oq-overview-trend-pill {
@@ -4126,6 +4116,7 @@ body.oq-page-light {
   border-radius: 14px;
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
+  align-content: start;
 }
 
 .oq-overview-trend-pill span {
@@ -4134,6 +4125,11 @@ body.oq-page-light {
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 1.1em;
 }
 
 .oq-overview-trend-pill strong {
@@ -6258,8 +6254,12 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   }
 
   .oq-overview-trendcard-head {
-    flex-direction: column;
-    align-items: flex-start;
+    grid-template-columns: 1fr;
+  }
+
+  .oq-overview-trendcard-meta {
+    justify-items: flex-start;
+    min-height: 0;
   }
 
   .oq-overview-trendcard-latest {
@@ -6642,6 +6642,19 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     gap: 10px;
     padding: 12px;
     border-radius: 16px;
+  }
+
+  .oq-overview-trendcard-copy {
+    min-height: 0;
+  }
+
+  .oq-overview-trendcard-copy p {
+    min-height: 0;
+    -webkit-line-clamp: 3;
+  }
+
+  .oq-overview-trendcard-meta {
+    min-height: 0;
   }
 
   .oq-overview-trend-hover {

--- a/openquatt/web/css/openquatt-app.css
+++ b/openquatt/web/css/openquatt-app.css
@@ -3928,6 +3928,442 @@ body.oq-page-light {
   color: var(--oq-overview-title);
 }
 
+.oq-overview-trends {
+  margin-top: 16px;
+  padding: 20px;
+  border-radius: 24px;
+  background: var(--oq-overview-panel-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: var(--oq-overview-shell-shadow);
+}
+
+.oq-overview-trends-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  margin-top: 14px;
+}
+
+.oq-overview-trends-note,
+.oq-overview-trends-window {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-lane-border);
+  box-shadow: var(--oq-overview-lane-shadow);
+}
+
+.oq-overview-trends-note span,
+.oq-overview-trends-window span {
+  color: var(--oq-overview-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trends-note strong {
+  color: var(--oq-overview-title);
+  font-size: 0.98rem;
+  line-height: 1.15;
+}
+
+.oq-overview-trends-note p {
+  margin: 0;
+  color: var(--oq-overview-soft);
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.oq-overview-trends-window {
+  justify-items: start;
+}
+
+.oq-overview-trends-disabled {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 18px 16px;
+  border-radius: 18px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-lane-border);
+  box-shadow: var(--oq-overview-lane-shadow);
+}
+
+.oq-overview-trends-disabled p {
+  margin: 0;
+  color: var(--oq-overview-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trends-disabled strong {
+  color: var(--oq-overview-title);
+  font-size: 0.98rem;
+  line-height: 1.2;
+}
+
+.oq-overview-trends-disabled span {
+  color: var(--oq-overview-soft);
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.oq-overview-trends-windowbar {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.oq-overview-trends-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.oq-overview-trendcard {
+  position: relative;
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 20px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-lane-border);
+  box-shadow: var(--oq-overview-lane-shadow);
+  overflow: hidden;
+}
+
+.oq-overview-trendcard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+}
+
+.oq-overview-trendcard--orange::before {
+  background: linear-gradient(180deg, #f59e0b, #ef4444);
+}
+
+.oq-overview-trendcard--green::before {
+  background: linear-gradient(180deg, #22c55e, #16a34a);
+}
+
+.oq-overview-trendcard--slate::before {
+  background: linear-gradient(180deg, #94a3b8, #475569);
+}
+
+.oq-overview-trendcard-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.oq-overview-trendcard-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.oq-overview-trendcard-kicker {
+  margin: 0;
+  color: var(--oq-overview-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trendcard-copy h4 {
+  margin: 0;
+  color: var(--oq-overview-title);
+  font-size: 1rem;
+  line-height: 1.1;
+}
+
+.oq-overview-trendcard-copy p {
+  margin: 0;
+  color: var(--oq-overview-soft);
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
+.oq-overview-trendcard-latest {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.oq-overview-trendcard-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(249, 115, 22, 0.22);
+  background: rgba(249, 115, 22, 0.08);
+  color: #b45309;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trend-pill {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 82px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  border: 1px solid var(--oq-overview-chip-border);
+  background: var(--oq-overview-chip-bg);
+}
+
+.oq-overview-trend-pill span {
+  color: var(--oq-overview-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trend-pill strong {
+  color: var(--oq-overview-title);
+  font-size: 0.88rem;
+  line-height: 1.1;
+}
+
+.oq-overview-trend-pill--orange {
+  border-color: rgba(249, 115, 22, 0.24);
+}
+
+.oq-overview-trend-pill--green {
+  border-color: rgba(34, 197, 94, 0.24);
+}
+
+.oq-overview-trend-chart {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.oq-overview-trend-hover-layer {
+  pointer-events: none;
+}
+
+.oq-overview-trend-hover-layer[hidden] {
+  display: none;
+}
+
+.oq-overview-trend-chart-bg {
+  fill: var(--oq-overview-lane-bg);
+  stroke: var(--oq-overview-row-border);
+}
+
+.oq-overview-trend-grid {
+  stroke: rgba(148, 163, 184, 0.28);
+  stroke-width: 1;
+  stroke-dasharray: 4 5;
+}
+
+.oq-overview-trend-axis {
+  stroke: rgba(148, 163, 184, 0.45);
+  stroke-width: 1.25;
+}
+
+.oq-overview-trend-axis-label {
+  fill: var(--oq-overview-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.oq-overview-trend-line {
+  fill: none;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.oq-overview-trend-line--orange {
+  stroke: #f97316;
+}
+
+.oq-overview-trend-line--green {
+  stroke: #16a34a;
+}
+
+.oq-overview-trend-line--blue {
+  stroke: #3b82f6;
+}
+
+.oq-overview-trend-line--sky {
+  stroke: #0ea5e9;
+}
+
+.oq-overview-trend-line--slate {
+  stroke: #64748b;
+}
+
+.oq-overview-trend-dot {
+  stroke: #ffffff;
+  stroke-width: 1.5;
+}
+
+.oq-overview-trend-dot--orange {
+  fill: #f97316;
+}
+
+.oq-overview-trend-dot--green {
+  fill: #16a34a;
+}
+
+.oq-overview-trend-dot--blue {
+  fill: #3b82f6;
+}
+
+.oq-overview-trend-dot--sky {
+  fill: #0ea5e9;
+}
+
+.oq-overview-trend-dot--slate {
+  fill: #64748b;
+}
+
+.oq-overview-trend-hover {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 1;
+  display: grid;
+  gap: 8px;
+  min-width: 164px;
+  max-width: min(260px, calc(100% - 32px));
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.10);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.oq-overview-trend-hover[hidden] {
+  display: none;
+}
+
+.oq-overview-trend-hover-head {
+  display: grid;
+  gap: 2px;
+}
+
+.oq-overview-trend-hover-kicker {
+  color: var(--oq-overview-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trend-hover-head strong {
+  color: var(--oq-overview-title);
+  font-size: 0.94rem;
+  line-height: 1.15;
+}
+
+.oq-overview-trend-hover-note {
+  color: var(--oq-overview-soft);
+  font-size: 0.76rem;
+  line-height: 1.25;
+}
+
+.oq-overview-trend-hover-values {
+  display: grid;
+  gap: 6px;
+}
+
+.oq-overview-trend-hover-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.oq-overview-trend-hover-row span {
+  color: var(--oq-overview-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trend-hover-row strong {
+  color: var(--oq-overview-title);
+  font-size: 0.92rem;
+  line-height: 1.1;
+}
+
+.oq-overview-trend-hover-row--orange strong {
+  color: #c2410c;
+}
+
+.oq-overview-trend-hover-row--green strong {
+  color: #15803d;
+}
+
+.oq-overview-trend-hover-row--blue strong {
+  color: #2563eb;
+}
+
+.oq-overview-trend-hover-row--sky strong {
+  color: #0284c7;
+}
+
+.oq-overview-trend-hover-row--slate strong {
+  color: #475569;
+}
+
+.oq-overview-trend-hover-line {
+  stroke: rgba(15, 23, 42, 0.34);
+  stroke-width: 1.15;
+  stroke-dasharray: 4 4;
+}
+
+.oq-overview-trend-hover-dot {
+  stroke: #fff;
+  stroke-width: 2;
+}
+
+.oq-overview-trend-hover-dot--orange {
+  fill: #f97316;
+}
+
+.oq-overview-trend-hover-dot--green {
+  fill: #16a34a;
+}
+
+.oq-overview-trend-hover-dot--blue {
+  fill: #3b82f6;
+}
+
+.oq-overview-trend-hover-dot--sky {
+  fill: #0ea5e9;
+}
+
+.oq-overview-trends-windowbar .oq-overview-controlpanel-segment {
+  min-height: 36px;
+  padding: 0 12px;
+}
+
 /* --- css/src/30-energy.css --- */
 .oq-overview-energy {
   margin-top: 16px;
@@ -5767,6 +6203,7 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-overview-top,
   .oq-overview-main,
+  .oq-overview-trends-grid,
   .oq-overview-hp-grid,
   .oq-overview-hp-stats,
   .oq-overview-hp-meta {
@@ -5805,6 +6242,28 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-overview-metrics--three-column {
     grid-template-columns: 1fr;
+  }
+
+  .oq-overview-trends {
+    padding: 16px;
+    border-radius: 20px;
+  }
+
+  .oq-overview-trends-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .oq-overview-trendcard {
+    padding: 14px;
+  }
+
+  .oq-overview-trendcard-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .oq-overview-trendcard-latest {
+    justify-content: flex-start;
   }
 
   .oq-hp-schematic-topbar,
@@ -6152,6 +6611,68 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   .oq-overview-hp-grid {
     gap: 6px;
     margin-top: 10px;
+  }
+
+  .oq-overview-trends {
+    margin-top: 10px;
+    padding: 12px;
+  }
+
+  .oq-overview-trends-toolbar {
+    margin-top: 10px;
+    gap: 10px;
+  }
+
+  .oq-overview-trends-note,
+  .oq-overview-trends-window {
+    padding: 12px;
+    border-radius: 16px;
+  }
+
+  .oq-overview-trends-windowbar {
+    gap: 6px;
+  }
+
+  .oq-overview-trends-grid {
+    gap: 10px;
+    margin-top: 10px;
+  }
+
+  .oq-overview-trendcard {
+    gap: 10px;
+    padding: 12px;
+    border-radius: 16px;
+  }
+
+  .oq-overview-trend-hover {
+    top: 10px;
+    right: 10px;
+    min-width: 140px;
+    max-width: calc(100% - 20px);
+    padding: 10px 11px;
+    border-radius: 14px;
+  }
+
+  .oq-overview-trend-hover-row span {
+    font-size: 0.7rem;
+  }
+
+  .oq-overview-trend-hover-row strong {
+    font-size: 0.84rem;
+  }
+
+  .oq-overview-trend-pill {
+    min-width: 72px;
+    padding: 7px 9px;
+    border-radius: 12px;
+  }
+
+  .oq-overview-trend-pill span {
+    font-size: 0.64rem;
+  }
+
+  .oq-overview-trend-pill strong {
+    font-size: 0.82rem;
   }
 
   .oq-overview-hp-head,

--- a/openquatt/web/css/src/20-overview.css
+++ b/openquatt/web/css/src/20-overview.css
@@ -634,3 +634,438 @@
   color: var(--oq-overview-title);
 }
 
+.oq-overview-trends {
+  margin-top: 16px;
+  padding: 20px;
+  border-radius: 24px;
+  background: var(--oq-overview-panel-bg);
+  border: 1px solid var(--oq-overview-panel-border);
+  box-shadow: var(--oq-overview-shell-shadow);
+}
+
+.oq-overview-trends-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  margin-top: 14px;
+}
+
+.oq-overview-trends-note,
+.oq-overview-trends-window {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-lane-border);
+  box-shadow: var(--oq-overview-lane-shadow);
+}
+
+.oq-overview-trends-note span,
+.oq-overview-trends-window span {
+  color: var(--oq-overview-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trends-note strong {
+  color: var(--oq-overview-title);
+  font-size: 0.98rem;
+  line-height: 1.15;
+}
+
+.oq-overview-trends-note p {
+  margin: 0;
+  color: var(--oq-overview-soft);
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.oq-overview-trends-window {
+  justify-items: start;
+}
+
+.oq-overview-trends-disabled {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 18px 16px;
+  border-radius: 18px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-lane-border);
+  box-shadow: var(--oq-overview-lane-shadow);
+}
+
+.oq-overview-trends-disabled p {
+  margin: 0;
+  color: var(--oq-overview-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trends-disabled strong {
+  color: var(--oq-overview-title);
+  font-size: 0.98rem;
+  line-height: 1.2;
+}
+
+.oq-overview-trends-disabled span {
+  color: var(--oq-overview-soft);
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
+.oq-overview-trends-windowbar {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.oq-overview-trends-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.oq-overview-trendcard {
+  position: relative;
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 20px;
+  background: var(--oq-overview-lane-bg);
+  border: 1px solid var(--oq-overview-lane-border);
+  box-shadow: var(--oq-overview-lane-shadow);
+  overflow: hidden;
+}
+
+.oq-overview-trendcard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 5px;
+}
+
+.oq-overview-trendcard--orange::before {
+  background: linear-gradient(180deg, #f59e0b, #ef4444);
+}
+
+.oq-overview-trendcard--green::before {
+  background: linear-gradient(180deg, #22c55e, #16a34a);
+}
+
+.oq-overview-trendcard--slate::before {
+  background: linear-gradient(180deg, #94a3b8, #475569);
+}
+
+.oq-overview-trendcard-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.oq-overview-trendcard-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.oq-overview-trendcard-kicker {
+  margin: 0;
+  color: var(--oq-overview-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trendcard-copy h4 {
+  margin: 0;
+  color: var(--oq-overview-title);
+  font-size: 1rem;
+  line-height: 1.1;
+}
+
+.oq-overview-trendcard-copy p {
+  margin: 0;
+  color: var(--oq-overview-soft);
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
+.oq-overview-trendcard-latest {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.oq-overview-trendcard-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(249, 115, 22, 0.22);
+  background: rgba(249, 115, 22, 0.08);
+  color: #b45309;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trend-pill {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 82px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  border: 1px solid var(--oq-overview-chip-border);
+  background: var(--oq-overview-chip-bg);
+}
+
+.oq-overview-trend-pill span {
+  color: var(--oq-overview-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trend-pill strong {
+  color: var(--oq-overview-title);
+  font-size: 0.88rem;
+  line-height: 1.1;
+}
+
+.oq-overview-trend-pill--orange {
+  border-color: rgba(249, 115, 22, 0.24);
+}
+
+.oq-overview-trend-pill--green {
+  border-color: rgba(34, 197, 94, 0.24);
+}
+
+.oq-overview-trend-chart {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.oq-overview-trend-hover-layer {
+  pointer-events: none;
+}
+
+.oq-overview-trend-hover-layer[hidden] {
+  display: none;
+}
+
+.oq-overview-trend-chart-bg {
+  fill: var(--oq-overview-lane-bg);
+  stroke: var(--oq-overview-row-border);
+}
+
+.oq-overview-trend-grid {
+  stroke: rgba(148, 163, 184, 0.28);
+  stroke-width: 1;
+  stroke-dasharray: 4 5;
+}
+
+.oq-overview-trend-axis {
+  stroke: rgba(148, 163, 184, 0.45);
+  stroke-width: 1.25;
+}
+
+.oq-overview-trend-axis-label {
+  fill: var(--oq-overview-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.oq-overview-trend-line {
+  fill: none;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.oq-overview-trend-line--orange {
+  stroke: #f97316;
+}
+
+.oq-overview-trend-line--green {
+  stroke: #16a34a;
+}
+
+.oq-overview-trend-line--blue {
+  stroke: #3b82f6;
+}
+
+.oq-overview-trend-line--sky {
+  stroke: #0ea5e9;
+}
+
+.oq-overview-trend-line--slate {
+  stroke: #64748b;
+}
+
+.oq-overview-trend-dot {
+  stroke: #ffffff;
+  stroke-width: 1.5;
+}
+
+.oq-overview-trend-dot--orange {
+  fill: #f97316;
+}
+
+.oq-overview-trend-dot--green {
+  fill: #16a34a;
+}
+
+.oq-overview-trend-dot--blue {
+  fill: #3b82f6;
+}
+
+.oq-overview-trend-dot--sky {
+  fill: #0ea5e9;
+}
+
+.oq-overview-trend-dot--slate {
+  fill: #64748b;
+}
+
+.oq-overview-trend-hover {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 1;
+  display: grid;
+  gap: 8px;
+  min-width: 164px;
+  max-width: min(260px, calc(100% - 32px));
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.10);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.oq-overview-trend-hover[hidden] {
+  display: none;
+}
+
+.oq-overview-trend-hover-head {
+  display: grid;
+  gap: 2px;
+}
+
+.oq-overview-trend-hover-kicker {
+  color: var(--oq-overview-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trend-hover-head strong {
+  color: var(--oq-overview-title);
+  font-size: 0.94rem;
+  line-height: 1.15;
+}
+
+.oq-overview-trend-hover-note {
+  color: var(--oq-overview-soft);
+  font-size: 0.76rem;
+  line-height: 1.25;
+}
+
+.oq-overview-trend-hover-values {
+  display: grid;
+  gap: 6px;
+}
+
+.oq-overview-trend-hover-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.oq-overview-trend-hover-row span {
+  color: var(--oq-overview-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.oq-overview-trend-hover-row strong {
+  color: var(--oq-overview-title);
+  font-size: 0.92rem;
+  line-height: 1.1;
+}
+
+.oq-overview-trend-hover-row--orange strong {
+  color: #c2410c;
+}
+
+.oq-overview-trend-hover-row--green strong {
+  color: #15803d;
+}
+
+.oq-overview-trend-hover-row--blue strong {
+  color: #2563eb;
+}
+
+.oq-overview-trend-hover-row--sky strong {
+  color: #0284c7;
+}
+
+.oq-overview-trend-hover-row--slate strong {
+  color: #475569;
+}
+
+.oq-overview-trend-hover-line {
+  stroke: rgba(15, 23, 42, 0.34);
+  stroke-width: 1.15;
+  stroke-dasharray: 4 4;
+}
+
+.oq-overview-trend-hover-dot {
+  stroke: #fff;
+  stroke-width: 2;
+}
+
+.oq-overview-trend-hover-dot--orange {
+  fill: #f97316;
+}
+
+.oq-overview-trend-hover-dot--green {
+  fill: #16a34a;
+}
+
+.oq-overview-trend-hover-dot--blue {
+  fill: #3b82f6;
+}
+
+.oq-overview-trend-hover-dot--sky {
+  fill: #0ea5e9;
+}
+
+.oq-overview-trends-windowbar .oq-overview-controlpanel-segment {
+  min-height: 36px;
+  padding: 0 12px;
+}

--- a/openquatt/web/css/src/20-overview.css
+++ b/openquatt/web/css/src/20-overview.css
@@ -643,11 +643,15 @@
   box-shadow: var(--oq-overview-shell-shadow);
 }
 
+.oq-overview-trends-head {
+  margin: 0;
+}
+
 .oq-overview-trends-toolbar {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
   gap: 12px;
-  align-items: start;
+  align-items: stretch;
   margin-top: 14px;
 }
 
@@ -660,6 +664,7 @@
   background: var(--oq-overview-lane-bg);
   border: 1px solid var(--oq-overview-lane-border);
   box-shadow: var(--oq-overview-lane-shadow);
+  align-content: start;
 }
 
 .oq-overview-trends-note span,
@@ -746,35 +751,22 @@
 }
 
 .oq-overview-trendcard::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 5px;
-}
-
-.oq-overview-trendcard--orange::before {
-  background: linear-gradient(180deg, #f59e0b, #ef4444);
-}
-
-.oq-overview-trendcard--green::before {
-  background: linear-gradient(180deg, #22c55e, #16a34a);
-}
-
-.oq-overview-trendcard--slate::before {
-  background: linear-gradient(180deg, #94a3b8, #475569);
+  content: none;
 }
 
 .oq-overview-trendcard-head {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(250px, 300px);
   gap: 14px;
-  align-items: flex-start;
+  align-items: start;
 }
 
 .oq-overview-trendcard-copy {
   min-width: 0;
   display: grid;
   gap: 4px;
+  align-content: start;
+  min-height: 88px;
 }
 
 .oq-overview-trendcard-kicker {
@@ -789,15 +781,29 @@
 .oq-overview-trendcard-copy h4 {
   margin: 0;
   color: var(--oq-overview-title);
-  font-size: 1rem;
-  line-height: 1.1;
+  font-size: 0.96rem;
+  line-height: 1.06;
 }
 
 .oq-overview-trendcard-copy p {
   margin: 0;
   color: var(--oq-overview-soft);
-  font-size: 0.84rem;
+  font-size: 0.81rem;
   line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.7em;
+}
+
+.oq-overview-trendcard-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-content: flex-start;
+  gap: 8px;
+  min-width: 0;
 }
 
 .oq-overview-trendcard-latest {
@@ -805,22 +811,6 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px;
-  flex: 0 0 auto;
-}
-
-.oq-overview-trendcard-badge {
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  padding: 0 10px;
-  border-radius: 999px;
-  border: 1px solid rgba(249, 115, 22, 0.22);
-  background: rgba(249, 115, 22, 0.08);
-  color: #b45309;
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
 }
 
 .oq-overview-trend-pill {
@@ -832,6 +822,7 @@
   border-radius: 14px;
   border: 1px solid var(--oq-overview-chip-border);
   background: var(--oq-overview-chip-bg);
+  align-content: start;
 }
 
 .oq-overview-trend-pill span {
@@ -840,6 +831,11 @@
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 1.1em;
 }
 
 .oq-overview-trend-pill strong {

--- a/openquatt/web/css/src/90-responsive.css
+++ b/openquatt/web/css/src/90-responsive.css
@@ -219,6 +219,7 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-overview-top,
   .oq-overview-main,
+  .oq-overview-trends-grid,
   .oq-overview-hp-grid,
   .oq-overview-hp-stats,
   .oq-overview-hp-meta {
@@ -257,6 +258,28 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-overview-metrics--three-column {
     grid-template-columns: 1fr;
+  }
+
+  .oq-overview-trends {
+    padding: 16px;
+    border-radius: 20px;
+  }
+
+  .oq-overview-trends-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .oq-overview-trendcard {
+    padding: 14px;
+  }
+
+  .oq-overview-trendcard-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .oq-overview-trendcard-latest {
+    justify-content: flex-start;
   }
 
   .oq-hp-schematic-topbar,
@@ -604,6 +627,68 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   .oq-overview-hp-grid {
     gap: 6px;
     margin-top: 10px;
+  }
+
+  .oq-overview-trends {
+    margin-top: 10px;
+    padding: 12px;
+  }
+
+  .oq-overview-trends-toolbar {
+    margin-top: 10px;
+    gap: 10px;
+  }
+
+  .oq-overview-trends-note,
+  .oq-overview-trends-window {
+    padding: 12px;
+    border-radius: 16px;
+  }
+
+  .oq-overview-trends-windowbar {
+    gap: 6px;
+  }
+
+  .oq-overview-trends-grid {
+    gap: 10px;
+    margin-top: 10px;
+  }
+
+  .oq-overview-trendcard {
+    gap: 10px;
+    padding: 12px;
+    border-radius: 16px;
+  }
+
+  .oq-overview-trend-hover {
+    top: 10px;
+    right: 10px;
+    min-width: 140px;
+    max-width: calc(100% - 20px);
+    padding: 10px 11px;
+    border-radius: 14px;
+  }
+
+  .oq-overview-trend-hover-row span {
+    font-size: 0.7rem;
+  }
+
+  .oq-overview-trend-hover-row strong {
+    font-size: 0.84rem;
+  }
+
+  .oq-overview-trend-pill {
+    min-width: 72px;
+    padding: 7px 9px;
+    border-radius: 12px;
+  }
+
+  .oq-overview-trend-pill span {
+    font-size: 0.64rem;
+  }
+
+  .oq-overview-trend-pill strong {
+    font-size: 0.82rem;
   }
 
   .oq-overview-hp-head,

--- a/openquatt/web/css/src/90-responsive.css
+++ b/openquatt/web/css/src/90-responsive.css
@@ -274,8 +274,12 @@ esp-app.oq-native-app.oq-native-app--collapsed {
   }
 
   .oq-overview-trendcard-head {
-    flex-direction: column;
-    align-items: flex-start;
+    grid-template-columns: 1fr;
+  }
+
+  .oq-overview-trendcard-meta {
+    justify-items: flex-start;
+    min-height: 0;
   }
 
   .oq-overview-trendcard-latest {
@@ -658,6 +662,19 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     gap: 10px;
     padding: 12px;
     border-radius: 16px;
+  }
+
+  .oq-overview-trendcard-copy {
+    min-height: 0;
+  }
+
+  .oq-overview-trendcard-copy p {
+    min-height: 0;
+    -webkit-line-clamp: 3;
+  }
+
+  .oq-overview-trendcard-meta {
+    min-height: 0;
   }
 
   .oq-overview-trend-hover {

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>OpenQuatt UI Preview</title>
-    <link rel="stylesheet" href="./css/openquatt-app.css?v=quick-start-single-toggle-1">
+    <link rel="stylesheet" href="./css/openquatt-app.css?v=trend-toggle-2">
     <style>
       :root {
         color-scheme: light;
@@ -32,7 +32,7 @@
     <div class="oq-dev-page">
       <esp-app></esp-app>
     </div>
-    <script src="./js/mock-device.js?v=cic-compatibility-mode-1"></script>
-    <script src="./js/openquatt-app.js?v=cic-compatibility-mode-1"></script>
+    <script src="./js/mock-device.js?v=trend-toggle-2"></script>
+    <script src="./js/openquatt-app.js?v=trend-toggle-2"></script>
   </body>
 </html>

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -378,6 +378,7 @@
     setEntity("switch", "OpenQuatt Enabled", { value: true, state: true });
     setEntity("switch", "Manual Cooling Enable", { value: false, state: false });
     setEntity("switch", "CiC Compatibility Mode", { value: false, state: false });
+    setEntity("switch", "Trendopslag", { value: true, state: true });
     setEntity("select", "Silent Mode Override", {
       value: "Schedule",
       state: "Schedule",
@@ -1217,6 +1218,8 @@
     entity.state = Boolean(enabled);
     if (name === "OpenQuatt Enabled" && enabled && getEntity("datetime", "OpenQuatt resume at")) {
       setText("datetime", "OpenQuatt resume at", OPENQUATT_RESUME_CLEAR_VALUE);
+    } else if (name === "Trendopslag" && !enabled && getEntity("text_sensor", "Overview Trend History")) {
+      setText("text_sensor", "Overview Trend History", "");
     }
     applyScenario(state.scenario);
     updateSummary();

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -7056,7 +7056,7 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
       {
         id: "temperatures",
         title: "Temperaturen",
-        copy: isMockData ? `Voorbeelddata voor de laatste ${windowText}, totdat de ESP-historie beschikbaar is.` : `Buitentemperatuur en aanvoertemperatuur van de laatste ${windowText}.`,
+        copy: `Buiten- en aanvoertemperatuur van de laatste ${windowText}.`,
         tone: "orange",
         samples,
         mock: isMockData,
@@ -7069,7 +7069,7 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
       {
         id: "power",
         title: "Vermogen",
-        copy: isMockData ? `Voorbeelddata voor elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.` : `Elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.`,
+        copy: `Elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.`,
         tone: "green",
         samples,
         mock: isMockData,
@@ -7082,7 +7082,7 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
       {
         id: "rendement",
         title: "Rendement",
-        copy: isMockData ? `Voorbeelddata voor COP van de laatste ${windowText}.` : `COP van de laatste ${windowText}.`,
+        copy: `COP van de laatste ${windowText}.`,
         tone: "slate",
         samples,
         mock: isMockData,
@@ -7108,7 +7108,7 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
       {
         id: "comfort",
         title: "Comfort",
-        copy: isMockData ? `Voorbeelddata voor kamertemperatuur en setpoint van de laatste ${windowText}.` : `Kamertemperatuur en setpoint van de laatste ${windowText}.`,
+        copy: `Kamertemperatuur en setpoint van de laatste ${windowText}.`,
         tone: "blue",
         samples,
         mock: isMockData,
@@ -7121,7 +7121,7 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
       {
         id: "flow",
         title: "Flow",
-        copy: isMockData ? `Voorbeelddata voor flow van de laatste ${windowText}.` : `Flow van de laatste ${windowText}.`,
+        copy: `Flow van de laatste ${windowText}.`,
         tone: "sky",
         samples,
         mock: isMockData,
@@ -7399,9 +7399,10 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
             <h4>${escapeHtml(card.title)}</h4>
             <p>${escapeHtml(card.copy)}</p>
           </div>
-          <div class="oq-overview-trendcard-latest">
-            ${card.mock ? `<span class="oq-overview-trendcard-badge">Voorbeelddata</span>` : ""}
-            ${card.series.map((series) => renderOverviewTrendLatestPill(series, latest)).join("")}
+          <div class="oq-overview-trendcard-meta">
+            <div class="oq-overview-trendcard-latest">
+              ${card.series.map((series) => renderOverviewTrendLatestPill(series, latest)).join("")}
+            </div>
           </div>
         </div>
         ${renderOverviewTrendChart(card.samples, card.series, card.mock, card.windowHours)}
@@ -7421,7 +7422,6 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
     const cards = getOverviewTrendCardsModel();
     return `
       <section class="oq-overview-trends" aria-label="Trends" data-render-signature="${escapeHtml(getOverviewTrendRenderSignature())}">
-        ${renderOverviewSectionHead("Grafieken")}
         <div class="oq-overview-trends-grid">
           ${cards.map(renderOverviewTrendCard).join("")}
         </div>
@@ -7464,9 +7464,12 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
     return `
       <section class="oq-helper-panel oq-helper-panel--flush">
         <div class="oq-overview-board oq-overview-board--${escapeHtml(state.overviewTheme)}">
-          <div class="oq-overview-system-copy">
-            <h3>Trendoverzicht</h3>
-            <p>Bekijk temperatuur, vermogen, rendement, comfort en flow voor 24, 12, 6 of 3 uur.</p>
+          <div class="oq-overview-head oq-overview-trends-head">
+            <div>
+              <p class="oq-helper-label">Trends</p>
+              <h2 class="oq-helper-section-title">Grafieken</h2>
+              <p class="oq-helper-section-copy">Bekijk temperatuur, vermogen, rendement, comfort en flow over 24, 12, 6 of 3 uur.</p>
+            </div>
           </div>
           <div class="oq-overview-trends-toolbar">
             <div class="oq-overview-trends-note">

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -120,6 +120,7 @@
     wifiSsid: { domain: "text_sensor", name: "WiFi SSID", optional: true },
     projectVersionText: { domain: "text_sensor", name: "OpenQuatt Version", optional: true },
     releaseChannelText: { domain: "text_sensor", name: "OpenQuatt Release Channel", optional: true },
+    trendHistory: { domain: "text_sensor", name: "Overview Trend History", optional: true },
     wifiSignal: { domain: "sensor", name: "WiFi Signal", optional: true },
     espInternalTemp: { domain: "sensor", name: "ESP Internal Temperature", optional: true },
     hpGeneration: { domain: "select", name: "Quatt Hybrid version" },
@@ -164,6 +165,7 @@
     boilerHeatPower: { domain: "sensor", name: "Boiler Heat Power", optional: true },
     systemHeatPower: { domain: "sensor", name: "System Heat Power", optional: true },
     flowSelected: { domain: "sensor", name: "Flow average (Selected)" },
+    trendHistoryEnabled: { domain: "switch", name: "Trendopslag", optional: true },
     electricalEnergyDaily: { domain: "sensor", name: "Electrical Energy Daily", optional: true },
     electricalEnergyCumulative: { domain: "sensor", name: "Electrical Energy Cumulative", optional: true },
     heatingElectricalEnergyDaily: { domain: "sensor", name: "Heating Electrical Energy Daily", optional: true },
@@ -269,6 +271,7 @@
 
   const APP_VIEWS = [
     { id: "overview", label: "Overzicht" },
+    { id: "trends", label: "Trends" },
     { id: "energy", label: "Energie" },
     { id: "settings", label: "Instellingen" },
   ];
@@ -572,6 +575,7 @@
     "openquattEnabled",
     "manualCoolingEnable",
     "silentModeOverride",
+    "trendHistoryEnabled",
     ...CIC_COMPATIBILITY_KEYS,
     ...FLOW_SETTING_KEYS,
     ...COOLING_SETTING_KEYS,
@@ -588,6 +592,8 @@
   const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
 
 /* --- js/src/01-runtime.js --- */
+  const TREND_WINDOW_HOURS_OPTIONS = [24, 12, 6, 3];
+
   const state = {
     mounted: false,
     root: null,
@@ -607,6 +613,7 @@
     overviewTheme: getStoredOverviewTheme(),
     hpVisualMode: getStoredHpVisualMode(),
     hpLayoutMode: getStoredHpLayoutMode(),
+    trendWindowHours: getStoredTrendWindowHours(),
     busyAction: "",
     controlError: "",
     controlNotice: "",
@@ -768,6 +775,24 @@
     }
   }
 
+  function getStoredTrendWindowHours() {
+    try {
+      const stored = Number(window.localStorage.getItem("oq-trend-window-hours"));
+      return TREND_WINDOW_HOURS_OPTIONS.includes(stored) ? stored : TREND_WINDOW_HOURS_OPTIONS[0];
+    } catch (_error) {
+      return TREND_WINDOW_HOURS_OPTIONS[0];
+    }
+  }
+
+  function setTrendWindowHours(hours) {
+    state.trendWindowHours = TREND_WINDOW_HOURS_OPTIONS.includes(hours) ? hours : TREND_WINDOW_HOURS_OPTIONS[0];
+    try {
+      window.localStorage.setItem("oq-trend-window-hours", String(state.trendWindowHours));
+    } catch (_error) {
+      // Ignore storage failures in embedded browsers.
+    }
+  }
+
   function getDefaultAppView() {
     return "overview";
   }
@@ -824,7 +849,13 @@
   }
 
   function normalizeAppView(view) {
-    return APP_VIEW_IDS.has(view) ? view : "";
+    if (!APP_VIEW_IDS.has(view)) {
+      return "";
+    }
+    if (view === "trends" && !isTrendHistoryEnabled()) {
+      return "";
+    }
+    return view;
   }
 
   function getUrlAppView() {
@@ -863,6 +894,10 @@
     const mode = options.syncMode || "replace";
     const changed = state.appView !== normalized;
     state.appView = normalized;
+
+    if (normalized === "settings" && !options.preserveSettingsGroup) {
+      setSettingsGroup(SETTINGS_GROUPS[0].id);
+    }
 
     if (changed || options.forceSync) {
       syncUrlAppView(mode);
@@ -2886,6 +2921,9 @@
       : false;
     state.stage = state.complete ? "Gereed" : "Quick Start";
     state.summary = renderAppSummary();
+    if (state.appView === "trends" && !isTrendHistoryEnabled()) {
+      setAppView(getDefaultAppView(), { syncMode: "replace", forceSync: true });
+    }
     if (!state.appView) {
       setAppView(getUrlAppView() || getDefaultAppView(), { syncMode: "replace", forceSync: true });
     }
@@ -2912,7 +2950,7 @@
       return;
     }
 
-    const keys = state.appView === "overview"
+    const keys = state.appView === "overview" || state.appView === "trends"
       ? [...OVERVIEW_KEYS, ...HEADER_ENTITY_KEYS, "setupComplete", ...FIRMWARE_ENTITY_KEYS]
       : state.appView === "settings"
         ? ["setupComplete", ...FIRMWARE_ENTITY_KEYS, ...HEADER_ENTITY_KEYS, ...SETTINGS_KEYS]
@@ -2946,6 +2984,12 @@
           return;
         }
         if (!patchSettingsDom()) {
+          render();
+        }
+        return;
+      }
+      if (state.appView === "trends") {
+        if (!patchTrendsDom()) {
           render();
         }
         return;
@@ -3189,9 +3233,18 @@
     }
 
     if (action === "select-view") {
+      if ((button.dataset.viewId || "") === "trends" && !isTrendHistoryEnabled()) {
+        return;
+      }
       setAppView(button.dataset.viewId || "overview", { syncMode: "push" });
       render();
       syncEntities();
+      return;
+    }
+
+    if (action === "select-trend-window") {
+      setTrendWindowHours(Number(button.dataset.trendHours || 24));
+      render();
       return;
     }
 
@@ -4117,23 +4170,7 @@
       parts.push(`max water ${formatValue("maxWater")}`);
     }
 
-    return parts.filter(Boolean).join(", ") || "Quick Start-instellingen beschikbaar";
-  }
-
-  function renderQuickStartLauncher() {
-    if (state.complete) {
-      return "";
-    }
-
-    return `
-      <button
-        class="oq-helper-app-tab oq-helper-app-tab--launch"
-        type="button"
-        data-oq-action="open-quickstart-modal"
-      >
-        <span>Quick Start</span>
-      </button>
-    `;
+    return parts.filter(Boolean).join(", ") || "Instellingen beschikbaar";
   }
 
   function hasEntity(key) {
@@ -4192,11 +4229,14 @@
     return raw === "on" || raw === "true" || raw === "1";
   }
 
+  function isTrendHistoryEnabled() {
+    return !hasEntity("trendHistoryEnabled") || isEntityActive("trendHistoryEnabled");
+  }
+
   function renderAppNav() {
     return `
       <div class="oq-helper-app-nav">
-        ${renderQuickStartLauncher()}
-        ${APP_VIEWS.map((view) => `
+        ${APP_VIEWS.filter((view) => view.id !== "trends" || isTrendHistoryEnabled()).map((view) => `
           <button
             class="oq-helper-app-tab ${state.appView === view.id ? "is-active" : ""}"
             type="button"
@@ -4539,6 +4579,7 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
               ]
             : [
                 renderSettingsQuickStartSection(),
+                renderSettingsTrendSection(),
                 renderSettingsLoginSection(),
                 renderSettingsDiagnosticsSection(),
               ];
@@ -5345,6 +5386,29 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
             </button>
           </div>
           <p class="oq-settings-quickstart-status-copy">${escapeHtml(statusCopy)}</p>
+        </div>
+      `,
+    );
+  }
+
+  function renderSettingsTrendSection() {
+    if (!hasEntity("trendHistoryEnabled")) {
+      return "";
+    }
+
+    return renderSettingsSection(
+      "Trends",
+      "Trendopslag",
+      "Sla 24 uur aan trenddata tijdelijk op in het werkgeheugen. Zet dit uit als je de grafieken niet gebruikt.",
+      `
+        <div class="oq-settings-grid">
+          ${renderSettingsSwitchField(
+            "trendHistoryEnabled",
+            "Trendopslag",
+            "Schakel de trendopslag voor de grafieken in of uit.",
+            "OpenQuatt bewaart trenddata tijdelijk in het werkgeheugen en toont de Trends-tab.",
+            "OpenQuatt bewaart geen trenddata en verbergt de Trends-tab."
+          )}
         </div>
       `,
     );
@@ -6205,6 +6269,65 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
     return `${numeric.toFixed(decimals)}${unit ? ` ${unit}` : ""}`;
   }
 
+  function formatOverviewTrendDurationLabel(totalMinutes) {
+    if (!Number.isFinite(totalMinutes) || totalMinutes < 0) {
+      return "—";
+    }
+    const wholeMinutes = Math.floor(totalMinutes);
+    const days = Math.floor(wholeMinutes / 1440);
+    const hours = Math.floor((wholeMinutes % 1440) / 60);
+    const minutes = wholeMinutes % 60;
+    if (days > 0) {
+      return `${days}d ${hours}u`;
+    }
+    if (hours > 0) {
+      return `${hours}u ${minutes}m`;
+    }
+    return `${minutes}m`;
+  }
+
+  function parseOverviewClockMinutes(rawValue) {
+    const value = String(rawValue || "").trim();
+    const match = value.match(/^(\d{1,2}):(\d{2})$/);
+    if (!match) {
+      return Number.NaN;
+    }
+    const hours = Number(match[1]);
+    const minutes = Number(match[2]);
+    if (Number.isNaN(hours) || Number.isNaN(minutes) || hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+      return Number.NaN;
+    }
+    return (hours * 60) + minutes;
+  }
+
+  function formatOverviewTrendClockLabel(totalMinutes) {
+    const clockMinutes = parseOverviewClockMinutes(getEntityStateText("timeNowHhmm", ""));
+    if (!Number.isFinite(clockMinutes)) {
+      return "";
+    }
+    const offsetMinutes = Math.round(totalMinutes);
+    const sampleMinutes = ((clockMinutes - offsetMinutes) % 1440 + 1440) % 1440;
+    const hours = Math.floor(sampleMinutes / 60);
+    const minutes = sampleMinutes % 60;
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+  }
+
+  function formatOverviewTrendPointTime(sampleTimestamp, endTime) {
+    const ageMinutes = Math.max(0, (Number(endTime) - Number(sampleTimestamp)) / 60000);
+    const ageLabel = formatOverviewTrendDurationLabel(ageMinutes);
+    const clockLabel = hasEntity("timeValid") && isEntityActive("timeValid") ? formatOverviewTrendClockLabel(ageMinutes) : "";
+    if (clockLabel) {
+      return {
+        value: clockLabel,
+        note: `${ageLabel} geleden`,
+      };
+    }
+    return {
+      value: `${ageLabel} geleden`,
+      note: "Geen tijdsync",
+    };
+  }
+
   function formatSignedPower(value) {
     const numeric = Number(value);
     if (Number.isNaN(numeric)) {
@@ -6553,8 +6676,8 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
   function getOverviewTopCards() {
     const coolingActive = isCoolingOverviewActive();
     return [
-      { key: "totalPower", label: "Stroomverbruik", tone: "blue", note: "hele systeem" },
-      { key: coolingActive ? "totalCoolingPower" : "totalHeat", label: coolingActive ? "Koelafgifte" : "Warmteafgifte", tone: "orange", note: "thermisch vermogen" },
+      { key: "totalPower", label: "Elektrisch vermogen", tone: "blue", note: "hele systeem" },
+      { key: coolingActive ? "totalCoolingPower" : "totalHeat", label: coolingActive ? "Koelvermogen" : "Verwarmingsvermogen", tone: "orange", note: "thermisch vermogen" },
       { key: coolingActive ? "totalEer" : "totalCop", label: coolingActive ? "COP (EER)" : "COP", tone: "green", note: "rendement" },
       { key: "flowSelected", label: "Flow", tone: "sky", note: "watercircuit" },
     ];
@@ -6778,6 +6901,744 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
           ${model.rows.map((row) => renderTempRow(row.label, row.key, row.value || "")).join("")}
         </div>
       `,
+    });
+  }
+
+  const OVERVIEW_TREND_MAX_POINTS = 288;
+
+  function getOverviewTrendWindowHours() {
+    const hours = Number(state.trendWindowHours || 24);
+    return TREND_WINDOW_HOURS_OPTIONS.includes(hours) ? hours : TREND_WINDOW_HOURS_OPTIONS[0];
+  }
+
+  function getOverviewTrendWindowMs(windowHours = getOverviewTrendWindowHours()) {
+    return Math.max(1, Number(windowHours) || 24) * 60 * 60 * 1000;
+  }
+
+  function formatOverviewTrendWindowLabel(windowHours = getOverviewTrendWindowHours()) {
+    const hours = Number(windowHours) || 24;
+    return `${hours}u`;
+  }
+
+  function formatOverviewTrendWindowText(windowHours = getOverviewTrendWindowHours()) {
+    const hours = Number(windowHours) || 24;
+    return `${hours} uur`;
+  }
+
+  function formatOverviewTrendAxisLabel(totalMinutes) {
+    if (!Number.isFinite(totalMinutes) || totalMinutes < 0) {
+      return "—";
+    }
+    const roundedMinutes = Math.round(totalMinutes);
+    if (roundedMinutes % 60 === 0) {
+      return `${roundedMinutes / 60}u`;
+    }
+    return formatOverviewTrendDurationLabel(roundedMinutes);
+  }
+
+  function getOverviewUptimeMillis() {
+    const entity = state.entities.uptime;
+    if (!entity) {
+      return Number.NaN;
+    }
+
+    const numeric = getEntityNumericValue("uptime");
+    if (!Number.isFinite(numeric)) {
+      return Number.NaN;
+    }
+
+    const unit = String(entity.uom ?? entity.unit_of_measurement ?? "").trim().toLowerCase();
+    if (unit === "d") {
+      return numeric * 24 * 60 * 60 * 1000;
+    }
+    if (unit === "h") {
+      return numeric * 60 * 60 * 1000;
+    }
+    if (unit === "m" || unit === "min") {
+      return numeric * 60 * 1000;
+    }
+    return numeric * 1000;
+  }
+
+  function parseOverviewTrendRow(row) {
+    const parts = String(row || "").trim().split("|");
+    if (parts.length < 5) {
+      return null;
+    }
+
+    const timestamp = Number(parts[0]);
+    if (!Number.isFinite(timestamp)) {
+      return null;
+    }
+
+    const parseValue = (value) => {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+
+    return {
+      t: timestamp,
+      outside: parseValue(parts[1]),
+      supply: parseValue(parts[2]),
+      room: parts.length >= 8 ? parseValue(parts[3]) : null,
+      roomSetpoint: parts.length >= 8 ? parseValue(parts[4]) : null,
+      flow: parts.length >= 8 ? parseValue(parts[5]) : null,
+      input: parts.length >= 8 ? parseValue(parts[6]) : parseValue(parts[3]),
+      output: parts.length >= 8 ? parseValue(parts[7]) : parseValue(parts[4]),
+    };
+  }
+
+  function getOverviewTrendSamples() {
+    const windowMs = getOverviewTrendWindowMs();
+    if (!hasEntity("trendHistory")) {
+      return buildOverviewTrendMockSamples();
+    }
+
+    const raw = String(getEntityStateText("trendHistory", "") || "").trim();
+    if (!raw) {
+      return buildOverviewTrendMockSamples();
+    }
+
+    const uptimeMs = getOverviewUptimeMillis();
+    const rows = raw
+      .split(/\r?\n/)
+      .map(parseOverviewTrendRow)
+      .filter(Boolean);
+
+    const latestTimestamp = rows.length ? rows[rows.length - 1].t : Number.NaN;
+    const endTime = Number.isFinite(uptimeMs)
+      ? uptimeMs
+      : (Number.isFinite(latestTimestamp) ? latestTimestamp : Number.NaN);
+
+    if (!Number.isFinite(endTime)) {
+      return rows.length ? rows.slice(-OVERVIEW_TREND_MAX_POINTS) : buildOverviewTrendMockSamples();
+    }
+
+    const cutoff = Math.max(0, endTime - windowMs);
+    const filtered = rows.filter((sample) => sample.t >= cutoff).slice(-OVERVIEW_TREND_MAX_POINTS);
+    return filtered.length ? filtered : buildOverviewTrendMockSamples();
+  }
+
+  function buildOverviewTrendMockSamples(windowHours = getOverviewTrendWindowHours()) {
+    const windowMs = getOverviewTrendWindowMs(windowHours);
+    const points = Math.max(12, Math.round(windowHours * 12));
+    const startTime = 0;
+    const span = Math.max(points - 1, 1);
+    const samples = [];
+
+    for (let index = 0; index < points; index += 1) {
+      const fraction = index / span;
+      const dayWave = Math.sin((fraction * Math.PI * 2) - 1.1);
+      const detailWave = Math.sin(fraction * Math.PI * 10);
+      const driftWave = Math.cos((fraction * Math.PI * 2) + 0.45);
+
+      samples.push({
+        t: startTime + Math.round(fraction * windowMs),
+        outside: 8.5 + (dayWave * 3.4) + (detailWave * 0.5),
+        supply: 35.5 + (Math.sin((fraction * Math.PI * 2) - 0.35) * 4.8) + (detailWave * 0.9),
+        room: 20.2 + (Math.sin((fraction * Math.PI * 2) - 0.22) * 0.35) + (detailWave * 0.08),
+        roomSetpoint: 20.6 + (Math.cos((fraction * Math.PI * 2) - 0.1) * 0.10),
+        flow: Math.max(0, 760 + (Math.cos((fraction * Math.PI * 2) + 0.1) * 110) + (detailWave * 18)),
+        input: Math.max(280, 1180 + (dayWave * 380) + (detailWave * 150) + (driftWave * 110)),
+        output: Math.max(1000, 4250 + (dayWave * 860) + (detailWave * 260)),
+      });
+    }
+
+    return samples;
+  }
+
+  function getOverviewTrendCardsModel() {
+    const windowHours = getOverviewTrendWindowHours();
+    const windowText = formatOverviewTrendWindowText(windowHours);
+    const samples = getOverviewTrendSamples();
+    const isMockData = !hasEntity("trendHistory") || !String(getEntityStateText("trendHistory", "") || "").trim();
+    return [
+      {
+        id: "temperatures",
+        title: "Temperaturen",
+        copy: isMockData ? `Voorbeelddata voor de laatste ${windowText}, totdat de ESP-historie beschikbaar is.` : `Buitentemperatuur en aanvoertemperatuur van de laatste ${windowText}.`,
+        tone: "orange",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          { id: "outside", sampleKey: "outside", label: "Buiten", tone: "orange", decimals: 1, unit: " °C" },
+          { id: "supply", sampleKey: "supply", label: "Aanvoer", tone: "blue", decimals: 1, unit: " °C" },
+        ],
+      },
+      {
+        id: "power",
+        title: "Vermogen",
+        copy: isMockData ? `Voorbeelddata voor elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.` : `Elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.`,
+        tone: "green",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          { id: "input", sampleKey: "input", label: "Elektrisch vermogen", tone: "green", decimals: 0, unit: " W" },
+          { id: "output", sampleKey: "output", label: "Verwarmingsvermogen", tone: "sky", decimals: 0, unit: " W" },
+        ],
+      },
+      {
+        id: "rendement",
+        title: "Rendement",
+        copy: isMockData ? `Voorbeelddata voor COP van de laatste ${windowText}.` : `COP van de laatste ${windowText}.`,
+        tone: "slate",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          {
+            id: "cop",
+            label: "COP",
+            tone: "slate",
+            decimals: 1,
+            unit: "",
+            derive: (sample) => {
+              const input = Number(sample?.input);
+              const output = Number(sample?.output);
+              if (!Number.isFinite(input) || !Number.isFinite(output) || input <= 0) {
+                return Number.NaN;
+              }
+              return output / input;
+            },
+          },
+        ],
+      },
+      {
+        id: "comfort",
+        title: "Comfort",
+        copy: isMockData ? `Voorbeelddata voor kamertemperatuur en setpoint van de laatste ${windowText}.` : `Kamertemperatuur en setpoint van de laatste ${windowText}.`,
+        tone: "blue",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          { id: "roomTemp", sampleKey: "room", label: "Kamertemperatuur", tone: "blue", decimals: 1, unit: " °C" },
+          { id: "roomSetpoint", sampleKey: "roomSetpoint", label: "Kamer setpoint", tone: "orange", decimals: 1, unit: " °C" },
+        ],
+      },
+      {
+        id: "flow",
+        title: "Flow",
+        copy: isMockData ? `Voorbeelddata voor flow van de laatste ${windowText}.` : `Flow van de laatste ${windowText}.`,
+        tone: "sky",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          { id: "flow", sampleKey: "flow", label: "Flow", tone: "sky", decimals: 0, unit: " L/h" },
+        ],
+      },
+    ];
+  }
+
+  function getOverviewTrendSeriesValue(series, sample) {
+    if (!series || !sample) {
+      return Number.NaN;
+    }
+    const raw = typeof series.derive === "function"
+      ? series.derive(sample)
+      : sample?.[series.sampleKey];
+    const numeric = Number(raw);
+    return Number.isFinite(numeric) ? numeric : Number.NaN;
+  }
+
+  function getOverviewTrendRange(samples, series) {
+    const values = [];
+    samples.forEach((sample) => {
+      series.forEach((item) => {
+        const numeric = getOverviewTrendSeriesValue(item, sample);
+        if (Number.isFinite(numeric)) {
+          values.push(numeric);
+        }
+      });
+    });
+
+    if (!values.length) {
+      return { min: 0, max: 1 };
+    }
+
+    let min = Math.min(...values);
+    let max = Math.max(...values);
+    if (min === max) {
+      const offset = Math.max(Math.abs(min) * 0.1, 1);
+      min -= offset;
+      max += offset;
+    } else {
+      const pad = Math.max((max - min) * 0.12, 1);
+      min -= pad;
+      max += pad;
+    }
+    return { min, max };
+  }
+
+  function getOverviewTrendChartModel(samples, series, options = {}) {
+    const rawWindowHours = Number(options.windowHours);
+    const windowHours = Number.isFinite(rawWindowHours) ? rawWindowHours : getOverviewTrendWindowHours();
+    const windowMs = getOverviewTrendWindowMs(windowHours);
+    const width = 640;
+    const height = 220;
+    const left = 22;
+    const right = 18;
+    const top = 18;
+    const bottom = 34;
+    const plotWidth = width - left - right;
+    const plotHeight = height - top - bottom;
+    const latest = samples[samples.length - 1];
+    const mockData = Boolean(options.mockData);
+    const uptimeMs = getOverviewUptimeMillis();
+    const endTime = mockData
+      ? windowMs
+      : (Number.isFinite(uptimeMs) ? uptimeMs : (latest ? latest.t : 0));
+    const startTime = mockData ? 0 : Math.max(endTime - windowMs, 0);
+    const span = Math.max(endTime - startTime, 1);
+    const range = getOverviewTrendRange(samples, series);
+
+    const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
+    const yOf = (value) => {
+      if (!Number.isFinite(value)) {
+        return Number.NaN;
+      }
+      const ratio = (value - range.min) / Math.max(range.max - range.min, 1);
+      return top + ((1 - Math.min(1, Math.max(0, ratio))) * plotHeight);
+    };
+
+    const gridXs = [0, 0.5, 1].map((fraction) => left + (plotWidth * fraction));
+    const gridYs = [0.25, 0.5, 0.75].map((fraction) => top + (plotHeight * fraction));
+
+    const points = samples.map((sample) => {
+      const x = xOf(sample.t);
+      const values = series.map((item) => {
+        const numeric = getOverviewTrendSeriesValue(item, sample);
+        if (!Number.isFinite(numeric)) {
+          return null;
+        }
+        return {
+          seriesId: item.id || item.sampleKey || item.label,
+          tone: item.tone,
+          label: item.label,
+          decimals: item.decimals,
+          unit: item.unit,
+          value: numeric,
+          x,
+          y: yOf(numeric),
+        };
+      });
+      return {
+        sample,
+        x,
+        values,
+      };
+    });
+
+    const tracks = series.flatMap((item) => {
+      const segments = [];
+      let current = [];
+      samples.forEach((sample) => {
+        const numeric = getOverviewTrendSeriesValue(item, sample);
+        if (!Number.isFinite(numeric)) {
+          if (current.length) {
+            segments.push(current);
+            current = [];
+          }
+          return;
+        }
+
+        current.push({
+          x: xOf(sample.t),
+          y: yOf(numeric),
+        });
+      });
+      if (current.length) {
+        segments.push(current);
+      }
+
+      return segments.map((segment) => {
+        if (segment.length < 2) {
+          return {
+            tone: item.tone,
+            points: segment,
+            path: "",
+          };
+        }
+
+        return {
+          tone: item.tone,
+          points: segment,
+          path: segment.map((point, pointIndex) => `${pointIndex === 0 ? "M" : "L"} ${point.x.toFixed(1)} ${point.y.toFixed(1)}`).join(" "),
+        };
+      });
+    });
+
+    return {
+      width,
+      height,
+      left,
+      right,
+      top,
+      bottom,
+      plotWidth,
+      plotHeight,
+      latest,
+      uptimeMs,
+      endTime,
+      startTime,
+      span,
+      windowHours,
+      range,
+      gridXs,
+      gridYs,
+      points,
+      tracks,
+      series,
+    };
+  }
+
+  function getOverviewTrendRenderSignature() {
+    return getRenderSignature({
+      windowHours: getOverviewTrendWindowHours(),
+      samples: getOverviewTrendSamples(),
+    });
+  }
+
+  function getOverviewTrendCardById(cardId) {
+    return getOverviewTrendCardsModel().find((card) => card.id === cardId) || null;
+  }
+
+  function getNearestOverviewTrendPointIndex(model, x) {
+    if (!model || !Array.isArray(model.points) || model.points.length === 0) {
+      return -1;
+    }
+
+    let nearestIndex = 0;
+    let nearestDistance = Math.abs(model.points[0].x - x);
+    model.points.forEach((point, index) => {
+      const distance = Math.abs(point.x - x);
+      if (distance < nearestDistance) {
+        nearestIndex = index;
+        nearestDistance = distance;
+      }
+    });
+    return nearestIndex;
+  }
+
+  function renderOverviewTrendLatestPill(series, sample) {
+    const value = getOverviewTrendSeriesValue(series, sample);
+    return `
+      <div class="oq-overview-trend-pill oq-overview-trend-pill--${escapeHtml(series.tone)}">
+        <span>${escapeHtml(series.label)}</span>
+        <strong>${escapeHtml(formatNumericState(value, series.decimals, series.unit))}</strong>
+      </div>
+    `;
+  }
+
+  function renderOverviewTrendChart(samples, series, mockData = false, windowHours = getOverviewTrendWindowHours()) {
+    const model = getOverviewTrendChartModel(samples, series, { mockData, windowHours });
+    const windowLabel = formatOverviewTrendWindowLabel(windowHours);
+    const midpointLabel = formatOverviewTrendAxisLabel((windowHours * 60) / 2);
+    const seriesPaths = model.tracks.flatMap((track) => {
+      if (track.points.length < 2) {
+        const point = track.points[0];
+        if (!point) {
+          return [];
+        }
+        return `
+          <circle
+            cx="${point.x.toFixed(1)}"
+            cy="${point.y.toFixed(1)}"
+            r="3.8"
+            class="oq-overview-trend-dot oq-overview-trend-dot--${escapeHtml(track.tone)}"
+          ></circle>
+        `;
+      }
+
+      return `
+        <path d="${track.path}" class="oq-overview-trend-line oq-overview-trend-line--${escapeHtml(track.tone)}"></path>
+        <circle
+          cx="${track.points[track.points.length - 1].x.toFixed(1)}"
+          cy="${track.points[track.points.length - 1].y.toFixed(1)}"
+          r="3.8"
+          class="oq-overview-trend-dot oq-overview-trend-dot--${escapeHtml(track.tone)}"
+        ></circle>
+      `;
+    }).join("");
+
+    return `
+      <svg class="oq-overview-trend-chart" viewBox="0 0 ${model.width} ${model.height}" role="img" aria-label="Trendgrafiek van de laatste ${windowHours} uur">
+        <rect x="0" y="0" width="${model.width}" height="${model.height}" rx="20" class="oq-overview-trend-chart-bg"></rect>
+        ${model.gridXs.map((x) => `<line x1="${x.toFixed(1)}" y1="${model.top}" x2="${x.toFixed(1)}" y2="${model.height - model.bottom}" class="oq-overview-trend-grid oq-overview-trend-grid--vertical"></line>`).join("")}
+        ${model.gridYs.map((y) => `<line x1="${model.left}" y1="${y.toFixed(1)}" x2="${model.width - model.right}" y2="${y.toFixed(1)}" class="oq-overview-trend-grid oq-overview-trend-grid--horizontal"></line>`).join("")}
+        ${seriesPaths}
+        <g class="oq-overview-trend-hover-layer" data-oq-trend-hover-layer hidden>
+          <line x1="${model.left}" y1="${model.top}" x2="${model.left}" y2="${model.height - model.bottom}" class="oq-overview-trend-hover-line"></line>
+          ${series.map((item) => `
+            <circle
+              r="4.5"
+              class="oq-overview-trend-hover-dot oq-overview-trend-hover-dot--${escapeHtml(item.tone)}"
+              data-oq-trend-hover-dot="${escapeHtml(item.id || item.sampleKey || item.label)}"
+            ></circle>
+          `).join("")}
+        </g>
+        <line x1="${model.left}" y1="${model.height - model.bottom}" x2="${model.width - model.right}" y2="${model.height - model.bottom}" class="oq-overview-trend-axis"></line>
+        <text x="${model.left}" y="${model.height - 12}" class="oq-overview-trend-axis-label" text-anchor="start">${escapeHtml(windowLabel)}</text>
+        <text x="${model.left + (model.plotWidth / 2)}" y="${model.height - 12}" class="oq-overview-trend-axis-label" text-anchor="middle">${escapeHtml(midpointLabel)}</text>
+        <text x="${model.width - model.right}" y="${model.height - 12}" class="oq-overview-trend-axis-label" text-anchor="end">nu</text>
+      </svg>
+    `;
+  }
+
+  function renderOverviewTrendCard(card) {
+    const latest = card.samples[card.samples.length - 1] || null;
+    const windowText = formatOverviewTrendWindowText(card.windowHours);
+    return `
+      <article class="oq-overview-trendcard oq-overview-trendcard--${escapeHtml(card.tone)}" data-oq-trend-card="${escapeHtml(card.id)}" data-render-signature="${escapeHtml(getRenderSignature(card))}">
+        <div class="oq-overview-trendcard-head">
+          <div class="oq-overview-trendcard-copy">
+            <p class="oq-overview-trendcard-kicker">${escapeHtml(windowText)}</p>
+            <h4>${escapeHtml(card.title)}</h4>
+            <p>${escapeHtml(card.copy)}</p>
+          </div>
+          <div class="oq-overview-trendcard-latest">
+            ${card.mock ? `<span class="oq-overview-trendcard-badge">Voorbeelddata</span>` : ""}
+            ${card.series.map((series) => renderOverviewTrendLatestPill(series, latest)).join("")}
+          </div>
+        </div>
+        ${renderOverviewTrendChart(card.samples, card.series, card.mock, card.windowHours)}
+        <div class="oq-overview-trend-hover" data-oq-trend-hover hidden>
+          <div class="oq-overview-trend-hover-head">
+            <span class="oq-overview-trend-hover-kicker">Punt</span>
+            <strong data-oq-trend-hover-time>—</strong>
+            <span class="oq-overview-trend-hover-note" data-oq-trend-hover-note></span>
+          </div>
+          <div class="oq-overview-trend-hover-values" data-oq-trend-hover-values></div>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderOverviewTrendsPanel() {
+    const cards = getOverviewTrendCardsModel();
+    return `
+      <section class="oq-overview-trends" aria-label="Trends" data-render-signature="${escapeHtml(getOverviewTrendRenderSignature())}">
+        ${renderOverviewSectionHead("Grafieken")}
+        <div class="oq-overview-trends-grid">
+          ${cards.map(renderOverviewTrendCard).join("")}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderOverviewTrendsDisabledNotice() {
+    return `
+      <div class="oq-overview-trends-disabled">
+        <p>Trendopslag staat uit.</p>
+        <strong>Schakel trendopslag in om grafieken en historie te tonen.</strong>
+        <span>Je vindt deze instelling onder Instellingen &rsaquo; Systeem.</span>
+        <button class="oq-helper-button oq-helper-button--ghost" type="button" data-oq-action="select-view" data-view-id="settings">
+          Naar instellingen
+        </button>
+      </div>
+    `;
+  }
+
+  function renderTrendWindowSwitcher() {
+    const windowHours = getOverviewTrendWindowHours();
+    return `
+      <div class="oq-overview-trends-windowbar" role="group" aria-label="Kies trendvenster">
+        ${TREND_WINDOW_HOURS_OPTIONS.map((hours) => `
+          <button
+            class="oq-overview-controlpanel-segment${windowHours === hours ? " is-selected" : ""}"
+            type="button"
+            data-oq-action="select-trend-window"
+            data-trend-hours="${hours}"
+            aria-pressed="${windowHours === hours ? "true" : "false"}"
+          >${hours}u</button>
+        `).join("")}
+      </div>
+    `;
+  }
+
+  function renderTrendsView() {
+    const trendHistoryEnabled = isTrendHistoryEnabled();
+    return `
+      <section class="oq-helper-panel oq-helper-panel--flush">
+        <div class="oq-overview-board oq-overview-board--${escapeHtml(state.overviewTheme)}">
+          <div class="oq-overview-system-copy">
+            <h3>Trendoverzicht</h3>
+            <p>Bekijk temperatuur, vermogen, rendement, comfort en flow voor 24, 12, 6 of 3 uur.</p>
+          </div>
+          <div class="oq-overview-trends-toolbar">
+            <div class="oq-overview-trends-note">
+              <span>Opmerking</span>
+              <strong>Max. 24 uur in werkgeheugen</strong>
+              <p>De OpenQuatt Controller bewaart trenddata tijdelijk in het werkgeheugen. Na een herstart verdwijnt die historie.</p>
+            </div>
+            ${trendHistoryEnabled ? `
+              <div class="oq-overview-trends-window">
+                <span>Venster</span>
+                ${renderTrendWindowSwitcher()}
+              </div>
+            ` : ""}
+          </div>
+          ${trendHistoryEnabled ? renderOverviewTrendsPanel() : renderOverviewTrendsDisabledNotice()}
+        </div>
+      </section>
+    `;
+  }
+
+  function patchTrendsDom() {
+    if (!state.root || state.appView !== "trends") {
+      return false;
+    }
+
+    const board = state.root.querySelector(".oq-overview-board");
+    if (!board) {
+      return false;
+    }
+
+    const trends = board.querySelector(".oq-overview-trends");
+    if (!trends) {
+      return false;
+    }
+
+    replaceOuterHtmlIfSignatureChanged(
+      trends,
+      getOverviewTrendRenderSignature(),
+      renderOverviewTrendsPanel(),
+    );
+    syncOverviewTrendInteractions(board);
+    return true;
+  }
+
+  function updateOverviewTrendHoverCard(card, model, pointIndex) {
+    if (!card || !model || !Array.isArray(model.points) || model.points.length === 0) {
+      return;
+    }
+
+    const index = Math.max(0, Math.min(model.points.length - 1, pointIndex));
+    const point = model.points[index];
+    if (!point) {
+      return;
+    }
+
+    const chart = card.querySelector(".oq-overview-trend-chart");
+    const hoverLayer = card.querySelector("[data-oq-trend-hover-layer]");
+    const hoverPanel = card.querySelector("[data-oq-trend-hover]");
+    const hoverTime = card.querySelector("[data-oq-trend-hover-time]");
+    const hoverNote = card.querySelector("[data-oq-trend-hover-note]");
+    const hoverValues = card.querySelector("[data-oq-trend-hover-values]");
+
+    if (!chart || !hoverLayer || !hoverPanel || !hoverTime || !hoverNote || !hoverValues) {
+      return;
+    }
+
+    const timeLabel = formatOverviewTrendPointTime(point.sample.t, model.endTime);
+    hoverPanel.hidden = false;
+    hoverLayer.removeAttribute("hidden");
+    hoverTime.textContent = timeLabel.value;
+    hoverNote.textContent = timeLabel.note;
+
+    const hoverLine = hoverLayer.querySelector(".oq-overview-trend-hover-line");
+    if (hoverLine) {
+      hoverLine.setAttribute("x1", point.x.toFixed(1));
+      hoverLine.setAttribute("x2", point.x.toFixed(1));
+    }
+
+    const rows = [];
+    model.series.forEach((series) => {
+      const value = getOverviewTrendSeriesValue(series, point.sample);
+      const seriesId = series.id || series.sampleKey || series.label;
+      const dot = hoverLayer.querySelector(`[data-oq-trend-hover-dot="${seriesId}"]`);
+      if (!Number.isFinite(value)) {
+        if (dot) {
+          dot.setAttribute("display", "none");
+        }
+        return;
+      }
+      const trackValue = point.values.find((item) => item.seriesId === seriesId);
+      if (dot && trackValue) {
+        dot.removeAttribute("display");
+        dot.setAttribute("cx", trackValue.x.toFixed(1));
+        dot.setAttribute("cy", trackValue.y.toFixed(1));
+      }
+      rows.push(`
+        <div class="oq-overview-trend-hover-row oq-overview-trend-hover-row--${escapeHtml(series.tone)}">
+          <span>${escapeHtml(series.label)}</span>
+          <strong>${escapeHtml(formatNumericState(value, series.decimals, series.unit))}</strong>
+        </div>
+      `);
+    });
+
+    hoverValues.innerHTML = rows.join("");
+    card.dataset.oqTrendHoverIndex = String(index);
+  }
+
+  function clearOverviewTrendHoverCard(card) {
+    if (!card) {
+      return;
+    }
+    const hoverPanel = card.querySelector("[data-oq-trend-hover]");
+    const hoverLayer = card.querySelector("[data-oq-trend-hover-layer]");
+    if (hoverPanel) {
+      hoverPanel.hidden = true;
+    }
+    if (hoverLayer) {
+      hoverLayer.setAttribute("hidden", "");
+    }
+    delete card.dataset.oqTrendHoverIndex;
+  }
+
+  function syncOverviewTrendInteractions(root = state.root) {
+    if (!root) {
+      return;
+    }
+
+    const cards = root.querySelectorAll("[data-oq-trend-card]");
+    cards.forEach((card) => {
+      const signature = card.dataset.renderSignature || "";
+      if (card.__oqTrendBoundSignature === signature) {
+        return;
+      }
+      card.__oqTrendBoundSignature = signature;
+
+      const chart = card.querySelector(".oq-overview-trend-chart");
+      if (!chart) {
+        return;
+      }
+
+      const cardModel = getOverviewTrendCardById(card.dataset.oqTrendCard);
+      if (!cardModel) {
+        return;
+      }
+      const model = getOverviewTrendChartModel(cardModel.samples, cardModel.series, { mockData: cardModel.mock });
+
+      card.__oqTrendModel = model;
+
+      const handleMove = (event) => {
+        const rect = chart.getBoundingClientRect();
+        if (!rect.width || !rect.height) {
+          return;
+        }
+        const clientX = Number(event.clientX);
+        if (!Number.isFinite(clientX)) {
+          updateOverviewTrendHoverCard(card, model, model.points.length - 1);
+          return;
+        }
+        const localX = Math.min(rect.width, Math.max(0, clientX - rect.left));
+        const svgX = (localX / rect.width) * model.width;
+        const pointIndex = getNearestOverviewTrendPointIndex(model, svgX);
+        updateOverviewTrendHoverCard(card, model, pointIndex);
+      };
+
+      const handleLeave = () => clearOverviewTrendHoverCard(card);
+
+      chart.addEventListener("pointermove", handleMove);
+      chart.addEventListener("pointerenter", handleMove);
+      chart.addEventListener("pointerleave", handleLeave);
+      chart.addEventListener("focus", handleMove);
+      chart.addEventListener("blur", handleLeave);
+      chart.addEventListener("touchstart", handleMove, { passive: true });
     });
   }
 
@@ -7988,6 +8849,7 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
     const summaryShell = board.querySelector(".oq-overview-summary-shell");
     const system = board.querySelector(".oq-overview-system");
     const temps = board.querySelector(".oq-overview-temps");
+    const trends = board.querySelector(".oq-overview-trends");
     const hpTools = board.querySelector(".oq-overview-hp-tools");
     const hpGrid = board.querySelector(".oq-overview-hp-grid");
     const heatPumpPanels = getHeatPumpPanels();
@@ -8034,6 +8896,16 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
       );
     }
 
+    if (trends && state.appView === "overview") {
+      replaceOuterHtmlIfSignatureChanged(
+        trends,
+        getOverviewTrendRenderSignature(),
+        renderOverviewTrendsPanel(),
+      );
+    }
+
+    syncOverviewTrendInteractions(board);
+
     if (!hpTools || !hpGrid) {
       return false;
     }
@@ -8076,8 +8948,8 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
     return `
       <section class="oq-helper-panel">
         <p class="oq-helper-label">OpenQuatt</p>
-        <h2 class="oq-helper-section-title">Interface laden</h2>
-        <p class="oq-helper-section-copy">We bepalen eerst even of Quick Start al is afgerond, zodat je direct op de juiste plek binnenkomt.</p>
+        <h2 class="oq-helper-section-title">OpenQuatt laden</h2>
+        <p class="oq-helper-section-copy">We halen de actuele gegevens op en zetten de interface klaar.</p>
       </section>
     `;
   }
@@ -8106,10 +8978,12 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
       ? renderInitialLoadingView()
       : state.appView === "overview"
       ? renderOverviewView()
+      : state.appView === "trends"
+      ? renderTrendsView()
       : state.appView === "energy"
       ? renderEnergyView()
       : renderSettingsView();
-    const wideFlushCard = state.appView === "overview" || state.appView === "energy";
+    const wideFlushCard = state.appView === "overview" || state.appView === "trends" || state.appView === "energy";
 
     state.root.innerHTML = `
       ${renderDevPanel()}
@@ -8140,6 +9014,7 @@ const HP_GENERATION_IMAGE_V2 = "data:image/webp;base64,UklGRgoWAABXRUJQVlA4WAoAA
     clearLegacyMotionVariables();
     syncTechTooltipLayers();
     refreshMotionTargets();
+    syncOverviewTrendInteractions();
     syncNativeVisibility();
     bindHeaderDevControls();
     syncDocumentTheme();

--- a/openquatt/web/js/src/00-config.js
+++ b/openquatt/web/js/src/00-config.js
@@ -116,6 +116,7 @@
     wifiSsid: { domain: "text_sensor", name: "WiFi SSID", optional: true },
     projectVersionText: { domain: "text_sensor", name: "OpenQuatt Version", optional: true },
     releaseChannelText: { domain: "text_sensor", name: "OpenQuatt Release Channel", optional: true },
+    trendHistory: { domain: "text_sensor", name: "Overview Trend History", optional: true },
     wifiSignal: { domain: "sensor", name: "WiFi Signal", optional: true },
     espInternalTemp: { domain: "sensor", name: "ESP Internal Temperature", optional: true },
     hpGeneration: { domain: "select", name: "Quatt Hybrid version" },
@@ -160,6 +161,7 @@
     boilerHeatPower: { domain: "sensor", name: "Boiler Heat Power", optional: true },
     systemHeatPower: { domain: "sensor", name: "System Heat Power", optional: true },
     flowSelected: { domain: "sensor", name: "Flow average (Selected)" },
+    trendHistoryEnabled: { domain: "switch", name: "Trendopslag", optional: true },
     electricalEnergyDaily: { domain: "sensor", name: "Electrical Energy Daily", optional: true },
     electricalEnergyCumulative: { domain: "sensor", name: "Electrical Energy Cumulative", optional: true },
     heatingElectricalEnergyDaily: { domain: "sensor", name: "Heating Electrical Energy Daily", optional: true },
@@ -265,6 +267,7 @@
 
   const APP_VIEWS = [
     { id: "overview", label: "Overzicht" },
+    { id: "trends", label: "Trends" },
     { id: "energy", label: "Energie" },
     { id: "settings", label: "Instellingen" },
   ];
@@ -568,6 +571,7 @@
     "openquattEnabled",
     "manualCoolingEnable",
     "silentModeOverride",
+    "trendHistoryEnabled",
     ...CIC_COMPATIBILITY_KEYS,
     ...FLOW_SETTING_KEYS,
     ...COOLING_SETTING_KEYS,

--- a/openquatt/web/js/src/01-runtime.js
+++ b/openquatt/web/js/src/01-runtime.js
@@ -1,3 +1,5 @@
+  const TREND_WINDOW_HOURS_OPTIONS = [24, 12, 6, 3];
+
   const state = {
     mounted: false,
     root: null,
@@ -17,6 +19,7 @@
     overviewTheme: getStoredOverviewTheme(),
     hpVisualMode: getStoredHpVisualMode(),
     hpLayoutMode: getStoredHpLayoutMode(),
+    trendWindowHours: getStoredTrendWindowHours(),
     busyAction: "",
     controlError: "",
     controlNotice: "",
@@ -178,6 +181,24 @@
     }
   }
 
+  function getStoredTrendWindowHours() {
+    try {
+      const stored = Number(window.localStorage.getItem("oq-trend-window-hours"));
+      return TREND_WINDOW_HOURS_OPTIONS.includes(stored) ? stored : TREND_WINDOW_HOURS_OPTIONS[0];
+    } catch (_error) {
+      return TREND_WINDOW_HOURS_OPTIONS[0];
+    }
+  }
+
+  function setTrendWindowHours(hours) {
+    state.trendWindowHours = TREND_WINDOW_HOURS_OPTIONS.includes(hours) ? hours : TREND_WINDOW_HOURS_OPTIONS[0];
+    try {
+      window.localStorage.setItem("oq-trend-window-hours", String(state.trendWindowHours));
+    } catch (_error) {
+      // Ignore storage failures in embedded browsers.
+    }
+  }
+
   function getDefaultAppView() {
     return "overview";
   }
@@ -234,7 +255,13 @@
   }
 
   function normalizeAppView(view) {
-    return APP_VIEW_IDS.has(view) ? view : "";
+    if (!APP_VIEW_IDS.has(view)) {
+      return "";
+    }
+    if (view === "trends" && !isTrendHistoryEnabled()) {
+      return "";
+    }
+    return view;
   }
 
   function getUrlAppView() {

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -341,6 +341,9 @@
       : false;
     state.stage = state.complete ? "Gereed" : "Quick Start";
     state.summary = renderAppSummary();
+    if (state.appView === "trends" && !isTrendHistoryEnabled()) {
+      setAppView(getDefaultAppView(), { syncMode: "replace", forceSync: true });
+    }
     if (!state.appView) {
       setAppView(getUrlAppView() || getDefaultAppView(), { syncMode: "replace", forceSync: true });
     }
@@ -367,7 +370,7 @@
       return;
     }
 
-    const keys = state.appView === "overview"
+    const keys = state.appView === "overview" || state.appView === "trends"
       ? [...OVERVIEW_KEYS, ...HEADER_ENTITY_KEYS, "setupComplete", ...FIRMWARE_ENTITY_KEYS]
       : state.appView === "settings"
         ? ["setupComplete", ...FIRMWARE_ENTITY_KEYS, ...HEADER_ENTITY_KEYS, ...SETTINGS_KEYS]
@@ -401,6 +404,12 @@
           return;
         }
         if (!patchSettingsDom()) {
+          render();
+        }
+        return;
+      }
+      if (state.appView === "trends") {
+        if (!patchTrendsDom()) {
           render();
         }
         return;
@@ -644,9 +653,18 @@
     }
 
     if (action === "select-view") {
+      if ((button.dataset.viewId || "") === "trends" && !isTrendHistoryEnabled()) {
+        return;
+      }
       setAppView(button.dataset.viewId || "overview", { syncMode: "push" });
       render();
       syncEntities();
+      return;
+    }
+
+    if (action === "select-trend-window") {
+      setTrendWindowHours(Number(button.dataset.trendHours || 24));
+      render();
       return;
     }
 

--- a/openquatt/web/js/src/05-app-shared.js
+++ b/openquatt/web/js/src/05-app-shared.js
@@ -25,23 +25,7 @@
       parts.push(`max water ${formatValue("maxWater")}`);
     }
 
-    return parts.filter(Boolean).join(", ") || "Quick Start-instellingen beschikbaar";
-  }
-
-  function renderQuickStartLauncher() {
-    if (state.complete) {
-      return "";
-    }
-
-    return `
-      <button
-        class="oq-helper-app-tab oq-helper-app-tab--launch"
-        type="button"
-        data-oq-action="open-quickstart-modal"
-      >
-        <span>Quick Start</span>
-      </button>
-    `;
+    return parts.filter(Boolean).join(", ") || "Instellingen beschikbaar";
   }
 
   function hasEntity(key) {
@@ -100,11 +84,14 @@
     return raw === "on" || raw === "true" || raw === "1";
   }
 
+  function isTrendHistoryEnabled() {
+    return !hasEntity("trendHistoryEnabled") || isEntityActive("trendHistoryEnabled");
+  }
+
   function renderAppNav() {
     return `
       <div class="oq-helper-app-nav">
-        ${renderQuickStartLauncher()}
-        ${APP_VIEWS.map((view) => `
+        ${APP_VIEWS.filter((view) => view.id !== "trends" || isTrendHistoryEnabled()).map((view) => `
           <button
             class="oq-helper-app-tab ${state.appView === view.id ? "is-active" : ""}"
             type="button"

--- a/openquatt/web/js/src/10-settings.js
+++ b/openquatt/web/js/src/10-settings.js
@@ -293,6 +293,7 @@
               ]
             : [
                 renderSettingsQuickStartSection(),
+                renderSettingsTrendSection(),
                 renderSettingsLoginSection(),
                 renderSettingsDiagnosticsSection(),
               ];
@@ -1099,6 +1100,29 @@
             </button>
           </div>
           <p class="oq-settings-quickstart-status-copy">${escapeHtml(statusCopy)}</p>
+        </div>
+      `,
+    );
+  }
+
+  function renderSettingsTrendSection() {
+    if (!hasEntity("trendHistoryEnabled")) {
+      return "";
+    }
+
+    return renderSettingsSection(
+      "Trends",
+      "Trendopslag",
+      "Sla 24 uur aan trenddata tijdelijk op in het werkgeheugen. Zet dit uit als je de grafieken niet gebruikt.",
+      `
+        <div class="oq-settings-grid">
+          ${renderSettingsSwitchField(
+            "trendHistoryEnabled",
+            "Trendopslag",
+            "Schakel de trendopslag voor de grafieken in of uit.",
+            "OpenQuatt bewaart trenddata tijdelijk in het werkgeheugen en toont de Trends-tab.",
+            "OpenQuatt bewaart geen trenddata en verbergt de Trends-tab."
+          )}
         </div>
       `,
     );

--- a/openquatt/web/js/src/20-overview.js
+++ b/openquatt/web/js/src/20-overview.js
@@ -908,7 +908,7 @@
       {
         id: "temperatures",
         title: "Temperaturen",
-        copy: isMockData ? `Voorbeelddata voor de laatste ${windowText}, totdat de ESP-historie beschikbaar is.` : `Buitentemperatuur en aanvoertemperatuur van de laatste ${windowText}.`,
+        copy: `Buiten- en aanvoertemperatuur van de laatste ${windowText}.`,
         tone: "orange",
         samples,
         mock: isMockData,
@@ -921,7 +921,7 @@
       {
         id: "power",
         title: "Vermogen",
-        copy: isMockData ? `Voorbeelddata voor elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.` : `Elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.`,
+        copy: `Elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.`,
         tone: "green",
         samples,
         mock: isMockData,
@@ -934,7 +934,7 @@
       {
         id: "rendement",
         title: "Rendement",
-        copy: isMockData ? `Voorbeelddata voor COP van de laatste ${windowText}.` : `COP van de laatste ${windowText}.`,
+        copy: `COP van de laatste ${windowText}.`,
         tone: "slate",
         samples,
         mock: isMockData,
@@ -960,7 +960,7 @@
       {
         id: "comfort",
         title: "Comfort",
-        copy: isMockData ? `Voorbeelddata voor kamertemperatuur en setpoint van de laatste ${windowText}.` : `Kamertemperatuur en setpoint van de laatste ${windowText}.`,
+        copy: `Kamertemperatuur en setpoint van de laatste ${windowText}.`,
         tone: "blue",
         samples,
         mock: isMockData,
@@ -973,7 +973,7 @@
       {
         id: "flow",
         title: "Flow",
-        copy: isMockData ? `Voorbeelddata voor flow van de laatste ${windowText}.` : `Flow van de laatste ${windowText}.`,
+        copy: `Flow van de laatste ${windowText}.`,
         tone: "sky",
         samples,
         mock: isMockData,
@@ -1251,9 +1251,10 @@
             <h4>${escapeHtml(card.title)}</h4>
             <p>${escapeHtml(card.copy)}</p>
           </div>
-          <div class="oq-overview-trendcard-latest">
-            ${card.mock ? `<span class="oq-overview-trendcard-badge">Voorbeelddata</span>` : ""}
-            ${card.series.map((series) => renderOverviewTrendLatestPill(series, latest)).join("")}
+          <div class="oq-overview-trendcard-meta">
+            <div class="oq-overview-trendcard-latest">
+              ${card.series.map((series) => renderOverviewTrendLatestPill(series, latest)).join("")}
+            </div>
           </div>
         </div>
         ${renderOverviewTrendChart(card.samples, card.series, card.mock, card.windowHours)}
@@ -1273,7 +1274,6 @@
     const cards = getOverviewTrendCardsModel();
     return `
       <section class="oq-overview-trends" aria-label="Trends" data-render-signature="${escapeHtml(getOverviewTrendRenderSignature())}">
-        ${renderOverviewSectionHead("Grafieken")}
         <div class="oq-overview-trends-grid">
           ${cards.map(renderOverviewTrendCard).join("")}
         </div>
@@ -1316,9 +1316,12 @@
     return `
       <section class="oq-helper-panel oq-helper-panel--flush">
         <div class="oq-overview-board oq-overview-board--${escapeHtml(state.overviewTheme)}">
-          <div class="oq-overview-system-copy">
-            <h3>Trendoverzicht</h3>
-            <p>Bekijk temperatuur, vermogen, rendement, comfort en flow voor 24, 12, 6 of 3 uur.</p>
+          <div class="oq-overview-head oq-overview-trends-head">
+            <div>
+              <p class="oq-helper-label">Trends</p>
+              <h2 class="oq-helper-section-title">Grafieken</h2>
+              <p class="oq-helper-section-copy">Bekijk temperatuur, vermogen, rendement, comfort en flow over 24, 12, 6 of 3 uur.</p>
+            </div>
           </div>
           <div class="oq-overview-trends-toolbar">
             <div class="oq-overview-trends-note">

--- a/openquatt/web/js/src/20-overview.js
+++ b/openquatt/web/js/src/20-overview.js
@@ -121,6 +121,65 @@
     return `${numeric.toFixed(decimals)}${unit ? ` ${unit}` : ""}`;
   }
 
+  function formatOverviewTrendDurationLabel(totalMinutes) {
+    if (!Number.isFinite(totalMinutes) || totalMinutes < 0) {
+      return "—";
+    }
+    const wholeMinutes = Math.floor(totalMinutes);
+    const days = Math.floor(wholeMinutes / 1440);
+    const hours = Math.floor((wholeMinutes % 1440) / 60);
+    const minutes = wholeMinutes % 60;
+    if (days > 0) {
+      return `${days}d ${hours}u`;
+    }
+    if (hours > 0) {
+      return `${hours}u ${minutes}m`;
+    }
+    return `${minutes}m`;
+  }
+
+  function parseOverviewClockMinutes(rawValue) {
+    const value = String(rawValue || "").trim();
+    const match = value.match(/^(\d{1,2}):(\d{2})$/);
+    if (!match) {
+      return Number.NaN;
+    }
+    const hours = Number(match[1]);
+    const minutes = Number(match[2]);
+    if (Number.isNaN(hours) || Number.isNaN(minutes) || hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+      return Number.NaN;
+    }
+    return (hours * 60) + minutes;
+  }
+
+  function formatOverviewTrendClockLabel(totalMinutes) {
+    const clockMinutes = parseOverviewClockMinutes(getEntityStateText("timeNowHhmm", ""));
+    if (!Number.isFinite(clockMinutes)) {
+      return "";
+    }
+    const offsetMinutes = Math.round(totalMinutes);
+    const sampleMinutes = ((clockMinutes - offsetMinutes) % 1440 + 1440) % 1440;
+    const hours = Math.floor(sampleMinutes / 60);
+    const minutes = sampleMinutes % 60;
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+  }
+
+  function formatOverviewTrendPointTime(sampleTimestamp, endTime) {
+    const ageMinutes = Math.max(0, (Number(endTime) - Number(sampleTimestamp)) / 60000);
+    const ageLabel = formatOverviewTrendDurationLabel(ageMinutes);
+    const clockLabel = hasEntity("timeValid") && isEntityActive("timeValid") ? formatOverviewTrendClockLabel(ageMinutes) : "";
+    if (clockLabel) {
+      return {
+        value: clockLabel,
+        note: `${ageLabel} geleden`,
+      };
+    }
+    return {
+      value: `${ageLabel} geleden`,
+      note: "Geen tijdsync",
+    };
+  }
+
   function formatSignedPower(value) {
     const numeric = Number(value);
     if (Number.isNaN(numeric)) {
@@ -469,8 +528,8 @@
   function getOverviewTopCards() {
     const coolingActive = isCoolingOverviewActive();
     return [
-      { key: "totalPower", label: "Stroomverbruik", tone: "blue", note: "hele systeem" },
-      { key: coolingActive ? "totalCoolingPower" : "totalHeat", label: coolingActive ? "Koelafgifte" : "Warmteafgifte", tone: "orange", note: "thermisch vermogen" },
+      { key: "totalPower", label: "Elektrisch vermogen", tone: "blue", note: "hele systeem" },
+      { key: coolingActive ? "totalCoolingPower" : "totalHeat", label: coolingActive ? "Koelvermogen" : "Verwarmingsvermogen", tone: "orange", note: "thermisch vermogen" },
       { key: coolingActive ? "totalEer" : "totalCop", label: coolingActive ? "COP (EER)" : "COP", tone: "green", note: "rendement" },
       { key: "flowSelected", label: "Flow", tone: "sky", note: "watercircuit" },
     ];
@@ -697,3 +756,740 @@
     });
   }
 
+  const OVERVIEW_TREND_MAX_POINTS = 288;
+
+  function getOverviewTrendWindowHours() {
+    const hours = Number(state.trendWindowHours || 24);
+    return TREND_WINDOW_HOURS_OPTIONS.includes(hours) ? hours : TREND_WINDOW_HOURS_OPTIONS[0];
+  }
+
+  function getOverviewTrendWindowMs(windowHours = getOverviewTrendWindowHours()) {
+    return Math.max(1, Number(windowHours) || 24) * 60 * 60 * 1000;
+  }
+
+  function formatOverviewTrendWindowLabel(windowHours = getOverviewTrendWindowHours()) {
+    const hours = Number(windowHours) || 24;
+    return `${hours}u`;
+  }
+
+  function formatOverviewTrendWindowText(windowHours = getOverviewTrendWindowHours()) {
+    const hours = Number(windowHours) || 24;
+    return `${hours} uur`;
+  }
+
+  function formatOverviewTrendAxisLabel(totalMinutes) {
+    if (!Number.isFinite(totalMinutes) || totalMinutes < 0) {
+      return "—";
+    }
+    const roundedMinutes = Math.round(totalMinutes);
+    if (roundedMinutes % 60 === 0) {
+      return `${roundedMinutes / 60}u`;
+    }
+    return formatOverviewTrendDurationLabel(roundedMinutes);
+  }
+
+  function getOverviewUptimeMillis() {
+    const entity = state.entities.uptime;
+    if (!entity) {
+      return Number.NaN;
+    }
+
+    const numeric = getEntityNumericValue("uptime");
+    if (!Number.isFinite(numeric)) {
+      return Number.NaN;
+    }
+
+    const unit = String(entity.uom ?? entity.unit_of_measurement ?? "").trim().toLowerCase();
+    if (unit === "d") {
+      return numeric * 24 * 60 * 60 * 1000;
+    }
+    if (unit === "h") {
+      return numeric * 60 * 60 * 1000;
+    }
+    if (unit === "m" || unit === "min") {
+      return numeric * 60 * 1000;
+    }
+    return numeric * 1000;
+  }
+
+  function parseOverviewTrendRow(row) {
+    const parts = String(row || "").trim().split("|");
+    if (parts.length < 5) {
+      return null;
+    }
+
+    const timestamp = Number(parts[0]);
+    if (!Number.isFinite(timestamp)) {
+      return null;
+    }
+
+    const parseValue = (value) => {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    };
+
+    return {
+      t: timestamp,
+      outside: parseValue(parts[1]),
+      supply: parseValue(parts[2]),
+      room: parts.length >= 8 ? parseValue(parts[3]) : null,
+      roomSetpoint: parts.length >= 8 ? parseValue(parts[4]) : null,
+      flow: parts.length >= 8 ? parseValue(parts[5]) : null,
+      input: parts.length >= 8 ? parseValue(parts[6]) : parseValue(parts[3]),
+      output: parts.length >= 8 ? parseValue(parts[7]) : parseValue(parts[4]),
+    };
+  }
+
+  function getOverviewTrendSamples() {
+    const windowMs = getOverviewTrendWindowMs();
+    if (!hasEntity("trendHistory")) {
+      return buildOverviewTrendMockSamples();
+    }
+
+    const raw = String(getEntityStateText("trendHistory", "") || "").trim();
+    if (!raw) {
+      return buildOverviewTrendMockSamples();
+    }
+
+    const uptimeMs = getOverviewUptimeMillis();
+    const rows = raw
+      .split(/\r?\n/)
+      .map(parseOverviewTrendRow)
+      .filter(Boolean);
+
+    const latestTimestamp = rows.length ? rows[rows.length - 1].t : Number.NaN;
+    const endTime = Number.isFinite(uptimeMs)
+      ? uptimeMs
+      : (Number.isFinite(latestTimestamp) ? latestTimestamp : Number.NaN);
+
+    if (!Number.isFinite(endTime)) {
+      return rows.length ? rows.slice(-OVERVIEW_TREND_MAX_POINTS) : buildOverviewTrendMockSamples();
+    }
+
+    const cutoff = Math.max(0, endTime - windowMs);
+    const filtered = rows.filter((sample) => sample.t >= cutoff).slice(-OVERVIEW_TREND_MAX_POINTS);
+    return filtered.length ? filtered : buildOverviewTrendMockSamples();
+  }
+
+  function buildOverviewTrendMockSamples(windowHours = getOverviewTrendWindowHours()) {
+    const windowMs = getOverviewTrendWindowMs(windowHours);
+    const points = Math.max(12, Math.round(windowHours * 12));
+    const startTime = 0;
+    const span = Math.max(points - 1, 1);
+    const samples = [];
+
+    for (let index = 0; index < points; index += 1) {
+      const fraction = index / span;
+      const dayWave = Math.sin((fraction * Math.PI * 2) - 1.1);
+      const detailWave = Math.sin(fraction * Math.PI * 10);
+      const driftWave = Math.cos((fraction * Math.PI * 2) + 0.45);
+
+      samples.push({
+        t: startTime + Math.round(fraction * windowMs),
+        outside: 8.5 + (dayWave * 3.4) + (detailWave * 0.5),
+        supply: 35.5 + (Math.sin((fraction * Math.PI * 2) - 0.35) * 4.8) + (detailWave * 0.9),
+        room: 20.2 + (Math.sin((fraction * Math.PI * 2) - 0.22) * 0.35) + (detailWave * 0.08),
+        roomSetpoint: 20.6 + (Math.cos((fraction * Math.PI * 2) - 0.1) * 0.10),
+        flow: Math.max(0, 760 + (Math.cos((fraction * Math.PI * 2) + 0.1) * 110) + (detailWave * 18)),
+        input: Math.max(280, 1180 + (dayWave * 380) + (detailWave * 150) + (driftWave * 110)),
+        output: Math.max(1000, 4250 + (dayWave * 860) + (detailWave * 260)),
+      });
+    }
+
+    return samples;
+  }
+
+  function getOverviewTrendCardsModel() {
+    const windowHours = getOverviewTrendWindowHours();
+    const windowText = formatOverviewTrendWindowText(windowHours);
+    const samples = getOverviewTrendSamples();
+    const isMockData = !hasEntity("trendHistory") || !String(getEntityStateText("trendHistory", "") || "").trim();
+    return [
+      {
+        id: "temperatures",
+        title: "Temperaturen",
+        copy: isMockData ? `Voorbeelddata voor de laatste ${windowText}, totdat de ESP-historie beschikbaar is.` : `Buitentemperatuur en aanvoertemperatuur van de laatste ${windowText}.`,
+        tone: "orange",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          { id: "outside", sampleKey: "outside", label: "Buiten", tone: "orange", decimals: 1, unit: " °C" },
+          { id: "supply", sampleKey: "supply", label: "Aanvoer", tone: "blue", decimals: 1, unit: " °C" },
+        ],
+      },
+      {
+        id: "power",
+        title: "Vermogen",
+        copy: isMockData ? `Voorbeelddata voor elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.` : `Elektrisch vermogen en verwarmingsvermogen van de laatste ${windowText}.`,
+        tone: "green",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          { id: "input", sampleKey: "input", label: "Elektrisch vermogen", tone: "green", decimals: 0, unit: " W" },
+          { id: "output", sampleKey: "output", label: "Verwarmingsvermogen", tone: "sky", decimals: 0, unit: " W" },
+        ],
+      },
+      {
+        id: "rendement",
+        title: "Rendement",
+        copy: isMockData ? `Voorbeelddata voor COP van de laatste ${windowText}.` : `COP van de laatste ${windowText}.`,
+        tone: "slate",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          {
+            id: "cop",
+            label: "COP",
+            tone: "slate",
+            decimals: 1,
+            unit: "",
+            derive: (sample) => {
+              const input = Number(sample?.input);
+              const output = Number(sample?.output);
+              if (!Number.isFinite(input) || !Number.isFinite(output) || input <= 0) {
+                return Number.NaN;
+              }
+              return output / input;
+            },
+          },
+        ],
+      },
+      {
+        id: "comfort",
+        title: "Comfort",
+        copy: isMockData ? `Voorbeelddata voor kamertemperatuur en setpoint van de laatste ${windowText}.` : `Kamertemperatuur en setpoint van de laatste ${windowText}.`,
+        tone: "blue",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          { id: "roomTemp", sampleKey: "room", label: "Kamertemperatuur", tone: "blue", decimals: 1, unit: " °C" },
+          { id: "roomSetpoint", sampleKey: "roomSetpoint", label: "Kamer setpoint", tone: "orange", decimals: 1, unit: " °C" },
+        ],
+      },
+      {
+        id: "flow",
+        title: "Flow",
+        copy: isMockData ? `Voorbeelddata voor flow van de laatste ${windowText}.` : `Flow van de laatste ${windowText}.`,
+        tone: "sky",
+        samples,
+        mock: isMockData,
+        windowHours,
+        series: [
+          { id: "flow", sampleKey: "flow", label: "Flow", tone: "sky", decimals: 0, unit: " L/h" },
+        ],
+      },
+    ];
+  }
+
+  function getOverviewTrendSeriesValue(series, sample) {
+    if (!series || !sample) {
+      return Number.NaN;
+    }
+    const raw = typeof series.derive === "function"
+      ? series.derive(sample)
+      : sample?.[series.sampleKey];
+    const numeric = Number(raw);
+    return Number.isFinite(numeric) ? numeric : Number.NaN;
+  }
+
+  function getOverviewTrendRange(samples, series) {
+    const values = [];
+    samples.forEach((sample) => {
+      series.forEach((item) => {
+        const numeric = getOverviewTrendSeriesValue(item, sample);
+        if (Number.isFinite(numeric)) {
+          values.push(numeric);
+        }
+      });
+    });
+
+    if (!values.length) {
+      return { min: 0, max: 1 };
+    }
+
+    let min = Math.min(...values);
+    let max = Math.max(...values);
+    if (min === max) {
+      const offset = Math.max(Math.abs(min) * 0.1, 1);
+      min -= offset;
+      max += offset;
+    } else {
+      const pad = Math.max((max - min) * 0.12, 1);
+      min -= pad;
+      max += pad;
+    }
+    return { min, max };
+  }
+
+  function getOverviewTrendChartModel(samples, series, options = {}) {
+    const rawWindowHours = Number(options.windowHours);
+    const windowHours = Number.isFinite(rawWindowHours) ? rawWindowHours : getOverviewTrendWindowHours();
+    const windowMs = getOverviewTrendWindowMs(windowHours);
+    const width = 640;
+    const height = 220;
+    const left = 22;
+    const right = 18;
+    const top = 18;
+    const bottom = 34;
+    const plotWidth = width - left - right;
+    const plotHeight = height - top - bottom;
+    const latest = samples[samples.length - 1];
+    const mockData = Boolean(options.mockData);
+    const uptimeMs = getOverviewUptimeMillis();
+    const endTime = mockData
+      ? windowMs
+      : (Number.isFinite(uptimeMs) ? uptimeMs : (latest ? latest.t : 0));
+    const startTime = mockData ? 0 : Math.max(endTime - windowMs, 0);
+    const span = Math.max(endTime - startTime, 1);
+    const range = getOverviewTrendRange(samples, series);
+
+    const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
+    const yOf = (value) => {
+      if (!Number.isFinite(value)) {
+        return Number.NaN;
+      }
+      const ratio = (value - range.min) / Math.max(range.max - range.min, 1);
+      return top + ((1 - Math.min(1, Math.max(0, ratio))) * plotHeight);
+    };
+
+    const gridXs = [0, 0.5, 1].map((fraction) => left + (plotWidth * fraction));
+    const gridYs = [0.25, 0.5, 0.75].map((fraction) => top + (plotHeight * fraction));
+
+    const points = samples.map((sample) => {
+      const x = xOf(sample.t);
+      const values = series.map((item) => {
+        const numeric = getOverviewTrendSeriesValue(item, sample);
+        if (!Number.isFinite(numeric)) {
+          return null;
+        }
+        return {
+          seriesId: item.id || item.sampleKey || item.label,
+          tone: item.tone,
+          label: item.label,
+          decimals: item.decimals,
+          unit: item.unit,
+          value: numeric,
+          x,
+          y: yOf(numeric),
+        };
+      });
+      return {
+        sample,
+        x,
+        values,
+      };
+    });
+
+    const tracks = series.flatMap((item) => {
+      const segments = [];
+      let current = [];
+      samples.forEach((sample) => {
+        const numeric = getOverviewTrendSeriesValue(item, sample);
+        if (!Number.isFinite(numeric)) {
+          if (current.length) {
+            segments.push(current);
+            current = [];
+          }
+          return;
+        }
+
+        current.push({
+          x: xOf(sample.t),
+          y: yOf(numeric),
+        });
+      });
+      if (current.length) {
+        segments.push(current);
+      }
+
+      return segments.map((segment) => {
+        if (segment.length < 2) {
+          return {
+            tone: item.tone,
+            points: segment,
+            path: "",
+          };
+        }
+
+        return {
+          tone: item.tone,
+          points: segment,
+          path: segment.map((point, pointIndex) => `${pointIndex === 0 ? "M" : "L"} ${point.x.toFixed(1)} ${point.y.toFixed(1)}`).join(" "),
+        };
+      });
+    });
+
+    return {
+      width,
+      height,
+      left,
+      right,
+      top,
+      bottom,
+      plotWidth,
+      plotHeight,
+      latest,
+      uptimeMs,
+      endTime,
+      startTime,
+      span,
+      windowHours,
+      range,
+      gridXs,
+      gridYs,
+      points,
+      tracks,
+      series,
+    };
+  }
+
+  function getOverviewTrendRenderSignature() {
+    return getRenderSignature({
+      windowHours: getOverviewTrendWindowHours(),
+      samples: getOverviewTrendSamples(),
+    });
+  }
+
+  function getOverviewTrendCardById(cardId) {
+    return getOverviewTrendCardsModel().find((card) => card.id === cardId) || null;
+  }
+
+  function getNearestOverviewTrendPointIndex(model, x) {
+    if (!model || !Array.isArray(model.points) || model.points.length === 0) {
+      return -1;
+    }
+
+    let nearestIndex = 0;
+    let nearestDistance = Math.abs(model.points[0].x - x);
+    model.points.forEach((point, index) => {
+      const distance = Math.abs(point.x - x);
+      if (distance < nearestDistance) {
+        nearestIndex = index;
+        nearestDistance = distance;
+      }
+    });
+    return nearestIndex;
+  }
+
+  function renderOverviewTrendLatestPill(series, sample) {
+    const value = getOverviewTrendSeriesValue(series, sample);
+    return `
+      <div class="oq-overview-trend-pill oq-overview-trend-pill--${escapeHtml(series.tone)}">
+        <span>${escapeHtml(series.label)}</span>
+        <strong>${escapeHtml(formatNumericState(value, series.decimals, series.unit))}</strong>
+      </div>
+    `;
+  }
+
+  function renderOverviewTrendChart(samples, series, mockData = false, windowHours = getOverviewTrendWindowHours()) {
+    const model = getOverviewTrendChartModel(samples, series, { mockData, windowHours });
+    const windowLabel = formatOverviewTrendWindowLabel(windowHours);
+    const midpointLabel = formatOverviewTrendAxisLabel((windowHours * 60) / 2);
+    const seriesPaths = model.tracks.flatMap((track) => {
+      if (track.points.length < 2) {
+        const point = track.points[0];
+        if (!point) {
+          return [];
+        }
+        return `
+          <circle
+            cx="${point.x.toFixed(1)}"
+            cy="${point.y.toFixed(1)}"
+            r="3.8"
+            class="oq-overview-trend-dot oq-overview-trend-dot--${escapeHtml(track.tone)}"
+          ></circle>
+        `;
+      }
+
+      return `
+        <path d="${track.path}" class="oq-overview-trend-line oq-overview-trend-line--${escapeHtml(track.tone)}"></path>
+        <circle
+          cx="${track.points[track.points.length - 1].x.toFixed(1)}"
+          cy="${track.points[track.points.length - 1].y.toFixed(1)}"
+          r="3.8"
+          class="oq-overview-trend-dot oq-overview-trend-dot--${escapeHtml(track.tone)}"
+        ></circle>
+      `;
+    }).join("");
+
+    return `
+      <svg class="oq-overview-trend-chart" viewBox="0 0 ${model.width} ${model.height}" role="img" aria-label="Trendgrafiek van de laatste ${windowHours} uur">
+        <rect x="0" y="0" width="${model.width}" height="${model.height}" rx="20" class="oq-overview-trend-chart-bg"></rect>
+        ${model.gridXs.map((x) => `<line x1="${x.toFixed(1)}" y1="${model.top}" x2="${x.toFixed(1)}" y2="${model.height - model.bottom}" class="oq-overview-trend-grid oq-overview-trend-grid--vertical"></line>`).join("")}
+        ${model.gridYs.map((y) => `<line x1="${model.left}" y1="${y.toFixed(1)}" x2="${model.width - model.right}" y2="${y.toFixed(1)}" class="oq-overview-trend-grid oq-overview-trend-grid--horizontal"></line>`).join("")}
+        ${seriesPaths}
+        <g class="oq-overview-trend-hover-layer" data-oq-trend-hover-layer hidden>
+          <line x1="${model.left}" y1="${model.top}" x2="${model.left}" y2="${model.height - model.bottom}" class="oq-overview-trend-hover-line"></line>
+          ${series.map((item) => `
+            <circle
+              r="4.5"
+              class="oq-overview-trend-hover-dot oq-overview-trend-hover-dot--${escapeHtml(item.tone)}"
+              data-oq-trend-hover-dot="${escapeHtml(item.id || item.sampleKey || item.label)}"
+            ></circle>
+          `).join("")}
+        </g>
+        <line x1="${model.left}" y1="${model.height - model.bottom}" x2="${model.width - model.right}" y2="${model.height - model.bottom}" class="oq-overview-trend-axis"></line>
+        <text x="${model.left}" y="${model.height - 12}" class="oq-overview-trend-axis-label" text-anchor="start">${escapeHtml(windowLabel)}</text>
+        <text x="${model.left + (model.plotWidth / 2)}" y="${model.height - 12}" class="oq-overview-trend-axis-label" text-anchor="middle">${escapeHtml(midpointLabel)}</text>
+        <text x="${model.width - model.right}" y="${model.height - 12}" class="oq-overview-trend-axis-label" text-anchor="end">nu</text>
+      </svg>
+    `;
+  }
+
+  function renderOverviewTrendCard(card) {
+    const latest = card.samples[card.samples.length - 1] || null;
+    const windowText = formatOverviewTrendWindowText(card.windowHours);
+    return `
+      <article class="oq-overview-trendcard oq-overview-trendcard--${escapeHtml(card.tone)}" data-oq-trend-card="${escapeHtml(card.id)}" data-render-signature="${escapeHtml(getRenderSignature(card))}">
+        <div class="oq-overview-trendcard-head">
+          <div class="oq-overview-trendcard-copy">
+            <p class="oq-overview-trendcard-kicker">${escapeHtml(windowText)}</p>
+            <h4>${escapeHtml(card.title)}</h4>
+            <p>${escapeHtml(card.copy)}</p>
+          </div>
+          <div class="oq-overview-trendcard-latest">
+            ${card.mock ? `<span class="oq-overview-trendcard-badge">Voorbeelddata</span>` : ""}
+            ${card.series.map((series) => renderOverviewTrendLatestPill(series, latest)).join("")}
+          </div>
+        </div>
+        ${renderOverviewTrendChart(card.samples, card.series, card.mock, card.windowHours)}
+        <div class="oq-overview-trend-hover" data-oq-trend-hover hidden>
+          <div class="oq-overview-trend-hover-head">
+            <span class="oq-overview-trend-hover-kicker">Punt</span>
+            <strong data-oq-trend-hover-time>—</strong>
+            <span class="oq-overview-trend-hover-note" data-oq-trend-hover-note></span>
+          </div>
+          <div class="oq-overview-trend-hover-values" data-oq-trend-hover-values></div>
+        </div>
+      </article>
+    `;
+  }
+
+  function renderOverviewTrendsPanel() {
+    const cards = getOverviewTrendCardsModel();
+    return `
+      <section class="oq-overview-trends" aria-label="Trends" data-render-signature="${escapeHtml(getOverviewTrendRenderSignature())}">
+        ${renderOverviewSectionHead("Grafieken")}
+        <div class="oq-overview-trends-grid">
+          ${cards.map(renderOverviewTrendCard).join("")}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderOverviewTrendsDisabledNotice() {
+    return `
+      <div class="oq-overview-trends-disabled">
+        <p>Trendopslag staat uit.</p>
+        <strong>Schakel trendopslag in om grafieken en historie te tonen.</strong>
+        <span>Je vindt deze instelling onder Instellingen &rsaquo; Systeem.</span>
+        <button class="oq-helper-button oq-helper-button--ghost" type="button" data-oq-action="select-view" data-view-id="settings">
+          Naar instellingen
+        </button>
+      </div>
+    `;
+  }
+
+  function renderTrendWindowSwitcher() {
+    const windowHours = getOverviewTrendWindowHours();
+    return `
+      <div class="oq-overview-trends-windowbar" role="group" aria-label="Kies trendvenster">
+        ${TREND_WINDOW_HOURS_OPTIONS.map((hours) => `
+          <button
+            class="oq-overview-controlpanel-segment${windowHours === hours ? " is-selected" : ""}"
+            type="button"
+            data-oq-action="select-trend-window"
+            data-trend-hours="${hours}"
+            aria-pressed="${windowHours === hours ? "true" : "false"}"
+          >${hours}u</button>
+        `).join("")}
+      </div>
+    `;
+  }
+
+  function renderTrendsView() {
+    const trendHistoryEnabled = isTrendHistoryEnabled();
+    return `
+      <section class="oq-helper-panel oq-helper-panel--flush">
+        <div class="oq-overview-board oq-overview-board--${escapeHtml(state.overviewTheme)}">
+          <div class="oq-overview-system-copy">
+            <h3>Trendoverzicht</h3>
+            <p>Bekijk temperatuur, vermogen, rendement, comfort en flow voor 24, 12, 6 of 3 uur.</p>
+          </div>
+          <div class="oq-overview-trends-toolbar">
+            <div class="oq-overview-trends-note">
+              <span>Opmerking</span>
+              <strong>Max. 24 uur in werkgeheugen</strong>
+              <p>De OpenQuatt Controller bewaart trenddata tijdelijk in het werkgeheugen. Na een herstart verdwijnt die historie.</p>
+            </div>
+            ${trendHistoryEnabled ? `
+              <div class="oq-overview-trends-window">
+                <span>Venster</span>
+                ${renderTrendWindowSwitcher()}
+              </div>
+            ` : ""}
+          </div>
+          ${trendHistoryEnabled ? renderOverviewTrendsPanel() : renderOverviewTrendsDisabledNotice()}
+        </div>
+      </section>
+    `;
+  }
+
+  function patchTrendsDom() {
+    if (!state.root || state.appView !== "trends") {
+      return false;
+    }
+
+    const board = state.root.querySelector(".oq-overview-board");
+    if (!board) {
+      return false;
+    }
+
+    const trends = board.querySelector(".oq-overview-trends");
+    if (!trends) {
+      return false;
+    }
+
+    replaceOuterHtmlIfSignatureChanged(
+      trends,
+      getOverviewTrendRenderSignature(),
+      renderOverviewTrendsPanel(),
+    );
+    syncOverviewTrendInteractions(board);
+    return true;
+  }
+
+  function updateOverviewTrendHoverCard(card, model, pointIndex) {
+    if (!card || !model || !Array.isArray(model.points) || model.points.length === 0) {
+      return;
+    }
+
+    const index = Math.max(0, Math.min(model.points.length - 1, pointIndex));
+    const point = model.points[index];
+    if (!point) {
+      return;
+    }
+
+    const chart = card.querySelector(".oq-overview-trend-chart");
+    const hoverLayer = card.querySelector("[data-oq-trend-hover-layer]");
+    const hoverPanel = card.querySelector("[data-oq-trend-hover]");
+    const hoverTime = card.querySelector("[data-oq-trend-hover-time]");
+    const hoverNote = card.querySelector("[data-oq-trend-hover-note]");
+    const hoverValues = card.querySelector("[data-oq-trend-hover-values]");
+
+    if (!chart || !hoverLayer || !hoverPanel || !hoverTime || !hoverNote || !hoverValues) {
+      return;
+    }
+
+    const timeLabel = formatOverviewTrendPointTime(point.sample.t, model.endTime);
+    hoverPanel.hidden = false;
+    hoverLayer.removeAttribute("hidden");
+    hoverTime.textContent = timeLabel.value;
+    hoverNote.textContent = timeLabel.note;
+
+    const hoverLine = hoverLayer.querySelector(".oq-overview-trend-hover-line");
+    if (hoverLine) {
+      hoverLine.setAttribute("x1", point.x.toFixed(1));
+      hoverLine.setAttribute("x2", point.x.toFixed(1));
+    }
+
+    const rows = [];
+    model.series.forEach((series) => {
+      const value = getOverviewTrendSeriesValue(series, point.sample);
+      const seriesId = series.id || series.sampleKey || series.label;
+      const dot = hoverLayer.querySelector(`[data-oq-trend-hover-dot="${seriesId}"]`);
+      if (!Number.isFinite(value)) {
+        if (dot) {
+          dot.setAttribute("display", "none");
+        }
+        return;
+      }
+      const trackValue = point.values.find((item) => item.seriesId === seriesId);
+      if (dot && trackValue) {
+        dot.removeAttribute("display");
+        dot.setAttribute("cx", trackValue.x.toFixed(1));
+        dot.setAttribute("cy", trackValue.y.toFixed(1));
+      }
+      rows.push(`
+        <div class="oq-overview-trend-hover-row oq-overview-trend-hover-row--${escapeHtml(series.tone)}">
+          <span>${escapeHtml(series.label)}</span>
+          <strong>${escapeHtml(formatNumericState(value, series.decimals, series.unit))}</strong>
+        </div>
+      `);
+    });
+
+    hoverValues.innerHTML = rows.join("");
+    card.dataset.oqTrendHoverIndex = String(index);
+  }
+
+  function clearOverviewTrendHoverCard(card) {
+    if (!card) {
+      return;
+    }
+    const hoverPanel = card.querySelector("[data-oq-trend-hover]");
+    const hoverLayer = card.querySelector("[data-oq-trend-hover-layer]");
+    if (hoverPanel) {
+      hoverPanel.hidden = true;
+    }
+    if (hoverLayer) {
+      hoverLayer.setAttribute("hidden", "");
+    }
+    delete card.dataset.oqTrendHoverIndex;
+  }
+
+  function syncOverviewTrendInteractions(root = state.root) {
+    if (!root) {
+      return;
+    }
+
+    const cards = root.querySelectorAll("[data-oq-trend-card]");
+    cards.forEach((card) => {
+      const signature = card.dataset.renderSignature || "";
+      if (card.__oqTrendBoundSignature === signature) {
+        return;
+      }
+      card.__oqTrendBoundSignature = signature;
+
+      const chart = card.querySelector(".oq-overview-trend-chart");
+      if (!chart) {
+        return;
+      }
+
+      const cardModel = getOverviewTrendCardById(card.dataset.oqTrendCard);
+      if (!cardModel) {
+        return;
+      }
+      const model = getOverviewTrendChartModel(cardModel.samples, cardModel.series, { mockData: cardModel.mock });
+
+      card.__oqTrendModel = model;
+
+      const handleMove = (event) => {
+        const rect = chart.getBoundingClientRect();
+        if (!rect.width || !rect.height) {
+          return;
+        }
+        const clientX = Number(event.clientX);
+        if (!Number.isFinite(clientX)) {
+          updateOverviewTrendHoverCard(card, model, model.points.length - 1);
+          return;
+        }
+        const localX = Math.min(rect.width, Math.max(0, clientX - rect.left));
+        const svgX = (localX / rect.width) * model.width;
+        const pointIndex = getNearestOverviewTrendPointIndex(model, svgX);
+        updateOverviewTrendHoverCard(card, model, pointIndex);
+      };
+
+      const handleLeave = () => clearOverviewTrendHoverCard(card);
+
+      chart.addEventListener("pointermove", handleMove);
+      chart.addEventListener("pointerenter", handleMove);
+      chart.addEventListener("pointerleave", handleLeave);
+      chart.addEventListener("focus", handleMove);
+      chart.addEventListener("blur", handleLeave);
+      chart.addEventListener("touchstart", handleMove, { passive: true });
+    });
+  }

--- a/openquatt/web/js/src/40-heatpump.js
+++ b/openquatt/web/js/src/40-heatpump.js
@@ -1114,6 +1114,7 @@
     const summaryShell = board.querySelector(".oq-overview-summary-shell");
     const system = board.querySelector(".oq-overview-system");
     const temps = board.querySelector(".oq-overview-temps");
+    const trends = board.querySelector(".oq-overview-trends");
     const hpTools = board.querySelector(".oq-overview-hp-tools");
     const hpGrid = board.querySelector(".oq-overview-hp-grid");
     const heatPumpPanels = getHeatPumpPanels();
@@ -1160,6 +1161,16 @@
       );
     }
 
+    if (trends && state.appView === "overview") {
+      replaceOuterHtmlIfSignatureChanged(
+        trends,
+        getOverviewTrendRenderSignature(),
+        renderOverviewTrendsPanel(),
+      );
+    }
+
+    syncOverviewTrendInteractions(board);
+
     if (!hpTools || !hpGrid) {
       return false;
     }
@@ -1184,4 +1195,3 @@
 
     return true;
   }
-

--- a/openquatt/web/js/src/90-shell.js
+++ b/openquatt/web/js/src/90-shell.js
@@ -14,8 +14,8 @@
     return `
       <section class="oq-helper-panel">
         <p class="oq-helper-label">OpenQuatt</p>
-        <h2 class="oq-helper-section-title">Interface laden</h2>
-        <p class="oq-helper-section-copy">We bepalen eerst even of Quick Start al is afgerond, zodat je direct op de juiste plek binnenkomt.</p>
+        <h2 class="oq-helper-section-title">OpenQuatt laden</h2>
+        <p class="oq-helper-section-copy">We halen de actuele gegevens op en zetten de interface klaar.</p>
       </section>
     `;
   }
@@ -44,10 +44,12 @@
       ? renderInitialLoadingView()
       : state.appView === "overview"
       ? renderOverviewView()
+      : state.appView === "trends"
+      ? renderTrendsView()
       : state.appView === "energy"
       ? renderEnergyView()
       : renderSettingsView();
-    const wideFlushCard = state.appView === "overview" || state.appView === "energy";
+    const wideFlushCard = state.appView === "overview" || state.appView === "trends" || state.appView === "energy";
 
     state.root.innerHTML = `
       ${renderDevPanel()}
@@ -78,6 +80,7 @@
     clearLegacyMotionVariables();
     syncTechTooltipLayers();
     refreshMotionTargets();
+    syncOverviewTrendInteractions();
     syncNativeVisibility();
     bindHeaderDevControls();
     syncDocumentTheme();


### PR DESCRIPTION
## Summary
This PR introduces the new `Trends` tab in the OpenQuatt web app. It gives immediate insight into temperature, power, efficiency, comfort, and flow across multiple time windows, without requiring an external backend.

Trend data is stored temporarily in the OpenQuatt Controller’s working memory. That makes it possible to show historical charts while keeping the app lightweight and avoiding flash writes.

## What’s included
- New `Trends` tab alongside `Overview`, `Energy`, and `Settings`
- Trend charts for:
  - Temperatures
  - Power
  - Efficiency
  - Comfort
  - Flow
- Window selection for `24h`, `12h`, `6h`, and `3h`
- Trend storage toggle under `Settings > System`
- UI messaging that trend data is kept in working memory for up to 24 hours and is lost after a restart
- Mock data support in `dev.html`, so the new tab can be developed and tested without live firmware

## UI/UX updates
- The trends page has been aligned with the rest of the app’s tab structure
- Trend cards now use a cleaner and more consistent header layout
- Extra badges and accent stripes were removed to make the cards visually lighter
- Card copy has been simplified and made more uniform

## Technical notes
- Trend data is buffered on the controller in RAM, so no flash writes are needed
- The frontend reads the stored trend history and renders charts for the selected window
- When trend storage is disabled, the Trends tab is removed from navigation and data collection stops immediately
- The `dev.html` mock layer includes the same toggle so the new setting is visible during local preview

## Verification
- Web assets rebuilt
- Syntax and diff checks passed
- The web app was exercised in `dev.html` during development

## Follow-up
This PR lays the foundation for trends in the app. Further refinements, additional series, and future enhancements can build on this base.