### PR TITLE
Polish OpenQuatt log copy and timestamps

### DIFF
--- a/openquatt/web/css/openquatt-app.css
+++ b/openquatt/web/css/openquatt-app.css
@@ -2550,14 +2550,31 @@ body.oq-page-light {
 }
 
 .oq-webserver-log-entry {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.18rem 0.1rem;
   margin: 0;
   white-space: normal;
   word-break: break-word;
 }
 
-.oq-webserver-log-entry span {
+.oq-webserver-log-entry-time {
+  color: var(--oq-helper-faint);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+
+.oq-webserver-log-entry-text {
   display: block;
   white-space: pre-wrap;
+}
+
+.oq-webserver-log-entry span {
+  display: block;
 }
 
 .oq-webserver-log-entry--plain {
@@ -2589,6 +2606,10 @@ body.oq-page-light {
 .oq-helper-shell--dark .oq-webserver-log-empty,
 .oq-helper-shell--dark .oq-webserver-log-entry--plain {
   color: #cbd5e1;
+}
+
+.oq-helper-shell--dark .oq-webserver-log-entry-time {
+  color: #94a3b8;
 }
 
 .oq-helper-shell--dark .oq-webserver-log-entry--error {

--- a/openquatt/web/css/src/10-settings.css
+++ b/openquatt/web/css/src/10-settings.css
@@ -577,14 +577,31 @@
 }
 
 .oq-webserver-log-entry {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.18rem 0.1rem;
   margin: 0;
   white-space: normal;
   word-break: break-word;
 }
 
-.oq-webserver-log-entry span {
+.oq-webserver-log-entry-time {
+  color: var(--oq-helper-faint);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+
+.oq-webserver-log-entry-text {
   display: block;
   white-space: pre-wrap;
+}
+
+.oq-webserver-log-entry span {
+  display: block;
 }
 
 .oq-webserver-log-entry--plain {
@@ -616,6 +633,10 @@
 .oq-helper-shell--dark .oq-webserver-log-empty,
 .oq-helper-shell--dark .oq-webserver-log-entry--plain {
   color: #cbd5e1;
+}
+
+.oq-helper-shell--dark .oq-webserver-log-entry-time {
+  color: #94a3b8;
 }
 
 .oq-helper-shell--dark .oq-webserver-log-entry--error {

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -5266,18 +5266,47 @@ function getWebServerLogStatusLabel() {
   if (isWebServerLogDemoMode()) {
     return "Voorbeeld";
   }
-  if (state.webServerLogConnected) {
-    return "Live";
-  }
   if (state.webServerLogEnabled === false) {
     return "Niet beschikbaar";
   }
   return "Beschikbaar";
 }
 
+function formatWebServerLogDateTime(value) {
+  const date = value instanceof Date ? value : new Date(Number(value) || Date.now());
+  try {
+    const timePart = new Intl.DateTimeFormat("nl-NL", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(date);
+    return timePart;
+  } catch (_error) {
+    return date.toLocaleTimeString("nl-NL", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  }
+}
+
+function getDemoLogReceivedAt(index, total) {
+  const spacingMs = 90 * 1000;
+  const offset = Math.max(0, total - index - 1) * spacingMs;
+  return Date.now() - offset;
+}
+
+function seedWebServerLogDemoEntries() {
+  const entries = getWebServerLogDemoEntries();
+  const total = entries.length;
+  return entries.map((entry, index) => createWebServerLogEntry(entry, {
+    receivedAt: getDemoLogReceivedAt(index, total),
+  }));
+}
+
 function openWebServerLogsModal() {
   if (isWebServerLogDemoMode() && state.webServerLogEntries.length === 0) {
-    state.webServerLogEntries = getWebServerLogDemoEntries().map((entry) => createWebServerLogEntry(entry));
+    state.webServerLogEntries = seedWebServerLogDemoEntries();
   }
   state.systemModal = "webserver-logs";
   render();
@@ -5512,12 +5541,14 @@ function getWebServerLogTone(value) {
   return "verbose";
 }
 
-function createWebServerLogEntry(raw) {
+function createWebServerLogEntry(raw, options = {}) {
   const text = stripAnsiSequences(raw).trimEnd();
+  const receivedAt = Number(options.receivedAt);
   return {
     raw,
     text,
     tone: getWebServerLogTone(raw),
+    receivedAt: Number.isFinite(receivedAt) ? receivedAt : Date.now(),
   };
 }
 
@@ -5568,9 +5599,19 @@ function appendWebServerLogEntriesToDom(entries, output) {
 }
 
 function renderWebServerLogEntry(entry) {
+  const timestamp = formatWebServerLogDateTime(entry.receivedAt);
+  const fullTimestamp = new Date(Number(entry.receivedAt) || Date.now()).toLocaleString("nl-NL", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
   return `
     <div class="oq-webserver-log-entry oq-webserver-log-entry--${escapeHtml(entry.tone)}">
-      <span>${escapeHtml(entry.text || entry.raw || " ")}</span>
+      <time class="oq-webserver-log-entry-time" datetime="${escapeHtml(new Date(Number(entry.receivedAt) || Date.now()).toISOString())}" title="${escapeHtml(fullTimestamp)}">${escapeHtml(timestamp)}</time>
+      <span class="oq-webserver-log-entry-text">${escapeHtml(entry.text || entry.raw || " ")}</span>
     </div>
   `;
 }
@@ -5590,7 +5631,7 @@ function renderWebServerLogStatusBanner() {
     return `
       <div class="oq-helper-modal-success oq-helper-modal-success--compact">
         <strong>Voorbeeldlog</strong>
-        <span>De lokale preview toont voorbeeldregels. Op de echte firmware loopt de stream al mee terwijl de app open is via <code>/events</code>.</span>
+        <span>De lokale preview vult deze lijst met voorbeeldmeldingen en bewaart ze zolang de app open is.</span>
       </div>
     `;
   }
@@ -5599,20 +5640,16 @@ function renderWebServerLogStatusBanner() {
     return `<p class="oq-helper-modal-note oq-helper-modal-note--error">${escapeHtml(state.webServerLogError)}</p>`;
   }
 
-  if (state.webServerLogConnected) {
+  if (state.webServerLogConnected || state.webServerLogSource) {
     return `
       <div class="oq-helper-modal-success oq-helper-modal-success--compact">
-        <strong>Live verbinding</strong>
-        <span>ESPHome web_server v3 streamt logregels via <code>/events</code>.</span>
+        <strong>Recente meldingen</strong>
+        <span>Laatste meldingen blijven zichtbaar terwijl OpenQuatt open is.</span>
       </div>
     `;
   }
 
-  if (state.webServerLogSource) {
-    return `<p class="oq-helper-modal-note">Verbinding maken met de live logstream via <code>/events</code>...</p>`;
-  }
-
-  return `<p class="oq-helper-modal-note">Open de log om een live stream via <code>/events</code> te starten.</p>`;
+  return `<p class="oq-helper-modal-note">Open de log om recente meldingen te bekijken.</p>`;
 }
 
 function renderWebServerLogsModal() {
@@ -5623,13 +5660,13 @@ function renderWebServerLogsModal() {
         <div class="oq-helper-modal-head">
           <div>
             <p class="oq-helper-modal-kicker">Diagnostiek</p>
-            <h2 class="oq-helper-modal-title" id="oq-webserver-log-modal-title">ESPHome debuglog</h2>
+            <h2 class="oq-helper-modal-title" id="oq-webserver-log-modal-title">OpenQuatt log</h2>
           </div>
             <button class="oq-helper-modal-close" type="button" data-oq-action="close-system-modal" aria-label="Sluit logboek">&times;</button>
         </div>
         <p class="oq-helper-modal-copy">${demoMode
-          ? "Hier zie je voorbeeldregels voor de lokale preview. Op de echte firmware loopt de logstream al mee zolang de app open is via <code>/events</code>."
-          : "Hier zie je de live debuglog van de ESPHome web_server v3 via <code>/events</code>. De kleuren volgen de originele logseverity."
+          ? "Hier zie je voorbeeldmeldingen uit de lokale preview."
+          : "Hier zie je recente meldingen van OpenQuatt. Handig als je wilt terugzoeken wat er net gebeurde."
         }</p>
         ${renderWebServerLogStatusBanner()}
         <div class="oq-webserver-log-panel" data-oq-webserver-log-scroller>

--- a/openquatt/web/js/src/06-webserver-logs.js
+++ b/openquatt/web/js/src/06-webserver-logs.js
@@ -38,18 +38,47 @@ function getWebServerLogStatusLabel() {
   if (isWebServerLogDemoMode()) {
     return "Voorbeeld";
   }
-  if (state.webServerLogConnected) {
-    return "Live";
-  }
   if (state.webServerLogEnabled === false) {
     return "Niet beschikbaar";
   }
   return "Beschikbaar";
 }
 
+function formatWebServerLogDateTime(value) {
+  const date = value instanceof Date ? value : new Date(Number(value) || Date.now());
+  try {
+    const timePart = new Intl.DateTimeFormat("nl-NL", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(date);
+    return timePart;
+  } catch (_error) {
+    return date.toLocaleTimeString("nl-NL", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  }
+}
+
+function getDemoLogReceivedAt(index, total) {
+  const spacingMs = 90 * 1000;
+  const offset = Math.max(0, total - index - 1) * spacingMs;
+  return Date.now() - offset;
+}
+
+function seedWebServerLogDemoEntries() {
+  const entries = getWebServerLogDemoEntries();
+  const total = entries.length;
+  return entries.map((entry, index) => createWebServerLogEntry(entry, {
+    receivedAt: getDemoLogReceivedAt(index, total),
+  }));
+}
+
 function openWebServerLogsModal() {
   if (isWebServerLogDemoMode() && state.webServerLogEntries.length === 0) {
-    state.webServerLogEntries = getWebServerLogDemoEntries().map((entry) => createWebServerLogEntry(entry));
+    state.webServerLogEntries = seedWebServerLogDemoEntries();
   }
   state.systemModal = "webserver-logs";
   render();
@@ -284,12 +313,14 @@ function getWebServerLogTone(value) {
   return "verbose";
 }
 
-function createWebServerLogEntry(raw) {
+function createWebServerLogEntry(raw, options = {}) {
   const text = stripAnsiSequences(raw).trimEnd();
+  const receivedAt = Number(options.receivedAt);
   return {
     raw,
     text,
     tone: getWebServerLogTone(raw),
+    receivedAt: Number.isFinite(receivedAt) ? receivedAt : Date.now(),
   };
 }
 
@@ -340,9 +371,19 @@ function appendWebServerLogEntriesToDom(entries, output) {
 }
 
 function renderWebServerLogEntry(entry) {
+  const timestamp = formatWebServerLogDateTime(entry.receivedAt);
+  const fullTimestamp = new Date(Number(entry.receivedAt) || Date.now()).toLocaleString("nl-NL", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
   return `
     <div class="oq-webserver-log-entry oq-webserver-log-entry--${escapeHtml(entry.tone)}">
-      <span>${escapeHtml(entry.text || entry.raw || " ")}</span>
+      <time class="oq-webserver-log-entry-time" datetime="${escapeHtml(new Date(Number(entry.receivedAt) || Date.now()).toISOString())}" title="${escapeHtml(fullTimestamp)}">${escapeHtml(timestamp)}</time>
+      <span class="oq-webserver-log-entry-text">${escapeHtml(entry.text || entry.raw || " ")}</span>
     </div>
   `;
 }
@@ -362,7 +403,7 @@ function renderWebServerLogStatusBanner() {
     return `
       <div class="oq-helper-modal-success oq-helper-modal-success--compact">
         <strong>Voorbeeldlog</strong>
-        <span>De lokale preview toont voorbeeldregels. Op de echte firmware loopt de stream al mee terwijl de app open is via <code>/events</code>.</span>
+        <span>De lokale preview vult deze lijst met voorbeeldmeldingen en bewaart ze zolang de app open is.</span>
       </div>
     `;
   }
@@ -371,20 +412,16 @@ function renderWebServerLogStatusBanner() {
     return `<p class="oq-helper-modal-note oq-helper-modal-note--error">${escapeHtml(state.webServerLogError)}</p>`;
   }
 
-  if (state.webServerLogConnected) {
+  if (state.webServerLogConnected || state.webServerLogSource) {
     return `
       <div class="oq-helper-modal-success oq-helper-modal-success--compact">
-        <strong>Live verbinding</strong>
-        <span>ESPHome web_server v3 streamt logregels via <code>/events</code>.</span>
+        <strong>Recente meldingen</strong>
+        <span>Laatste meldingen blijven zichtbaar terwijl OpenQuatt open is.</span>
       </div>
     `;
   }
 
-  if (state.webServerLogSource) {
-    return `<p class="oq-helper-modal-note">Verbinding maken met de live logstream via <code>/events</code>...</p>`;
-  }
-
-  return `<p class="oq-helper-modal-note">Open de log om een live stream via <code>/events</code> te starten.</p>`;
+  return `<p class="oq-helper-modal-note">Open de log om recente meldingen te bekijken.</p>`;
 }
 
 function renderWebServerLogsModal() {
@@ -395,13 +432,13 @@ function renderWebServerLogsModal() {
         <div class="oq-helper-modal-head">
           <div>
             <p class="oq-helper-modal-kicker">Diagnostiek</p>
-            <h2 class="oq-helper-modal-title" id="oq-webserver-log-modal-title">ESPHome debuglog</h2>
+            <h2 class="oq-helper-modal-title" id="oq-webserver-log-modal-title">OpenQuatt log</h2>
           </div>
             <button class="oq-helper-modal-close" type="button" data-oq-action="close-system-modal" aria-label="Sluit logboek">&times;</button>
         </div>
         <p class="oq-helper-modal-copy">${demoMode
-          ? "Hier zie je voorbeeldregels voor de lokale preview. Op de echte firmware loopt de logstream al mee zolang de app open is via <code>/events</code>."
-          : "Hier zie je de live debuglog van de ESPHome web_server v3 via <code>/events</code>. De kleuren volgen de originele logseverity."
+          ? "Hier zie je voorbeeldmeldingen uit de lokale preview."
+          : "Hier zie je recente meldingen van OpenQuatt. Handig als je wilt terugzoeken wat er net gebeurde."
         }</p>
         ${renderWebServerLogStatusBanner()}
         <div class="oq-webserver-log-panel" data-oq-webserver-log-scroller>


### PR DESCRIPTION
## Summary
- Rename the diagnostics log modal to a more user-friendly OpenQuatt log view.
- Replace technical log copy with simpler wording for the modal title, helper text, and status banner.
- Show time-only labels for each log line, with the full date/time kept in a tooltip for context.
- Keep the local `file://` preview useful with seeded example log history.

## Notes
- The log stream behavior from the previous PR is preserved.
- This follow-up focuses on readability and presentation rather than transport changes.

## Validation
- `node openquatt/web/build-assets.mjs`
- `node --check openquatt/web/js/openquatt-app.js`
- Local browser verification on `file:///C:/Codex%20projecten/OpenQuatt/openquatt/web/dev.html?view=settings`