### PR TITLE
Align OTA polling pauses and logs

### DIFF
--- a/components/openquatt_cic/OpenQuattCIC.cpp
+++ b/components/openquatt_cic/OpenQuattCIC.cpp
@@ -33,6 +33,10 @@ void OpenQuattCIC::setup() {
 void OpenQuattCIC::update() {
   const uint32_t now_ms = millis();
 
+  if (this->pause_sensor_ != nullptr && this->pause_sensor_->state) {
+    return;
+  }
+
   if (this->enabled_switch_ == nullptr || !this->enabled_switch_->state) {
     this->handle_disabled_();
     this->publish_diagnostics_if_due_(now_ms, false);
@@ -61,6 +65,10 @@ void OpenQuattCIC::update() {
 }
 
 void OpenQuattCIC::loop() {
+  if (this->pause_sensor_ != nullptr && this->pause_sensor_->state) {
+    return;
+  }
+
   if (this->fetch_result_.ready) {
     this->finalize_fetch_();
   }

--- a/components/openquatt_cic/OpenQuattCIC.h
+++ b/components/openquatt_cic/OpenQuattCIC.h
@@ -42,6 +42,7 @@ class OpenQuattCIC : public PollingComponent {
   void set_cic_cooling_enabled(binary_sensor::BinarySensor *binary_sensor) { this->cic_cooling_enabled_ = binary_sensor; }
   void set_feed_ok(binary_sensor::BinarySensor *binary_sensor) { this->feed_ok_ = binary_sensor; }
   void set_data_stale(binary_sensor::BinarySensor *binary_sensor) { this->data_stale_ = binary_sensor; }
+  void set_pause_sensor(binary_sensor::BinarySensor *binary_sensor) { this->pause_sensor_ = binary_sensor; }
   void set_backoff_sensor(sensor::Sensor *sensor) { this->backoff_sensor_ = sensor; }
   void set_last_success_age_sensor(sensor::Sensor *sensor) { this->last_success_age_sensor_ = sensor; }
   void set_request_count_sensor(sensor::Sensor *sensor) { this->request_count_sensor_ = sensor; }
@@ -116,6 +117,7 @@ class OpenQuattCIC : public PollingComponent {
   binary_sensor::BinarySensor *cic_cooling_enabled_{nullptr};
   binary_sensor::BinarySensor *feed_ok_{nullptr};
   binary_sensor::BinarySensor *data_stale_{nullptr};
+  binary_sensor::BinarySensor *pause_sensor_{nullptr};
   sensor::Sensor *backoff_sensor_{nullptr};
   sensor::Sensor *last_success_age_sensor_{nullptr};
   sensor::Sensor *request_count_sensor_{nullptr};

--- a/components/openquatt_cic/__init__.py
+++ b/components/openquatt_cic/__init__.py
@@ -27,6 +27,7 @@ CONF_CIC_CH_ENABLED = "cic_ch_enabled"
 CONF_CIC_COOLING_ENABLED = "cic_cooling_enabled"
 CONF_FEED_OK = "feed_ok"
 CONF_DATA_STALE = "data_stale"
+CONF_PAUSE_SENSOR = "pause_sensor"
 CONF_BACKOFF_SENSOR = "backoff_sensor"
 CONF_LAST_SUCCESS_AGE_SENSOR = "last_success_age_sensor"
 CONF_REQUEST_COUNT_SENSOR = "request_count_sensor"
@@ -59,6 +60,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_CIC_COOLING_ENABLED): cv.use_id(binary_sensor.BinarySensor),
         cv.Required(CONF_FEED_OK): cv.use_id(binary_sensor.BinarySensor),
         cv.Required(CONF_DATA_STALE): cv.use_id(binary_sensor.BinarySensor),
+        cv.Required(CONF_PAUSE_SENSOR): cv.use_id(binary_sensor.BinarySensor),
         cv.Required(CONF_BACKOFF_SENSOR): cv.use_id(sensor.Sensor),
         cv.Required(CONF_LAST_SUCCESS_AGE_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_REQUEST_COUNT_SENSOR): cv.use_id(sensor.Sensor),
@@ -100,6 +102,7 @@ async def to_code(config):
         CONF_CIC_COOLING_ENABLED,
         CONF_FEED_OK,
         CONF_DATA_STALE,
+        CONF_PAUSE_SENSOR,
         CONF_BACKOFF_SENSOR,
         CONF_LAST_SUCCESS_AGE_SENSOR,
     ]:

--- a/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
+++ b/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
@@ -263,13 +263,13 @@ namespace esphome {
 		{
 			if (state == ota::OTA_STARTED) {
 				if (!m_otaActive) {
-					ESP_LOGI(TAG, "Pausing OpenTherm during OTA");
+					ESP_LOGI(TAG, "OpenTherm runtime paused for OTA.");
 					m_otaActive = true;
 					stop_opentherm_();
 				}
 			} else if (state == ota::OTA_ABORT || state == ota::OTA_ERROR || state == ota::OTA_COMPLETED) {
 				if (m_otaActive) {
-					ESP_LOGI(TAG, "OpenTherm OTA state ended");
+					ESP_LOGI(TAG, "OpenTherm runtime resumed after OTA.");
 					m_otaActive = false;
 					if (m_enabled && !m_updatePrepareActive) {
 						schedule_opentherm_start_();

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -1232,4 +1232,9 @@ interval:
   - interval: ${oq_modbus_update_interval_s}s
     startup_delay: ${oq_modbus_startup_delay_ms}ms
     then:
-      - component.update: ${hp_id}
+      - if:
+          condition:
+            lambda: |-
+              return !id(oq_runtime_polling_paused).state;
+          then:
+            - component.update: ${hp_id}

--- a/openquatt/oq_cic.yaml
+++ b/openquatt/oq_cic.yaml
@@ -197,5 +197,6 @@ openquatt_cic:
   cic_cooling_enabled: cic_cooling_enabled
   feed_ok: feed_ok
   data_stale: cic_data_stale
+  pause_sensor: oq_runtime_polling_paused
   backoff_sensor: cic_backoff_s
   last_success_age_sensor: cic_last_success_age_s

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -12,6 +12,14 @@
 # ==============================================================================
 # CORE RUNTIME SERVICES
 # ==============================================================================
+esphome:
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          // Always start from a clean paused state after reboot or OTA.
+          id(oq_runtime_polling_paused).publish_state(false);
+
 logger:
   level: DEBUG
   initial_level: INFO
@@ -29,6 +37,8 @@ ota:
     on_begin:
       then:
         - lambda: |-
+            id(oq_runtime_polling_paused).publish_state(true);
+            ESP_LOGI("oq_fw", "Runtime polling paused for OTA.");
             id(oq_ota_phase_code) = 1;
             id(oq_ota_progress_pct) = 0.0f;
             id(oq_firmware_update_status).publish_state("Starting");
@@ -43,6 +53,8 @@ ota:
     on_end:
       then:
         - lambda: |-
+            id(oq_runtime_polling_paused).publish_state(false);
+            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA.");
             id(oq_ota_phase_code) = 3;
             id(oq_ota_progress_pct) = 100.0f;
             id(oq_firmware_update_status).publish_state("Rebooting");
@@ -50,17 +62,23 @@ ota:
     on_error:
       then:
         - lambda: |-
+            id(oq_runtime_polling_paused).publish_state(false);
+            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA error.");
             id(oq_ota_phase_code) = 5;
             id(oq_firmware_update_status).publish_state("Error");
     on_abort:
       then:
         - lambda: |-
+            id(oq_runtime_polling_paused).publish_state(false);
+            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA abort.");
             id(oq_ota_phase_code) = 6;
             id(oq_firmware_update_status).publish_state("Aborted");
   - platform: http_request
     on_begin:
       then:
         - lambda: |-
+            id(oq_runtime_polling_paused).publish_state(true);
+            ESP_LOGI("oq_fw", "Runtime polling paused for OTA.");
             id(oq_ota_phase_code) = 1;
             id(oq_ota_progress_pct) = 0.0f;
             id(oq_firmware_update_status).publish_state("Starting");
@@ -75,6 +93,8 @@ ota:
     on_end:
       then:
         - lambda: |-
+            id(oq_runtime_polling_paused).publish_state(false);
+            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA.");
             id(oq_ota_phase_code) = 3;
             id(oq_ota_progress_pct) = 100.0f;
             id(oq_firmware_update_status).publish_state("Rebooting");
@@ -82,11 +102,15 @@ ota:
     on_error:
       then:
         - lambda: |-
+            id(oq_runtime_polling_paused).publish_state(false);
+            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA error.");
             id(oq_ota_phase_code) = 5;
             id(oq_firmware_update_status).publish_state("Error");
     on_abort:
       then:
         - lambda: |-
+            id(oq_runtime_polling_paused).publish_state(false);
+            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA abort.");
             id(oq_ota_phase_code) = 6;
             id(oq_firmware_update_status).publish_state("Aborted");
 
@@ -185,6 +209,9 @@ script:
     then:
       - lambda: |-
           // Verzamel een compacte trendregel en sla alleen echte meetwaarden op.
+          if (id(oq_runtime_polling_paused).state) {
+            return;
+          }
           if (!id(oq_trend_history_enabled_switch).state) {
             return;
           }
@@ -420,6 +447,13 @@ binary_sensor:
     entity_category: diagnostic
     web_server:
       sorting_group_id: oq_system_diagnostics
+  - platform: template
+    id: oq_runtime_polling_paused
+    name: Runtime polling paused
+    internal: true
+    entity_category: diagnostic
+    lambda: |-
+      return false;
 
 sensor:
   - platform: debug

--- a/openquatt/oq_ot_slave.yaml
+++ b/openquatt/oq_ot_slave.yaml
@@ -95,61 +95,66 @@ sensor:
 interval:
   - interval: 2s
     then:
-      - lambda: |-
-          // Push canonical OpenQuatt runtime into the OT slave model off the ISR path.
-          if (id(water_supply_temp_selected).has_state() && !isnan(id(water_supply_temp_selected).state)) {
-            id(oq_ot_slave_hub).set_slave_t_boiler(id(water_supply_temp_selected).state);
-          }
-          if (id(hp1_water_in_temp).has_state() && !isnan(id(hp1_water_in_temp).state)) {
-            id(oq_ot_slave_hub).set_slave_t_ret(id(hp1_water_in_temp).state);
-          }
-          if (id(max_water_temp_limit_c).has_state() && !isnan(id(max_water_temp_limit_c).state)) {
-            id(oq_ot_slave_hub).set_slave_max_t_set(id(max_water_temp_limit_c).state);
-          }
-          if (id(outside_temp_selected).has_state() && !isnan(id(outside_temp_selected).state)) {
-            id(oq_ot_slave_hub).set_slave_t_outside(id(outside_temp_selected).state);
-          }
+      - if:
+          condition:
+            lambda: |-
+              return !id(oq_runtime_polling_paused).state;
+          then:
+            - lambda: |-
+                // Push canonical OpenQuatt runtime into the OT slave model off the ISR path.
+                if (id(water_supply_temp_selected).has_state() && !isnan(id(water_supply_temp_selected).state)) {
+                  id(oq_ot_slave_hub).set_slave_t_boiler(id(water_supply_temp_selected).state);
+                }
+                if (id(hp1_water_in_temp).has_state() && !isnan(id(hp1_water_in_temp).state)) {
+                  id(oq_ot_slave_hub).set_slave_t_ret(id(hp1_water_in_temp).state);
+                }
+                if (id(max_water_temp_limit_c).has_state() && !isnan(id(max_water_temp_limit_c).state)) {
+                  id(oq_ot_slave_hub).set_slave_max_t_set(id(max_water_temp_limit_c).state);
+                }
+                if (id(outside_temp_selected).has_state() && !isnan(id(outside_temp_selected).state)) {
+                  id(oq_ot_slave_hub).set_slave_t_outside(id(outside_temp_selected).state);
+                }
 
-          float ot_rel_mod_level = id(oq_demand_filtered) * 5.0f;
-          if (ot_rel_mod_level < 0.0f) ot_rel_mod_level = 0.0f;
-          if (ot_rel_mod_level > 100.0f) ot_rel_mod_level = 100.0f;
-          id(oq_ot_slave_hub).set_slave_rel_mod_level(ot_rel_mod_level);
-          id(oq_ot_slave_hub).set_slave_ch_pressure(1.5f);
+                float ot_rel_mod_level = id(oq_demand_filtered) * 5.0f;
+                if (ot_rel_mod_level < 0.0f) ot_rel_mod_level = 0.0f;
+                if (ot_rel_mod_level > 100.0f) ot_rel_mod_level = 100.0f;
+                id(oq_ot_slave_hub).set_slave_rel_mod_level(ot_rel_mod_level);
+                id(oq_ot_slave_hub).set_slave_ch_pressure(1.5f);
 
-          auto is_active_problem = [](auto *binary) -> bool {
-            return binary != nullptr && binary->has_state() && binary->state;
-          };
-          auto is_active_mode = [](int level, auto *mode_sensor, int target_mode) -> bool {
-            return level > 0 &&
-                   mode_sensor != nullptr &&
-                   mode_sensor->has_state() &&
-                   !isnan(mode_sensor->state) &&
-                   (static_cast<int>(roundf(mode_sensor->state)) == target_mode);
-          };
+                auto is_active_problem = [](auto *binary) -> bool {
+                  return binary != nullptr && binary->has_state() && binary->state;
+                };
+                auto is_active_mode = [](int level, auto *mode_sensor, int target_mode) -> bool {
+                  return level > 0 &&
+                         mode_sensor != nullptr &&
+                         mode_sensor->has_state() &&
+                         !isnan(mode_sensor->state) &&
+                         (static_cast<int>(roundf(mode_sensor->state)) == target_mode);
+                };
 
-          const bool hp1_heating_active = is_active_mode(id(hp1_last_applied_level), id(hp1_working_mode), 2);
-          const bool hp2_heating_active =
-              (${ot_secondary_present} != 0) &&
-              is_active_mode(id(${ot_secondary_last_applied_level_id}), id(${ot_secondary_working_mode_id}), 2);
-          const bool hp1_cooling_active = is_active_mode(id(hp1_last_applied_level), id(hp1_working_mode), 1);
-          const bool hp2_cooling_active =
-              (${ot_secondary_present} != 0) &&
-              is_active_mode(id(${ot_secondary_last_applied_level_id}), id(${ot_secondary_working_mode_id}), 1);
-          const bool boiler_on = id(boiler_active).has_state() && id(boiler_active).state;
-          const bool ch_active = hp1_heating_active || hp2_heating_active || boiler_on;
-          const bool cooling_active = hp1_cooling_active || hp2_cooling_active;
+                const bool hp1_heating_active = is_active_mode(id(hp1_last_applied_level), id(hp1_working_mode), 2);
+                const bool hp2_heating_active =
+                    (${ot_secondary_present} != 0) &&
+                    is_active_mode(id(${ot_secondary_last_applied_level_id}), id(${ot_secondary_working_mode_id}), 2);
+                const bool hp1_cooling_active = is_active_mode(id(hp1_last_applied_level), id(hp1_working_mode), 1);
+                const bool hp2_cooling_active =
+                    (${ot_secondary_present} != 0) &&
+                    is_active_mode(id(${ot_secondary_last_applied_level_id}), id(${ot_secondary_working_mode_id}), 1);
+                const bool boiler_on = id(boiler_active).has_state() && id(boiler_active).state;
+                const bool ch_active = hp1_heating_active || hp2_heating_active || boiler_on;
+                const bool cooling_active = hp1_cooling_active || hp2_cooling_active;
 
-          const bool hp1_fault = is_active_problem(id(hp1_ot_fault_active));
-          const bool hp2_fault =
-              (${ot_secondary_present} != 0) && is_active_problem(id(${ot_secondary_fault_binary_sensor_id}));
-          const bool lowflow_fault = id(oq_lowflow_fault_active);
-          const bool temp_trip = id(oq_water_temp_trip_active) || id(oq_water_temp_hard_trip_active);
+                const bool hp1_fault = is_active_problem(id(hp1_ot_fault_active));
+                const bool hp2_fault =
+                    (${ot_secondary_present} != 0) && is_active_problem(id(${ot_secondary_fault_binary_sensor_id}));
+                const bool lowflow_fault = id(oq_lowflow_fault_active);
+                const bool temp_trip = id(oq_water_temp_trip_active) || id(oq_water_temp_hard_trip_active);
 
-          id(oq_ot_fault_active) = hp1_fault || hp2_fault;
-          id(oq_ot_diagnostic_active) = id(oq_ot_fault_active) || lowflow_fault || temp_trip;
+                id(oq_ot_fault_active) = hp1_fault || hp2_fault;
+                id(oq_ot_diagnostic_active) = id(oq_ot_fault_active) || lowflow_fault || temp_trip;
 
-          id(oq_ot_slave_hub).set_slave_ch_active(ch_active);
-          id(oq_ot_slave_hub).set_slave_flame_on(ch_active);
-          id(oq_ot_slave_hub).set_slave_cooling_active(cooling_active);
-          id(oq_ot_slave_hub).set_slave_fault(id(oq_ot_fault_active));
-          id(oq_ot_slave_hub).set_slave_diagnostic(id(oq_ot_diagnostic_active));
+                id(oq_ot_slave_hub).set_slave_ch_active(ch_active);
+                id(oq_ot_slave_hub).set_slave_flame_on(ch_active);
+                id(oq_ot_slave_hub).set_slave_cooling_active(cooling_active);
+                id(oq_ot_slave_hub).set_slave_fault(id(oq_ot_fault_active));
+                id(oq_ot_slave_hub).set_slave_diagnostic(id(oq_ot_diagnostic_active));


### PR DESCRIPTION
This PR aligns runtime polling pause handling across OTA-related paths:
- adds a shared runtime polling pause flag for CIC, Modbus, and trend sampling
- gates the OT runtime update loop on the same shared pause state
- keeps OT component OTA lifecycle handling intact while making logs consistent
- adds the CIC pause wiring and removes the temporary entity overview docs

Validated with the Waveshare duo config-only check.