### PR TITLE
Make flow autotune step adaptive

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2821,7 +2821,7 @@ views:
               - Start **Flow autotune** only on a stable installation without
               active faults.
 
-              - Set `u_step` and `max duration` first, then start autotune.
+              - Autotune uses a fixed duration and an adaptive step preset.
 
               - Apply `Apply autotune Kp/Ki` only if suggested values are
               sensible.
@@ -2840,10 +2840,6 @@ views:
                 name: Flow autotune abort
               - entity: button.openquatt_apply_flow_autotune_kp_ki
                 name: Apply autotune Kp/Ki
-              - entity: number.openquatt_flow_autotune_u_step_ipwm
-                name: Autotune u_step (iPWM)
-              - entity: number.openquatt_flow_autotune_max_duration_s
-                name: Autotune max duration
               - entity: number.openquatt_flow_autotune_kp_suggested
                 name: Autotune Kp suggested
               - entity: number.openquatt_flow_autotune_ki_suggested

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2945,7 +2945,7 @@ views:
               - **Flow autotune** starten bij stabiele installatie en zonder
               actieve fouten.
 
-              - Eerst `u_step` en `max duration` bepalen, daarna pas autotune
+              - Autotune gebruikt een vaste duur en een adaptieve stap-preset.
               starten.
 
               - `Apply autotune Kp/Ki` alleen toepassen als de voorgestelde
@@ -2965,10 +2965,6 @@ views:
                 name: Flow autotune afbreken
               - entity: button.openquatt_apply_flow_autotune_kp_ki
                 name: Pas autotune Kp/Ki toe
-              - entity: number.openquatt_flow_autotune_u_step_ipwm
-                name: Autotune u_step (iPWM)
-              - entity: number.openquatt_flow_autotune_max_duration_s
-                name: Autotune maximale duur
               - entity: number.openquatt_flow_autotune_kp_suggested
                 name: Autotune Kp voorstel
               - entity: number.openquatt_flow_autotune_ki_suggested

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2544,7 +2544,7 @@ views:
               - Start **Flow autotune** only on a stable installation without
               active faults.
 
-              - Set `u_step` and `max duration` first, then start autotune.
+              - Autotune uses a fixed duration and an adaptive step preset.
 
               - Apply `Apply autotune Kp/Ki` only if suggested values are
               sensible.
@@ -2563,10 +2563,6 @@ views:
                 name: Flow autotune abort
               - entity: button.openquatt_apply_flow_autotune_kp_ki
                 name: Apply autotune Kp/Ki
-              - entity: number.openquatt_flow_autotune_u_step_ipwm
-                name: Autotune u_step (iPWM)
-              - entity: number.openquatt_flow_autotune_max_duration_s
-                name: Autotune max duration
               - entity: number.openquatt_flow_autotune_kp_suggested
                 name: Autotune Kp suggested
               - entity: number.openquatt_flow_autotune_ki_suggested

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2635,7 +2635,7 @@ views:
               - **Flow autotune** starten bij stabiele installatie en zonder
               actieve fouten.
 
-              - Eerst `u_step` en `max duration` bepalen, daarna pas autotune
+              - Autotune gebruikt een vaste duur en een adaptieve stap-preset.
               starten.
 
               - `Apply autotune Kp/Ki` alleen toepassen als de voorgestelde
@@ -2655,10 +2655,6 @@ views:
                 name: Flow autotune afbreken
               - entity: button.openquatt_apply_flow_autotune_kp_ki
                 name: Pas autotune Kp/Ki toe
-              - entity: number.openquatt_flow_autotune_u_step_ipwm
-                name: Autotune u_step (iPWM)
-              - entity: number.openquatt_flow_autotune_max_duration_s
-                name: Autotune maximale duur
               - entity: number.openquatt_flow_autotune_kp_suggested
                 name: Autotune Kp voorstel
               - entity: number.openquatt_flow_autotune_ki_suggested

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -16,6 +16,7 @@
 #   1) Arm/Settle: force baseline PWM (last_good_pwm) and wait for stable flow
 #   2) Step: decrease iPWM with an adaptive step sized from the baseline PWM
 #   3) Measure: determine Δpv_ss and t63 (time to 63% response)
+#      and stop early once the response is settled and confirmed
 #   4) Compute: K = Δpv/Δu, τ = t63, θ≈Ts (5s), IMC-PI:
 #        Kp = τ / (K * (λ + θ))
 #        Ti = τ
@@ -80,6 +81,10 @@ globals:
     type: float
     restore_value: false
     initial_value: 'NAN'
