### PR TITLE
Same-rate staged Modbus polling

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -297,7 +297,6 @@ sensor:
           max_value: 16
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
-    register_count: 10  # 2101 - 2110
     force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
@@ -320,6 +319,7 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -361,6 +361,7 @@ sensor:
           max_value: 1000
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -374,6 +375,7 @@ sensor:
     unit_of_measurement: "RPM"
     state_class: "measurement"
     accuracy_decimals: 0
+    # register_count: 2  # 2105 - 2106
     filters:
       - multiply: 1
       - clamp:
@@ -452,7 +454,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
-    register_count: 7  # 2111 - 2117
     force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
@@ -490,6 +491,7 @@ sensor:
     device_class: "temperature"
     state_class: "measurement"
     accuracy_decimals: 2
+    register_count: 2  # 2113 - 2114
     filters:
       - offset: -3000
       - multiply: 0.01
@@ -533,6 +535,7 @@ sensor:
     device_class: "pressure"
     state_class: "measurement"
     accuracy_decimals: 2
+    # register_count: 5  # 2117 - 2121
     filters:
       - multiply: 0.1
       - clamp:
@@ -554,14 +557,25 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
-    name: "${prefix}Raw status / firmware block"
+    name: "${prefix}Firmware EEPROM"
     disabled_by_default: true
     icon: mdi:memory
     register_type: holding
-    register_count: 14  # 2119 - 2132
-    address: 2119
+    register_count: 4  # 2123 - 2127
+    address: 2123
     skip_updates: ${oq_skip_30s}
-    force_new_range: true
+    web_server:
+      sorting_group_id: oq_${hp_id}
+
+  - platform: modbus_controller
+    modbus_controller_id: ${hp_id}
+    name: "${prefix}Control board item number"
+    disabled_by_default: true
+    icon: mdi:identifier
+    register_type: holding
+    register_count: 4  # 2127 - 2131
+    address: 2127
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -667,6 +681,7 @@ sensor:
     device_class: "temperature"
     state_class: "measurement"
     accuracy_decimals: 2
+    # register_count: 2  # 2135 - 2137
     filters:
       - offset: -3000
       - multiply: 0.01
@@ -675,7 +690,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
-    register_count: 3  # 2135 - 2137
     force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -135,7 +135,7 @@ select:
       "8": 8
       "9": 9
       "10": 10
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -151,7 +151,7 @@ select:
     optionsmap:
       "Off": 0
       "On": 1
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -167,7 +167,7 @@ select:
     optionsmap:
       "Off": 0
       "On": 4096
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -233,7 +233,7 @@ number:
     min_value: 0
     max_value: 1000
     mode: slider
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -275,7 +275,6 @@ sensor:
           max_value: 300
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
-    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -296,8 +295,7 @@ sensor:
           min_value: 0
           max_value: 16
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
-    force_new_range: true
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -319,7 +317,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
-    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -360,8 +357,7 @@ sensor:
           min_value: 0
           max_value: 1000
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
-    force_new_range: true
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -382,7 +378,7 @@ sensor:
           min_value: 0
           max_value: 1000
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -454,7 +450,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
-    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -643,7 +638,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
-    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -690,7 +684,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
-    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -701,6 +694,7 @@ sensor:
     icon: mdi:pump
     register_type: holding
     address: 2137
+    # force_new_range: true
     unit_of_measurement: "W"
     device_class: "power"
     state_class: "measurement"
@@ -725,7 +719,6 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.618
-    force_new_range: true
     on_value:
       then:
         - lambda: |-
@@ -874,7 +867,6 @@ sensor:
     address: 2119
     value_type: U_WORD
     skip_updates: ${oq_skip_30s}
-    force_new_range: true
     internal: true
 
   - platform: modbus_controller
@@ -1007,7 +999,6 @@ binary_sensor:
     register_type: holding
     address: 2118
     #skip_updates: 0
-    force_new_range: true
     on_state:
       then:
         - lambda: |-
@@ -1142,7 +1133,7 @@ text_sensor:
     id: ${hp_id}_active_failures_list
     name: "${prefix}Active Failures List"
     entity_category: diagnostic
-    update_interval: 30s
+    update_interval: 5s
     web_server:
       sorting_group_id: oq_hp_diagnostics
     icon: mdi:alert-circle-outline

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -135,7 +135,7 @@ select:
       "8": 8
       "9": 9
       "10": 10
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -151,7 +151,7 @@ select:
     optionsmap:
       "Off": 0
       "On": 1
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -167,7 +167,7 @@ select:
     optionsmap:
       "Off": 0
       "On": 4096
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -233,7 +233,7 @@ number:
     min_value: 0
     max_value: 1000
     mode: slider
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -297,6 +297,7 @@ sensor:
           max_value: 16
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
+    register_count: 10  # 2101 - 2110
     force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
@@ -319,7 +320,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
-    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -361,7 +361,6 @@ sensor:
           max_value: 1000
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
-    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -375,7 +374,6 @@ sensor:
     unit_of_measurement: "RPM"
     state_class: "measurement"
     accuracy_decimals: 0
