### PR TITLE
Add CM100 commissioning service mode, boiler test, and flow autotune

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2912,8 +2912,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: switch.openquatt_flow_autotune_enable
-                name: Flow autotune enable
               - entity: button.openquatt_flow_autotune_start
                 name: Flow autotune start
               - entity: button.openquatt_flow_autotune_abort

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2809,6 +2809,83 @@ views:
         cards:
           - type: heading
             icon: mdi:tools
+            heading: CM100 commissioning
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Start **CM100** first. In this mode nothing happens yet: no
+              flow, no boiler, and no autotune.
+
+              - Then choose exactly one commissioning task: **Boiler power
+              test** or **Flow autotune**.
+
+              - The task buttons can also request CM100 themselves, but the
+              recommended workflow is: start CM100 first, then start the task.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_commissioning_cm100_start
+                name: Start CM100
+              - entity: button.openquatt_commissioning_cm100_stop
+                name: Stop CM100
+              - entity: sensor.openquatt_control_mode_label
+                name: ControlMode
+              - entity: binary_sensor.openquatt_commissioning_cm100_active
+                name: CM100 active
+              - entity: text_sensor.openquatt_commissioning_status
+                name: CM100 status
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:water-boiler
+            heading: Boiler power test
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Measures the effective boiler output at stable flow.
+
+              - Prefer starting the test from an already active **CM100**.
+
+              - Apply the measured value only if it looks sensible.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_boiler_power_test_start
+                name: Start boiler power test
+              - entity: button.openquatt_boiler_power_test_abort
+                name: Abort boiler power test
+              - entity: button.openquatt_boiler_power_test_apply
+                name: Apply boiler power
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Boiler rated heat power
+              - entity: sensor.openquatt_boiler_power_test_result
+                name: Boiler power test result
+              - entity: sensor.openquatt_boiler_power_test_confidence
+                name: Boiler power test confidence
+              - entity: sensor.openquatt_boiler_power_test_status
+                name: Boiler power test status
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:tools
             heading: Flow autotune
             heading_style: title
           - type: markdown
@@ -2818,8 +2895,11 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - Start **Flow autotune** only on a stable installation without
-              active faults.
+              - Start **Flow autotune** preferably from an already active
+              **CM100**.
+
+              - In CM100, autotune starts the flow itself and then measures
+              the response.
 
               - Autotune uses a fixed duration and an adaptive step preset.
 

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2824,8 +2824,8 @@ views:
               - Then choose exactly one commissioning task: **Boiler power
               test** or **Flow autotune**.
 
-              - The task buttons can also request CM100 themselves, but the
-              recommended workflow is: start CM100 first, then start the task.
+              - Start **CM100** first. Only then can you start exactly one
+              commissioning task.
 
 
               </details>
@@ -2858,7 +2858,7 @@ views:
 
               - Measures the effective boiler output at stable flow.
 
-              - Prefer starting the test from an already active **CM100**.
+              - Start the test only while **CM100** is already active.
 
               - Apply the measured value only if it looks sensible.
 
@@ -2895,8 +2895,8 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - Start **Flow autotune** preferably from an already active
-              **CM100**.
+              - Start **Flow autotune** only while **CM100** is already
+              active.
 
               - In CM100, autotune starts the flow itself and then measures
               the response.

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2833,13 +2833,13 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: button.openquatt_commissioning_cm100_start
+              - entity: button.openquatt_cm100_start
                 name: Start CM100
-              - entity: button.openquatt_commissioning_cm100_stop
+              - entity: button.openquatt_cm100_stop
                 name: Stop CM100
               - entity: sensor.openquatt_control_mode_label
                 name: ControlMode
-              - entity: binary_sensor.openquatt_commissioning_cm100_active
+              - entity: binary_sensor.openquatt_cm100_active
                 name: CM100 active
               - entity: text_sensor.openquatt_commissioning_status
                 name: CM100 status
@@ -2880,7 +2880,7 @@ views:
                 name: Boiler power test result
               - entity: sensor.openquatt_boiler_power_test_confidence
                 name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
+              - entity: text_sensor.openquatt_boiler_power_test_status
                 name: Boiler power test status
       - type: grid
         cards:
@@ -2924,7 +2924,7 @@ views:
                 name: Autotune Kp suggested
               - entity: number.openquatt_flow_autotune_ki_suggested
                 name: Autotune Ki suggested
-              - entity: sensor.openquatt_flow_autotune_status
+              - entity: text_sensor.openquatt_flow_autotune_status
                 name: Autotune status
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2841,7 +2841,7 @@ views:
                 name: ControlMode
               - entity: binary_sensor.openquatt_cm100_active
                 name: CM100 active
-              - entity: text_sensor.openquatt_commissioning_status
+              - entity: sensor.openquatt_commissioning_status
                 name: CM100 status
       - type: grid
         cards:
@@ -2880,7 +2880,7 @@ views:
                 name: Boiler power test result
               - entity: sensor.openquatt_boiler_power_test_confidence
                 name: Boiler power test confidence
-              - entity: text_sensor.openquatt_boiler_power_test_status
+              - entity: sensor.openquatt_boiler_power_test_status
                 name: Boiler power test status
       - type: grid
         cards:
@@ -2924,7 +2924,7 @@ views:
                 name: Autotune Kp suggested
               - entity: number.openquatt_flow_autotune_ki_suggested
                 name: Autotune Ki suggested
-              - entity: text_sensor.openquatt_flow_autotune_status
+              - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -3036,8 +3036,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: switch.openquatt_flow_autotune_enable
-                name: Flow autotune inschakelen
               - entity: button.openquatt_flow_autotune_start
                 name: Flow autotune starten
               - entity: button.openquatt_flow_autotune_abort

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2933,6 +2933,83 @@ views:
         cards:
           - type: heading
             icon: mdi:tools
+            heading: CM100 commissioning
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Start eerst **CM100**. In deze stand gebeurt nog niets: geen
+              flow, geen boiler en geen autotune.
+
+              - Kies daarna precies één commissioningtaak: **Boiler power test**
+              of **Flow autotune**.
+
+              - De taakknoppen kunnen CM100 ook zelf aanvragen, maar de
+              aanbevolen workflow is: eerst CM100 starten, daarna de taak.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_commissioning_cm100_start
+                name: CM100 starten
+              - entity: button.openquatt_commissioning_cm100_stop
+                name: CM100 stoppen
+              - entity: sensor.openquatt_control_mode_label
+                name: ControlMode
+              - entity: binary_sensor.openquatt_commissioning_cm100_active
+                name: CM100 actief
+              - entity: text_sensor.openquatt_commissioning_status
+                name: CM100 status
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:water-boiler
+            heading: Boiler power test
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Meet het effectieve ketelvermogen bij stabiele flow.
+
+              - Start de test liefst vanuit een al actieve **CM100**.
+
+              - Pas de gemeten waarde toe als die logisch oogt.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_boiler_power_test_start
+                name: Boiler power test starten
+              - entity: button.openquatt_boiler_power_test_abort
+                name: Boiler power test afbreken
+              - entity: button.openquatt_boiler_power_test_apply
+                name: Pas boilervermogen toe
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Boiler rated heat power
+              - entity: sensor.openquatt_boiler_power_test_result
+                name: Boiler power test resultaat
+              - entity: sensor.openquatt_boiler_power_test_confidence
+                name: Boiler power test confidence
+              - entity: sensor.openquatt_boiler_power_test_status
+                name: Boiler power test status
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:tools
             heading: Flow autotune
             heading_style: title
           - type: markdown
@@ -2942,8 +3019,10 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Flow autotune** starten bij stabiele installatie en zonder
-              actieve fouten.
+              - Start **Flow autotune** liefst vanuit een al actieve **CM100**.
+
+              - In CM100 start de autotune zelf de flow op en meet daarna de
+              respons.
 
               - Autotune gebruikt een vaste duur en een adaptieve stap-preset.
               starten.

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2948,8 +2948,8 @@ views:
               - Kies daarna precies één commissioningtaak: **Boiler power test**
               of **Flow autotune**.
 
-              - De taakknoppen kunnen CM100 ook zelf aanvragen, maar de
-              aanbevolen workflow is: eerst CM100 starten, daarna de taak.
+              - Start eerst **CM100**. Pas daarna kun je precies één
+              commissioningtaak starten.
 
 
               </details>
@@ -2982,7 +2982,7 @@ views:
 
               - Meet het effectieve ketelvermogen bij stabiele flow.
 
-              - Start de test liefst vanuit een al actieve **CM100**.
+              - Start de test alleen terwijl **CM100** al actief is.
 
               - Pas de gemeten waarde toe als die logisch oogt.
 
@@ -3019,9 +3019,9 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - Start **Flow autotune** liefst vanuit een al actieve **CM100**.
+              - Start **Flow autotune** alleen terwijl **CM100** al actief is.
 
-              - In CM100 start de autotune zelf de flow op en meet daarna de
+              - In CM100 start autotune zelf de flow op en meet daarna de
               respons.
 
               - Autotune gebruikt een vaste duur en een adaptieve stap-preset.

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2965,7 +2965,7 @@ views:
                 name: ControlMode
               - entity: binary_sensor.openquatt_cm100_active
                 name: CM100 actief
-              - entity: text_sensor.openquatt_commissioning_status
+              - entity: sensor.openquatt_commissioning_status
                 name: CM100 status
       - type: grid
         cards:
@@ -3004,7 +3004,7 @@ views:
                 name: Boiler power test resultaat
               - entity: sensor.openquatt_boiler_power_test_confidence
                 name: Boiler power test confidence
-              - entity: text_sensor.openquatt_boiler_power_test_status
+              - entity: sensor.openquatt_boiler_power_test_status
                 name: Boiler power test status
       - type: grid
         cards:
@@ -3048,7 +3048,7 @@ views:
                 name: Autotune Kp voorstel
               - entity: number.openquatt_flow_autotune_ki_suggested
                 name: Autotune Ki voorstel
-              - entity: text_sensor.openquatt_flow_autotune_status
+              - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2957,13 +2957,13 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: button.openquatt_commissioning_cm100_start
+              - entity: button.openquatt_cm100_start
                 name: CM100 starten
-              - entity: button.openquatt_commissioning_cm100_stop
+              - entity: button.openquatt_cm100_stop
                 name: CM100 stoppen
               - entity: sensor.openquatt_control_mode_label
                 name: ControlMode
-              - entity: binary_sensor.openquatt_commissioning_cm100_active
+              - entity: binary_sensor.openquatt_cm100_active
                 name: CM100 actief
               - entity: text_sensor.openquatt_commissioning_status
                 name: CM100 status
@@ -3004,7 +3004,7 @@ views:
                 name: Boiler power test resultaat
               - entity: sensor.openquatt_boiler_power_test_confidence
                 name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
+              - entity: text_sensor.openquatt_boiler_power_test_status
                 name: Boiler power test status
       - type: grid
         cards:
@@ -3048,7 +3048,7 @@ views:
                 name: Autotune Kp voorstel
               - entity: number.openquatt_flow_autotune_ki_suggested
                 name: Autotune Ki voorstel
-              - entity: sensor.openquatt_flow_autotune_status
+              - entity: text_sensor.openquatt_flow_autotune_status
                 name: Autotune status
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2532,6 +2532,83 @@ views:
         cards:
           - type: heading
             icon: mdi:tools
+            heading: CM100 commissioning
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Start **CM100** first. In this mode nothing happens yet: no
+              flow, no boiler, and no autotune.
+
+              - Then choose exactly one commissioning task: **Boiler power
+              test** or **Flow autotune**.
+
+              - The task buttons can also request CM100 themselves, but the
+              recommended workflow is: start CM100 first, then start the task.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_commissioning_cm100_start
+                name: Start CM100
+              - entity: button.openquatt_commissioning_cm100_stop
+                name: Stop CM100
+              - entity: sensor.openquatt_control_mode_label
+                name: ControlMode
+              - entity: binary_sensor.openquatt_commissioning_cm100_active
+                name: CM100 active
+              - entity: text_sensor.openquatt_commissioning_status
+                name: CM100 status
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:water-boiler
+            heading: Boiler power test
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Measures the effective boiler output at stable flow.
+
+              - Prefer starting the test from an already active **CM100**.
+
+              - Apply the measured value only if it looks sensible.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_boiler_power_test_start
+                name: Start boiler power test
+              - entity: button.openquatt_boiler_power_test_abort
+                name: Abort boiler power test
+              - entity: button.openquatt_boiler_power_test_apply
+                name: Apply boiler power
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Boiler rated heat power
+              - entity: sensor.openquatt_boiler_power_test_result
+                name: Boiler power test result
+              - entity: sensor.openquatt_boiler_power_test_confidence
+                name: Boiler power test confidence
+              - entity: sensor.openquatt_boiler_power_test_status
+                name: Boiler power test status
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:tools
             heading: Flow autotune
             heading_style: title
           - type: markdown
@@ -2541,8 +2618,11 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - Start **Flow autotune** only on a stable installation without
-              active faults.
+              - Start **Flow autotune** preferably from an already active
+              **CM100**.
+
+              - In CM100, autotune starts the flow itself and then measures
+              the response.
 
               - Autotune uses a fixed duration and an adaptive step preset.
 

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2635,8 +2635,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: switch.openquatt_flow_autotune_enable
-                name: Flow autotune enable
               - entity: button.openquatt_flow_autotune_start
                 name: Flow autotune start
               - entity: button.openquatt_flow_autotune_abort

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2547,8 +2547,8 @@ views:
               - Then choose exactly one commissioning task: **Boiler power
               test** or **Flow autotune**.
 
-              - The task buttons can also request CM100 themselves, but the
-              recommended workflow is: start CM100 first, then start the task.
+              - Start **CM100** first. Only then can you start exactly one
+              commissioning task.
 
 
               </details>
@@ -2581,7 +2581,7 @@ views:
 
               - Measures the effective boiler output at stable flow.
 
-              - Prefer starting the test from an already active **CM100**.
+              - Start the test only while **CM100** is already active.
 
               - Apply the measured value only if it looks sensible.
 
@@ -2618,8 +2618,8 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - Start **Flow autotune** preferably from an already active
-              **CM100**.
+              - Start **Flow autotune** only while **CM100** is already
+              active.
 
               - In CM100, autotune starts the flow itself and then measures
               the response.

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2556,13 +2556,13 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: button.openquatt_commissioning_cm100_start
+              - entity: button.openquatt_cm100_start
                 name: Start CM100
-              - entity: button.openquatt_commissioning_cm100_stop
+              - entity: button.openquatt_cm100_stop
                 name: Stop CM100
               - entity: sensor.openquatt_control_mode_label
                 name: ControlMode
-              - entity: binary_sensor.openquatt_commissioning_cm100_active
+              - entity: binary_sensor.openquatt_cm100_active
                 name: CM100 active
               - entity: text_sensor.openquatt_commissioning_status
                 name: CM100 status
@@ -2603,7 +2603,7 @@ views:
                 name: Boiler power test result
               - entity: sensor.openquatt_boiler_power_test_confidence
                 name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
+              - entity: text_sensor.openquatt_boiler_power_test_status
                 name: Boiler power test status
       - type: grid
         cards:
@@ -2647,7 +2647,7 @@ views:
                 name: Autotune Kp suggested
               - entity: number.openquatt_flow_autotune_ki_suggested
                 name: Autotune Ki suggested
-              - entity: sensor.openquatt_flow_autotune_status
+              - entity: text_sensor.openquatt_flow_autotune_status
                 name: Autotune status
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2564,7 +2564,7 @@ views:
                 name: ControlMode
               - entity: binary_sensor.openquatt_cm100_active
                 name: CM100 active
-              - entity: text_sensor.openquatt_commissioning_status
+              - entity: sensor.openquatt_commissioning_status
                 name: CM100 status
       - type: grid
         cards:
@@ -2603,7 +2603,7 @@ views:
                 name: Boiler power test result
               - entity: sensor.openquatt_boiler_power_test_confidence
                 name: Boiler power test confidence
-              - entity: text_sensor.openquatt_boiler_power_test_status
+              - entity: sensor.openquatt_boiler_power_test_status
                 name: Boiler power test status
       - type: grid
         cards:
@@ -2647,7 +2647,7 @@ views:
                 name: Autotune Kp suggested
               - entity: number.openquatt_flow_autotune_ki_suggested
                 name: Autotune Ki suggested
-              - entity: text_sensor.openquatt_flow_autotune_status
+              - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2638,8 +2638,8 @@ views:
               - Kies daarna precies één commissioningtaak: **Boiler power test**
               of **Flow autotune**.
 
