### PR TITLE
Update HA dashboard controls and overview cards

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1255,7 +1255,6 @@ views:
             columns: 1
             cards:
               - type: picture-elements
-                title: Quatt HP1
                 image: https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
                   - type: image
@@ -1276,169 +1275,295 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp1_outside_temperature
                     style:
-                      top: 3%
+                      top: 4%
                       left: 8%
-                      font-weight: bold
-                      color: black
-                      font-size: 0.75em
                       transform: none
+                      color: #0f172a
+                      background: rgba(255, 255, 255, 0.78)
+                      border: 1px solid rgba(255, 255, 255, 0.72)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.76em
+                      line-height: 1.2
                     prefix: 'Outside: '
-                  - type: state-badge
+                  - type: state-label
                     entity: sensor.openquatt_hp1_gas_discharge_temperature
                     style:
-                      top: 22%
-                      left: 58%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 22%
+                        left: 60%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 60%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 61%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #f59e0b
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_eev_steps
                     style:
-                      top: 70%
-                      left: 42%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 42%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #f59e0b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #38bdf8
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporating_temperature
                     style:
-                      top: 70%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 25%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #2563eb
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 6%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 8%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_condenser_pressure
                     style:
-                      top: 11%
-                      left: 55%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 11%
+                        left: 56%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporator_pressure
                     style:
                       top: 11%
-                      left: 30%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 31%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_fan_speed
                     style:
-                      top: 53%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 54%
+                        left: 27%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #64748b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_compressor_frequency
                     style:
                       top: 18%
-                      left: 40%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 42%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #111827
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_water_out_temperature
                     style:
-                      top: 43%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 43%
+                        left: 88%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_water_in_temperature
                     style:
                       top: 63%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 88%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_flow
                     style:
-                      top: 76%
-                      left: 81%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
+                        top: 78%
+                        left: 82%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #0f766e
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
                   - type: state-label
                     entity: sensor.openquatt_hp1_working_mode_label
                     style:
                       top: 8%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Mode: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_power_input
                     style:
                       top: 11%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Power In: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_heat_power
                     style:
                       top: 14%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Power Out: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_cop
                     style:
                       top: 17%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1451,8 +1576,13 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_defrost
@@ -1464,8 +1594,12 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1477,8 +1611,13 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1490,8 +1629,12 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
             grid_options:
               columns: 12
               rows: auto
@@ -1540,7 +1683,6 @@ views:
             columns: 1
             cards:
               - type: picture-elements
-                title: Quatt HP2
                 image: https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
                   - type: image
@@ -1561,169 +1703,295 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp2_outside_temperature
                     style:
-                      top: 3%
+                      top: 4%
                       left: 8%
-                      font-weight: bold
-                      color: black
-                      font-size: 0.75em
                       transform: none
+                      color: #0f172a
+                      background: rgba(255, 255, 255, 0.78)
+                      border: 1px solid rgba(255, 255, 255, 0.72)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.76em
+                      line-height: 1.2
                     prefix: 'Outside: '
-                  - type: state-badge
+                  - type: state-label
                     entity: sensor.openquatt_hp2_gas_discharge_temperature
                     style:
-                      top: 22%
-                      left: 58%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 22%
+                        left: 60%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 60%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 61%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #f59e0b
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_eev_steps
                     style:
-                      top: 70%
-                      left: 42%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 42%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #f59e0b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #38bdf8
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_evaporating_temperature
                     style:
-                      top: 70%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 25%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #2563eb
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 6%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 8%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_condenser_pressure
                     style:
-                      top: 11%
-                      left: 55%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 11%
+                        left: 56%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_evaporator_pressure
                     style:
                       top: 11%
-                      left: 30%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 31%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_fan_speed
                     style:
-                      top: 53%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 54%
+                        left: 27%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #64748b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_compressor_frequency
                     style:
                       top: 18%
-                      left: 40%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 42%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #111827
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_water_out_temperature
                     style:
-                      top: 43%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 43%
+                        left: 88%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_water_in_temperature
                     style:
                       top: 63%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 88%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_flow
                     style:
-                      top: 76%
-                      left: 81%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
+                        top: 78%
+                        left: 82%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #0f766e
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
                   - type: state-label
                     entity: sensor.openquatt_hp2_working_mode_label
                     style:
                       top: 8%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Mode: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_power_input
                     style:
                       top: 11%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Power In: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_heat_power
                     style:
                       top: 14%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Power Out: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_cop
                     style:
                       top: 17%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1736,8 +2004,13 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_defrost
@@ -1749,8 +2022,12 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
@@ -1762,8 +2039,13 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
@@ -1775,8 +2057,12 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
             grid_options:
               columns: 12
               rows: auto

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -14,7 +14,7 @@ views:
             heading: Live performance
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -87,7 +87,7 @@ views:
             heading: Supervisory status
             icon: mdi:state-machine
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -139,7 +139,7 @@ views:
             heading: Controls
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -196,7 +196,7 @@ views:
             heading: Debug
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary><ha-alert
@@ -225,7 +225,7 @@ views:
             heading_style: title
             icon: mdi:home-thermometer
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -269,7 +269,7 @@ views:
             heading: Silent mode settings
             icon: mdi:volume-off
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -769,7 +769,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energy
 
           Energy overview of heat pump, boiler, and total system (daily + cumulative).
@@ -1440,6 +1440,58 @@ views:
                       font-size: 0.75em
                       transform: none
                     prefix: 'COP: '
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_defrost
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp1_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_defrost
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp1_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: grey
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto
@@ -1673,6 +1725,58 @@ views:
                       font-size: 0.75em
                       transform: none
                     prefix: 'COP: '
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp2_defrost
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp2_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp2_defrost
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp2_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: grey
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp2_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp2_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto
@@ -1718,7 +1822,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:heat-pump-outline"></ha-icon> Overview HP1&HP2
 
           This tab shows a per-HP technical snapshot of refrigerant/water-side
@@ -2367,7 +2471,7 @@ views:
             heading: Quatt Hybrid version
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -2389,7 +2493,7 @@ views:
             heading: Silent mode settings
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2421,7 +2525,7 @@ views:
             heading: House model (PH)
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2489,7 +2593,7 @@ views:
             heading: Heating curve control
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2543,11 +2647,41 @@ views:
       - type: grid
         cards:
           - type: heading
+            icon: mdi:water-thermometer
+            heading: Water temperature limit
+            heading_style: title
+          - type: markdown
+            content: |-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Uses `Water Supply Temp (Selected)` as the measured limit source.
+
+              - **Maximum water temperature** is the normal ceiling for measured
+              supply temperature.
+
+              - OpenQuatt derives an internal rollback band and a hard trip at
+              `max + 5°C` from that setting. In `CM3` the boiler drops out
+              first; a hard HP stop follows only if the overshoot persists.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_maximum_water_temperature
+                name: Maximum water temperature
+      - type: grid
+        cards:
+          - type: heading
             icon: mdi:snowflake
             heading: Cooling settings
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2581,41 +2715,11 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:water-thermometer
-            heading: Water temperature limit
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Uses `Water Supply Temp (Selected)` as the measured limit source.
-
-              - **Maximum water temperature** is the normal ceiling for measured
-              supply temperature.
-
-              - OpenQuatt derives an internal rollback band and a hard trip at
-              `max + 5°C` from that setting. In `CM3` the boiler drops out
-              first; a hard HP stop follows only if the overshoot persists.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: number.openquatt_maximum_water_temperature
-                name: Maximum water temperature
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:heat-wave
             heading: Thermal request control
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2643,7 +2747,7 @@ views:
             heading: Flow tuning
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2669,21 +2773,25 @@ views:
             heading: Boiler control
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
 
-              - **CM3 deficit ON/OFF thresholds** define when boiler assist may
-              switch on/off.
+              - **Boiler rated power** is the reference for boiler assist and
+              the boiler power test.
+
+              - The **CM3 deficit turn-on and turn-off thresholds** define
+              when boiler assist may switch on/off.
 
               - Boiler assist is still blocked by the water temperature limit
               when measured supply temperature gets too high.
 
-              - Keep ON clearly higher than OFF to reduce toggling around the
-              threshold.
+              - Keep the turn-on threshold clearly higher than the turn-off
+              threshold to reduce toggling around the boundary.
 
-              - If behavior is too aggressive: increase ON or decrease OFF.
+              - If behavior is too aggressive: increase the turn-on threshold
+              or decrease the turn-off threshold.
 
 
               </details>
@@ -2691,10 +2799,12 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Boiler rated power
               - entity: number.openquatt_cm3_deficit_on_threshold
