### PR TITLE
Harmonize firmware logging for transitions and blocks

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -42,12 +42,12 @@ modbus_controller:
       then:
         - lambda: |-
             id(${hp_id}_is_online) = false;
-        - logger.log: "${prefix}Modbus OFFLINE"
+            ESP_LOGW("quatt", "%sModbus OFFLINE", "${prefix}");
     on_online:
       then:
         - lambda: |-
             id(${hp_id}_is_online) = true;
-        - logger.log: "${prefix}Modbus ONLINE"
+            ESP_LOGI("quatt", "%sModbus ONLINE", "${prefix}");
 
 # ----------------------------
 # GLOBALS

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -114,12 +114,33 @@ interval:
           const bool in_cm3 = (id(oq_control_mode_code) == 3);
           const float supply_c = id(water_supply_temp_selected).state;
           const bool has_valid_supply_temp = !isnan(supply_c);
+          std::string boiler_block_reason;
+          if (!in_cm3) {
+            boiler_block_reason = "Control Mode is not CM3";
+          } else if (!has_valid_supply_temp) {
+            boiler_block_reason = "water supply temperature unavailable";
+          } else if (id(oq_boot_startup_inhibit_active)) {
+            boiler_block_reason = "startup inhibit active";
+          } else if (id(oq_water_temp_boiler_inhibit_active)) {
+            boiler_block_reason = "water temperature boiler inhibit active";
+          } else if (id(oq_water_temp_hard_trip_active)) {
+            boiler_block_reason = "water temperature hard trip active";
+          }
           const bool boiler_allowed =
-              in_cm3 &&
-              has_valid_supply_temp &&
-              !id(oq_boot_startup_inhibit_active) &&
-              !id(oq_water_temp_boiler_inhibit_active) &&
-              !id(oq_water_temp_hard_trip_active);
+              boiler_block_reason.empty();
+          static bool last_boiler_allowed = false;
+          static std::string last_boiler_block_reason = "";
+          if (boiler_allowed != last_boiler_allowed || boiler_block_reason != last_boiler_block_reason) {
+            if (boiler_allowed) {
+              ESP_LOGI("quatt.boiler", "Boiler enabled: CM3 and safety guards clear");
+            } else if (id(oq_water_temp_hard_trip_active)) {
+              ESP_LOGW("quatt.boiler", "Boiler blocked: %s", boiler_block_reason.c_str());
+            } else {
+              ESP_LOGI("quatt.boiler", "Boiler blocked: %s", boiler_block_reason.c_str());
+            }
+            last_boiler_allowed = boiler_allowed;
+            last_boiler_block_reason = boiler_block_reason;
+          }
 
           if (boiler_allowed) {
             if (!id(boiler_relay).state) id(boiler_relay).turn_on();

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -251,7 +251,7 @@ select:
                 const uint32_t last_request_ms = id(oq_fw_check_last_request_ms);
                 if (last_request_ms > 0 && now_ms >= last_request_ms &&
                     (now_ms - last_request_ms) < fw_check_cooldown_ms) {
-                  ESP_LOGW("oq_fw", "Skip firmware update check: cooldown active after a recent request.");
+                  ESP_LOGI("oq_fw", "Firmware update check skipped: cooldown active after a recent request.");
                   return false;
                 }
                 id(oq_fw_check_last_request_ms) = now_ms;
@@ -295,6 +295,7 @@ select:
               (x == "CONFIG")  ? 4 :
                                  5;  // DEBUG
 
+            ESP_LOGI("oq_fw", "Runtime logger level updated to %s", x.c_str());
             esphome::logger::global_logger->set_log_level(lvl);
 
   - platform: template
@@ -322,6 +323,7 @@ select:
 
             auto *logger = esphome::logger::global_logger;
 
+            ESP_LOGI("oq_fw", "Runtime Modbus logger levels updated to %s", x.c_str());
             logger->set_log_level("modbus", lvl);
             logger->set_log_level("modbus_controller", lvl);
 
@@ -367,7 +369,7 @@ button:
               const uint32_t last_request_ms = id(oq_fw_check_last_request_ms);
               if (last_request_ms > 0 && now_ms >= last_request_ms &&
                   (now_ms - last_request_ms) < fw_check_cooldown_ms) {
-                ESP_LOGW("oq_fw", "Skip firmware update check: cooldown active after a recent request.");
+                ESP_LOGI("oq_fw", "Firmware update check skipped: cooldown active after a recent request.");
                 return false;
               }
               id(oq_fw_check_last_request_ms) = now_ms;

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -432,6 +432,40 @@ interval:
             return hp_has_any_allowed_level(is_hp1) && !hp_restart_blocked(is_hp1);
           };
 
