### PR TITLE
Improve view-switch responsiveness in the web app

### DIFF
--- a/openquatt/web/css/openquatt-app.css
+++ b/openquatt/web/css/openquatt-app.css
@@ -2553,6 +2553,7 @@ body.oq-surface-native {
   border: 1px solid var(--oq-helper-line);
   border-radius: 18px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(249, 250, 251, 0.98));
+  overflow-anchor: none;
 }
 
 .oq-helper-shell--dark .oq-webserver-log-panel {

--- a/openquatt/web/css/src/10-settings.css
+++ b/openquatt/web/css/src/10-settings.css
@@ -553,6 +553,7 @@
   border: 1px solid var(--oq-helper-line);
   border-radius: 18px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(249, 250, 251, 0.98));
+  overflow-anchor: none;
 }
 
 .oq-helper-shell--dark .oq-webserver-log-panel {

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -35,7 +35,7 @@
     <script>
       window.__OQ_DEV_LOAD_DELAY_MS = 2000;
     </script>
-    <script src="./js/mock-device.js?v=fast-view-3"></script>
-    <script src="./js/openquatt-app.js?v=fast-view-3"></script>
+    <script src="./js/mock-device.js?v=fast-view-4"></script>
+    <script src="./js/openquatt-app.js?v=fast-view-4"></script>
   </body>
 </html>

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -35,7 +35,7 @@
     <script>
       window.__OQ_DEV_LOAD_DELAY_MS = 2000;
     </script>
-    <script src="./js/mock-device.js?v=trend-toggle-3"></script>
-    <script src="./js/openquatt-app.js?v=trend-toggle-3"></script>
+    <script src="./js/mock-device.js?v=fast-view-1"></script>
+    <script src="./js/openquatt-app.js?v=fast-view-1"></script>
   </body>
 </html>

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -35,7 +35,7 @@
     <script>
       window.__OQ_DEV_LOAD_DELAY_MS = 2000;
     </script>
-    <script src="./js/mock-device.js?v=fast-view-2"></script>
-    <script src="./js/openquatt-app.js?v=fast-view-2"></script>
+    <script src="./js/mock-device.js?v=fast-view-3"></script>
+    <script src="./js/openquatt-app.js?v=fast-view-3"></script>
   </body>
 </html>

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -35,7 +35,7 @@
     <script>
       window.__OQ_DEV_LOAD_DELAY_MS = 2000;
     </script>
-    <script src="./js/mock-device.js?v=fast-view-4"></script>
-    <script src="./js/openquatt-app.js?v=fast-view-4"></script>
+    <script src="./js/mock-device.js?v=fast-view-7"></script>
+    <script src="./js/openquatt-app.js?v=fast-view-7"></script>
   </body>
 </html>

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -35,7 +35,7 @@
     <script>
       window.__OQ_DEV_LOAD_DELAY_MS = 2000;
     </script>
-    <script src="./js/mock-device.js?v=fast-view-1"></script>
-    <script src="./js/openquatt-app.js?v=fast-view-1"></script>
+    <script src="./js/mock-device.js?v=fast-view-2"></script>
+    <script src="./js/openquatt-app.js?v=fast-view-2"></script>
   </body>
 </html>

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -771,6 +771,8 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     trendHistoryFetchPromise: null,
     deviceReconnectMode: "",
     deviceReconnectStartedAt: 0,
+    deviceReconnectRecoveryStartedAt: 0,
+    deviceReconnectRecoveryTimer: null,
     deviceReconnectLastError: "",
     entitySyncFailureCount: 0,
     lastEntitySyncAt: 0,
@@ -2039,11 +2041,68 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     return new Promise((resolve) => window.setTimeout(resolve, ms));
   }
 
+  const DEVICE_RECONNECT_RECOVERY_CLEAR_DELAY_MS = 1500;
+
+  function clearDeviceReconnectRecoveryTimer() {
+    if (!state.deviceReconnectRecoveryTimer) {
+      return;
+    }
+    window.clearTimeout(state.deviceReconnectRecoveryTimer);
+    state.deviceReconnectRecoveryTimer = null;
+  }
+
+  function isDeviceReconnectRecovering() {
+    return Number(state.deviceReconnectRecoveryStartedAt || 0) > 0;
+  }
+
+  function getDeviceReconnectPhaseStartedAt() {
+    return isDeviceReconnectRecovering()
+      ? Number(state.deviceReconnectRecoveryStartedAt || 0)
+      : Number(state.deviceReconnectStartedAt || 0);
+  }
+
+  function getDeviceReconnectStatusLabel() {
+    return isDeviceReconnectRecovering() ? "Gegevens verversen" : "Wachten op gegevens";
+  }
+
+  function getDeviceReconnectStatusCopy() {
+    const startedAt = getDeviceReconnectPhaseStartedAt();
+    const elapsedSeconds = startedAt > 0 ? Math.max(0, Math.round((Date.now() - startedAt) / 1000)) : 0;
+    if (isDeviceReconnectRecovering()) {
+      return elapsedSeconds > 0 ? `${elapsedSeconds}s aan het verversen` : "Net weer online";
+    }
+    return elapsedSeconds > 0 ? `${elapsedSeconds}s bezig` : "Net gestart";
+  }
+
+  function markDeviceReconnectRecovered() {
+    if (!state.deviceReconnectMode || isDeviceReconnectRecovering()) {
+      return false;
+    }
+
+    clearDeviceReconnectRecoveryTimer();
+    state.deviceReconnectRecoveryStartedAt = Date.now();
+    state.deviceReconnectLastError = "";
+    state.entitySyncFailureCount = 0;
+
+    const recoveryStartedAt = state.deviceReconnectRecoveryStartedAt;
+    state.deviceReconnectRecoveryTimer = window.setTimeout(() => {
+      if (state.deviceReconnectMode && Number(state.deviceReconnectRecoveryStartedAt || 0) === recoveryStartedAt) {
+        clearDeviceReconnect();
+        render();
+      }
+    }, DEVICE_RECONNECT_RECOVERY_CLEAR_DELAY_MS);
+
+    render();
+    return true;
+  }
+
   function beginDeviceReconnect(mode = "reconnect", error = "") {
     if (!state.deviceReconnectMode) {
       state.deviceReconnectStartedAt = Date.now();
     }
+    clearDeviceReconnectRecoveryTimer();
     state.deviceReconnectMode = mode;
+    state.deviceReconnectRecoveryStartedAt = 0;
     state.deviceReconnectLastError = error ? String(error) : state.deviceReconnectLastError;
     state.systemModal = "";
     state.updateModalOpen = false;
@@ -2051,16 +2110,21 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
   }
 
   function clearDeviceReconnect() {
+    clearDeviceReconnectRecoveryTimer();
     if (!state.deviceReconnectMode && !state.entitySyncFailureCount) {
       return;
     }
     state.deviceReconnectMode = "";
     state.deviceReconnectStartedAt = 0;
+    state.deviceReconnectRecoveryStartedAt = 0;
     state.deviceReconnectLastError = "";
     state.entitySyncFailureCount = 0;
   }
 
   function getDeviceReconnectTitle() {
+    if (isDeviceReconnectRecovering()) {
+      return "OpenQuatt is weer online";
+    }
     if (state.deviceReconnectMode === "ota") {
       return "OpenQuatt wordt bijgewerkt";
     }
@@ -2071,6 +2135,12 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
   }
 
   function getDeviceReconnectCopy() {
+    if (isDeviceReconnectRecovering()) {
+      if (state.deviceReconnectMode === "ota") {
+        return "De update is bijna klaar. We verversen nu de gegevens en het logboek.";
+      }
+      return "De controller reageert weer. We verversen nu de gegevens en het logboek.";
+    }
     if (state.deviceReconnectMode === "ota") {
       return "De controller installeert de update en start daarna opnieuw op. Deze melding verdwijnt zodra de web-app weer gegevens ontvangt.";
     }
@@ -2084,9 +2154,6 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     if (!state.deviceReconnectMode) {
       return "";
     }
-    const startedAt = Number(state.deviceReconnectStartedAt || 0);
-    const elapsedSeconds = startedAt > 0 ? Math.max(0, Math.round((Date.now() - startedAt) / 1000)) : 0;
-    const elapsedCopy = elapsedSeconds > 0 ? `${elapsedSeconds}s bezig` : "Net gestart";
     return `
       <div class="oq-helper-modal-backdrop${state.overviewTheme === "dark" ? " oq-helper-modal-backdrop--dark" : ""}" data-oq-modal="reconnect">
         <section class="oq-helper-modal oq-helper-modal--reconnect" role="status" aria-live="polite" aria-labelledby="oq-reconnect-modal-title">
@@ -2100,8 +2167,8 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
           <div class="oq-helper-reconnect-status">
             <span class="oq-helper-reconnect-spinner" aria-hidden="true"></span>
             <div>
-              <strong>Wachten op gegevens</strong>
-              <span>${escapeHtml(elapsedCopy)}</span>
+              <strong>${escapeHtml(getDeviceReconnectStatusLabel())}</strong>
+              <span>${escapeHtml(getDeviceReconnectStatusCopy())}</span>
             </div>
           </div>
         </section>
@@ -3467,8 +3534,10 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
   function noteEntityRefreshSuccess() {
     state.lastEntitySyncAt = Date.now();
     const wasReconnectActive = Boolean(state.deviceReconnectMode);
-    clearDeviceReconnect();
-    if (wasReconnectActive) {
+    const reconnectRecovered = wasReconnectActive && typeof markDeviceReconnectRecovered === "function"
+      ? markDeviceReconnectRecovered()
+      : false;
+    if (reconnectRecovered) {
       state.lastFastEntitySyncAt = 0;
       state.lastBulkEntitySyncAt = 0;
       state.lastStaticEntitySyncAt = 0;
@@ -6258,6 +6327,9 @@ function resetWebServerLogRecoveryState() {
   state.webServerLogEnabled = null;
   state.webServerLogConnected = false;
   clearWebServerLogOutput();
+  if (state.systemModal === "webserver-logs") {
+    void refreshWebServerLogHistory();
+  }
 }
 
 function syncWebServerLogStream() {

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -11,6 +11,7 @@ const LOGO_MARKUP = `
   };
   const OFFICIAL_ESPHOME_UI_URL = "https://oi.esphome.io/v3/www.js";
   const ENTITY_REFRESH_CONCURRENCY = 2;