-              - De taakknoppen kunnen CM100 ook zelf aanvragen, maar de
-              aanbevolen workflow is: eerst CM100 starten, daarna de taak.
+              - Start eerst **CM100**. Pas daarna kun je precies één
+              commissioningtaak starten.
 
 
               </details>
@@ -2672,7 +2672,7 @@ views:
 
               - Meet het effectieve ketelvermogen bij stabiele flow.
 
-              - Start de test liefst vanuit een al actieve **CM100**.
+              - Start de test alleen terwijl **CM100** al actief is.
 
               - Pas de gemeten waarde toe als die logisch oogt.
 
@@ -2709,9 +2709,9 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - Start **Flow autotune** liefst vanuit een al actieve **CM100**.
+              - Start **Flow autotune** alleen terwijl **CM100** al actief is.
 
-              - In CM100 start de autotune zelf de flow op en meet daarna de
+              - In CM100 start autotune zelf de flow op en meet daarna de
               respons.
 
               - Autotune gebruikt een vaste duur en een adaptieve stap-preset.

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2726,8 +2726,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: switch.openquatt_flow_autotune_enable
-                name: Flow autotune inschakelen
               - entity: button.openquatt_flow_autotune_start
                 name: Flow autotune starten
               - entity: button.openquatt_flow_autotune_abort

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2623,6 +2623,83 @@ views:
         cards:
           - type: heading
             icon: mdi:tools
+            heading: CM100 commissioning
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Start eerst **CM100**. In deze stand gebeurt nog niets: geen
+              flow, geen boiler en geen autotune.
+
+              - Kies daarna precies één commissioningtaak: **Boiler power test**
+              of **Flow autotune**.
+
+              - De taakknoppen kunnen CM100 ook zelf aanvragen, maar de
+              aanbevolen workflow is: eerst CM100 starten, daarna de taak.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_commissioning_cm100_start
+                name: CM100 starten
+              - entity: button.openquatt_commissioning_cm100_stop
+                name: CM100 stoppen
+              - entity: sensor.openquatt_control_mode_label
+                name: ControlMode
+              - entity: binary_sensor.openquatt_commissioning_cm100_active
+                name: CM100 actief
+              - entity: text_sensor.openquatt_commissioning_status
+                name: CM100 status
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:water-boiler
+            heading: Boiler power test
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Meet het effectieve ketelvermogen bij stabiele flow.
+
+              - Start de test liefst vanuit een al actieve **CM100**.
+
+              - Pas de gemeten waarde toe als die logisch oogt.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_boiler_power_test_start
+                name: Boiler power test starten
+              - entity: button.openquatt_boiler_power_test_abort
+                name: Boiler power test afbreken
+              - entity: button.openquatt_boiler_power_test_apply
+                name: Pas boilervermogen toe
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Boiler rated heat power
+              - entity: sensor.openquatt_boiler_power_test_result
+                name: Boiler power test resultaat
+              - entity: sensor.openquatt_boiler_power_test_confidence
+                name: Boiler power test confidence
+              - entity: sensor.openquatt_boiler_power_test_status
+                name: Boiler power test status
+      - type: grid
+        cards:
+          - type: heading
+            icon: mdi:tools
             heading: Flow autotune
             heading_style: title
           - type: markdown
@@ -2632,8 +2709,10 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Flow autotune** starten bij stabiele installatie en zonder
-              actieve fouten.
+              - Start **Flow autotune** liefst vanuit een al actieve **CM100**.
+
+              - In CM100 start de autotune zelf de flow op en meet daarna de
+              respons.
 
               - Autotune gebruikt een vaste duur en een adaptieve stap-preset.
               starten.

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2655,7 +2655,7 @@ views:
                 name: ControlMode
               - entity: binary_sensor.openquatt_cm100_active
                 name: CM100 actief
-              - entity: text_sensor.openquatt_commissioning_status
+              - entity: sensor.openquatt_commissioning_status
                 name: CM100 status
       - type: grid
         cards:
@@ -2694,7 +2694,7 @@ views:
                 name: Boiler power test resultaat
               - entity: sensor.openquatt_boiler_power_test_confidence
                 name: Boiler power test confidence
-              - entity: text_sensor.openquatt_boiler_power_test_status
+              - entity: sensor.openquatt_boiler_power_test_status
                 name: Boiler power test status
       - type: grid
         cards:
@@ -2738,7 +2738,7 @@ views:
                 name: Autotune Kp voorstel
               - entity: number.openquatt_flow_autotune_ki_suggested
                 name: Autotune Ki voorstel
-              - entity: text_sensor.openquatt_flow_autotune_status
+              - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
     header:
       card:

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2647,13 +2647,13 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: button.openquatt_commissioning_cm100_start
+              - entity: button.openquatt_cm100_start
                 name: CM100 starten
-              - entity: button.openquatt_commissioning_cm100_stop
+              - entity: button.openquatt_cm100_stop
                 name: CM100 stoppen
               - entity: sensor.openquatt_control_mode_label
                 name: ControlMode
-              - entity: binary_sensor.openquatt_commissioning_cm100_active
+              - entity: binary_sensor.openquatt_cm100_active
                 name: CM100 actief
               - entity: text_sensor.openquatt_commissioning_status
                 name: CM100 status
@@ -2694,7 +2694,7 @@ views:
                 name: Boiler power test resultaat
               - entity: sensor.openquatt_boiler_power_test_confidence
                 name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
+              - entity: text_sensor.openquatt_boiler_power_test_status
                 name: Boiler power test status
       - type: grid
         cards:
@@ -2738,7 +2738,7 @@ views:
                 name: Autotune Kp voorstel
               - entity: number.openquatt_flow_autotune_ki_suggested
                 name: Autotune Ki voorstel
-              - entity: sensor.openquatt_flow_autotune_status
+              - entity: text_sensor.openquatt_flow_autotune_status
                 name: Autotune status
     header:
       card:

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -53,7 +53,7 @@ In gewone taal:
 
 De ketel springt dus normaal niet op elk kort dipje direct bij.
 
-`CM100` is iets anders: dat is een expliciete service- of commissioningstand voor metingen zoals het boilervermogentestje. Daar hoort geen normale warmtevraaglogica bij.
+`CM100` is iets anders: dat is een expliciete service- of commissioningstand voor metingen zoals het boilervermogentestje of flow-autotune. Daar hoort geen normale warmtevraaglogica bij.
 
 ## Waarom blijft het systeem soms juist te lang in een tussenstand?
 

--- a/docs/regelgedrag-van-openquatt.md
+++ b/docs/regelgedrag-van-openquatt.md
@@ -23,6 +23,7 @@ Daardoor kun je vreemd gedrag bijna nooit verklaren vanuit alleen een pompstand 
 | `CM2` | normaal verwarmen met warmtepomp |
 | `CM3` | warmtepomp met ketelhulp |
 | `CM98` | vorstbeveiliging |
+| `CM100` | commissioning / servicedoel |
 
 Voor gebruikers zijn vooral deze twee dingen belangrijk:
 
@@ -51,6 +52,8 @@ In gewone taal:
 - pas dan mag ketelhulp actief worden.
 
 De ketel springt dus normaal niet op elk kort dipje direct bij.
+
+`CM100` is iets anders: dat is een expliciete service- of commissioningstand voor metingen zoals het boilervermogentestje. Daar hoort geen normale warmtevraaglogica bij.
 
 ## Waarom blijft het systeem soms juist te lang in een tussenstand?
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -40,24 +40,25 @@ Package include order is intentional:
 
 1. `oq_common`
 2. `oq_supervisory_controlmode`
-3. `oq_thermal_limits`
-4. `oq_strategy_manager`
-5. `oq_cooling_strategy`
-6. `oq_heating_curve_strategy`
-7. `oq_power_house_strategy`
-8. `oq_thermal_request_control`
-9. `oq_thermal_actuator`
-10. `oq_flow_control`
-11. `oq_flow_autotune`
-12. `oq_boiler_control`
-13. `oq_energy`
-14. `oq_cic`
-15. `oq_ha_inputs`
-16. `oq_local_sensors`
-17. `oq_sensor_sources`
-18. `oq_ot_slave`
-19. `oq_webserver`
-20. `oq_HP_io` (HP1 always; HP2 only on Duo)
+3. `oq_commissioning`
+4. `oq_thermal_limits`
+5. `oq_strategy_manager`
+6. `oq_cooling_strategy`
+7. `oq_heating_curve_strategy`
+8. `oq_power_house_strategy`
+9. `oq_thermal_request_control`
+10. `oq_thermal_actuator`
+11. `oq_flow_control`
+12. `oq_flow_autotune`
+13. `oq_boiler_control`
+14. `oq_energy`
+15. `oq_cic`
+16. `oq_ha_inputs`
+17. `oq_local_sensors`
+18. `oq_sensor_sources`
+19. `oq_ot_slave`
+20. `oq_webserver`
+21. `oq_HP_io` (HP1 always; HP2 only on Duo)
 
 This order mirrors data dependencies and ownership boundaries.
 `oq_ot_slave` uses the ESP-IDF RMT-based OpenTherm runtime and is only intended for RMT-capable ESP32 targets.
@@ -67,6 +68,7 @@ This order mirrors data dependencies and ownership boundaries.
 OpenQuatt follows strict subsystem ownership:
 
 - **Control Mode state machine**: `oq_supervisory_controlmode`
+- **Commissioning / service tasks**: `oq_commissioning`
 - **Shared heating strategy interface (`oq_heat_mode_code`, `oq_strategy_*`)**: `oq_strategy_manager`
 - **Heating-curve demand and compressor requests**: `oq_heating_curve_strategy`
 - **Power House demand and compressor requests**: `oq_power_house_strategy`
@@ -94,7 +96,7 @@ This prevents hidden control coupling and keeps debugging deterministic.
 | Cooling | `${oq_heat_loop_tick_s}` | Cooling target, PI demand, and cooling compressor requests |
 | Thermal request control | Tick `${oq_heat_loop_tick_s}` (default 5s), effective cadence `${oq_heat_loop_curve_s}` (Curve) / `${oq_heat_loop_powerhouse_s}` (Power House) | Shared request control, guards, and actuator input |
 | Flow control | `${oq_flow_loop_s}` (default 5s) | Pump iPWM control (AUTO/MANUAL/FROST/autotune override) |
-| Boiler control | `${oq_boiler_loop_s}` (default 5s) | CM3 gating under the shared water-temperature guardrail |
+| Boiler control | `${oq_boiler_loop_s}` (default 5s) | CM3 gating plus CM100 boiler test under the shared water-temperature guardrail |
 | CIC polling tick | `${cic_poll_tick_ms}` (default 5s) | Poll scheduler, stale detection, feed invalidation |
 
 ## 4. Data Pipeline

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -95,7 +95,7 @@ This prevents hidden control coupling and keeps debugging deterministic.
 | Power House | `${oq_heat_loop_tick_s}` with effective cadence `${oq_heat_loop_powerhouse_s}` | Power model, filtered demand, and Power House compressor requests |
 | Cooling | `${oq_heat_loop_tick_s}` | Cooling target, PI demand, and cooling compressor requests |
 | Thermal request control | Tick `${oq_heat_loop_tick_s}` (default 5s), effective cadence `${oq_heat_loop_curve_s}` (Curve) / `${oq_heat_loop_powerhouse_s}` (Power House) | Shared request control, guards, and actuator input |
-| Flow control | `${oq_flow_loop_s}` (default 5s) | Pump iPWM control (AUTO/MANUAL/FROST/autotune override) |
+| Flow control | `${oq_flow_loop_s}` (default 5s) | Pump iPWM control (AUTO/MANUAL/FROST/CM100 autotune override) |
 | Boiler control | `${oq_boiler_loop_s}` (default 5s) | CM3 gating plus CM100 boiler test under the shared water-temperature guardrail |
 | CIC polling tick | `${cic_poll_tick_ms}` (default 5s) | Poll scheduler, stale detection, feed invalidation |
 
@@ -246,7 +246,7 @@ Power House duo request selection works in simple steps:
 Flow control execution priority:
 
 1. CM0 early return
-2. autotune override (CM1 only)
+2. autotune override (CM100 commissioning task only)
 3. manual/frost fixed iPWM
 4. AUTO PI path
 

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -3,7 +3,8 @@
 # ==============================================================================
 #
 # Goal:
-#   Controls the electric inline heater (boiler) as auxiliary heating based on Control Mode (CM3).
+#   Controls the electric inline heater (boiler) as auxiliary heating in CM3
+#   and during the explicit CM100 boiler power test.
 #
 # Role in architecture:
 #   Owner of the boiler relay; boiler control is passive and follows CM status from supervisory.
@@ -25,6 +26,7 @@
 #
 # Interaction with Control Modes:
 #   - CM3 -> boiler ON (unless the shared water-temperature guardrail blocks it)
+#   - CM100 + boiler power test -> boiler ON only while the commissioning task requests it
 #   - CM0/CM1/CM2/CM98 → boiler OFF
 #
 # Safety / fail-safe:
@@ -78,13 +80,18 @@ sensor:
     device_class: power
     state_class: measurement
     accuracy_decimals: 0
-    update_interval: 10s
+    update_interval: 5s
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      // Only meaningful in CM3 (boiler operation). Outside CM3, show 0 W.
-      const bool in_cm3 = (id(oq_control_mode_code) == 3);
-      if (!in_cm3) return 0.0f;
+      const int cm_code = id(oq_control_mode_code);
+      const bool commissioning_boiler =
+          (cm_code == 100) &&
+          id(oq_commissioning_active) &&
+          (id(oq_commissioning_task_code) == 1) &&
+          id(oq_commissioning_boiler_request);
+      const bool in_cm3 = (cm_code == 3);
+      if (!in_cm3 && !commissioning_boiler) return 0.0f;
 
       const float hp2_outlet_c = id(${heatpump_outlet_temp_id}).state;
       const float supply_c = id(water_supply_temp_selected).state;
@@ -109,15 +116,19 @@ interval:
     startup_delay: 4600ms
     then:
       - lambda: |-
+          const int cm_code = id(oq_control_mode_code);
+          const bool commissioning_boiler =
+              (cm_code == 100) &&
+              id(oq_commissioning_active) &&
+              (id(oq_commissioning_task_code) == 1) &&
+              id(oq_commissioning_boiler_request);
           // Boiler follows Control Mode CM3, but the shared water-temperature model
           // may block it independently from CM ownership.
-          const bool in_cm3 = (id(oq_control_mode_code) == 3);
+          const bool in_cm3 = (cm_code == 3);
           const float supply_c = id(water_supply_temp_selected).state;
           const bool has_valid_supply_temp = !isnan(supply_c);
           std::string boiler_block_reason;
