### PR TITLE
Stabilize API security transport state

### DIFF
--- a/components/openquatt_web_auth/OpenQuattWebAuth.cpp
+++ b/components/openquatt_web_auth/OpenQuattWebAuth.cpp
@@ -1,6 +1,7 @@
 #include "OpenQuattWebAuth.h"
 
 #include <array>
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 
@@ -197,8 +198,9 @@ class OpenQuattWebAuthRequestHandler : public AsyncWebHandler {
 
     if (url == "/api-security/status" && request->method() == HTTP_GET) {
       auto *stream = request->beginResponseStream("application/json");
-      stream->printf(R"({"enabled":%s,"key":"%s","source":"%s","csrf_token":"%s"})",
+      stream->printf(R"({"enabled":%s,"transport_active":%s,"key":"%s","source":"%s","csrf_token":"%s"})",
                      this->parent_->is_api_security_enabled() ? "true" : "false",
+                     this->parent_->is_api_security_transport_active() ? "true" : "false",
                      this->parent_->get_api_security_key().c_str(),
                      this->parent_->get_api_security_source().c_str(),
                      this->parent_->get_csrf_token().c_str());
@@ -310,6 +312,11 @@ void OpenQuattWebAuth::loop() {
   if (!this->api_security_ready_) {
     this->initialize_api_security_();
   }
+#ifdef USE_API_NOISE
+  if (api::global_api_server != nullptr) {
+    this->api_security_transport_active_ = api::global_api_server->get_noise_ctx().has_psk();
+  }
+#endif
   if (this->restore_suspended_auth_if_needed_()) {
     ESP_LOGW(TAG, "Recovery setup window expired; restored previous protected credentials");
   }
@@ -470,23 +477,40 @@ bool OpenQuattWebAuth::apply_api_security_storage_(const ApiSecurityStorage &sto
   const bool key_present = storage.key_present != 0;
   const std::string key = key_present ? encode_api_security_key_(storage.key) : "";
 
+  bool transport_active = false;
+#ifdef USE_API_NOISE
+  transport_active = api::global_api_server->get_noise_ctx().has_psk();
   if (enabled) {
     if (!key_present) {
       return false;
     }
-    if (!api::global_api_server->save_noise_psk(storage.key, true)) {
-      ESP_LOGE(TAG, "Failed to activate API encryption");
+    const bool key_matches = transport_active && std::equal(storage.key.begin(), storage.key.end(),
+                                                             api::global_api_server->get_noise_ctx().get_psk().begin());
+    if (!key_matches) {
+      if (!api::global_api_server->save_noise_psk(storage.key, true)) {
+        ESP_LOGE(TAG, "Failed to activate API encryption");
+        return false;
+      }
+      transport_active = true;
+    }
+  } else if (transport_active) {
+    if (!api::global_api_server->clear_noise_psk(true)) {
+      ESP_LOGE(TAG, "Failed to clear API encryption");
       return false;
     }
-  } else if (!api::global_api_server->clear_noise_psk(true)) {
-    ESP_LOGE(TAG, "Failed to clear API encryption");
+    transport_active = false;
+  }
+#else
+  if (enabled) {
     return false;
   }
+#endif
 
   this->api_security_key_present_ = key_present;
   this->api_security_key_ = key;
   this->api_security_enabled_ = enabled;
   this->api_security_source_ = source != nullptr ? source : "";
+  this->api_security_transport_active_ = transport_active;
 
   return true;
 }
@@ -616,6 +640,10 @@ bool OpenQuattWebAuth::initialize_api_security_() {
 
   this->api_security_ready_ = true;
   return true;
+}
+
+bool OpenQuattWebAuth::is_api_security_transport_active() const {
+  return this->api_security_transport_active_;
 }
 
 bool OpenQuattWebAuth::is_valid_storage_(const AuthStorage &storage) const {

--- a/components/openquatt_web_auth/OpenQuattWebAuth.h
+++ b/components/openquatt_web_auth/OpenQuattWebAuth.h
@@ -36,6 +36,7 @@ class OpenQuattWebAuth : public Component {
   bool has_api_security_key() const { return this->api_security_key_present_; }
   const std::string &get_api_security_key() const { return this->api_security_key_; }
   const std::string &get_api_security_source() const { return this->api_security_source_; }
+  bool is_api_security_transport_active() const;
 
  protected:
   static constexpr uint32_t STORAGE_MAGIC = 0x4F514157;
@@ -91,6 +92,7 @@ class OpenQuattWebAuth : public Component {
   bool default_auth_enabled_{true};
   bool api_security_enabled_{false};
   bool api_security_key_present_{false};
+  bool api_security_transport_active_{false};
   ESPPreferenceObject pref_;
   ESPPreferenceObject api_security_pref_;
   bool handlers_registered_{false};

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -21,6 +21,7 @@
     },
     apiSecurity: {
       enabled: false,
+      transportActive: false,
       key: "",
       source: "bootstrap-disabled",
       csrfToken: "",
@@ -292,6 +293,7 @@
   function getApiSecurityStatusPayload() {
     return {
       enabled: Boolean(state.apiSecurity.enabled),
+      transport_active: Boolean(state.apiSecurity.transportActive),
       key: String(state.apiSecurity.key || ""),
       source: String(state.apiSecurity.source || ""),
       csrf_token: String(state.apiSecurity.csrfToken || ""),
@@ -313,6 +315,7 @@
       state.apiSecurity.key = generateApiKey();
     }
     state.apiSecurity.enabled = true;
+    state.apiSecurity.transportActive = true;
     state.apiSecurity.source = "runtime-enabled";
     refreshApiSecurityToken();
     return makeAuthResponse(200, {
@@ -330,6 +333,7 @@
 
     state.apiSecurity.key = generateApiKey();
     state.apiSecurity.enabled = true;
+    state.apiSecurity.transportActive = true;
     state.apiSecurity.source = "runtime-rotated";
     refreshApiSecurityToken();
     return makeAuthResponse(200, {
@@ -346,6 +350,7 @@
     }
 
     state.apiSecurity.enabled = false;
+    state.apiSecurity.transportActive = false;
     state.apiSecurity.source = "runtime-disabled";
     refreshApiSecurityToken();
     return makeAuthResponse(200, {

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -2414,8 +2414,11 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     if (!status) {
       return "We halen de huidige API-beveiliging op.";
     }
-    if (status.enabled) {
+    if (status.transport_active === true) {
       return "De native API is beveiligd. Je kunt de sleutel hier bekijken, kopiëren of roteren.";
+    }
+    if (status.enabled) {
+      return "API-encryptie wordt net aangepast. Geef het apparaat even de tijd om de status bij te werken.";
     }
     if (status.key) {
       return "De sleutel blijft opgeslagen, ook wanneer encryptie uit staat. Je kunt hem hier meteen kopiëren of opnieuw inschakelen.";
@@ -3811,6 +3814,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
   function getApiSecurityStatusSignature(status = state.apiSecurityStatus || {}) {
     return [
       status.enabled ? "on" : "off",
+      status.transport_active ? "active" : "idle",
       String(status.key || ""),
       String(status.source || ""),
       String(status.csrf_token || ""),
@@ -3858,6 +3862,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       const payload = await response.json();
       const nextStatus = {
         enabled: Boolean(payload.enabled),
+        transport_active: Boolean(payload.transport_active),
         key: String(payload.key || ""),
         source: String(payload.source || ""),
         csrf_token: String(payload.csrf_token || ""),
@@ -8780,6 +8785,12 @@ function renderWebServerLogsModal() {
     if (!status) {
       return "Laden...";
     }
+    if (status.transport_active === true) {
+      return "Aan";
+    }
+    if (status.transport_active === false) {
+      return "Uit";
+    }
     return status.enabled ? "Aan" : "Uit";
   }
 
@@ -8788,8 +8799,11 @@ function renderWebServerLogsModal() {
     if (!status) {
       return "API-encryptie wordt geladen.";
     }
-    if (status.enabled) {
+    if (status.transport_active === true) {
       return "API-encryptie staat aan. Gebruik dezelfde sleutel in Home Assistant.";
+    }
+    if (status.enabled) {
+      return "API-encryptie wordt net aangepast. Wacht even tot de status is bijgewerkt.";
     }
     if (status.key) {
       return "De sleutel blijft opgeslagen, maar de native API staat nu open op je lokale netwerk.";

--- a/openquatt/web/js/src/02-firmware-header.js
+++ b/openquatt/web/js/src/02-firmware-header.js
@@ -971,8 +971,11 @@
     if (!status) {
       return "We halen de huidige API-beveiliging op.";
     }
-    if (status.enabled) {
+    if (status.transport_active === true) {
       return "De native API is beveiligd. Je kunt de sleutel hier bekijken, kopiëren of roteren.";
+    }
+    if (status.enabled) {
+      return "API-encryptie wordt net aangepast. Geef het apparaat even de tijd om de status bij te werken.";
     }
     if (status.key) {
       return "De sleutel blijft opgeslagen, ook wanneer encryptie uit staat. Je kunt hem hier meteen kopiëren of opnieuw inschakelen.";

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -596,6 +596,7 @@
   function getApiSecurityStatusSignature(status = state.apiSecurityStatus || {}) {
     return [
       status.enabled ? "on" : "off",
+      status.transport_active ? "active" : "idle",
       String(status.key || ""),
       String(status.source || ""),
       String(status.csrf_token || ""),
@@ -643,6 +644,7 @@
       const payload = await response.json();
       const nextStatus = {
         enabled: Boolean(payload.enabled),
+        transport_active: Boolean(payload.transport_active),
         key: String(payload.key || ""),
         source: String(payload.source || ""),
         csrf_token: String(payload.csrf_token || ""),

--- a/openquatt/web/js/src/10-settings.js
+++ b/openquatt/web/js/src/10-settings.js
@@ -1428,6 +1428,12 @@
     if (!status) {
       return "Laden...";
     }
+    if (status.transport_active === true) {
+      return "Aan";
+    }
+    if (status.transport_active === false) {
+      return "Uit";
+    }
     return status.enabled ? "Aan" : "Uit";
   }
 
@@ -1436,8 +1442,11 @@
     if (!status) {
       return "API-encryptie wordt geladen.";
     }
-    if (status.enabled) {
+    if (status.transport_active === true) {
       return "API-encryptie staat aan. Gebruik dezelfde sleutel in Home Assistant.";
+    }
+    if (status.enabled) {
+      return "API-encryptie wordt net aangepast. Wacht even tot de status is bijgewerkt.";
     }
     if (status.key) {
       return "De sleutel blijft opgeslagen, maar de native API staat nu open op je lokale netwerk.";


### PR DESCRIPTION
This PR tightens the optional ESPHome API encryption flow so the web-app status follows the actual runtime transport state instead of only the saved preference.

What changed:
- Expose live `transport_active` in the API-security status endpoint.
- Stop issuing a no-op `clear_noise_psk(true)` when the API is already open, which was causing the OTA reset loop.
- Use the live transport state in the settings view and API-security modal copy.
- Keep the mock preview aligned with the new status payload.

Checks:
- `node --check openquatt/web/js/src/02-firmware-header.js`
- `node --check openquatt/web/js/src/03-entities-controls.js`
- `node --check openquatt/web/js/src/10-settings.js`
- `node --check openquatt/web/js/mock-device.js`
- `node openquatt/web/build-assets.mjs`
- `git diff --check`