+  const FAST_VIEW_ENTITY_REFRESH_CONCURRENCY = 4;
   const TREND_HISTORY_REFRESH_INTERVAL_MS = 60000;
   const STRATEGY_OPTION_POWER_HOUSE = "Power House";
   const STRATEGY_OPTION_CURVE = "Water Temperature Control (heating curve)";
@@ -1074,7 +1075,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       void primeEntities();
       return;
     }
-    void syncEntities({ forceBulk: true });
+    void syncEntities(state.appView === "settings" ? { forceBulk: true } : { forceFast: true });
   }
 
   function normalizeAppView(view) {
@@ -1164,7 +1165,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       }
     }
     render();
-    void syncEntities({ forceBulk: true });
+    void syncEntities(nextView === "settings" ? { forceBulk: true } : { forceFast: true });
   }
 
   function syncNativeVisibility() {
@@ -3282,6 +3283,21 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     return [...new Set(INITIAL_SETTINGS_READY_KEY_MAP[normalized] || INITIAL_SETTINGS_READY_KEY_MAP.installation)];
   }
 
+  function queuePendingEntitySyncOptions(options = {}) {
+    const current = state.pendingEntitySyncOptions || {};
+    const merged = {
+      ...current,
+      ...options,
+    };
+    if (current.forceBulk || options.forceBulk) {
+      merged.forceBulk = true;
+      merged.forceFast = false;
+    } else if (current.forceFast || options.forceFast) {
+      merged.forceFast = true;
+    }
+    state.pendingEntitySyncOptions = merged;
+  }
+
   function hasUsableEntityValue(key) {
     const value = String(getEntityValue(key) ?? "").trim().toLowerCase();
     return value !== "" && value !== "unknown" && value !== "unavailable" && value !== "nan";
@@ -3445,10 +3461,14 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     }
   }
 
