### PR TITLE
Move cooling settings into HA dashboards

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1236,13 +1236,6 @@ views:
                 name: Cooling supply error
               - entity: sensor.openquatt_cooling_demand_raw
                 name: Cooling demand (raw)
-              - entity: number.openquatt_cooling_minimum_supply_temp
-                name: Cooling minimum supply temp
-              - entity: number.openquatt_cooling_demand_max
-                name: Cooling demand max
-              - entity: number.openquatt_cooling_safety_margin
-                name: Cooling safety margin
-                icon: mdi:delta
     cards: []
     header:
       card:
@@ -2547,6 +2540,44 @@ views:
                 name: Heating Curve PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: Heating Curve PID Kd
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:snowflake
+            heading: Cooling settings
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - **Cooling Minimum Supply Temp** sets the lower limit for cooling supply temperature.
+              - **Cooling Demand Max** limits the maximum cooling demand the controller may build.
+              - **Cooling Safety Margin** sets the margin above the selected dew point.
+              - **Cooling PID Kp/Ki/Kd** tune the cooling PID:
+                - Kp: direct reaction.
+                - Ki: longer-term correction.
+                - Kd: damping.
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_cooling_minimum_supply_temp
+                name: Cooling minimum supply temp
+              - entity: number.openquatt_cooling_demand_max
+                name: Cooling demand max
+              - entity: number.openquatt_cooling_safety_margin
+                name: Cooling safety margin
+              - entity: number.openquatt_cooling_pid_kp
+                name: Cooling PID Kp
+              - entity: number.openquatt_cooling_pid_ki
+                name: Cooling PID Ki
+              - entity: number.openquatt_cooling_pid_kd
+                name: Cooling PID Kd
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1312,13 +1312,6 @@ views:
                 name: Cooling supply error
               - entity: sensor.openquatt_cooling_demand_raw
                 name: Cooling demand (raw)
-              - entity: number.openquatt_cooling_minimum_supply_temp
-                name: Cooling minimum supply temp
-              - entity: number.openquatt_cooling_demand_max
-                name: Cooling demand max
-              - entity: number.openquatt_cooling_safety_margin
-                name: Cooling safety margin
-                icon: mdi:delta
     cards: []
     header:
       card:
@@ -2668,6 +2661,44 @@ views:
                 name: Stooklijn-PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: Stooklijn-PID Kd
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:snowflake
+            heading: Koelingsinstellingen
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - **Cooling Minimum Supply Temp** begrenst de minimale koel-aanvoertemperatuur.
+              - **Cooling Demand Max** begrenst de maximale koelvraag.
+              - **Cooling Safety Margin** bepaalt de marge boven het geselecteerde dauwpunt.
+              - **Cooling PID Kp/Ki/Kd** stuurt de koel-PID:
+                - Kp: directe reactie.
+                - Ki: langdurige correctie.
+                - Kd: demping.
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_cooling_minimum_supply_temp
+                name: Cooling minimum supply temp
+              - entity: number.openquatt_cooling_demand_max
+                name: Cooling demand max
+              - entity: number.openquatt_cooling_safety_margin
+                name: Cooling safety margin
+              - entity: number.openquatt_cooling_pid_kp
+                name: Cooling PID Kp
+              - entity: number.openquatt_cooling_pid_ki
+                name: Cooling PID Ki
+              - entity: number.openquatt_cooling_pid_kd
+                name: Cooling PID Kd
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1224,13 +1224,6 @@ views:
                 name: Cooling supply error
               - entity: sensor.openquatt_cooling_demand_raw
                 name: Cooling demand (raw)
-              - entity: number.openquatt_cooling_minimum_supply_temp
-                name: Cooling minimum supply temp
-              - entity: number.openquatt_cooling_demand_max
-                name: Cooling demand max
-              - entity: number.openquatt_cooling_safety_margin
-                name: Cooling safety margin
-                icon: mdi:delta
     cards: []
     header:
       card:
@@ -2288,6 +2281,44 @@ views:
                 name: Heating Curve PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: Heating Curve PID Kd
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:snowflake
+            heading: Cooling settings
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - **Cooling Minimum Supply Temp** sets the lower limit for cooling supply temperature.
+              - **Cooling Demand Max** limits the maximum cooling demand the controller may build.
+              - **Cooling Safety Margin** sets the margin above the selected dew point.
+              - **Cooling PID Kp/Ki/Kd** tune the cooling PID:
+                - Kp: direct reaction.
+                - Ki: longer-term correction.
+                - Kd: damping.
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_cooling_minimum_supply_temp
+                name: Cooling minimum supply temp
+              - entity: number.openquatt_cooling_demand_max
+                name: Cooling demand max
+              - entity: number.openquatt_cooling_safety_margin
+                name: Cooling safety margin
+              - entity: number.openquatt_cooling_pid_kp
+                name: Cooling PID Kp
+              - entity: number.openquatt_cooling_pid_ki
+                name: Cooling PID Ki
+              - entity: number.openquatt_cooling_pid_kd
+                name: Cooling PID Kd
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1287,13 +1287,6 @@ views:
                 name: Cooling supply error
               - entity: sensor.openquatt_cooling_demand_raw
                 name: Cooling demand (raw)
