### PR TITLE
Allow longer RAM log history lines

### DIFF
--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -31,7 +31,7 @@ class OpenQuattLogHistory : public Component {
 
  protected:
   static constexpr size_t ENTRY_CAPACITY = 250;
-  static constexpr size_t RAW_MAX_LEN = 96;
+  static constexpr size_t RAW_MAX_LEN = 224;
 
   struct LogEntry {
     uint16_t seq{0};


### PR DESCRIPTION
## Summary
- increase the RAM log history per-line storage from 96 to 224 bytes
- prevents longer ESPHome/OpenQuatt log lines from being truncated before they reach the web log modal

## Validation
- compiled `openquatt_duo_waveshare.yaml`
- verified factory-bin merge still completes cleanly

## Notes
- the extra storage is allocated in PSRAM for the Waveshare profile
- at 250 entries this adds roughly 32 KB to the history buffer
