### PR TITLE
Reduce diagnostic update bursts

### DIFF
--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -277,7 +277,7 @@ text_sensor:
     name: "Cooling Block Reason"
     icon: mdi:information-outline
     entity_category: diagnostic
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       // Report the first blocking condition in operator-friendly terms.
       if (!id(cooling_room_count_selected).has_state() || isnan(id(cooling_room_count_selected).state)) {

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -745,7 +745,7 @@ sensor:
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 2
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_heating_curve
@@ -760,7 +760,7 @@ sensor:
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_heating_curve
@@ -775,7 +775,7 @@ sensor:
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_heating_curve
@@ -790,7 +790,7 @@ sensor:
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_heating_curve
@@ -805,7 +805,7 @@ sensor:
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_heating_curve
@@ -818,7 +818,7 @@ sensor:
     disabled_by_default: true
     icon: mdi:timer-sand-paused
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_heating_curve
@@ -830,7 +830,7 @@ text_sensor:
     id: oq_curve_phase_sensor
     name: "Curve Phase"
     icon: mdi:state-machine
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -843,7 +843,7 @@ text_sensor:
     id: oq_curve_regime_sensor
     name: "Curve operating regime"
     icon: mdi:state-machine
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -859,7 +859,7 @@ text_sensor:
     id: oq_curve_capacity_mode_sensor
     name: "Curve capacity mode"
     icon: mdi:state-machine
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -326,7 +326,7 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 3
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -342,7 +342,7 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -266,7 +266,7 @@ text_sensor:
     disabled_by_default: true
     icon: mdi:timer-sand
     entity_category: diagnostic
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       // Report which selected-source inputs are currently being held through source dropouts.
       std::string active;

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -207,7 +207,7 @@ text_sensor:
     id: oq_room_temperature_effective_source
     name: "Room Temperature Effective Source"
     icon: mdi:source-branch
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       if (!id(room_temp_source).has_state()) return {"Unknown"};
       return {id(room_temp_source).current_option().c_str()};
@@ -219,7 +219,7 @@ text_sensor:
     id: oq_room_setpoint_effective_source
     name: "Room Setpoint Effective Source"
     icon: mdi:source-branch
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       if (!id(room_setpoint_source).has_state()) return {"Unknown"};
       return {id(room_setpoint_source).current_option().c_str()};
@@ -232,7 +232,7 @@ text_sensor:
     name: "Cooling Enable Effective Source"
     icon: mdi:source-branch
     entity_category: diagnostic
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       // Report which raw source is currently granting cooling enable.
       if (!id(cooling_enable_source).has_state()) return {"Unknown"};

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -133,7 +133,7 @@ text_sensor:
     id: heating_strategy_status
     name: "Heating Strategy"
     icon: mdi:state-machine
-    update_interval: 5s
+    update_interval: 30s
     web_server:
       sorting_group_id: oq_overview
     lambda: |-

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -227,7 +227,7 @@ sensor:
     name: "Strategy active code"
     icon: mdi:counter
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -240,7 +240,7 @@ sensor:
     name: "Strategy phase code"
     icon: mdi:counter
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -255,7 +255,7 @@ sensor:
     unit_of_measurement: "W"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -271,7 +271,7 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 1
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -284,7 +284,7 @@ sensor:
     name: "Strategy water limit factor"
     icon: mdi:water-percent-alert
     accuracy_decimals: 2
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -188,3 +188,4 @@ oq_modbus_command_throttle_ms: "300"                 # Minimum spacing between M
 oq_modbus_max_cmd_retries: "1"                       # Retries per Modbus command; keep low to avoid long blocking on bad links.
 oq_skip_10s: "1"                                      # 1 skip; effective polling every 10s.
 oq_skip_30s: "5"                                      # 5 skips; effective polling every 30s.
+oq_diagnostic_update_interval_s: "30"                 # Slow diagnostic-only template entities to reduce API publish bursts.

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -491,7 +491,7 @@ text_sensor:
     id: oq_low_load_dyn_status
     name: "Low-load dynamic thresholds"
     icon: mdi:chart-bell-curve
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:


### PR DESCRIPTION
## Summary
- add a shared 30s diagnostic update interval substitution
- slow disabled-by-default strategy, heating-curve, power-house, sensor-source, and low-load diagnostic entities from 5s to 30s
- leave control-loop, overview, selected-input, Modbus, and performance entities at their existing cadence

## Rationale
This reduces low-value API publish bursts while preserving runtime control responsiveness. The PR is intentionally stacked on PR #121 so OTA testing can include both the deterministic trend-history memory work and the diagnostic publish-rate reduction.

## Validation
- python3 scripts/dev.py validate --config openquatt_duo_waveshare.yaml --jobs 1