-          if (!in_cm3) {
-            boiler_block_reason = "Control Mode is not CM3";
-          } else if (!has_valid_supply_temp) {
+          if (!has_valid_supply_temp) {
             boiler_block_reason = "water supply temperature unavailable";
           } else if (id(oq_boot_startup_inhibit_active)) {
             boiler_block_reason = "startup inhibit active";
@@ -125,6 +136,8 @@ interval:
             boiler_block_reason = "water temperature boiler inhibit active";
           } else if (id(oq_water_temp_hard_trip_active)) {
             boiler_block_reason = "water temperature hard trip active";
+          } else if (!in_cm3 && !commissioning_boiler) {
+            boiler_block_reason = "Control Mode is not CM3";
           }
           const bool boiler_allowed =
               boiler_block_reason.empty();
@@ -132,7 +145,11 @@ interval:
           static std::string last_boiler_block_reason = "";
           if (boiler_allowed != last_boiler_allowed || boiler_block_reason != last_boiler_block_reason) {
             if (boiler_allowed) {
-              ESP_LOGI("quatt.boiler", "Boiler enabled: CM3 and safety guards clear");
+              if (commissioning_boiler) {
+                ESP_LOGI("quatt.boiler", "Boiler enabled: CM100 commissioning task and safety guards clear");
+              } else {
+                ESP_LOGI("quatt.boiler", "Boiler enabled: CM3 and safety guards clear");
+              }
             } else if (id(oq_water_temp_hard_trip_active)) {
               ESP_LOGW("quatt.boiler", "Boiler blocked: %s", boiler_block_reason.c_str());
             } else {

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -136,6 +136,11 @@ interval:
             boiler_block_reason = "water temperature boiler inhibit active";
           } else if (id(oq_water_temp_hard_trip_active)) {
             boiler_block_reason = "water temperature hard trip active";
+          } else if ((cm_code == 100) &&
+                     id(oq_commissioning_active) &&
+                     (id(oq_commissioning_task_code) == 1) &&
+                     !id(oq_commissioning_boiler_request)) {
+            boiler_block_reason = "CM100 boiler commissioning waiting for flow settle";
           } else if (!in_cm3 && !commissioning_boiler) {
             boiler_block_reason = "Control Mode is not CM3";
           }

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -130,8 +130,6 @@ interval:
           std::string boiler_block_reason;
           if (!has_valid_supply_temp) {
             boiler_block_reason = "water supply temperature unavailable";
-          } else if (id(oq_boot_startup_inhibit_active)) {
-            boiler_block_reason = "startup inhibit active";
           } else if (id(oq_water_temp_boiler_inhibit_active)) {
             boiler_block_reason = "water temperature boiler inhibit active";
           } else if (id(oq_water_temp_hard_trip_active)) {

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -147,7 +147,7 @@ interval:
           static bool last_boiler_allowed = false;
           static std::string last_boiler_block_reason = "";
           if (boiler_allowed != last_boiler_allowed || boiler_block_reason != last_boiler_block_reason) {
-            if (boiler_allowed) {
+          if (boiler_allowed) {
               if (commissioning_boiler) {
                 ESP_LOGI("quatt.boiler", "Boiler enabled: CM100 commissioning task and safety guards clear");
               } else {
@@ -155,6 +155,8 @@ interval:
               }
             } else if (id(oq_water_temp_hard_trip_active)) {
               ESP_LOGW("quatt.boiler", "Boiler blocked: %s", boiler_block_reason.c_str());
+            } else if (boiler_block_reason == "CM100 boiler commissioning waiting for flow settle") {
+              ESP_LOGI("quatt.boiler", "Boiler commissioning: waiting for flow to settle");
             } else {
               ESP_LOGI("quatt.boiler", "Boiler blocked: %s", boiler_block_reason.c_str());
             }

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -196,9 +196,9 @@ button:
       sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
-          // Boiler test can start directly inside CM100, otherwise it requests CM100 first.
+          // Boiler test may only start while the system is already in CM100.
           const int cm_code = id(oq_control_mode_code);
-          const bool cm100_ready = (cm_code == 100) && id(oq_commissioning_active) && id(oq_commissioning_task_code) == 0;
+          const bool cm100_ready = (cm_code == 100);
           const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0;
           if (task_running) {
             id(oq_boiler_power_test_status).publish_state("REFUSED: BUSY");
@@ -220,12 +220,18 @@ button:
             id(oq_boiler_power_test_status).publish_state("REFUSED: flow setpoint unavailable");
             return;
           }
+          if (!cm100_ready) {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: not CM100");
+            return;
+          }
 
           id(oq_commissioning_task_code) = 1;
-          id(oq_commissioning_request_pending) = !cm100_ready;
-          id(oq_commissioning_active) = cm100_ready;
+          id(oq_commissioning_request_pending) = false;
+          id(oq_commissioning_active) = true;
           id(oq_commissioning_abort_requested) = false;
           id(oq_commissioning_state_code) = 1;
+          id(oq_commissioning_started_ms) = (uint32_t) millis();
+          id(oq_commissioning_state_since_ms) = (uint32_t) millis();
           id(oq_commissioning_boiler_request) = false;
           id(oq_commissioning_sample_count) = 0;
           id(oq_commissioning_flow_stable_count) = 0;
@@ -241,15 +247,7 @@ button:
           set_flow.set_value(800.0f);
           set_flow.perform();
 
-          if (cm100_ready) {
-            id(oq_commissioning_started_ms) = (uint32_t) millis();
-            id(oq_commissioning_state_since_ms) = (uint32_t) millis();
-            id(oq_commissioning_status).publish_state("CM100 READY -> BOILER TEST");
-          } else {
-            id(oq_commissioning_started_ms) = 0;
-            id(oq_commissioning_state_since_ms) = 0;
-            id(oq_commissioning_status).publish_state("BOILER TEST REQUESTED");
-          }
+          id(oq_commissioning_status).publish_state("BOILER TEST STARTED");
           id(oq_boiler_power_test_status).publish_state("REQUESTED");
 
   - platform: template
@@ -492,7 +490,10 @@ interval:
                 publish_status("CM100 READY");
                 id(oq_commissioning_status).publish_state("CM100 READY");
               }
-            } else if (id(oq_commissioning_active) && in_cm100) {
+            } else if (in_cm100) {
+              if (!id(oq_commissioning_active)) {
+                id(oq_commissioning_active) = true;
+              }
               publish_status("CM100 READY");
               id(oq_commissioning_status).publish_state("CM100 READY");
             }

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -110,6 +110,84 @@ globals:
 # ----------------------------
 button:
   - platform: template
+    id: oq_commissioning_cm100_start
+    name: "CM100 Start"
+    icon: mdi:play-circle-outline
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_boiler
+    on_press:
+      - lambda: |-
+          // Request CM100 as a neutral service state with no task yet.
+          if (!id(oq_enabled).state) {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: OpenQuatt disabled");
+            return;
+          }
+          if (id(oq_cm_override).has_state() && id(oq_cm_override).current_option() != "Auto") {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: CM Override not Auto");
+            return;
+          }
+          if (id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0) {
+            id(oq_commissioning_status).publish_state("REFUSED: BUSY");
+            return;
+          }
+
+          id(oq_commissioning_task_code) = 0;
+          id(oq_commissioning_request_pending) = true;
+          id(oq_commissioning_active) = false;
+          id(oq_commissioning_abort_requested) = false;
+          id(oq_commissioning_state_code) = 0;
+          id(oq_commissioning_started_ms) = 0;
+          id(oq_commissioning_state_since_ms) = 0;
+          id(oq_commissioning_boiler_request) = false;
+          id(oq_flow_autotune_req) = false;
+          id(oq_flow_autotune_abort) = false;
+          id(oq_flow_autotune_active) = false;
+          id(oq_flow_autotune_state) = 0;
+          id(oq_commissioning_status).publish_state("CM100 REQUESTED");
+
+  - platform: template
+    id: oq_commissioning_cm100_stop
+    name: "CM100 Stop"
+    icon: mdi:stop-circle-outline
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_boiler
+    on_press:
+      - lambda: |-
+          // Stop CM100 immediately when no task is active; otherwise abort the running task.
+          const int cm_code = id(oq_control_mode_code);
+          const int task_code = id(oq_commissioning_task_code);
+          if (id(oq_commissioning_active) && task_code != 0) {
+            if (task_code == 2) {
+              id(oq_flow_autotune_abort) = true;
+            } else {
+              id(oq_commissioning_abort_requested) = true;
+            }
+            id(oq_commissioning_status).publish_state("ABORT REQUESTED");
+            return;
+          }
+          if (task_code == 2 || id(oq_flow_autotune_req)) {
+            id(oq_flow_autotune_abort) = true;
+            id(oq_commissioning_abort_requested) = true;
+            id(oq_commissioning_status).publish_state("ABORT REQUESTED");
+            return;
+          }
+          id(oq_commissioning_request_pending) = false;
+          id(oq_commissioning_active) = false;
+          id(oq_commissioning_abort_requested) = false;
+          id(oq_commissioning_task_code) = 0;
+          id(oq_commissioning_state_code) = 0;
+          id(oq_commissioning_started_ms) = 0;
+          id(oq_commissioning_state_since_ms) = 0;
+          id(oq_commissioning_boiler_request) = false;
+          id(oq_flow_autotune_req) = false;
+          id(oq_flow_autotune_abort) = false;
+          id(oq_flow_autotune_active) = false;
+          id(oq_flow_autotune_state) = 0;
+          id(oq_commissioning_status).publish_state("IDLE");
+
+  - platform: template
     id: oq_boiler_power_test_start
     name: "Boiler Power Test Start"
     icon: mdi:play-circle-outline
@@ -118,11 +196,11 @@ button:
       sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
-          // Commissioning starts by taking the flow setpoint temporarily to 800 L/h.
-          const bool busy =
-              id(oq_commissioning_request_pending) ||
-              id(oq_commissioning_active);
-          if (busy) {
+          // Boiler test can start directly inside CM100, otherwise it requests CM100 first.
+          const int cm_code = id(oq_control_mode_code);
+          const bool cm100_ready = (cm_code == 100) && id(oq_commissioning_active) && id(oq_commissioning_task_code) == 0;
+          const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0;
+          if (task_running) {
             id(oq_boiler_power_test_status).publish_state("REFUSED: BUSY");
             return;
           }
@@ -144,12 +222,10 @@ button:
           }
 
           id(oq_commissioning_task_code) = 1;
-          id(oq_commissioning_request_pending) = true;
-          id(oq_commissioning_active) = false;
+          id(oq_commissioning_request_pending) = !cm100_ready;
+          id(oq_commissioning_active) = cm100_ready;
           id(oq_commissioning_abort_requested) = false;
           id(oq_commissioning_state_code) = 1;
-          id(oq_commissioning_started_ms) = 0;
-          id(oq_commissioning_state_since_ms) = 0;
           id(oq_commissioning_boiler_request) = false;
           id(oq_commissioning_sample_count) = 0;
           id(oq_commissioning_flow_stable_count) = 0;
@@ -165,6 +241,15 @@ button:
           set_flow.set_value(800.0f);
           set_flow.perform();
 
+          if (cm100_ready) {
+            id(oq_commissioning_started_ms) = (uint32_t) millis();
+            id(oq_commissioning_state_since_ms) = (uint32_t) millis();
+            id(oq_commissioning_status).publish_state("CM100 READY -> BOILER TEST");
+          } else {
+            id(oq_commissioning_started_ms) = 0;
+            id(oq_commissioning_state_since_ms) = 0;
+            id(oq_commissioning_status).publish_state("BOILER TEST REQUESTED");
+          }
           id(oq_boiler_power_test_status).publish_state("REQUESTED");
 
   - platform: template
@@ -176,7 +261,37 @@ button:
       sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
-          id(oq_commissioning_abort_requested) = true;
+          // Abort the running commissioning task, or clear a pending CM100 request.
+          const int task_code = id(oq_commissioning_task_code);
+          const bool task_running = id(oq_commissioning_active) && task_code != 0;
+          if (task_running) {
+            if (task_code == 2) {
+              id(oq_flow_autotune_abort) = true;
+            } else {
+              id(oq_commissioning_abort_requested) = true;
+            }
+            id(oq_commissioning_status).publish_state("ABORT REQUESTED");
+            return;
+          }
+          if (task_code == 2 || id(oq_flow_autotune_req)) {
+            id(oq_flow_autotune_abort) = true;
+            id(oq_commissioning_abort_requested) = true;
+            id(oq_commissioning_status).publish_state("ABORT REQUESTED");
+            return;
+          }
+          id(oq_commissioning_request_pending) = false;
+          id(oq_commissioning_active) = false;
+          id(oq_commissioning_abort_requested) = false;
+          id(oq_commissioning_task_code) = 0;
+          id(oq_commissioning_state_code) = 0;
+          id(oq_commissioning_started_ms) = 0;
+          id(oq_commissioning_state_since_ms) = 0;
+          id(oq_commissioning_boiler_request) = false;
+          id(oq_flow_autotune_req) = false;
+          id(oq_flow_autotune_abort) = false;
+          id(oq_flow_autotune_active) = false;
+          id(oq_flow_autotune_state) = 0;
+          id(oq_commissioning_status).publish_state("IDLE");
 
   - platform: template
     id: oq_boiler_power_test_apply
@@ -244,6 +359,16 @@ sensor:
 
 binary_sensor:
   - platform: template
+    id: oq_commissioning_cm100_active
+    name: "CM100 active"
+    icon: mdi:state-machine
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return id(oq_control_mode_code) == 100 && id(oq_commissioning_active);
+
+  - platform: template
     id: oq_boiler_power_test_active
     name: "Boiler power test active"
     icon: mdi:test-tube
@@ -254,6 +379,14 @@ binary_sensor:
       return id(oq_commissioning_active) && id(oq_commissioning_task_code) == 1;
 
 text_sensor:
+  - platform: template
+    id: oq_commissioning_status
+    name: "Commissioning status"
+    icon: mdi:state-machine
+    update_interval: never
+    web_server:
+      sorting_group_id: oq_boiler
+
   - platform: template
     id: oq_boiler_power_test_status
     name: "Boiler power test status"
@@ -285,6 +418,7 @@ interval:
           const int cm_code = id(oq_control_mode_code);
           const bool in_cm3 = (cm_code == 3);
           const bool in_cm100 = (cm_code == 100);
+          const bool task_is_none = (id(oq_commissioning_task_code) == 0);
           const bool task_is_boiler = (id(oq_commissioning_task_code) == 1);
           const bool task_is_flow_autotune = (id(oq_commissioning_task_code) == 2);
           const bool boiler_test_running = id(oq_commissioning_active) && task_is_boiler;
@@ -341,6 +475,26 @@ interval:
                 id(oq_commissioning_started_ms) = now_ms;
                 id(oq_commissioning_state_since_ms) = now_ms;
               }
+            }
+            return;
+          }
+
+          if (task_is_none) {
+            if (id(oq_commissioning_request_pending)) {
+              if (!in_cm100) {
+                publish_status("WAITING_FOR_CM100");
+                id(oq_commissioning_status).publish_state("WAITING_FOR_CM100");
+              } else {
+                id(oq_commissioning_active) = true;
+                id(oq_commissioning_request_pending) = false;
+                id(oq_commissioning_started_ms) = now_ms;
+                id(oq_commissioning_state_since_ms) = now_ms;
+                publish_status("CM100 READY");
+                id(oq_commissioning_status).publish_state("CM100 READY");
+              }
+            } else if (id(oq_commissioning_active) && in_cm100) {
+              publish_status("CM100 READY");
+              id(oq_commissioning_status).publish_state("CM100 READY");
             }
             return;
           }

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -524,6 +524,7 @@ interval:
               id(oq_commissioning_result_confidence) = 0.0f;
             }
             publish_status(status);
