### PR TITLE
Clean up HA tuning entities and PH fallback

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2624,35 +2624,9 @@ views:
               - **Minimum runtime** keeps a started compressor on for at least
               `300 s`. You can lengthen this runtime, but not lower it.
 
-              - **Demand filter ramp up** controls how many demand steps per
-              minute `Demand filtered` may rise toward `Demand raw` in Power
-              House mode.
-
               - In heating-curve mode, PID demand is passed through directly;
               allocation is single-HP-first with dual-enable hysteresis and
               sequential level steps.
-
-              - In Power House mode, OpenQuatt compares the best single-HP and
-              dual-HP options, prefers the lower-power topology by default, and
-              lets a less efficient topology win only when heat match is clearly
-              better. Switches toward a higher-power topology are held briefly to
-              reduce back-and-forth switching.
-
-              - **Dual HP enable level (lvl)** defines at which sustained
-              single-HP compressor level a second HP may be enabled in
-              heating-curve mode.
-
-              - Disable level is derived internally as `enable - 1` to keep tuning
-              compact.
-
-              - **Enable/disable hold** adds time hysteresis to damp frequent
-              toggling in heating-curve mode.
-
-              - Lower enable level or shorter enable-hold = faster second-HP
-              activation in heating-curve mode.
-
-              - Longer disable-hold = dual-HP stays active longer in
-              heating-curve mode.
 
 
               </details>
@@ -2662,14 +2636,6 @@ views:
             entities:
               - entity: number.openquatt_minimum_runtime
                 name: Minimum runtime
-              - entity: number.openquatt_demand_filter_ramp_up
-                name: Demand filter ramp up
-              - entity: number.openquatt_dual_hp_enable_level
-                name: Dual HP enable level
-              - entity: number.openquatt_dual_hp_enable_hold
-                name: Dual HP enable hold
-              - entity: number.openquatt_dual_hp_disable_hold
-                name: Dual HP disable hold
       - type: grid
         cards:
           - type: heading
@@ -3051,8 +3017,8 @@ views:
               - First compare `Supply target` and `Supply actual` to see control
               error.
 
-              - Use `Heating Curve PID` and `Reset PID integral` for fine tuning
-              when response is too slow or too nervous.
+              - Use `Heating Curve PID` for fine tuning when response is too
+              slow or too nervous.
 
               - `Outside temp (selected)` helps explain why `Supply target`
               rises or drops.
@@ -3071,8 +3037,6 @@ views:
                 name: Supply target
               - entity: sensor.openquatt_water_supply_temp_selected
                 name: Supply actual (selected)
-              - entity: button.openquatt_reset_heating_curve_pid_integral
-                name: Reset PID integral
     cards: []
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2748,36 +2748,9 @@ views:
               `300 s` aan. Je kunt deze runtime verlengen, maar niet lager
               zetten.
 
-              - **Demand filter ramp up** bepaalt met hoeveel demand-stappen per
-              minuut `Demand filtered` maximaal mag stijgen richting `Demand
-              raw` in PH-modus.
-
               - In heating-curve mode wordt PID-demand direct doorgezet; de
               allocatie is single-HP-first met dual-enable hysterese en
               sequentiële levelstappen.
-
-              - In Power House mode vergelijkt OpenQuatt de beste single-HP- en
-              dual-HP-opties, kiest normaal de topology met het laagste
-              elektrische verbruik en laat een minder zuinige topology alleen
-              winnen als de warmtematch duidelijk beter is. Wissels naar een
-              duurdere topology worden kort vastgehouden om op en neer schakelen
-              te beperken.
-
-              - **Dual HP enable level (lvl)** bepaalt bij welk aanhoudend
-              single-HP compressorlevel een tweede HP mag worden geactiveerd in
-              heating-curve mode.
-
-              - Disable-level wordt intern afgeleid als `enable - 1` om het
-              aantal instellingen beperkt te houden.
-
-              - **Enable/disable hold** voegt tijdhysterese toe om op en neer
-              schakelen te dempen in heating-curve mode.
-
-              - Lager enable-level of kortere enable-hold = sneller 2 HP actief
-              in heating-curve mode.
-
-              - Hogere disable-hold = langer dual-HP actief in heating-curve
-              mode.
 
 
               </details>
