### PR TITLE
Enable PSRAM on Waveshare builds

### DIFF
--- a/openquatt/profiles/oq_psram_waveshare.yaml
+++ b/openquatt/profiles/oq_psram_waveshare.yaml
@@ -1,0 +1,22 @@
+# ==============================================================================
+# OpenQuatt - Waveshare ESP32-S3 PSRAM
+# ==============================================================================
+# Enables the 8MB PSRAM present on the Waveshare ESP32-S3 relay board and exposes
+# free PSRAM as a disabled-by-default diagnostic sensor for runtime validation.
+# ==============================================================================
+
+psram:
+  mode: octal
+  speed: 80MHz
+  ignore_not_found: false
+
+sensor:
+  - platform: debug
+    psram:
+      name: "PSRAM Free"
+      icon: mdi:memory
+      entity_category: diagnostic
+      disabled_by_default: true
+      accuracy_decimals: 0
+      web_server:
+        sorting_group_id: oq_system_diagnostics

--- a/openquatt_duo_waveshare.yaml
+++ b/openquatt_duo_waveshare.yaml
@@ -9,4 +9,5 @@ esphome:
   build_path: build/openquatt_duo_waveshare
 
 packages:
+  oq_waveshare_psram: !include openquatt/profiles/oq_psram_waveshare.yaml
   openquatt_base: !include openquatt_base.yaml

--- a/openquatt_single_waveshare.yaml
+++ b/openquatt_single_waveshare.yaml
@@ -9,4 +9,5 @@ esphome:
   build_path: build/openquatt_single_waveshare
 
 packages:
+  oq_waveshare_psram: !include openquatt/profiles/oq_psram_waveshare.yaml
   openquatt_base: !include openquatt_base_single.yaml


### PR DESCRIPTION
## Summary
- enable octal 80MHz PSRAM for Waveshare ESP32-S3 duo and single builds
- add a disabled-by-default PSRAM Free debug sensor under System Diagnostics
- keep ESP32 heatpump-listener builds unchanged by putting PSRAM in a Waveshare-only package

## Validation
- esphome compile openquatt_duo_waveshare.yaml
- generated sdkconfig includes CONFIG_SPIRAM=y, CONFIG_SPIRAM_MODE_OCT=y, CONFIG_SPIRAM_SPEED_80M=y
- esphome config openquatt_duo_heatpump_listener.yaml remains valid without psram