-  async function refreshEntities(keys, detail = "state") {
+  async function refreshEntities(keys, detail = "state", options = {}) {
+    const requestedConcurrency = Number(options.concurrency);
+    const concurrency = Number.isFinite(requestedConcurrency) && requestedConcurrency > 0
+      ? Math.floor(requestedConcurrency)
+      : ENTITY_REFRESH_CONCURRENCY;
     const results = [];
-    for (let index = 0; index < keys.length; index += ENTITY_REFRESH_CONCURRENCY) {
-      const batch = keys.slice(index, index + ENTITY_REFRESH_CONCURRENCY);
+    for (let index = 0; index < keys.length; index += concurrency) {
+      const batch = keys.slice(index, index + concurrency);
       const batchResults = await Promise.allSettled(
         batch.map(async (key) => ({ key, payload: await fetchEntityPayload(key, detail) }))
       );
@@ -4171,7 +4191,9 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
 
     state.entitySyncInFlight = true;
     try {
-      await refreshEntities(keys, detail);
+      await refreshEntities(keys, detail, {
+        concurrency: detail === "all" ? ENTITY_REFRESH_CONCURRENCY : FAST_VIEW_ENTITY_REFRESH_CONCURRENCY,
+      });
     } finally {
       state.entitySyncInFlight = false;
       const pendingOptions = state.pendingEntitySyncOptions;
@@ -4217,8 +4239,11 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     }
     const initialKeys = getInitialPrimeKeys();
     const deferredKeys = getDeferredPrimeKeys(initialKeys);
+    const initialDetail = state.appView === "settings" ? "all" : "state";
     try {
-      await refreshEntities(initialKeys, "all");
+      await refreshEntities(initialKeys, initialDetail, {
+        concurrency: initialDetail === "all" ? ENTITY_REFRESH_CONCURRENCY : FAST_VIEW_ENTITY_REFRESH_CONCURRENCY,
+      });
       if (state.appView === "settings") {
         await waitForInitialSettingsReady();
       } else {
@@ -4240,13 +4265,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       return;
     }
     if (state.entitySyncInFlight) {
-      if (options.forceBulk === true) {
-        state.pendingEntitySyncOptions = {
-          ...(state.pendingEntitySyncOptions || {}),
-          ...options,
-          forceBulk: true,
-        };
-      }
+      queuePendingEntitySyncOptions(options);
       return;
     }
 
@@ -4256,15 +4275,16 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     }
 
     const appView = state.appView;
-    const isOverviewLike = appView === "overview" || appView === "trends";
-    const isBulkDue = options.forceBulk === true || (now - Number(state.lastBulkEntitySyncAt || 0)) >= BULK_POLL_INTERVAL_MS;
+    const isOverviewLike = appView === "overview" || appView === "trends" || appView === "energy";
+    const forceFast = options.forceFast === true && !options.forceBulk;
+    const isBulkDue = !forceFast && (options.forceBulk === true || (now - Number(state.lastBulkEntitySyncAt || 0)) >= BULK_POLL_INTERVAL_MS);
     const isStaticDue = (now - Number(state.lastStaticEntitySyncAt || 0)) >= STATIC_POLL_INTERVAL_MS;
     const staticKeys = isStaticDue || state.updateInstallBusy || state.updateInstallPhaseHint
       ? FIRMWARE_ENTITY_KEYS
       : [];
     const keys = isOverviewLike
       ? [
-          ...(isBulkDue ? OVERVIEW_KEYS : FAST_OVERVIEW_KEYS),
+          ...(forceFast ? FAST_OVERVIEW_KEYS : isBulkDue ? OVERVIEW_KEYS : FAST_OVERVIEW_KEYS),
           ...HEADER_ENTITY_KEYS,
           "setupComplete",
           ...staticKeys,
@@ -4287,7 +4307,9 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     state.lastEntitySyncAttemptAt = now;
     try {
       const reconnectModeBefore = state.deviceReconnectMode;
-      await refreshEntities([...new Set(keys)], appView === "settings" ? "all" : "state");
+      await refreshEntities([...new Set(keys)], appView === "settings" ? "all" : "state", {
+        concurrency: forceFast && isOverviewLike ? FAST_VIEW_ENTITY_REFRESH_CONCURRENCY : ENTITY_REFRESH_CONCURRENCY,
+      });
       state.lastFastEntitySyncAt = Date.now();
       if (isBulkDue) {
         state.lastBulkEntitySyncAt = state.lastFastEntitySyncAt;
@@ -4296,10 +4318,13 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
         state.lastStaticEntitySyncAt = state.lastFastEntitySyncAt;
       }
       const reconnectChanged = reconnectModeBefore !== state.deviceReconnectMode;
-      const trendChanged = isOverviewLike
-        ? await refreshTrendHistoryData()
-        : false;
-      const authChanged = await refreshAuthStatus();
+      const shouldDeferSupplementary = forceFast && isOverviewLike;
+      const trendChanged = shouldDeferSupplementary
+        ? false
+        : isOverviewLike
+          ? await refreshTrendHistoryData()
+          : false;
+      const authChanged = shouldDeferSupplementary ? false : await refreshAuthStatus();
       const nextHeaderSignature = getHeaderRenderSignature();
       if (reconnectChanged) {
         render();
@@ -4338,6 +4363,11 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (!patchOverviewDom()) {
         render();
       }
+      if (shouldDeferSupplementary && !state.nativeOpen) {
+        window.setTimeout(() => {
+          void primeSupplementaryData();
+        }, 0);
+      }
     } catch (error) {
       state.controlError = `Helperstatus kon niet worden geladen. ${error.message}`;
       render();
@@ -4348,6 +4378,11 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (pendingOptions && !state.nativeOpen) {
         window.setTimeout(() => {
           void syncEntities(pendingOptions);
+        }, 0);
+      }
+      if (forceFast && isOverviewLike && !state.nativeOpen && !pendingOptions) {
+        window.setTimeout(() => {
+          void syncEntities({ forceBulk: true });
         }, 0);
       }
     }
@@ -4606,9 +4641,10 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if ((button.dataset.viewId || "") === "trends" && !isTrendHistoryEnabled()) {
         return;
       }
-      setAppView(button.dataset.viewId || "overview", { syncMode: "push" });
+      const nextView = button.dataset.viewId || "overview";
+      setAppView(nextView, { syncMode: "push" });
       render();
-      syncEntities({ forceBulk: true });
+      syncEntities(nextView === "settings" ? { forceBulk: true } : { forceFast: true });
       return;
     }
 
@@ -5481,6 +5517,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       }
       state.quickStartModalOpen = action !== "apply";
       setAppView("overview", { syncMode: "replace" });
+      syncEntities({ forceFast: true });
     } catch (error) {
       state.controlError = `Actie mislukt voor "${entity.name}". ${error.message}`;
     } finally {
@@ -6031,22 +6068,10 @@ async function refreshWebServerLogHistory() {
       state.webServerLogHistoryLoading = false;
     }
     if (state.systemModal === "webserver-logs" && state.webServerLogHistoryRequestToken === requestToken) {
-      const scroller = getWebServerLogScrollerElement();
-      const stickToBottom = isWebServerLogScrollerNearBottom(scroller);
-      const previousDistanceFromBottom = scroller ? scroller.scrollHeight - scroller.scrollTop : 0;
       render();
       window.requestAnimationFrame(() => {
         if (state.systemModal === "webserver-logs" && state.webServerLogHistoryRequestToken === requestToken) {
-          const nextScroller = getWebServerLogScrollerElement();
-          if (!nextScroller) {
-            return;
-          }
-          if (stickToBottom) {
-            nextScroller.scrollTop = nextScroller.scrollHeight;
-            return;
-          }
-          const targetScrollTop = nextScroller.scrollHeight - previousDistanceFromBottom;
-          nextScroller.scrollTop = Math.max(0, targetScrollTop);
+          scrollWebServerLogToBottom();
         }
       });
     }

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -3412,9 +3412,39 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     };
   }
 
+  const ENTITY_REQUEST_TIMEOUT_MS = 8000;
+  const RECONNECT_ENTITY_REQUEST_TIMEOUT_MS = 3000;
+
+  function getEntityRequestTimeoutMs() {
+    return state.deviceReconnectMode || state.busyAction === "restartAction" || state.updateInstallBusy || state.updateInstallPhaseHint
+      ? RECONNECT_ENTITY_REQUEST_TIMEOUT_MS
+      : ENTITY_REQUEST_TIMEOUT_MS;
+  }
+
   async function fetchEntityPayload(key, detail = "state") {
     const entity = ENTITY_DEFS[key];
     const url = `${buildEntityPath(entity.domain, entity.name)}${detail === "all" ? "?detail=all" : ""}`;
+    const timeoutMs = getEntityRequestTimeoutMs();
+
+    if (typeof AbortController === "function") {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error(`${entity.name} HTTP ${response.status}`);
+        }
+        return response.json();
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw new Error(`${entity.name} request timed out after ${timeoutMs}ms`);
+        }
+        throw error;
+      } finally {
+        window.clearTimeout(timeoutId);
+      }
+    }
+
     const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`${entity.name} HTTP ${response.status}`);
@@ -3436,7 +3466,26 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
 
   function noteEntityRefreshSuccess() {
     state.lastEntitySyncAt = Date.now();
+    const wasReconnectActive = Boolean(state.deviceReconnectMode);
     clearDeviceReconnect();
+    if (wasReconnectActive) {
+      state.lastFastEntitySyncAt = 0;
+      state.lastBulkEntitySyncAt = 0;
+      state.lastStaticEntitySyncAt = 0;
+      state.trendHistoryRaw = "";
+      state.trendHistoryError = "";
+      state.trendHistorySignature = "";
+      state.trendHistoryNowMs = Number.NaN;
+      state.trendHistoryLastFetchAt = 0;
+      if (typeof resetWebServerLogRecoveryState === "function") {
+        resetWebServerLogRecoveryState();
+      } else {
+        closeWebServerLogStream();
+        clearWebServerLogOutput();
+        state.webServerLogEnabled = null;
+        state.webServerLogConnected = false;
+      }
+    }
   }
 
   function noteEntityRefreshFailure(message) {
@@ -6202,6 +6251,13 @@ function clearWebServerLogOutput() {
   if (state.systemModal === "webserver-logs") {
     render();
   }
+}
+
+function resetWebServerLogRecoveryState() {
+  closeWebServerLogStream();
+  state.webServerLogEnabled = null;
+  state.webServerLogConnected = false;
+  clearWebServerLogOutput();
 }
 
 function syncWebServerLogStream() {

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -4210,6 +4210,30 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     }
   }
 
+  function scheduleOverviewPrefetch() {
+    if (state.nativeOpen || state.appView !== "settings") {
+      return;
+    }
+
+    const run = () => {
+      if (state.nativeOpen || state.appView !== "settings") {
+        return;
+      }
+      if (state.loadingEntities || state.focusedField || state.draggingCurveKey || state.busyAction || state.settingsInteractionLock) {
+        window.setTimeout(scheduleOverviewPrefetch, 250);
+        return;
+      }
+      void syncEntities({ prefetchView: "overview", forceFast: true });
+    };
+
+    if (typeof window.requestIdleCallback === "function") {
+      window.requestIdleCallback(run, { timeout: 2000 });
+      return;
+    }
+
+    window.setTimeout(run, 0);
+  }
+
   async function primeSupplementaryData() {
     if (state.nativeOpen) {
       return;
@@ -4224,6 +4248,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (state.mounted && !state.nativeOpen) {
         render();
       }
+      scheduleOverviewPrefetch();
     }
   }
 
@@ -4275,14 +4300,23 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     }
 
     const appView = state.appView;
-    const isOverviewLike = appView === "overview" || appView === "trends" || appView === "energy";
+    const isPrefetchOverview = options.prefetchView === "overview" && !options.forceBulk && appView === "settings";
+    const syncView = isPrefetchOverview ? "overview" : appView;
+    const isOverviewLike = syncView === "overview" || syncView === "trends" || syncView === "energy";
     const forceFast = options.forceFast === true && !options.forceBulk;
-    const isBulkDue = !forceFast && (options.forceBulk === true || (now - Number(state.lastBulkEntitySyncAt || 0)) >= BULK_POLL_INTERVAL_MS);
+    const isBulkDue = !forceFast && !isPrefetchOverview && (options.forceBulk === true || (now - Number(state.lastBulkEntitySyncAt || 0)) >= BULK_POLL_INTERVAL_MS);
     const isStaticDue = (now - Number(state.lastStaticEntitySyncAt || 0)) >= STATIC_POLL_INTERVAL_MS;
     const staticKeys = isStaticDue || state.updateInstallBusy || state.updateInstallPhaseHint
       ? FIRMWARE_ENTITY_KEYS
       : [];
