### PR TITLE
Bound OpenTherm processing time

### DIFF
--- a/components/openquatt_ot_slave/OpenTherm.cpp
+++ b/components/openquatt_ot_slave/OpenTherm.cpp
@@ -7,6 +7,7 @@ Copyright 2018, Ihor Melnyk
 #include "esphome/core/log.h"
 #include "esp_err.h"
 #include "esp_private/esp_clk.h"
+#include "esp_timer.h"
 static const char * TAG = "OpenThermV2";
 using namespace esphome;
 
@@ -598,9 +599,21 @@ bool OpenTherm::sendResponse(unsigned long request)
 bool OpenTherm::process()
 {
 #if OQ_OT_RMT_SUPPORTED
+	const uint64_t process_start_us = static_cast<uint64_t>(esp_timer_get_time());
+	size_t processed_frames = 0;
 	RxFrame frame{};
 	while (pop_rx_frame_(frame)) {
 		process_rmt_frame_(frame);
+		++processed_frames;
+		if (status == OpenThermStatus::RESPONSE_READY || status == OpenThermStatus::RESPONSE_INVALID) {
+			break;
+		}
+		if (processed_frames >= PROCESS_MAX_RX_FRAMES) {
+			break;
+		}
+		if ((static_cast<uint64_t>(esp_timer_get_time()) - process_start_us) >= PROCESS_BUDGET_US) {
+			break;
+		}
 	}
 
 	if (edge_overflow_) {

--- a/components/openquatt_ot_slave/OpenTherm.h
+++ b/components/openquatt_ot_slave/OpenTherm.h
@@ -210,6 +210,9 @@ public:
 	float getFloat(const unsigned long response) const;	
 
 private:
+	static constexpr uint8_t PROCESS_MAX_RX_FRAMES = 2;
+	static constexpr uint32_t PROCESS_BUDGET_US = 250;
+
 	const int inPin;
 	const int outPin;
 	const bool isSlave;


### PR DESCRIPTION
This PR caps the amount of OpenTherm work done per `process()` call so the main loop stays more responsive.

What changed:
- `OpenTherm::process()` no longer drains the RX queue without limit.
- Processing is bounded by a small per-call frame budget and a short time budget.
- The existing bounded RX ring buffer stays in place; we are not adding another queue.

Intent:
- Reduce long `openquatt_ot_slave` loop spikes.
- Keep OpenTherm timing predictable.
- Preserve the existing OT protocol behavior and response handling.

Validation:
- `python3 scripts/dev.py validate --config openquatt_duo_waveshare.yaml --jobs 1`