+          auto hp_restart_remaining_s = [&](bool is_hp1)->uint32_t {
+            int min_off_s = (int) ${oq_hp_min_off_s};
+            if (min_off_s <= 0) return 0;
+            const uint32_t last_stop_ms = is_hp1 ? id(hp1_last_stop_ms) : id(${cc_secondary_last_stop_ms_id});
+            if (last_stop_ms == 0 || now_ms <= last_stop_ms) return 0;
+            const uint32_t min_off_ms = (uint32_t) min_off_s * 1000UL;
+            const uint32_t elapsed_off_ms = now_ms - last_stop_ms;
+            if (elapsed_off_ms >= min_off_ms) return 0;
+            return (min_off_ms - elapsed_off_ms + 999UL) / 1000UL;
+          };
+
+          static bool last_hp1_restart_blocked = false;
+          static bool last_hp2_restart_blocked = false;
+          const bool hp1_restart_blocked_now = hp_restart_blocked(true);
+          const bool hp2_restart_blocked_now = hp_restart_blocked(false);
+          if (hp1_restart_blocked_now != last_hp1_restart_blocked) {
+            if (hp1_restart_blocked_now) {
+              ESP_LOGI("quatt.cool", "HP1 cooling start blocked: minimum off-time remaining %u s",
+                       (unsigned int) hp_restart_remaining_s(true));
+            } else {
+              ESP_LOGI("quatt.cool", "HP1 cooling start block cleared");
+            }
+            last_hp1_restart_blocked = hp1_restart_blocked_now;
+          }
+          if (hp2_restart_blocked_now != last_hp2_restart_blocked) {
+            if (hp2_restart_blocked_now) {
+              ESP_LOGI("quatt.cool", "HP2 cooling start blocked: minimum off-time remaining %u s",
+                       (unsigned int) hp_restart_remaining_s(false));
+            } else {
+              ESP_LOGI("quatt.cool", "HP2 cooling start block cleared");
+            }
+            last_hp2_restart_blocked = hp2_restart_blocked_now;
+          }
+
           auto hp_last_activity_ms = [&](bool is_hp1)->uint32_t {
             const uint32_t last_start_ms =
                 is_hp1 ? id(hp1_last_start_ms) : id(${cc_secondary_last_start_ms_id});
@@ -443,9 +477,9 @@ interval:
           int hp1_req = 0;
           int hp2_req = 0;
           int owner = 0;
+          const bool demand_active = (f > 0);
 
           #if OQ_TOPOLOGY_DUO
-          const bool demand_active = (f > 0);
           const bool prev_hp1_on = (id(hp1_last_applied_level) > 0);
           const bool prev_hp2_on = (id(${cc_secondary_last_applied_level_id}) > 0);
           const bool hp1_can_start_cooling = hp_can_take_cooling_start(true);
@@ -479,6 +513,17 @@ interval:
             }
           }
 
+          static bool last_cooling_start_blocked = false;
+          const bool cooling_start_blocked = demand_active && owner == 0 && !hp1_can_start_cooling && !hp2_can_start_cooling;
+          if (cooling_start_blocked != last_cooling_start_blocked) {
+            if (cooling_start_blocked) {
+              ESP_LOGI("quatt.cool", "Cooling request blocked: both HPs are still in minimum off-time or unavailable");
+            } else {
+              ESP_LOGI("quatt.cool", "Cooling request block cleared");
+            }
+            last_cooling_start_blocked = cooling_start_blocked;
+          }
+
           oq_request::reset_dual_runtime_state(
               id(oq_dual_hp_enabled),
               id(oq_dual_hp_enable_hold_elapsed_accum_min),
@@ -499,6 +544,16 @@ interval:
               id(oq_duo_request_hold_until_ms),
               1);
           owner = (f > 0) ? 1 : 0;
+          static bool last_cooling_start_blocked = false;
+          const bool cooling_start_blocked = demand_active && !hp_can_take_cooling_start(true);
+          if (cooling_start_blocked != last_cooling_start_blocked) {
+            if (cooling_start_blocked) {
+              ESP_LOGI("quatt.cool", "Cooling request blocked: HP1 is still in minimum off-time or unavailable");
+            } else {
+              ESP_LOGI("quatt.cool", "Cooling request block cleared");
+            }
+            last_cooling_start_blocked = cooling_start_blocked;
+          }
           hp1_req = f;
           hp2_req = 0;
           #endif

--- a/openquatt/oq_energy.yaml
+++ b/openquatt/oq_energy.yaml
@@ -22,7 +22,7 @@ button:
           id(oq_heatpump_cooling_energy_cumulative).reset();
           id(oq_boiler_thermal_energy_cumulative).reset();
           id(oq_system_thermal_energy_cumulative).reset();