+  - id: oq_flow_at_ss_confirm_cnt
+    type: int
+    restore_value: false
+    initial_value: '0'
 
 # ----------------------------
 # CONTROL INPUTS
@@ -225,6 +230,7 @@ interval:
             id(oq_flow_at_w0) = NAN;
             id(oq_flow_at_w1) = NAN;
             id(oq_flow_at_w2) = NAN;
+            id(oq_flow_at_ss_confirm_cnt) = 0;
             if (id(oq_flow_autotune_state) != 0) {
               id(oq_flow_autotune_state) = 0;
               id(oq_flow_autotune_status).publish_state("DISABLED");
@@ -261,6 +267,7 @@ interval:
               id(oq_flow_at_w0) = NAN;
               id(oq_flow_at_w1) = NAN;
               id(oq_flow_at_w2) = NAN;
+              id(oq_flow_at_ss_confirm_cnt) = 0;
               id(oq_flow_at_t) = 0;
 
               // Start from last known stable PWM (instead of instantaneous last_pwm),
@@ -285,6 +292,7 @@ interval:
               const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
               id(oq_flow_autotune_pwm) = pwm0;
               id(oq_flow_autotune_active) = true;
+              id(oq_flow_at_ss_confirm_cnt) = 0;
 
               // Baseline stability check on rolling 3-sample window.
               id(oq_flow_at_w0) = id(oq_flow_at_w1);
@@ -324,6 +332,7 @@ interval:
                     id(oq_flow_at_w0) = NAN;
                     id(oq_flow_at_w1) = NAN;
                     id(oq_flow_at_w2) = NAN;
+                    id(oq_flow_at_ss_confirm_cnt) = 0;
 
                     id(oq_flow_autotune_pwm) = pwm_step;
                     id(oq_flow_autotune_status).publish_state("STEP");
@@ -365,6 +374,9 @@ interval:
                 const bool ss_ready = (spread <= 6.0f) && (slope01 <= 2.0f) && (slope12 <= 2.0f);
                 if (ss_ready) {
                   id(oq_flow_at_pv_ss) = (w0 + w1 + w2) / 3.0f;
+                  if (id(oq_flow_at_ss_confirm_cnt) < 255) id(oq_flow_at_ss_confirm_cnt)++;
+                } else {
+                  id(oq_flow_at_ss_confirm_cnt) = 0;
                 }
               }
 
@@ -380,9 +392,14 @@ interval:
                 }
               }
 
+              const bool early_done =
+                  !isnan(id(oq_flow_at_pv_ss)) &&
+                  !isnan(id(oq_flow_at_pv63_time_s)) &&
+                  (id(oq_flow_at_ss_confirm_cnt) >= 2);
+
               id(oq_flow_at_t) = t + (int) sample_time_s;
 
