### PR TITLE
Keep flow feedback fast while reducing web and Modbus pressure

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -712,6 +712,7 @@ sensor:
     icon: mdi:water-pump
     register_type: holding
     address: 2138
+    force_new_range: true
     #skip_updates: 0
     unit_of_measurement: "L/h"
     device_class: "volume_flow_rate"

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -185,7 +185,7 @@ ha_cooling_room_6_humidity_entity_id: "sensor.openquatt_ext_cooling_room_6_humid
 # HP IO (MODBUS POLLING)
 # ----------------------------
 oq_modbus_update_interval_s: "5"                    # Base Modbus controller polling interval [s].
-oq_modbus_command_throttle_ms: "300"                 # Minimum spacing between Modbus commands [ms].
+oq_modbus_command_throttle_ms: "500"                 # Minimum spacing between Modbus commands [ms].
 oq_modbus_max_cmd_retries: "1"                       # Retries per Modbus command; keep low to avoid long blocking on bad links.
 oq_modbus_startup_delay_ms: "0"                      # Default startup offset for staged Modbus polling [ms].
 oq_skip_10s: "1"                                      # 1 skip; effective polling every 10s.

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -11,6 +11,7 @@ const LOGO_MARKUP = `
   };
   const OFFICIAL_ESPHOME_UI_URL = "https://oi.esphome.io/v3/www.js";
   const ENTITY_REFRESH_CONCURRENCY = 4;
+  const TREND_HISTORY_REFRESH_INTERVAL_MS = 60000;
   const STRATEGY_OPTION_POWER_HOUSE = "Power House";
   const STRATEGY_OPTION_CURVE = "Water Temperature Control (heating curve)";
 
@@ -708,6 +709,8 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     trendHistoryError: "",
     trendHistorySignature: "",
     trendHistoryNowMs: Number.NaN,
+    trendHistoryLastFetchAt: 0,
+    trendHistoryFetchPromise: null,
     deviceReconnectMode: "",
     deviceReconnectStartedAt: 0,
     deviceReconnectLastError: "",
@@ -3756,20 +3759,31 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     );
   }
 
-  async function refreshTrendHistoryData() {
+  async function refreshTrendHistoryData(options = {}) {
     if (!isTrendHistoryEnabled()) {
       const changed = Boolean(state.trendHistoryRaw || state.trendHistoryError);
       state.trendHistoryRaw = "";
       state.trendHistoryError = "";
       state.trendHistorySignature = "";
       state.trendHistoryNowMs = Number.NaN;
+      state.trendHistoryLastFetchAt = 0;
       return changed;
     }
     if (isDevPreviewEnvironmentForFetches()) {
       return false;
     }
 
-    try {
+    const force = options.force === true;
+    const now = Date.now();
+    if (!force && state.trendHistoryFetchPromise) {
+      return state.trendHistoryFetchPromise;
+    }
+    if (!force && (state.trendHistoryRaw || state.trendHistoryError) &&
+        (now - Number(state.trendHistoryLastFetchAt || 0)) < TREND_HISTORY_REFRESH_INTERVAL_MS) {
+      return false;
+    }
+
+    state.trendHistoryFetchPromise = (async () => {
       const windowHours = normalizeTrendWindowHours(state.trendWindowHours || DEFAULT_TREND_WINDOW_HOURS);
       if (windowHours !== state.trendWindowHours) {
         setTrendWindowHours(windowHours);
@@ -3798,7 +3812,12 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       state.trendHistoryError = "";
       state.trendHistorySignature = signature;
       state.trendHistoryNowMs = Number.isFinite(nowMs) ? nowMs : Number.NaN;
+      state.trendHistoryLastFetchAt = Date.now();
       return changed;
+    })();
+
+    try {
+      return await state.trendHistoryFetchPromise;
     } catch (error) {
       const nextError = `Trendhistorie kon niet worden geladen. ${error.message}`;
       const changed = state.trendHistoryError !== nextError;
@@ -3806,7 +3825,10 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       state.trendHistoryRaw = "";
       state.trendHistorySignature = "";
       state.trendHistoryNowMs = Number.NaN;
+      state.trendHistoryLastFetchAt = Date.now();
       return changed;
+    } finally {
+      state.trendHistoryFetchPromise = null;
     }
   }
 
@@ -3832,7 +3854,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     try {
       await refreshEntities(keys, "all");
       if (state.appView === "overview" || state.appView === "trends") {
-        await refreshTrendHistoryData();
+        await refreshTrendHistoryData({ force: true });
       }
       await refreshAuthStatus();
     } finally {
@@ -4165,7 +4187,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       }
       setTrendWindowHours(Number(button.dataset.trendHours || 24));
       render();
-      void refreshTrendHistoryData().then((changed) => {
+      void refreshTrendHistoryData({ force: true }).then((changed) => {
         if (changed) {
           render();
         }

--- a/openquatt/web/js/src/00-config.js
+++ b/openquatt/web/js/src/00-config.js
@@ -7,6 +7,7 @@ const LOGO_MARKUP = `
   };
   const OFFICIAL_ESPHOME_UI_URL = "https://oi.esphome.io/v3/www.js";
   const ENTITY_REFRESH_CONCURRENCY = 4;