@@ -2787,14 +2760,6 @@ views:
             entities:
               - entity: number.openquatt_minimum_runtime
                 name: Minimum runtime
-              - entity: number.openquatt_demand_filter_ramp_up
-                name: Demand filter ramp up
-              - entity: number.openquatt_dual_hp_enable_level
-                name: Dual HP enable level
-              - entity: number.openquatt_dual_hp_enable_hold
-                name: Dual HP enable hold
-              - entity: number.openquatt_dual_hp_disable_hold
-                name: Dual HP disable hold
       - type: grid
         cards:
           - type: heading
@@ -3193,8 +3158,8 @@ views:
               - Vergelijk eerst `Aanvoerdoel` met `Werkelijke aanvoer (gekozen)`
               om de regelafwijking te zien.
 
-              - Gebruik `Stooklijn-PID` en `Reset PID-integraal` bij finetuning
-              als de regeling te traag of te nerveus reageert.
+              - Gebruik `Stooklijn-PID` bij finetuning als de regeling te
+              traag of te nerveus reageert.
 
               - `Buitentemp (gekozen)` helpt verklaren waarom het `Supply
               target` stijgt of daalt.
@@ -3213,8 +3178,6 @@ views:
                 name: Aanvoerdoel
               - entity: sensor.openquatt_water_supply_temp_selected
                 name: Werkelijke aanvoer (gekozen)
-              - entity: button.openquatt_reset_heating_curve_pid_integral
-                name: Reset PID-integraal
     cards: []
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2365,12 +2365,6 @@ views:
               - **Minimum runtime** keeps a started compressor on for at least
               `300 s`. You can lengthen this runtime, but not lower it.
 
-              - **Demand filter ramp up** controls how many demand steps per
-              minute `Demand filtered` may rise toward `Demand raw` in Power
-              House mode.
-
-
-
               </details>
             text_only: true
           - type: entities
@@ -2378,8 +2372,6 @@ views:
             entities:
               - entity: number.openquatt_minimum_runtime
                 name: Minimum runtime
-              - entity: number.openquatt_demand_filter_ramp_up
-                name: Demand filter ramp up
       - type: grid
         cards:
           - type: heading
@@ -2748,8 +2740,8 @@ views:
               - First compare `Supply target` and `Supply actual` to see control
               error.
 
-              - Use `Heating Curve PID` and `Reset PID integral` for fine tuning
-              when response is too slow or too nervous.
+              - Use `Heating Curve PID` for fine tuning when response is too
+              slow or too nervous.
 
               - `Outside temp (selected)` helps explain why `Supply target`
               rises or drops.
@@ -2768,8 +2760,6 @@ views:
                 name: Supply target
               - entity: sensor.openquatt_water_supply_temp_selected
                 name: Supply actual (selected)
-              - entity: button.openquatt_reset_heating_curve_pid_integral
-                name: Reset PID integral
     cards: []
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2451,10 +2451,6 @@ views:
               `300 s` aan. Je kunt deze runtime verlengen, maar niet lager
               zetten.
 
-              - **Demand filter ramp up** bepaalt met hoeveel demand-stappen per
-              minuut `Demand filtered` maximaal mag stijgen richting `Demand
-              raw` in PH-modus.
-
               - In heating-curve mode wordt PID-demand direct doorgezet en
               vertaald naar sequentiële levelstappen op HP1.
 
@@ -2466,8 +2462,6 @@ views:
             entities:
               - entity: number.openquatt_minimum_runtime
                 name: Minimum runtime
-              - entity: number.openquatt_demand_filter_ramp_up
-                name: Demand filter ramp up
       - type: grid
         cards:
           - type: heading