-              if (t >= max_s) {
+              if (early_done || t >= max_s) {
                 if (isnan(id(oq_flow_at_pv_ss))) {
                   st = 4;
                   id(oq_flow_autotune_status).publish_state("ABORT: NO_STEADY_STATE");
@@ -470,6 +487,7 @@ interval:
             id(oq_flow_at_w0) = NAN;
             id(oq_flow_at_w1) = NAN;
             id(oq_flow_at_w2) = NAN;
+            id(oq_flow_at_ss_confirm_cnt) = 0;
 
             id(oq_flow_autotune_state) = 0;
             return;
@@ -482,6 +500,7 @@ interval:
             id(oq_flow_at_w0) = NAN;
             id(oq_flow_at_w1) = NAN;
             id(oq_flow_at_w2) = NAN;
+            id(oq_flow_at_ss_confirm_cnt) = 0;
             id(oq_flow_autotune_status).publish_state("ABORTED");
             id(oq_flow_autotune_state) = 0;
             return;

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -14,7 +14,7 @@
 #
 # Operation (high level):
 #   1) Arm/Settle: force baseline PWM (last_good_pwm) and wait for stable flow
-#   2) Step: decrease iPWM with u_step (=> stronger pumping) during max_s
+#   2) Step: decrease iPWM with an adaptive step sized from the baseline PWM
 #   3) Measure: determine Δpv_ss and t63 (time to 63% response)
 #   4) Compute: K = Δpv/Δu, τ = t63, θ≈Ts (5s), IMC-PI:
 #        Kp = τ / (K * (λ + θ))
@@ -149,38 +149,6 @@ button:
 
 number:
   - platform: template
-    id: oq_flow_autotune_u_step
-    name: "Flow Autotune u_step (iPWM)"
-    icon: mdi:arrow-expand-vertical
-    unit_of_measurement: "iPWM"
-    mode: slider
-    min_value: 5
-    max_value: 120
-    step: 1
-    restore_value: true
-    optimistic: true
-    initial_value: 40
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_flow
-
-  - platform: template
-    id: oq_flow_autotune_max_s
-    name: "Flow Autotune max duration (s)"
-    icon: mdi:timer-outline
-    unit_of_measurement: "s"
-    mode: slider
-    min_value: 30
-    max_value: 240
-    step: 5
-    restore_value: true
-    optimistic: true
-    initial_value: 120
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_flow
-
-  - platform: template
     id: oq_flow_kp_suggested
     name: "Flow Autotune Kp suggested"
     icon: mdi:alpha-k-circle-outline
@@ -227,6 +195,10 @@ interval:
     then:
       - lambda: |-
           const float sample_time_s = ${oq_flow_ts}.0f;
+          constexpr float kAutotuneStepFrac = 0.08f;
+          constexpr int kAutotuneStepMinIpwm = 10;
+          constexpr int kAutotuneStepMaxIpwm = 40;
+          constexpr int kAutotuneDurationS = 120;
 
           auto clamp_ipwm = [](int value) -> int {
             if (value < ${oq_flow_pwm_min}) return ${oq_flow_pwm_min};
@@ -335,19 +307,28 @@ interval:
                 if (t >= ${oq_flow_autotune_settle_s} && spread <= ${oq_flow_autotune_stable_band_lph}) {
                   id(oq_flow_at_pv0) = mean;
 
-                  int u_step = (int) roundf(id(oq_flow_autotune_u_step).state);
-                  if (u_step < ${oq_flow_autotune_min_step}) u_step = ${oq_flow_autotune_min_step};
+                  const int pwm_headroom = pwm0 - ${oq_flow_pwm_min};
+                  if (pwm_headroom < ${oq_flow_autotune_min_step}) {
+                    st = 4;
+                    id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
+                  } else {
+                    int u_step = (int) roundf(kAutotuneStepFrac * (float) pwm0);
+                    if (u_step < kAutotuneStepMinIpwm) u_step = kAutotuneStepMinIpwm;
+                    if (u_step > kAutotuneStepMaxIpwm) u_step = kAutotuneStepMaxIpwm;
+                    if (u_step > pwm_headroom) u_step = pwm_headroom;
+                    if (u_step < ${oq_flow_autotune_min_step}) u_step = ${oq_flow_autotune_min_step};
 
-                  const int pwm_step = clamp_ipwm(pwm0 - u_step);
-                  id(oq_flow_at_pwm_step) = pwm_step;
-                  id(oq_flow_at_t) = 0;
-                  id(oq_flow_at_w0) = NAN;
-                  id(oq_flow_at_w1) = NAN;
-                  id(oq_flow_at_w2) = NAN;
+                    const int pwm_step = clamp_ipwm(pwm0 - u_step);
+                    id(oq_flow_at_pwm_step) = pwm_step;
+                    id(oq_flow_at_t) = 0;
+                    id(oq_flow_at_w0) = NAN;
+                    id(oq_flow_at_w1) = NAN;
+                    id(oq_flow_at_w2) = NAN;
 
-                  id(oq_flow_autotune_pwm) = pwm_step;
-                  id(oq_flow_autotune_status).publish_state("STEP");
-                  st = 2;
+                    id(oq_flow_autotune_pwm) = pwm_step;
+                    id(oq_flow_autotune_status).publish_state("STEP");
+                    st = 2;
+                  }
                 }
               }
             }
@@ -362,7 +343,7 @@ interval:
             else {
               const float pv0 = id(oq_flow_at_pv0);
               const int t = id(oq_flow_at_t);
-              const int max_s = (int) roundf(id(oq_flow_autotune_max_s).state);
+              const int max_s = kAutotuneDurationS;
 
               // Rolling window for ss-estimate.
               id(oq_flow_at_w0) = id(oq_flow_at_w1);


### PR DESCRIPTION
## What
- Replace the manual `u_step` and `max duration` autotune sliders with internal presets.
- Compute the step size adaptively from the baseline PWM (`round(0.08 * pwm0)`) with sane bounds.
- Keep a fixed 120-second cap, but stop early once the step response is settled and confirmed.
- Update the dashboard copy so the UI matches the new behavior.

## Why
Autotune is meant to work across many installations, so the step should scale with the operating point instead of relying on a manually chosen absolute iPWM delta. A conservative early-stop path keeps the tune short on fast systems without sacrificing the hard safety cap.

## Impact
This makes autotune more universal and removes two configuration knobs from the service UI, while still keeping the run bounded and predictable. On installations that settle quickly, the tune should now finish sooner than the full cap.