### PR TITLE
Only open live log stream while viewing logs

### DIFF
--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -5685,7 +5685,7 @@ function syncWebServerLogStream() {
     return;
   }
 
-  const shouldConnect = state.mounted && !state.nativeOpen;
+  const shouldConnect = state.mounted && !state.nativeOpen && state.systemModal === "webserver-logs";
   if (!shouldConnect) {
     closeWebServerLogStream();
     return;

--- a/openquatt/web/js/src/06-webserver-logs.js
+++ b/openquatt/web/js/src/06-webserver-logs.js
@@ -379,7 +379,7 @@ function syncWebServerLogStream() {
     return;
   }
 
-  const shouldConnect = state.mounted && !state.nativeOpen;
+  const shouldConnect = state.mounted && !state.nativeOpen && state.systemModal === "webserver-logs";
   if (!shouldConnect) {
     closeWebServerLogStream();
     return;


### PR DESCRIPTION
## Summary
- only connect the web app `/events` live log stream while the OpenQuatt log modal is open
- close the stream again when the modal is not visible

## Why
Testing showed ordinary overview/trends tabs no longer need to keep the ESPHome live log stream open. Keeping `/events` connected in every app tab adds avoidable web-server pressure, especially while we are reducing sources of Modbus timing interference.

## Validation
- `node openquatt/web/build-assets.mjs`
- `node --check openquatt/web/js/openquatt-app.js`
- `esphome compile openquatt_duo_waveshare.yaml`
- OTA tested locally on the Waveshare Duo device
- manually verified: ordinary app views work without the live log stream, opening the log modal activates live logs as expected