+            id(oq_commissioning_status).publish_state(keep_cm100 ? "CM100 READY" : "IDLE");
           };
 
           if (id(oq_commissioning_abort_requested)) {

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -5,11 +5,9 @@
 # Goal:
 #   Provides temporary service modes outside normal heating behavior.
 #
-# Current task:
+# Current tasks:
 #   - Boiler power test: measure effective boiler heat output at stable flow.
-#
-# Future task:
-#   - Flow autotune can join the same CM100 container later.
+#   - Flow autotune: use the same CM100 container for the step-test flow tuning routine.
 #
 # Safety:
 #   - CM100 is only entered by an explicit request.
@@ -40,7 +38,7 @@ globals:
   - id: oq_commissioning_task_code
     type: int
     restore_value: false
-    initial_value: '0'   # 0=NONE, 1=BOILER_POWER_TEST, 2=FLOW_AUTOTUNE (later)
+    initial_value: '0'   # 0=NONE, 1=BOILER_POWER_TEST, 2=FLOW_AUTOTUNE
 
   - id: oq_commissioning_state_code
     type: int
@@ -288,6 +286,7 @@ interval:
           const bool in_cm3 = (cm_code == 3);
           const bool in_cm100 = (cm_code == 100);
           const bool task_is_boiler = (id(oq_commissioning_task_code) == 1);
+          const bool task_is_flow_autotune = (id(oq_commissioning_task_code) == 2);
           const bool boiler_test_running = id(oq_commissioning_active) && task_is_boiler;
 
           auto restore_flow_setpoint = [&]() {
@@ -320,6 +319,7 @@ interval:
             id(oq_commissioning_request_pending) = false;
             id(oq_commissioning_active) = false;
             id(oq_commissioning_abort_requested) = false;
+            id(oq_commissioning_task_code) = 0;
             id(oq_commissioning_state_code) = next_state;
             if (!keep_result) {
               id(oq_commissioning_result_w) = NAN;
@@ -330,6 +330,18 @@ interval:
 
           if (id(oq_commissioning_abort_requested)) {
             finish_task("ABORTED", 7, true);
+            return;
+          }
+
+          if (task_is_flow_autotune) {
+            if (id(oq_commissioning_request_pending)) {
+              if (in_cm100) {
+                id(oq_commissioning_active) = true;
+                id(oq_commissioning_request_pending) = false;
+                id(oq_commissioning_started_ms) = now_ms;
+                id(oq_commissioning_state_since_ms) = now_ms;
+              }
+            }
             return;
           }
 

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -1,0 +1,487 @@
+# ==============================================================================
+# OpenQuatt - Commissioning / Service Tasks
+# ==============================================================================
+#
+# Goal:
+#   Provides temporary service modes outside normal heating behavior.
+#
+# Current task:
+#   - Boiler power test: measure effective boiler heat output at stable flow.
+#
+# Future task:
+#   - Flow autotune can join the same CM100 container later.
+#
+# Safety:
+#   - CM100 is only entered by an explicit request.
+#   - Normal heating/cooling request generation is suppressed while a task runs.
+#   - Boiler and flow remain behind the existing water-temperature and flow guards.
+#
+# ==============================================================================
+
+# ----------------------------
+# INTERNAL STATE
+# ----------------------------
+globals:
+  - id: oq_commissioning_request_pending
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_commissioning_active
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_commissioning_abort_requested
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_commissioning_task_code
+    type: int
+    restore_value: false
+    initial_value: '0'   # 0=NONE, 1=BOILER_POWER_TEST, 2=FLOW_AUTOTUNE (later)
+
+  - id: oq_commissioning_state_code
+    type: int
+    restore_value: false
+    initial_value: '0'   # 0=IDLE,1=REQUESTED,2=FLOW_SETTLE,3=BOILER_SETTLE,4=MEASURE,5=COOLDOWN,6=DONE,7=ABORT,8=FAILED
+
+  - id: oq_commissioning_started_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_commissioning_state_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_commissioning_flow_setpoint_saved
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_commissioning_prev_flow_setpoint_lph
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
+  - id: oq_commissioning_boiler_request
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_commissioning_result_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
+  - id: oq_commissioning_result_confidence
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+
+  - id: oq_commissioning_sample_count
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_commissioning_flow_stable_count
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_commissioning_result_sum_w
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+
+  - id: oq_commissioning_result_min_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
+  - id: oq_commissioning_result_max_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
+# ----------------------------
+# CONTROL INPUTS
+# ----------------------------
+button:
+  - platform: template
+    id: oq_boiler_power_test_start
+    name: "Boiler Power Test Start"
+    icon: mdi:play-circle-outline
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_boiler
+    on_press:
+      - lambda: |-
+          // Commissioning starts by taking the flow setpoint temporarily to 800 L/h.
+          const bool busy =
+              id(oq_commissioning_request_pending) ||
+              id(oq_commissioning_active);
+          if (busy) {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: BUSY");
+            return;
+          }
+          if (!id(oq_enabled).state) {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: OpenQuatt disabled");
+            return;
+          }
+          if (id(oq_cm_override).has_state() && id(oq_cm_override).current_option() != "Auto") {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: CM Override not Auto");
+            return;
+          }
+          if (!id(oq_flow_control_mode).has_state() || id(oq_flow_control_mode).current_option() != "Flow Setpoint") {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: Flow mode must be Flow Setpoint");
+            return;
+          }
+          if (!id(oq_flow_setpoint_lph).has_state()) {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: flow setpoint unavailable");
+            return;
+          }
+
+          id(oq_commissioning_task_code) = 1;
+          id(oq_commissioning_request_pending) = true;
+          id(oq_commissioning_active) = false;
+          id(oq_commissioning_abort_requested) = false;
+          id(oq_commissioning_state_code) = 1;
+          id(oq_commissioning_started_ms) = 0;
+          id(oq_commissioning_state_since_ms) = 0;
+          id(oq_commissioning_boiler_request) = false;
+          id(oq_commissioning_sample_count) = 0;
+          id(oq_commissioning_flow_stable_count) = 0;
+          id(oq_commissioning_result_sum_w) = 0.0f;
+          id(oq_commissioning_result_min_w) = NAN;
+          id(oq_commissioning_result_max_w) = NAN;
+          id(oq_commissioning_result_w) = NAN;
+          id(oq_commissioning_result_confidence) = 0.0f;
+
+          id(oq_commissioning_prev_flow_setpoint_lph) = id(oq_flow_setpoint_lph).state;
+          id(oq_commissioning_flow_setpoint_saved) = true;
+          auto set_flow = id(oq_flow_setpoint_lph).make_call();
+          set_flow.set_value(800.0f);
+          set_flow.perform();
+
+          id(oq_boiler_power_test_status).publish_state("REQUESTED");
+
+  - platform: template
+    id: oq_boiler_power_test_abort
+    name: "Boiler Power Test Abort"
+    icon: mdi:stop-circle-outline
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_boiler
+    on_press:
+      - lambda: |-
+          id(oq_commissioning_abort_requested) = true;
+
+  - platform: template
+    id: oq_boiler_power_test_apply
+    name: "Apply Boiler Power Test"
+    icon: mdi:check-circle-outline
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_boiler
+    on_press:
+      - lambda: |-
+          const float result = id(oq_commissioning_result_w);
+          if (!isnan(result) && result > 0.0f) {
+            auto call = id(oq_boiler_rated_heat_power).make_call();
+            call.set_value(result);
+            call.perform();
+            id(oq_boiler_power_test_status).publish_state("APPLIED");
+          } else {
+            id(oq_boiler_power_test_status).publish_state("APPLY_FAILED");
+          }
+
+number:
+  - platform: template
+    id: oq_boiler_rated_heat_power
+    name: "Boiler rated heat power"
+    icon: mdi:radiator
+    unit_of_measurement: "W"
+    mode: slider
+    min_value: 1000
+    max_value: 20000
+    step: 10
+    restore_value: true
+    optimistic: true
+    initial_value: 6000
+    entity_category: config
+    web_server:
+      sorting_group_id: oq_boiler
+
+sensor:
+  - platform: template
+    id: oq_boiler_power_test_result
+    name: "Boiler power test result"
+    icon: mdi:chart-line
+    unit_of_measurement: "W"
+    device_class: power
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return id(oq_commissioning_result_w);
+
+  - platform: template
+    id: oq_boiler_power_test_confidence
+    name: "Boiler power test confidence"
+    icon: mdi:percent-outline
+    unit_of_measurement: "%"
+    state_class: measurement
+    accuracy_decimals: 0
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return id(oq_commissioning_result_confidence);
+
+binary_sensor:
+  - platform: template
+    id: oq_boiler_power_test_active
+    name: "Boiler power test active"
+    icon: mdi:test-tube
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return id(oq_commissioning_active) && id(oq_commissioning_task_code) == 1;
+
+text_sensor:
+  - platform: template
+    id: oq_boiler_power_test_status
+    name: "Boiler power test status"
+    icon: mdi:information-outline
+    update_interval: never
+    web_server:
+      sorting_group_id: oq_boiler
+
+# ----------------------------
+# MAIN LOOP
+# ----------------------------
+interval:
+  - interval: ${oq_boiler_loop_s}s
+    startup_delay: 4600ms
+    then:
+      - lambda: |-
+          // Phase-based boiler commissioning: request CM100, settle flow, measure output, then restore flow.
+          constexpr uint32_t kMaxRuntimeMs = 15UL * 60UL * 1000UL;
+          constexpr uint32_t kFlowSettleMinMs = 20UL * 1000UL;
+          constexpr uint32_t kBoilerSettleMinMs = 30UL * 1000UL;
+          constexpr uint32_t kMeasureMinMs = 60UL * 1000UL;
+          constexpr uint32_t kCooldownMs = 15UL * 1000UL;
+          constexpr float kTargetFlowLph = 800.0f;
+          constexpr float kFlowBandLph = 40.0f;
+          constexpr int kStableFlowSamples = 4;
+          constexpr int kMeasureMinSamples = 8;
+
+          const uint32_t now_ms = (uint32_t) millis();
+          const int cm_code = id(oq_control_mode_code);
+          const bool in_cm3 = (cm_code == 3);
+          const bool in_cm100 = (cm_code == 100);
+          const bool task_is_boiler = (id(oq_commissioning_task_code) == 1);
+          const bool boiler_test_running = id(oq_commissioning_active) && task_is_boiler;
+
+          auto restore_flow_setpoint = [&]() {
+            if (!id(oq_commissioning_flow_setpoint_saved)) return;
+            auto call = id(oq_flow_setpoint_lph).make_call();
+            call.set_value(id(oq_commissioning_prev_flow_setpoint_lph));
+            call.perform();
+            id(oq_commissioning_flow_setpoint_saved) = false;
+          };
+
+          auto publish_status = [&](const std::string &status) {
+            static std::string last_status;
+            if (status != last_status) {
+              id(oq_boiler_power_test_status).publish_state(status.c_str());
+              last_status = status;
+            }
+          };
+
+          auto reset_measurement = [&]() {
+            id(oq_commissioning_sample_count) = 0;
+            id(oq_commissioning_flow_stable_count) = 0;
+            id(oq_commissioning_result_sum_w) = 0.0f;
+            id(oq_commissioning_result_min_w) = NAN;
+            id(oq_commissioning_result_max_w) = NAN;
+          };
+
+          auto finish_task = [&](const char *status, int next_state, bool keep_result) {
+            id(oq_commissioning_boiler_request) = false;
+            restore_flow_setpoint();
+            id(oq_commissioning_request_pending) = false;
+            id(oq_commissioning_active) = false;
+            id(oq_commissioning_abort_requested) = false;
+            id(oq_commissioning_state_code) = next_state;
+            if (!keep_result) {
+              id(oq_commissioning_result_w) = NAN;
+              id(oq_commissioning_result_confidence) = 0.0f;
+            }
+            publish_status(status);
+          };
+
+          if (id(oq_commissioning_abort_requested)) {
+            finish_task("ABORTED", 7, true);
+            return;
+          }
+
+          if (!boiler_test_running) {
+            if (id(oq_commissioning_request_pending)) {
+              if (!in_cm100) {
+                publish_status("WAITING_FOR_CM100");
+              } else {
+                id(oq_commissioning_active) = true;
+                id(oq_commissioning_request_pending) = false;
+                id(oq_commissioning_started_ms) = now_ms;
+                id(oq_commissioning_state_since_ms) = now_ms;
+                id(oq_commissioning_state_code) = 2;
+                publish_status("FLOW_SETTLING");
+              }
+            }
+            return;
+          }
+
+          if (!in_cm100) {
+            finish_task("ABORTED: CM100 exited", 7, true);
+            return;
+          }
+
+          if (id(oq_commissioning_started_ms) == 0) {
+            id(oq_commissioning_started_ms) = now_ms;
+            id(oq_commissioning_state_since_ms) = now_ms;
+          }
+
+          const uint32_t elapsed_ms = now_ms - id(oq_commissioning_started_ms);
+          if (elapsed_ms >= kMaxRuntimeMs) {
+            finish_task("FAILED: timeout", 8, false);
+            return;
+          }
+
+          const float flow_lph = id(flow_rate_selected).state;
+          const bool flow_valid = !isnan(flow_lph) && flow_lph > 0.0f;
+          const bool flow_on_target = flow_valid && fabsf(flow_lph - kTargetFlowLph) <= kFlowBandLph;
+          const bool flow_stable_now = flow_on_target;
+
+          const float heat_w = id(boiler_heat_power).state;
+          const bool heat_valid = !isnan(heat_w) && heat_w >= 0.0f;
+
+          if (id(oq_water_temp_hard_trip_active)) {
+            finish_task("FAILED: hard trip active", 8, false);
+            return;
+          }
+          if (id(oq_water_temp_boiler_inhibit_active)) {
+            finish_task("FAILED: boiler inhibit active", 8, false);
+            return;
+          }
+
+          if (id(oq_commissioning_state_code) == 2) {
+            if (flow_stable_now) id(oq_commissioning_flow_stable_count)++;
+            else id(oq_commissioning_flow_stable_count) = 0;
+
+            if (id(oq_commissioning_flow_stable_count) >= kStableFlowSamples &&
+                (now_ms - id(oq_commissioning_state_since_ms)) >= kFlowSettleMinMs) {
+              id(oq_commissioning_boiler_request) = true;
+              id(oq_commissioning_state_code) = 3;
+              id(oq_commissioning_state_since_ms) = now_ms;
+              id(oq_commissioning_flow_stable_count) = 0;
+              publish_status("BOILER_SETTLING");
+            } else {
+              publish_status("FLOW_SETTLING");
+            }
+            return;
+          }
+
+          if (id(oq_commissioning_state_code) == 3) {
+            if (flow_stable_now) id(oq_commissioning_flow_stable_count)++;
+            else id(oq_commissioning_flow_stable_count) = 0;
+
+            if (!id(boiler_active).state) {
+              if ((now_ms - id(oq_commissioning_state_since_ms)) >= kBoilerSettleMinMs) {
+                finish_task("FAILED: boiler did not start", 8, false);
+                return;
+              }
+              publish_status("BOILER_SETTLING");
+              return;
+            }
+
+            if (id(oq_commissioning_flow_stable_count) >= kStableFlowSamples &&
+                (now_ms - id(oq_commissioning_state_since_ms)) >= kBoilerSettleMinMs) {
+              id(oq_commissioning_state_code) = 4;
+              id(oq_commissioning_state_since_ms) = now_ms;
+              reset_measurement();
+              publish_status("MEASURING");
+            } else {
+              publish_status("BOILER_SETTLING");
+            }
+            return;
+          }
+
+          if (id(oq_commissioning_state_code) == 4) {
+            if (flow_stable_now && heat_valid && heat_w > 0.0f) {
+              id(oq_commissioning_sample_count)++;
+              id(oq_commissioning_result_sum_w) += heat_w;
+              if (isnan(id(oq_commissioning_result_min_w)) || heat_w < id(oq_commissioning_result_min_w)) {
+                id(oq_commissioning_result_min_w) = heat_w;
+              }
+              if (isnan(id(oq_commissioning_result_max_w)) || heat_w > id(oq_commissioning_result_max_w)) {
+                id(oq_commissioning_result_max_w) = heat_w;
+              }
+            }
+
+            const uint32_t measure_age_ms = now_ms - id(oq_commissioning_state_since_ms);
+            const bool enough_samples = id(oq_commissioning_sample_count) >= kMeasureMinSamples;
+            const bool enough_time = measure_age_ms >= kMeasureMinMs;
+
+            if (enough_samples && enough_time) {
+              const float sample_count_f = (float) id(oq_commissioning_sample_count);
+              const float avg_w = id(oq_commissioning_result_sum_w) / sample_count_f;
+              const float min_w = id(oq_commissioning_result_min_w);
+              const float max_w = id(oq_commissioning_result_max_w);
+              const float spread_w = max_w - min_w;
+              float confidence = 100.0f;
+              if (sample_count_f < 10.0f) confidence -= (10.0f - sample_count_f) * 4.0f;
+              if (spread_w > avg_w * 0.05f) confidence -= 15.0f;
+              if (spread_w > avg_w * 0.10f) confidence -= 20.0f;
+              if (confidence < 0.0f) confidence = 0.0f;
+              if (confidence > 100.0f) confidence = 100.0f;
+
+              id(oq_commissioning_result_w) = avg_w;
+              id(oq_commissioning_result_confidence) = confidence;
+              id(oq_commissioning_state_code) = 5;
+              id(oq_commissioning_state_since_ms) = now_ms;
+              id(oq_commissioning_boiler_request) = false;
+              restore_flow_setpoint();
+              publish_status("COOLDOWN");
+            } else {
+              publish_status("MEASURING");
+            }
+            return;
+          }
+
+          if (id(oq_commissioning_state_code) == 5) {
+            if ((now_ms - id(oq_commissioning_state_since_ms)) >= kCooldownMs) {
+              char msg[128];
+              snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)",
+                       id(oq_commissioning_result_w), id(oq_commissioning_result_confidence));
+              finish_task(msg, 6, true);
+            } else {
+              publish_status("COOLDOWN");
+            }
+            return;
+          }
+
+          if (id(oq_commissioning_state_code) == 6) {
+            char msg[128];
+            snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)",
+                     id(oq_commissioning_result_w), id(oq_commissioning_result_confidence));
+            publish_status(msg);
+            return;
+          }

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -130,6 +130,11 @@ button:
               return;
             }
           }
+          ESP_LOGI("quatt.cm100", "CM100 requested via dashboard (override=%s task=%d active=%d pending=%d)",
+                   id(oq_cm_override).state.c_str(),
+                   id(oq_commissioning_task_code),
+                   (int) id(oq_commissioning_active),
+                   (int) id(oq_commissioning_request_pending));
           if (id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0) {
             id(oq_commissioning_status).publish_state("REFUSED: BUSY");
             return;
@@ -223,6 +228,18 @@ button:
             id(oq_boiler_power_test_status).publish_state("REFUSED: not CM100");
             return;
           }