-              - entity: number.openquatt_cooling_minimum_supply_temp
-                name: Cooling minimum supply temp
-              - entity: number.openquatt_cooling_demand_max
-                name: Cooling demand max
-              - entity: number.openquatt_cooling_safety_margin
-                name: Cooling safety margin
-                icon: mdi:delta
     cards: []
     header:
       card:
@@ -2372,6 +2365,44 @@ views:
                 name: Stooklijn-PID Ki
               - entity: number.openquatt_heating_curve_pid_kd
                 name: Stooklijn-PID Kd
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:snowflake
+            heading: Koelingsinstellingen
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - **Cooling Minimum Supply Temp** begrenst de minimale koel-aanvoertemperatuur.
+              - **Cooling Demand Max** begrenst de maximale koelvraag.
+              - **Cooling Safety Margin** bepaalt de marge boven het geselecteerde dauwpunt.
+              - **Cooling PID Kp/Ki/Kd** stuurt de koel-PID:
+                - Kp: directe reactie.
+                - Ki: langdurige correctie.
+                - Kd: demping.
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_cooling_minimum_supply_temp
+                name: Cooling minimum supply temp
+              - entity: number.openquatt_cooling_demand_max
+                name: Cooling demand max
+              - entity: number.openquatt_cooling_safety_margin
+                name: Cooling safety margin
+              - entity: number.openquatt_cooling_pid_kp
+                name: Cooling PID Kp
+              - entity: number.openquatt_cooling_pid_ki
+                name: Cooling PID Ki
+              - entity: number.openquatt_cooling_pid_kd
+                name: Cooling PID Kd
       - type: grid
         cards:
           - type: heading

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -127,6 +127,7 @@ binary_sensor:
   - platform: template
     id: cooling_fallback_active
     name: "Cooling Fallback Active"
+    internal: true
     icon: mdi:water-alert
     device_class: running
     lambda: |-
@@ -218,6 +219,7 @@ text_sensor:
   - platform: template
     id: cooling_guard_mode
     name: "Cooling Guard Mode"
+    disabled_by_default: true
     icon: mdi:shield-half-full
     entity_category: diagnostic
     update_interval: 10s
@@ -235,6 +237,7 @@ text_sensor:
   - platform: template
     id: cooling_block_reason
     name: "Cooling Block Reason"
+    disabled_by_default: true
     icon: mdi:information-outline
     entity_category: diagnostic
     update_interval: 5s
@@ -354,6 +357,7 @@ sensor:
   - platform: template
     id: cooling_fallback_night_min_outdoor_temp
     name: "Cooling Fallback Night Minimum Outdoor Temp"
+    disabled_by_default: true
     icon: mdi:weather-night
     unit_of_measurement: "°C"
     device_class: temperature
@@ -378,6 +382,7 @@ sensor:
   - platform: template
     id: cooling_fallback_min_supply_temp
     name: "Cooling Fallback Minimum Supply Temp"
+    disabled_by_default: true
     icon: mdi:thermometer-chevron-down
     unit_of_measurement: "°C"
     device_class: temperature

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -104,7 +104,6 @@ number:
   - platform: template
     id: cooling_pid_kp
     name: "Cooling PID Kp"
-    disabled_by_default: true
     icon: mdi:chart-bell-curve-cumulative
     min_value: 0.0
     max_value: 10.0
@@ -120,7 +119,6 @@ number:
   - platform: template
     id: cooling_pid_ki
     name: "Cooling PID Ki"
-    disabled_by_default: true
     icon: mdi:chart-timeline-variant
     min_value: 0.0
     max_value: 2.0
@@ -136,7 +134,6 @@ number:
   - platform: template
     id: cooling_pid_kd
     name: "Cooling PID Kd"
-    disabled_by_default: true
     icon: mdi:chart-line
     min_value: 0.0
     max_value: 2.0

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -230,7 +230,6 @@ text_sensor:
   - platform: template
     id: oq_cooling_enable_effective_source
     name: "Cooling Enable Effective Source"
-    internal: true
     icon: mdi:source-branch
     entity_category: diagnostic
     update_interval: 5s

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -230,6 +230,7 @@ text_sensor:
   - platform: template
     id: oq_cooling_enable_effective_source
     name: "Cooling Enable Effective Source"
+    internal: true
     icon: mdi:source-branch
     entity_category: diagnostic
     update_interval: 5s


### PR DESCRIPTION
This PR moves the cooling tuning/settings fields into the Home Assistant dashboards, while keeping the web app unchanged.

Included:
- Cooling Minimum Supply Temp
- Cooling Demand Max
- Cooling Safety Margin
- Cooling PID Kp/Ki/Kd
- cooling entity classification updates (internal / disabled by default)
- dashboard updates for Single and Duo, NL and EN

Excluded:
- autotune changes