### PR TITLE
Add closed-loop validation to flow autotune

### DIFF
--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -119,10 +119,6 @@ button:
     on_press:
       - lambda: |-
           // Request CM100 as a neutral service state with no task yet.
-          if (!id(oq_enabled).state) {
-            id(oq_boiler_power_test_status).publish_state("REFUSED: OpenQuatt disabled");
-            return;
-          }
           if (id(oq_cm_override).has_state()) {
             const std::string override_mode = id(oq_cm_override).current_option();
             if (override_mode != "Auto") {
@@ -210,10 +206,6 @@ button:
           const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0;
           if (task_running || id(oq_commissioning_request_pending)) {
             id(oq_boiler_power_test_status).publish_state("REFUSED: BUSY");
-            return;
-          }
-          if (!id(oq_enabled).state) {
-            id(oq_boiler_power_test_status).publish_state("REFUSED: OpenQuatt disabled");
             return;
           }
           if (!id(oq_flow_control_mode).has_state() || id(oq_flow_control_mode).current_option() != "Flow Setpoint") {

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -131,7 +131,7 @@ button:
             }
           }
           ESP_LOGI("quatt.cm100", "CM100 requested via dashboard (override=%s task=%d active=%d pending=%d)",
-                   id(oq_cm_override).state.c_str(),
+                   id(oq_cm_override).current_option().c_str(),
                    id(oq_commissioning_task_code),
                    (int) id(oq_commissioning_active),
                    (int) id(oq_commissioning_request_pending));
@@ -231,7 +231,7 @@ button:
           ESP_LOGI("quatt.cm100.boiler",
                    "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)",
                    cm_code,
-                   id(oq_flow_control_mode).state.c_str(),
+                   id(oq_flow_control_mode).current_option().c_str(),
                    id(oq_flow_setpoint_lph).state,
                    id(oq_commissioning_task_code),
                    (int) id(oq_commissioning_active));

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -1,10 +1,11 @@
 # ==============================================================================
-# OpenQuatt - Flow Autotune (Option A: Open-Loop Step Response, IMC-PI)
+# OpenQuatt - Flow Autotune (Hybrid Open-Loop Identification + Closed-Loop Validation)
 # ==============================================================================
 #
 # Goal:
 #   Automatically derives a PI proposal (Kp/Ki) for the flow controller
-#   by executing a short open-loop step test on the pump (iPWM).
+#   by identifying the plant with an open-loop step and then validating the
+#   candidate gains with a short closed-loop setpoint step.
 #
 # Important:
 #   - Flow control remains the owner of iPWM.
@@ -17,13 +18,15 @@
 #   2) Step: decrease iPWM with an adaptive step sized from the baseline PWM
 #   3) Measure: determine Δpv_ss and t63 (time to 63% response)
 #      and stop early once the response is settled and confirmed
-#   4) Compute: K = Δpv/Δu, τ = t63, θ≈Ts (5s), IMC-PI:
-#        Kp = τ / (K * (λ + θ))
-#        Ti = τ
-#        Ki = Kp / Ti
-#   5) Set suggested values; apply button writes them to oq_flow_kp/oq_flow_ki.
+#   4) Compute: K = Δpv/Δu, τ = t63, θ≈Ts (5s), then derive a conservative
+#      seed using a large lambda and a longer Ti.
+#   5) Validate the seed with a short closed-loop setpoint step while the
+#      normal PI loop is active.
+#   6) Publish the suggested values; apply button writes them to oq_flow_kp/
+#      oq_flow_ki.
 #
-# Defaults are conservative but responsive: λ = max(10s, 0.5*τ)
+# Defaults are conservative by design so the same logic can work across many
+# different installations, not just one tuned hydraulic curve.
 #
 # ==============================================================================
 
@@ -85,6 +88,30 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+  - id: oq_flow_at_saved_kp
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+  - id: oq_flow_at_saved_ki
+    type: float
+    restore_value: false
+    initial_value: '0.0'
+  - id: oq_flow_at_validate_sp0
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_flow_at_validate_sp1
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_flow_at_validate_peak_pv
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_flow_at_validate_confirm_cnt
+    type: int
+    restore_value: false
+    initial_value: '0'
 
 # ----------------------------
 # CONTROL INPUTS
@@ -142,6 +169,12 @@ button:
           id(oq_flow_at_w1) = NAN;
           id(oq_flow_at_w2) = NAN;
           id(oq_flow_at_ss_confirm_cnt) = 0;
+          id(oq_flow_at_saved_kp) = NAN;
+          id(oq_flow_at_saved_ki) = NAN;
+          id(oq_flow_at_validate_sp0) = NAN;
+          id(oq_flow_at_validate_sp1) = NAN;
+          id(oq_flow_at_validate_peak_pv) = NAN;
+          id(oq_flow_at_validate_confirm_cnt) = 0;
           id(oq_flow_autotune_active) = false;
           id(oq_flow_autotune_pwm) = id(oq_flow_last_good_pwm);
           id(oq_commissioning_status).publish_state("FLOW AUTOTUNE STARTED");
@@ -235,6 +268,17 @@ interval:
           constexpr int kAutotuneStepMinIpwm = 10;
           constexpr int kAutotuneStepMaxIpwm = 40;
           constexpr int kAutotuneDurationS = 120;
+          constexpr int kAutotuneValidateDurationS = 90;
+          constexpr float kAutotuneValidateStepFrac = 0.05f;
+          constexpr float kAutotuneValidateStepMinLph = 15.0f;
+          constexpr float kAutotuneValidateStepMaxLph = 40.0f;
+          constexpr float kAutotuneValidateBandFloorLph = 8.0f;
+          constexpr float kAutotuneValidateBandFrac = 0.15f;
+          constexpr float kAutotuneValidateOvershootFrac = 0.25f;
+          constexpr float kAutotuneValidateSeedLambdaFrac = 8.0f;
+          constexpr float kAutotuneValidateSeedTiFrac = 2.0f;
+          constexpr float kAutotuneValidateSeedMinLambdaS = 60.0f;
+          constexpr float kAutotuneValidateSeedMinTiS = 60.0f;
 
           auto clamp_ipwm = [](int value) -> int {
             if (value < ${oq_flow_pwm_min}) return ${oq_flow_pwm_min};
@@ -256,6 +300,11 @@ interval:
             id(oq_commissioning_started_ms) = 0;
             id(oq_commissioning_state_since_ms) = 0;
             id(oq_commissioning_status).publish_state(keep_cm100 ? "CM100 READY" : "IDLE");
+          };
+          auto set_number_value = [](auto &number_entity, float value) {
+            auto call = number_entity.make_call();
+            call.set_value(value);
+            call.perform();
           };
 
           // Abort button always works
@@ -462,10 +511,79 @@ interval:
                   ESP_LOGW("quatt.cm100.autotune", "Autotune aborted: no steady-state response (t=%ds pv=%.1f)", t, pv);
                   id(oq_flow_autotune_status).publish_state("ABORT: NO_STEADY_STATE");
                 } else {
-                  ESP_LOGI("quatt.cm100.autotune",
-                           "Response captured (pv0=%.1f pv_ss=%.1f t63=%.1f samples=%d t=%ds)",
-                           pv0, id(oq_flow_at_pv_ss), id(oq_flow_at_pv63_time_s), id(oq_flow_at_ss_confirm_cnt), t);
-                  st = 3;
+                  const float pv_ss = id(oq_flow_at_pv_ss);
+                  const float t63 = id(oq_flow_at_pv63_time_s);
+                  const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
+                  const int pwm_step = clamp_ipwm(id(oq_flow_at_pwm_step));
+                  const float du = (float)(pwm0 - pwm_step); // >0
+                  const float dpv = pv_ss - pv0;
+                  const float K = dpv / du;  // (L/h)/iPWM
+                  if (!(K > 0.0f)) {
+                    st = 4;
+                    ESP_LOGW("quatt.cm100.autotune", "Autotune failed: invalid open-loop gain (pv0=%.1f pv_ss=%.1f du=%.1f)", pv0, pv_ss, du);
+                    id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
+                  } else {
+                    float tau = t63;
+                    if (isnan(tau) || tau < sample_time_s) tau = ${oq_flow_autotune_tau_fallback_s};
+
+                    const float theta = sample_time_s;
+                    const float lambda_raw = 0.5f * tau;
+                    const float Kp_raw = tau / (K * (lambda_raw + theta));
+                    const float Ti_raw = tau;
+                    const float Ki_raw = (Ti_raw > 1e-3f) ? (Kp_raw / Ti_raw) : 0.0f;
+
+                    float lambda_seed = kAutotuneValidateSeedLambdaFrac * tau;
+                    if (lambda_seed < kAutotuneValidateSeedMinLambdaS) lambda_seed = kAutotuneValidateSeedMinLambdaS;
+                    float Ti_seed = kAutotuneValidateSeedTiFrac * tau;
+                    if (Ti_seed < kAutotuneValidateSeedMinTiS) Ti_seed = kAutotuneValidateSeedMinTiS;
+
+                    float Kp_seed = tau / (K * (lambda_seed + theta));
+                    float Ki_seed = (Ti_seed > 1e-3f) ? (Kp_seed / Ti_seed) : 0.0f;
+
+                    const float Kp_min = ${oq_flow_kp_min};
+                    const float Kp_max = ${oq_flow_kp_max};
+                    const float Ki_min = ${oq_flow_ki_min};
+                    const float Ki_max = ${oq_flow_ki_max};
+                    if (Kp_seed < Kp_min) Kp_seed = Kp_min;
+                    if (Kp_seed > Kp_max) Kp_seed = Kp_max;
+                    if (Ki_seed < Ki_min) Ki_seed = Ki_min;
+                    if (Ki_seed > Ki_max) Ki_seed = Ki_max;
+
+                    const float sp0 = id(oq_flow_setpoint_lph).state;
+                    float validate_step_lph = roundf(kAutotuneValidateStepFrac * fmaxf(pv0, sp0));
+                    if (validate_step_lph < kAutotuneValidateStepMinLph) validate_step_lph = kAutotuneValidateStepMinLph;
+                    if (validate_step_lph > kAutotuneValidateStepMaxLph) validate_step_lph = kAutotuneValidateStepMaxLph;
+                    float validate_sp1 = sp0 + validate_step_lph;
+                    if (!(validate_sp1 > sp0)) {
+                      st = 4;
+                      ESP_LOGW("quatt.cm100.autotune",
+                               "Autotune failed: invalid validation setpoint (sp0=%.1f step=%.1f)",
+                               sp0, validate_step_lph);
+                      id(oq_flow_autotune_status).publish_state("FAILED: INVALID_VALIDATION_STEP");
+                    } else {
+                      id(oq_flow_at_saved_kp) = id(oq_flow_kp).state;
+                      id(oq_flow_at_saved_ki) = id(oq_flow_ki).state;
+                      id(oq_flow_at_validate_sp0) = sp0;
+                      id(oq_flow_at_validate_sp1) = validate_sp1;
+                      id(oq_flow_at_validate_peak_pv) = pv;
+                      id(oq_flow_at_validate_confirm_cnt) = 0;
+                      id(oq_flow_at_t) = 0;
+                      id(oq_flow_at_w0) = NAN;
+                      id(oq_flow_at_w1) = NAN;
+                      id(oq_flow_at_w2) = NAN;
+
+                      set_number_value(id(oq_flow_kp), Kp_seed);
+                      set_number_value(id(oq_flow_ki), Ki_seed);
+                      set_number_value(id(oq_flow_setpoint_lph), validate_sp1);
+                      id(oq_flow_autotune_active) = false;
+
+                      ESP_LOGI("quatt.cm100.autotune",
+                               "Open-loop captured (pv0=%.1f pv_ss=%.1f t63=%.1f K=%.3f tau=%.0fs raw=%.3f/%.4f seed=%.3f/%.4f validate_sp=%.1f->%.1f)",
+                               pv0, pv_ss, tau, K, Kp_raw, Ki_raw, Kp_seed, Ki_seed, sp0, validate_sp1);
+                      id(oq_flow_autotune_status).publish_state("VALIDATING");
+                      st = 3;
+                    }
+                  }
                 }
               } else {
                 st = 2;
@@ -476,89 +594,138 @@ interval:
             id(oq_flow_autotune_state) = st;
           }
 