+  const TREND_HISTORY_REFRESH_INTERVAL_MS = 60000;
   const STRATEGY_OPTION_POWER_HOUSE = "Power House";
   const STRATEGY_OPTION_CURVE = "Water Temperature Control (heating curve)";
 

--- a/openquatt/web/js/src/01-runtime.js
+++ b/openquatt/web/js/src/01-runtime.js
@@ -25,6 +25,8 @@
     trendHistoryError: "",
     trendHistorySignature: "",
     trendHistoryNowMs: Number.NaN,
+    trendHistoryLastFetchAt: 0,
+    trendHistoryFetchPromise: null,
     deviceReconnectMode: "",
     deviceReconnectStartedAt: 0,
     deviceReconnectLastError: "",

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -905,20 +905,31 @@
     );
   }
 
-  async function refreshTrendHistoryData() {
+  async function refreshTrendHistoryData(options = {}) {
     if (!isTrendHistoryEnabled()) {
       const changed = Boolean(state.trendHistoryRaw || state.trendHistoryError);
       state.trendHistoryRaw = "";
       state.trendHistoryError = "";
       state.trendHistorySignature = "";
       state.trendHistoryNowMs = Number.NaN;
+      state.trendHistoryLastFetchAt = 0;
       return changed;
     }
     if (isDevPreviewEnvironmentForFetches()) {
       return false;
     }
 
-    try {
+    const force = options.force === true;
+    const now = Date.now();
+    if (!force && state.trendHistoryFetchPromise) {
+      return state.trendHistoryFetchPromise;
+    }
+    if (!force && (state.trendHistoryRaw || state.trendHistoryError) &&
+        (now - Number(state.trendHistoryLastFetchAt || 0)) < TREND_HISTORY_REFRESH_INTERVAL_MS) {
+      return false;
+    }
+
+    state.trendHistoryFetchPromise = (async () => {
       const windowHours = normalizeTrendWindowHours(state.trendWindowHours || DEFAULT_TREND_WINDOW_HOURS);
       if (windowHours !== state.trendWindowHours) {
         setTrendWindowHours(windowHours);
@@ -947,7 +958,12 @@
       state.trendHistoryError = "";
       state.trendHistorySignature = signature;
       state.trendHistoryNowMs = Number.isFinite(nowMs) ? nowMs : Number.NaN;
+      state.trendHistoryLastFetchAt = Date.now();
       return changed;
+    })();
+
+    try {
+      return await state.trendHistoryFetchPromise;
     } catch (error) {
       const nextError = `Trendhistorie kon niet worden geladen. ${error.message}`;
       const changed = state.trendHistoryError !== nextError;
@@ -955,7 +971,10 @@
       state.trendHistoryRaw = "";
       state.trendHistorySignature = "";
       state.trendHistoryNowMs = Number.NaN;
+      state.trendHistoryLastFetchAt = Date.now();
       return changed;
+    } finally {
+      state.trendHistoryFetchPromise = null;
     }
   }
 
@@ -981,7 +1000,7 @@
     try {
       await refreshEntities(keys, "all");
       if (state.appView === "overview" || state.appView === "trends") {
-        await refreshTrendHistoryData();
+        await refreshTrendHistoryData({ force: true });
       }
       await refreshAuthStatus();
     } finally {
@@ -1314,7 +1333,7 @@
       }
       setTrendWindowHours(Number(button.dataset.trendHours || 24));
       render();
-      void refreshTrendHistoryData().then((changed) => {
+      void refreshTrendHistoryData({ force: true }).then((changed) => {
         if (changed) {
           render();
         }


### PR DESCRIPTION
## Summary
- keep the Modbus base cadence at 5s for responsive flow control
- increase Modbus command spacing to 500ms and isolate HP flow register 2138 into its own range
- throttle web trend-history fetches to once per minute after the initial/forced load

## Why
The global 10s Modbus test made the bus calmer, but it also slowed register 2138 flow feedback and made the flow controller less able to settle cleanly at the 800 L/h setpoint. The app-open CRC bursts pointed to web trend-history refresh load disturbing Modbus timing, so this keeps the control feedback fast and reduces web/API pressure instead.

## Validation
- `node openquatt/web/build-assets.mjs`
- `node --check openquatt/web/js/openquatt-app.js`
- `esphome compile openquatt_duo_waveshare.yaml`
- OTA tested on the Waveshare Duo device, build `2026-05-05 08:26:47 +0200`, config hash `0x2a82e637`
- observed flow returning directly and stably to target after forcing CM1
- observed no CRC burst, duplicate Modbus command, HP offline flap, or post-boot Modbus timeout in the shared test log