-          ESP_LOGW("quatt", "Cumulative energy counters reset.");
+          ESP_LOGI("quatt", "Cumulative energy counters reset by user action.");
 
 sensor:
   # Electrical input energy (daily, kWh).

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -387,7 +387,7 @@ interval:
             int start_pwm = (int) id(oq_flow_last_good_pwm);
             if (start_pwm < 50 || start_pwm > 850) start_pwm = fallback;
 
-            ESP_LOGD("flow", "AUTO start(%s): iPWM=%d (last_good=%d fallback=%d, hold %ds, fixed iPWM)",
+            ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d fallback=%d, hold %ds, fixed iPWM)",
                      tag, start_pwm, (int)id(oq_flow_last_good_pwm), fallback, STARTUP_HOLD_S);
 
             id(oq_flow_last_pwm) = start_pwm;
@@ -411,7 +411,7 @@ interval:
             if (pi_failsafe) {
               constexpr int kFailsafeIpwm = 850;
               pwm_local = kFailsafeIpwm;
-              ESP_LOGW("flow", "Flow PI failsafe: sp=%0.1f pv=%0.1f -> forcing iPWM=%d", sp_target, pv, kFailsafeIpwm);
+              ESP_LOGW("flow", "Flow PI failsafe engaged: sp=%0.1f pv=%0.1f -> forcing iPWM=%d", sp_target, pv, kFailsafeIpwm);
               id(oq_flow_i) = 0.0f;
               last_pi_e = 0.0f;
               stable_cnt = 0;
@@ -618,7 +618,7 @@ interval:
           }
           if (mode_txt != last_mode) {
             id(oq_flow_mode).publish_state(mode_txt.c_str());
-            ESP_LOGD("flow", "Flow mode=%s (cm=%s manual=%d failsafe=%d hold=%d pwm=%d)",
+            ESP_LOGI("flow", "Flow mode changed: %s (cm=%s manual=%d failsafe=%d hold=%d pwm=%d)",
                      mode_txt.c_str(), id(oq_control_mode).state.c_str(), (int)want_manual, (int)pi_failsafe, startup_hold, pwm);
             last_mode = mode_txt;
           }

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -463,6 +463,11 @@ output:
               oil_return_active ||
               (id(oq_curve_oil_return_hold_until_ms) > 0 &&
                now_ms < id(oq_curve_oil_return_hold_until_ms));
+          static bool last_oil_return_mask_active = false;
+          if (oil_return_mask_active != last_oil_return_mask_active) {
+            ESP_LOGI("quatt.heatcurve", "Oil return hold %s", oil_return_mask_active ? "active" : "cleared");
+            last_oil_return_mask_active = oil_return_mask_active;
+          }
           bool heat_request_active = id(oq_curve_heat_request_active);
           const bool above_stop_band = pv >= (spw + stop_delta_c);
           const bool low_pid_for_off = d <= off_pid_max_f;
@@ -512,9 +517,34 @@ output:
               off_since_ms = 0;
             }
           }
