### PR TITLE
Use PSRAM for OpenQuatt history buffers

### DIFF
--- a/components/openquatt_common/PsramBuffer.h
+++ b/components/openquatt_common/PsramBuffer.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdlib>
+
+#include "esphome/core/helpers.h"
+
+namespace esphome::openquatt_common {
+
+/// Simple PSRAM-backed buffer for large, long-lived OpenQuatt history arrays.
+/// Allocates from external RAM only and frees with free().
+template<typename T> class PsramBuffer {
+ public:
+  PsramBuffer() = default;
+  ~PsramBuffer() { this->release(); }
+
+  PsramBuffer(const PsramBuffer &) = delete;
+  PsramBuffer &operator=(const PsramBuffer &) = delete;
+
+  bool allocate(size_t count) {
+    this->release();
+    if (count == 0) {
+      return true;
+    }
+
+    RAMAllocator<T> allocator(RAMAllocator<T>::ALLOC_EXTERNAL);
+    this->data_ = allocator.allocate(count);
+    if (this->data_ == nullptr) {
+      return false;
+    }
+
+    this->size_ = count;
+    return true;
+  }
+
+  void release() {
+    if (this->data_ != nullptr) {
+      free(this->data_);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+      this->data_ = nullptr;
+    }
+    this->size_ = 0;
+  }
+
+  T *data() { return this->data_; }
+  const T *data() const { return this->data_; }
+  size_t size() const { return this->size_; }
+  explicit operator bool() const { return this->data_ != nullptr; }
+
+  T &operator[](size_t index) { return this->data_[index]; }
+  const T &operator[](size_t index) const { return this->data_[index]; }
+
+ private:
+  T *data_{nullptr};
+  size_t size_{0};
+};
+
+}  // namespace esphome::openquatt_common