-                name: CM3 deficit ON threshold
+                name: CM3 deficit turn-on threshold
               - entity: number.openquatt_cm3_deficit_off_threshold
-                name: CM3 deficit OFF threshold
+                name: CM3 deficit turn-off threshold
       - type: grid
         column_span: 2
         cards:
@@ -2703,7 +2813,7 @@ views:
             heading: Excluded compressor levels
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2752,7 +2862,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:tune-vertical"></ha-icon> Tuning
 
           Structural control tuning for limits, house model, heating curve, heat
@@ -2771,7 +2881,7 @@ views:
             heading: Runtime / hours
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2812,7 +2922,7 @@ views:
             heading: CM100 commissioning
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2846,50 +2956,21 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:water-boiler
-            heading: Boiler power test
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Measures the effective boiler output at stable flow.
-
-              - Start the test only while **CM100** is already active.
-
-              - Apply the measured value only if it looks sensible.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_boiler_power_test_start
-                name: Start boiler power test
-              - entity: button.openquatt_boiler_power_test_abort
-                name: Abort boiler power test
-              - entity: button.openquatt_boiler_power_test_apply
-                name: Apply boiler power
-              - entity: number.openquatt_boiler_rated_heat_power
-                name: Boiler rated heat power
-              - entity: sensor.openquatt_boiler_power_test_result
-                name: Boiler power test result
-              - entity: sensor.openquatt_boiler_power_test_confidence
-                name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
-                name: Boiler power test status
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:tools
-            heading: Flow autotune
+            heading: CM100 - Flow autotune
             heading_style: title
+            grid_options:
+              columns: 12
+              rows: 1
+          - type: heading
+            icon: mdi:water-boiler
+            heading: CM100 - Boiler power test
+            heading_style: title
+            grid_options:
+              columns: 12
+              rows: auto
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2909,6 +2990,22 @@ views:
 
               </details>
             text_only: true
+          - type: markdown
+            content: |-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Measures the effective boiler output at stable flow.
+
+              - Start the test only while **CM100** is already active.
+
+              - Apply the measured value only if it looks sensible.
+
+
+              </details>
+            text_only: true
           - type: entities
             show_header_toggle: false
             entities:
@@ -2924,10 +3021,32 @@ views:
                 name: Autotune Ki suggested
               - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_boiler_power_test_start
+                name: Start boiler power test
+              - entity: button.openquatt_boiler_power_test_abort
+                name: Abort boiler power test
+              - entity: button.openquatt_boiler_power_test_apply
+                name: Apply boiler power
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Boiler rated power
+              - entity: sensor.openquatt_boiler_power_test_result
+                name: Boiler power test result
+              - entity: sensor.openquatt_boiler_power_test_confidence
+                name: Boiler power test confidence
+              - entity: sensor.openquatt_boiler_power_test_status
+                name: Boiler power test status
+        visibility:
+          - condition: state
+            entity: binary_sensor.openquatt_cm100_active
+            state: 'on'
+        column_span: 2
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:toolbox-outline"></ha-icon> Service & Test
 
           Manual service actions.
@@ -3033,7 +3152,7 @@ views:
             heading: PH diagnostics
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -3077,7 +3196,7 @@ views:
             heading: Heating Curve diagnostics
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1255,6 +1255,7 @@ views:
             columns: 1
             cards:
               - type: picture-elements
+                title: Quatt HP1
                 image: https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
                   - type: image
@@ -1275,295 +1276,169 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp1_outside_temperature
                     style:
-                      top: 4%
+                      top: 3%
                       left: 8%
+                      font-weight: bold
+                      color: black
+                      font-size: 0.75em
                       transform: none
-                      color: #0f172a
-                      background: rgba(255, 255, 255, 0.78)
-                      border: 1px solid rgba(255, 255, 255, 0.72)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.76em
-                      line-height: 1.2
                     prefix: 'Outside: '
-                  - type: state-label
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_gas_discharge_temperature
                     style:
-                        top: 22%
-                        left: 60%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 22%
+                      left: 58%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 61%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #f59e0b
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 60%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_eev_steps
                     style:
-                        top: 70%
-                        left: 42%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #f59e0b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 42%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #38bdf8
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporating_temperature
                     style:
-                        top: 70%
-                        left: 25%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #2563eb
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 8%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 6%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_condenser_pressure
                     style:
-                        top: 11%
-                        left: 56%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 11%
+                      left: 55%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporator_pressure
                     style:
                       top: 11%
-                      left: 31%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 30%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_fan_speed
                     style:
-                        top: 54%
-                        left: 27%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #64748b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 53%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_compressor_frequency
                     style:
                       top: 18%
-                      left: 42%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #111827
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 40%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_water_out_temperature
                     style:
-                        top: 43%
-                        left: 88%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 43%
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_water_in_temperature
                     style:
                       top: 63%
-                      left: 88%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_flow
                     style:
-                        top: 78%
-                        left: 82%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #0f766e
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
+                      top: 76%
+                      left: 81%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
                   - type: state-label
                     entity: sensor.openquatt_hp1_working_mode_label
                     style:
                       top: 8%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Mode: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_power_input
                     style:
                       top: 11%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Power In: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_heat_power
                     style:
                       top: 14%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Power Out: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_cop
                     style:
                       top: 17%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1576,13 +1451,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_defrost
@@ -1594,12 +1464,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1611,13 +1477,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1629,12 +1490,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto
@@ -1683,6 +1540,7 @@ views:
             columns: 1
             cards:
               - type: picture-elements
+                title: Quatt HP2
                 image: https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
                   - type: image
@@ -1703,295 +1561,169 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp2_outside_temperature
                     style:
-                      top: 4%
+                      top: 3%
                       left: 8%
+                      font-weight: bold
+                      color: black
+                      font-size: 0.75em
                       transform: none
-                      color: #0f172a
-                      background: rgba(255, 255, 255, 0.78)
-                      border: 1px solid rgba(255, 255, 255, 0.72)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.76em
-                      line-height: 1.2
                     prefix: 'Outside: '
-                  - type: state-label
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_gas_discharge_temperature
                     style:
-                        top: 22%
-                        left: 60%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 22%
+                      left: 58%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 61%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #f59e0b
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 60%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_eev_steps
                     style:
-                        top: 70%
-                        left: 42%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #f59e0b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 42%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #38bdf8
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_evaporating_temperature
                     style:
-                        top: 70%
-                        left: 25%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #2563eb
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 8%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 6%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_condenser_pressure
                     style:
-                        top: 11%
-                        left: 56%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 11%
+                      left: 55%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_evaporator_pressure
                     style:
                       top: 11%
-                      left: 31%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 30%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_fan_speed
                     style:
-                        top: 54%
-                        left: 27%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #64748b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 53%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_compressor_frequency
                     style:
                       top: 18%
-                      left: 42%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #111827
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 40%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_water_out_temperature
                     style:
-                        top: 43%
-                        left: 88%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 43%
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_water_in_temperature
                     style:
                       top: 63%
-                      left: 88%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_flow
                     style:
-                        top: 78%
-                        left: 82%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #0f766e
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
+                      top: 76%
+                      left: 81%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
                   - type: state-label
                     entity: sensor.openquatt_hp2_working_mode_label
                     style:
                       top: 8%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Mode: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_power_input
                     style:
                       top: 11%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Power In: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_heat_power
                     style:
                       top: 14%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Power Out: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_cop
                     style:
                       top: 17%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -2004,13 +1736,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_defrost
@@ -2022,12 +1749,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
@@ -2039,13 +1762,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
@@ -2057,12 +1775,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1351,7 +1351,6 @@ views:
             columns: 1
             cards:
               - type: picture-elements
-                title: Quatt HP1
                 image: >-
                   https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
@@ -1377,169 +1376,295 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp1_outside_temperature
                     style:
-                      top: 3%
+                      top: 4%
                       left: 8%
-                      font-weight: bold
-                      color: black
-                      font-size: 0.75em
                       transform: none
+                      color: #0f172a
+                      background: rgba(255, 255, 255, 0.78)
+                      border: 1px solid rgba(255, 255, 255, 0.72)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.76em
+                      line-height: 1.2
                     prefix: 'Buiten: '
-                  - type: state-badge
+                  - type: state-label
                     entity: sensor.openquatt_hp1_gas_discharge_temperature
                     style:
-                      top: 22%
-                      left: 58%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 22%
+                        left: 60%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 60%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 61%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #f59e0b
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_eev_steps
                     style:
-                      top: 70%
-                      left: 42%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 42%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #f59e0b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #38bdf8
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporating_temperature
                     style:
-                      top: 70%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 25%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #2563eb
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 6%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 8%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_condenser_pressure
                     style:
-                      top: 11%
-                      left: 55%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 11%
+                        left: 56%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporator_pressure
                     style:
                       top: 11%
-                      left: 30%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 31%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_fan_speed
                     style:
-                      top: 53%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 54%
+                        left: 27%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #64748b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_compressor_frequency
                     style:
                       top: 18%
-                      left: 40%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 42%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #111827
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_water_out_temperature
                     style:
-                      top: 43%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 43%
+                        left: 88%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_water_in_temperature
                     style:
                       top: 63%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 88%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_flow
                     style:
-                      top: 76%
-                      left: 81%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
+                        top: 78%
+                        left: 82%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #0f766e
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
                   - type: state-label
                     entity: sensor.openquatt_hp1_working_mode_label
                     style:
                       top: 8%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Modus: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_power_input
                     style:
                       top: 11%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'PowerInput: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_heat_power
                     style:
                       top: 14%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Heat Power: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_cop
                     style:
                       top: 17%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1552,8 +1677,13 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_defrost
@@ -1565,8 +1695,12 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1578,8 +1712,13 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1591,8 +1730,12 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
             grid_options:
               columns: 12
               rows: auto
@@ -1641,7 +1784,6 @@ views:
             columns: 1
             cards:
               - type: picture-elements
-                title: Quatt HP2
                 image: >-
                   https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
@@ -1667,169 +1809,295 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp2_outside_temperature
                     style:
-                      top: 3%
+                      top: 4%
                       left: 8%
-                      font-weight: bold
-                      color: black
-                      font-size: 0.75em
                       transform: none
+                      color: #0f172a
+                      background: rgba(255, 255, 255, 0.78)
+                      border: 1px solid rgba(255, 255, 255, 0.72)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.76em
+                      line-height: 1.2
                     prefix: 'Buiten: '
-                  - type: state-badge
+                  - type: state-label
                     entity: sensor.openquatt_hp2_gas_discharge_temperature
                     style:
-                      top: 22%
-                      left: 58%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 22%
+                        left: 60%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 60%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 61%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #f59e0b
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_eev_steps
                     style:
-                      top: 70%
-                      left: 42%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 42%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #f59e0b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #38bdf8
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_evaporating_temperature
                     style:
-                      top: 70%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 25%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #2563eb
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 6%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 8%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_condenser_pressure
                     style:
-                      top: 11%
-                      left: 55%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 11%
+                        left: 56%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_evaporator_pressure
                     style:
                       top: 11%
-                      left: 30%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 31%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_fan_speed
                     style:
-                      top: 53%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 54%
+                        left: 27%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #64748b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_compressor_frequency
                     style:
                       top: 18%
-                      left: 40%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 42%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #111827
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_water_out_temperature
                     style:
-                      top: 43%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 43%
+                        left: 88%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_water_in_temperature
                     style:
                       top: 63%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 88%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp2_flow
                     style:
-                      top: 76%
-                      left: 81%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
+                        top: 78%
+                        left: 82%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #0f766e
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
                   - type: state-label
                     entity: sensor.openquatt_hp2_working_mode_label
                     style:
                       top: 8%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Modus: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_power_input
                     style:
                       top: 11%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'PowerInput: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_heat_power
                     style:
                       top: 14%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Heat Power: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_cop
                     style:
                       top: 17%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1842,8 +2110,13 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_defrost