+          if (id(oq_boot_startup_inhibit_active)) {
+            id(oq_boiler_power_test_status).publish_state("REFUSED: startup inhibit active");
+            ESP_LOGW("quatt.cm100.boiler", "Boiler power test refused: startup inhibit active");
+            return;
+          }
+          ESP_LOGI("quatt.cm100.boiler",
+                   "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)",
+                   cm_code,
+                   id(oq_flow_control_mode).state.c_str(),
+                   id(oq_flow_setpoint_lph).state,
+                   id(oq_commissioning_task_code),
+                   (int) id(oq_commissioning_active));
 
           id(oq_commissioning_task_code) = 1;
           id(oq_commissioning_request_pending) = false;
@@ -242,6 +259,10 @@ button:
 
           id(oq_commissioning_prev_flow_setpoint_lph) = id(oq_flow_setpoint_lph).state;
           id(oq_commissioning_flow_setpoint_saved) = true;
+          ESP_LOGI("quatt.cm100.boiler",
+                   "Boiler test armed: target_flow=800L/h saved_flow=%.0fL/h state=%d",
+                   id(oq_commissioning_prev_flow_setpoint_lph),
+                   id(oq_commissioning_state_code));
           auto set_flow = id(oq_flow_setpoint_lph).make_call();
           set_flow.set_value(800.0f);
           set_flow.perform();
@@ -420,6 +441,31 @@ interval:
           const bool task_is_boiler = (id(oq_commissioning_task_code) == 1);
           const bool task_is_flow_autotune = (id(oq_commissioning_task_code) == 2);
           const bool boiler_test_running = id(oq_commissioning_active) && task_is_boiler;
+          const float flow_lph = id(flow_rate_selected).state;
+          const bool flow_valid = !isnan(flow_lph) && flow_lph > 0.0f;
+          const bool flow_on_target = flow_valid && fabsf(flow_lph - kTargetFlowLph) <= kFlowBandLph;
+          const bool flow_stable_now = flow_on_target;
+          const float heat_w = id(boiler_heat_power).state;
+          const bool heat_valid = !isnan(heat_w) && heat_w >= 0.0f;
+          const uint32_t commissioning_elapsed_ms =
+              (id(oq_commissioning_started_ms) == 0) ? 0 : (now_ms - id(oq_commissioning_started_ms));
+          static int last_boiler_state_logged = -1;
+          if (task_is_boiler && id(oq_commissioning_state_code) != last_boiler_state_logged) {
+            ESP_LOGI("quatt.cm100.boiler",
+                     "state=%d cm=%d active=%d pending=%d flow=%.0fL/h target=800L/h stable=%d/%d boiler_req=%d boiler_active=%d heat=%.0fW elapsed=%lus",
+                     id(oq_commissioning_state_code),
+                     cm_code,
+                     (int) id(oq_commissioning_active),
+                     (int) id(oq_commissioning_request_pending),
+                     flow_lph,
+                     (int) id(oq_commissioning_flow_stable_count),
+                     (int) kStableFlowSamples,
+                     (int) id(oq_commissioning_boiler_request),
+                     (int) id(boiler_active).state,
+                     heat_w,
+                     (unsigned long) (commissioning_elapsed_ms / 1000UL));
+            last_boiler_state_logged = id(oq_commissioning_state_code);
+          }
 
           auto restore_flow_setpoint = [&]() {
             if (!id(oq_commissioning_flow_setpoint_saved)) return;
@@ -461,6 +507,9 @@ interval:
           };
 
           if (id(oq_commissioning_abort_requested)) {
+            ESP_LOGW("quatt.cm100.boiler", "Boiler test abort requested (state=%d cm=%d active=%d pending=%d)",
+                     id(oq_commissioning_state_code), cm_code,
+                     (int) id(oq_commissioning_active), (int) id(oq_commissioning_request_pending));
             finish_task("ABORTED", 7, true);
             return;
           }
@@ -468,6 +517,7 @@ interval:
           if (task_is_flow_autotune) {
             if (id(oq_commissioning_request_pending)) {
               if (in_cm100) {
+                ESP_LOGI("quatt.cm100.autotune", "Autotune request accepted in CM100; activating commissioning container");
                 id(oq_commissioning_active) = true;
                 id(oq_commissioning_request_pending) = false;
                 id(oq_commissioning_started_ms) = now_ms;
@@ -482,7 +532,9 @@ interval:
               if (!in_cm100) {
                 publish_status("WAITING_FOR_CM100");
                 id(oq_commissioning_status).publish_state("WAITING_FOR_CM100");
+                ESP_LOGI("quatt.cm100", "CM100 request pending while not in CM100; waiting");
               } else {
+                ESP_LOGI("quatt.cm100", "CM100 request accepted; entering neutral commissioning container");
                 id(oq_commissioning_active) = true;
                 id(oq_commissioning_request_pending) = false;
                 id(oq_commissioning_started_ms) = now_ms;
@@ -498,7 +550,9 @@ interval:
             if (id(oq_commissioning_request_pending)) {
               if (!in_cm100) {
                 publish_status("WAITING_FOR_CM100");
+                ESP_LOGI("quatt.cm100.boiler", "Boiler test waiting for CM100");
               } else {
+                ESP_LOGI("quatt.cm100.boiler", "Boiler test request accepted in CM100; entering FLOW_SETTLING");
                 id(oq_commissioning_active) = true;
                 id(oq_commissioning_request_pending) = false;
                 id(oq_commissioning_started_ms) = now_ms;
@@ -526,19 +580,13 @@ interval:
             return;
           }
 
-          const float flow_lph = id(flow_rate_selected).state;
-          const bool flow_valid = !isnan(flow_lph) && flow_lph > 0.0f;
-          const bool flow_on_target = flow_valid && fabsf(flow_lph - kTargetFlowLph) <= kFlowBandLph;
-          const bool flow_stable_now = flow_on_target;
-
-          const float heat_w = id(boiler_heat_power).state;
-          const bool heat_valid = !isnan(heat_w) && heat_w >= 0.0f;
-
           if (id(oq_water_temp_hard_trip_active)) {
+            ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: hard trip active");
             finish_task("FAILED: hard trip active", 8, false);
             return;
           }
           if (id(oq_water_temp_boiler_inhibit_active)) {
+            ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: boiler inhibit active");
             finish_task("FAILED: boiler inhibit active", 8, false);
             return;
           }
@@ -553,6 +601,10 @@ interval:
               id(oq_commissioning_state_code) = 3;
               id(oq_commissioning_state_since_ms) = now_ms;
               id(oq_commissioning_flow_stable_count) = 0;
+              ESP_LOGI("quatt.cm100.boiler",
+                       "Flow settled at %.0fL/h after %lus; requesting boiler relay",
+                       flow_lph,
+                       (unsigned long) ((now_ms - id(oq_commissioning_started_ms)) / 1000UL));
               publish_status("BOILER_SETTLING");
             } else {
               publish_status("FLOW_SETTLING");
@@ -566,6 +618,11 @@ interval:
 
             if (!id(boiler_active).state) {
               if ((now_ms - id(oq_commissioning_state_since_ms)) >= kBoilerSettleMinMs) {
+                ESP_LOGW("quatt.cm100.boiler",
+                         "Boiler did not start in time (flow=%.0fL/h boiler_req=%d elapsed=%lus)",
+                         flow_lph,
+                         (int) id(oq_commissioning_boiler_request),
+                         (unsigned long) ((now_ms - id(oq_commissioning_state_since_ms)) / 1000UL));
                 finish_task("FAILED: boiler did not start", 8, false);
                 return;
               }
@@ -578,6 +635,9 @@ interval:
               id(oq_commissioning_state_code) = 4;
               id(oq_commissioning_state_since_ms) = now_ms;
               reset_measurement();
+              ESP_LOGI("quatt.cm100.boiler",
+                       "Boiler settled; starting measurement window (flow=%.0fL/h heat=%.0fW boiler_active=%d)",
+                       flow_lph, heat_w, (int) id(boiler_active).state);
               publish_status("MEASURING");
             } else {
               publish_status("BOILER_SETTLING");
@@ -619,6 +679,9 @@ interval:
               id(oq_commissioning_state_code) = 5;
               id(oq_commissioning_state_since_ms) = now_ms;
               id(oq_commissioning_boiler_request) = false;
+              ESP_LOGI("quatt.cm100.boiler",
+                       "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%",
+                       avg_w, min_w, max_w, (unsigned int) id(oq_commissioning_sample_count), confidence);
               restore_flow_setpoint();
               publish_status("COOLDOWN");
             } else {
@@ -632,6 +695,7 @@ interval:
               char msg[128];
               snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)",
                        id(oq_commissioning_result_w), id(oq_commissioning_result_confidence));
+              ESP_LOGI("quatt.cm100.boiler", "Cooldown complete; finishing boiler test (%s)", msg);
               finish_task(msg, 6, true);
             } else {
               publish_status("COOLDOWN");

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -123,9 +123,12 @@ button:
             id(oq_boiler_power_test_status).publish_state("REFUSED: OpenQuatt disabled");
             return;
           }
-          if (id(oq_cm_override).has_state() && id(oq_cm_override).current_option() != "Auto") {
-            id(oq_boiler_power_test_status).publish_state("REFUSED: CM Override not Auto");
-            return;
+          if (id(oq_cm_override).has_state()) {
+            const std::string override_mode = id(oq_cm_override).current_option();
+            if (override_mode != "Auto" && override_mode != "Force CM100") {
+              id(oq_commissioning_status).publish_state("REFUSED: CM Override not CM100");
+              return;
+            }
           }
           if (id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0) {
             id(oq_commissioning_status).publish_state("REFUSED: BUSY");
@@ -206,10 +209,6 @@ button:
           }
           if (!id(oq_enabled).state) {
             id(oq_boiler_power_test_status).publish_state("REFUSED: OpenQuatt disabled");
-            return;
-          }
-          if (id(oq_cm_override).has_state() && id(oq_cm_override).current_option() != "Auto") {
-            id(oq_boiler_power_test_status).publish_state("REFUSED: CM Override not Auto");
             return;
           }
           if (!id(oq_flow_control_mode).has_state() || id(oq_flow_control_mode).current_option() != "Flow Setpoint") {

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -292,7 +292,7 @@ button:
 
   - platform: template
     id: oq_boiler_power_test_apply
-    name: "Apply Boiler Power Test"
+    name: "Boiler Power Test Apply"
     icon: mdi:check-circle-outline
     entity_category: config
     web_server:

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -225,10 +225,10 @@ button:
           }
 
           id(oq_commissioning_task_code) = 1;
-          id(oq_commissioning_request_pending) = true;
-          id(oq_commissioning_active) = false;
+          id(oq_commissioning_request_pending) = false;
+          id(oq_commissioning_active) = true;
           id(oq_commissioning_abort_requested) = false;
-          id(oq_commissioning_state_code) = 1;
+          id(oq_commissioning_state_code) = 2;
           id(oq_commissioning_started_ms) = (uint32_t) millis();
           id(oq_commissioning_state_since_ms) = (uint32_t) millis();
           id(oq_commissioning_boiler_request) = false;
@@ -247,7 +247,7 @@ button:
           set_flow.perform();
 
           id(oq_commissioning_status).publish_state("BOILER TEST STARTED");
-          id(oq_boiler_power_test_status).publish_state("REQUESTED");
+          id(oq_boiler_power_test_status).publish_state("FLOW_SETTLING");
 
   - platform: template
     id: oq_boiler_power_test_abort

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -489,12 +489,6 @@ interval:
                 publish_status("CM100 READY");
                 id(oq_commissioning_status).publish_state("CM100 READY");
               }
-            } else if (in_cm100) {
-              if (!id(oq_commissioning_active)) {
-                id(oq_commissioning_active) = true;
-              }
-              publish_status("CM100 READY");
-              id(oq_commissioning_status).publish_state("CM100 READY");
             }
             return;
           }

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -203,7 +203,7 @@ button:
           const int cm_code = id(oq_control_mode_code);
           const bool cm100_ready = (cm_code == 100);
           const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0;
-          if (task_running) {
+          if (task_running || id(oq_commissioning_request_pending)) {
             id(oq_boiler_power_test_status).publish_state("REFUSED: BUSY");
             return;
           }
@@ -225,8 +225,8 @@ button:
           }
 
           id(oq_commissioning_task_code) = 1;
-          id(oq_commissioning_request_pending) = false;
-          id(oq_commissioning_active) = true;
+          id(oq_commissioning_request_pending) = true;
+          id(oq_commissioning_active) = false;
           id(oq_commissioning_abort_requested) = false;
           id(oq_commissioning_state_code) = 1;
           id(oq_commissioning_started_ms) = (uint32_t) millis();

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -423,7 +423,7 @@ interval:
       - lambda: |-
           // Phase-based boiler commissioning: request CM100, settle flow, measure output, then restore flow.
           constexpr uint32_t kMaxRuntimeMs = 15UL * 60UL * 1000UL;
-          constexpr uint32_t kFlowSettleMinMs = 20UL * 1000UL;
+          constexpr uint32_t kFlowSettleMinMs = 2UL * 60UL * 1000UL;
           constexpr uint32_t kBoilerSettleMinMs = 30UL * 1000UL;
           constexpr uint32_t kMeasureMinMs = 3UL * 60UL * 1000UL;
           constexpr uint32_t kCooldownMs = 15UL * 1000UL;

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -363,7 +363,8 @@ binary_sensor:
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      return id(oq_control_mode_code) == 100 && id(oq_commissioning_active);
+      // This is the mode indicator: true whenever Control Mode is CM100.
+      return id(oq_control_mode_code) == 100;
 
   - platform: template
     id: oq_boiler_power_test_active

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -421,7 +421,7 @@ interval:
           constexpr uint32_t kMaxRuntimeMs = 15UL * 60UL * 1000UL;
           constexpr uint32_t kFlowSettleMinMs = 20UL * 1000UL;
           constexpr uint32_t kBoilerSettleMinMs = 30UL * 1000UL;
-          constexpr uint32_t kMeasureMinMs = 60UL * 1000UL;
+          constexpr uint32_t kMeasureMinMs = 3UL * 60UL * 1000UL;
           constexpr uint32_t kCooldownMs = 15UL * 1000UL;
           constexpr float kTargetFlowLph = 800.0f;
           constexpr float kFlowBandLph = 40.0f;

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -486,11 +486,11 @@ interval:
             id(oq_commissioning_result_max_w) = NAN;
           };
 
-          auto finish_task = [&](const char *status, int next_state, bool keep_result) {
+          auto finish_task = [&](const char *status, int next_state, bool keep_result, bool keep_cm100) {
             id(oq_commissioning_boiler_request) = false;
             restore_flow_setpoint();
             id(oq_commissioning_request_pending) = false;
-            id(oq_commissioning_active) = false;
+            id(oq_commissioning_active) = keep_cm100;
             id(oq_commissioning_abort_requested) = false;
             id(oq_commissioning_task_code) = 0;
             id(oq_commissioning_state_code) = next_state;
@@ -505,7 +505,7 @@ interval:
             ESP_LOGW("quatt.cm100.boiler", "Boiler test abort requested (state=%d cm=%d active=%d pending=%d)",
                      id(oq_commissioning_state_code), cm_code,
                      (int) id(oq_commissioning_active), (int) id(oq_commissioning_request_pending));
-            finish_task("ABORTED", 7, true);
+            finish_task("ABORTED", 7, true, true);
             return;
           }
 
@@ -560,7 +560,7 @@ interval:
           }
 
           if (!in_cm100) {
-            finish_task("ABORTED: CM100 exited", 7, true);
+            finish_task("ABORTED: CM100 exited", 7, true, false);
             return;
           }
 
@@ -571,18 +571,18 @@ interval:
 
           const uint32_t elapsed_ms = now_ms - id(oq_commissioning_started_ms);
           if (elapsed_ms >= kMaxRuntimeMs) {
-            finish_task("FAILED: timeout", 8, false);
+            finish_task("FAILED: timeout", 8, false, true);
             return;
           }
 
           if (id(oq_water_temp_hard_trip_active)) {
             ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: hard trip active");
-            finish_task("FAILED: hard trip active", 8, false);
+            finish_task("FAILED: hard trip active", 8, false, true);
             return;
           }
           if (id(oq_water_temp_boiler_inhibit_active)) {
             ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: boiler inhibit active");
-            finish_task("FAILED: boiler inhibit active", 8, false);
+            finish_task("FAILED: boiler inhibit active", 8, false, true);
             return;
           }
 
@@ -618,7 +618,7 @@ interval:
                          flow_lph,
                          (int) id(oq_commissioning_boiler_request),
                          (unsigned long) ((now_ms - id(oq_commissioning_state_since_ms)) / 1000UL));