-    # register_count: 2  # 2105 - 2106
     filters:
       - multiply: 1
       - clamp:
@@ -454,6 +452,7 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
+    register_count: 7  # 2111 - 2117
     force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
@@ -491,7 +490,6 @@ sensor:
     device_class: "temperature"
     state_class: "measurement"
     accuracy_decimals: 2
-    register_count: 2  # 2113 - 2114
     filters:
       - offset: -3000
       - multiply: 0.01
@@ -535,7 +533,6 @@ sensor:
     device_class: "pressure"
     state_class: "measurement"
     accuracy_decimals: 2
-    # register_count: 5  # 2117 - 2121
     filters:
       - multiply: 0.1
       - clamp:
@@ -557,25 +554,14 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
-    name: "${prefix}Firmware EEPROM"
+    name: "${prefix}Raw status / firmware block"
     disabled_by_default: true
     icon: mdi:memory
     register_type: holding
-    register_count: 4  # 2123 - 2127
-    address: 2123
+    register_count: 14  # 2119 - 2132
+    address: 2119
     skip_updates: ${oq_skip_30s}
-    web_server:
-      sorting_group_id: oq_${hp_id}
-
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
-    name: "${prefix}Control board item number"
-    disabled_by_default: true
-    icon: mdi:identifier
-    register_type: holding
-    register_count: 4  # 2127 - 2131
-    address: 2127
-    skip_updates: ${oq_skip_30s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -681,7 +667,6 @@ sensor:
     device_class: "temperature"
     state_class: "measurement"
     accuracy_decimals: 2
-    # register_count: 2  # 2135 - 2137
     filters:
       - offset: -3000
       - multiply: 0.01
@@ -690,6 +675,7 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
+    register_count: 3  # 2135 - 2137
     force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -33,7 +33,7 @@ modbus_controller:
   - id: ${hp_id}
     address: ${device_address}
     modbus_id: mod_bus
-    update_interval: ${oq_modbus_update_interval_s}s
+    update_interval: never
     command_throttle: ${oq_modbus_command_throttle_ms}ms
     max_cmd_retries: ${oq_modbus_max_cmd_retries}
     offline_skip_updates: 5
@@ -275,6 +275,7 @@ sensor:
           max_value: 300
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -317,6 +318,7 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -358,6 +360,7 @@ sensor:
           max_value: 1000
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -450,6 +453,7 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -638,6 +642,7 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_10s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -684,6 +689,7 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_skip_30s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -694,7 +700,6 @@ sensor:
     icon: mdi:pump
     register_type: holding
     address: 2137
-    # force_new_range: true
     unit_of_measurement: "W"
     device_class: "power"
     state_class: "measurement"
@@ -719,6 +724,7 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.618
+    force_new_range: true
     on_value:
       then:
         - lambda: |-
@@ -867,6 +873,7 @@ sensor:
     address: 2119
     value_type: U_WORD
     skip_updates: ${oq_skip_30s}
+    force_new_range: true
     internal: true
 
   - platform: modbus_controller
@@ -999,6 +1006,7 @@ binary_sensor:
     register_type: holding
     address: 2118
     #skip_updates: 0
+    force_new_range: true
     on_state:
       then:
         - lambda: |-
@@ -1226,3 +1234,9 @@ text_sensor:
     update_interval: never
     web_server:
       sorting_group_id: oq_hp_diagnostics
+
+interval:
+  - interval: ${oq_modbus_update_interval_s}s
+    startup_delay: ${oq_modbus_startup_delay_ms}ms
+    then:
+      - component.update: ${hp_id}

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -274,7 +274,7 @@ sensor:
           min_value: 0
           max_value: 300
           ignore_out_of_range: true
-    #skip_updates: 0
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -295,7 +295,7 @@ sensor:
           min_value: 0
           max_value: 16
           ignore_out_of_range: true
-    #skip_updates: 0
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -378,7 +378,7 @@ sensor:
           min_value: 0
           max_value: 1000
           ignore_out_of_range: true
-    #skip_updates: 0
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -421,6 +421,7 @@ sensor:
           min_value: -30
           max_value: 100
           ignore_out_of_range: true
+    skip_updates: ${oq_skip_10s}
     on_value:
       then:
         - lambda: |-
@@ -636,6 +637,7 @@ sensor:
           min_value: -10
           max_value: 100
           ignore_out_of_range: true
+    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -658,6 +660,7 @@ sensor:
           min_value: -10
           max_value: 100
           ignore_out_of_range: true
+    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -698,7 +701,7 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.1
-    #skip_updates: 0
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -296,7 +296,8 @@ sensor:
           min_value: 0
           max_value: 16
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_skip_10s}
+    force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -359,7 +360,7 @@ sensor:
           min_value: 0
           max_value: 1000
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_skip_10s}
     force_new_range: true
     web_server:
       sorting_group_id: oq_${hp_id}