@@ -1855,8 +2128,12 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
@@ -1868,8 +2145,13 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
@@ -1881,8 +2163,12 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
             grid_options:
               columns: 12
               rows: auto

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -14,7 +14,7 @@ views:
             heading: Live prestaties
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -90,7 +90,7 @@ views:
             heading: Systeemstatus
             icon: mdi:state-machine
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -144,7 +144,7 @@ views:
             heading: Bediening
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -201,7 +201,7 @@ views:
             heading: Debug
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary><ha-alert
@@ -230,7 +230,7 @@ views:
             heading_style: title
             icon: mdi:home-thermometer
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -275,7 +275,7 @@ views:
             heading: Instellingen stille modus
             icon: mdi:volume-off
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -331,7 +331,7 @@ views:
             heading: Performance (12h)
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -617,7 +617,7 @@ views:
             heading: Energietrends (7d/30d)
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -794,7 +794,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energie
 
           Energie-overzicht van Warmtepomp, boiler en totaal systeem (dag +
@@ -816,7 +816,7 @@ views:
             heading: Status
             heading_style: subtitle
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -872,7 +872,7 @@ views:
             heading: Regeling
             heading_style: subtitle
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -990,7 +990,7 @@ views:
             heading: Regelinstellingen
             heading_style: subtitle
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -1034,7 +1034,7 @@ views:
             heading: Kern KPI
             heading_style: subtitle
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -1133,7 +1133,7 @@ views:
             heading: Trends
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -1259,27 +1259,47 @@ views:
             heading: Dauwpuntveiligheid
             heading_style: title
           - type: markdown
-            content: |-
+            content: >-
               <details>
-              <summary><strong>Uitleg fallback zonder dauwpunt</strong></summary>
 
-              Normaal gebruikt OpenQuatt het hoogste geldige dauwpunt plus de ingestelde veiligheidsmarge.
+              <summary><strong>Uitleg fallback zonder
+              dauwpunt</strong></summary>
 
-              Zonder dauwpuntbron blijft koeling standaard geblokkeerd. Alleen als `Koeling zonder dauwpunt` expliciet is toegestaan, gebruikt OpenQuatt een conservatieve fallback:
+
+              Normaal gebruikt OpenQuatt het hoogste geldige dauwpunt plus de
+              ingestelde veiligheidsmarge.
+
+
+              Zonder dauwpuntbron blijft koeling standaard geblokkeerd. Alleen
+              als `Koeling zonder dauwpunt` expliciet is toegestaan, gebruikt
+              OpenQuatt een conservatieve fallback:
+
 
               - `< 20°C` buiten: uit
+
               - `20–24°C`: minimum water `19°C`
+
               - `24–28°C`: minimum water `20°C`
+
               - `28–32°C`: minimum water `21°C`
+
               - `> 32°C`: minimum water `22°C`
 
+
               Nachtcorrectie:
+
               - nachtminimum `< 18°C`: `+0°C`
+
               - `18–19°C`: `+1°C`
+
               - `19–20°C`: `+2°C`
+
               - `>= 20°C`: fallback uit
 
-              Deze staffel vervangt de normale dauwpuntmarge; er komt dus niet nog eens extra `+2K` bovenop.
+
+              Deze staffel vervangt de normale dauwpuntmarge; er komt dus niet
+              nog eens extra `+2K` bovenop.
+
               </details>
             text_only: true
             grid_options:
@@ -1521,6 +1541,58 @@ views:
                       font-size: 0.75em
                       transform: none
                     prefix: 'COP: '
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_defrost
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp1_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_defrost
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp1_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: grey
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto
@@ -1759,6 +1831,58 @@ views:
                       font-size: 0.75em
                       transform: none
                     prefix: 'COP: '
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp2_defrost
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp2_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp2_defrost
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp2_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: grey
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp2_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp2_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto
@@ -1804,7 +1928,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:heat-pump-outline"></ha-icon> Overzicht HP1 en
           HP2
 
@@ -1826,7 +1950,7 @@ views:
             heading: Sensorselectie
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -2067,7 +2191,7 @@ views:
                 heading: HA proxywaarden en validiteit
                 heading_style: subtitle
               - type: markdown
-                content: >-
+                content: |-
                   <details>
 
                   <summary><strong>Uitleg</strong></summary>
@@ -2462,7 +2586,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensorconfiguratie
 
 
@@ -2485,7 +2609,7 @@ views:
             heading: Quatt Hybrid-versie
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -2507,7 +2631,7 @@ views:
             heading: Instellingen stille modus
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2540,7 +2664,7 @@ views:
             heading: Huismodel (PH)
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2609,7 +2733,7 @@ views:
             heading: Stooklijnregeling
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2664,49 +2788,11 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:snowflake
-            heading: Koelingsinstellingen
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - **Cooling Minimum Supply Temp** begrenst de minimale koel-aanvoertemperatuur.
-              - **Cooling Demand Max** begrenst de maximale koelvraag.
-              - **Cooling Safety Margin** bepaalt de marge boven het geselecteerde dauwpunt.
-              - **Cooling PID Kp/Ki/Kd** stuurt de koel-PID:
-                - Kp: directe reactie.
-                - Ki: langdurige correctie.
-                - Kd: demping.
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: number.openquatt_cooling_minimum_supply_temp
-                name: Cooling minimum supply temp
-              - entity: number.openquatt_cooling_demand_max
-                name: Cooling demand max
-              - entity: number.openquatt_cooling_safety_margin
-                name: Cooling safety margin
-              - entity: number.openquatt_cooling_pid_kp
-                name: Cooling PID Kp
-              - entity: number.openquatt_cooling_pid_ki
-                name: Cooling PID Ki
-              - entity: number.openquatt_cooling_pid_kd
-                name: Cooling PID Kd
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:water-thermometer
             heading: Watertempbegrenzing
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2734,11 +2820,56 @@ views:
       - type: grid
         cards:
           - type: heading
+            icon: mdi:snowflake
+            heading: Koelingsinstellingen
+            heading_style: title
+          - type: markdown
+            content: >-
+              <details>
+
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+
+              - **Cooling Minimum Supply Temp** begrenst de minimale
+              koel-aanvoertemperatuur.
+
+              - **Cooling Demand Max** begrenst de maximale koelvraag.
+
+              - **Cooling Safety Margin** bepaalt de marge boven het
+              geselecteerde dauwpunt.
+
+              - **Cooling PID Kp/Ki/Kd** stuurt de koel-PID:
+                - Kp: directe reactie.
+                - Ki: langdurige correctie.
+                - Kd: demping.
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_cooling_minimum_supply_temp
+                name: Cooling minimum supply temp
+              - entity: number.openquatt_cooling_demand_max
+                name: Cooling demand max
+              - entity: number.openquatt_cooling_safety_margin
+                name: Cooling safety margin
+              - entity: number.openquatt_cooling_pid_kp
+                name: Cooling PID Kp
+              - entity: number.openquatt_cooling_pid_ki
+                name: Cooling PID Ki
+              - entity: number.openquatt_cooling_pid_kd
+                name: Cooling PID Kd
+      - type: grid
+        cards:
+          - type: heading
             icon: mdi:heat-wave
             heading: Thermal request control
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2767,7 +2898,7 @@ views:
             heading: Flow afstellen
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2793,21 +2924,25 @@ views:
             heading: Ketelregeling
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
 
-              - **CM3 deficit ON/OFF thresholds** bepalen wanneer boiler-assist
-              mag inschakelen/uitschakelen.
+              - **Nominaal ketelvermogen** is de referentie voor
+              boiler-assist en de boiler power test.
+
+              - De **CM3-tekort inschakel- en uitschakeldrempels** bepalen
+              wanneer boiler-assist mag inschakelen/uitschakelen.
 
               - Boiler-assist wordt daarnaast geblokkeerd door de
               watertempbegrenzing als de gemeten aanvoer te hoog wordt.
 
-              - Houd ON duidelijk hoger dan OFF om schakelen rond de grens te
-              beperken.
+              - Houd de inschakeldrempel duidelijk hoger dan de
+              uitschakeldrempel om schakelen rond de grens te beperken.
 
-              - Bij te agressief gedrag: ON verhogen of OFF verlagen.
+              - Bij te agressief gedrag: inschakeldrempel verhogen of
+              uitschakeldrempel verlagen.
 
 
               </details>
@@ -2815,10 +2950,12 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Nominaal ketelvermogen
               - entity: number.openquatt_cm3_deficit_on_threshold
-                name: CM3 deficit ON threshold
+                name: CM3-tekort inschakeldrempel
               - entity: number.openquatt_cm3_deficit_off_threshold
-                name: CM3 deficit OFF threshold
+                name: CM3-tekort uitschakeldrempel
       - type: grid
         column_span: 2
         cards:
@@ -2827,7 +2964,7 @@ views:
             heading: Uitgesloten compressorlevels
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2876,7 +3013,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:tune-vertical"></ha-icon> Instellingen
 
           Structurele regelinstellingen voor limieten, huismodel, stooklijn,
@@ -2895,7 +3032,7 @@ views:
             heading: Runtime / draaiuren
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2929,6 +3066,7 @@ views:
                 name: HP2 draaitijd
               - entity: sensor.openquatt_runtime_lead_hp
                 name: Leidende HP
+        column_span: 1
       - type: grid
         cards:
           - type: heading
@@ -2936,7 +3074,7 @@ views:
             heading: CM100 commissioning
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2970,50 +3108,21 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:water-boiler
-            heading: Boiler power test
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Meet het effectieve ketelvermogen bij stabiele flow.
-
-              - Start de test alleen terwijl **CM100** al actief is.
-
-              - Pas de gemeten waarde toe als die logisch oogt.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_boiler_power_test_start
-                name: Boiler power test starten
-              - entity: button.openquatt_boiler_power_test_abort
-                name: Boiler power test afbreken
-              - entity: button.openquatt_boiler_power_test_apply
-                name: Pas boilervermogen toe
-              - entity: number.openquatt_boiler_rated_heat_power
-                name: Boiler rated heat power
-              - entity: sensor.openquatt_boiler_power_test_result
-                name: Boiler power test resultaat
-              - entity: sensor.openquatt_boiler_power_test_confidence
-                name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
-                name: Boiler power test status
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:tools
-            heading: Flow autotune
+            heading: CM100 - Flow autotune
             heading_style: title
+            grid_options:
+              columns: 12
+              rows: 1
+          - type: heading
+            icon: mdi:water-boiler
+            heading: CM100 - Boiler power test
+            heading_style: title
+            grid_options:
+              columns: 12
+              rows: auto
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -3033,6 +3142,22 @@ views:
 
               </details>
             text_only: true
+          - type: markdown
+            content: |-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Meet het effectieve ketelvermogen bij stabiele flow.
+
+              - Start de test alleen terwijl **CM100** al actief is.
+
+              - Pas de gemeten waarde toe als die logisch oogt.
+
+
+              </details>
+            text_only: true
           - type: entities
             show_header_toggle: false
             entities:
@@ -3048,6 +3173,28 @@ views:
                 name: Autotune Ki voorstel
               - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_boiler_power_test_start
+                name: Boiler power test starten
+              - entity: button.openquatt_boiler_power_test_abort
+                name: Boiler power test afbreken
+              - entity: button.openquatt_boiler_power_test_apply
+                name: Pas boilervermogen toe
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Nominaal ketelvermogen
+              - entity: sensor.openquatt_boiler_power_test_result
+                name: Boiler power test resultaat
+              - entity: sensor.openquatt_boiler_power_test_confidence
+                name: Boiler power test confidence
+              - entity: sensor.openquatt_boiler_power_test_status
+                name: Boiler power test status
+        visibility:
+          - condition: state
+            entity: binary_sensor.openquatt_cm100_active
+            state: 'on'
+        column_span: 2
     header:
       card:
         type: markdown
@@ -3068,7 +3215,7 @@ views:
             heading: Versie informatie
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -3126,21 +3273,33 @@ views:
             heading: Regelaarinformatie
             heading_style: title
           - type: markdown
-            content: |-
+            content: >-
               <details>
+
 
               <summary><strong>Uitleg</strong></summary>
 
+
               Basis runtime-diagnostiek van de controller:
 
+
               - `Status`: online/offline van de ESP-node.
+
               - `Uptime`: tijd sinds laatste reboot.
-              - `ESP Internal Temperature`: interne controller-temperatuur voor behuizing/thermische diagnose.
+
+              - `ESP Internal Temperature`: interne controller-temperatuur voor
+              behuizing/thermische diagnose.
+
               - `IP-adres`: huidig netwerkadres.
+
               - `Wifi-SSID`: verbonden draadloos netwerk.
+
               - `Wifi-signaal`: RSSI-signaalsterkte in dBm.
+
               - `ESPHome-versie`: versie van de ESPHome runtime.
+
               - `Herstart`: herstart de controllernode vanuit Home Assistant.
+
 
               </details>
             text_only: true
@@ -3172,7 +3331,7 @@ views:
             heading: PH-diagnose
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -3216,7 +3375,7 @@ views:
             heading: Stooklijndiagnose
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -1351,6 +1351,7 @@ views:
             columns: 1
             cards:
               - type: picture-elements
+                title: Quatt HP1
                 image: >-
                   https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
@@ -1376,295 +1377,169 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp1_outside_temperature
                     style:
-                      top: 4%
+                      top: 3%
                       left: 8%
+                      font-weight: bold
+                      color: black
+                      font-size: 0.75em
                       transform: none
-                      color: #0f172a
-                      background: rgba(255, 255, 255, 0.78)
-                      border: 1px solid rgba(255, 255, 255, 0.72)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.76em
-                      line-height: 1.2
                     prefix: 'Buiten: '
-                  - type: state-label
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_gas_discharge_temperature
                     style:
-                        top: 22%
-                        left: 60%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 22%
+                      left: 58%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 61%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #f59e0b
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 60%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_eev_steps
                     style:
-                        top: 70%
-                        left: 42%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #f59e0b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 42%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #38bdf8
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporating_temperature
                     style:
-                        top: 70%
-                        left: 25%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #2563eb
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 8%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 6%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_condenser_pressure
                     style:
-                        top: 11%
-                        left: 56%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 11%
+                      left: 55%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporator_pressure
                     style:
                       top: 11%
-                      left: 31%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 30%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_fan_speed
                     style:
-                        top: 54%
-                        left: 27%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #64748b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 53%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_compressor_frequency
                     style:
                       top: 18%
-                      left: 42%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #111827
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 40%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_water_out_temperature
                     style:
-                        top: 43%
-                        left: 88%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 43%
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_water_in_temperature
                     style:
                       top: 63%
-                      left: 88%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_flow
                     style:
-                        top: 78%
-                        left: 82%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #0f766e
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
+                      top: 76%
+                      left: 81%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
                   - type: state-label
                     entity: sensor.openquatt_hp1_working_mode_label
                     style:
                       top: 8%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Modus: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_power_input
                     style:
                       top: 11%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'PowerInput: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_heat_power
                     style:
                       top: 14%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Heat Power: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_cop
                     style:
                       top: 17%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1677,13 +1552,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_defrost
@@ -1695,12 +1565,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1712,13 +1578,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1730,12 +1591,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto
@@ -1784,6 +1641,7 @@ views:
             columns: 1
             cards:
               - type: picture-elements
+                title: Quatt HP2
                 image: >-
                   https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
@@ -1809,295 +1667,169 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp2_outside_temperature
                     style:
-                      top: 4%
+                      top: 3%
                       left: 8%
+                      font-weight: bold
+                      color: black
+                      font-size: 0.75em
                       transform: none
-                      color: #0f172a
-                      background: rgba(255, 255, 255, 0.78)
-                      border: 1px solid rgba(255, 255, 255, 0.72)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.76em
-                      line-height: 1.2
                     prefix: 'Buiten: '
-                  - type: state-label
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_gas_discharge_temperature
                     style:
-                        top: 22%
-                        left: 60%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 22%
+                      left: 58%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 61%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #f59e0b
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 60%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_eev_steps
                     style:
-                        top: 70%
-                        left: 42%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #f59e0b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 42%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #38bdf8
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_evaporating_temperature
                     style:
-                        top: 70%
-                        left: 25%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #2563eb
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 8%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 6%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_condenser_pressure
                     style:
-                        top: 11%
-                        left: 56%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 11%
+                      left: 55%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_evaporator_pressure
                     style:
                       top: 11%
-                      left: 31%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 30%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_fan_speed
                     style:
-                        top: 54%
-                        left: 27%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #64748b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 53%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_compressor_frequency
                     style:
                       top: 18%
-                      left: 42%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #111827
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 40%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_water_out_temperature
                     style:
-                        top: 43%
-                        left: 88%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 43%
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_water_in_temperature
                     style:
                       top: 63%
-                      left: 88%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp2_flow
                     style:
-                        top: 78%
-                        left: 82%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #0f766e
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
+                      top: 76%
+                      left: 81%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
                   - type: state-label
                     entity: sensor.openquatt_hp2_working_mode_label
                     style:
                       top: 8%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Modus: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_power_input
                     style:
                       top: 11%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'PowerInput: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_heat_power
                     style:
                       top: 14%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Heat Power: '
                   - type: state-label
                     entity: sensor.openquatt_hp2_cop
                     style:
                       top: 17%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -2110,13 +1842,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_defrost
@@ -2128,12 +1855,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
@@ -2145,13 +1868,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp2_bottom_plate_heater
@@ -2163,12 +1881,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -14,7 +14,7 @@ views:
             heading: Live performance
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -87,7 +87,7 @@ views:
             heading: Supervisory status
             icon: mdi:state-machine
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -139,7 +139,7 @@ views:
             heading: Controls
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -196,7 +196,7 @@ views:
             heading: Debug
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary><ha-alert
@@ -225,7 +225,7 @@ views:
             heading_style: title
             icon: mdi:home-thermometer
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -269,7 +269,7 @@ views:
             heading: Silent mode settings
             icon: mdi:volume-off
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -769,7 +769,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energy
 
           Energy overview of heat pump, boiler, and total system (daily + cumulative).
@@ -1428,6 +1428,58 @@ views:
                       font-size: 0.75em
                       transform: none
                     prefix: 'COP: '
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_defrost
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp1_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_defrost
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp1_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: grey
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto
@@ -1473,7 +1525,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:heat-pump-outline"></ha-icon> Overview HP1
 
           This tab shows a technical snapshot of HP1 refrigerant/water-side behavior. Use it mainly for diagnostics.
@@ -2108,7 +2160,7 @@ views:
             heading: Quatt Hybrid version
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>
@@ -2130,7 +2182,7 @@ views:
             heading: Silent mode settings
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2162,7 +2214,7 @@ views:
             heading: House model (PH)
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2230,7 +2282,7 @@ views:
             heading: Heating curve control
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2284,11 +2336,41 @@ views:
       - type: grid
         cards:
           - type: heading
+            icon: mdi:water-thermometer
+            heading: Water temperature limit
+            heading_style: title
+          - type: markdown
+            content: |-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Uses `Water Supply Temp (Selected)` as the measured limit source.
+
+              - **Maximum water temperature** is the normal ceiling for measured
+              supply temperature.
+
+              - OpenQuatt derives an internal rollback band and a hard trip at
+              `max + 5°C` from that setting. In `CM3` the boiler drops out
+              first; a hard HP stop follows only if the overshoot persists.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_maximum_water_temperature
+                name: Maximum water temperature
+      - type: grid
+        cards:
+          - type: heading
             icon: mdi:snowflake
             heading: Cooling settings
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2322,41 +2404,11 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:water-thermometer
-            heading: Water temperature limit
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Uses `Water Supply Temp (Selected)` as the measured limit source.
-
-              - **Maximum water temperature** is the normal ceiling for measured
-              supply temperature.
-
-              - OpenQuatt derives an internal rollback band and a hard trip at
-              `max + 5°C` from that setting. In `CM3` the boiler drops out
-              first; a hard HP stop follows only if the overshoot persists.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: number.openquatt_maximum_water_temperature
-                name: Maximum water temperature
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:heat-wave
             heading: Thermal request control
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2379,7 +2431,7 @@ views:
             heading: Flow tuning
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2405,21 +2457,25 @@ views:
             heading: Boiler control
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
 
-              - **CM3 deficit ON/OFF thresholds** define when boiler assist may
-              switch on/off.
+              - **Boiler rated power** is the reference for boiler assist and
+              the boiler power test.
+
+              - The **CM3 deficit turn-on and turn-off thresholds** define
+              when boiler assist may switch on/off.
 
               - Boiler assist is still blocked by the water temperature limit
               when measured supply temperature gets too high.
 
-              - Keep ON clearly higher than OFF to reduce toggling around the
-              threshold.
+              - Keep the turn-on threshold clearly higher than the turn-off
+              threshold to reduce toggling around the boundary.
 
-              - If behavior is too aggressive: increase ON or decrease OFF.
+              - If behavior is too aggressive: increase the turn-on threshold
+              or decrease the turn-off threshold.
 
 
               </details>
@@ -2427,10 +2483,12 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Boiler rated power
               - entity: number.openquatt_cm3_deficit_on_threshold
-                name: CM3 deficit ON threshold
+                name: CM3 deficit turn-on threshold
               - entity: number.openquatt_cm3_deficit_off_threshold
-                name: CM3 deficit OFF threshold
+                name: CM3 deficit turn-off threshold
       - type: grid
         column_span: 2
         cards:
@@ -2439,7 +2497,7 @@ views:
             heading: Excluded compressor levels
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2478,7 +2536,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:tune-vertical"></ha-icon> Tuning
 
           Structural control tuning for limits, house model, heating curve, heat
@@ -2497,7 +2555,7 @@ views:
             heading: Runtime / hours
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2535,7 +2593,7 @@ views:
             heading: CM100 commissioning
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2569,50 +2627,21 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:water-boiler
-            heading: Boiler power test
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Measures the effective boiler output at stable flow.
-
-              - Start the test only while **CM100** is already active.
-
-              - Apply the measured value only if it looks sensible.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_boiler_power_test_start
-                name: Start boiler power test
-              - entity: button.openquatt_boiler_power_test_abort
-                name: Abort boiler power test
-              - entity: button.openquatt_boiler_power_test_apply
-                name: Apply boiler power
-              - entity: number.openquatt_boiler_rated_heat_power
-                name: Boiler rated heat power
-              - entity: sensor.openquatt_boiler_power_test_result
-                name: Boiler power test result
-              - entity: sensor.openquatt_boiler_power_test_confidence
-                name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
-                name: Boiler power test status
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:tools
-            heading: Flow autotune
+            heading: CM100 - Flow autotune
             heading_style: title
+            grid_options:
+              columns: 12
+              rows: 1
+          - type: heading
+            icon: mdi:water-boiler
+            heading: CM100 - Boiler power test
+            heading_style: title
+            grid_options:
+              columns: 12
+              rows: auto
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Parameter explanation</strong></summary>
@@ -2632,6 +2661,22 @@ views:
 
               </details>
             text_only: true
+          - type: markdown
+            content: |-
+              <details>
+
+              <summary><strong>Parameter explanation</strong></summary>
+
+
+              - Measures the effective boiler output at stable flow.
+
+              - Start the test only while **CM100** is already active.
+
+              - Apply the measured value only if it looks sensible.
+
+
+              </details>
+            text_only: true
           - type: entities
             show_header_toggle: false
             entities:
@@ -2647,10 +2692,32 @@ views:
                 name: Autotune Ki suggested
               - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_boiler_power_test_start
+                name: Start boiler power test
+              - entity: button.openquatt_boiler_power_test_abort
+                name: Abort boiler power test
+              - entity: button.openquatt_boiler_power_test_apply
+                name: Apply boiler power
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Boiler rated power
+              - entity: sensor.openquatt_boiler_power_test_result
+                name: Boiler power test result
+              - entity: sensor.openquatt_boiler_power_test_confidence
+                name: Boiler power test confidence
+              - entity: sensor.openquatt_boiler_power_test_status
+                name: Boiler power test status
+        visibility:
+          - condition: state
+            entity: binary_sensor.openquatt_cm100_active
+            state: 'on'
+        column_span: 2
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:toolbox-outline"></ha-icon> Service & Test
 
           Manual service actions.
@@ -2756,7 +2823,7 @@ views:
             heading: PH diagnostics
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -2800,7 +2867,7 @@ views:
             heading: Heating Curve diagnostics
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Explanation</strong></summary>

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1243,7 +1243,6 @@ views:
             columns: 1
             cards:
               - type: picture-elements
-                title: Quatt HP1
                 image: https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
                   - type: image
@@ -1264,169 +1263,295 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp1_outside_temperature
                     style:
-                      top: 3%
+                      top: 4%
                       left: 8%
-                      font-weight: bold
-                      color: black
-                      font-size: 0.75em
                       transform: none
+                      color: #0f172a
+                      background: rgba(255, 255, 255, 0.78)
+                      border: 1px solid rgba(255, 255, 255, 0.72)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.76em
+                      line-height: 1.2
                     prefix: 'Outside: '
-                  - type: state-badge
+                  - type: state-label
                     entity: sensor.openquatt_hp1_gas_discharge_temperature
                     style:
-                      top: 22%
-                      left: 58%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 22%
+                        left: 60%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 60%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 61%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #f59e0b
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_eev_steps
                     style:
-                      top: 70%
-                      left: 42%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 42%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #f59e0b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #38bdf8
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporating_temperature
                     style:
-                      top: 70%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 25%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #2563eb
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 6%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 8%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_condenser_pressure
                     style:
-                      top: 11%
-                      left: 55%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 11%
+                        left: 56%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporator_pressure
                     style:
                       top: 11%
-                      left: 30%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 31%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_fan_speed
                     style:
-                      top: 53%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 54%
+                        left: 27%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #64748b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_compressor_frequency
                     style:
                       top: 18%
-                      left: 40%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 42%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #111827
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_water_out_temperature
                     style:
-                      top: 43%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 43%
+                        left: 88%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_water_in_temperature
                     style:
                       top: 63%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 88%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_flow
                     style:
-                      top: 76%
-                      left: 81%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
+                        top: 78%
+                        left: 82%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #0f766e
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
                   - type: state-label
                     entity: sensor.openquatt_hp1_working_mode_label
                     style:
                       top: 8%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Mode: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_power_input
                     style:
                       top: 11%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Power In: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_heat_power
                     style:
                       top: 14%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Power Out: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_cop
                     style:
                       top: 17%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1439,8 +1564,13 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_defrost
@@ -1452,8 +1582,12 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1465,8 +1599,13 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1478,8 +1617,12 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
             grid_options:
               columns: 12
               rows: auto

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1243,6 +1243,7 @@ views:
             columns: 1
             cards:
               - type: picture-elements
+                title: Quatt HP1
                 image: https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
                   - type: image
@@ -1263,295 +1264,169 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp1_outside_temperature
                     style:
-                      top: 4%
+                      top: 3%
                       left: 8%
+                      font-weight: bold
+                      color: black
+                      font-size: 0.75em
                       transform: none
-                      color: #0f172a
-                      background: rgba(255, 255, 255, 0.78)
-                      border: 1px solid rgba(255, 255, 255, 0.72)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.76em
-                      line-height: 1.2
                     prefix: 'Outside: '
-                  - type: state-label
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_gas_discharge_temperature
                     style:
-                        top: 22%
-                        left: 60%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 22%
+                      left: 58%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 61%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #f59e0b
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 60%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_eev_steps
                     style:
-                        top: 70%
-                        left: 42%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #f59e0b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 42%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #38bdf8
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporating_temperature
                     style:
-                        top: 70%
-                        left: 25%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #2563eb
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 8%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 6%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_condenser_pressure
                     style:
-                        top: 11%
-                        left: 56%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 11%
+                      left: 55%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporator_pressure
                     style:
                       top: 11%
-                      left: 31%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 30%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_fan_speed
                     style:
-                        top: 54%
-                        left: 27%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #64748b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 53%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_compressor_frequency
                     style:
                       top: 18%
-                      left: 42%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #111827
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 40%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_water_out_temperature
                     style:
-                        top: 43%
-                        left: 88%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 43%
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_water_in_temperature
                     style:
                       top: 63%
-                      left: 88%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_flow
                     style:
-                        top: 78%
-                        left: 82%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #0f766e
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
+                      top: 76%
+                      left: 81%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
                   - type: state-label
                     entity: sensor.openquatt_hp1_working_mode_label
                     style:
                       top: 8%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Mode: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_power_input
                     style:
                       top: 11%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Power In: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_heat_power
                     style:
                       top: 14%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Power Out: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_cop
                     style:
                       top: 17%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1564,13 +1439,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_defrost
@@ -1582,12 +1452,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1599,13 +1465,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1617,12 +1478,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1306,7 +1306,6 @@ views:
             columns: 1
             cards:
               - type: picture-elements
-                title: Quatt HP1
                 image: https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
                   - type: image
@@ -1327,169 +1326,295 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp1_outside_temperature
                     style:
-                      top: 3%
+                      top: 4%
                       left: 8%
-                      font-weight: bold
-                      color: black
-                      font-size: 0.75em
                       transform: none
+                      color: #0f172a
+                      background: rgba(255, 255, 255, 0.78)
+                      border: 1px solid rgba(255, 255, 255, 0.72)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.76em
+                      line-height: 1.2
                     prefix: 'Buiten: '
-                  - type: state-badge
+                  - type: state-label
                     entity: sensor.openquatt_hp1_gas_discharge_temperature
                     style:
-                      top: 22%
-                      left: 58%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 22%
+                        left: 60%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 60%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 61%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #f59e0b
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_eev_steps
                     style:
-                      top: 70%
-                      left: 42%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 42%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #f59e0b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #38bdf8
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporating_temperature
                     style:
-                      top: 70%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 70%
+                        left: 25%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #2563eb
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 6%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 8%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_condenser_pressure
                     style:
-                      top: 11%
-                      left: 55%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 11%
+                        left: 56%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_evaporator_pressure
                     style:
                       top: 11%
-                      left: 30%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 31%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_fan_speed
                     style:
-                      top: 53%
-                      left: 25%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 54%
+                        left: 27%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #64748b
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_compressor_frequency
                     style:
                       top: 18%
-                      left: 40%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 42%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #111827
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_water_out_temperature
                     style:
-                      top: 43%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                        top: 43%
+                        left: 88%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #ef4444
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_water_in_temperature
                     style:
                       top: 63%
-                      left: 92%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
-                  - type: state-badge
+                      left: 88%
+                      transform: translate(-50%, -50%)
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.82)
+                      border: 1px solid #2563eb
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.72em
+                      line-height: 1.2
+                  - type: state-label
                     entity: sensor.openquatt_hp1_flow
                     style:
-                      top: 76%
-                      left: 81%
-                      font-weight: bold
-                      color: rgba(0,0,0,0)
-                      transform: none
-                      font-size: 0.65em
+                        top: 78%
+                        left: 82%
+                        transform: translate(-50%, -50%)
+                        color: #ffffff
+                        background: rgba(15, 23, 42, 0.82)
+                        border: 1px solid #0f766e
+                        border-radius: 999px
+                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                        backdrop-filter: blur(6px)
+                        padding: 2px 7px
+                        font-weight: 800
+                        font-size: 0.72em
+                        line-height: 1.2
                   - type: state-label
                     entity: sensor.openquatt_hp1_working_mode_label
                     style:
                       top: 8%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Modus: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_power_input
                     style:
                       top: 11%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'PowerInput: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_heat_power
                     style:
                       top: 14%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'Heat Power: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_cop
                     style:
                       top: 17%
                       left: 8%
-                      font-weight: bold
-                      color: white
-                      font-size: 0.75em
                       transform: none
+                      color: #ffffff
+                      background: rgba(15, 23, 42, 0.66)
+                      border: 1px solid rgba(255, 255, 255, 0.22)
+                      border-radius: 999px
+                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
+                      backdrop-filter: blur(6px)
+                      padding: 2px 7px
+                      font-weight: 800
+                      font-size: 0.74em
+                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1502,8 +1627,13 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_defrost
@@ -1515,8 +1645,12 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1528,8 +1662,13 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
+                          transform: translate(-50%, -50%)
                           color: white