-                finish_task("FAILED: boiler did not start", 8, false);
+                finish_task("FAILED: boiler did not start", 8, false, true);
                 return;
               }
               publish_status("BOILER_SETTLING");
@@ -691,7 +691,7 @@ interval:
               snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)",
                        id(oq_commissioning_result_w), id(oq_commissioning_result_confidence));
               ESP_LOGI("quatt.cm100.boiler", "Cooldown complete; finishing boiler test (%s)", msg);
-              finish_task(msg, 6, true);
+              finish_task(msg, 6, true, true);
             } else {
               publish_status("COOLDOWN");
             }

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -125,8 +125,8 @@ button:
           }
           if (id(oq_cm_override).has_state()) {
             const std::string override_mode = id(oq_cm_override).current_option();
-            if (override_mode != "Auto" && override_mode != "Force CM100") {
-              id(oq_commissioning_status).publish_state("REFUSED: CM Override not CM100");
+            if (override_mode != "Auto") {
+              id(oq_commissioning_status).publish_state("REFUSED: CM Override must be Auto");
               return;
             }
           }

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -694,7 +694,9 @@ interval:
               char msg[128];
               snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)",
                        id(oq_commissioning_result_w), id(oq_commissioning_result_confidence));
-              ESP_LOGI("quatt.cm100.boiler", "Cooldown complete; finishing boiler test (%s)", msg);
+              ESP_LOGI("quatt.cm100.boiler",
+                       "Cooldown complete; CM100 idle after boiler test (flow restored, boiler off, %s)",
+                       msg);
               finish_task(msg, 6, true, true);
             } else {
               publish_status("COOLDOWN");

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -315,12 +315,16 @@ button:
       sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
+          // Round the applied boiler rating to the nearest 100 W for a cleaner persistent setting.
           const float result = id(oq_commissioning_result_w);
           if (!isnan(result) && result > 0.0f) {
+            const int rounded_result = (int) roundf(result / 100.0f) * 100;
             auto call = id(oq_boiler_rated_heat_power).make_call();
-            call.set_value(result);
+            call.set_value((float) rounded_result);
             call.perform();
-            id(oq_boiler_power_test_status).publish_state("APPLIED");
+            char msg[64];
+            snprintf(msg, sizeof(msg), "APPLIED: %dW", rounded_result);
+            id(oq_boiler_power_test_status).publish_state(msg);
           } else {
             id(oq_boiler_power_test_status).publish_state("APPLY_FAILED");
           }

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -228,11 +228,6 @@ button:
             id(oq_boiler_power_test_status).publish_state("REFUSED: not CM100");
             return;
           }