-          // DONE
+          // VALIDATION
           if (id(oq_flow_autotune_state) == 3) {
-            id(oq_flow_autotune_active) = false;
+            if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
+            else if (!flow_valid) { st = 4; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during validation (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
+            else {
+              const float sp0 = id(oq_flow_at_validate_sp0);
+              const float sp1 = id(oq_flow_at_validate_sp1);
+              if (isnan(sp0) || isnan(sp1) || !(sp1 > sp0)) {
+                st = 4;
+                ESP_LOGW("quatt.cm100.autotune",
+                         "Autotune failed: invalid validation state (sp0=%.1f sp1=%.1f)",
+                         sp0, sp1);
+                id(oq_flow_autotune_status).publish_state("FAILED: INVALID_VALIDATION_STATE");
+              } else {
+                const float step_lph = sp1 - sp0;
+                const float settle_band = fmaxf(kAutotuneValidateBandFloorLph, kAutotuneValidateBandFrac * step_lph);
+                const float overshoot_band = fmaxf(settle_band, kAutotuneValidateOvershootFrac * step_lph);
 
-            const float pv0 = id(oq_flow_at_pv0);
-            const float pv_ss = id(oq_flow_at_pv_ss);
-            const float t63 = id(oq_flow_at_pv63_time_s);
+                id(oq_flow_at_validate_peak_pv) = fmaxf(id(oq_flow_at_validate_peak_pv), pv);
+                id(oq_flow_at_w0) = id(oq_flow_at_w1);
+                id(oq_flow_at_w1) = id(oq_flow_at_w2);
+                id(oq_flow_at_w2) = pv;
 
-            const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
-            const int pwm_step = clamp_ipwm(id(oq_flow_at_pwm_step));
-            const float du = (float)(pwm0 - pwm_step); // >0
+                const int t = id(oq_flow_at_t);
+                id(oq_flow_at_t) = t + (int) sample_time_s;
 
-            if (isnan(pv0) || isnan(pv_ss) || du <= 0.0f) {
-              ESP_LOGW("quatt.cm100.autotune", "Autotune failed: no response (pv0=%.1f pv_ss=%.1f du=%d)", pv0, pv_ss, (int) du);
-              id(oq_flow_autotune_status).publish_state("FAILED: NO_RESPONSE");
-              release_commissioning();
-              id(oq_flow_autotune_state) = 0;
-              return;
+                const bool win_ready = !isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2));
+                if (win_ready) {
+                  const float w0 = id(oq_flow_at_w0);
+                  const float w1 = id(oq_flow_at_w1);
+                  const float w2 = id(oq_flow_at_w2);
+                  const float w_min = fminf(w0, fminf(w1, w2));
+                  const float w_max = fmaxf(w0, fmaxf(w1, w2));
+                  const float spread = w_max - w_min;
+                  const float slope01 = fabsf(w1 - w0);
+                  const float slope12 = fabsf(w2 - w1);
+                  const bool settled_now = (spread <= settle_band) &&
+                                           (slope01 <= settle_band) &&
+                                           (slope12 <= settle_band) &&
+                                           (fabsf(pv - sp1) <= settle_band);
+                  if (settled_now) {
+                    if (id(oq_flow_at_validate_confirm_cnt) < 255) id(oq_flow_at_validate_confirm_cnt)++;
+                  } else {
+                    id(oq_flow_at_validate_confirm_cnt) = 0;
+                  }
+                }
+
+                const float peak_pv = id(oq_flow_at_validate_peak_pv);
+                const float overshoot = peak_pv - sp1;
+                const bool overshot = overshoot > overshoot_band;
+                const bool settled = (id(oq_flow_at_validate_confirm_cnt) >= 2) &&
+                                     !overshot &&
+                                     (fabsf(pv - sp1) <= settle_band);
+                const bool timed_out = t >= kAutotuneValidateDurationS;
+
+                if (settled || timed_out) {
+                  const float seed_kp = id(oq_flow_kp).state;
+                  const float seed_ki = id(oq_flow_ki).state;
+                  float scale = 1.0f;
+                  if (overshoot > (2.0f * settle_band)) {
+                    scale = 0.80f;
+                  } else if (overshoot > settle_band) {
+                    scale = 0.90f;
+                  } else if (settled && t <= ((int) sample_time_s * 3) && overshoot <= (0.5f * settle_band)) {
+                    scale = 1.05f;
+                  }
+                  if (timed_out && !settled) {
+                    scale = fminf(scale, 0.95f);
+                  }
+
+                  float Kp = seed_kp * scale;
+                  float Ki = seed_ki * scale;
+                  const float Kp_min = ${oq_flow_kp_min};
+                  const float Kp_max = ${oq_flow_kp_max};
+                  const float Ki_min = ${oq_flow_ki_min};
+                  const float Ki_max = ${oq_flow_ki_max};
+                  if (Kp < Kp_min) Kp = Kp_min;
+                  if (Kp > Kp_max) Kp = Kp_max;
+                  if (Ki < Ki_min) Ki = Ki_min;
+                  if (Ki > Ki_max) Ki = Ki_max;
+                  const bool clamped = (fabsf(Kp - (seed_kp * scale)) > 1e-7f) || (fabsf(Ki - (seed_ki * scale)) > 1e-7f);
+
+                  auto ckp = id(oq_flow_kp_suggested).make_call();
+                  ckp.set_value(Kp);
+                  ckp.perform();
+                  auto cki = id(oq_flow_ki_suggested).make_call();
+                  cki.set_value(Ki);
+                  cki.perform();
+
+                  const float saved_kp = id(oq_flow_at_saved_kp);
+                  const float saved_ki = id(oq_flow_at_saved_ki);
+                  const float saved_sp = id(oq_flow_at_validate_sp0);
+                  set_number_value(id(oq_flow_kp), saved_kp);
+                  set_number_value(id(oq_flow_ki), saved_ki);
+                  set_number_value(id(oq_flow_setpoint_lph), saved_sp);
+                  id(oq_flow_autotune_active) = false;
+                  id(oq_flow_at_saved_kp) = NAN;
+                  id(oq_flow_at_saved_ki) = NAN;
+                  id(oq_flow_at_validate_sp0) = NAN;
+                  id(oq_flow_at_validate_sp1) = NAN;
+                  id(oq_flow_at_validate_peak_pv) = NAN;
+                  id(oq_flow_at_w0) = NAN;
+                  id(oq_flow_at_w1) = NAN;
+                  id(oq_flow_at_w2) = NAN;
+                  id(oq_flow_at_validate_confirm_cnt) = 0;
+
+                  char msg[220];
+                  if (timed_out && !settled) {
+                    snprintf(msg, sizeof(msg),
+                             "DONE (LIMITED): seed=%.3f/%.4f -> Kp=%.3f Ki=%.4f peak=%.1f target=%.1f",
+                             seed_kp, seed_ki, Kp, Ki, peak_pv, sp1);
+                  } else if (clamped) {
+                    snprintf(msg, sizeof(msg),
+                             "DONE (CLAMPED): seed=%.3f/%.4f -> Kp=%.3f Ki=%.4f peak=%.1f target=%.1f",
+                             seed_kp, seed_ki, Kp, Ki, peak_pv, sp1);
+                  } else {
+                    snprintf(msg, sizeof(msg),
+                             "DONE (CLOSED-LOOP): seed=%.3f/%.4f -> Kp=%.3f Ki=%.4f peak=%.1f target=%.1f",
+                             seed_kp, seed_ki, Kp, Ki, peak_pv, sp1);
+                  }
+                  ESP_LOGI("quatt.cm100.autotune",
+                           "Validation done: seed=%.3f/%.4f scale=%.2f peak=%.1f sp0=%.1f sp1=%.1f band=%.1f t=%ds settled=%d timed_out=%d",
+                           seed_kp, seed_ki, scale, peak_pv, sp0, sp1, settle_band, t, (int) settled, (int) timed_out);
+                  id(oq_flow_autotune_status).publish_state(msg);
+
+                  release_commissioning();
+                  id(oq_flow_autotune_state) = 0;
+                  return;
+                }
+              }
             }
-
-            const float dpv = pv_ss - pv0;
-            const float K = dpv / du;  // (L/h)/iPWM
-            if (!(K > 0.0f)) {
-              ESP_LOGW("quatt.cm100.autotune", "Autotune failed: invalid gain (pv0=%.1f pv_ss=%.1f du=%.1f)", pv0, pv_ss, du);
-              id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
-              release_commissioning();
-              id(oq_flow_autotune_state) = 0;
-              return;
-            }
-            float tau = t63;
-            if (isnan(tau) || tau < sample_time_s) tau = ${oq_flow_autotune_tau_fallback_s};
-
-            const float theta = sample_time_s;
-            float lambda = 0.5f * tau;
-            if (lambda < ${oq_flow_autotune_lambda_min_s}) lambda = ${oq_flow_autotune_lambda_min_s};
-
-            const float Kp_raw = tau / (K * (lambda + theta));
-            const float Ti = tau;
-            const float Ki_raw = (Ti > 1e-3f) ? (Kp_raw / Ti) : 0.0f;
-
-            float Kp = Kp_raw;
-            float Ki = Ki_raw;
-
-            // clamp to oq_flow_kp/ki ranges
-            const float Kp_min = ${oq_flow_kp_min};
-            const float Kp_max = ${oq_flow_kp_max};
-            const float Ki_min = ${oq_flow_ki_min};
-            const float Ki_max = ${oq_flow_ki_max};
-            if (Kp < Kp_min) Kp = Kp_min;
-            if (Kp > Kp_max) Kp = Kp_max;
-            if (Ki < Ki_min) Ki = Ki_min;
-            if (Ki > Ki_max) Ki = Ki_max;
-            const bool clamped = (fabsf(Kp - Kp_raw) > 1e-7f) || (fabsf(Ki - Ki_raw) > 1e-7f);
-
-            auto ckp = id(oq_flow_kp_suggested).make_call();
-            ckp.set_value(Kp);
-            ckp.perform();
-            auto cki = id(oq_flow_ki_suggested).make_call();
-            cki.set_value(Ki);
-            cki.perform();
-
-            char msg[192];
-            if (clamped) {
-              snprintf(msg, sizeof(msg),
-                       "DONE (CLAMPED): K=%.3f tau=%.0fs Kp_raw=%.3f Ki_raw=%.4f -> Kp=%.3f Ki=%.4f",
-                       K, tau, Kp_raw, Ki_raw, Kp, Ki);
-            } else {
-              snprintf(msg, sizeof(msg), "DONE: K=%.3f tau=%.0fs -> Kp=%.3f Ki=%.4f", K, tau, Kp, Ki);
-            }
-            ESP_LOGI("quatt.cm100.autotune",
-                     "Autotune done: K=%.3f tau=%.0fs theta=%.0fs Kp=%.3f Ki=%.4f clamped=%d pv0=%.1f pv_ss=%.1f pwm0=%d pwm_step=%d",
-                     K, tau, theta, Kp, Ki, (int) clamped, pv0, pv_ss, pwm0, pwm_step);
-            id(oq_flow_autotune_status).publish_state(msg);
-
-            // restore previous pwm best-effort
-            id(oq_flow_autotune_pwm) = pwm0;
-            id(oq_flow_at_w0) = NAN;
-            id(oq_flow_at_w1) = NAN;
-            id(oq_flow_at_w2) = NAN;
-            id(oq_flow_at_ss_confirm_cnt) = 0;
-            release_commissioning();
-
-            id(oq_flow_autotune_state) = 0;
+            id(oq_flow_autotune_state) = st;
             return;
           }
 
@@ -566,10 +733,23 @@ interval:
           if (id(oq_flow_autotune_state) == 4) {
             id(oq_flow_autotune_active) = false;
             id(oq_flow_autotune_pwm) = clamp_ipwm((int) id(oq_flow_last_pwm));
+            if (!isnan(id(oq_flow_at_saved_kp)) && !isnan(id(oq_flow_at_saved_ki))) {
+              set_number_value(id(oq_flow_kp), id(oq_flow_at_saved_kp));
+              set_number_value(id(oq_flow_ki), id(oq_flow_at_saved_ki));
+            }
+            if (!isnan(id(oq_flow_at_validate_sp0))) {
+              set_number_value(id(oq_flow_setpoint_lph), id(oq_flow_at_validate_sp0));
+            }
+            id(oq_flow_at_saved_kp) = NAN;
+            id(oq_flow_at_saved_ki) = NAN;
+            id(oq_flow_at_validate_sp0) = NAN;
+            id(oq_flow_at_validate_sp1) = NAN;
+            id(oq_flow_at_validate_peak_pv) = NAN;
             id(oq_flow_at_w0) = NAN;
             id(oq_flow_at_w1) = NAN;
             id(oq_flow_at_w2) = NAN;
             id(oq_flow_at_ss_confirm_cnt) = 0;
+            id(oq_flow_at_validate_confirm_cnt) = 0;
             ESP_LOGW("quatt.cm100.autotune", "Autotune aborted; restoring last PWM=%d", (int) id(oq_flow_last_pwm));
             release_commissioning();
             id(oq_flow_autotune_status).publish_state("ABORTED");

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -144,7 +144,7 @@ button:
           ESP_LOGI("quatt.cm100.autotune",
                    "Autotune requested (cm=%d flow_mode=%s setpoint=%.0fL/h last_good_pwm=%d baseline_pwm=%d active=%d state=%d)",
                    cm_code,
-                   id(oq_flow_control_mode).state.c_str(),
+                   id(oq_flow_control_mode).current_option().c_str(),
                    id(oq_flow_setpoint_lph).state,
                    (int) id(oq_flow_last_good_pwm),
                    400,

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -301,8 +301,8 @@ interval:
             id(oq_commissioning_state_since_ms) = 0;
             id(oq_commissioning_status).publish_state(keep_cm100 ? "CM100 READY" : "IDLE");
           };
-          auto set_number_value = [](auto &number_entity, float value) {
-            auto call = number_entity.make_call();
+          auto set_number_value = [](auto *number_entity, float value) {
+            auto call = number_entity->make_call();
             call.set_value(value);
             call.perform();
           };

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -306,7 +306,10 @@ interval:
           constexpr float kAutotuneValidateSeedTiFrac = 2.0f;
           constexpr float kAutotuneValidateSeedMinLambdaS = 60.0f;
           constexpr float kAutotuneValidateSeedMinTiS = 60.0f;
-          constexpr int kAutotuneValidateDurationS = 120;
+          // Closed-loop validation needs a bit more breathing room than the
+          // open-loop identification, because the controller has to settle
+          // after the seed gains are applied.
+          constexpr int kAutotuneValidateDurationS = 180;
           constexpr int kAutotuneBaselinePwm = 400;
           constexpr int kAutotuneBaselineWaitMaxS = 60;
           constexpr float kAutotuneStep1Frac = 0.06f;

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -136,6 +136,10 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+  - id: oq_flow_at_validate_settle_ready
+    type: bool
+    restore_value: false
+    initial_value: 'false'
 
 # ----------------------------
 # CONTROL INPUTS
@@ -206,6 +210,7 @@ button:
           id(oq_flow_at_validate_sp1) = NAN;
           id(oq_flow_at_validate_peak_pv) = NAN;
           id(oq_flow_at_validate_confirm_cnt) = 0;
+          id(oq_flow_at_validate_settle_ready) = false;
           id(oq_flow_autotune_active) = false;
           id(oq_flow_autotune_pwm) = 400;
           id(oq_commissioning_status).publish_state("FLOW AUTOTUNE STARTED");
@@ -840,6 +845,7 @@ interval:
                       id(oq_flow_at_validate_sp1) = validate_sp1;
                       id(oq_flow_at_validate_peak_pv) = validate_sp1;
                       id(oq_flow_at_validate_confirm_cnt) = 0;
+                      id(oq_flow_at_validate_settle_ready) = false;
                       id(oq_flow_at_t) = 0;
                       id(oq_flow_at_w0) = NAN;
                       id(oq_flow_at_w1) = NAN;
@@ -857,7 +863,7 @@ interval:
                                id(oq_flow_at_step1_pv0), id(oq_flow_at_step1_pv_ss), id(oq_flow_at_step1_pv63_time_s), K1, tau1,
                                pv0, pv_ss2, t63_2, K2, tau2,
                                K, tau, Kp_raw, Ki_raw, Kp_seed, Ki_seed, sp0, validate_sp1);
-                      id(oq_flow_autotune_status).publish_state("VALIDATING");
+                      id(oq_flow_autotune_status).publish_state("VALIDATING_SETTLING");
                       st = 5;
                     }
                   }