@@ -381,7 +382,7 @@ sensor:
           min_value: 0
           max_value: 1000
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -1141,7 +1142,7 @@ text_sensor:
     id: ${hp_id}_active_failures_list
     name: "${prefix}Active Failures List"
     entity_category: diagnostic
-    update_interval: 5s
+    update_interval: 30s
     web_server:
       sorting_group_id: oq_hp_diagnostics
     icon: mdi:alert-circle-outline

--- a/openquatt/oq_packages_common.yaml
+++ b/openquatt/oq_packages_common.yaml
@@ -160,3 +160,4 @@ heatpump1: !include
     hp_id: "hp1"
     prefix: "HP1 - "
     device_address: 0x01
+    oq_modbus_update_interval_s: "${oq_modbus_update_interval_hp1_s}"

--- a/openquatt/oq_packages_common.yaml
+++ b/openquatt/oq_packages_common.yaml
@@ -160,4 +160,3 @@ heatpump1: !include
     hp_id: "hp1"
     prefix: "HP1 - "
     device_address: 0x01
-    oq_modbus_update_interval_s: "${oq_modbus_update_interval_hp1_s}"

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -187,5 +187,7 @@ ha_cooling_room_6_humidity_entity_id: "sensor.openquatt_ext_cooling_room_6_humid
 oq_modbus_update_interval_s: "5"                    # Base Modbus controller polling interval [s].
 oq_modbus_command_throttle_ms: "300"                 # Minimum spacing between Modbus commands [ms].
 oq_modbus_max_cmd_retries: "1"                       # Retries per Modbus command; keep low to avoid long blocking on bad links.
+oq_modbus_update_interval_hp1_s: "5"                 # HP1 Modbus polling cadence [s].
+oq_modbus_update_interval_hp2_s: "7"                 # HP2 Modbus polling cadence [s]; offset from HP1 to de-sync bursts.
 oq_skip_10s: "1"                                      # 1 skip; effective polling every 10s.
 oq_skip_30s: "5"                                      # 5 skips; effective polling every 30s.

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -187,7 +187,6 @@ ha_cooling_room_6_humidity_entity_id: "sensor.openquatt_ext_cooling_room_6_humid
 oq_modbus_update_interval_s: "5"                    # Base Modbus controller polling interval [s].
 oq_modbus_command_throttle_ms: "300"                 # Minimum spacing between Modbus commands [ms].
 oq_modbus_max_cmd_retries: "1"                       # Retries per Modbus command; keep low to avoid long blocking on bad links.
-oq_modbus_update_interval_hp1_s: "5"                 # HP1 Modbus polling cadence [s].
-oq_modbus_update_interval_hp2_s: "7"                 # HP2 Modbus polling cadence [s]; offset from HP1 to de-sync bursts.
+oq_modbus_startup_delay_ms: "0"                      # Default startup offset for staged Modbus polling [ms].
 oq_skip_10s: "1"                                      # 1 skip; effective polling every 10s.
 oq_skip_30s: "5"                                      # 5 skips; effective polling every 30s.

--- a/openquatt/topology/oq_topology_packages_duo.yaml
+++ b/openquatt/topology/oq_topology_packages_duo.yaml
@@ -4,6 +4,7 @@ heatpump2: !include
     hp_id: "hp2"
     prefix: "HP2 - "
     device_address: 0x02
+    oq_modbus_update_interval_s: "${oq_modbus_update_interval_hp2_s}"
 oq_cic_compatibility_hp2: !include
   file: ../oq_cic_compatibility_server.yaml
   vars:

--- a/openquatt/topology/oq_topology_packages_duo.yaml
+++ b/openquatt/topology/oq_topology_packages_duo.yaml
@@ -4,7 +4,7 @@ heatpump2: !include
     hp_id: "hp2"
     prefix: "HP2 - "
     device_address: 0x02
-    oq_modbus_update_interval_s: "${oq_modbus_update_interval_hp2_s}"
+    oq_modbus_startup_delay_ms: "2500"
 oq_cic_compatibility_hp2: !include
   file: ../oq_cic_compatibility_server.yaml
   vars:


### PR DESCRIPTION
Stacked on PR #124.

This PR now locks the Modbus change back down to the narrow baseline that matched the best real-device signal:
- both HP controllers use the same shared `oq_modbus_update_interval_s` cadence
- HP2 is staged with a fixed `2500ms` startup delay
- the existing Modbus read range layout from `17aa4ad` is preserved
- the extra `force_new_range` additions from the later staged experiment are not included
- the larger merged read-block experiment is not included

Why: testing showed that same-rate staging without the extra range splits produced a quiet first observation window, while the later force-range and block-consolidation variants reintroduced Modbus timeout/partial-response churn.

Goal: keep the cleaner same-rate staged polling model while avoiding extra request fragmentation and broad padded reads.

Validated with `./scripts/validate_local.sh --config openquatt_duo_waveshare.yaml --jobs 1` on top of the PR124 base.