-    const keys = isOverviewLike
+    const keys = isPrefetchOverview
+      ? [
+          ...FAST_OVERVIEW_KEYS,
+          ...HEADER_ENTITY_KEYS,
+          "setupComplete",
+          ...staticKeys,
+        ]
+      : isOverviewLike
       ? [
           ...(forceFast ? FAST_OVERVIEW_KEYS : isBulkDue ? OVERVIEW_KEYS : FAST_OVERVIEW_KEYS),
           ...HEADER_ENTITY_KEYS,
@@ -4307,7 +4341,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     state.lastEntitySyncAttemptAt = now;
     try {
       const reconnectModeBefore = state.deviceReconnectMode;
-      await refreshEntities([...new Set(keys)], appView === "settings" ? "all" : "state", {
+      await refreshEntities([...new Set(keys)], isPrefetchOverview ? "state" : appView === "settings" ? "all" : "state", {
         concurrency: forceFast && isOverviewLike ? FAST_VIEW_ENTITY_REFRESH_CONCURRENCY : ENTITY_REFRESH_CONCURRENCY,
       });
       state.lastFastEntitySyncAt = Date.now();
@@ -4316,6 +4350,9 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       }
       if (staticKeys.length) {
         state.lastStaticEntitySyncAt = state.lastFastEntitySyncAt;
+      }
+      if (isPrefetchOverview) {
+        return;
       }
       const reconnectChanged = reconnectModeBefore !== state.deviceReconnectMode;
       const shouldDeferSupplementary = forceFast && isOverviewLike;
@@ -4369,8 +4406,10 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
         }, 0);
       }
     } catch (error) {
-      state.controlError = `Helperstatus kon niet worden geladen. ${error.message}`;
-      render();
+      if (!isPrefetchOverview) {
+        state.controlError = `Helperstatus kon niet worden geladen. ${error.message}`;
+        render();
+      }
     } finally {
       state.entitySyncInFlight = false;
       const pendingOptions = state.pendingEntitySyncOptions;
@@ -4380,7 +4419,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
           void syncEntities(pendingOptions);
         }, 0);
       }