@@ -888,6 +894,64 @@ interval:
                 const float step_lph = sp1 - sp0;
                 const float settle_band = fmaxf(kAutotuneValidateBandFloorLph, kAutotuneValidateBandFrac * step_lph);
                 const float overshoot_band = fmaxf(settle_band, kAutotuneValidateOvershootFrac * step_lph);
+                constexpr int kAutotuneValidateSettleGraceS = 20;
+                constexpr int kAutotuneValidateSettleMaxS = 60;
+
+                if (!id(oq_flow_at_validate_settle_ready)) {
+                  id(oq_flow_at_validate_peak_pv) = fmaxf(id(oq_flow_at_validate_peak_pv), pv);
+                  id(oq_flow_at_w0) = id(oq_flow_at_w1);
+                  id(oq_flow_at_w1) = id(oq_flow_at_w2);
+                  id(oq_flow_at_w2) = pv;
+
+                  const int t = id(oq_flow_at_t);
+                  id(oq_flow_at_t) = t + (int) sample_time_s;
+
+                  const bool win_ready = !isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2));
+                  if (win_ready) {
+                    const float w0 = id(oq_flow_at_w0);
+                    const float w1 = id(oq_flow_at_w1);
+                    const float w2 = id(oq_flow_at_w2);
+                    const float w_min = fminf(w0, fminf(w1, w2));
+                    const float w_max = fmaxf(w0, fmaxf(w1, w2));
+                    const float spread = w_max - w_min;
+                    const float slope01 = fabsf(w1 - w0);
+                    const float slope12 = fabsf(w2 - w1);
+                    const bool settle_ready_now = (t >= kAutotuneValidateSettleGraceS) &&
+                                                  (spread <= settle_band) &&
+                                                  (slope01 <= settle_band) &&
+                                                  (slope12 <= settle_band) &&
+                                                  (fabsf(pv - sp1) <= settle_band);
+                    if (settle_ready_now) {
+                      if (id(oq_flow_at_validate_confirm_cnt) < 255) id(oq_flow_at_validate_confirm_cnt)++;
+                    } else {
+                      id(oq_flow_at_validate_confirm_cnt) = 0;
+                    }
+                  }
+
+                  if (id(oq_flow_at_validate_confirm_cnt) >= 2 || t >= kAutotuneValidateSettleMaxS) {
+                    if (t >= kAutotuneValidateSettleMaxS && id(oq_flow_at_validate_confirm_cnt) < 2) {
+                      ESP_LOGW("quatt.cm100.autotune",
+                               "Validation settle timeout; starting measurement anyway (sp0=%.1f sp1=%.1f t=%ds)",
+                               sp0, sp1, t);
+                    } else {
+                      ESP_LOGI("quatt.cm100.autotune",
+                               "Validation settle done (sp0=%.1f sp1=%.1f t=%ds)",
+                               sp0, sp1, t);
+                    }
+                    id(oq_flow_at_validate_settle_ready) = true;
+                    id(oq_flow_at_validate_confirm_cnt) = 0;
+                    id(oq_flow_at_validate_peak_pv) = sp1;
+                    id(oq_flow_at_w0) = NAN;
+                    id(oq_flow_at_w1) = NAN;
+                    id(oq_flow_at_w2) = NAN;
+                    id(oq_flow_at_t) = 0;
+                    id(oq_flow_autotune_status).publish_state("VALIDATING");
+                  } else {
+                    id(oq_flow_autotune_status).publish_state("VALIDATING_SETTLING");
+                  }
+                  id(oq_flow_autotune_state) = st;
+                  return;
+                }
 
                 id(oq_flow_at_validate_peak_pv) = fmaxf(id(oq_flow_at_validate_peak_pv), pv);
                 id(oq_flow_at_w0) = id(oq_flow_at_w1);