+          static bool last_restart_inhibit_active = false;
+          if (restart_inhibit_active != last_restart_inhibit_active) {
+            if (restart_inhibit_active) {
+              const uint32_t off_age_ms = (off_since_ms > 0 && now_ms > off_since_ms) ? (now_ms - off_since_ms) : 0;
+              const uint32_t off_age_s = off_age_ms / 1000UL;
+              const uint32_t off_min_s = off_reentry_min_ms / 1000UL;
+              ESP_LOGI("quatt.heatcurve", "Restart inhibit active: off-time hold (%u/%u s)",
+                       (unsigned int) off_age_s, (unsigned int) off_min_s);
+            } else {
+              ESP_LOGI("quatt.heatcurve", "Restart inhibit cleared");
+            }
+            last_restart_inhibit_active = restart_inhibit_active;
+          }
           if (heat_request_active) {
             restart_inhibit_active = false;
             off_since_ms = 0;
+          }
+
+          static bool last_heat_request_active = false;
+          if (heat_request_active != last_heat_request_active) {
+            if (heat_request_active) {
+              ESP_LOGI("quatt.heatcurve", "Heat request resumed: %s",
+                       room_requests_heat ? "room demand" : "restart band reached");
+            } else {
+              ESP_LOGI("quatt.heatcurve", "Heat request stopped: %s",
+                       low_load_release_condition ? "low-load release" : (normal_stop_condition ? "normal stop" : "oil return hold"));
+            }
+            last_heat_request_active = heat_request_active;
           }
 
           if (!heat_request_active) {

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -1039,11 +1039,19 @@ interval:
           // 4) CM selection with CM1 timer (pre/postflow) + flow interlock
           // -------------------------------------------------
           const char* cur_cm = id(oq_control_mode).state.c_str();
+          std::string cm_transition_reason = "control decision updated";
           auto resolve_desired_cm = [&]() -> int {
             // Helper: start CM1 window
             auto start_cm1 = [&](int next_after)->void {
               id(oq_cm1_until_ms) = now_ms + prepost_ms;
               id(oq_cm1_next_after) = next_after; // 0=CM0, 2=CM2, 5=CM5, 98=CM98
+              cm_transition_reason =
+                  (next_after == 2) ? "pre/postflow hold for heating" :
+                  (next_after == 5) ? "pre/postflow hold for cooling" :
+                  (next_after == 98) ? "pre/postflow hold for frost" :
+                  "postflow hold for standby";
+              ESP_LOGI("supervisory", "CM1 hold started: next_after=%d, heating_req=%d, cooling_req=%d",
+                       next_after, (int) heating_req, (int) cooling_req);
             };
 
             // Determine base target (without CM1 timer)
@@ -1078,6 +1086,8 @@ interval:
             if (override_mode == 3) {
               const uint32_t MAX_MS = (uint32_t)(${oq_cm98_diag_max_s}UL * 1000UL);
               if (id(oq_override_cm98_since_ms) != 0 && (uint32_t)(now_ms - id(oq_override_cm98_since_ms)) >= MAX_MS) {
+                ESP_LOGI("supervisory", "CM98 diagnostic override expired after %u s; returning to Auto.",
+                         (unsigned int) ${oq_cm98_diag_max_s});
                 auto call = id(oq_cm_override).make_call();
                 call.set_option("Auto");
                 call.perform();
@@ -1094,9 +1104,16 @@ interval:
               id(oq_cm1_next_after) = 0;
               id(oq_cm3_need_since_ms) = 0;
               id(oq_cm3_demote_since_ms) = 0;
-              if (override_mode == 1) desired_local = 0;       // CM0
-              else if (override_mode == 2) desired_local = 1;  // CM1
-              else if (override_mode == 3) desired_local = 98; // CM98
+              if (override_mode == 1) {
+                desired_local = 0;       // CM0
+                cm_transition_reason = "supervisory override: Force CM0";
+              } else if (override_mode == 2) {
+                desired_local = 1;  // CM1
+                cm_transition_reason = "supervisory override: Force CM1";
+              } else if (override_mode == 3) {
+                desired_local = 98; // CM98
+                cm_transition_reason = "supervisory override: Force CM98";
+              }
             } else {
               // Snapshot CM1 timer state (before we touch globals)
               const bool cm1_timer_active  = (id(oq_cm1_until_ms) != 0);
@@ -1107,6 +1124,7 @@ interval:
               // 1) If we're in CM1 and timer is still running -> stay CM1
               if (cm1_timer_running && strcmp(cur_cm, "CM1") == 0) {
                 desired_local = 1;
+                cm_transition_reason = "CM1 hold timer active";
 
                   // 2) If we're in CM1 and timer just expired -> advance to next_after
                   } else if (cm1_timer_expired && strcmp(cur_cm, "CM1") == 0) {
@@ -1134,7 +1152,12 @@ interval:
                       desired_local = (base_target == 5) ? 5 : ((base_target == 2) ? 2 : (base_target == 98 ? 98 : 0));
                     }
 
-                    ESP_LOGI("supervisory", "CM1 expired: next_after=%d, heating_req=%d, cooling_req=%d, base_target=%d -> desired=%d",
+                    cm_transition_reason =
+                        (desired_local == 2) ? "CM1 hold expired -> heating" :
+                        (desired_local == 5) ? "CM1 hold expired -> cooling" :
+                        (desired_local == 98) ? "CM1 hold expired -> frost" :
+                        "CM1 hold expired -> standby";
+                    ESP_LOGI("supervisory", "CM1 hold expired: next_after=%d, heating_req=%d, cooling_req=%d, base_target=%d -> desired=%d",
                              cm1_next_after, (int) heating_req, (int) cooling_req, base_target, desired_local);
 
                 // Clear CM1 window only AFTER we have used next_after
@@ -1151,12 +1174,15 @@ interval:
                   if (base_target == 5) {
                     if (strcmp(cur_cm, "CM5") == 0) {
                       desired_local = 5;
+                      cm_transition_reason = "cooling already active";
                     } else {
                       start_cm1(5);
                       desired_local = 1;
+                      cm_transition_reason = "cooling request waiting for CM1 hold";
                     }
                   } else {
                     desired_local = 1; // flow interlock holding state
+                    cm_transition_reason = "cooling request held by flow interlock";
                   }
                 } else if (heating_req) {
                   if (base_target == 2) {
@@ -1164,19 +1190,24 @@ interval:
                     // should not force an artificial CM1 detour that drops compressor requests.
                     if (strcmp(cur_cm, "CM2") == 0 || strcmp(cur_cm, "CM3") == 0) {
                       desired_local = 2;
+                      cm_transition_reason = "heating already active";
                     } else {
                       start_cm1(2);
                       desired_local = 1;
+                      cm_transition_reason = "heating request waiting for CM1 hold";
                     }
                   } else {
                     desired_local = 1; // flow interlock holding state
+                    cm_transition_reason = "heating request held by flow interlock";
                   }
                 } else {
                   if (strcmp(cur_cm, "CM2") == 0 || strcmp(cur_cm, "CM5") == 0) {
                     start_cm1(0); // postflow to CM0
                     desired_local = 1;
+                    cm_transition_reason = "postflow before standby";
                   } else {
                     desired_local = (base_target == 98) ? 98 : 0;
+                    cm_transition_reason = (desired_local == 98) ? "frost protection" : "no thermal demand";
                   }
                 }
               }
@@ -1212,7 +1243,10 @@ interval:
                   if (now_ms - id(oq_cm_last_change_ms) >= MIN_CM2_MS) {
                     if (need_on) {
                       if (id(oq_cm3_need_since_ms) == 0) id(oq_cm3_need_since_ms) = now_ms;
-                      if (now_ms - id(oq_cm3_need_since_ms) >= T_ON_MS) desired_local = 3;
+                      if (now_ms - id(oq_cm3_need_since_ms) >= T_ON_MS) {
+                        desired_local = 3;
+                        cm_transition_reason = "power-house deficit promoted to CM3";
+                      }
                     } else {
                       id(oq_cm3_need_since_ms) = 0;
                     }
@@ -1221,7 +1255,10 @@ interval:
                   if (now_ms - id(oq_cm_last_change_ms) >= MIN_CM3_MS) {
                     if (ok_off) {
                       if (id(oq_cm3_demote_since_ms) == 0) id(oq_cm3_demote_since_ms) = now_ms;
-                      if (now_ms - id(oq_cm3_demote_since_ms) >= T_OFF_MS) desired_local = 2;
+                      if (now_ms - id(oq_cm3_demote_since_ms) >= T_OFF_MS) {
+                        desired_local = 2;
+                        cm_transition_reason = "power-house deficit cleared, demoting to CM2";
+                      }
                     } else {
                       id(oq_cm3_demote_since_ms) = 0;
                     }
@@ -1235,6 +1272,7 @@ interval:
                 id(oq_cm3_demote_since_ms) = 0;
                 if (cm_now == 3 && heating_req && base_target == 2) {
                   desired_local = 2;
+                  cm_transition_reason = "Power House assist disabled, returning to CM2";
                 }
               }
             }
@@ -1247,7 +1285,12 @@ interval:
           // 5) Publish CM (writes-only-on-change)
           // -------------------------------------------------
           if (id(oq_control_mode).state != desired_cm) {
+            const std::string previous_cm = id(oq_control_mode).state;
             id(oq_control_mode).publish_state(desired_cm);
+            ESP_LOGI("supervisory", "ControlMode transition: %s -> %s (%s)",
+                     previous_cm.empty() ? "(unset)" : previous_cm.c_str(),
+                     desired_cm,
+                     cm_transition_reason.c_str());
             // DEBUG-RUNTIME: anchor CM dwell timers on actual mode transitions.
             id(oq_cm_last_change_ms) = now_ms;
             if (desired == 2) {

--- a/openquatt/oq_thermal_actuator.yaml
+++ b/openquatt/oq_thermal_actuator.yaml
@@ -199,6 +199,21 @@ interval:
             return true;
           };
 
+          auto log_hp_block_change = [&](bool is_hp1, const std::string &reason)->void {
+            static std::string last_hp1_block_reason = "";
+            static std::string last_hp2_block_reason = "";
+            std::string &last = is_hp1 ? last_hp1_block_reason : last_hp2_block_reason;
+            const char *hp = is_hp1 ? "HP1" : "HP2";
+            if (reason != last) {
+              if (reason.empty()) {
+                ESP_LOGI("quatt.act", "%s compressor block cleared", hp);
+              } else {
+                ESP_LOGI("quatt.act", "%s compressor block: %s", hp, reason.c_str());
+              }
+              last = reason;
+            }
+          };
+
           auto set_mode = [&](bool is_hp1, bool active) {
             const char* opt = (active && request_thermal_active) ? request_thermal_mode_opt : oq_request::request_mode_option(0);
             if (is_hp1) {
@@ -241,10 +256,16 @@ interval:
 
           auto apply_level = [&](bool is_hp1, int req_level)->int {
             req_level = std::max(min_level, std::min(max_level, req_level));
+            const int requested_level = req_level;
             const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${ta_secondary_last_applied_level_id});
             const int retained_level = defrost_stop_hold_level(is_hp1);
+            std::string block_reason;
 
             if (req_level == 0 && retained_level > 0) {
+              char reason_buf[96];
+              snprintf(reason_buf, sizeof(reason_buf), "defrost hold at level %d", retained_level);
+              block_reason = reason_buf;
+              log_hp_block_change(is_hp1, reason_buf);
               apply_active_mode_hold(is_hp1, retained_level);
               publish_optimizer_reason("defrost_protect_hold");
               return retained_level;
@@ -260,6 +281,15 @@ interval:
                 const uint32_t elapsed_off_ms = now_ms - last_stop_ms;
                 const uint32_t min_off_ms = (uint32_t) min_off_s * 1000UL;
                 if (elapsed_off_ms < min_off_ms) req_level = 0;
+                if (req_level == 0) {
+                  const uint32_t remaining_s = (min_off_ms > elapsed_off_ms) ? ((min_off_ms - elapsed_off_ms + 999UL) / 1000UL) : 0;
+                  char reason_buf[144];
+                  snprintf(reason_buf, sizeof(reason_buf),
+                           "minimum off-time remaining %u s after stop (requested %d)",
+                           (unsigned int) remaining_s, requested_level);
+                  block_reason = reason_buf;
+                  log_hp_block_change(is_hp1, reason_buf);
+                }
               }
             }
 
@@ -281,6 +311,27 @@ interval:
             // control cycle on mode-transition latency.
             if (req_level > 0 && !mode_is_active_thermal(is_hp1) && !mode_target_is_active_thermal(is_hp1)) {
               applied = 0;
+              block_reason = "waiting for thermal mode confirmation";
+              log_hp_block_change(is_hp1, "waiting for thermal mode confirmation");
+            }
+
+            if (applied == 0 && req_level > 0) {
+              if (block_reason.empty() && req_level > cap) {
+                char reason_buf[128];
+                snprintf(reason_buf, sizeof(reason_buf), "silent/day cap limited request to 0 (cap=%d, requested=%d)", cap, requested_level);
+                block_reason = reason_buf;
+                log_hp_block_change(is_hp1, reason_buf);
+              } else if (block_reason.empty() && !oq_request::level_allowed_for_excluded_levels(excluded_levels(is_hp1), requested_level)) {
+                char reason_buf[128];
+                snprintf(reason_buf, sizeof(reason_buf), "excluded compressor levels blocked request %d", requested_level);
+                block_reason = reason_buf;
+                log_hp_block_change(is_hp1, reason_buf);
+              } else if (block_reason.empty() && retained_level == 0) {
+                block_reason = "actuator gating held request at 0";
+                log_hp_block_change(is_hp1, "actuator gating held request at 0");
+              }
+            } else if (block_reason.empty()) {
+              log_hp_block_change(is_hp1, "");
             }
 
             if (applied == 0 && retained_level > 0) {

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -219,6 +219,10 @@ globals:
     type: bool
     restore_value: false
     initial_value: 'false'
+  - id: oq_boot_startup_inhibit_cleared_logged
+    type: bool
+    restore_value: false
+    initial_value: 'false'
 
 # ----------------------------
 # TUNING INPUTS
@@ -314,13 +318,13 @@ button:
           id(hp2_last_real_heat_start_ms) = 0;
           id(hp1_prev_heating_mode_active) = false;
           id(hp2_prev_heating_mode_active) = false;
-          ESP_LOGW("quatt", "Runtime counters reset (HP1+HP2).");
+          ESP_LOGI("quatt", "Runtime counters reset at boot (HP1+HP2).");
           #else
           id(hp1_minutes) = 0;
           id(hp1_runtime_accum_ms) = 0;
           id(hp1_last_real_heat_start_ms) = 0;
           id(hp1_prev_heating_mode_active) = false;
-          ESP_LOGW("quatt", "Runtime counters reset (HP1).");
+          ESP_LOGI("quatt", "Runtime counters reset at boot (HP1).");
           #endif
 
 # ----------------------------
@@ -655,14 +659,22 @@ interval:
             id(oq_boot_startup_inhibit_until_ms) = now_ms + inhibit_ms;
             id(oq_boot_startup_inhibit_active) = (inhibit_ms > 0);
             if (!id(oq_boot_startup_inhibit_logged) && inhibit_ms > 0) {
-              ESP_LOGW("quatt", "Startup inhibit armed for %us after reboot; compressors and boiler remain blocked.", (unsigned int) ${oq_hp_min_off_s});
+              ESP_LOGI("quatt", "Startup inhibit armed for %us after reboot; compressors and boiler remain blocked.", (unsigned int) ${oq_hp_min_off_s});
               id(oq_boot_startup_inhibit_logged) = true;
+              id(oq_boot_startup_inhibit_cleared_logged) = false;
             }
           }
           const bool startup_inhibit_active =
               id(oq_boot_startup_inhibit_until_ms) > 0 &&
               now_ms < id(oq_boot_startup_inhibit_until_ms);
           id(oq_boot_startup_inhibit_active) = startup_inhibit_active;
+          if (!startup_inhibit_active &&
+              id(oq_boot_startup_inhibit_until_ms) > 0 &&
+              id(oq_boot_startup_inhibit_logged) &&
+              !id(oq_boot_startup_inhibit_cleared_logged)) {
+            ESP_LOGI("quatt", "Startup inhibit cleared after reboot; compressors and boiler may resume.");
+            id(oq_boot_startup_inhibit_cleared_logged) = true;
+          }
 
           // On mode switch, execute immediately on this tick instead of waiting for previous cadence window.
           if (id(oq_heat_last_mode_code) != control_flavor_code) {
@@ -804,6 +816,7 @@ interval:
             const std::string s(reason);
             if (s != last_optimizer_reason) {
               id(oq_duo_optimizer_reason).publish_state(s.c_str());
+              ESP_LOGI("quatt.req", "Optimizer reason: %s", s.c_str());
               last_optimizer_reason = s;
             }
             #else
@@ -827,6 +840,14 @@ interval:
             const std::string s = reason ? std::string(reason) : std::string("inactive");
             if (s != last_request_reason) {
               id(oq_request_reason).publish_state(s.c_str());
+              ESP_LOGI("quatt.req", "Request reason: %s (mode=%d strategy=%d owner=%d topology=%d hp1=%d hp2=%d)",
+                       s.c_str(),
+                       published.mode_code,
+                       published.strategy_code,
+                       published.owner_hp,
+                       published.topology_code,
+                       published.hp1_level,
+                       published.hp2_level);
               last_request_reason = s;
             }
           };
@@ -1278,9 +1299,24 @@ interval:
                 (id(hp1_last_real_heat_start_ms) > 0) &&
                 (now_ms > id(hp1_last_real_heat_start_ms)) &&
                 ((uint32_t)(now_ms - id(hp1_last_real_heat_start_ms)) < min_rt_ms);
-            if (hp1_req == 0 && !cooling_floor_trip && hp1_min_runtime_active &&
-                (id(hp1_last_applied_level) > 0 || hp1_measured_thermal)) {
+            const bool hp1_min_runtime_hold =
+                (hp1_req == 0 && !cooling_floor_trip && hp1_min_runtime_active &&
+                 (id(hp1_last_applied_level) > 0 || hp1_measured_thermal));
+            if (hp1_min_runtime_hold) {
               hp1_req = pick_allowed(1, true);
+            }
+            static bool last_hp1_min_runtime_hold = false;
+            if (hp1_min_runtime_hold != last_hp1_min_runtime_hold) {
+              if (hp1_min_runtime_hold) {
+                const uint32_t elapsed_ms = (now_ms > id(hp1_last_real_heat_start_ms))
+                    ? (now_ms - id(hp1_last_real_heat_start_ms)) : 0;
+                const uint32_t remaining_s =
+                    (min_rt_ms > elapsed_ms) ? ((min_rt_ms - elapsed_ms + 999UL) / 1000UL) : 0;
+                ESP_LOGI("quatt.req", "HP1 minimum runtime hold active: keeping level 1 for %u s", (unsigned int) remaining_s);
+              } else {
+                ESP_LOGI("quatt.req", "HP1 minimum runtime hold cleared");
+              }
+              last_hp1_min_runtime_hold = hp1_min_runtime_hold;
             }
 
             #if OQ_TOPOLOGY_DUO
@@ -1288,9 +1324,24 @@ interval:
                 (id(hp2_last_real_heat_start_ms) > 0) &&
                 (now_ms > id(hp2_last_real_heat_start_ms)) &&
                 ((uint32_t)(now_ms - id(hp2_last_real_heat_start_ms)) < min_rt_ms);
-            if (hp2_req == 0 && !cooling_floor_trip && hp2_min_runtime_active &&
-                (id(${hc_secondary_last_applied_level_id}) > 0 || hp2_measured_thermal)) {
+            const bool hp2_min_runtime_hold =
+                (hp2_req == 0 && !cooling_floor_trip && hp2_min_runtime_active &&
+                 (id(${hc_secondary_last_applied_level_id}) > 0 || hp2_measured_thermal));
+            if (hp2_min_runtime_hold) {
               hp2_req = pick_allowed(1, false);
+            }
+            static bool last_hp2_min_runtime_hold = false;
+            if (hp2_min_runtime_hold != last_hp2_min_runtime_hold) {
+              if (hp2_min_runtime_hold) {
+                const uint32_t elapsed_ms = (now_ms > id(hp2_last_real_heat_start_ms))
+                    ? (now_ms - id(hp2_last_real_heat_start_ms)) : 0;
+                const uint32_t remaining_s =
+                    (min_rt_ms > elapsed_ms) ? ((min_rt_ms - elapsed_ms + 999UL) / 1000UL) : 0;
+                ESP_LOGI("quatt.req", "HP2 minimum runtime hold active: keeping level 1 for %u s", (unsigned int) remaining_s);
+              } else {
+                ESP_LOGI("quatt.req", "HP2 minimum runtime hold cleared");
+              }
+              last_hp2_min_runtime_hold = hp2_min_runtime_hold;
             }
             #else
             hp2_req = 0;

--- a/openquatt/oq_web_access.yaml
+++ b/openquatt/oq_web_access.yaml
@@ -34,7 +34,7 @@ binary_sensor:
       then:
         - lambda: |-
             if (id(oq_web_auth_store).start_recovery_window()) {
-              ESP_LOGW("openquatt.web_auth", "Armed login recovery window from temporary recovery pin");
+              ESP_LOGI("openquatt.web_auth", "Login recovery window armed from temporary recovery pin");
             } else {
               ESP_LOGW("openquatt.web_auth", "Failed to arm login recovery window from temporary recovery pin");
             }


### PR DESCRIPTION
## Summary
This PR harmonizes firmware logging in `openquatt/` so logs become more consistent, more useful, and easier to search for both end users and maintainers.

The main focus is twofold:
- make important state transitions visible, especially around `ControlMode` and request/strategy transitions
- explicitly log why a compressor start, mode switch, or boiler/cooling activation is being blocked

## Why this matters
The current firmware has a lot of log statements spread across multiple packages, with different tone, detail level, and log-level choices. In practice, that makes it difficult to read the logs and understand:
- why the firmware chose a specific path
- why a request was built but not executed
- whether a block is temporary or a real fault
- when a transition or guardrail has been released again

This PR turns logging into a more consistent operational tool instead of a collection of isolated debug messages.

## What changed
### 1. More consistent log levels
- More user-relevant runtime events have been moved to `INFO`.
- Recoverable blocks and guardrails remain `INFO` or `WARN`, depending on severity.
- Real errors remain `ERROR` or `WARN` where appropriate.
- `CONFIG` remains primarily for boot-time or static configuration output.

### 2. ControlMode transitions are now explicit
`oq_supervisory_controlmode.yaml` now logs:
- actual `ControlMode` transitions with source, target, and reason
- start and expiry of CM1 hold / pre-postflow windows
- CM98 diagnostic override expiry
- override behavior for Force CM0 / CM1 / CM98
- reasons for the selected desired mode, such as:
  - heating request waiting for CM1 hold
  - cooling request held by flow interlock
  - power-house deficit promoted to CM3
  - power-house deficit cleared, demoting to CM2

### 3. Compressor start blocks are now visible
The firmware now makes it clear when a compressor was requested but is still not allowed to start. Examples include:
- minimum off-time after stop
- waiting for thermal mode confirmation
- defrost hold
- silent/day cap limiting
- excluded compressor levels
- actuator gating holding the request at 0

The logic is designed to log only real state changes, so the output stays readable instead of becoming cycle-by-cycle spam.

### 4. More insight into request and runtime behavior
In `oq_thermal_request_control.yaml` and related packages, additional `INFO` logs were added for:
- optimizer reason changes
- request reason changes
- startup inhibit armed / cleared
- minimum runtime hold active / cleared per compressor
- runtime counter resets at boot

### 5. Better visibility for cooling and boiler guardrails
Additional explicit logs were added for:
- cooling start blocked / cleared because of minimum off-time or unavailable heat pumps
- boiler enabled / blocked with a concrete reason, including hard-trip cases
- oil return hold and restart inhibit in the heating curve strategy

### 6. Device I/O and other user-visible events
Some existing messages were standardized or made more visible:
- Modbus online / offline status
- firmware update cooldown skipped
- runtime logger level updates
- energy reset events
- recovery window armed / failure status

## Expected impact
- It becomes much easier to follow what the firmware is doing behind the scenes.
- Troubleshooting questions like “why didn’t the compressor start?” or “why did ControlMode stay in CM1?” become much easier to answer.
- The log style feels more consistent across packages.