-      if (forceFast && isOverviewLike && !state.nativeOpen && !pendingOptions) {
+      if (forceFast && isOverviewLike && !isPrefetchOverview && !state.nativeOpen && !pendingOptions) {
         window.setTimeout(() => {
           void syncEntities({ forceBulk: true });
         }, 0);

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -787,6 +787,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     webServerLogHistoryError: "",
     webServerLogHistoryRequestToken: 0,
     webServerLogHistoryLoaded: false,
+    webServerLogScrollRestoreToken: 0,
     webServerLogCopyMessage: "",
     webServerLogCopyError: "",
     webServerLogRecentTail: [],
@@ -6184,11 +6185,66 @@ function scrollWebServerLogToBottom() {
   scroller.scrollTop = scroller.scrollHeight;
 }
 
-async function refreshWebServerLogHistory() {
+function captureWebServerLogScrollState() {
+  const scroller = getWebServerLogScrollerElement();
+  if (!scroller) {
+    return null;
+  }
+
+  return {
+    scrollHeight: scroller.scrollHeight,
+    scrollTop: scroller.scrollTop,
+    stickToBottom: isWebServerLogScrollerNearBottom(scroller),
+  };
+}
+
+function restoreWebServerLogScrollState(scrollState) {
+  if (!scrollState) {
+    return;
+  }
+
+  const scroller = getWebServerLogScrollerElement();
+  if (!scroller) {
+    return;
+  }
+
+  if (scrollState.stickToBottom) {
+    scroller.scrollTop = scroller.scrollHeight;
+    return;
+  }
+
+  const restoredScrollTop = scrollState.scrollTop + (scroller.scrollHeight - scrollState.scrollHeight);
+  scroller.scrollTop = Math.max(0, restoredScrollTop);
+}
+
+function queueWebServerLogScrollRestore(scrollState, defer = true) {
+  if (!scrollState) {
+    return;
+  }
+
+  const restoreToken = Number(state.webServerLogScrollRestoreToken || 0) + 1;
+  state.webServerLogScrollRestoreToken = restoreToken;
+  const applyScrollState = () => {
+    if (state.webServerLogScrollRestoreToken !== restoreToken || state.systemModal !== "webserver-logs") {
+      return;
+    }
+    restoreWebServerLogScrollState(scrollState);
+  };
+
+  if (defer) {
+    window.requestAnimationFrame(applyScrollState);
+    return;
+  }
+
+  applyScrollState();
+}
+
+async function refreshWebServerLogHistory(options = {}) {
   if (state.nativeOpen || typeof window.fetch !== "function") {
     return;
   }
 
+  const scrollState = options.scrollState || captureWebServerLogScrollState();
   const requestToken = Number(state.webServerLogHistoryRequestToken || 0) + 1;
   state.webServerLogHistoryRequestToken = requestToken;
   state.webServerLogHistoryLoading = true;
@@ -6226,11 +6282,7 @@ async function refreshWebServerLogHistory() {
     }
     if (state.systemModal === "webserver-logs" && state.webServerLogHistoryRequestToken === requestToken) {
       render();
-      window.requestAnimationFrame(() => {
-        if (state.systemModal === "webserver-logs" && state.webServerLogHistoryRequestToken === requestToken) {
-          scrollWebServerLogToBottom();
-        }
-      });
+      queueWebServerLogScrollRestore(scrollState);
     }
   }
 }
@@ -6312,6 +6364,7 @@ function clearWebServerLogOutput() {
   state.webServerLogHistoryError = "";
   state.webServerLogHistoryLoading = false;
   state.webServerLogHistoryLoaded = false;
+  state.webServerLogScrollRestoreToken = Number(state.webServerLogScrollRestoreToken || 0) + 1;
   state.webServerLogCopyMessage = "";
   state.webServerLogCopyError = "";
   state.webServerLogHistoryRequestToken += 1;
@@ -6323,12 +6376,13 @@ function clearWebServerLogOutput() {
 }
 
 function resetWebServerLogRecoveryState() {
+  const scrollState = captureWebServerLogScrollState();
   closeWebServerLogStream();
   state.webServerLogEnabled = null;
   state.webServerLogConnected = false;
   clearWebServerLogOutput();
   if (state.systemModal === "webserver-logs") {
-    void refreshWebServerLogHistory();
+    void refreshWebServerLogHistory({ scrollState });
   }
 }
 
@@ -6407,10 +6461,14 @@ function handleWebServerLogOpen() {
     return;
   }
 
+  const scrollState = state.systemModal === "webserver-logs"
+    ? captureWebServerLogScrollState()
+    : null;
   state.webServerLogEnabled = true;
   state.webServerLogConnected = true;
   state.webServerLogError = "";
   render();
+  queueWebServerLogScrollRestore(scrollState);
 }
 
 function handleWebServerLogPing() {
@@ -6418,11 +6476,15 @@ function handleWebServerLogPing() {
     return;
   }
 
+  const scrollState = state.systemModal === "webserver-logs"
+    ? captureWebServerLogScrollState()
+    : null;
   state.webServerLogEnabled = true;
   if (!state.webServerLogConnected) {
     state.webServerLogConnected = true;
     state.webServerLogError = "";
     render();
+    queueWebServerLogScrollRestore(scrollState);
   }
 }
 
@@ -6431,11 +6493,15 @@ function handleWebServerLogError() {
     return;
   }
 
+  const scrollState = state.systemModal === "webserver-logs"
+    ? captureWebServerLogScrollState()
+    : null;
   state.webServerLogEnabled = false;
   state.webServerLogConnected = false;
   state.webServerLogError = "De live logstream kon niet worden geopend.";
   closeWebServerLogStream();
   render();
+  queueWebServerLogScrollRestore(scrollState);
 }
 
 function handleWebServerLogMessage(event) {
@@ -6443,6 +6509,7 @@ function handleWebServerLogMessage(event) {
     return;
   }
 
+  const scrollState = captureWebServerLogScrollState();
   const payload = normalizeWebServerLogPayload(event.data);
   if (!payload) {
     return;
@@ -6463,14 +6530,13 @@ function handleWebServerLogMessage(event) {
 
   const output = getWebServerLogOutputElement();
   const scroller = getWebServerLogScrollerElement();
-  const stickToBottom = isWebServerLogScrollerNearBottom(scroller);
 
   trimWebServerLogEntries(output);
   appendWebServerLogEntriesToDom(filteredEntries, output);
 
   state.webServerLogEnabled = true;
-  if (scroller && stickToBottom) {
-    scroller.scrollTop = scroller.scrollHeight;
+  if (scroller && scrollState) {
+    queueWebServerLogScrollRestore(scrollState, false);
   }
 }
 

--- a/openquatt/web/js/src/00-config.js
+++ b/openquatt/web/js/src/00-config.js
@@ -7,6 +7,7 @@ const LOGO_MARKUP = `
   };
   const OFFICIAL_ESPHOME_UI_URL = "https://oi.esphome.io/v3/www.js";
   const ENTITY_REFRESH_CONCURRENCY = 2;
+  const FAST_VIEW_ENTITY_REFRESH_CONCURRENCY = 4;
   const TREND_HISTORY_REFRESH_INTERVAL_MS = 60000;
   const STRATEGY_OPTION_POWER_HOUSE = "Power House";
   const STRATEGY_OPTION_CURVE = "Water Temperature Control (heating curve)";

--- a/openquatt/web/js/src/01-runtime.js
+++ b/openquatt/web/js/src/01-runtime.js
@@ -35,6 +35,8 @@
     trendHistoryFetchPromise: null,
     deviceReconnectMode: "",
     deviceReconnectStartedAt: 0,
+    deviceReconnectRecoveryStartedAt: 0,
+    deviceReconnectRecoveryTimer: null,
     deviceReconnectLastError: "",
     entitySyncFailureCount: 0,
     lastEntitySyncAt: 0,

--- a/openquatt/web/js/src/01-runtime.js
+++ b/openquatt/web/js/src/01-runtime.js
@@ -339,7 +339,7 @@
       void primeEntities();
       return;
     }
-    void syncEntities({ forceBulk: true });
+    void syncEntities(state.appView === "settings" ? { forceBulk: true } : { forceFast: true });
   }
 
   function normalizeAppView(view) {
@@ -429,7 +429,7 @@
       }
     }
     render();
-    void syncEntities({ forceBulk: true });
+    void syncEntities(nextView === "settings" ? { forceBulk: true } : { forceFast: true });
   }
 
   function syncNativeVisibility() {

--- a/openquatt/web/js/src/01-runtime.js
+++ b/openquatt/web/js/src/01-runtime.js
@@ -51,6 +51,7 @@
     webServerLogHistoryError: "",
     webServerLogHistoryRequestToken: 0,
     webServerLogHistoryLoaded: false,
+    webServerLogScrollRestoreToken: 0,
     webServerLogCopyMessage: "",
     webServerLogCopyError: "",
     webServerLogRecentTail: [],

--- a/openquatt/web/js/src/02-firmware-header.js
+++ b/openquatt/web/js/src/02-firmware-header.js
@@ -609,11 +609,68 @@
     return new Promise((resolve) => window.setTimeout(resolve, ms));
   }
 
+  const DEVICE_RECONNECT_RECOVERY_CLEAR_DELAY_MS = 1500;
+
+  function clearDeviceReconnectRecoveryTimer() {
+    if (!state.deviceReconnectRecoveryTimer) {
+      return;
+    }
+    window.clearTimeout(state.deviceReconnectRecoveryTimer);
+    state.deviceReconnectRecoveryTimer = null;
+  }
+
+  function isDeviceReconnectRecovering() {
+    return Number(state.deviceReconnectRecoveryStartedAt || 0) > 0;
+  }
+
+  function getDeviceReconnectPhaseStartedAt() {
+    return isDeviceReconnectRecovering()
+      ? Number(state.deviceReconnectRecoveryStartedAt || 0)
+      : Number(state.deviceReconnectStartedAt || 0);
+  }
+
+  function getDeviceReconnectStatusLabel() {
+    return isDeviceReconnectRecovering() ? "Gegevens verversen" : "Wachten op gegevens";
+  }
+
+  function getDeviceReconnectStatusCopy() {
+    const startedAt = getDeviceReconnectPhaseStartedAt();
+    const elapsedSeconds = startedAt > 0 ? Math.max(0, Math.round((Date.now() - startedAt) / 1000)) : 0;
+    if (isDeviceReconnectRecovering()) {
+      return elapsedSeconds > 0 ? `${elapsedSeconds}s aan het verversen` : "Net weer online";
+    }
+    return elapsedSeconds > 0 ? `${elapsedSeconds}s bezig` : "Net gestart";
+  }
+
+  function markDeviceReconnectRecovered() {
+    if (!state.deviceReconnectMode || isDeviceReconnectRecovering()) {
+      return false;
+    }
+
+    clearDeviceReconnectRecoveryTimer();
+    state.deviceReconnectRecoveryStartedAt = Date.now();
+    state.deviceReconnectLastError = "";
+    state.entitySyncFailureCount = 0;
+
+    const recoveryStartedAt = state.deviceReconnectRecoveryStartedAt;
+    state.deviceReconnectRecoveryTimer = window.setTimeout(() => {
+      if (state.deviceReconnectMode && Number(state.deviceReconnectRecoveryStartedAt || 0) === recoveryStartedAt) {
+        clearDeviceReconnect();
+        render();
+      }
+    }, DEVICE_RECONNECT_RECOVERY_CLEAR_DELAY_MS);
+
+    render();
+    return true;
+  }
+
   function beginDeviceReconnect(mode = "reconnect", error = "") {
     if (!state.deviceReconnectMode) {
       state.deviceReconnectStartedAt = Date.now();
     }
+    clearDeviceReconnectRecoveryTimer();
     state.deviceReconnectMode = mode;
+    state.deviceReconnectRecoveryStartedAt = 0;
     state.deviceReconnectLastError = error ? String(error) : state.deviceReconnectLastError;
     state.systemModal = "";
     state.updateModalOpen = false;
@@ -621,16 +678,21 @@
   }
 
   function clearDeviceReconnect() {
+    clearDeviceReconnectRecoveryTimer();
     if (!state.deviceReconnectMode && !state.entitySyncFailureCount) {
       return;
     }
     state.deviceReconnectMode = "";
     state.deviceReconnectStartedAt = 0;
+    state.deviceReconnectRecoveryStartedAt = 0;
     state.deviceReconnectLastError = "";
     state.entitySyncFailureCount = 0;
   }
 
   function getDeviceReconnectTitle() {
+    if (isDeviceReconnectRecovering()) {
+      return "OpenQuatt is weer online";
+    }
     if (state.deviceReconnectMode === "ota") {
       return "OpenQuatt wordt bijgewerkt";
     }
@@ -641,6 +703,12 @@
   }
 
   function getDeviceReconnectCopy() {
+    if (isDeviceReconnectRecovering()) {
+      if (state.deviceReconnectMode === "ota") {
+        return "De update is bijna klaar. We verversen nu de gegevens en het logboek.";
+      }
+      return "De controller reageert weer. We verversen nu de gegevens en het logboek.";
+    }
     if (state.deviceReconnectMode === "ota") {
       return "De controller installeert de update en start daarna opnieuw op. Deze melding verdwijnt zodra de web-app weer gegevens ontvangt.";
     }
@@ -654,9 +722,6 @@
     if (!state.deviceReconnectMode) {
       return "";
     }
-    const startedAt = Number(state.deviceReconnectStartedAt || 0);
-    const elapsedSeconds = startedAt > 0 ? Math.max(0, Math.round((Date.now() - startedAt) / 1000)) : 0;
-    const elapsedCopy = elapsedSeconds > 0 ? `${elapsedSeconds}s bezig` : "Net gestart";
     return `
       <div class="oq-helper-modal-backdrop${state.overviewTheme === "dark" ? " oq-helper-modal-backdrop--dark" : ""}" data-oq-modal="reconnect">
         <section class="oq-helper-modal oq-helper-modal--reconnect" role="status" aria-live="polite" aria-labelledby="oq-reconnect-modal-title">
@@ -670,8 +735,8 @@
           <div class="oq-helper-reconnect-status">
             <span class="oq-helper-reconnect-spinner" aria-hidden="true"></span>
             <div>
-              <strong>Wachten op gegevens</strong>
-              <span>${escapeHtml(elapsedCopy)}</span>
+              <strong>${escapeHtml(getDeviceReconnectStatusLabel())}</strong>
+              <span>${escapeHtml(getDeviceReconnectStatusCopy())}</span>
             </div>
           </div>
         </section>

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -304,6 +304,21 @@
     return [...new Set(INITIAL_SETTINGS_READY_KEY_MAP[normalized] || INITIAL_SETTINGS_READY_KEY_MAP.installation)];
   }
 
+  function queuePendingEntitySyncOptions(options = {}) {
+    const current = state.pendingEntitySyncOptions || {};
+    const merged = {
+      ...current,
+      ...options,
+    };
+    if (current.forceBulk || options.forceBulk) {
+      merged.forceBulk = true;
+      merged.forceFast = false;
+    } else if (current.forceFast || options.forceFast) {
+      merged.forceFast = true;
+    }
+    state.pendingEntitySyncOptions = merged;
+  }
+
   function hasUsableEntityValue(key) {
     const value = String(getEntityValue(key) ?? "").trim().toLowerCase();
     return value !== "" && value !== "unknown" && value !== "unavailable" && value !== "nan";
@@ -467,10 +482,14 @@
     }
   }
 
-  async function refreshEntities(keys, detail = "state") {
+  async function refreshEntities(keys, detail = "state", options = {}) {
+    const requestedConcurrency = Number(options.concurrency);
+    const concurrency = Number.isFinite(requestedConcurrency) && requestedConcurrency > 0
+      ? Math.floor(requestedConcurrency)
+      : ENTITY_REFRESH_CONCURRENCY;
     const results = [];
-    for (let index = 0; index < keys.length; index += ENTITY_REFRESH_CONCURRENCY) {
-      const batch = keys.slice(index, index + ENTITY_REFRESH_CONCURRENCY);
+    for (let index = 0; index < keys.length; index += concurrency) {
+      const batch = keys.slice(index, index + concurrency);
       const batchResults = await Promise.allSettled(
         batch.map(async (key) => ({ key, payload: await fetchEntityPayload(key, detail) }))
       );
@@ -1193,7 +1212,9 @@
 
     state.entitySyncInFlight = true;
     try {
-      await refreshEntities(keys, detail);
+      await refreshEntities(keys, detail, {
+        concurrency: detail === "all" ? ENTITY_REFRESH_CONCURRENCY : FAST_VIEW_ENTITY_REFRESH_CONCURRENCY,
+      });
     } finally {
       state.entitySyncInFlight = false;
       const pendingOptions = state.pendingEntitySyncOptions;
@@ -1239,8 +1260,11 @@
     }
     const initialKeys = getInitialPrimeKeys();
     const deferredKeys = getDeferredPrimeKeys(initialKeys);
+    const initialDetail = state.appView === "settings" ? "all" : "state";
     try {
-      await refreshEntities(initialKeys, "all");
+      await refreshEntities(initialKeys, initialDetail, {
+        concurrency: initialDetail === "all" ? ENTITY_REFRESH_CONCURRENCY : FAST_VIEW_ENTITY_REFRESH_CONCURRENCY,
+      });
       if (state.appView === "settings") {
         await waitForInitialSettingsReady();
       } else {
@@ -1262,13 +1286,7 @@
       return;
     }
     if (state.entitySyncInFlight) {
-      if (options.forceBulk === true) {
-        state.pendingEntitySyncOptions = {
-          ...(state.pendingEntitySyncOptions || {}),
-          ...options,
-          forceBulk: true,
-        };
-      }
+      queuePendingEntitySyncOptions(options);
       return;
     }
 
@@ -1278,15 +1296,16 @@
     }
 
     const appView = state.appView;
-    const isOverviewLike = appView === "overview" || appView === "trends";
-    const isBulkDue = options.forceBulk === true || (now - Number(state.lastBulkEntitySyncAt || 0)) >= BULK_POLL_INTERVAL_MS;
+    const isOverviewLike = appView === "overview" || appView === "trends" || appView === "energy";
+    const forceFast = options.forceFast === true && !options.forceBulk;
+    const isBulkDue = !forceFast && (options.forceBulk === true || (now - Number(state.lastBulkEntitySyncAt || 0)) >= BULK_POLL_INTERVAL_MS);
     const isStaticDue = (now - Number(state.lastStaticEntitySyncAt || 0)) >= STATIC_POLL_INTERVAL_MS;
     const staticKeys = isStaticDue || state.updateInstallBusy || state.updateInstallPhaseHint
       ? FIRMWARE_ENTITY_KEYS
       : [];
     const keys = isOverviewLike
       ? [
-          ...(isBulkDue ? OVERVIEW_KEYS : FAST_OVERVIEW_KEYS),
+          ...(forceFast ? FAST_OVERVIEW_KEYS : isBulkDue ? OVERVIEW_KEYS : FAST_OVERVIEW_KEYS),
           ...HEADER_ENTITY_KEYS,
           "setupComplete",
           ...staticKeys,
@@ -1309,7 +1328,9 @@
     state.lastEntitySyncAttemptAt = now;
     try {
       const reconnectModeBefore = state.deviceReconnectMode;
-      await refreshEntities([...new Set(keys)], appView === "settings" ? "all" : "state");
+      await refreshEntities([...new Set(keys)], appView === "settings" ? "all" : "state", {
+        concurrency: forceFast && isOverviewLike ? FAST_VIEW_ENTITY_REFRESH_CONCURRENCY : ENTITY_REFRESH_CONCURRENCY,
+      });
       state.lastFastEntitySyncAt = Date.now();
       if (isBulkDue) {
         state.lastBulkEntitySyncAt = state.lastFastEntitySyncAt;
@@ -1318,10 +1339,13 @@
         state.lastStaticEntitySyncAt = state.lastFastEntitySyncAt;
       }
       const reconnectChanged = reconnectModeBefore !== state.deviceReconnectMode;
-      const trendChanged = isOverviewLike
-        ? await refreshTrendHistoryData()
-        : false;
-      const authChanged = await refreshAuthStatus();
+      const shouldDeferSupplementary = forceFast && isOverviewLike;
+      const trendChanged = shouldDeferSupplementary
+        ? false
+        : isOverviewLike
+          ? await refreshTrendHistoryData()
+          : false;
+      const authChanged = shouldDeferSupplementary ? false : await refreshAuthStatus();
       const nextHeaderSignature = getHeaderRenderSignature();
       if (reconnectChanged) {
         render();
@@ -1360,6 +1384,11 @@
       if (!patchOverviewDom()) {
         render();
       }
+      if (shouldDeferSupplementary && !state.nativeOpen) {
+        window.setTimeout(() => {
+          void primeSupplementaryData();
+        }, 0);
+      }
     } catch (error) {
       state.controlError = `Helperstatus kon niet worden geladen. ${error.message}`;
       render();
@@ -1370,6 +1399,11 @@
       if (pendingOptions && !state.nativeOpen) {
         window.setTimeout(() => {
           void syncEntities(pendingOptions);
+        }, 0);
+      }
+      if (forceFast && isOverviewLike && !state.nativeOpen && !pendingOptions) {
+        window.setTimeout(() => {
+          void syncEntities({ forceBulk: true });
         }, 0);
       }
     }
@@ -1628,9 +1662,10 @@
       if ((button.dataset.viewId || "") === "trends" && !isTrendHistoryEnabled()) {
         return;
       }
-      setAppView(button.dataset.viewId || "overview", { syncMode: "push" });
+      const nextView = button.dataset.viewId || "overview";
+      setAppView(nextView, { syncMode: "push" });
       render();
-      syncEntities({ forceBulk: true });
+      syncEntities(nextView === "settings" ? { forceBulk: true } : { forceFast: true });
       return;
     }
 
@@ -2503,6 +2538,7 @@
       }
       state.quickStartModalOpen = action !== "apply";
       setAppView("overview", { syncMode: "replace" });
+      syncEntities({ forceFast: true });
     } catch (error) {
       state.controlError = `Actie mislukt voor "${entity.name}". ${error.message}`;
     } finally {

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -488,8 +488,10 @@
   function noteEntityRefreshSuccess() {
     state.lastEntitySyncAt = Date.now();
     const wasReconnectActive = Boolean(state.deviceReconnectMode);
-    clearDeviceReconnect();
-    if (wasReconnectActive) {
+    const reconnectRecovered = wasReconnectActive && typeof markDeviceReconnectRecovered === "function"
+      ? markDeviceReconnectRecovered()
+      : false;
+    if (reconnectRecovered) {
       state.lastFastEntitySyncAt = 0;
       state.lastBulkEntitySyncAt = 0;
       state.lastStaticEntitySyncAt = 0;

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -433,9 +433,39 @@
     };
   }
 
+  const ENTITY_REQUEST_TIMEOUT_MS = 8000;
+  const RECONNECT_ENTITY_REQUEST_TIMEOUT_MS = 3000;
+
+  function getEntityRequestTimeoutMs() {
+    return state.deviceReconnectMode || state.busyAction === "restartAction" || state.updateInstallBusy || state.updateInstallPhaseHint
+      ? RECONNECT_ENTITY_REQUEST_TIMEOUT_MS
+      : ENTITY_REQUEST_TIMEOUT_MS;
+  }
+
   async function fetchEntityPayload(key, detail = "state") {
     const entity = ENTITY_DEFS[key];
     const url = `${buildEntityPath(entity.domain, entity.name)}${detail === "all" ? "?detail=all" : ""}`;
+    const timeoutMs = getEntityRequestTimeoutMs();
+
+    if (typeof AbortController === "function") {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error(`${entity.name} HTTP ${response.status}`);
+        }
+        return response.json();
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw new Error(`${entity.name} request timed out after ${timeoutMs}ms`);
+        }
+        throw error;
+      } finally {
+        window.clearTimeout(timeoutId);
+      }
+    }
+
     const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`${entity.name} HTTP ${response.status}`);
@@ -457,7 +487,26 @@
 
   function noteEntityRefreshSuccess() {
     state.lastEntitySyncAt = Date.now();
+    const wasReconnectActive = Boolean(state.deviceReconnectMode);
     clearDeviceReconnect();
+    if (wasReconnectActive) {
+      state.lastFastEntitySyncAt = 0;
+      state.lastBulkEntitySyncAt = 0;
+      state.lastStaticEntitySyncAt = 0;
+      state.trendHistoryRaw = "";
+      state.trendHistoryError = "";
+      state.trendHistorySignature = "";
+      state.trendHistoryNowMs = Number.NaN;
+      state.trendHistoryLastFetchAt = 0;
+      if (typeof resetWebServerLogRecoveryState === "function") {
+        resetWebServerLogRecoveryState();
+      } else {
+        closeWebServerLogStream();
+        clearWebServerLogOutput();
+        state.webServerLogEnabled = null;
+        state.webServerLogConnected = false;
+      }
+    }
   }
 
   function noteEntityRefreshFailure(message) {

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -1231,6 +1231,30 @@
     }
   }
 
+  function scheduleOverviewPrefetch() {
+    if (state.nativeOpen || state.appView !== "settings") {
+      return;
+    }
+
+    const run = () => {
+      if (state.nativeOpen || state.appView !== "settings") {
+        return;
+      }
+      if (state.loadingEntities || state.focusedField || state.draggingCurveKey || state.busyAction || state.settingsInteractionLock) {
+        window.setTimeout(scheduleOverviewPrefetch, 250);
+        return;
+      }
+      void syncEntities({ prefetchView: "overview", forceFast: true });
+    };
+
+    if (typeof window.requestIdleCallback === "function") {
+      window.requestIdleCallback(run, { timeout: 2000 });
+      return;
+    }
+
+    window.setTimeout(run, 0);
+  }
+
   async function primeSupplementaryData() {
     if (state.nativeOpen) {
       return;
@@ -1245,6 +1269,7 @@
       if (state.mounted && !state.nativeOpen) {
         render();
       }
+      scheduleOverviewPrefetch();
     }
   }
 
@@ -1296,14 +1321,23 @@
     }
 
     const appView = state.appView;
-    const isOverviewLike = appView === "overview" || appView === "trends" || appView === "energy";
+    const isPrefetchOverview = options.prefetchView === "overview" && !options.forceBulk && appView === "settings";
+    const syncView = isPrefetchOverview ? "overview" : appView;
+    const isOverviewLike = syncView === "overview" || syncView === "trends" || syncView === "energy";
     const forceFast = options.forceFast === true && !options.forceBulk;
-    const isBulkDue = !forceFast && (options.forceBulk === true || (now - Number(state.lastBulkEntitySyncAt || 0)) >= BULK_POLL_INTERVAL_MS);
+    const isBulkDue = !forceFast && !isPrefetchOverview && (options.forceBulk === true || (now - Number(state.lastBulkEntitySyncAt || 0)) >= BULK_POLL_INTERVAL_MS);
     const isStaticDue = (now - Number(state.lastStaticEntitySyncAt || 0)) >= STATIC_POLL_INTERVAL_MS;
     const staticKeys = isStaticDue || state.updateInstallBusy || state.updateInstallPhaseHint
       ? FIRMWARE_ENTITY_KEYS
       : [];
-    const keys = isOverviewLike
+    const keys = isPrefetchOverview
+      ? [
+          ...FAST_OVERVIEW_KEYS,
+          ...HEADER_ENTITY_KEYS,
+          "setupComplete",
+          ...staticKeys,
+        ]
+      : isOverviewLike
       ? [
           ...(forceFast ? FAST_OVERVIEW_KEYS : isBulkDue ? OVERVIEW_KEYS : FAST_OVERVIEW_KEYS),
           ...HEADER_ENTITY_KEYS,
@@ -1328,7 +1362,7 @@
     state.lastEntitySyncAttemptAt = now;
     try {
       const reconnectModeBefore = state.deviceReconnectMode;
-      await refreshEntities([...new Set(keys)], appView === "settings" ? "all" : "state", {
+      await refreshEntities([...new Set(keys)], isPrefetchOverview ? "state" : appView === "settings" ? "all" : "state", {
         concurrency: forceFast && isOverviewLike ? FAST_VIEW_ENTITY_REFRESH_CONCURRENCY : ENTITY_REFRESH_CONCURRENCY,
       });
       state.lastFastEntitySyncAt = Date.now();
@@ -1337,6 +1371,9 @@
       }
       if (staticKeys.length) {
         state.lastStaticEntitySyncAt = state.lastFastEntitySyncAt;
+      }
+      if (isPrefetchOverview) {
+        return;
       }
       const reconnectChanged = reconnectModeBefore !== state.deviceReconnectMode;
       const shouldDeferSupplementary = forceFast && isOverviewLike;
@@ -1390,8 +1427,10 @@
         }, 0);
       }
     } catch (error) {
-      state.controlError = `Helperstatus kon niet worden geladen. ${error.message}`;
-      render();
+      if (!isPrefetchOverview) {
+        state.controlError = `Helperstatus kon niet worden geladen. ${error.message}`;
+        render();
+      }
     } finally {
       state.entitySyncInFlight = false;
       const pendingOptions = state.pendingEntitySyncOptions;
@@ -1401,7 +1440,7 @@
           void syncEntities(pendingOptions);
         }, 0);
       }