@@ -976,6 +1040,7 @@ interval:
                   id(oq_flow_at_w1) = NAN;
                   id(oq_flow_at_w2) = NAN;
                   id(oq_flow_at_validate_confirm_cnt) = 0;
+                  id(oq_flow_at_validate_settle_ready) = false;
 
                   char msg[220];
                   if (timed_out && !settled) {
@@ -1027,6 +1092,7 @@ interval:
             id(oq_flow_at_w2) = NAN;
             id(oq_flow_at_ss_confirm_cnt) = 0;
             id(oq_flow_at_validate_confirm_cnt) = 0;
+            id(oq_flow_at_validate_settle_ready) = false;
             ESP_LOGW("quatt.cm100.autotune", "Autotune aborted; restoring last PWM=%d", (int) id(oq_flow_last_pwm));
             release_commissioning();
             id(oq_flow_autotune_status).publish_state("ABORTED");

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -584,7 +584,9 @@ interval:
                       id(oq_flow_at_saved_ki) = id(oq_flow_ki).state;
                       id(oq_flow_at_validate_sp0) = sp0;
                       id(oq_flow_at_validate_sp1) = validate_sp1;
-                      id(oq_flow_at_validate_peak_pv) = pv;
+                      // Start the validation peak at the new target so the
+                      // open-loop end state does not count as overshoot.
+                      id(oq_flow_at_validate_peak_pv) = validate_sp1;
                       id(oq_flow_at_validate_confirm_cnt) = 0;
                       id(oq_flow_at_t) = 0;
                       id(oq_flow_at_w0) = NAN;

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -14,7 +14,7 @@
 #   - Autotune is only allowed in CM100 together with commissioning task FLOW_AUTOTUNE.
 #
 # Operation (high level):
-#   1) Arm/Settle: force baseline PWM (last_good_pwm) and wait for stable flow
+#   1) Arm/Settle: force a fixed baseline PWM and wait for stable flow
 #   2) Step: decrease iPWM with an adaptive step sized from the baseline PWM
 #   3) Measure: determine Δpv_ss and t63 (time to 63% response)
 #      and stop early once the response is settled and confirmed
@@ -142,11 +142,12 @@ button:
             return;
           }
           ESP_LOGI("quatt.cm100.autotune",
-                   "Autotune requested (cm=%d flow_mode=%s setpoint=%.0fL/h last_good_pwm=%d active=%d state=%d)",
+                   "Autotune requested (cm=%d flow_mode=%s setpoint=%.0fL/h last_good_pwm=%d baseline_pwm=%d active=%d state=%d)",
                    cm_code,
                    id(oq_flow_control_mode).state.c_str(),
                    id(oq_flow_setpoint_lph).state,
                    (int) id(oq_flow_last_good_pwm),
+                   400,
                    (int) id(oq_flow_autotune_active),
                    (int) id(oq_flow_autotune_state));
           id(oq_commissioning_task_code) = 2;