-          if (id(oq_boot_startup_inhibit_active)) {
-            id(oq_boiler_power_test_status).publish_state("REFUSED: startup inhibit active");
-            ESP_LOGW("quatt.cm100.boiler", "Boiler power test refused: startup inhibit active");
-            return;
-          }
           ESP_LOGI("quatt.cm100.boiler",
                    "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)",
                    cm_code,

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -449,6 +449,7 @@ interval:
           const uint32_t commissioning_elapsed_ms =
               (id(oq_commissioning_started_ms) == 0) ? 0 : (now_ms - id(oq_commissioning_started_ms));
           static int last_boiler_state_logged = -1;
+          static uint32_t last_boiler_heartbeat_ms = 0;
           if (task_is_boiler && id(oq_commissioning_state_code) != last_boiler_state_logged) {
             ESP_LOGI("quatt.cm100.boiler",
                      "state=%d cm=%d active=%d pending=%d flow=%.0fL/h target=800L/h stable=%d/%d boiler_req=%d boiler_active=%d heat=%.0fW elapsed=%lus",
@@ -464,6 +465,26 @@ interval:
                      heat_w,
                      (unsigned long) (commissioning_elapsed_ms / 1000UL));
             last_boiler_state_logged = id(oq_commissioning_state_code);
+          }
+          if (task_is_boiler && id(oq_commissioning_state_code) >= 2 && id(oq_commissioning_state_code) <= 5) {
+            if (last_boiler_heartbeat_ms == 0 || (uint32_t)(now_ms - last_boiler_heartbeat_ms) >= 30000UL) {
+              ESP_LOGI("quatt.cm100.boiler",
+                       "state=%d cm=%d active=%d pending=%d flow=%.0fL/h target=800L/h stable=%d/%d boiler_req=%d boiler_active=%d heat=%.0fW elapsed=%lus",
+                       id(oq_commissioning_state_code),
+                       cm_code,
+                       (int) id(oq_commissioning_active),
+                       (int) id(oq_commissioning_request_pending),
+                       flow_lph,
+                       (int) id(oq_commissioning_flow_stable_count),
+                       (int) kStableFlowSamples,
+                       (int) id(oq_commissioning_boiler_request),
+                       (int) id(boiler_active).state,
+                       heat_w,
+                       (unsigned long) (commissioning_elapsed_ms / 1000UL));
+              last_boiler_heartbeat_ms = now_ms;
+            }
+          } else {
+            last_boiler_heartbeat_ms = 0;
           }
 
           auto restore_flow_setpoint = [&]() {

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -10,7 +10,7 @@
 #   - Flow control remains the owner of iPWM.
 #   - This package only requests a temporary PWM override via:
 #       * globals: oq_flow_autotune_active, oq_flow_autotune_pwm (added in flow_control)
-#   - Autotune is only allowed in CM1 (pre/postflow), not in CM0/CM2/CM3/CM98.
+#   - Autotune is only allowed in CM100 together with commissioning task FLOW_AUTOTUNE.
 #
 # Operation (high level):
 #   1) Arm/Settle: force baseline PWM (last_good_pwm) and wait for stable flow
@@ -110,11 +110,38 @@ button:
       sorting_group_id: oq_tuning_flow
     on_press:
       - lambda: |-
-          if (id(oq_flow_autotune_state) != 0 || id(oq_flow_autotune_active)) {
+          // Start a CM100 commissioning request and reset the autotune state.
+          if (id(oq_flow_autotune_state) != 0 ||
+              id(oq_flow_autotune_active) ||
+              id(oq_flow_autotune_req) ||
+              id(oq_commissioning_request_pending) ||
+              id(oq_commissioning_active)) {
             id(oq_flow_autotune_status).publish_state("REFUSED: BUSY");
             return;
           }
+          id(oq_commissioning_task_code) = 2;
+          id(oq_commissioning_request_pending) = true;
+          id(oq_commissioning_active) = false;
+          id(oq_commissioning_abort_requested) = false;
+          id(oq_commissioning_state_code) = 0;
+          id(oq_commissioning_started_ms) = 0;
+          id(oq_commissioning_state_since_ms) = 0;
           id(oq_flow_autotune_req) = true;
+          id(oq_flow_autotune_abort) = false;
+          id(oq_flow_autotune_state) = 0;
+          id(oq_flow_at_t) = 0;
+          id(oq_flow_at_pwm0) = 850;
+          id(oq_flow_at_pwm_step) = 850;
+          id(oq_flow_at_pv0) = NAN;
+          id(oq_flow_at_pv_ss) = NAN;
+          id(oq_flow_at_pv63_time_s) = NAN;
+          id(oq_flow_at_w0) = NAN;
+          id(oq_flow_at_w1) = NAN;
+          id(oq_flow_at_w2) = NAN;
+          id(oq_flow_at_ss_confirm_cnt) = 0;
+          id(oq_flow_autotune_active) = false;
+          id(oq_flow_autotune_pwm) = id(oq_flow_last_good_pwm);
+          id(oq_flow_autotune_status).publish_state("REQUESTED");
 
   - platform: template
     id: oq_flow_autotune_abort_btn
@@ -211,7 +238,19 @@ interval:
             return value;
           };
           auto in_valid_autotune_mode = []() -> bool {
-            return id(oq_control_mode_code) == 1;
+            return id(oq_control_mode_code) == 100 && id(oq_commissioning_task_code) == 2;
+          };
+          auto release_commissioning = [&]() {
+            id(oq_flow_autotune_active) = false;
+            id(oq_flow_autotune_abort) = false;
+            id(oq_flow_autotune_req) = false;
+            id(oq_commissioning_request_pending) = false;
+            id(oq_commissioning_active) = false;
+            id(oq_commissioning_abort_requested) = false;
+            id(oq_commissioning_task_code) = 0;
+            id(oq_commissioning_state_code) = 0;
+            id(oq_commissioning_started_ms) = 0;
+            id(oq_commissioning_state_since_ms) = 0;
           };
 
           // Abort button always works
@@ -227,10 +266,19 @@ interval:
           if (!id(oq_flow_autotune_enable).state) {
             id(oq_flow_autotune_active) = false;
             id(oq_flow_autotune_req) = false;
+            id(oq_flow_autotune_abort) = false;
+            id(oq_commissioning_request_pending) = false;
+            id(oq_commissioning_active) = false;
+            id(oq_commissioning_abort_requested) = false;
+            id(oq_commissioning_task_code) = 0;
+            id(oq_commissioning_state_code) = 0;
+            id(oq_commissioning_started_ms) = 0;
+            id(oq_commissioning_state_since_ms) = 0;
             id(oq_flow_at_w0) = NAN;
             id(oq_flow_at_w1) = NAN;
             id(oq_flow_at_w2) = NAN;
             id(oq_flow_at_ss_confirm_cnt) = 0;
+            id(oq_flow_autotune_pwm) = clamp_ipwm((int) id(oq_flow_last_pwm));
             if (id(oq_flow_autotune_state) != 0) {
               id(oq_flow_autotune_state) = 0;
               id(oq_flow_autotune_status).publish_state("DISABLED");
@@ -249,13 +297,15 @@ interval:
           // IDLE
           if (st == 0) {
             if (id(oq_flow_autotune_req)) {
-              id(oq_flow_autotune_req) = false;
-
               if (!in_valid_autotune_mode()) {
-                id(oq_flow_autotune_status).publish_state("REFUSED: not CM1");
+                id(oq_commissioning_request_pending) = true;
+                id(oq_commissioning_active) = false;
+                id(oq_flow_autotune_status).publish_state("WAITING_FOR_CM100");
                 return;
               }
+              id(oq_flow_autotune_req) = false;
               if (!flow_valid) {
+                release_commissioning();
                 id(oq_flow_autotune_status).publish_state("REFUSED: FLOW_INVALID");
                 return;
               }
@@ -276,6 +326,11 @@ interval:
               id(oq_flow_at_pwm0) = pwm0;
               id(oq_flow_autotune_pwm) = pwm0;
               id(oq_flow_autotune_active) = true;
+              id(oq_commissioning_request_pending) = false;
+              id(oq_commissioning_active) = true;
+              id(oq_commissioning_abort_requested) = false;
+              id(oq_commissioning_started_ms) = (uint32_t) millis();
+              id(oq_commissioning_state_since_ms) = (uint32_t) millis();
 
               id(oq_flow_autotune_status).publish_state("SETTLING");
               id(oq_flow_autotune_state) = 1;
@@ -285,7 +340,7 @@ interval:
 
           // ARM
           if (st == 1) {
-            if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM1"); }
+            if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
             else if (!flow_valid) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
             else {
               // Keep baseline override active while settling.
@@ -347,7 +402,7 @@ interval:
 
           // STEP / MEASURE
           if (st == 2) {
-            if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM1"); }
+            if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
             else if (!flow_valid) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
             else {
               const float pv0 = id(oq_flow_at_pv0);
@@ -429,6 +484,7 @@ interval:
 
             if (isnan(pv0) || isnan(pv_ss) || du <= 0.0f) {
               id(oq_flow_autotune_status).publish_state("FAILED: NO_RESPONSE");
+              release_commissioning();
               id(oq_flow_autotune_state) = 0;
               return;
             }
@@ -437,6 +493,7 @@ interval:
             const float K = dpv / du;  // (L/h)/iPWM
             if (!(K > 0.0f)) {
               id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
+              release_commissioning();
               id(oq_flow_autotune_state) = 0;
               return;
             }
@@ -488,6 +545,7 @@ interval:
             id(oq_flow_at_w1) = NAN;
             id(oq_flow_at_w2) = NAN;
             id(oq_flow_at_ss_confirm_cnt) = 0;
+            release_commissioning();
 
             id(oq_flow_autotune_state) = 0;
             return;
@@ -501,6 +559,7 @@ interval:
             id(oq_flow_at_w1) = NAN;
             id(oq_flow_at_w2) = NAN;
             id(oq_flow_at_ss_confirm_cnt) = 0;
+            release_commissioning();
             id(oq_flow_autotune_status).publish_state("ABORTED");
             id(oq_flow_autotune_state) = 0;
             return;

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -255,6 +255,7 @@ interval:
             id(oq_commissioning_state_code) = 0;
             id(oq_commissioning_started_ms) = 0;
             id(oq_commissioning_state_since_ms) = 0;
+            id(oq_commissioning_status).publish_state(keep_cm100 ? "CM100 READY" : "IDLE");
           };
 
           // Abort button always works

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -111,21 +111,21 @@ button:
     on_press:
       - lambda: |-
           // Start a CM100 commissioning request and reset the autotune state.
+          const int cm_code = id(oq_control_mode_code);
+          const bool cm100_ready = (cm_code == 100) && id(oq_commissioning_active) && id(oq_commissioning_task_code) == 0;
+          const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0;
           if (id(oq_flow_autotune_state) != 0 ||
               id(oq_flow_autotune_active) ||
               id(oq_flow_autotune_req) ||
-              id(oq_commissioning_request_pending) ||
-              id(oq_commissioning_active)) {
+              task_running) {
             id(oq_flow_autotune_status).publish_state("REFUSED: BUSY");
             return;
           }
           id(oq_commissioning_task_code) = 2;
-          id(oq_commissioning_request_pending) = true;
-          id(oq_commissioning_active) = false;
+          id(oq_commissioning_request_pending) = !cm100_ready;
+          id(oq_commissioning_active) = cm100_ready;
           id(oq_commissioning_abort_requested) = false;
           id(oq_commissioning_state_code) = 0;
-          id(oq_commissioning_started_ms) = 0;
-          id(oq_commissioning_state_since_ms) = 0;
           id(oq_flow_autotune_req) = true;
           id(oq_flow_autotune_abort) = false;
           id(oq_flow_autotune_state) = 0;
@@ -141,6 +141,15 @@ button:
           id(oq_flow_at_ss_confirm_cnt) = 0;
           id(oq_flow_autotune_active) = false;
           id(oq_flow_autotune_pwm) = id(oq_flow_last_good_pwm);
+          if (cm100_ready) {
+            id(oq_commissioning_started_ms) = (uint32_t) millis();
+            id(oq_commissioning_state_since_ms) = (uint32_t) millis();
+            id(oq_commissioning_status).publish_state("CM100 READY -> FLOW AUTOTUNE");
+          } else {
+            id(oq_commissioning_started_ms) = 0;
+            id(oq_commissioning_state_since_ms) = 0;
+            id(oq_commissioning_status).publish_state("FLOW AUTOTUNE REQUESTED");
+          }
           id(oq_flow_autotune_status).publish_state("REQUESTED");
 
   - platform: template

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -110,9 +110,9 @@ button:
       sorting_group_id: oq_tuning_flow
     on_press:
       - lambda: |-
-          // Start a CM100 commissioning request and reset the autotune state.
+          // Start autotune only when the system is already in CM100.
           const int cm_code = id(oq_control_mode_code);
-          const bool cm100_ready = (cm_code == 100) && id(oq_commissioning_active) && id(oq_commissioning_task_code) == 0;
+          const bool cm100_ready = (cm_code == 100);
           const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0;
           if (id(oq_flow_autotune_state) != 0 ||
               id(oq_flow_autotune_active) ||
@@ -121,11 +121,17 @@ button:
             id(oq_flow_autotune_status).publish_state("REFUSED: BUSY");
             return;
           }
+          if (!cm100_ready) {
+            id(oq_flow_autotune_status).publish_state("REFUSED: not CM100");
+            return;
+          }
           id(oq_commissioning_task_code) = 2;
-          id(oq_commissioning_request_pending) = !cm100_ready;
-          id(oq_commissioning_active) = cm100_ready;
+          id(oq_commissioning_request_pending) = false;
+          id(oq_commissioning_active) = true;
           id(oq_commissioning_abort_requested) = false;
-          id(oq_commissioning_state_code) = 0;
+          id(oq_commissioning_state_code) = 1;
+          id(oq_commissioning_started_ms) = (uint32_t) millis();
+          id(oq_commissioning_state_since_ms) = (uint32_t) millis();
           id(oq_flow_autotune_req) = true;
           id(oq_flow_autotune_abort) = false;
           id(oq_flow_autotune_state) = 0;
@@ -141,15 +147,7 @@ button:
           id(oq_flow_at_ss_confirm_cnt) = 0;
           id(oq_flow_autotune_active) = false;
           id(oq_flow_autotune_pwm) = id(oq_flow_last_good_pwm);
-          if (cm100_ready) {
-            id(oq_commissioning_started_ms) = (uint32_t) millis();
-            id(oq_commissioning_state_since_ms) = (uint32_t) millis();
-            id(oq_commissioning_status).publish_state("CM100 READY -> FLOW AUTOTUNE");
-          } else {
-            id(oq_commissioning_started_ms) = 0;
-            id(oq_commissioning_state_since_ms) = 0;
-            id(oq_commissioning_status).publish_state("FLOW AUTOTUNE REQUESTED");
-          }
+          id(oq_commissioning_status).publish_state("FLOW AUTOTUNE STARTED");
           id(oq_flow_autotune_status).publish_state("REQUESTED");
 
   - platform: template

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -89,17 +89,6 @@ globals:
 # ----------------------------
 # CONTROL INPUTS
 # ----------------------------
-switch:
-  - platform: template
-    id: oq_flow_autotune_enable
-    name: "Flow Autotune Enable"
-    icon: mdi:auto-fix
-    restore_mode: RESTORE_DEFAULT_OFF
-    optimistic: true
-    entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_flow
-
 button:
   - platform: template
     id: oq_flow_autotune_start
@@ -268,30 +257,6 @@ interval:
 
           const float pv = id(flow_rate_selected).state;
           const bool flow_valid = !(isnan(pv) || pv <= 0.0f);
-
-          // Only run when enabled
-          if (!id(oq_flow_autotune_enable).state) {
-            id(oq_flow_autotune_active) = false;
-            id(oq_flow_autotune_req) = false;
-            id(oq_flow_autotune_abort) = false;
-            id(oq_commissioning_request_pending) = false;
-            id(oq_commissioning_active) = false;
-            id(oq_commissioning_abort_requested) = false;
-            id(oq_commissioning_task_code) = 0;
-            id(oq_commissioning_state_code) = 0;
-            id(oq_commissioning_started_ms) = 0;
-            id(oq_commissioning_state_since_ms) = 0;
-            id(oq_flow_at_w0) = NAN;
-            id(oq_flow_at_w1) = NAN;
-            id(oq_flow_at_w2) = NAN;
-            id(oq_flow_at_ss_confirm_cnt) = 0;
-            id(oq_flow_autotune_pwm) = clamp_ipwm((int) id(oq_flow_last_pwm));
-            if (id(oq_flow_autotune_state) != 0) {
-              id(oq_flow_autotune_state) = 0;
-              id(oq_flow_autotune_status).publish_state("DISABLED");
-            }
-            return;
-          }
 
           int st = id(oq_flow_autotune_state);
 

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -114,6 +114,14 @@ button:
             id(oq_flow_autotune_status).publish_state("REFUSED: not CM100");
             return;
           }
+          ESP_LOGI("quatt.cm100.autotune",
+                   "Autotune requested (cm=%d flow_mode=%s setpoint=%.0fL/h last_good_pwm=%d active=%d state=%d)",
+                   cm_code,
+                   id(oq_flow_control_mode).state.c_str(),
+                   id(oq_flow_setpoint_lph).state,
+                   (int) id(oq_flow_last_good_pwm),
+                   (int) id(oq_flow_autotune_active),
+                   (int) id(oq_flow_autotune_state));
           id(oq_commissioning_task_code) = 2;
           id(oq_commissioning_request_pending) = false;
           id(oq_commissioning_active) = true;
@@ -273,10 +281,12 @@ interval:
                 id(oq_commissioning_request_pending) = true;
                 id(oq_commissioning_active) = false;
                 id(oq_flow_autotune_status).publish_state("WAITING_FOR_CM100");
+                ESP_LOGI("quatt.cm100.autotune", "Waiting for CM100 before autotune can start");
                 return;
               }
               id(oq_flow_autotune_req) = false;
               if (!flow_valid) {
+                ESP_LOGW("quatt.cm100.autotune", "Autotune refused: flow invalid at request time (pv=%.1f)", pv);
                 release_commissioning();
                 id(oq_flow_autotune_status).publish_state("REFUSED: FLOW_INVALID");
                 return;
@@ -304,6 +314,11 @@ interval:
               id(oq_commissioning_started_ms) = (uint32_t) millis();
               id(oq_commissioning_state_since_ms) = (uint32_t) millis();
 
+              ESP_LOGI("quatt.cm100.autotune",
+                       "Baseline settle started (pwm0=%d pv=%.1f target=%.1f settle=%us stable_band=%.1f)",
+                       pwm0, pv, id(oq_flow_setpoint_lph).state,
+                       (unsigned int) ${oq_flow_autotune_settle_s},
+                       (float) ${oq_flow_autotune_stable_band_lph});
               id(oq_flow_autotune_status).publish_state("SETTLING");
               id(oq_flow_autotune_state) = 1;
             }
@@ -313,7 +328,7 @@ interval:
           // ARM
           if (st == 1) {
             if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else if (!flow_valid) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
+            else if (!flow_valid) { st = 4; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid while settling (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
             else {
               // Keep baseline override active while settling.
               const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
@@ -341,10 +356,16 @@ interval:
 
                 if (t >= ${oq_flow_autotune_settle_s} && spread <= ${oq_flow_autotune_stable_band_lph}) {
                   id(oq_flow_at_pv0) = mean;
+                  ESP_LOGI("quatt.cm100.autotune",
+                           "Baseline stable (pv0=%.1f pwm0=%d spread=%.1f t=%ds)",
+                           mean, pwm0, spread, t);
 
                   const int pwm_headroom = pwm0 - ${oq_flow_pwm_min};
                   if (pwm_headroom < ${oq_flow_autotune_min_step}) {
                     st = 4;
+                    ESP_LOGW("quatt.cm100.autotune",
+                             "Autotune refused: insufficient step headroom (pwm0=%d min=%d headroom=%d required=%d)",
+                             pwm0, ${oq_flow_pwm_min}, pwm_headroom, ${oq_flow_autotune_min_step});
                     id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
                   } else {
                     int u_step = (int) roundf(kAutotuneStepFrac * (float) pwm0);
@@ -362,6 +383,9 @@ interval:
                     id(oq_flow_at_ss_confirm_cnt) = 0;
 
                     id(oq_flow_autotune_pwm) = pwm_step;
+                    ESP_LOGI("quatt.cm100.autotune",
+                             "Step applied (pwm0=%d step=%d pwm_step=%d pv0=%.1f)",
+                             pwm0, u_step, pwm_step, mean);
                     id(oq_flow_autotune_status).publish_state("STEP");
                     st = 2;
                   }
@@ -375,7 +399,7 @@ interval:
           // STEP / MEASURE
           if (st == 2) {
             if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else if (!flow_valid) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
+            else if (!flow_valid) { st = 4; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during step (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
             else {
               const float pv0 = id(oq_flow_at_pv0);
               const int t = id(oq_flow_at_t);
@@ -402,6 +426,11 @@ interval:
                 if (ss_ready) {
                   id(oq_flow_at_pv_ss) = (w0 + w1 + w2) / 3.0f;
                   if (id(oq_flow_at_ss_confirm_cnt) < 255) id(oq_flow_at_ss_confirm_cnt)++;
+                  if (id(oq_flow_at_ss_confirm_cnt) == 1) {
+                    ESP_LOGI("quatt.cm100.autotune",
+                             "Steady-state candidate locked (pv_ss=%.1f t=%ds spread=%.1f slopes=%.1f/%.1f)",
+                             id(oq_flow_at_pv_ss), t, spread, slope01, slope12);
+                  }
                 } else {
                   id(oq_flow_at_ss_confirm_cnt) = 0;
                 }
@@ -429,8 +458,12 @@ interval:
               if (early_done || t >= max_s) {
                 if (isnan(id(oq_flow_at_pv_ss))) {
                   st = 4;
+                  ESP_LOGW("quatt.cm100.autotune", "Autotune aborted: no steady-state response (t=%ds pv=%.1f)", t, pv);
                   id(oq_flow_autotune_status).publish_state("ABORT: NO_STEADY_STATE");
                 } else {
+                  ESP_LOGI("quatt.cm100.autotune",
+                           "Response captured (pv0=%.1f pv_ss=%.1f t63=%.1f samples=%d t=%ds)",
+                           pv0, id(oq_flow_at_pv_ss), id(oq_flow_at_pv63_time_s), id(oq_flow_at_ss_confirm_cnt), t);
                   st = 3;
                 }
               } else {
@@ -455,6 +488,7 @@ interval:
             const float du = (float)(pwm0 - pwm_step); // >0
 
             if (isnan(pv0) || isnan(pv_ss) || du <= 0.0f) {
+              ESP_LOGW("quatt.cm100.autotune", "Autotune failed: no response (pv0=%.1f pv_ss=%.1f du=%d)", pv0, pv_ss, (int) du);
               id(oq_flow_autotune_status).publish_state("FAILED: NO_RESPONSE");
               release_commissioning();
               id(oq_flow_autotune_state) = 0;
@@ -464,6 +498,7 @@ interval:
             const float dpv = pv_ss - pv0;
             const float K = dpv / du;  // (L/h)/iPWM
             if (!(K > 0.0f)) {
+              ESP_LOGW("quatt.cm100.autotune", "Autotune failed: invalid gain (pv0=%.1f pv_ss=%.1f du=%.1f)", pv0, pv_ss, du);
               id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
               release_commissioning();
               id(oq_flow_autotune_state) = 0;
@@ -509,6 +544,9 @@ interval:
             } else {
               snprintf(msg, sizeof(msg), "DONE: K=%.3f tau=%.0fs -> Kp=%.3f Ki=%.4f", K, tau, Kp, Ki);
             }
+            ESP_LOGI("quatt.cm100.autotune",
+                     "Autotune done: K=%.3f tau=%.0fs theta=%.0fs Kp=%.3f Ki=%.4f clamped=%d pv0=%.1f pv_ss=%.1f pwm0=%d pwm_step=%d",
+                     K, tau, theta, Kp, Ki, (int) clamped, pv0, pv_ss, pwm0, pwm_step);
             id(oq_flow_autotune_status).publish_state(msg);
 
             // restore previous pwm best-effort
@@ -531,6 +569,7 @@ interval:
             id(oq_flow_at_w1) = NAN;
             id(oq_flow_at_w2) = NAN;
             id(oq_flow_at_ss_confirm_cnt) = 0;
+            ESP_LOGW("quatt.cm100.autotune", "Autotune aborted; restoring last PWM=%d", (int) id(oq_flow_last_pwm));
             release_commissioning();
             id(oq_flow_autotune_status).publish_state("ABORTED");
             id(oq_flow_autotune_state) = 0;

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -244,12 +244,12 @@ interval:
           auto in_valid_autotune_mode = []() -> bool {
             return id(oq_control_mode_code) == 100 && id(oq_commissioning_task_code) == 2;
           };
-          auto release_commissioning = [&]() {
+          auto release_commissioning = [&](bool keep_cm100 = true) {
             id(oq_flow_autotune_active) = false;
             id(oq_flow_autotune_abort) = false;
             id(oq_flow_autotune_req) = false;
             id(oq_commissioning_request_pending) = false;
-            id(oq_commissioning_active) = false;
+            id(oq_commissioning_active) = keep_cm100;
             id(oq_commissioning_abort_requested) = false;
             id(oq_commissioning_task_code) = 0;
             id(oq_commissioning_state_code) = 0;

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -323,7 +323,7 @@ interval:
           //
           // Priority (highest -> lowest):
           // 1) CM0 early return (no writes from this loop)
-          // 2) AUTOTUNE override (CM1 only)
+          // 2) AUTOTUNE override (CM100 commissioning task only)
           // 3) MANUAL / FROST fixed iPWM
           // 4) AUTO PI path (with startup-hold + failsafe)
           //
@@ -547,7 +547,7 @@ interval:
           id(oq_flow_last_mode) = mode;
 
           // Autotune temporarily overrides PWM (flow_control remains output owner).
-          if (id(oq_flow_autotune_active) && (cm_code == 1) && !is_frost) {
+          if (id(oq_flow_autotune_active) && (cm_code == 100) && (id(oq_commissioning_task_code) == 2) && !is_frost) {
             int at_pwm = clamp_iPWM((int) id(oq_flow_autotune_pwm));
             id(oq_flow_last_pwm) = at_pwm;
             stable_cnt = 0;

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -23,7 +23,7 @@
 #   - Pump output is correctly configured for PWM
 #
 # Interaction with Control Modes:
-#   - Active in CM1/CM2/CM3 (AUTO=PI, MANUAL=fixed iPWM)
+#   - Active in CM1/CM2/CM3/CM100 (AUTO=PI, MANUAL=fixed iPWM)
 #   - CM0: early return (supervisory owns pump state in idle)
 #   - CM98: fixed frost PWM path
 #

--- a/openquatt/oq_packages_common.yaml
+++ b/openquatt/oq_packages_common.yaml
@@ -4,22 +4,23 @@
 # Package load order is intentional:
 # 1) Common platform runtime (API/OTA/UART/diagnostics)
 # 2) Supervisory/state
-# 3) Thermal limits / abstractions
-# 4) Strategy manager + cooling strategy
-# 5) Heating strategy implementations
-# 6) Shared thermal-request control + actuator layers
-# 7) Flow/boiler and other actuation followers
-# 8) Aggregation/energy telemetry
-# 9) External inputs (CIC)
-# 10) CiC compatibility bridge
-# 11) External HA proxy inputs
-# 12) Local sensors
-# 13) Source selection and merged selected-source signals
-# 14) OpenTherm thermostat bridge
-# 15) Setup/status
-# 16) Web UI
-# 17) Web access runtime
-# 18) Per-HP hardware adapters
+# 3) Commissioning/service tasks
+# 4) Thermal limits / abstractions
+# 5) Strategy manager + cooling strategy
+# 6) Heating strategy implementations
+# 7) Shared thermal-request control + actuator layers
+# 8) Flow/boiler and other actuation followers
+# 9) Aggregation/energy telemetry
+# 10) External inputs (CIC)
+# 11) CiC compatibility bridge
+# 12) External HA proxy inputs
+# 13) Local sensors
+# 14) Source selection and merged selected-source signals
+# 15) OpenTherm thermostat bridge
+# 16) Setup/status
+# 17) Web UI
+# 18) Web access runtime
+# 19) Per-HP hardware adapters
 # ==============================================================================
 # Shared modules use `*_secondary_*` template vars so topology wiring stays
 # centralized in topology substitutions and avoids duplicated module files.
@@ -35,6 +36,7 @@ oq_supervisory_controlmode: !include
     supervisory_secondary_low_noise_mode_id: "${secondary_hp_id}_low_noise_mode"
     supervisory_secondary_set_pump_mode_id: "${secondary_hp_id}_set_pump_mode"
     supervisory_secondary_pump_speed_id: "${secondary_hp_id}_pump_speed"
+oq_commissioning: !include oq_commissioning.yaml
 oq_thermal_limits: !include
   file: oq_thermal_limits.yaml
   vars:

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -11,7 +11,7 @@
 # What this package DOES do:
 #   - Determines base mode (idle / heating / cooling / frost) based on demand and conditions
 #   - Applies flow override: with insufficient flow -> CM1 (holding)
-#   - Supports test override: Force CM0/CM1 and Diagnostic Force CM98 (auto-expire)
+#   - Supports test override: Force CM0/CM1/CM100 and Diagnostic Force CM98 (auto-expire)
 #   - Exposes CM100 commissioning when a service task is explicitly requested
 #   - Automatically switches CM2 <-> CM3 based on thermal deficit (`oq_P_deficit_w`) with timers/hysteresis
 #   - Publishes current CM as text_sensor (for example 'CM2', 'CM3', 'CM5', 'CM100')
@@ -206,6 +206,7 @@ select:
       - Force CM0
       - Force CM1
       - Force CM98
+      - Force CM100
     initial_option: Auto
     restore_value: false
     optimistic: true
@@ -1077,10 +1078,10 @@ interval:
 
             // Supervisory override (test/commissioning)
             // - Auto (normal logic)
-            // - Force CM0 / Force CM1
+            // - Force CM0 / Force CM1 / Force CM100
             // - Force CM98 (auto-expire after 30 min)
-            int override_mode = id(oq_cm_override).active_index().value_or(0); // 0=AUTO,1=CM0,2=CM1,3=CM98_DIAG
-            if (override_mode < 0 || override_mode > 3) override_mode = 0;
+            int override_mode = id(oq_cm_override).active_index().value_or(0); // 0=AUTO,1=CM0,2=CM1,3=CM98_DIAG,4=CM100
+            if (override_mode < 0 || override_mode > 4) override_mode = 0;
             // Track entry into CM98 diagnostic override for auto-expire
             if (override_mode != id(oq_override_last_mode)) {
               id(oq_override_last_mode) = override_mode;
@@ -1117,6 +1118,9 @@ interval:
               } else if (override_mode == 3) {
                 desired_local = 98; // CM98
                 cm_transition_reason = "supervisory override: Force CM98";
+              } else if (override_mode == 4) {
+                desired_local = 100; // CM100
+                cm_transition_reason = "supervisory override: Force CM100";
               }
             } else {
               const bool commissioning_in_progress =

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -6,14 +6,15 @@
 #   Determines the active Control Mode (CM) as central state machine and publishes the system decision to the other packages.
 #
 # Role in architecture:
-#   Single owner of Control Mode; coordinates subsystems by selecting CM (CM0/CM1/CM2/CM3/CM5/CM98).
+#   Single owner of Control Mode; coordinates subsystems by selecting CM (CM0/CM1/CM2/CM3/CM5/CM98/CM100).
 #
 # What this package DOES do:
 #   - Determines base mode (idle / heating / cooling / frost) based on demand and conditions
 #   - Applies flow override: with insufficient flow -> CM1 (holding)
 #   - Supports test override: Force CM0/CM1 and Diagnostic Force CM98 (auto-expire)
+#   - Exposes CM100 commissioning when a service task is explicitly requested
 #   - Automatically switches CM2 <-> CM3 based on thermal deficit (`oq_P_deficit_w`) with timers/hysteresis
-#   - Publishes current CM as text_sensor (for example 'CM2', 'CM3', 'CM5')
+#   - Publishes current CM as text_sensor (for example 'CM2', 'CM3', 'CM5', 'CM100')
 #
 # What this package DOES NOT do:
 #   - Does not control compressor levels directly (heat-control does)
@@ -32,6 +33,7 @@
 #   - CM3: heating (HP + boiler auxiliary heating)
 #   - CM5: cooling
 #   - CM98: frost
+#   - CM100: commissioning / service task container
 #
 # Safety / fail-safe:
 #   - Flow override always has priority: at low flow, CM1 is enforced
@@ -683,6 +685,7 @@ interval:
             }
           };
           auto cm_code_to_id = [](int cm) -> const char* {
+            if (cm == 100) return "CM100";
             if (cm == 98) return "CM98";
             if (cm == 5) return "CM5";
             if (cm == 3) return "CM3";
@@ -692,6 +695,7 @@ interval:
           };
           auto cm_code_to_label = [&](int cm) -> std::string {
             const char* cm_id = cm_code_to_id(cm);
+            if (strcmp(cm_id, "CM100") == 0) return std::string("CM100 - Commissioning");
             if (strcmp(cm_id, "CM0") == 0) return std::string("CM0 - Standby");
             if (strcmp(cm_id, "CM1") == 0) return std::string("CM1 - Preflow/Postflow");
             if (strcmp(cm_id, "CM2") == 0) return std::string("CM2 - Heating - Heat Pump Only");
@@ -1115,6 +1119,16 @@ interval:
                 cm_transition_reason = "supervisory override: Force CM98";
               }
             } else {
+              const bool commissioning_in_progress =
+                  id(oq_commissioning_request_pending) || id(oq_commissioning_active);
+              if (commissioning_in_progress) {
+                id(oq_cm1_until_ms) = 0;
+                id(oq_cm1_next_after) = 0;
+                id(oq_cm3_need_since_ms) = 0;
+                id(oq_cm3_demote_since_ms) = 0;
+                desired_local = 100;
+                cm_transition_reason = "commissioning task active";
+              } else {
               // Snapshot CM1 timer state (before we touch globals)
               const bool cm1_timer_active  = (id(oq_cm1_until_ms) != 0);
               const bool cm1_timer_running = cm1_timer_active && now_before_until;
@@ -1274,6 +1288,7 @@ interval:
                   desired_local = 2;
                   cm_transition_reason = "Power House assist disabled, returning to CM2";
                 }
+              }
               }
             }
             return desired_local;

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -1433,8 +1433,15 @@ interval:
             }
 
             const bool sticky_active = in_cm0 && ms_window_active(id(oq_sticky_until_ms));
+            const bool cm100_task_active =
+                (strcmp(desired_cm, "CM100") == 0) &&
+                (id(oq_commissioning_task_code) != 0);
             // Pump failsafe: never stop circulation while any HP is still active.
-            const bool pump_on = (strcmp(desired_cm, "CM0") != 0) || sticky_active || any_hp_active_guard;
+            // CM100 idle is a service stand, not an active circulation mode.
+            const bool pump_on = (strcmp(desired_cm, "CM0") != 0 && strcmp(desired_cm, "CM100") != 0) ||
+                                 cm100_task_active ||
+                                 sticky_active ||
+                                 any_hp_active_guard;
             set_select_option(id(hp1_set_pump_mode), pump_on ? "On" : "Off");
             #if OQ_TOPOLOGY_DUO
             set_select_option(id(${supervisory_secondary_set_pump_mode_id}), pump_on ? "On" : "Off");

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -11,7 +11,7 @@
 # What this package DOES do:
 #   - Determines base mode (idle / heating / cooling / frost) based on demand and conditions
 #   - Applies flow override: with insufficient flow -> CM1 (holding)
-#   - Supports test override: Force CM0/CM1/CM100 and Diagnostic Force CM98 (auto-expire)
+#   - Supports test override: Force CM0/CM1 and Diagnostic Force CM98 (auto-expire)
 #   - Exposes CM100 commissioning when a service task is explicitly requested
 #   - Automatically switches CM2 <-> CM3 based on thermal deficit (`oq_P_deficit_w`) with timers/hysteresis
 #   - Publishes current CM as text_sensor (for example 'CM2', 'CM3', 'CM5', 'CM100')
@@ -206,7 +206,6 @@ select:
       - Force CM0
       - Force CM1
       - Force CM98
-      - Force CM100
     initial_option: Auto
     restore_value: false
     optimistic: true
@@ -1078,10 +1077,10 @@ interval:
 
             // Supervisory override (test/commissioning)
             // - Auto (normal logic)
-            // - Force CM0 / Force CM1 / Force CM100
+            // - Force CM0 / Force CM1
             // - Force CM98 (auto-expire after 30 min)
-            int override_mode = id(oq_cm_override).active_index().value_or(0); // 0=AUTO,1=CM0,2=CM1,3=CM98_DIAG,4=CM100
-            if (override_mode < 0 || override_mode > 4) override_mode = 0;
+            int override_mode = id(oq_cm_override).active_index().value_or(0); // 0=AUTO,1=CM0,2=CM1,3=CM98_DIAG
+            if (override_mode < 0 || override_mode > 3) override_mode = 0;
             // Track entry into CM98 diagnostic override for auto-expire
             if (override_mode != id(oq_override_last_mode)) {
               id(oq_override_last_mode) = override_mode;
@@ -1118,9 +1117,6 @@ interval:
               } else if (override_mode == 3) {
                 desired_local = 98; // CM98
                 cm_transition_reason = "supervisory override: Force CM98";
-              } else if (override_mode == 4) {
-                desired_local = 100; // CM100
-                cm_transition_reason = "supervisory override: Force CM100";
               }
             } else {
               const bool commissioning_in_progress =

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -33,7 +33,7 @@
 #
 # Interaction with Control Modes:
 #   - Active in CM2/CM3 (heating)
-#   - In CM0/CM1/CM98, compressor levels are forced to 0
+#   - In CM0/CM1/CM98/CM100, compressor levels are forced to 0
 #
 # Safety / fail-safe:
 #   - With inactive CM: compressor levels 0 (no heat production)

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -636,14 +636,14 @@ interval:
           const int active_thermal_mode_code = is_cooling_mode ? 1 : 2;
           const uint32_t loop_target_ms = (uint32_t) ((is_curve_mode ? ${oq_heat_loop_curve_s} : ${oq_heat_loop_powerhouse_s}) * 1000UL);
 
-          // After any controller reboot we intentionally keep all heat outputs blocked for a while.
+          // After any controller reboot we intentionally keep the compressors blocked for a while.
           // This makes the compressor restart guard reboot-safe without relying on lost pre-crash timestamps.
           if (id(oq_boot_startup_inhibit_until_ms) == 0) {
             const uint32_t inhibit_ms = (uint32_t) ${oq_hp_min_off_s} * 1000UL;
             id(oq_boot_startup_inhibit_until_ms) = now_ms + inhibit_ms;
             id(oq_boot_startup_inhibit_active) = (inhibit_ms > 0);
             if (!id(oq_boot_startup_inhibit_logged) && inhibit_ms > 0) {
-              ESP_LOGI("quatt", "Startup inhibit armed for %us after reboot; compressors and boiler remain blocked.", (unsigned int) ${oq_hp_min_off_s});
+              ESP_LOGI("quatt", "Startup inhibit armed for %us after reboot; compressors remain blocked.", (unsigned int) ${oq_hp_min_off_s});
               id(oq_boot_startup_inhibit_logged) = true;
               id(oq_boot_startup_inhibit_cleared_logged) = false;
             }
@@ -656,7 +656,7 @@ interval:
               id(oq_boot_startup_inhibit_until_ms) > 0 &&
               id(oq_boot_startup_inhibit_logged) &&
               !id(oq_boot_startup_inhibit_cleared_logged)) {
-            ESP_LOGI("quatt", "Startup inhibit cleared after reboot; compressors and boiler may resume.");
+            ESP_LOGI("quatt", "Startup inhibit cleared after reboot; compressors may resume.");
             id(oq_boot_startup_inhibit_cleared_logged) = true;
           }
 

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -71,6 +71,7 @@ STRICT_TOP_LEVEL_ORDER_RULES = {
     "openquatt/oq_packages_common.yaml": (
         "oq_common",
         "oq_supervisory_controlmode",
+        "oq_commissioning",
         "oq_thermal_limits",
         "oq_strategy_manager",
         "oq_cooling_strategy",

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -42,6 +42,8 @@ STAGE_EXCLUDE_FILES = ("*.pyc", "*.pyo")
 
 EFUSE_DUPLICATE_SOURCE = '"src/esp_efuse_fields.c"'
 EFUSE_DUPLICATE_UTILITY_SOURCE = '"src/esp_efuse_utility.c"'
+EFUSE_SOC_UTILITY_SOURCE = '"esp_efuse_utility.c"'
+EFUSE_SOC_UTILITY_RENAMED = '"esp_efuse_utility_esp32s3.c"'
 EFUSE_PATCH_MARKER_PREFIX = (
     "# OpenQuatt validate patch: target-specific sources.cmake already provides "
 )
@@ -255,40 +257,16 @@ def patch_framework_espidf_efuse_main_cmake(package_dir: Path) -> bool:
         return False
 
     text = cmake_path.read_text(encoding="utf-8")
-    if EFUSE_PATCH_MARKER_PREFIX not in text and EFUSE_DUPLICATE_SOURCE not in text:
-        return False
-
     updated = text
-    if EFUSE_DUPLICATE_SOURCE in updated:
-        updated = updated.replace('                 "src/esp_efuse_fields.c"\n', "", 1)
-
-    if EFUSE_DUPLICATE_UTILITY_SOURCE not in updated:
+    if 'src/esp_efuse_utility.c' not in updated and 'list(APPEND srcs "src/esp_efuse_api.c"\n                 "src/efuse_controller/keys/${type}/esp_efuse_api_key.c")' in updated:
         updated = updated.replace(
-            'list(APPEND srcs "src/esp_efuse_api.c"\n',
-            'list(APPEND srcs "src/esp_efuse_api.c"\n'
-            '                 "src/esp_efuse_utility.c"\n',
+            'list(APPEND srcs "src/esp_efuse_api.c"\n                 "src/efuse_controller/keys/${type}/esp_efuse_api_key.c")',
+            'list(APPEND srcs "src/esp_efuse_api.c"\n                 "src/esp_efuse_utility.c"\n                 "src/efuse_controller/keys/${type}/esp_efuse_api_key.c")',
             1,
         )
 
     if updated == text:
         return False
-
-    if EFUSE_PATCH_MARKER_PREFIX not in updated:
-        old = (
-            'list(APPEND srcs "src/esp_efuse_api.c"\n'
-            '                 "src/esp_efuse_fields.c"\n'
-            '                 "src/esp_efuse_utility.c"\n'
-            '                 "src/efuse_controller/keys/${type}/esp_efuse_api_key.c")'
-        )
-        new = (
-            EFUSE_PATCH_MARKER
-            +
-            'list(APPEND srcs "src/esp_efuse_api.c"\n'
-            '                 "src/esp_efuse_utility.c"\n'
-            '                 "src/efuse_controller/keys/${type}/esp_efuse_api_key.c")'
-        )
-        if old in text:
-            updated = text.replace(old, new, 1)
 
     cmake_path.write_text(updated, encoding="utf-8")
     return True
@@ -296,17 +274,22 @@ def patch_framework_espidf_efuse_main_cmake(package_dir: Path) -> bool:
 
 def patch_framework_espidf_efuse_sources(package_dir: Path) -> bool:
     patched = False
-    for sources_path in package_dir.glob("*/sources.cmake"):
+    for sources_path in package_dir.glob("components/efuse/*/sources.cmake"):
         if not sources_path.is_file():
             continue
 
         text = sources_path.read_text(encoding="utf-8")
-        if EFUSE_DUPLICATE_UTILITY_SOURCE not in text:
+        target_dir = sources_path.parent.name
+        if target_dir != "esp32s3" or EFUSE_SOC_UTILITY_SOURCE not in text:
             continue
 
-        updated = text.replace('                    "esp_efuse_utility.c"\n', "", 1)
+        updated = text.replace(EFUSE_SOC_UTILITY_SOURCE, EFUSE_SOC_UTILITY_RENAMED, 1)
         if updated != text:
             sources_path.write_text(updated, encoding="utf-8")
+            renamed_path = sources_path.parent / "esp_efuse_utility_esp32s3.c"
+            original_path = sources_path.parent / "esp_efuse_utility.c"
+            if original_path.is_file() and not renamed_path.exists():
+                renamed_path.write_text(original_path.read_text(encoding="utf-8"), encoding="utf-8")
             patched = True
     return patched
 
@@ -327,7 +310,9 @@ def has_framework_espidf_efuse_workaround(pio_core_dir: Path) -> bool:
         if not cmake_path.is_file():
             continue
         text = cmake_path.read_text(encoding="utf-8")
-        if EFUSE_PATCH_MARKER_PREFIX in text and 'src/esp_efuse_utility.c' in text:
+        esp32s3_sources = package_dir / "components" / "efuse" / "esp32s3" / "sources.cmake"
+        renamed_source = package_dir / "components" / "efuse" / "esp32s3" / "esp_efuse_utility_esp32s3.c"
+        if 'src/esp_efuse_utility.c' in text and esp32s3_sources.is_file() and renamed_source.is_file():
             return True
     return False
 
@@ -574,6 +559,7 @@ def validate_command(args: argparse.Namespace) -> int:
 
     env = os.environ.copy()
     env["PLATFORMIO_CORE_DIR"] = str(pio_core_dir)
+    env["PLATFORMIO_HOME_DIR"] = str(pio_core_dir)
 
     print(f"Workspace root: {root_dir}")
     if command_root != root_dir:


### PR DESCRIPTION
This PR makes `CM100` the explicit commissioning/service container and keeps task start separate from mode selection.

Changes:
- Keep `CM100 Start/Stop` as the explicit way to enter and leave commissioning service mode.
- Require the system to already be in `CM100` before starting `Boiler power test` or `Flow autotune`.
- Keep `CM100` idle after a task completes: no flow unless a commissioning task is running.
- Boiler power test now uses the fixed 800 L/h commissioning flow, waits 2 minutes for flow stabilisation, measures for 3 minutes, and publishes a 30s heartbeat during the run.
- The measured boiler result is applied rounded to the nearest 100 W.
- Flow autotune runs under the same `CM100` container and starts its own flow inside the autotune routine.

Validation:
- `python3 scripts/dev.py validate --config openquatt_duo_waveshare.yaml --jobs 1`