--- a/components/openquatt_common/PsramBuffer.h
+++ b/components/openquatt_common/PsramBuffer.h
@@ -7,8 +7,8 @@
 
 namespace esphome::openquatt_common {
 
-/// Simple PSRAM-backed buffer for large, long-lived OpenQuatt history arrays.
-/// Allocates from external RAM only and frees with free().
+/// Large OpenQuatt history buffer that prefers PSRAM but falls back to internal RAM
+/// when PSRAM is not available on the target hardware.
 template<typename T> class PsramBuffer {
  public:
   PsramBuffer() = default;
@@ -23,10 +23,17 @@ template<typename T> class PsramBuffer {
       return true;
     }
 
-    RAMAllocator<T> allocator(RAMAllocator<T>::ALLOC_EXTERNAL);
-    this->data_ = allocator.allocate(count);
+    RAMAllocator<T> external_allocator(RAMAllocator<T>::ALLOC_EXTERNAL);
+    this->data_ = external_allocator.allocate(count);
     if (this->data_ == nullptr) {
-      return false;
+      RAMAllocator<T> internal_allocator(RAMAllocator<T>::ALLOC_INTERNAL);
+      this->data_ = internal_allocator.allocate(count);
+      this->external_ = false;
+      if (this->data_ == nullptr) {
+        return false;
+      }
+    } else {
+      this->external_ = true;
     }
 
     this->size_ = count;
@@ -39,11 +46,13 @@ template<typename T> class PsramBuffer {
       this->data_ = nullptr;
     }
     this->size_ = 0;
+    this->external_ = false;
   }
 
   T *data() { return this->data_; }
   const T *data() const { return this->data_; }
   size_t size() const { return this->size_; }
+  bool is_external() const { return this->external_; }
   explicit operator bool() const { return this->data_ != nullptr; }
 
   T &operator[](size_t index) { return this->data_[index]; }
@@ -52,6 +61,7 @@ template<typename T> class PsramBuffer {
  private:
   T *data_{nullptr};
   size_t size_{0};
+  bool external_{false};
 };
 
 }  // namespace esphome::openquatt_common

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -17,7 +17,7 @@ namespace {
 
 class ChunkedJsonWriter {
  public:
-  explicit ChunkedJsonWriter(httpd_req_t *req) : req_(req) {}
+  explicit ChunkedJsonWriter(httpd_req_t *req) : req_(req) { this->buffer_.allocate(BUFFER_SIZE); }
 
   bool write_char(char c) { return this->write_bytes_(&c, 1); }
 
@@ -104,7 +104,8 @@ class ChunkedJsonWriter {
     if (this->used_ == 0) {
       return true;
     }
-    if (httpd_resp_send_chunk(this->req_, this->buffer_, static_cast<ssize_t>(this->used_)) != ESP_OK) {
+    if (!this->buffer_ ||
+        httpd_resp_send_chunk(this->req_, this->buffer_.data(), static_cast<ssize_t>(this->used_)) != ESP_OK) {
       return false;
     }
     this->used_ = 0;
@@ -115,6 +116,9 @@ class ChunkedJsonWriter {
   static constexpr size_t BUFFER_SIZE = 512;
 
   bool write_bytes_(const char *data, size_t len) {
+    if (!this->buffer_) {
+      return false;
+    }
     if (data == nullptr || len == 0) {
       return true;
     }
@@ -128,7 +132,7 @@ class ChunkedJsonWriter {
 
       const size_t space = BUFFER_SIZE - this->used_;
       const size_t to_copy = std::min(space, remaining);
-      std::memcpy(this->buffer_ + this->used_, cursor, to_copy);
+      std::memcpy(this->buffer_.data() + this->used_, cursor, to_copy);
       this->used_ += to_copy;
       cursor += to_copy;
       remaining -= to_copy;
@@ -142,7 +146,7 @@ class ChunkedJsonWriter {
   }
 
   httpd_req_t *req_;
-  char buffer_[BUFFER_SIZE]{};
+  PsramBuffer<char> buffer_{};
   size_t used_{0};
 };
 

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -181,7 +181,7 @@ class OpenQuattLogHistoryRequestHandler : public AsyncWebHandler {
 
 float OpenQuattLogHistory::get_setup_priority() const { return setup_priority::WIFI; }
 
-bool OpenQuattLogHistory::capture_enabled_() const { return this->enabled_; }
+bool OpenQuattLogHistory::capture_enabled_() const { return this->enabled_ && this->entries_; }
 
 bool OpenQuattLogHistory::time_is_valid_() const { return this->clock_ != nullptr && this->clock_->now().is_valid(); }
 
@@ -330,6 +330,9 @@ void OpenQuattLogHistory::split_log_fields_(const char *raw, const char **tag_st
 }
 
 void OpenQuattLogHistory::push_entry_(const LogEntry &entry) {
+  if (!this->entries_) {
+    return;
+  }
   if (ENTRY_CAPACITY == 0) {
     return;
   }
@@ -407,6 +410,10 @@ void OpenQuattLogHistory::setup() {
     this->enabled_ = this->enabled_switch_->state;
   }
 
+  if (!this->entries_.allocate(ENTRY_CAPACITY)) {
+    ESP_LOGE(TAG, "Failed to allocate log history buffer in PSRAM");
+  }
+
   logger::global_logger->add_log_callback(this, [](void *self, uint8_t level, const char *tag, const char *message,
                                                    size_t message_len) {
     static_cast<OpenQuattLogHistory *>(self)->on_log_(level, tag, message, message_len);
@@ -424,6 +431,7 @@ void OpenQuattLogHistory::dump_config() {
   ESP_LOGCONFIG(TAG, "  Clock: %s", this->clock_ == nullptr ? "<missing>" : "configured");
   ESP_LOGCONFIG(TAG, "  Enabled: %s", YESNO(this->enabled_));
   ESP_LOGCONFIG(TAG, "  Entries: %u / %u", static_cast<unsigned>(this->count_), static_cast<unsigned>(ENTRY_CAPACITY));
+  ESP_LOGCONFIG(TAG, "  PSRAM buffer: %s", this->entries_ ? "allocated" : "missing");
 }
 
 void OpenQuattLogHistory::write_recent_logs(httpd_req_t *req) const {

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -431,7 +431,7 @@ void OpenQuattLogHistory::dump_config() {
   ESP_LOGCONFIG(TAG, "  Clock: %s", this->clock_ == nullptr ? "<missing>" : "configured");
   ESP_LOGCONFIG(TAG, "  Enabled: %s", YESNO(this->enabled_));
   ESP_LOGCONFIG(TAG, "  Entries: %u / %u", static_cast<unsigned>(this->count_), static_cast<unsigned>(ENTRY_CAPACITY));
-  ESP_LOGCONFIG(TAG, "  PSRAM buffer: %s", this->entries_ ? "allocated" : "missing");
+  ESP_LOGCONFIG(TAG, "  History buffer: %s", !this->entries_ ? "missing" : (this->entries_.is_external() ? "PSRAM" : "internal"));
 }
 
 void OpenQuattLogHistory::write_recent_logs(httpd_req_t *req) const {

--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -6,6 +6,7 @@
 
 #include <esp_http_server.h>
 
+#include "../openquatt_common/PsramBuffer.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/components/web_server_base/web_server_base.h"
@@ -44,7 +45,7 @@ class OpenQuattLogHistory : public Component {
   bool time_rebased_{false};
   switch_::Switch *enabled_switch_{nullptr};
   time::RealTimeClock *clock_{nullptr};
-  std::array<LogEntry, ENTRY_CAPACITY> entries_{};
+  openquatt_common::PsramBuffer<LogEntry> entries_{};
   size_t head_{0};
   size_t count_{0};
   uint32_t next_seq_{1};

--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -6,7 +6,7 @@
 
 #include <esp_http_server.h>
 
-#include "../openquatt_common/PsramBuffer.h"
+#include "PsramBuffer.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/components/web_server_base/web_server_base.h"
@@ -45,7 +45,7 @@ class OpenQuattLogHistory : public Component {
   bool time_rebased_{false};
   switch_::Switch *enabled_switch_{nullptr};
   time::RealTimeClock *clock_{nullptr};
-  openquatt_common::PsramBuffer<LogEntry> entries_{};
+  PsramBuffer<LogEntry> entries_{};
   size_t head_{0};
   size_t count_{0};
   uint32_t next_seq_{1};

--- a/components/openquatt_log_history/PsramBuffer.h
+++ b/components/openquatt_log_history/PsramBuffer.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdlib>
+
+#include "esphome/core/helpers.h"
+
+namespace esphome::openquatt_log_history {
+
+template<typename T> class PsramBuffer {
+ public:
+  PsramBuffer() = default;
+  ~PsramBuffer() { this->release(); }
+
+  PsramBuffer(const PsramBuffer &) = delete;
+  PsramBuffer &operator=(const PsramBuffer &) = delete;
+
+  bool allocate(size_t count) {
+    this->release();
+    if (count == 0) {
+      return true;
+    }
+
+    RAMAllocator<T> external_allocator(RAMAllocator<T>::ALLOC_EXTERNAL);
+    this->data_ = external_allocator.allocate(count);
+    if (this->data_ == nullptr) {
+      RAMAllocator<T> internal_allocator(RAMAllocator<T>::ALLOC_INTERNAL);
+      this->data_ = internal_allocator.allocate(count);
+      this->external_ = false;
+      if (this->data_ == nullptr) {
+        return false;
+      }
+    } else {
+      this->external_ = true;
+    }
+
+    this->size_ = count;
+    return true;
+  }
+
+  void release() {
+    if (this->data_ != nullptr) {
+      free(this->data_);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+      this->data_ = nullptr;
+    }
+    this->size_ = 0;
+    this->external_ = false;
+  }
+
+  T *data() { return this->data_; }
+  const T *data() const { return this->data_; }
+  size_t size() const { return this->size_; }
+  bool is_external() const { return this->external_; }
+  explicit operator bool() const { return this->data_ != nullptr; }
+
+  T &operator[](size_t index) { return this->data_[index]; }
+  const T &operator[](size_t index) const { return this->data_[index]; }
+
+ private:
+  T *data_{nullptr};
+  size_t size_{0};
+  bool external_{false};
+};
+
+}  // namespace esphome::openquatt_log_history

--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -55,30 +55,37 @@ uint32_t parse_window_hours_from_url(const char *url) {
 
 class ChunkedTextWriter {
  public:
-  explicit ChunkedTextWriter(httpd_req_t *req) : req_(req) {}
+  explicit ChunkedTextWriter(httpd_req_t *req) : req_(req) {
+    this->buffer_.allocate(BUFFER_SIZE);
+    this->scratch_.allocate(SCRATCH_SIZE);
+  }
 
   bool printf(const char *format, ...) {
+    if (!this->buffer_ || !this->scratch_) {
+      return false;
+    }
     va_list args;
     va_start(args, format);
-    const int written = std::vsnprintf(this->scratch_, sizeof(this->scratch_), format, args);
+    const int written = std::vsnprintf(this->scratch_.data(), this->scratch_.size(), format, args);
     va_end(args);
     if (written < 0) {
       return false;
     }
-    if (static_cast<size_t>(written) < sizeof(this->scratch_)) {
-      return this->write_bytes_(this->scratch_, static_cast<size_t>(written));
+    if (static_cast<size_t>(written) < this->scratch_.size()) {
+      return this->write_bytes_(this->scratch_.data(), static_cast<size_t>(written));
     }
 
     // Trend lines are intentionally compact. If this ever grows, truncate the
     // single line instead of allocating a dynamic buffer on the heap.
-    return this->write_bytes_(this->scratch_, sizeof(this->scratch_) - 1);
+    return this->write_bytes_(this->scratch_.data(), this->scratch_.size() - 1);
   }
 
   bool flush() {
     if (this->used_ == 0) {
       return true;
     }
-    if (httpd_resp_send_chunk(this->req_, this->buffer_, static_cast<ssize_t>(this->used_)) != ESP_OK) {
+    if (!this->buffer_ ||
+        httpd_resp_send_chunk(this->req_, this->buffer_.data(), static_cast<ssize_t>(this->used_)) != ESP_OK) {
       return false;
     }
     this->used_ = 0;
@@ -90,6 +97,9 @@ class ChunkedTextWriter {
   static constexpr size_t SCRATCH_SIZE = 160;
 
   bool write_bytes_(const char *data, size_t len) {
+    if (!this->buffer_) {
+      return false;
+    }
     size_t remaining = len;
     const char *cursor = data;
     while (remaining > 0) {
@@ -98,7 +108,7 @@ class ChunkedTextWriter {
       }
       const size_t space = BUFFER_SIZE - this->used_;
       const size_t to_copy = std::min(space, remaining);
-      std::memcpy(this->buffer_ + this->used_, cursor, to_copy);
+      std::memcpy(this->buffer_.data() + this->used_, cursor, to_copy);
       this->used_ += to_copy;
       cursor += to_copy;
       remaining -= to_copy;
@@ -107,8 +117,8 @@ class ChunkedTextWriter {
   }
 
   httpd_req_t *req_;
-  char buffer_[BUFFER_SIZE]{};
-  char scratch_[SCRATCH_SIZE]{};
+  PsramBuffer<char> buffer_{};
+  PsramBuffer<char> scratch_{};
   size_t used_{0};
 };
 

--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -149,6 +149,10 @@ void OpenQuattTrends::setup() {
     return;
   }
 
+  if (!this->ram_history_.allocate(RAM_CAPACITY)) {
+    ESP_LOGE(TAG, "Failed to allocate trend history buffer in PSRAM");
+  }
+
   this->flash_partition_ = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "openquatt_data");
   if (this->flash_partition_ == nullptr) {
     ESP_LOGW(TAG, "Trend flash partition 'openquatt_data' not found");
@@ -193,6 +197,7 @@ void OpenQuattTrends::dump_config() {
   ESP_LOGCONFIG(TAG, "  Clock: %s", this->clock_ == nullptr ? "<missing>" : "configured");
   ESP_LOGCONFIG(TAG, "  Flash partition: %s", this->flash_partition_ == nullptr ? "<missing>" : "configured");
   ESP_LOGCONFIG(TAG, "  RAM samples: %u / %u", static_cast<unsigned>(this->ram_count_), static_cast<unsigned>(RAM_CAPACITY));
+  ESP_LOGCONFIG(TAG, "  PSRAM buffer: %s", this->ram_history_ ? "allocated" : "missing");
   ESP_LOGCONFIG(TAG, "  Flash enabled: %s", YESNO(this->flash_enabled_));
   ESP_LOGCONFIG(TAG, "  Flash archive scanned: %s", YESNO(this->flash_archive_scanned_));
 }
@@ -200,7 +205,7 @@ void OpenQuattTrends::dump_config() {
 float OpenQuattTrends::get_setup_priority() const { return setup_priority::WIFI; }
 
 bool OpenQuattTrends::capture_enabled_() const {
-  return this->capture_switch_ != nullptr && this->capture_switch_->state;
+  return this->ram_history_ && this->capture_switch_ != nullptr && this->capture_switch_->state;
 }
 
 bool OpenQuattTrends::flash_switch_enabled_() const {
@@ -289,6 +294,9 @@ void OpenQuattTrends::rebase_ram_history_(uint64_t offset_ms) {
   if (offset_ms == 0) {
     return;
   }
+  if (!this->ram_history_) {
+    return;
+  }
 
   for (size_t i = 0; i < this->ram_count_; ++i) {
     const size_t index = (this->ram_head_ + i) % RAM_CAPACITY;
@@ -319,7 +327,7 @@ void OpenQuattTrends::sync_time_state_() {
 }
 
 void OpenQuattTrends::load_archive_if_needed_() {
-  if (!this->flash_enabled_ || this->flash_partition_ == nullptr || !this->time_is_valid_()) {
+  if (!this->ram_history_ || !this->flash_enabled_ || this->flash_partition_ == nullptr || !this->time_is_valid_()) {
     return;
   }
 
@@ -337,6 +345,9 @@ void OpenQuattTrends::load_archive_if_needed_() {
 }
 
 void OpenQuattTrends::push_ram_sample_(const TrendSample &sample) {
+  if (!this->ram_history_) {
+    return;
+  }
   if (RAM_CAPACITY == 0) {
     return;
   }
@@ -351,7 +362,7 @@ void OpenQuattTrends::push_ram_sample_(const TrendSample &sample) {
 }
 
 bool OpenQuattTrends::get_ram_sample_at_(size_t ordered_index, TrendSample *sample) const {
-  if (sample == nullptr || ordered_index >= this->ram_count_) {
+  if (sample == nullptr || !this->ram_history_ || ordered_index >= this->ram_count_) {
     return false;
   }
   const size_t index = (this->ram_head_ + ordered_index) % RAM_CAPACITY;
@@ -397,6 +408,9 @@ bool OpenQuattTrends::scan_flash_archive_() {
 }
 
 bool OpenQuattTrends::merge_flash_history_into_ram_() {
+  if (!this->ram_history_) {
+    return false;
+  }
   if (!this->flash_archive_scanned_) {
     if (!this->scan_flash_archive_()) {
       return false;

--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -197,7 +197,8 @@ void OpenQuattTrends::dump_config() {
   ESP_LOGCONFIG(TAG, "  Clock: %s", this->clock_ == nullptr ? "<missing>" : "configured");
   ESP_LOGCONFIG(TAG, "  Flash partition: %s", this->flash_partition_ == nullptr ? "<missing>" : "configured");
   ESP_LOGCONFIG(TAG, "  RAM samples: %u / %u", static_cast<unsigned>(this->ram_count_), static_cast<unsigned>(RAM_CAPACITY));
-  ESP_LOGCONFIG(TAG, "  PSRAM buffer: %s", this->ram_history_ ? "allocated" : "missing");
+  ESP_LOGCONFIG(TAG, "  RAM history buffer: %s",
+                !this->ram_history_ ? "missing" : (this->ram_history_.is_external() ? "PSRAM" : "internal"));
   ESP_LOGCONFIG(TAG, "  Flash enabled: %s", YESNO(this->flash_enabled_));
   ESP_LOGCONFIG(TAG, "  Flash archive scanned: %s", YESNO(this->flash_archive_scanned_));
 }

--- a/components/openquatt_trends/OpenQuattTrends.h
+++ b/components/openquatt_trends/OpenQuattTrends.h
@@ -6,6 +6,7 @@
 
 #include <esp_http_server.h>
 #include "esp_partition.h"
+#include "../openquatt_common/PsramBuffer.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/components/web_server_base/web_server_base.h"
@@ -174,7 +175,7 @@ class OpenQuattTrends : public Component {
   uint64_t flash_last_flush_timestamp_ms_{0};
   uint16_t flash_valid_block_count_{0};
 
-  std::array<TrendSample, RAM_CAPACITY> ram_history_{};
+  openquatt_common::PsramBuffer<TrendSample> ram_history_{};
   size_t ram_head_{0};
   size_t ram_count_{0};
 

--- a/components/openquatt_trends/OpenQuattTrends.h
+++ b/components/openquatt_trends/OpenQuattTrends.h
@@ -6,7 +6,7 @@
 
 #include <esp_http_server.h>
 #include "esp_partition.h"
-#include "../openquatt_common/PsramBuffer.h"
+#include "PsramBuffer.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/components/web_server_base/web_server_base.h"
@@ -175,7 +175,7 @@ class OpenQuattTrends : public Component {
   uint64_t flash_last_flush_timestamp_ms_{0};
   uint16_t flash_valid_block_count_{0};
 
-  openquatt_common::PsramBuffer<TrendSample> ram_history_{};
+  PsramBuffer<TrendSample> ram_history_{};
   size_t ram_head_{0};
   size_t ram_count_{0};
 

--- a/components/openquatt_trends/PsramBuffer.h
+++ b/components/openquatt_trends/PsramBuffer.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdlib>
+
+#include "esphome/core/helpers.h"
+
+namespace esphome::openquatt_trends {
+
+template<typename T> class PsramBuffer {
+ public:
+  PsramBuffer() = default;
+  ~PsramBuffer() { this->release(); }
+
+  PsramBuffer(const PsramBuffer &) = delete;
+  PsramBuffer &operator=(const PsramBuffer &) = delete;
+
+  bool allocate(size_t count) {
+    this->release();
+    if (count == 0) {
+      return true;
+    }
+
+    RAMAllocator<T> external_allocator(RAMAllocator<T>::ALLOC_EXTERNAL);
+    this->data_ = external_allocator.allocate(count);
+    if (this->data_ == nullptr) {
+      RAMAllocator<T> internal_allocator(RAMAllocator<T>::ALLOC_INTERNAL);
+      this->data_ = internal_allocator.allocate(count);
+      this->external_ = false;
+      if (this->data_ == nullptr) {
+        return false;
+      }
+    } else {
+      this->external_ = true;
+    }
+
+    this->size_ = count;
+    return true;
+  }
+
+  void release() {
+    if (this->data_ != nullptr) {
+      free(this->data_);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+      this->data_ = nullptr;
+    }
+    this->size_ = 0;
+    this->external_ = false;
+  }
+
+  T *data() { return this->data_; }
+  const T *data() const { return this->data_; }
+  size_t size() const { return this->size_; }
+  bool is_external() const { return this->external_; }
+  explicit operator bool() const { return this->data_ != nullptr; }
+
+  T &operator[](size_t index) { return this->data_[index]; }
+  const T &operator[](size_t index) const { return this->data_[index]; }
+
+ private:
+  T *data_{nullptr};
+  size_t size_{0};
+  bool external_{false};
+};
+
+}  // namespace esphome::openquatt_trends


### PR DESCRIPTION
Move the large OpenQuatt trend and log history ring buffers into PSRAM on Waveshare builds.

What changes:
- Allocate the trends RAM history buffer from PSRAM
- Allocate the log history ring buffer from PSRAM
- Keep the existing response behavior if PSRAM allocation is unavailable
- Add a small reusable PSRAM buffer helper for these components

This keeps the implementation inside OpenQuatt components and avoids touching ESPHome core.