+                          background: rgba(14, 165, 233, 0.88)
+                          border-radius: 999px
+                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
+                          padding: 5px
+                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1541,8 +1680,12 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: none
-                          color: grey
+                          transform: translate(-50%, -50%)
+                          color: rgba(148, 163, 184, 0.72)
+                          background: rgba(15, 23, 42, 0.34)
+                          border-radius: 999px
+                          padding: 5px
+                          --mdc-icon-size: 18px
             grid_options:
               columns: 12
               rows: auto

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -14,7 +14,7 @@ views:
             heading: Live prestaties
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -90,7 +90,7 @@ views:
             heading: Systeemstatus
             icon: mdi:state-machine
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -143,7 +143,7 @@ views:
             heading: Bediening
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -200,7 +200,7 @@ views:
             heading: Debug
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary><ha-alert
@@ -229,7 +229,7 @@ views:
             heading_style: title
             icon: mdi:home-thermometer
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -274,7 +274,7 @@ views:
             heading: Instellingen stille modus
             icon: mdi:volume-off
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -330,7 +330,7 @@ views:
             heading: Performance (12h)
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -606,7 +606,7 @@ views:
             heading: Energietrends (7d/30d)
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -783,7 +783,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energie
 
           Energie-overzicht van Warmtepomp, boiler en totaal systeem (dag +
@@ -805,7 +805,7 @@ views:
             heading: Status
             heading_style: subtitle
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -853,7 +853,7 @@ views:
             heading: Regeling
             heading_style: subtitle
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -969,7 +969,7 @@ views:
             heading: Regelinstellingen
             heading_style: subtitle
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -1013,7 +1013,7 @@ views:
             heading: Kern KPI
             heading_style: subtitle
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -1112,7 +1112,7 @@ views:
             heading: Trends
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -1491,6 +1491,58 @@ views:
                       font-size: 0.75em
                       transform: none
                     prefix: 'COP: '
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_defrost
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp1_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_defrost
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:snowflake-melt
+                        entity: binary_sensor.openquatt_hp1_defrost
+                        style:
+                          top: 82%
+                          left: 15%
+                          transform: none
+                          color: grey
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        state: 'on'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: white
+                  - type: conditional
+                    conditions:
+                      - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        state: 'off'
+                    elements:
+                      - type: icon
+                        icon: mdi:heating-coil
+                        entity: binary_sensor.openquatt_hp1_bottom_plate_heater
+                        style:
+                          top: 82%
+                          left: 8%
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto
@@ -1536,7 +1588,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:heat-pump-outline"></ha-icon> Overzicht HP1
 
           Deze tab toont een technische momentopname van HP1 op
@@ -1770,7 +1822,7 @@ views:
                 heading: HA proxywaarden en validiteit
                 heading_style: subtitle
               - type: markdown
-                content: >-
+                content: |-
                   <details>
 
                   <summary><strong>Uitleg</strong></summary>
@@ -2166,7 +2218,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensorconfiguratie
 
 
@@ -2189,7 +2241,7 @@ views:
             heading: Quatt Hybrid-versie
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>
@@ -2211,7 +2263,7 @@ views:
             heading: Instellingen stille modus
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2244,7 +2296,7 @@ views:
             heading: Huismodel (PH)
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2313,7 +2365,7 @@ views:
             heading: Stooklijnregeling
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2368,11 +2420,42 @@ views:
       - type: grid
         cards:
           - type: heading
+            icon: mdi:water-thermometer
+            heading: Watertempbegrenzing
+            heading_style: title
+          - type: markdown
+            content: |-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Gebruikt `Water Supply Temp (Selected)` als gemeten begrenzingsbron.
+
+              - **Maximum water temperature** is het normale plafond voor de
+              gemeten aanvoertemperatuur.
+
+              - OpenQuatt leidt uit die instelling intern zelf een
+              terugregelband en een harde trip op `max + 5°C` af. In `CM3`
+              valt eerst de boiler weg; alleen bij aanhoudende overshoot volgt
+              daarna een harde HP-stop.
+
+
+              </details>
+            text_only: true
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: number.openquatt_maximum_water_temperature
+                name: Maximum water temperature
+      - type: grid
+        cards:
+          - type: heading
             icon: mdi:snowflake
             heading: Koelingsinstellingen
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2406,42 +2489,11 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:water-thermometer
-            heading: Watertempbegrenzing
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Gebruikt `Water Supply Temp (Selected)` als gemeten begrenzingsbron.
-
-              - **Maximum water temperature** is het normale plafond voor de
-              gemeten aanvoertemperatuur.
-
-              - OpenQuatt leidt uit die instelling intern zelf een
-              terugregelband en een harde trip op `max + 5°C` af. In `CM3`
-              valt eerst de boiler weg; alleen bij aanhoudende overshoot volgt
-              daarna een harde HP-stop.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: number.openquatt_maximum_water_temperature
-                name: Maximum water temperature
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:heat-wave
             heading: Thermal request control
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2469,7 +2521,7 @@ views:
             heading: Flow afstellen
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2495,21 +2547,25 @@ views:
             heading: Ketelregeling
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
 
-              - **CM3 deficit ON/OFF thresholds** bepalen wanneer boiler-assist
-              mag inschakelen/uitschakelen.
+              - **Nominaal ketelvermogen** is de referentie voor
+              boiler-assist en de boiler power test.
+
+              - De **CM3-tekort inschakel- en uitschakeldrempels** bepalen
+              wanneer boiler-assist mag inschakelen/uitschakelen.
 
               - Boiler-assist wordt daarnaast geblokkeerd door de
               watertempbegrenzing als de gemeten aanvoer te hoog wordt.
 
-              - Houd ON duidelijk hoger dan OFF om schakelen rond de grens te
-              beperken.
+              - Houd de inschakeldrempel duidelijk hoger dan de
+              uitschakeldrempel om schakelen rond de grens te beperken.
 
-              - Bij te agressief gedrag: ON verhogen of OFF verlagen.
+              - Bij te agressief gedrag: inschakeldrempel verhogen of
+              uitschakeldrempel verlagen.
 
 
               </details>
@@ -2517,10 +2573,12 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Nominaal ketelvermogen
               - entity: number.openquatt_cm3_deficit_on_threshold
-                name: CM3 deficit ON threshold
+                name: CM3-tekort inschakeldrempel
               - entity: number.openquatt_cm3_deficit_off_threshold
-                name: CM3 deficit OFF threshold
+                name: CM3-tekort uitschakeldrempel
       - type: grid
         column_span: 2
         cards:
@@ -2529,7 +2587,7 @@ views:
             heading: Uitgesloten compressorlevels
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2568,7 +2626,7 @@ views:
     header:
       card:
         type: markdown
-        content: >-
+        content: |-
           # <ha-icon icon="mdi:tune-vertical"></ha-icon> Instellingen
 
           Structurele regelinstellingen voor limieten, huismodel, stooklijn,
@@ -2587,7 +2645,7 @@ views:
             heading: Runtime / draaiuren
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2626,7 +2684,7 @@ views:
             heading: CM100 commissioning
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2660,50 +2718,21 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:water-boiler
-            heading: Boiler power test
-            heading_style: title
-          - type: markdown
-            content: >-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Meet het effectieve ketelvermogen bij stabiele flow.
-
-              - Start de test alleen terwijl **CM100** al actief is.
-
-              - Pas de gemeten waarde toe als die logisch oogt.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_boiler_power_test_start
-                name: Boiler power test starten
-              - entity: button.openquatt_boiler_power_test_abort
-                name: Boiler power test afbreken
-              - entity: button.openquatt_boiler_power_test_apply
-                name: Pas boilervermogen toe
-              - entity: number.openquatt_boiler_rated_heat_power
-                name: Boiler rated heat power
-              - entity: sensor.openquatt_boiler_power_test_result
-                name: Boiler power test resultaat
-              - entity: sensor.openquatt_boiler_power_test_confidence
-                name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
-                name: Boiler power test status
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:tools
-            heading: Flow autotune
+            heading: CM100 - Flow autotune
             heading_style: title
+            grid_options:
+              columns: 12
+              rows: 1
+          - type: heading
+            icon: mdi:water-boiler
+            heading: CM100 - Boiler power test
+            heading_style: title
+            grid_options:
+              columns: 12
+              rows: auto
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg parameters</strong></summary>
@@ -2723,6 +2752,22 @@ views:
 
               </details>
             text_only: true
+          - type: markdown
+            content: |-
+              <details>
+
+              <summary><strong>Uitleg parameters</strong></summary>
+
+
+              - Meet het effectieve ketelvermogen bij stabiele flow.
+
+              - Start de test alleen terwijl **CM100** al actief is.
+
+              - Pas de gemeten waarde toe als die logisch oogt.
+
+
+              </details>
+            text_only: true
           - type: entities
             show_header_toggle: false
             entities:
@@ -2738,6 +2783,28 @@ views:
                 name: Autotune Ki voorstel
               - entity: sensor.openquatt_flow_autotune_status
                 name: Autotune status
+          - type: entities
+            show_header_toggle: false
+            entities:
+              - entity: button.openquatt_boiler_power_test_start
+                name: Boiler power test starten
+              - entity: button.openquatt_boiler_power_test_abort
+                name: Boiler power test afbreken
+              - entity: button.openquatt_boiler_power_test_apply
+                name: Pas boilervermogen toe
+              - entity: number.openquatt_boiler_rated_heat_power
+                name: Nominaal ketelvermogen
+              - entity: sensor.openquatt_boiler_power_test_result
+                name: Boiler power test resultaat
+              - entity: sensor.openquatt_boiler_power_test_confidence
+                name: Boiler power test confidence
+              - entity: sensor.openquatt_boiler_power_test_status
+                name: Boiler power test status
+        visibility:
+          - condition: state
+            entity: binary_sensor.openquatt_cm100_active
+            state: 'on'
+        column_span: 2
     header:
       card:
         type: markdown
@@ -2846,7 +2913,7 @@ views:
             heading: PH-diagnose
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
 
@@ -2890,7 +2957,7 @@ views:
             heading: Stooklijndiagnose
             heading_style: title
           - type: markdown
-            content: >-
+            content: |-
               <details>
 
               <summary><strong>Uitleg</strong></summary>

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1306,6 +1306,7 @@ views:
             columns: 1
             cards:
               - type: picture-elements
+                title: Quatt HP1
                 image: https://raw.githubusercontent.com/jeroen85/OpenQuatt/refs/heads/main/docs/dashboard/heatpump/Quatt.png
                 elements:
                   - type: image
@@ -1326,295 +1327,169 @@ views:
                   - type: state-label
                     entity: sensor.openquatt_hp1_outside_temperature
                     style:
-                      top: 4%
+                      top: 3%
                       left: 8%
+                      font-weight: bold
+                      color: black
+                      font-size: 0.75em
                       transform: none
-                      color: #0f172a
-                      background: rgba(255, 255, 255, 0.78)
-                      border: 1px solid rgba(255, 255, 255, 0.72)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.76em
-                      line-height: 1.2
                     prefix: 'Buiten: '
-                  - type: state-label
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_gas_discharge_temperature
                     style:
-                        top: 22%
-                        left: 60%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 22%
+                      left: 58%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_inner_coil_temperature
                     style:
                       top: 70%
-                      left: 61%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #f59e0b
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 60%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_eev_steps
                     style:
-                        top: 70%
-                        left: 42%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #f59e0b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 42%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_gas_return_temperature
                     style:
                       top: 22%
                       left: 26%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #38bdf8
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporating_temperature
                     style:
-                        top: 70%
-                        left: 25%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #2563eb
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 70%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporator_coil_temperature
                     style:
                       top: 58%
-                      left: 8%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 6%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_condenser_pressure
                     style:
-                        top: 11%
-                        left: 56%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 11%
+                      left: 55%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_evaporator_pressure
                     style:
                       top: 11%
-                      left: 31%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 30%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_fan_speed
                     style:
-                        top: 54%
-                        left: 27%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #64748b
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 53%
+                      left: 25%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_compressor_frequency
                     style:
                       top: 18%
-                      left: 42%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #111827
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 40%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_water_out_temperature
                     style:
-                        top: 43%
-                        left: 88%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #ef4444
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
-                  - type: state-label
+                      top: 43%
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_water_in_temperature
                     style:
                       top: 63%
-                      left: 88%
-                      transform: translate(-50%, -50%)
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.82)
-                      border: 1px solid #2563eb
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.72em
-                      line-height: 1.2
-                  - type: state-label
+                      left: 92%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
+                  - type: state-badge
                     entity: sensor.openquatt_hp1_flow
                     style:
-                        top: 78%
-                        left: 82%
-                        transform: translate(-50%, -50%)
-                        color: #ffffff
-                        background: rgba(15, 23, 42, 0.82)
-                        border: 1px solid #0f766e
-                        border-radius: 999px
-                        box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                        backdrop-filter: blur(6px)
-                        padding: 2px 7px
-                        font-weight: 800
-                        font-size: 0.72em
-                        line-height: 1.2
+                      top: 76%
+                      left: 81%
+                      font-weight: bold
+                      color: rgba(0,0,0,0)
+                      transform: none
+                      font-size: 0.65em
                   - type: state-label
                     entity: sensor.openquatt_hp1_working_mode_label
                     style:
                       top: 8%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Modus: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_power_input
                     style:
                       top: 11%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'PowerInput: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_heat_power
                     style:
                       top: 14%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'Heat Power: '
                   - type: state-label
                     entity: sensor.openquatt_hp1_cop
                     style:
                       top: 17%
                       left: 8%
+                      font-weight: bold
+                      color: white
+                      font-size: 0.75em
                       transform: none
-                      color: #ffffff
-                      background: rgba(15, 23, 42, 0.66)
-                      border: 1px solid rgba(255, 255, 255, 0.22)
-                      border-radius: 999px
-                      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.28)
-                      backdrop-filter: blur(6px)
-                      padding: 2px 7px
-                      font-weight: 800
-                      font-size: 0.74em
-                      line-height: 1.2
                     prefix: 'COP: '
                   - type: conditional
                     conditions:
@@ -1627,13 +1502,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_defrost
@@ -1645,12 +1515,8 @@ views:
                         style:
                           top: 82%
                           left: 15%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1662,13 +1528,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
+                          transform: none
                           color: white
-                          background: rgba(14, 165, 233, 0.88)
-                          border-radius: 999px
-                          box-shadow: 0 0 18px rgba(14, 165, 233, 0.65)
-                          padding: 5px
-                          --mdc-icon-size: 18px
                   - type: conditional
                     conditions:
                       - entity: binary_sensor.openquatt_hp1_bottom_plate_heater
@@ -1680,12 +1541,8 @@ views:
                         style:
                           top: 82%
                           left: 8%
-                          transform: translate(-50%, -50%)
-                          color: rgba(148, 163, 184, 0.72)
-                          background: rgba(15, 23, 42, 0.34)
-                          border-radius: 999px
-                          padding: 5px
-                          --mdc-icon-size: 18px
+                          transform: none
+                          color: grey
             grid_options:
               columns: 12
               rows: auto


### PR DESCRIPTION
Broaden the OpenQuatt HA dashboard updates across the NL and EN single/duo dashboards.

Changes:
- add Boiler rated power to Boiler control / Ketelregeling while keeping it in Boiler power test
- rename the CM3 deficit threshold labels in the NL dashboards and update the explanation text
- normalize markdown explanation blocks so lists render correctly
- align the Settings / Instellingen section order across all four dashboards
- apply the CM100 active conditional layout consistently to the other dashboards
- add defrost and bottom plate heater status icons to the HP overview picture-elements

Validation:
- YAML parse check passed for all four dashboard files.