### PR TITLE
Reduce remaining burst sources

### DIFF
--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -287,7 +287,7 @@ sensor:
     device_class: power
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_power_house
     lambda: |-
@@ -312,7 +312,7 @@ sensor:
     device_class: power
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_power_house
     lambda: |-

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -71,6 +71,7 @@ oq_sticky_pwm: "850"                                  # Fixed iPWM fallback used
 # HEATING STRATEGY
 # ----------------------------
 oq_strategy_loop_s: "5"                               # Interval for strategy calculations and mode switching [s].
+oq_diagnostic_update_interval_s: "30"                # Shared cadence for slower operator-facing diagnostics [s].
 oq_strategy_demand_max_f: "20.0"                      # Upper bound of demand scale for mapping PID/power -> f.
 oq_selected_input_stale_hold_s: "300"                 # Hold selected HA-backed inputs this long when they briefly disappear during reloads [s].
 oq_temp_guard_delta_c: "0.5"                          # Minimum valid margin between T0 and Tc in the house model [°C].

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -491,7 +491,7 @@ text_sensor:
     id: oq_low_load_dyn_status
     name: "Low-load dynamic thresholds"
     icon: mdi:chart-bell-curve
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -525,7 +525,7 @@ sensor:
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_overview
     lambda: |-

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -495,7 +495,7 @@ sensor:
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_heating_strategy
     lambda: |-
@@ -508,7 +508,7 @@ sensor:
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_heating_strategy
     lambda: |-
@@ -521,7 +521,7 @@ sensor:
     unit_of_measurement: "lvl"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_heating_strategy
     lambda: |-
@@ -538,7 +538,7 @@ sensor:
     unit_of_measurement: "lvl"
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_heating_strategy
     lambda: |-
@@ -563,7 +563,7 @@ sensor:
     device_class: power
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_heating_strategy
     lambda: |-
@@ -577,7 +577,7 @@ sensor:
     device_class: power
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_heating_strategy
     lambda: |-


### PR DESCRIPTION
This PR continues the heap/burst reduction work on top of the current dev base.

What changed:
- Slows the remaining 5s status/request sensors in thermal request control to the shared 30s diagnostic cadence.
- Slows the remaining Power House overview outputs to 30s.
- Slows the low-load dynamic status and power-cap overview sensors in supervisory control mode to 30s.
- Adds the shared 30s diagnostic interval substitution to the common config so the branch compiles cleanly on dev.

Intent:
- Reduce remaining API publish bursts and status churn.
- Keep control-critical signals unchanged.
- Preserve the existing live regulation behavior.

Validation:
- `python3 scripts/dev.py validate --config openquatt_duo_waveshare.yaml --jobs 1`