@@ -176,7 +177,7 @@ button:
           id(oq_flow_at_validate_peak_pv) = NAN;
           id(oq_flow_at_validate_confirm_cnt) = 0;
           id(oq_flow_autotune_active) = false;
-          id(oq_flow_autotune_pwm) = id(oq_flow_last_good_pwm);
+          id(oq_flow_autotune_pwm) = 400;
           id(oq_commissioning_status).publish_state("FLOW AUTOTUNE STARTED");
           id(oq_flow_autotune_status).publish_state("REQUESTED");
 
@@ -279,6 +280,8 @@ interval:
           constexpr float kAutotuneValidateSeedTiFrac = 2.0f;
           constexpr float kAutotuneValidateSeedMinLambdaS = 60.0f;
           constexpr float kAutotuneValidateSeedMinTiS = 60.0f;
+          constexpr int kAutotuneBaselinePwm = 400;
+          constexpr int kAutotuneBaselineWaitMaxS = 60;
 
           auto clamp_ipwm = [](int value) -> int {
             if (value < ${oq_flow_pwm_min}) return ${oq_flow_pwm_min};
@@ -335,13 +338,6 @@ interval:
                 return;
               }
               id(oq_flow_autotune_req) = false;
-              if (!flow_valid) {
-                ESP_LOGW("quatt.cm100.autotune", "Autotune refused: flow invalid at request time (pv=%.1f)", pv);
-                release_commissioning();
-                id(oq_flow_autotune_status).publish_state("REFUSED: FLOW_INVALID");
-                return;
-              }
-
               // Baseline window is tracked via w0/w1/w2 rolling samples.
               id(oq_flow_at_pv0) = NAN;
               id(oq_flow_at_pv_ss) = NAN;
@@ -352,9 +348,9 @@ interval:
               id(oq_flow_at_ss_confirm_cnt) = 0;
               id(oq_flow_at_t) = 0;
 
-              // Start from last known stable PWM (instead of instantaneous last_pwm),
-              // then wait until baseline flow is stable before the step test.
-              const int pwm0 = clamp_ipwm((int) id(oq_flow_last_good_pwm));
+              // Start from a fixed baseline PWM so autotune begins in a
+              // consistent place across installations, then wait for a stable flow.
+              const int pwm0 = clamp_ipwm(kAutotuneBaselinePwm);
               id(oq_flow_at_pwm0) = pwm0;
               id(oq_flow_autotune_pwm) = pwm0;
               id(oq_flow_autotune_active) = true;
@@ -369,7 +365,7 @@ interval:
                        pwm0, pv, id(oq_flow_setpoint_lph).state,
                        (unsigned int) ${oq_flow_autotune_settle_s},
                        (float) ${oq_flow_autotune_stable_band_lph});
-              id(oq_flow_autotune_status).publish_state("SETTLING");
+              id(oq_flow_autotune_status).publish_state(flow_valid ? "SETTLING" : "WAITING_FOR_FLOW");
               id(oq_flow_autotune_state) = 1;
             }
             return;