-      if (forceFast && isOverviewLike && !state.nativeOpen && !pendingOptions) {
+      if (forceFast && isOverviewLike && !isPrefetchOverview && !state.nativeOpen && !pendingOptions) {
         window.setTimeout(() => {
           void syncEntities({ forceBulk: true });
         }, 0);

--- a/openquatt/web/js/src/06-webserver-logs.js
+++ b/openquatt/web/js/src/06-webserver-logs.js
@@ -276,22 +276,10 @@ async function refreshWebServerLogHistory() {
       state.webServerLogHistoryLoading = false;
     }
     if (state.systemModal === "webserver-logs" && state.webServerLogHistoryRequestToken === requestToken) {
-      const scroller = getWebServerLogScrollerElement();
-      const stickToBottom = isWebServerLogScrollerNearBottom(scroller);
-      const previousDistanceFromBottom = scroller ? scroller.scrollHeight - scroller.scrollTop : 0;
       render();
       window.requestAnimationFrame(() => {
         if (state.systemModal === "webserver-logs" && state.webServerLogHistoryRequestToken === requestToken) {
-          const nextScroller = getWebServerLogScrollerElement();
-          if (!nextScroller) {
-            return;
-          }
-          if (stickToBottom) {
-            nextScroller.scrollTop = nextScroller.scrollHeight;
-            return;
-          }
-          const targetScrollTop = nextScroller.scrollHeight - previousDistanceFromBottom;
-          nextScroller.scrollTop = Math.max(0, targetScrollTop);
+          scrollWebServerLogToBottom();
         }
       });
     }
@@ -383,6 +371,13 @@ function clearWebServerLogOutput() {
   if (state.systemModal === "webserver-logs") {
     render();
   }
+}
+
+function resetWebServerLogRecoveryState() {
+  closeWebServerLogStream();
+  state.webServerLogEnabled = null;
+  state.webServerLogConnected = false;
+  clearWebServerLogOutput();
 }
 
 function syncWebServerLogStream() {

--- a/openquatt/web/js/src/06-webserver-logs.js
+++ b/openquatt/web/js/src/06-webserver-logs.js
@@ -378,6 +378,9 @@ function resetWebServerLogRecoveryState() {
   state.webServerLogEnabled = null;
   state.webServerLogConnected = false;
   clearWebServerLogOutput();
+  if (state.systemModal === "webserver-logs") {
+    void refreshWebServerLogHistory();
+  }
 }
 
 function syncWebServerLogStream() {

--- a/openquatt/web/js/src/06-webserver-logs.js
+++ b/openquatt/web/js/src/06-webserver-logs.js
@@ -235,11 +235,66 @@ function scrollWebServerLogToBottom() {
   scroller.scrollTop = scroller.scrollHeight;
 }
 
-async function refreshWebServerLogHistory() {
+function captureWebServerLogScrollState() {
+  const scroller = getWebServerLogScrollerElement();
+  if (!scroller) {
+    return null;
+  }
+
+  return {
+    scrollHeight: scroller.scrollHeight,
+    scrollTop: scroller.scrollTop,
+    stickToBottom: isWebServerLogScrollerNearBottom(scroller),
+  };
+}
+
+function restoreWebServerLogScrollState(scrollState) {
+  if (!scrollState) {
+    return;
+  }
+
+  const scroller = getWebServerLogScrollerElement();
+  if (!scroller) {
+    return;
+  }
+
+  if (scrollState.stickToBottom) {
+    scroller.scrollTop = scroller.scrollHeight;
+    return;
+  }
+
+  const restoredScrollTop = scrollState.scrollTop + (scroller.scrollHeight - scrollState.scrollHeight);
+  scroller.scrollTop = Math.max(0, restoredScrollTop);
+}
+
+function queueWebServerLogScrollRestore(scrollState, defer = true) {
+  if (!scrollState) {
+    return;
+  }
+
+  const restoreToken = Number(state.webServerLogScrollRestoreToken || 0) + 1;
+  state.webServerLogScrollRestoreToken = restoreToken;
+  const applyScrollState = () => {
+    if (state.webServerLogScrollRestoreToken !== restoreToken || state.systemModal !== "webserver-logs") {
+      return;
+    }
+    restoreWebServerLogScrollState(scrollState);
+  };
+
+  if (defer) {
+    window.requestAnimationFrame(applyScrollState);
+    return;
+  }
+
+  applyScrollState();
+}
+
+async function refreshWebServerLogHistory(options = {}) {
   if (state.nativeOpen || typeof window.fetch !== "function") {
     return;
   }
 
+  const scrollState = options.scrollState || captureWebServerLogScrollState();
   const requestToken = Number(state.webServerLogHistoryRequestToken || 0) + 1;
   state.webServerLogHistoryRequestToken = requestToken;
   state.webServerLogHistoryLoading = true;
@@ -277,11 +332,7 @@ async function refreshWebServerLogHistory() {
     }
     if (state.systemModal === "webserver-logs" && state.webServerLogHistoryRequestToken === requestToken) {
       render();
-      window.requestAnimationFrame(() => {
-        if (state.systemModal === "webserver-logs" && state.webServerLogHistoryRequestToken === requestToken) {
-          scrollWebServerLogToBottom();
-        }
-      });
+      queueWebServerLogScrollRestore(scrollState);
     }
   }
 }
@@ -363,6 +414,7 @@ function clearWebServerLogOutput() {
   state.webServerLogHistoryError = "";
   state.webServerLogHistoryLoading = false;
   state.webServerLogHistoryLoaded = false;
+  state.webServerLogScrollRestoreToken = Number(state.webServerLogScrollRestoreToken || 0) + 1;
   state.webServerLogCopyMessage = "";
   state.webServerLogCopyError = "";
   state.webServerLogHistoryRequestToken += 1;
@@ -374,12 +426,13 @@ function clearWebServerLogOutput() {
 }
 
 function resetWebServerLogRecoveryState() {
+  const scrollState = captureWebServerLogScrollState();
   closeWebServerLogStream();
   state.webServerLogEnabled = null;
   state.webServerLogConnected = false;
   clearWebServerLogOutput();
   if (state.systemModal === "webserver-logs") {
-    void refreshWebServerLogHistory();
+    void refreshWebServerLogHistory({ scrollState });
   }
 }
 
@@ -458,10 +511,14 @@ function handleWebServerLogOpen() {
     return;
   }
 
+  const scrollState = state.systemModal === "webserver-logs"
+    ? captureWebServerLogScrollState()
+    : null;
   state.webServerLogEnabled = true;
   state.webServerLogConnected = true;
   state.webServerLogError = "";
   render();
+  queueWebServerLogScrollRestore(scrollState);
 }
 
 function handleWebServerLogPing() {
@@ -469,11 +526,15 @@ function handleWebServerLogPing() {
     return;
   }
 
+  const scrollState = state.systemModal === "webserver-logs"
+    ? captureWebServerLogScrollState()
+    : null;
   state.webServerLogEnabled = true;
   if (!state.webServerLogConnected) {
     state.webServerLogConnected = true;
     state.webServerLogError = "";
     render();
+    queueWebServerLogScrollRestore(scrollState);
   }
 }
 
@@ -482,11 +543,15 @@ function handleWebServerLogError() {
     return;
   }
 
+  const scrollState = state.systemModal === "webserver-logs"
+    ? captureWebServerLogScrollState()
+    : null;
   state.webServerLogEnabled = false;
   state.webServerLogConnected = false;
   state.webServerLogError = "De live logstream kon niet worden geopend.";
   closeWebServerLogStream();
   render();
+  queueWebServerLogScrollRestore(scrollState);
 }
 
 function handleWebServerLogMessage(event) {
@@ -494,6 +559,7 @@ function handleWebServerLogMessage(event) {
     return;
   }
 
+  const scrollState = captureWebServerLogScrollState();
   const payload = normalizeWebServerLogPayload(event.data);
   if (!payload) {
     return;
@@ -514,14 +580,13 @@ function handleWebServerLogMessage(event) {
 
   const output = getWebServerLogOutputElement();
   const scroller = getWebServerLogScrollerElement();
-  const stickToBottom = isWebServerLogScrollerNearBottom(scroller);
 
   trimWebServerLogEntries(output);
   appendWebServerLogEntriesToDom(filteredEntries, output);
 
   state.webServerLogEnabled = true;
-  if (scroller && stickToBottom) {
-    scroller.scrollTop = scroller.scrollHeight;
+  if (scroller && scrollState) {
+    queueWebServerLogScrollRestore(scrollState, false);
   }
 }
 


### PR DESCRIPTION
## What changed
- View switches to overview / trends / energy now use a fast path: render the visible data first, then hydrate the rest in the background.
- Overview data is prefetched while you stay on Settings, so switching from `settings/system` to Overview has data ready earlier even before the page is requested.
- During restart / reconnect, entity requests time out faster so the UI does not wait as long on stale in-flight requests.
- Reconnect recovery now transitions through a visible "back online, refreshing data" state instead of dropping the modal immediately the moment the controller responds again.
- When the controller comes back online, reconnect recovery clears stale trend caches and refreshes the web server log history so the logbook does not keep showing old entries after a restart.
- Web server logs now preserve scroll position more robustly during history refreshes, live stream reconnects, and log trimming, so the viewer no longer jumps back to the top as new entries arrive.
- Visible entity refresh uses higher concurrency than the default bulk/settings flow.
- Supplementary data such as trends/auth no longer blocks the first render.
- Settings still uses the heavier bulk flow on purpose to preserve consistency.

## Why
The HAR showed that the web app performs many small requests and that view switches sometimes wait on bulk refreshes and extra data. After a restart, the app could also keep showing an old reconnect state and stale log buffer for longer than necessary. The log viewer also had a remaining scroll-jump edge case while newer messages were appended or old entries were trimmed. This change makes the UI feel noticeably snappier and improves recovery after the controller comes back.

## Verification
- `node openquatt/web/build-assets.mjs`
- `node --check openquatt/web/js/openquatt-app.js`