@@ -2838,8 +2832,8 @@ views:
               - Vergelijk eerst `Aanvoerdoel` met `Werkelijke aanvoer (gekozen)` om de
               regelafwijking te zien.
 
-              - Gebruik `Stooklijn-PID` en `Reset PID-integraal` bij
-              finetuning als de regeling te traag of te nerveus reageert.
+              - Gebruik `Stooklijn-PID` bij finetuning als de regeling te
+              traag of te nerveus reageert.
 
               - `Buitentemp (gekozen)` helpt verklaren waarom het `Supply
               target` stijgt of daalt.
@@ -2858,8 +2852,6 @@ views:
                 name: Aanvoerdoel
               - entity: sensor.openquatt_water_supply_temp_selected
                 name: Werkelijke aanvoer (gekozen)
-              - entity: button.openquatt_reset_heating_curve_pid_integral
-                name: Reset PID-integraal
     cards: []
     header:
       card:

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -328,35 +328,6 @@ select:
             ESP_LOGI("oq_fw", "Runtime logger level updated to %s", x.c_str());
             esphome::logger::global_logger->set_log_level(lvl);
 
-  - platform: template
-    name: "Debug Level Modbus"
-    id: debug_level_modbus_master
-    disabled_by_default: true
-    icon: mdi:lan
-    web_server:
-      sorting_group_id: oq_system_diagnostics
-    entity_category: diagnostic
-    optimistic: true
-    restore_value: true
-    options: [NONE, ERROR, WARN, INFO, CONFIG, DEBUG]
-    initial_option: WARN
-    on_value:
-      then:
-        - lambda: |-
-            int lvl =
-              (x == "NONE")    ? 0 :
-              (x == "ERROR")   ? 1 :
-              (x == "WARN")    ? 2 :
-              (x == "INFO")    ? 3 :
-              (x == "CONFIG")  ? 4 :
-                                 5;  // DEBUG
-
-            auto *logger = esphome::logger::global_logger;
-
-            ESP_LOGI("oq_fw", "Runtime Modbus logger levels updated to %s", x.c_str());
-            logger->set_log_level("modbus", lvl);
-            logger->set_log_level("modbus_controller", lvl);
-
 button:
   - platform: restart
     name: Restart
@@ -375,6 +346,7 @@ button:
   - platform: template
     id: oq_trend_history_flush_button
     name: Trendhistorie nu opslaan
+    disabled_by_default: true
     icon: mdi:content-save
     entity_category: config
     web_server:
@@ -412,6 +384,7 @@ switch:
   - platform: template
     id: oq_trend_history_enabled_switch
     name: Trendopslag
+    disabled_by_default: true
     icon: mdi:chart-line
     entity_category: config
     optimistic: true

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -331,6 +331,7 @@ button:
   - platform: template
     id: reset_heating_curve_pid_integral
     name: "Reset Heating Curve PID integral"