@@ -378,21 +374,35 @@ interval:
           // ARM
           if (st == 1) {
             if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else if (!flow_valid) { st = 4; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid while settling (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
             else {
               // Keep baseline override active while settling.
               const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
               id(oq_flow_autotune_pwm) = pwm0;
               id(oq_flow_autotune_active) = true;
+              const int t = id(oq_flow_at_t);
+              id(oq_flow_at_t) = t + (int) sample_time_s;
+
+              if (!flow_valid) {
+                if (t >= kAutotuneBaselineWaitMaxS) {
+                  st = 4;
+                  ESP_LOGW("quatt.cm100.autotune",
+                           "Autotune aborted: baseline flow never became valid (pwm0=%d pv=%.1f t=%ds)",
+                           pwm0, pv, t);
+                  id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
+                } else {
+                  id(oq_flow_at_ss_confirm_cnt) = 0;
+                  id(oq_flow_autotune_status).publish_state("WAITING_FOR_FLOW");
+                }
+                id(oq_flow_autotune_state) = st;
+                return;
+              }
+
               id(oq_flow_at_ss_confirm_cnt) = 0;
 
               // Baseline stability check on rolling 3-sample window.
               id(oq_flow_at_w0) = id(oq_flow_at_w1);
               id(oq_flow_at_w1) = id(oq_flow_at_w2);
               id(oq_flow_at_w2) = pv;
-
-              const int t = id(oq_flow_at_t);
-              id(oq_flow_at_t) = t + (int) sample_time_s;
 
               const bool win_ready = !isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2));
               if (win_ready) {
@@ -404,7 +414,10 @@ interval:
                 const float spread = w_max - w_min;
                 const float mean = (w0 + w1 + w2) / 3.0f;
 
-                if (t >= ${oq_flow_autotune_settle_s} && spread <= ${oq_flow_autotune_stable_band_lph}) {
+                if (t >= ${oq_flow_autotune_settle_s} &&
+                    t <= kAutotuneBaselineWaitMaxS &&
+                    spread <= ${oq_flow_autotune_stable_band_lph} &&
+                    mean > 0.0f) {
                   id(oq_flow_at_pv0) = mean;
                   ESP_LOGI("quatt.cm100.autotune",
                            "Baseline stable (pv0=%.1f pwm0=%d spread=%.1f t=%ds)",
@@ -439,6 +452,12 @@ interval:
                     id(oq_flow_autotune_status).publish_state("STEP");
                     st = 2;
                   }
+                } else if (t >= kAutotuneBaselineWaitMaxS) {
+                  st = 4;
+                  ESP_LOGW("quatt.cm100.autotune",
+                           "Autotune aborted: baseline never stabilized (pwm0=%d pv=%.1f spread=%.1f t=%ds)",
+                           pwm0, pv, spread, t);
+                  id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
                 }
               }
             }

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -15,14 +15,14 @@
 #
 # Operation (high level):
 #   1) Arm/Settle: force a fixed baseline PWM and wait for stable flow
-#   2) Step: decrease iPWM with an adaptive step sized from the baseline PWM
-#   3) Measure: determine Δpv_ss and t63 (time to 63% response)
-#      and stop early once the response is settled and confirmed
-#   4) Compute: K = Δpv/Δu, τ = t63, θ≈Ts (5s), then derive a conservative
-#      seed using a large lambda and a longer Ti.
-#   5) Validate the seed with a short closed-loop setpoint step while the
+#   2) Step A: decrease iPWM with a conservative adaptive step
+#   3) Recover: return to baseline and let the loop settle again
+#   4) Step B: repeat with a larger step so the estimate is not based on
+#      a single amplitude only
+#   5) Compute: combine both step responses into a conservative seed
+#   6) Validate the seed with a short closed-loop setpoint step while the
 #      normal PI loop is active.
-#   6) Publish the suggested values; apply button writes them to oq_flow_kp/
+#   7) Publish the suggested values; apply button writes them to oq_flow_kp/
 #      oq_flow_ki.
 #
 # Defaults are conservative by design so the same logic can work across many
@@ -37,7 +37,7 @@ globals:
   - id: oq_flow_autotune_state
     type: int
     restore_value: false
-    initial_value: '0'   # 0=IDLE,1=ARM,2=STEP,3=DONE,4=ABORT
+    initial_value: '0'   # 0=IDLE,1=ARM,2=STEP1,3=RECOVER,4=STEP2,5=VALIDATE,6=ABORT
   - id: oq_flow_autotune_req
     type: bool
     restore_value: false
@@ -64,7 +64,15 @@ globals:
     type: float
     restore_value: false
     initial_value: 'NAN'
+  - id: oq_flow_at_step1_pv0
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
   - id: oq_flow_at_pv_ss
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_flow_at_step1_pv_ss
     type: float
     restore_value: false
     initial_value: 'NAN'
@@ -72,6 +80,22 @@ globals:
     type: float
     restore_value: false
     initial_value: 'NAN'
+  - id: oq_flow_at_step1_pv63_time_s
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_flow_at_step1_k
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_flow_at_step1_tau
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+  - id: oq_flow_at_step1_pwm_step
+    type: int
+    restore_value: false
+    initial_value: '850'
   - id: oq_flow_at_w0
     type: float
     restore_value: false
@@ -164,8 +188,14 @@ button:
           id(oq_flow_at_pwm0) = 850;
           id(oq_flow_at_pwm_step) = 850;
           id(oq_flow_at_pv0) = NAN;
+          id(oq_flow_at_step1_pv0) = NAN;
           id(oq_flow_at_pv_ss) = NAN;
+          id(oq_flow_at_step1_pv_ss) = NAN;
           id(oq_flow_at_pv63_time_s) = NAN;
+          id(oq_flow_at_step1_pv63_time_s) = NAN;
+          id(oq_flow_at_step1_k) = NAN;
+          id(oq_flow_at_step1_tau) = NAN;
+          id(oq_flow_at_step1_pwm_step) = 850;
           id(oq_flow_at_w0) = NAN;
           id(oq_flow_at_w1) = NAN;
           id(oq_flow_at_w2) = NAN;
@@ -265,11 +295,7 @@ interval:
     then:
       - lambda: |-
           const float sample_time_s = ${oq_flow_ts}.0f;
-          constexpr float kAutotuneStepFrac = 0.08f;
-          constexpr int kAutotuneStepMinIpwm = 10;
-          constexpr int kAutotuneStepMaxIpwm = 40;
           constexpr int kAutotuneDurationS = 120;
-          constexpr int kAutotuneValidateDurationS = 90;
           constexpr float kAutotuneValidateStepFrac = 0.05f;
           constexpr float kAutotuneValidateStepMinLph = 15.0f;
           constexpr float kAutotuneValidateStepMaxLph = 40.0f;
@@ -280,8 +306,16 @@ interval:
           constexpr float kAutotuneValidateSeedTiFrac = 2.0f;
           constexpr float kAutotuneValidateSeedMinLambdaS = 60.0f;
           constexpr float kAutotuneValidateSeedMinTiS = 60.0f;
+          constexpr int kAutotuneValidateDurationS = 120;
           constexpr int kAutotuneBaselinePwm = 400;
           constexpr int kAutotuneBaselineWaitMaxS = 60;
+          constexpr float kAutotuneStep1Frac = 0.06f;
+          constexpr int kAutotuneStep1MinIpwm = 10;
+          constexpr int kAutotuneStep1MaxIpwm = 28;
+          constexpr float kAutotuneStep2Frac = 0.10f;
+          constexpr int kAutotuneStep2MinIpwm = 15;
+          constexpr int kAutotuneStep2MaxIpwm = 40;
+          constexpr float kAutotuneStepConsistencyFrac = 0.20f;
 
           auto clamp_ipwm = [](int value) -> int {
             if (value < ${oq_flow_pwm_min}) return ${oq_flow_pwm_min};
@@ -313,7 +347,7 @@ interval:
           // Abort button always works
           if (id(oq_flow_autotune_abort)) {
             id(oq_flow_autotune_abort) = false;
-            id(oq_flow_autotune_state) = 4;
+            id(oq_flow_autotune_state) = 6;
           }
 
           const float pv = id(flow_rate_selected).state;
@@ -373,7 +407,7 @@ interval:
 
           // ARM
           if (st == 1) {
-            if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
+            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
             else {
               // Keep baseline override active while settling.
               const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
@@ -384,7 +418,7 @@ interval:
 
               if (!flow_valid) {
                 if (t >= kAutotuneBaselineWaitMaxS) {
-                  st = 4;
+                  st = 6;
                   ESP_LOGW("quatt.cm100.autotune",
                            "Autotune aborted: baseline flow never became valid (pwm0=%d pv=%.1f t=%ds)",
                            pwm0, pv, t);
@@ -425,15 +459,15 @@ interval:
 
                   const int pwm_headroom = pwm0 - ${oq_flow_pwm_min};
                   if (pwm_headroom < ${oq_flow_autotune_min_step}) {
-                    st = 4;
+                    st = 6;
                     ESP_LOGW("quatt.cm100.autotune",
                              "Autotune refused: insufficient step headroom (pwm0=%d min=%d headroom=%d required=%d)",
                              pwm0, ${oq_flow_pwm_min}, pwm_headroom, ${oq_flow_autotune_min_step});
                     id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
                   } else {
-                    int u_step = (int) roundf(kAutotuneStepFrac * (float) pwm0);
-                    if (u_step < kAutotuneStepMinIpwm) u_step = kAutotuneStepMinIpwm;
-                    if (u_step > kAutotuneStepMaxIpwm) u_step = kAutotuneStepMaxIpwm;
+                    int u_step = (int) roundf(kAutotuneStep1Frac * (float) pwm0);
+                    if (u_step < kAutotuneStep1MinIpwm) u_step = kAutotuneStep1MinIpwm;
+                    if (u_step > kAutotuneStep1MaxIpwm) u_step = kAutotuneStep1MaxIpwm;
                     if (u_step > pwm_headroom) u_step = pwm_headroom;
                     if (u_step < ${oq_flow_autotune_min_step}) u_step = ${oq_flow_autotune_min_step};
 
@@ -453,7 +487,7 @@ interval:
                     st = 2;
                   }
                 } else if (t >= kAutotuneBaselineWaitMaxS) {
-                  st = 4;
+                  st = 6;
                   ESP_LOGW("quatt.cm100.autotune",
                            "Autotune aborted: baseline never stabilized (pwm0=%d pv=%.1f spread=%.1f t=%ds)",
                            pwm0, pv, spread, t);
@@ -465,10 +499,10 @@ interval:
             return;
           }
 
-          // STEP / MEASURE
+          // STEP 1 / MEASURE
           if (st == 2) {
-            if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else if (!flow_valid) { st = 4; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during step (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
+            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
+            else if (!flow_valid) { st = 6; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during step1 (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
             else {
               const float pv0 = id(oq_flow_at_pv0);
               const int t = id(oq_flow_at_t);
@@ -487,17 +521,13 @@ interval:
                 const float spread = w_max - w_min;
                 const float slope01 = fabsf(w1 - w0);
                 const float slope12 = fabsf(w2 - w1);
-
-                // Only trust the final value once the response has flattened out.
-                // This keeps the 63% latch conservative instead of locking on to a
-                // transient rolling average that is still climbing toward steady state.
                 const bool ss_ready = (spread <= 6.0f) && (slope01 <= 2.0f) && (slope12 <= 2.0f);
                 if (ss_ready) {
                   id(oq_flow_at_pv_ss) = (w0 + w1 + w2) / 3.0f;
                   if (id(oq_flow_at_ss_confirm_cnt) < 255) id(oq_flow_at_ss_confirm_cnt)++;
                   if (id(oq_flow_at_ss_confirm_cnt) == 1) {
                     ESP_LOGI("quatt.cm100.autotune",
-                             "Steady-state candidate locked (pv_ss=%.1f t=%ds spread=%.1f slopes=%.1f/%.1f)",
+                             "Step1 steady-state candidate locked (pv_ss=%.1f t=%ds spread=%.1f slopes=%.1f/%.1f)",
                              id(oq_flow_at_pv_ss), t, spread, slope01, slope12);
                   }
                 } else {
@@ -509,7 +539,6 @@ interval:
               if (!isnan(pv_ss_est) && isnan(id(oq_flow_at_pv63_time_s))) {
                 const float dpv = pv_ss_est - pv0;
                 const float pv63 = pv0 + 0.632f * dpv;
-
                 if (dpv >= 0.0f) {
                   if (pv >= pv63) id(oq_flow_at_pv63_time_s) = (float) t;
                 } else {
@@ -526,23 +555,245 @@ interval:
 
               if (early_done || t >= max_s) {
                 if (isnan(id(oq_flow_at_pv_ss))) {
-                  st = 4;
-                  ESP_LOGW("quatt.cm100.autotune", "Autotune aborted: no steady-state response (t=%ds pv=%.1f)", t, pv);
+                  st = 6;
+                  ESP_LOGW("quatt.cm100.autotune", "Autotune aborted: no step1 steady-state response (t=%ds pv=%.1f)", t, pv);
                   id(oq_flow_autotune_status).publish_state("ABORT: NO_STEADY_STATE");
                 } else {
-                  const float pv_ss = id(oq_flow_at_pv_ss);
-                  const float t63 = id(oq_flow_at_pv63_time_s);
+                  const float pv_ss1 = id(oq_flow_at_pv_ss);
+                  const float t63_1 = id(oq_flow_at_pv63_time_s);
                   const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
-                  const int pwm_step = clamp_ipwm(id(oq_flow_at_pwm_step));
-                  const float du = (float)(pwm0 - pwm_step); // >0
-                  const float dpv = pv_ss - pv0;
-                  const float K = dpv / du;  // (L/h)/iPWM
-                  if (!(K > 0.0f)) {
-                    st = 4;
-                    ESP_LOGW("quatt.cm100.autotune", "Autotune failed: invalid open-loop gain (pv0=%.1f pv_ss=%.1f du=%.1f)", pv0, pv_ss, du);
+                  const int pwm_step1 = clamp_ipwm(id(oq_flow_at_pwm_step));
+                  const float du1 = (float)(pwm0 - pwm_step1); // >0
+                  const float dpv1 = pv_ss1 - pv0;
+                  const float K1 = dpv1 / du1;
+                  if (!(K1 > 0.0f)) {
+                    st = 6;
+                    ESP_LOGW("quatt.cm100.autotune",
+                             "Autotune failed: invalid step1 gain (pv0=%.1f pv_ss=%.1f du=%.1f)",
+                             pv0, pv_ss1, du1);
                     id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
                   } else {
-                    float tau = t63;
+                    float tau1 = t63_1;
+                    if (isnan(tau1) || tau1 < sample_time_s) tau1 = ${oq_flow_autotune_tau_fallback_s};
+                    id(oq_flow_at_step1_pv0) = pv0;
+                    id(oq_flow_at_step1_pv_ss) = pv_ss1;
+                    id(oq_flow_at_step1_pv63_time_s) = t63_1;
+                    id(oq_flow_at_step1_k) = K1;
+                    id(oq_flow_at_step1_tau) = tau1;
+                    id(oq_flow_at_step1_pwm_step) = pwm_step1;
+
+                    const int pwm_headroom = pwm0 - ${oq_flow_pwm_min};
+                    if (pwm_headroom < ${oq_flow_autotune_min_step}) {
+                      st = 6;
+                      ESP_LOGW("quatt.cm100.autotune",
+                               "Autotune refused: insufficient recovery headroom (pwm0=%d min=%d headroom=%d required=%d)",
+                               pwm0, ${oq_flow_pwm_min}, pwm_headroom, ${oq_flow_autotune_min_step});
+                      id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
+                    } else {
+                      id(oq_flow_autotune_pwm) = pwm0;
+                      id(oq_flow_at_t) = 0;
+                      id(oq_flow_at_w0) = NAN;
+                      id(oq_flow_at_w1) = NAN;
+                      id(oq_flow_at_w2) = NAN;
+                      id(oq_flow_at_ss_confirm_cnt) = 0;
+                      id(oq_flow_at_pv0) = NAN;
+                      id(oq_flow_at_pv_ss) = NAN;
+                      id(oq_flow_at_pv63_time_s) = NAN;
+                      ESP_LOGI("quatt.cm100.autotune",
+                               "Step1 captured (pwm0=%d step=%d pv0=%.1f pv_ss=%.1f t63=%.1f K1=%.3f tau1=%.0fs) -> recover",
+                               pwm0, pwm_step1, pv0, pv_ss1, tau1, K1);
+                      id(oq_flow_autotune_status).publish_state("RECOVERING");
+                      st = 3;
+                    }
+                  }
+                }
+              } else {
+                st = 2;
+              }
+              id(oq_flow_autotune_state) = st;
+              return;
+            }
+            id(oq_flow_autotune_state) = st;
+          }
+
+          // RECOVER / STEP 2 ARM
+          if (st == 3) {
+            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
+            else {
+              const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
+              id(oq_flow_autotune_pwm) = pwm0;
+              id(oq_flow_autotune_active) = true;
+              const int t = id(oq_flow_at_t);
+              id(oq_flow_at_t) = t + (int) sample_time_s;
+
+              if (!flow_valid) {
+                if (t >= kAutotuneBaselineWaitMaxS) {
+                  st = 6;
+                  ESP_LOGW("quatt.cm100.autotune",
+                           "Autotune aborted: recovery flow never became valid (pwm0=%d pv=%.1f t=%ds)",
+                           pwm0, pv, t);
+                  id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
+                } else {
+                  id(oq_flow_at_ss_confirm_cnt) = 0;
+                  id(oq_flow_autotune_status).publish_state("WAITING_FOR_FLOW");
+                }
+                id(oq_flow_autotune_state) = st;
+                return;
+              }
+
+              id(oq_flow_at_ss_confirm_cnt) = 0;
+              id(oq_flow_at_w0) = id(oq_flow_at_w1);
+              id(oq_flow_at_w1) = id(oq_flow_at_w2);
+              id(oq_flow_at_w2) = pv;
+              const bool win_ready = !isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2));
+              if (win_ready) {
+                const float w0 = id(oq_flow_at_w0);
+                const float w1 = id(oq_flow_at_w1);
+                const float w2 = id(oq_flow_at_w2);
+                const float w_min = fminf(w0, fminf(w1, w2));
+                const float w_max = fmaxf(w0, fmaxf(w1, w2));
+                const float spread = w_max - w_min;
+                const float mean = (w0 + w1 + w2) / 3.0f;
+
+                if (t >= ${oq_flow_autotune_settle_s} &&
+                    t <= kAutotuneBaselineWaitMaxS &&
+                    spread <= ${oq_flow_autotune_stable_band_lph} &&
+                    mean > 0.0f) {
+                  ESP_LOGI("quatt.cm100.autotune",
+                           "Recovery stable (pv=%.1f pwm0=%d spread=%.1f t=%ds)",
+                           mean, pwm0, spread, t);
+
+                  int u_step = (int) roundf(kAutotuneStep2Frac * (float) pwm0);
+                  if (u_step < kAutotuneStep2MinIpwm) u_step = kAutotuneStep2MinIpwm;
+                  if (u_step > kAutotuneStep2MaxIpwm) u_step = kAutotuneStep2MaxIpwm;
+                  const int step1_u = pwm0 - clamp_ipwm(id(oq_flow_at_step1_pwm_step));
+                  if (u_step <= step1_u) u_step = step1_u + 8;
+                  if (u_step > pwm0 - ${oq_flow_pwm_min}) u_step = pwm0 - ${oq_flow_pwm_min};
+                  if (u_step <= step1_u) {
+                    st = 6;
+                    ESP_LOGW("quatt.cm100.autotune",
+                             "Autotune refused: insufficient distinct step2 headroom (step1=%d step2=%d pwm0=%d)",
+                             step1_u, u_step, pwm0);
+                    id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
+                  } else {
+                    const int pwm_step2 = clamp_ipwm(pwm0 - u_step);
+                    id(oq_flow_at_pv0) = mean;
+                    id(oq_flow_at_pwm_step) = pwm_step2;
+                    id(oq_flow_at_t) = 0;
+                    id(oq_flow_at_w0) = NAN;
+                    id(oq_flow_at_w1) = NAN;
+                    id(oq_flow_at_w2) = NAN;
+                    id(oq_flow_at_ss_confirm_cnt) = 0;
+                    id(oq_flow_autotune_pwm) = pwm_step2;
+                    ESP_LOGI("quatt.cm100.autotune",
+                             "Step2 applied (pwm0=%d step=%d pwm_step=%d pv0=%.1f)",
+                             pwm0, u_step, pwm_step2, mean);
+                    id(oq_flow_autotune_status).publish_state("STEP2");
+                    st = 4;
+                  }
+                } else if (t >= kAutotuneBaselineWaitMaxS) {
+                  st = 6;
+                  ESP_LOGW("quatt.cm100.autotune",
+                           "Autotune aborted: recovery never stabilized (pwm0=%d pv=%.1f spread=%.1f t=%ds)",
+                           pwm0, pv, spread, t);
+                  id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
+                }
+              }
+            }
+            id(oq_flow_autotune_state) = st;
+            return;
+          }
+
+          // STEP 2 / MEASURE
+          if (st == 4) {
+            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
+            else if (!flow_valid) { st = 6; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during step2 (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
+            else {
+              const float pv0 = id(oq_flow_at_pv0);
+              const int t = id(oq_flow_at_t);
+              const int max_s = kAutotuneDurationS;
+
+              // Rolling window for ss-estimate.
+              id(oq_flow_at_w0) = id(oq_flow_at_w1);
+              id(oq_flow_at_w1) = id(oq_flow_at_w2);
+              id(oq_flow_at_w2) = pv;
+              if (!isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2)) && ${oq_flow_autotune_ss_window} == 3) {
+                const float w0 = id(oq_flow_at_w0);
+                const float w1 = id(oq_flow_at_w1);
+                const float w2 = id(oq_flow_at_w2);
+                const float w_min = fminf(w0, fminf(w1, w2));
+                const float w_max = fmaxf(w0, fmaxf(w1, w2));
+                const float spread = w_max - w_min;
+                const float slope01 = fabsf(w1 - w0);
+                const float slope12 = fabsf(w2 - w1);
+                const bool ss_ready = (spread <= 6.0f) && (slope01 <= 2.0f) && (slope12 <= 2.0f);
+                if (ss_ready) {
+                  id(oq_flow_at_pv_ss) = (w0 + w1 + w2) / 3.0f;
+                  if (id(oq_flow_at_ss_confirm_cnt) < 255) id(oq_flow_at_ss_confirm_cnt)++;
+                  if (id(oq_flow_at_ss_confirm_cnt) == 1) {
+                    ESP_LOGI("quatt.cm100.autotune",
+                             "Step2 steady-state candidate locked (pv_ss=%.1f t=%ds spread=%.1f slopes=%.1f/%.1f)",
+                             id(oq_flow_at_pv_ss), t, spread, slope01, slope12);
+                  }
+                } else {
+                  id(oq_flow_at_ss_confirm_cnt) = 0;
+                }
+              }
+
+              const float pv_ss_est = id(oq_flow_at_pv_ss);
+              if (!isnan(pv_ss_est) && isnan(id(oq_flow_at_pv63_time_s))) {
+                const float dpv = pv_ss_est - pv0;
+                const float pv63 = pv0 + 0.632f * dpv;
+                if (dpv >= 0.0f) {
+                  if (pv >= pv63) id(oq_flow_at_pv63_time_s) = (float) t;
+                } else {
+                  if (pv <= pv63) id(oq_flow_at_pv63_time_s) = (float) t;
+                }
+              }
+
+              const bool early_done =
+                  !isnan(id(oq_flow_at_pv_ss)) &&
+                  !isnan(id(oq_flow_at_pv63_time_s)) &&
+                  (id(oq_flow_at_ss_confirm_cnt) >= 2);
+
+              id(oq_flow_at_t) = t + (int) sample_time_s;
+
+              if (early_done || t >= max_s) {
+                if (isnan(id(oq_flow_at_pv_ss))) {
+                  st = 6;
+                  ESP_LOGW("quatt.cm100.autotune", "Autotune aborted: no step2 steady-state response (t=%ds pv=%.1f)", t, pv);
+                  id(oq_flow_autotune_status).publish_state("ABORT: NO_STEADY_STATE");
+                } else {
+                  const float pv_ss2 = id(oq_flow_at_pv_ss);
+                  const float t63_2 = id(oq_flow_at_pv63_time_s);
+                  const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
+                  const int pwm_step2 = clamp_ipwm(id(oq_flow_at_pwm_step));
+                  const float du2 = (float)(pwm0 - pwm_step2); // >0
+                  const float dpv2 = pv_ss2 - pv0;
+                  const float K2 = dpv2 / du2;
+                  const float K1 = id(oq_flow_at_step1_k);
+                  const float tau1 = id(oq_flow_at_step1_tau);
+                  if (!(K2 > 0.0f) || !(K1 > 0.0f) || isnan(tau1)) {
+                    st = 6;
+                    ESP_LOGW("quatt.cm100.autotune",
+                             "Autotune failed: invalid step2 gain (pv0=%.1f pv_ss=%.1f du=%.1f step1_k=%.3f tau1=%.1f)",
+                             pv0, pv_ss2, du2, K1, tau1);
+                    id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
+                  } else {
+                    float tau2 = t63_2;
+                    if (isnan(tau2) || tau2 < sample_time_s) tau2 = ${oq_flow_autotune_tau_fallback_s};
+                    const float rel_k = fabsf(K1 - K2) / fmaxf(fmaxf(K1, K2), 1e-3f);
+                    const float rel_tau = fabsf(tau1 - tau2) / fmaxf(fmaxf(tau1, tau2), sample_time_s);
+                    const bool consistent = (rel_k <= kAutotuneStepConsistencyFrac) && (rel_tau <= 0.35f);
+
+                    const float du1 = (float)(pwm0 - clamp_ipwm(id(oq_flow_at_step1_pwm_step)));
+                    float K = 0.0f;
+                    if (consistent) {
+                      K = (K1 * du1 + K2 * du2) / fmaxf(du1 + du2, 1.0f);
+                    } else {
+                      K = fmaxf(K1, K2);
+                    }
+                    float tau = fmaxf(tau1, tau2);
                     if (isnan(tau) || tau < sample_time_s) tau = ${oq_flow_autotune_tau_fallback_s};
 
                     const float theta = sample_time_s;
@@ -574,7 +825,7 @@ interval:
                     if (validate_step_lph > kAutotuneValidateStepMaxLph) validate_step_lph = kAutotuneValidateStepMaxLph;
                     float validate_sp1 = sp0 + validate_step_lph;
                     if (!(validate_sp1 > sp0)) {
-                      st = 4;
+                      st = 6;
                       ESP_LOGW("quatt.cm100.autotune",
                                "Autotune failed: invalid validation setpoint (sp0=%.1f step=%.1f)",
                                sp0, validate_step_lph);
@@ -584,8 +835,6 @@ interval:
                       id(oq_flow_at_saved_ki) = id(oq_flow_ki).state;
                       id(oq_flow_at_validate_sp0) = sp0;
                       id(oq_flow_at_validate_sp1) = validate_sp1;
-                      // Start the validation peak at the new target so the
-                      // open-loop end state does not count as overshoot.
                       id(oq_flow_at_validate_peak_pv) = validate_sp1;
                       id(oq_flow_at_validate_confirm_cnt) = 0;
                       id(oq_flow_at_t) = 0;
@@ -598,16 +847,20 @@ interval:
                       set_number_value(id(oq_flow_setpoint_lph), validate_sp1);
                       id(oq_flow_autotune_active) = false;
 
+                      const char *consistency_tag = consistent ? "2STEP" : "2STEP (LIMITED)";
                       ESP_LOGI("quatt.cm100.autotune",
-                               "Open-loop captured (pv0=%.1f pv_ss=%.1f t63=%.1f K=%.3f tau=%.0fs raw=%.3f/%.4f seed=%.3f/%.4f validate_sp=%.1f->%.1f)",
-                               pv0, pv_ss, tau, K, Kp_raw, Ki_raw, Kp_seed, Ki_seed, sp0, validate_sp1);
+                               "Open-loop captured (%s) step1: pv0=%.1f pv_ss=%.1f t63=%.1f K=%.3f tau=%.0fs | step2: pv0=%.1f pv_ss=%.1f t63=%.1f K=%.3f tau=%.0fs | combined: K=%.3f tau=%.0fs raw=%.3f/%.4f seed=%.3f/%.4f validate_sp=%.1f->%.1f",
+                               consistency_tag,
+                               id(oq_flow_at_step1_pv0), id(oq_flow_at_step1_pv_ss), id(oq_flow_at_step1_pv63_time_s), K1, tau1,
+                               pv0, pv_ss2, t63_2, K2, tau2,
+                               K, tau, Kp_raw, Ki_raw, Kp_seed, Ki_seed, sp0, validate_sp1);
                       id(oq_flow_autotune_status).publish_state("VALIDATING");
-                      st = 3;
+                      st = 5;
                     }
                   }
                 }
               } else {
-                st = 2;
+                st = 4;
               }
               id(oq_flow_autotune_state) = st;
               return;
@@ -616,14 +869,14 @@ interval:
           }
 
           // VALIDATION
-          if (id(oq_flow_autotune_state) == 3) {
-            if (!in_valid_autotune_mode()) { st = 4; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else if (!flow_valid) { st = 4; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during validation (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
+          if (id(oq_flow_autotune_state) == 5) {
+            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
+            else if (!flow_valid) { st = 6; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during validation (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
             else {
               const float sp0 = id(oq_flow_at_validate_sp0);
               const float sp1 = id(oq_flow_at_validate_sp1);
               if (isnan(sp0) || isnan(sp1) || !(sp1 > sp0)) {
-                st = 4;
+                st = 6;
                 ESP_LOGW("quatt.cm100.autotune",
                          "Autotune failed: invalid validation state (sp0=%.1f sp1=%.1f)",
                          sp0, sp1);
@@ -751,7 +1004,7 @@ interval:
           }
 
           // ABORT
-          if (id(oq_flow_autotune_state) == 4) {
+          if (id(oq_flow_autotune_state) == 6) {
             id(oq_flow_autotune_active) = false;
             id(oq_flow_autotune_pwm) = clamp_ipwm((int) id(oq_flow_last_pwm));
             if (!isnan(id(oq_flow_at_saved_kp)) && !isnan(id(oq_flow_at_saved_ki))) {


### PR DESCRIPTION
This updates flow autotune from a single open-loop step into a more robust 2-step flow:

- open-loop step A still identifies K and tau at the current operating point
- autotune then recovers to the fixed baseline PWM and repeats with a larger step B
- the two step responses are combined conservatively into the final seed
- before the closed-loop check starts, the controller is given a short extra settle phase so the validation does not begin on a moving transient
- the normal flow PI loop is then briefly enabled with the seed and a temporary setpoint step
- validation runs longer so slower responses can settle before the suggestion is published
- original live gains/setpoint are restored after the closed-loop check

The goal is to make autotune behave better across many installations, not just one hydraulic curve.

Unrelated local web UI edits were left untouched.