### PR TITLE
Reduce static Modbus polling

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -135,7 +135,7 @@ select:
       "8": 8
       "9": 9
       "10": 10
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -151,7 +151,7 @@ select:
     optionsmap:
       "Off": 0
       "On": 1
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -167,7 +167,7 @@ select:
     optionsmap:
       "Off": 0
       "On": 4096
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -233,7 +233,7 @@ number:
     min_value: 0
     max_value: 1000
     mode: slider
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_skip_30s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -549,30 +549,6 @@ sensor:
     skip_updates: ${oq_skip_30s}
     value_type: U_WORD
     internal: true
-
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
-    name: "${prefix}Firmware EEPROM"
-    disabled_by_default: true
-    icon: mdi:memory
-    register_type: holding
-    register_count: 4  # 2123 - 2127
-    address: 2123
-    skip_updates: ${oq_skip_30s}
-    web_server:
-      sorting_group_id: oq_${hp_id}
-
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
-    name: "${prefix}Control board item number"
-    disabled_by_default: true
-    icon: mdi:identifier
-    register_type: holding
-    register_count: 4  # 2127 - 2131
-    address: 2127
-    skip_updates: ${oq_skip_30s}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -1133,7 +1109,7 @@ text_sensor:
     id: ${hp_id}_active_failures_list
     name: "${prefix}Active Failures List"
     entity_category: diagnostic
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     web_server:
       sorting_group_id: oq_hp_diagnostics
     icon: mdi:alert-circle-outline

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -552,6 +552,30 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    name: "${prefix}Firmware EEPROM"
+    disabled_by_default: true
+    icon: mdi:memory
+    register_type: holding
+    register_count: 4  # 2123 - 2127
+    address: 2123
+    skip_updates: ${oq_skip_30s}
+    web_server:
+      sorting_group_id: oq_${hp_id}
+
+  - platform: modbus_controller
+    modbus_controller_id: ${hp_id}
+    name: "${prefix}Control board item number"
+    disabled_by_default: true
+    icon: mdi:identifier
+    register_type: holding
+    register_count: 4  # 2127 - 2131
+    address: 2127
+    skip_updates: ${oq_skip_30s}
+    web_server:
+      sorting_group_id: oq_${hp_id}
+
+  - platform: modbus_controller
+    modbus_controller_id: ${hp_id}
     id: ${hp_id}_condensing_temp
     name: "${prefix}Condensing temperature"
     icon: mdi:thermometer


### PR DESCRIPTION
## Summary
- remove static firmware EEPROM and control board item-number Modbus readbacks from HP IO
- slow compressor level, silent mode, pump mode, and pump speed readback from 10s to 30s
- align Active Failures List refresh with its 30s raw status inputs

## Register/range notes
- removes two static 4-register readbacks at 2123 and 2127, so no wider Modbus ranges are introduced
- keeps 3999 Set Working Mode on the existing 10s cadence because it is closer to active guard/state logic
- leaves fast control/status registers unchanged

## Validation
- ./scripts/validate_local.sh --config openquatt_duo_waveshare.yaml --jobs 1