+    disabled_by_default: true
     icon: mdi:restart
     entity_category: config
     web_server:

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -680,9 +680,8 @@ interval:
           if (!perf_inputs_valid) {
             request_reason_code = 1;
             id(oq_duo_request_hold_until_ms) = 0;
-            int dual_on_f = (int) roundf(id(oq_dual_hp_enable_level).state);
-            if (dual_on_f < 2) dual_on_f = 2;
-            if (dual_on_f > demand_max_f) dual_on_f = demand_max_f;
+            // Use a fixed fallback threshold now that the tuning entity is gone.
+            int dual_on_f = std::max(2, std::min(5, demand_max_f));
             int dual_off_f = dual_on_f - 2;
             if (dual_off_f < 1) dual_off_f = 1;
 

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -247,6 +247,7 @@ number:
   - platform: template
     id: oq_demand_filter_ramp_up_step_min
     name: "Demand filter ramp up"
+    disabled_by_default: true
     icon: mdi:stairs-up
     unit_of_measurement: "step/min"
     min_value: 1

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -681,7 +681,7 @@ interval:
             request_reason_code = 1;
             id(oq_duo_request_hold_until_ms) = 0;
             // Use a fixed fallback threshold now that the tuning entity is gone.
-            int dual_on_f = std::max(2, std::min(5, demand_max_f));
+            int dual_on_f = std::max(2, std::min(9, demand_max_f));
             int dual_off_f = dual_on_f - 2;
             if (dual_off_f < 1) dual_off_f = 1;
 

--- a/openquatt/oq_setup_status.yaml
+++ b/openquatt/oq_setup_status.yaml
@@ -22,6 +22,7 @@ button:
   - platform: template
     id: oq_setup_complete_button
     name: "Complete setup"
+    disabled_by_default: true
     icon: mdi:check-bold
     entity_category: config
     web_server:
@@ -33,6 +34,7 @@ button:
   - platform: template
     id: oq_setup_reset_button
     name: "Reset setup state"
+    disabled_by_default: true
     icon: mdi:restart
     entity_category: config
     web_server:

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -243,25 +243,6 @@ number:
     web_server:
       sorting_group_id: oq_heating_strategy
 
-  # Dual-HP enable threshold on single-HP compressor level request (1..10).
-  # Disable threshold is derived internally as max(1, enable - 1) to keep parameter count low.
-  - platform: template
-    id: oq_dual_hp_enable_level
-    name: "Dual HP Enable Level"
-    internal: ${hc_dual_tuning_internal}
-    disabled_by_default: true
-    icon: mdi:arrow-up-bold-hexagon-outline
-    unit_of_measurement: "lvl"
-    min_value: 1
-    max_value: 10
-    step: 1
-    mode: slider
-    restore_value: true
-    optimistic: true
-    initial_value: 5
-    web_server:
-      sorting_group_id: oq_heating_strategy
-
   # Hold time before enabling dual-HP in curve mode.
   - platform: template
     id: oq_dual_hp_enable_hold_min

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -249,6 +249,7 @@ number:
     id: oq_dual_hp_enable_level
     name: "Dual HP Enable Level"
     internal: ${hc_dual_tuning_internal}
+    disabled_by_default: true
     icon: mdi:arrow-up-bold-hexagon-outline
     unit_of_measurement: "lvl"
     min_value: 1
@@ -266,6 +267,7 @@ number:
     id: oq_dual_hp_enable_hold_min
     name: "Dual HP Enable Hold"
     internal: ${hc_dual_tuning_internal}
+    disabled_by_default: true
     icon: mdi:timer-plus-outline
     unit_of_measurement: "min"
     min_value: 1
@@ -283,6 +285,7 @@ number:
     id: oq_dual_hp_disable_hold_min
     name: "Dual HP Disable Hold"
     internal: ${hc_dual_tuning_internal}
+    disabled_by_default: true
     icon: mdi:timer-minus-outline
     unit_of_measurement: "min"
     min_value: 1

--- a/openquatt/oq_web_access.yaml
+++ b/openquatt/oq_web_access.yaml
@@ -26,6 +26,7 @@ switch:
   - platform: template
     id: oq_ram_log_history_switch
     name: RAM log history
+    disabled_by_default: true
     icon: mdi:memory
     entity_category: config
     optimistic: true


### PR DESCRIPTION
This PR cleans up HA-facing tuning and diagnostic entities.

Changes:
- hide trend/history and setup/runtime helpers by default
- remove Debug Level Modbus and its logger plumbing
- hide Dual HP Hold controls by default and remove `Dual HP Enable Level`
- replace the Power House fallback dual threshold with a fixed map-based value
- remove those controls from the HA dashboard docs

Notes:
- The fallback dual threshold now uses a fixed value on the 0..20 demand scale, instead of a tunable entity.
- The web app is untouched.
- This keeps the PR focused on HA-facing cleanup and avoids the autotune changes.