### PR TITLE
Improve trend axis scaling and labels

### DIFF
--- a/openquatt/web/css/openquatt-app.css
+++ b/openquatt/web/css/openquatt-app.css
@@ -4917,6 +4917,12 @@ body.oq-surface-native {
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+
+.oq-overview-trend-axis-label--y {
+  font-size: 10px;
+  letter-spacing: 0;
 }
 
 .oq-overview-trend-line {

--- a/openquatt/web/css/openquatt-app.css
+++ b/openquatt/web/css/openquatt-app.css
@@ -4914,14 +4914,14 @@ body.oq-surface-native {
 
 .oq-overview-trend-axis-label {
   fill: var(--oq-overview-muted);
-  font-size: 11px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: 600;
   letter-spacing: 0.04em;
   font-variant-numeric: tabular-nums;
 }
 
 .oq-overview-trend-axis-label--y {
-  font-size: 10px;
+  opacity: 0.82;
   letter-spacing: 0;
 }
 

--- a/openquatt/web/css/src/20-overview.css
+++ b/openquatt/web/css/src/20-overview.css
@@ -925,6 +925,12 @@
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+
+.oq-overview-trend-axis-label--y {
+  font-size: 10px;
+  letter-spacing: 0;
 }
 
 .oq-overview-trend-line {

--- a/openquatt/web/css/src/20-overview.css
+++ b/openquatt/web/css/src/20-overview.css
@@ -922,14 +922,14 @@
 
 .oq-overview-trend-axis-label {
   fill: var(--oq-overview-muted);
-  font-size: 11px;
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: 600;
   letter-spacing: 0.04em;
   font-variant-numeric: tabular-nums;
 }
 
 .oq-overview-trend-axis-label--y {
-  font-size: 10px;
+  opacity: 0.82;
   letter-spacing: 0;
 }
 

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -10855,7 +10855,7 @@ function renderWebServerLogsModal() {
     const windowMs = getOverviewTrendWindowMs(windowHours);
     const width = 640;
     const height = 220;
-    const left = 22;
+    const left = 46;
     const right = 18;
     const top = 18;
     const bottom = 34;
@@ -10881,7 +10881,20 @@ function renderWebServerLogsModal() {
     };
 
     const gridXs = [0, 0.5, 1].map((fraction) => left + (plotWidth * fraction));
-    const gridYs = [0.25, 0.5, 0.75].map((fraction) => top + (plotHeight * fraction));
+    const gridFractions = [0.25, 0.5, 0.75];
+    const gridYs = gridFractions.map((fraction) => top + (plotHeight * fraction));
+    const axisDecimals = series.reduce((max, item) => {
+      const decimals = Number(item?.decimals);
+      return Math.max(max, Number.isFinite(decimals) ? decimals : 0);
+    }, 0);
+    const yAxisLabels = gridFractions.map((fraction, index) => {
+      const value = range.max - ((range.max - range.min) * fraction);
+      return {
+        x: 6,
+        y: gridYs[index],
+        text: formatNumericState(value, axisDecimals),
+      };
+    });
 
     const points = samples.map((sample) => {
       const x = xOf(sample.t);
@@ -10965,6 +10978,7 @@ function renderWebServerLogsModal() {
       range,
       gridXs,
       gridYs,
+      yAxisLabels,
       points,
       tracks,
       series,
@@ -11049,6 +11063,15 @@ function renderWebServerLogsModal() {
         ${model.gridXs.map((x) => `<line x1="${x.toFixed(1)}" y1="${model.top}" x2="${x.toFixed(1)}" y2="${model.height - model.bottom}" class="oq-overview-trend-grid oq-overview-trend-grid--vertical"></line>`).join("")}
         ${model.gridYs.map((y) => `<line x1="${model.left}" y1="${y.toFixed(1)}" x2="${model.width - model.right}" y2="${y.toFixed(1)}" class="oq-overview-trend-grid oq-overview-trend-grid--horizontal"></line>`).join("")}
         ${seriesPaths}
+        ${model.yAxisLabels.map((label) => `
+          <text
+            x="${label.x}"
+            y="${label.y.toFixed(1)}"
+            class="oq-overview-trend-axis-label oq-overview-trend-axis-label--y"
+            text-anchor="start"
+            dominant-baseline="middle"
+          >${escapeHtml(label.text)}</text>
+        `).join("")}
         <g class="oq-overview-trend-hover-layer" data-oq-trend-hover-layer hidden>
           <line x1="${model.left}" y1="${model.top}" x2="${model.left}" y2="${model.height - model.bottom}" class="oq-overview-trend-hover-line"></line>
           ${series.map((item) => `

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -10835,18 +10835,10 @@ function renderWebServerLogsModal() {
       return { min: 0, max: 1 };
     }
 
-    let min = Math.min(...values);
-    let max = Math.max(...values);
-    if (min === max) {
-      const offset = Math.max(Math.abs(min) * 0.1, 1);
-      min -= offset;
-      max += offset;
-    } else {
-      const pad = Math.max((max - min) * 0.12, 1);
-      min -= pad;
-      max += pad;
-    }
-    return { min, max };
+    return {
+      min: Math.min(...values),
+      max: Math.max(...values),
+    };
   }
 
   function getNiceTickStep(rawStep) {
@@ -10874,7 +10866,7 @@ function renderWebServerLogsModal() {
     const rangeSpan = Math.max(rangeMax - rangeMin, 1);
     const tickStep = Math.max(1, getNiceTickStep(rangeSpan / 4));
     const tickRatio = rangeSpan / tickStep;
-    const tickCount = tickRatio <= 2.25 ? 3 : (tickRatio <= 4.75 ? 5 : 7);
+    const tickCount = tickRatio <= 1.8 ? 3 : (tickRatio <= 4.25 ? 5 : 7);
     const halfCount = Math.floor(tickCount / 2);
     const midpoint = (rangeMin + rangeMax) / 2;
     const centerTick = Math.round(midpoint / tickStep) * tickStep;
@@ -10914,16 +10906,24 @@ function renderWebServerLogsModal() {
     const startTime = mockData ? 0 : (endTime - windowMs);
     const span = Math.max(endTime - startTime, 1);
     const uptimeMs = span;
-    const range = getOverviewTrendRange(samples, series);
-    const axisTicks = getOverviewTrendAxisTicks(range);
-    const axisSpan = Math.max(axisTicks.axisMax - axisTicks.axisMin, 1);
+    const rawRange = getOverviewTrendRange(samples, series);
+    const displayRange = rawRange.min === rawRange.max
+      ? {
+          min: rawRange.min - 1,
+          max: rawRange.max + 1,
+        }
+      : {
+          min: rawRange.min - Math.max((rawRange.max - rawRange.min) * 0.12, 1),
+          max: rawRange.max + Math.max((rawRange.max - rawRange.min) * 0.12, 1),
+        };
+    const axisTicks = getOverviewTrendAxisTicks(rawRange);
 
     const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
     const yOf = (value) => {
       if (!Number.isFinite(value)) {
         return Number.NaN;
       }
-      const ratio = (value - axisTicks.axisMin) / axisSpan;
+      const ratio = (value - displayRange.min) / Math.max(displayRange.max - displayRange.min, 1);
       return top + ((1 - Math.min(1, Math.max(0, ratio))) * plotHeight);
     };
 
@@ -11016,7 +11016,8 @@ function renderWebServerLogsModal() {
       startTime,
       span,
       windowHours,
-      range,
+      range: rawRange,
+      displayRange,
       gridXs,
       gridYs,
       yAxisLabels,

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -10849,6 +10849,25 @@ function renderWebServerLogsModal() {
     return { min, max };
   }
 
+  function getNiceTickStep(rawStep) {
+    if (!Number.isFinite(rawStep) || rawStep <= 0) {
+      return 1;
+    }
+    const exponent = Math.floor(Math.log10(rawStep));
+    const fraction = rawStep / (10 ** exponent);
+    let niceFraction;
+    if (fraction <= 1) {
+      niceFraction = 1;
+    } else if (fraction <= 2) {
+      niceFraction = 2;
+    } else if (fraction <= 5) {
+      niceFraction = 5;
+    } else {
+      niceFraction = 10;
+    }
+    return niceFraction * (10 ** exponent);
+  }
+
   function getOverviewTrendChartModel(samples, series, options = {}) {
     const rawWindowHours = Number(options.windowHours);
     const windowHours = Number.isFinite(rawWindowHours) ? rawWindowHours : getOverviewTrendWindowHours();
@@ -10870,27 +10889,31 @@ function renderWebServerLogsModal() {
     const span = Math.max(endTime - startTime, 1);
     const uptimeMs = span;
     const range = getOverviewTrendRange(samples, series);
+    const rangeSpan = Math.max(range.max - range.min, 1);
+    const tickStep = getNiceTickStep(rangeSpan / 4);
+    const axisMin = Math.floor(range.min / tickStep) * tickStep;
+    const axisMax = Math.ceil(range.max / tickStep) * tickStep;
+    const axisSpan = Math.max(axisMax - axisMin, tickStep);
+    const axisDecimals = tickStep < 1 ? 1 : 0;
+    const axisTicks = [];
+    for (let value = axisMin; value <= axisMax + (tickStep * 0.5); value += tickStep) {
+      axisTicks.push(value);
+    }
 
     const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
     const yOf = (value) => {
       if (!Number.isFinite(value)) {
         return Number.NaN;
       }
-      const ratio = (value - range.min) / Math.max(range.max - range.min, 1);
+      const ratio = (value - axisMin) / axisSpan;
       return top + ((1 - Math.min(1, Math.max(0, ratio))) * plotHeight);
     };
 
     const gridXs = [0, 0.5, 1].map((fraction) => left + (plotWidth * fraction));
-    const gridFractions = [0.25, 0.5, 0.75];
-    const gridYs = gridFractions.map((fraction) => top + (plotHeight * fraction));
-    const axisDecimals = series.reduce((max, item) => {
-      const decimals = Number(item?.decimals);
-      return Math.max(max, Number.isFinite(decimals) ? decimals : 0);
-    }, 0);
-    const yAxisLabels = gridFractions.map((fraction, index) => {
-      const value = range.max - ((range.max - range.min) * fraction);
+    const gridYs = axisTicks.map((value) => yOf(value));
+    const yAxisLabels = axisTicks.map((value, index) => {
       return {
-        x: 6,
+        x: left - 10,
         y: gridYs[index],
         text: formatNumericState(value, axisDecimals),
       };
@@ -11068,7 +11091,7 @@ function renderWebServerLogsModal() {
             x="${label.x}"
             y="${label.y.toFixed(1)}"
             class="oq-overview-trend-axis-label oq-overview-trend-axis-label--y"
-            text-anchor="start"
+            text-anchor="end"
             dominant-baseline="middle"
           >${escapeHtml(label.text)}</text>
         `).join("")}

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -10782,7 +10782,7 @@ function renderWebServerLogsModal() {
         mock: isMockData,
         windowHours,
         series: [
-          { id: "flow", sampleKey: "flow", label: "Flow", tone: "sky", decimals: 0, unit: " L/h" },
+          { id: "flow", sampleKey: "flow", label: "Flow", tone: "sky", decimals: 0, unit: " L/h", axisTickStep: 50 },
         ],
       },
     ];
@@ -10860,11 +10860,14 @@ function renderWebServerLogsModal() {
     return niceFraction * (10 ** exponent);
   }
 
-  function getOverviewTrendAxisTicks(range) {
+  function getOverviewTrendAxisTicks(range, series) {
     const rangeMin = Number.isFinite(range?.min) ? range.min : 0;
     const rangeMax = Number.isFinite(range?.max) ? range.max : 1;
     const rangeSpan = Math.max(rangeMax - rangeMin, 1);
-    const tickStep = Math.max(1, getNiceTickStep(rangeSpan / 4));
+    const explicitTickStep = Array.isArray(series)
+      ? series.map((item) => Number(item?.axisTickStep)).find((value) => Number.isFinite(value) && value > 0)
+      : Number.NaN;
+    const tickStep = Math.max(1, Number.isFinite(explicitTickStep) ? explicitTickStep : getNiceTickStep(rangeSpan / 4));
     const tickRatio = rangeSpan / tickStep;
     const tickCount = tickRatio <= 1.8 ? 3 : (tickRatio <= 4.25 ? 5 : 7);
     const halfCount = Math.floor(tickCount / 2);
@@ -10916,7 +10919,7 @@ function renderWebServerLogsModal() {
           min: rawRange.min - Math.max((rawRange.max - rawRange.min) * 0.12, 1),
           max: rawRange.max + Math.max((rawRange.max - rawRange.min) * 0.12, 1),
         };
-    const axisTicks = getOverviewTrendAxisTicks(rawRange);
+    const axisTicks = getOverviewTrendAxisTicks(rawRange, series);
 
     const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
     const yOf = (value) => {

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -10868,6 +10868,32 @@ function renderWebServerLogsModal() {
     return niceFraction * (10 ** exponent);
   }
 
+  function getOverviewTrendAxisTicks(range) {
+    const rangeMin = Number.isFinite(range?.min) ? range.min : 0;
+    const rangeMax = Number.isFinite(range?.max) ? range.max : 1;
+    const rangeSpan = Math.max(rangeMax - rangeMin, 1);
+    const tickStep = Math.max(1, getNiceTickStep(rangeSpan / 4));
+    const tickRatio = rangeSpan / tickStep;
+    const tickCount = tickRatio <= 2.25 ? 3 : (tickRatio <= 4.75 ? 5 : 7);
+    const halfCount = Math.floor(tickCount / 2);
+    const midpoint = (rangeMin + rangeMax) / 2;
+    const centerTick = Math.round(midpoint / tickStep) * tickStep;
+    const ticks = [];
+
+    for (let index = -halfCount; index <= halfCount; index += 1) {
+      ticks.push(centerTick + (index * tickStep));
+    }
+
+    const axisMin = ticks[0];
+    const axisMax = ticks[ticks.length - 1];
+    return {
+      ticks,
+      axisMin,
+      axisMax,
+      axisDecimals: 0,
+    };
+  }
+
   function getOverviewTrendChartModel(samples, series, options = {}) {
     const rawWindowHours = Number(options.windowHours);
     const windowHours = Number.isFinite(rawWindowHours) ? rawWindowHours : getOverviewTrendWindowHours();
@@ -10889,33 +10915,25 @@ function renderWebServerLogsModal() {
     const span = Math.max(endTime - startTime, 1);
     const uptimeMs = span;
     const range = getOverviewTrendRange(samples, series);
-    const rangeSpan = Math.max(range.max - range.min, 1);
-    const tickStep = getNiceTickStep(rangeSpan / 4);
-    const axisMin = Math.floor(range.min / tickStep) * tickStep;
-    const axisMax = Math.ceil(range.max / tickStep) * tickStep;
-    const axisSpan = Math.max(axisMax - axisMin, tickStep);
-    const axisDecimals = tickStep < 1 ? 1 : 0;
-    const axisTicks = [];
-    for (let value = axisMin; value <= axisMax + (tickStep * 0.5); value += tickStep) {
-      axisTicks.push(value);
-    }
+    const axisTicks = getOverviewTrendAxisTicks(range);
+    const axisSpan = Math.max(axisTicks.axisMax - axisTicks.axisMin, 1);
 
     const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
     const yOf = (value) => {
       if (!Number.isFinite(value)) {
         return Number.NaN;
       }
-      const ratio = (value - axisMin) / axisSpan;
+      const ratio = (value - axisTicks.axisMin) / axisSpan;
       return top + ((1 - Math.min(1, Math.max(0, ratio))) * plotHeight);
     };
 
     const gridXs = [0, 0.5, 1].map((fraction) => left + (plotWidth * fraction));
-    const gridYs = axisTicks.map((value) => yOf(value));
-    const yAxisLabels = axisTicks.map((value, index) => {
+    const gridYs = axisTicks.ticks.map((value) => yOf(value));
+    const yAxisLabels = axisTicks.ticks.map((value, index) => {
       return {
         x: left - 10,
         y: gridYs[index],
-        text: formatNumericState(value, axisDecimals),
+        text: formatNumericState(value, axisTicks.axisDecimals),
       };
     });
 

--- a/openquatt/web/js/src/20-overview.js
+++ b/openquatt/web/js/src/20-overview.js
@@ -1056,7 +1056,7 @@
     const windowMs = getOverviewTrendWindowMs(windowHours);
     const width = 640;
     const height = 220;
-    const left = 22;
+    const left = 46;
     const right = 18;
     const top = 18;
     const bottom = 34;
@@ -1082,7 +1082,20 @@
     };
 
     const gridXs = [0, 0.5, 1].map((fraction) => left + (plotWidth * fraction));
-    const gridYs = [0.25, 0.5, 0.75].map((fraction) => top + (plotHeight * fraction));
+    const gridFractions = [0.25, 0.5, 0.75];
+    const gridYs = gridFractions.map((fraction) => top + (plotHeight * fraction));
+    const axisDecimals = series.reduce((max, item) => {
+      const decimals = Number(item?.decimals);
+      return Math.max(max, Number.isFinite(decimals) ? decimals : 0);
+    }, 0);
+    const yAxisLabels = gridFractions.map((fraction, index) => {
+      const value = range.max - ((range.max - range.min) * fraction);
+      return {
+        x: 6,
+        y: gridYs[index],
+        text: formatNumericState(value, axisDecimals),
+      };
+    });
 
     const points = samples.map((sample) => {
       const x = xOf(sample.t);
@@ -1166,6 +1179,7 @@
       range,
       gridXs,
       gridYs,
+      yAxisLabels,
       points,
       tracks,
       series,
@@ -1250,6 +1264,15 @@
         ${model.gridXs.map((x) => `<line x1="${x.toFixed(1)}" y1="${model.top}" x2="${x.toFixed(1)}" y2="${model.height - model.bottom}" class="oq-overview-trend-grid oq-overview-trend-grid--vertical"></line>`).join("")}
         ${model.gridYs.map((y) => `<line x1="${model.left}" y1="${y.toFixed(1)}" x2="${model.width - model.right}" y2="${y.toFixed(1)}" class="oq-overview-trend-grid oq-overview-trend-grid--horizontal"></line>`).join("")}
         ${seriesPaths}
+        ${model.yAxisLabels.map((label) => `
+          <text
+            x="${label.x}"
+            y="${label.y.toFixed(1)}"
+            class="oq-overview-trend-axis-label oq-overview-trend-axis-label--y"
+            text-anchor="start"
+            dominant-baseline="middle"
+          >${escapeHtml(label.text)}</text>
+        `).join("")}
         <g class="oq-overview-trend-hover-layer" data-oq-trend-hover-layer hidden>
           <line x1="${model.left}" y1="${model.top}" x2="${model.left}" y2="${model.height - model.bottom}" class="oq-overview-trend-hover-line"></line>
           ${series.map((item) => `

--- a/openquatt/web/js/src/20-overview.js
+++ b/openquatt/web/js/src/20-overview.js
@@ -1036,18 +1036,10 @@
       return { min: 0, max: 1 };
     }
 
-    let min = Math.min(...values);
-    let max = Math.max(...values);
-    if (min === max) {
-      const offset = Math.max(Math.abs(min) * 0.1, 1);
-      min -= offset;
-      max += offset;
-    } else {
-      const pad = Math.max((max - min) * 0.12, 1);
-      min -= pad;
-      max += pad;
-    }
-    return { min, max };
+    return {
+      min: Math.min(...values),
+      max: Math.max(...values),
+    };
   }
 
   function getNiceTickStep(rawStep) {
@@ -1075,7 +1067,7 @@
     const rangeSpan = Math.max(rangeMax - rangeMin, 1);
     const tickStep = Math.max(1, getNiceTickStep(rangeSpan / 4));
     const tickRatio = rangeSpan / tickStep;
-    const tickCount = tickRatio <= 2.25 ? 3 : (tickRatio <= 4.75 ? 5 : 7);
+    const tickCount = tickRatio <= 1.8 ? 3 : (tickRatio <= 4.25 ? 5 : 7);
     const halfCount = Math.floor(tickCount / 2);
     const midpoint = (rangeMin + rangeMax) / 2;
     const centerTick = Math.round(midpoint / tickStep) * tickStep;
@@ -1115,16 +1107,24 @@
     const startTime = mockData ? 0 : (endTime - windowMs);
     const span = Math.max(endTime - startTime, 1);
     const uptimeMs = span;
-    const range = getOverviewTrendRange(samples, series);
-    const axisTicks = getOverviewTrendAxisTicks(range);
-    const axisSpan = Math.max(axisTicks.axisMax - axisTicks.axisMin, 1);
+    const rawRange = getOverviewTrendRange(samples, series);
+    const displayRange = rawRange.min === rawRange.max
+      ? {
+          min: rawRange.min - 1,
+          max: rawRange.max + 1,
+        }
+      : {
+          min: rawRange.min - Math.max((rawRange.max - rawRange.min) * 0.12, 1),
+          max: rawRange.max + Math.max((rawRange.max - rawRange.min) * 0.12, 1),
+        };
+    const axisTicks = getOverviewTrendAxisTicks(rawRange);
 
     const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
     const yOf = (value) => {
       if (!Number.isFinite(value)) {
         return Number.NaN;
       }
-      const ratio = (value - axisTicks.axisMin) / axisSpan;
+      const ratio = (value - displayRange.min) / Math.max(displayRange.max - displayRange.min, 1);
       return top + ((1 - Math.min(1, Math.max(0, ratio))) * plotHeight);
     };
 
@@ -1217,7 +1217,8 @@
       startTime,
       span,
       windowHours,
-      range,
+      range: rawRange,
+      displayRange,
       gridXs,
       gridYs,
       yAxisLabels,

--- a/openquatt/web/js/src/20-overview.js
+++ b/openquatt/web/js/src/20-overview.js
@@ -1050,6 +1050,25 @@
     return { min, max };
   }
 
+  function getNiceTickStep(rawStep) {
+    if (!Number.isFinite(rawStep) || rawStep <= 0) {
+      return 1;
+    }
+    const exponent = Math.floor(Math.log10(rawStep));
+    const fraction = rawStep / (10 ** exponent);
+    let niceFraction;
+    if (fraction <= 1) {
+      niceFraction = 1;
+    } else if (fraction <= 2) {
+      niceFraction = 2;
+    } else if (fraction <= 5) {
+      niceFraction = 5;
+    } else {
+      niceFraction = 10;
+    }
+    return niceFraction * (10 ** exponent);
+  }
+
   function getOverviewTrendChartModel(samples, series, options = {}) {
     const rawWindowHours = Number(options.windowHours);
     const windowHours = Number.isFinite(rawWindowHours) ? rawWindowHours : getOverviewTrendWindowHours();
@@ -1071,27 +1090,31 @@
     const span = Math.max(endTime - startTime, 1);
     const uptimeMs = span;
     const range = getOverviewTrendRange(samples, series);
+    const rangeSpan = Math.max(range.max - range.min, 1);
+    const tickStep = getNiceTickStep(rangeSpan / 4);
+    const axisMin = Math.floor(range.min / tickStep) * tickStep;
+    const axisMax = Math.ceil(range.max / tickStep) * tickStep;
+    const axisSpan = Math.max(axisMax - axisMin, tickStep);
+    const axisDecimals = tickStep < 1 ? 1 : 0;
+    const axisTicks = [];
+    for (let value = axisMin; value <= axisMax + (tickStep * 0.5); value += tickStep) {
+      axisTicks.push(value);
+    }
 
     const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
     const yOf = (value) => {
       if (!Number.isFinite(value)) {
         return Number.NaN;
       }
-      const ratio = (value - range.min) / Math.max(range.max - range.min, 1);
+      const ratio = (value - axisMin) / axisSpan;
       return top + ((1 - Math.min(1, Math.max(0, ratio))) * plotHeight);
     };
 
     const gridXs = [0, 0.5, 1].map((fraction) => left + (plotWidth * fraction));
-    const gridFractions = [0.25, 0.5, 0.75];
-    const gridYs = gridFractions.map((fraction) => top + (plotHeight * fraction));
-    const axisDecimals = series.reduce((max, item) => {
-      const decimals = Number(item?.decimals);
-      return Math.max(max, Number.isFinite(decimals) ? decimals : 0);
-    }, 0);
-    const yAxisLabels = gridFractions.map((fraction, index) => {
-      const value = range.max - ((range.max - range.min) * fraction);
+    const gridYs = axisTicks.map((value) => yOf(value));
+    const yAxisLabels = axisTicks.map((value, index) => {
       return {
-        x: 6,
+        x: left - 10,
         y: gridYs[index],
         text: formatNumericState(value, axisDecimals),
       };
@@ -1269,7 +1292,7 @@
             x="${label.x}"
             y="${label.y.toFixed(1)}"
             class="oq-overview-trend-axis-label oq-overview-trend-axis-label--y"
-            text-anchor="start"
+            text-anchor="end"
             dominant-baseline="middle"
           >${escapeHtml(label.text)}</text>
         `).join("")}

--- a/openquatt/web/js/src/20-overview.js
+++ b/openquatt/web/js/src/20-overview.js
@@ -983,7 +983,7 @@
         mock: isMockData,
         windowHours,
         series: [
-          { id: "flow", sampleKey: "flow", label: "Flow", tone: "sky", decimals: 0, unit: " L/h" },
+          { id: "flow", sampleKey: "flow", label: "Flow", tone: "sky", decimals: 0, unit: " L/h", axisTickStep: 50 },
         ],
       },
     ];
@@ -1061,11 +1061,14 @@
     return niceFraction * (10 ** exponent);
   }
 
-  function getOverviewTrendAxisTicks(range) {
+  function getOverviewTrendAxisTicks(range, series) {
     const rangeMin = Number.isFinite(range?.min) ? range.min : 0;
     const rangeMax = Number.isFinite(range?.max) ? range.max : 1;
     const rangeSpan = Math.max(rangeMax - rangeMin, 1);
-    const tickStep = Math.max(1, getNiceTickStep(rangeSpan / 4));
+    const explicitTickStep = Array.isArray(series)
+      ? series.map((item) => Number(item?.axisTickStep)).find((value) => Number.isFinite(value) && value > 0)
+      : Number.NaN;
+    const tickStep = Math.max(1, Number.isFinite(explicitTickStep) ? explicitTickStep : getNiceTickStep(rangeSpan / 4));
     const tickRatio = rangeSpan / tickStep;
     const tickCount = tickRatio <= 1.8 ? 3 : (tickRatio <= 4.25 ? 5 : 7);
     const halfCount = Math.floor(tickCount / 2);
@@ -1117,7 +1120,7 @@
           min: rawRange.min - Math.max((rawRange.max - rawRange.min) * 0.12, 1),
           max: rawRange.max + Math.max((rawRange.max - rawRange.min) * 0.12, 1),
         };
-    const axisTicks = getOverviewTrendAxisTicks(rawRange);
+    const axisTicks = getOverviewTrendAxisTicks(rawRange, series);
 
     const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
     const yOf = (value) => {

--- a/openquatt/web/js/src/20-overview.js
+++ b/openquatt/web/js/src/20-overview.js
@@ -1069,6 +1069,32 @@
     return niceFraction * (10 ** exponent);
   }
 
+  function getOverviewTrendAxisTicks(range) {
+    const rangeMin = Number.isFinite(range?.min) ? range.min : 0;
+    const rangeMax = Number.isFinite(range?.max) ? range.max : 1;
+    const rangeSpan = Math.max(rangeMax - rangeMin, 1);
+    const tickStep = Math.max(1, getNiceTickStep(rangeSpan / 4));
+    const tickRatio = rangeSpan / tickStep;
+    const tickCount = tickRatio <= 2.25 ? 3 : (tickRatio <= 4.75 ? 5 : 7);
+    const halfCount = Math.floor(tickCount / 2);
+    const midpoint = (rangeMin + rangeMax) / 2;
+    const centerTick = Math.round(midpoint / tickStep) * tickStep;
+    const ticks = [];
+
+    for (let index = -halfCount; index <= halfCount; index += 1) {
+      ticks.push(centerTick + (index * tickStep));
+    }
+
+    const axisMin = ticks[0];
+    const axisMax = ticks[ticks.length - 1];
+    return {
+      ticks,
+      axisMin,
+      axisMax,
+      axisDecimals: 0,
+    };
+  }
+
   function getOverviewTrendChartModel(samples, series, options = {}) {
     const rawWindowHours = Number(options.windowHours);
     const windowHours = Number.isFinite(rawWindowHours) ? rawWindowHours : getOverviewTrendWindowHours();
@@ -1090,33 +1116,25 @@
     const span = Math.max(endTime - startTime, 1);
     const uptimeMs = span;
     const range = getOverviewTrendRange(samples, series);
-    const rangeSpan = Math.max(range.max - range.min, 1);
-    const tickStep = getNiceTickStep(rangeSpan / 4);
-    const axisMin = Math.floor(range.min / tickStep) * tickStep;
-    const axisMax = Math.ceil(range.max / tickStep) * tickStep;
-    const axisSpan = Math.max(axisMax - axisMin, tickStep);
-    const axisDecimals = tickStep < 1 ? 1 : 0;
-    const axisTicks = [];
-    for (let value = axisMin; value <= axisMax + (tickStep * 0.5); value += tickStep) {
-      axisTicks.push(value);
-    }
+    const axisTicks = getOverviewTrendAxisTicks(range);
+    const axisSpan = Math.max(axisTicks.axisMax - axisTicks.axisMin, 1);
 
     const xOf = (timestamp) => left + (((timestamp - startTime) / span) * plotWidth);
     const yOf = (value) => {
       if (!Number.isFinite(value)) {
         return Number.NaN;
       }
-      const ratio = (value - axisMin) / axisSpan;
+      const ratio = (value - axisTicks.axisMin) / axisSpan;
       return top + ((1 - Math.min(1, Math.max(0, ratio))) * plotHeight);
     };
 
     const gridXs = [0, 0.5, 1].map((fraction) => left + (plotWidth * fraction));
-    const gridYs = axisTicks.map((value) => yOf(value));
-    const yAxisLabels = axisTicks.map((value, index) => {
+    const gridYs = axisTicks.ticks.map((value) => yOf(value));
+    const yAxisLabels = axisTicks.ticks.map((value, index) => {
       return {
         x: left - 10,
         y: gridYs[index],
-        text: formatNumericState(value, axisDecimals),
+        text: formatNumericState(value, axisTicks.axisDecimals),
       };
     });
 


### PR DESCRIPTION
This PR tightens the trend chart y-axis scaling and labels:

- add y-axis labels to the trend charts
- use compact, rounded ticks for COP and comfort
- keep flow on a tighter explicit step so it stays readable
- preserve the date/time x-axis labels and the trend history fixes from the previous PR

I verified the updated bundle locally on the separate worktree and the branch is pushed to `codex/trend-yaxis`.