### PR TITLE
Apply API security changes on restart

### DIFF
--- a/components/openquatt_web_auth/OpenQuattWebAuth.cpp
+++ b/components/openquatt_web_auth/OpenQuattWebAuth.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "esp_random.h"
+#include "esphome/core/application.h"
 #include "esphome/components/api/api_server.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -397,7 +398,7 @@ bool OpenQuattWebAuth::set_api_security_enabled(bool enabled) {
   if (!this->save_api_security_storage_(storage)) {
     return false;
   }
-  if (!this->apply_api_security_storage_(storage, enabled ? "runtime-enabled" : "runtime-disabled")) {
+  if (!this->apply_api_security_storage_(storage, enabled ? "runtime-enabled" : "runtime-disabled", false)) {
     return false;
   }
   this->api_security_ready_ = true;
@@ -417,7 +418,7 @@ bool OpenQuattWebAuth::rotate_api_security_key() {
   if (!this->save_api_security_storage_(storage)) {
     return false;
   }
-  if (!this->apply_api_security_storage_(storage, "runtime-rotated")) {
+  if (!this->apply_api_security_storage_(storage, "runtime-rotated", false)) {
     return false;
   }
   this->api_security_ready_ = true;
@@ -468,7 +469,8 @@ bool OpenQuattWebAuth::save_api_security_storage_(const ApiSecurityStorage &stor
   return true;
 }
 
-bool OpenQuattWebAuth::apply_api_security_storage_(const ApiSecurityStorage &storage, const char *source) {
+bool OpenQuattWebAuth::apply_api_security_storage_(const ApiSecurityStorage &storage, const char *source,
+                                                   bool apply_transport) {
   if (api::global_api_server == nullptr) {
     return false;
   }
@@ -480,28 +482,31 @@ bool OpenQuattWebAuth::apply_api_security_storage_(const ApiSecurityStorage &sto
   bool transport_active = false;
 #ifdef USE_API_NOISE
   transport_active = api::global_api_server->get_noise_ctx().has_psk();
-  if (enabled) {
-    if (!key_present) {
-      return false;
-    }
-    const bool key_matches = transport_active && std::equal(storage.key.begin(), storage.key.end(),
-                                                             api::global_api_server->get_noise_ctx().get_psk().begin());
-    if (!key_matches) {
-      if (!api::global_api_server->save_noise_psk(storage.key, true)) {
-        ESP_LOGE(TAG, "Failed to activate API encryption");
+  if (apply_transport) {
+    if (enabled) {
+      if (!key_present) {
         return false;
       }
-      transport_active = true;
+      const bool key_matches = transport_active &&
+                               std::equal(storage.key.begin(), storage.key.end(),
+                                          api::global_api_server->get_noise_ctx().get_psk().begin());
+      if (!key_matches) {
+        if (!api::global_api_server->save_noise_psk(storage.key, true)) {
+          ESP_LOGE(TAG, "Failed to activate API encryption");
+          return false;
+        }
+        transport_active = true;
+      }
+    } else if (transport_active) {
+      if (!api::global_api_server->clear_noise_psk(true)) {
+        ESP_LOGE(TAG, "Failed to clear API encryption");
+        return false;
+      }
+      transport_active = false;
     }
-  } else if (transport_active) {
-    if (!api::global_api_server->clear_noise_psk(true)) {
-      ESP_LOGE(TAG, "Failed to clear API encryption");
-      return false;
-    }
-    transport_active = false;
   }
 #else
-  if (enabled) {
+  if (apply_transport && enabled) {
     return false;
   }
 #endif

--- a/components/openquatt_web_auth/OpenQuattWebAuth.cpp
+++ b/components/openquatt_web_auth/OpenQuattWebAuth.cpp
@@ -199,9 +199,10 @@ class OpenQuattWebAuthRequestHandler : public AsyncWebHandler {
 
     if (url == "/api-security/status" && request->method() == HTTP_GET) {
       auto *stream = request->beginResponseStream("application/json");
-      stream->printf(R"({"enabled":%s,"transport_active":%s,"key":"%s","source":"%s","csrf_token":"%s"})",
+      stream->printf(R"({"enabled":%s,"transport_active":%s,"pending_restart":%s,"key":"%s","source":"%s","csrf_token":"%s"})",
                      this->parent_->is_api_security_enabled() ? "true" : "false",
                      this->parent_->is_api_security_transport_active() ? "true" : "false",
+                     this->parent_->is_api_security_restart_pending() ? "true" : "false",
                      this->parent_->get_api_security_key().c_str(),
                      this->parent_->get_api_security_source().c_str(),
                      this->parent_->get_csrf_token().c_str());
@@ -316,6 +317,9 @@ void OpenQuattWebAuth::loop() {
 #ifdef USE_API_NOISE
   if (api::global_api_server != nullptr) {
     this->api_security_transport_active_ = api::global_api_server->get_noise_ctx().has_psk();
+    if (!this->api_security_restart_pending_ && this->api_security_enabled_ == this->api_security_transport_active_) {
+      this->api_security_restart_pending_ = false;
+    }
   }
 #endif
   if (this->restore_suspended_auth_if_needed_()) {
@@ -401,6 +405,7 @@ bool OpenQuattWebAuth::set_api_security_enabled(bool enabled) {
   if (!this->apply_api_security_storage_(storage, enabled ? "runtime-enabled" : "runtime-disabled", false)) {
     return false;
   }
+  this->api_security_restart_pending_ = true;
   this->api_security_ready_ = true;
   return true;
 }
@@ -421,6 +426,7 @@ bool OpenQuattWebAuth::rotate_api_security_key() {
   if (!this->apply_api_security_storage_(storage, "runtime-rotated", false)) {
     return false;
   }
+  this->api_security_restart_pending_ = true;
   this->api_security_ready_ = true;
   return true;
 }
@@ -516,6 +522,7 @@ bool OpenQuattWebAuth::apply_api_security_storage_(const ApiSecurityStorage &sto
   this->api_security_enabled_ = enabled;
   this->api_security_source_ = source != nullptr ? source : "";
   this->api_security_transport_active_ = transport_active;
+  this->api_security_restart_pending_ = !apply_transport;
 
   return true;
 }

--- a/components/openquatt_web_auth/OpenQuattWebAuth.h
+++ b/components/openquatt_web_auth/OpenQuattWebAuth.h
@@ -68,7 +68,7 @@ class OpenQuattWebAuth : public Component {
   bool is_valid_storage_(const AuthStorage &storage) const;
   bool load_api_security_storage_(ApiSecurityStorage *storage);
   bool save_api_security_storage_(const ApiSecurityStorage &storage);
-  bool apply_api_security_storage_(const ApiSecurityStorage &storage, const char *source);
+  bool apply_api_security_storage_(const ApiSecurityStorage &storage, const char *source, bool apply_transport = true);
   bool build_api_security_storage_(bool enabled, const std::string &key, ApiSecurityStorage *storage);
   bool is_valid_api_security_storage_(const ApiSecurityStorage &storage) const;
   static std::string encode_api_security_key_(const std::array<uint8_t, 32> &key);

--- a/components/openquatt_web_auth/OpenQuattWebAuth.h
+++ b/components/openquatt_web_auth/OpenQuattWebAuth.h
@@ -37,6 +37,7 @@ class OpenQuattWebAuth : public Component {
   const std::string &get_api_security_key() const { return this->api_security_key_; }
   const std::string &get_api_security_source() const { return this->api_security_source_; }
   bool is_api_security_transport_active() const;
+  bool is_api_security_restart_pending() const { return this->api_security_restart_pending_; }
 
  protected:
   static constexpr uint32_t STORAGE_MAGIC = 0x4F514157;
@@ -93,6 +94,7 @@ class OpenQuattWebAuth : public Component {
   bool api_security_enabled_{false};
   bool api_security_key_present_{false};
   bool api_security_transport_active_{false};
+  bool api_security_restart_pending_{false};
   ESPPreferenceObject pref_;
   ESPPreferenceObject api_security_pref_;
   bool handlers_registered_{false};

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -35,7 +35,7 @@
     <script>
       window.__OQ_DEV_LOAD_DELAY_MS = 2000;
     </script>
-    <script src="./js/mock-device.js?v=fast-view-7"></script>
-    <script src="./js/openquatt-app.js?v=fast-view-7"></script>
+    <script src="./js/mock-device.js?v=api-security-reboot-2"></script>
+    <script src="./js/openquatt-app.js?v=api-security-reboot-2"></script>
   </body>
 </html>

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -22,6 +22,7 @@
     apiSecurity: {
       enabled: false,
       transportActive: false,
+      pendingRestart: false,
       key: "",
       source: "bootstrap-disabled",
       csrfToken: "",
@@ -294,6 +295,7 @@
     return {
       enabled: Boolean(state.apiSecurity.enabled),
       transport_active: Boolean(state.apiSecurity.transportActive),
+      pending_restart: Boolean(state.apiSecurity.pendingRestart),
       key: String(state.apiSecurity.key || ""),
       source: String(state.apiSecurity.source || ""),
       csrf_token: String(state.apiSecurity.csrfToken || ""),
@@ -315,7 +317,7 @@
       state.apiSecurity.key = generateApiKey();
     }
     state.apiSecurity.enabled = true;
-    state.apiSecurity.transportActive = true;
+    state.apiSecurity.pendingRestart = true;
     state.apiSecurity.source = "runtime-enabled";
     refreshApiSecurityToken();
     return makeAuthResponse(200, {
@@ -333,7 +335,7 @@
 
     state.apiSecurity.key = generateApiKey();
     state.apiSecurity.enabled = true;
-    state.apiSecurity.transportActive = true;
+    state.apiSecurity.pendingRestart = true;
     state.apiSecurity.source = "runtime-rotated";
     refreshApiSecurityToken();
     return makeAuthResponse(200, {
@@ -350,7 +352,7 @@
     }
 
     state.apiSecurity.enabled = false;
-    state.apiSecurity.transportActive = false;
+    state.apiSecurity.pendingRestart = true;
     state.apiSecurity.source = "runtime-disabled";
     refreshApiSecurityToken();
     return makeAuthResponse(200, {
@@ -475,6 +477,7 @@
     syncDevMeta();
     setEntity("text_sensor", "Summary", { state: "" });
     setEntity("button", "Check Firmware Updates", { state: "" });
+    setEntity("button", "Restart", { state: "" });
     setEntity("text_sensor", "OpenQuatt Version", { state: "v0.26.0", value: "v0.26.0" });
     setEntity("text_sensor", "OpenQuatt Release Channel", { state: "dev", value: "dev" });
     setEntity("sensor", "Uptime", { value: 0, uom: "h" });
@@ -1472,6 +1475,10 @@
       state.trendFlashNewestAt = Date.now() - (2 * 60 * 1000);
       state.trendFlashWrites += 1;
       state.trendFlashStoredKiB = Math.min(360, Number((state.trendFlashStoredKiB + 0.5).toFixed(1)));
+    } else if (name === "Restart") {
+      state.apiSecurity.transportActive = Boolean(state.apiSecurity.enabled);
+      state.apiSecurity.pendingRestart = false;
+      state.apiSecurity.source = state.apiSecurity.enabled ? "stored" : "bootstrap-disabled";
     }
     updateSummary();
     notifyMockUpdated();

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -2487,7 +2487,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     if (!status) {
       return "We halen de huidige API-beveiliging op.";
     }
-    if (status.enabled !== status.transport_active) {
+    if (status.pending_restart) {
       return "Deze wijziging wordt actief na herstart. Je kunt de sleutel hier bekijken, kopiëren of vernieuwen.";
     }
     if (status.transport_active === true) {
@@ -2504,7 +2504,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     if (!status) {
       return "Laden...";
     }
-    return status.enabled ? "Uitschakelen en herstarten" : status.key ? "Inschakelen en herstarten" : "Genereer en herstart";
+    return status.enabled ? "Uitschakelen" : "Inschakelen";
   }
 
   function getApiSecurityRotateLabel() {
@@ -2534,6 +2534,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     const status = state.apiSecurityStatus || {};
     const enabled = status.enabled === true;
     const hasKey = Boolean(status.key);
+    const restartPending = Boolean(status.pending_restart);
     const modalNotice = state.apiSecurityNotice;
     const errorMarkup = state.apiSecurityError
       ? `<div class="oq-helper-modal-note oq-helper-modal-note--error" aria-live="assertive">${escapeHtml(state.apiSecurityError)}</div>`
@@ -2568,17 +2569,19 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
                 ${escapeHtml(getApiSecurityToggleLabel())}
               </button>
             </div>
-              <div class="oq-settings-api-security-key">
+            <div class="oq-settings-api-security-key">
               <div class="oq-settings-field-head">
                 <h3>API-sleutel</h3>
               </div>
-              <p class="oq-settings-action-note">${escapeHtml(status.enabled === status.transport_active
+              <p class="oq-settings-action-note">${escapeHtml(restartPending
                 ? (hasKey
-                    ? "Gebruik deze sleutel in Home Assistant voor de ESPHome-integratie."
+                    ? "Deze sleutel is opgeslagen. Kopieer hem nu en kies daarna Opslaan en herstarten."
                     : "Inschakelen maakt direct een nieuwe sleutel aan. Deze wijziging wordt actief na herstart.")
-                : (status.enabled
-                    ? "De sleutel is opgeslagen. OpenQuatt start opnieuw op om API-encryptie in te schakelen."
-                    : "De sleutel blijft opgeslagen. OpenQuatt start opnieuw op om API-encryptie uit te schakelen."))}</p>
+                : (status.transport_active
+                    ? "Gebruik deze sleutel in Home Assistant voor de ESPHome-integratie."
+                    : status.key
+                      ? "De sleutel blijft opgeslagen, maar de native API staat nu open op je lokale netwerk."
+                      : "Er is nog geen API-sleutel opgeslagen."))}</p>
               ${hasKey ? `<div class="oq-settings-api-security-key-row"><div class="oq-settings-api-security-key-value">${escapeHtml(status.key)}</div></div>` : ""}
               ${hasKey
                 ? `
@@ -2605,6 +2608,16 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
             </div>
           </div>
           <div class="oq-helper-modal-actions">
+            ${restartPending ? `
+              <button
+                class="oq-helper-button oq-helper-button--primary"
+                type="button"
+                data-oq-action="restart-api-security"
+                ${state.apiSecurityBusy ? "disabled" : ""}
+              >
+                Opslaan en herstarten
+              </button>
+            ` : ""}
             <button class="oq-helper-button oq-helper-button--ghost" type="button" data-oq-action="close-system-modal" ${state.apiSecurityBusy ? "disabled" : ""}>Gereed</button>
           </div>
         </section>
@@ -4072,6 +4085,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     return [
       status.enabled ? "on" : "off",
       status.transport_active ? "active" : "idle",
+      status.pending_restart ? "pending" : "settled",
       String(status.key || ""),
       String(status.source || ""),
       String(status.csrf_token || ""),
@@ -4170,6 +4184,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       const nextStatus = {
         enabled: Boolean(payload.enabled),
         transport_active: Boolean(payload.transport_active),
+        pending_restart: Boolean(payload.pending_restart),
         key: String(payload.key || ""),
         source: String(payload.source || ""),
         csrf_token: String(payload.csrf_token || ""),
@@ -4332,9 +4347,10 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      state.apiSecurityNotice = "API-beveiliging is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
+      await refreshApiSecurityStatus();
+      state.apiSecurityNotice = "API-beveiliging is opgeslagen. Kopieer de sleutel en kies daarna Opslaan en herstarten.";
+      state.apiSecurityError = "";
       render();
-      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Inschakelen is mislukt. ${error.message}`;
       render();
@@ -4370,9 +4386,10 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      state.apiSecurityNotice = "API-sleutel is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
+      await refreshApiSecurityStatus();
+      state.apiSecurityNotice = "API-sleutel is opgeslagen. Kopieer de nieuwe sleutel en kies daarna Opslaan en herstarten.";
+      state.apiSecurityError = "";
       render();
-      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Roteren is mislukt. ${error.message}`;
       render();
@@ -4414,9 +4431,10 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      state.apiSecurityNotice = "API-beveiliging is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
+      await refreshApiSecurityStatus();
+      state.apiSecurityNotice = "API-beveiliging is opgeslagen. Kies daarna Opslaan en herstarten om dit toe te passen.";
+      state.apiSecurityError = "";
       render();
-      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Uitzetten is mislukt. ${error.message}`;
       render();
@@ -5857,6 +5875,11 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
 
     if (action === "disable-api-security") {
       void commitDisableApiSecurity();
+      return;
+    }
+
+    if (action === "restart-api-security") {
+      void restartForApiSecurityChange();
       return;
     }
 
@@ -9464,7 +9487,7 @@ function renderWebServerLogsModal() {
     if (!status) {
       return "Laden...";
     }
-    if (status.enabled !== status.transport_active) {
+    if (status.pending_restart) {
       return "Herstart nodig";
     }
     if (status.transport_active === true) {
@@ -9481,7 +9504,7 @@ function renderWebServerLogsModal() {
     if (!status) {
       return "API-encryptie wordt geladen.";
     }
-    if (status.enabled !== status.transport_active) {
+    if (status.pending_restart) {
       return status.key
         ? "Deze wijziging wordt actief na herstart. De sleutel blijft opgeslagen voor later gebruik."
         : "Deze wijziging wordt actief na herstart.";
@@ -9501,9 +9524,9 @@ function renderWebServerLogsModal() {
       return "Laden...";
     }
     if (status.enabled) {
-      return "Uitschakelen en herstarten";
+      return "Uitschakelen";
     }
-    return status.key ? "Inschakelen en herstarten" : "Genereer en herstart";
+    return "Inschakelen";
   }
 
   function renderSettingsBackupSection() {

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -2487,16 +2487,16 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     if (!status) {
       return "We halen de huidige API-beveiliging op.";
     }
-    if (status.transport_active === true) {
-      return "De native API is beveiligd. Je kunt de sleutel hier bekijken, kopiëren of roteren.";
+    if (status.enabled !== status.transport_active) {
+      return "Deze wijziging wordt actief na herstart. Je kunt de sleutel hier bekijken, kopiëren of vernieuwen.";
     }
-    if (status.enabled) {
-      return "API-encryptie wordt net aangepast. Geef het apparaat even de tijd om de status bij te werken.";
+    if (status.transport_active === true) {
+      return "De native API is beveiligd. Je kunt de sleutel hier bekijken, kopiëren of vernieuwen.";
     }
     if (status.key) {
       return "De sleutel blijft opgeslagen, ook wanneer encryptie uit staat. Je kunt hem hier meteen kopiëren of opnieuw inschakelen.";
     }
-    return "Er is nog geen API-sleutel opgeslagen. Inschakelen maakt direct een nieuwe sleutel aan.";
+    return "Er is nog geen API-sleutel opgeslagen. Deze wijziging wordt actief na herstart.";
   }
 
   function getApiSecurityToggleLabel() {
@@ -2504,7 +2504,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     if (!status) {
       return "Laden...";
     }
-    return status.enabled ? "Uitschakelen" : status.key ? "Inschakelen" : "Genereer en schakel in";
+    return status.enabled ? "Uitschakelen en herstarten" : status.key ? "Inschakelen en herstarten" : "Genereer en herstart";
   }
 
   function getApiSecurityRotateLabel() {
@@ -2512,7 +2512,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     if (!status) {
       return "Laden...";
     }
-    return status.key ? "Roteer sleutel" : "Genereer sleutel";
+    return status.key ? "Vernieuw sleutel" : "Genereer sleutel";
   }
 
   function renderLoginStatusRow(label, value, copy = "", loading = false) {
@@ -2568,11 +2568,17 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
                 ${escapeHtml(getApiSecurityToggleLabel())}
               </button>
             </div>
-            <div class="oq-settings-api-security-key">
+              <div class="oq-settings-api-security-key">
               <div class="oq-settings-field-head">
                 <h3>API-sleutel</h3>
               </div>
-              <p class="oq-settings-action-note">${escapeHtml(hasKey ? "Gebruik deze sleutel in Home Assistant voor de ESPHome-integratie." : "Inschakelen maakt direct een nieuwe sleutel aan.")}</p>
+              <p class="oq-settings-action-note">${escapeHtml(status.enabled === status.transport_active
+                ? (hasKey
+                    ? "Gebruik deze sleutel in Home Assistant voor de ESPHome-integratie."
+                    : "Inschakelen maakt direct een nieuwe sleutel aan. Deze wijziging wordt actief na herstart.")
+                : (status.enabled
+                    ? "De sleutel is opgeslagen. OpenQuatt start opnieuw op om API-encryptie in te schakelen."
+                    : "De sleutel blijft opgeslagen. OpenQuatt start opnieuw op om API-encryptie uit te schakelen."))}</p>
               ${hasKey ? `<div class="oq-settings-api-security-key-row"><div class="oq-settings-api-security-key-value">${escapeHtml(status.key)}</div></div>` : ""}
               ${hasKey
                 ? `
@@ -4292,6 +4298,14 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
     return success;
   }
 
+  async function restartForApiSecurityChange() {
+    await triggerNamedButton("restartAction", {
+      successNotice: "OpenQuatt wordt opnieuw opgestart om de API-beveiliging toe te passen.",
+      errorPrefix: "Herstart mislukt",
+      reconnectMode: "restart",
+    });
+  }
+
   async function commitEnableApiSecurity() {
     const status = state.apiSecurityStatus || {};
     if (!status.csrf_token) {
@@ -4318,9 +4332,9 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      await refreshApiSecurityStatus();
-      state.apiSecurityNotice = "API-encryptie staat nu aan.";
+      state.apiSecurityNotice = "API-beveiliging is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
       render();
+      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Inschakelen is mislukt. ${error.message}`;
       render();
@@ -4356,9 +4370,9 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      await refreshApiSecurityStatus();
-      state.apiSecurityNotice = "API-sleutel is vernieuwd.";
+      state.apiSecurityNotice = "API-sleutel is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
       render();
+      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Roteren is mislukt. ${error.message}`;
       render();
@@ -4400,9 +4414,9 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      await refreshApiSecurityStatus();
-      state.apiSecurityNotice = "API-encryptie staat nu uit.";
+      state.apiSecurityNotice = "API-beveiliging is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
       render();
+      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Uitzetten is mislukt. ${error.message}`;
       render();
@@ -9378,7 +9392,7 @@ function renderWebServerLogsModal() {
     return renderSettingsSection(
       "Toegang",
       "Toegang & Beveiliging",
-      "Pas hier de web-login of de ESPHome API-sleutel aan.",
+      "Pas hier de web-login of de ESPHome API-sleutel aan. Deze wijziging wordt actief na herstart.",
       `
         <div class="oq-settings-access-security-shell">
           <div class="oq-settings-quickstart-status" data-oq-access-security-item="login">
@@ -9450,6 +9464,9 @@ function renderWebServerLogsModal() {
     if (!status) {
       return "Laden...";
     }
+    if (status.enabled !== status.transport_active) {
+      return "Herstart nodig";
+    }
     if (status.transport_active === true) {
       return "Aan";
     }
@@ -9464,11 +9481,13 @@ function renderWebServerLogsModal() {
     if (!status) {
       return "API-encryptie wordt geladen.";
     }
+    if (status.enabled !== status.transport_active) {
+      return status.key
+        ? "Deze wijziging wordt actief na herstart. De sleutel blijft opgeslagen voor later gebruik."
+        : "Deze wijziging wordt actief na herstart.";
+    }
     if (status.transport_active === true) {
       return "API-encryptie staat aan. Gebruik dezelfde sleutel in Home Assistant.";
-    }
-    if (status.enabled) {
-      return "API-encryptie wordt net aangepast. Wacht even tot de status is bijgewerkt.";
     }
     if (status.key) {
       return "De sleutel blijft opgeslagen, maar de native API staat nu open op je lokale netwerk.";
@@ -9482,9 +9501,9 @@ function renderWebServerLogsModal() {
       return "Laden...";
     }
     if (status.enabled) {
-      return "Uitschakelen";
+      return "Uitschakelen en herstarten";
     }
-    return status.key ? "Inschakelen" : "Genereer en schakel in";
+    return status.key ? "Inschakelen en herstarten" : "Genereer en herstart";
   }
 
   function renderSettingsBackupSection() {

--- a/openquatt/web/js/src/02-firmware-header.js
+++ b/openquatt/web/js/src/02-firmware-header.js
@@ -971,16 +971,16 @@
     if (!status) {
       return "We halen de huidige API-beveiliging op.";
     }
-    if (status.transport_active === true) {
-      return "De native API is beveiligd. Je kunt de sleutel hier bekijken, kopiëren of roteren.";
+    if (status.enabled !== status.transport_active) {
+      return "Deze wijziging wordt actief na herstart. Je kunt de sleutel hier bekijken, kopiëren of vernieuwen.";
     }
-    if (status.enabled) {
-      return "API-encryptie wordt net aangepast. Geef het apparaat even de tijd om de status bij te werken.";
+    if (status.transport_active === true) {
+      return "De native API is beveiligd. Je kunt de sleutel hier bekijken, kopiëren of vernieuwen.";
     }
     if (status.key) {
       return "De sleutel blijft opgeslagen, ook wanneer encryptie uit staat. Je kunt hem hier meteen kopiëren of opnieuw inschakelen.";
     }
-    return "Er is nog geen API-sleutel opgeslagen. Inschakelen maakt direct een nieuwe sleutel aan.";
+    return "Er is nog geen API-sleutel opgeslagen. Deze wijziging wordt actief na herstart.";
   }
 
   function getApiSecurityToggleLabel() {
@@ -988,7 +988,7 @@
     if (!status) {
       return "Laden...";
     }
-    return status.enabled ? "Uitschakelen" : status.key ? "Inschakelen" : "Genereer en schakel in";
+    return status.enabled ? "Uitschakelen en herstarten" : status.key ? "Inschakelen en herstarten" : "Genereer en herstart";
   }
 
   function getApiSecurityRotateLabel() {
@@ -996,7 +996,7 @@
     if (!status) {
       return "Laden...";
     }
-    return status.key ? "Roteer sleutel" : "Genereer sleutel";
+    return status.key ? "Vernieuw sleutel" : "Genereer sleutel";
   }
 
   function renderLoginStatusRow(label, value, copy = "", loading = false) {
@@ -1052,11 +1052,17 @@
                 ${escapeHtml(getApiSecurityToggleLabel())}
               </button>
             </div>
-            <div class="oq-settings-api-security-key">
+              <div class="oq-settings-api-security-key">
               <div class="oq-settings-field-head">
                 <h3>API-sleutel</h3>
               </div>
-              <p class="oq-settings-action-note">${escapeHtml(hasKey ? "Gebruik deze sleutel in Home Assistant voor de ESPHome-integratie." : "Inschakelen maakt direct een nieuwe sleutel aan.")}</p>
+              <p class="oq-settings-action-note">${escapeHtml(status.enabled === status.transport_active
+                ? (hasKey
+                    ? "Gebruik deze sleutel in Home Assistant voor de ESPHome-integratie."
+                    : "Inschakelen maakt direct een nieuwe sleutel aan. Deze wijziging wordt actief na herstart.")
+                : (status.enabled
+                    ? "De sleutel is opgeslagen. OpenQuatt start opnieuw op om API-encryptie in te schakelen."
+                    : "De sleutel blijft opgeslagen. OpenQuatt start opnieuw op om API-encryptie uit te schakelen."))}</p>
               ${hasKey ? `<div class="oq-settings-api-security-key-row"><div class="oq-settings-api-security-key-value">${escapeHtml(status.key)}</div></div>` : ""}
               ${hasKey
                 ? `

--- a/openquatt/web/js/src/02-firmware-header.js
+++ b/openquatt/web/js/src/02-firmware-header.js
@@ -971,7 +971,7 @@
     if (!status) {
       return "We halen de huidige API-beveiliging op.";
     }
-    if (status.enabled !== status.transport_active) {
+    if (status.pending_restart) {
       return "Deze wijziging wordt actief na herstart. Je kunt de sleutel hier bekijken, kopiëren of vernieuwen.";
     }
     if (status.transport_active === true) {
@@ -988,7 +988,7 @@
     if (!status) {
       return "Laden...";
     }
-    return status.enabled ? "Uitschakelen en herstarten" : status.key ? "Inschakelen en herstarten" : "Genereer en herstart";
+    return status.enabled ? "Uitschakelen" : "Inschakelen";
   }
 
   function getApiSecurityRotateLabel() {
@@ -1018,6 +1018,7 @@
     const status = state.apiSecurityStatus || {};
     const enabled = status.enabled === true;
     const hasKey = Boolean(status.key);
+    const restartPending = Boolean(status.pending_restart);
     const modalNotice = state.apiSecurityNotice;
     const errorMarkup = state.apiSecurityError
       ? `<div class="oq-helper-modal-note oq-helper-modal-note--error" aria-live="assertive">${escapeHtml(state.apiSecurityError)}</div>`
@@ -1052,17 +1053,19 @@
                 ${escapeHtml(getApiSecurityToggleLabel())}
               </button>
             </div>
-              <div class="oq-settings-api-security-key">
+            <div class="oq-settings-api-security-key">
               <div class="oq-settings-field-head">
                 <h3>API-sleutel</h3>
               </div>
-              <p class="oq-settings-action-note">${escapeHtml(status.enabled === status.transport_active
+              <p class="oq-settings-action-note">${escapeHtml(restartPending
                 ? (hasKey
-                    ? "Gebruik deze sleutel in Home Assistant voor de ESPHome-integratie."
+                    ? "Deze sleutel is opgeslagen. Kopieer hem nu en kies daarna Opslaan en herstarten."
                     : "Inschakelen maakt direct een nieuwe sleutel aan. Deze wijziging wordt actief na herstart.")
-                : (status.enabled
-                    ? "De sleutel is opgeslagen. OpenQuatt start opnieuw op om API-encryptie in te schakelen."
-                    : "De sleutel blijft opgeslagen. OpenQuatt start opnieuw op om API-encryptie uit te schakelen."))}</p>
+                : (status.transport_active
+                    ? "Gebruik deze sleutel in Home Assistant voor de ESPHome-integratie."
+                    : status.key
+                      ? "De sleutel blijft opgeslagen, maar de native API staat nu open op je lokale netwerk."
+                      : "Er is nog geen API-sleutel opgeslagen."))}</p>
               ${hasKey ? `<div class="oq-settings-api-security-key-row"><div class="oq-settings-api-security-key-value">${escapeHtml(status.key)}</div></div>` : ""}
               ${hasKey
                 ? `
@@ -1089,6 +1092,16 @@
             </div>
           </div>
           <div class="oq-helper-modal-actions">
+            ${restartPending ? `
+              <button
+                class="oq-helper-button oq-helper-button--primary"
+                type="button"
+                data-oq-action="restart-api-security"
+                ${state.apiSecurityBusy ? "disabled" : ""}
+              >
+                Opslaan en herstarten
+              </button>
+            ` : ""}
             <button class="oq-helper-button oq-helper-button--ghost" type="button" data-oq-action="close-system-modal" ${state.apiSecurityBusy ? "disabled" : ""}>Gereed</button>
           </div>
         </section>

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -860,6 +860,14 @@
     return success;
   }
 
+  async function restartForApiSecurityChange() {
+    await triggerNamedButton("restartAction", {
+      successNotice: "OpenQuatt wordt opnieuw opgestart om de API-beveiliging toe te passen.",
+      errorPrefix: "Herstart mislukt",
+      reconnectMode: "restart",
+    });
+  }
+
   async function commitEnableApiSecurity() {
     const status = state.apiSecurityStatus || {};
     if (!status.csrf_token) {
@@ -886,9 +894,9 @@
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      await refreshApiSecurityStatus();
-      state.apiSecurityNotice = "API-encryptie staat nu aan.";
+      state.apiSecurityNotice = "API-beveiliging is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
       render();
+      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Inschakelen is mislukt. ${error.message}`;
       render();
@@ -924,9 +932,9 @@
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      await refreshApiSecurityStatus();
-      state.apiSecurityNotice = "API-sleutel is vernieuwd.";
+      state.apiSecurityNotice = "API-sleutel is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
       render();
+      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Roteren is mislukt. ${error.message}`;
       render();
@@ -968,9 +976,9 @@
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      await refreshApiSecurityStatus();
-      state.apiSecurityNotice = "API-encryptie staat nu uit.";
+      state.apiSecurityNotice = "API-beveiliging is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
       render();
+      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Uitzetten is mislukt. ${error.message}`;
       render();

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -634,6 +634,7 @@
     return [
       status.enabled ? "on" : "off",
       status.transport_active ? "active" : "idle",
+      status.pending_restart ? "pending" : "settled",
       String(status.key || ""),
       String(status.source || ""),
       String(status.csrf_token || ""),
@@ -732,6 +733,7 @@
       const nextStatus = {
         enabled: Boolean(payload.enabled),
         transport_active: Boolean(payload.transport_active),
+        pending_restart: Boolean(payload.pending_restart),
         key: String(payload.key || ""),
         source: String(payload.source || ""),
         csrf_token: String(payload.csrf_token || ""),
@@ -894,9 +896,10 @@
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      state.apiSecurityNotice = "API-beveiliging is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
+      await refreshApiSecurityStatus();
+      state.apiSecurityNotice = "API-beveiliging is opgeslagen. Kopieer de sleutel en kies daarna Opslaan en herstarten.";
+      state.apiSecurityError = "";
       render();
-      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Inschakelen is mislukt. ${error.message}`;
       render();
@@ -932,9 +935,10 @@
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      state.apiSecurityNotice = "API-sleutel is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
+      await refreshApiSecurityStatus();
+      state.apiSecurityNotice = "API-sleutel is opgeslagen. Kopieer de nieuwe sleutel en kies daarna Opslaan en herstarten.";
+      state.apiSecurityError = "";
       render();
-      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Roteren is mislukt. ${error.message}`;
       render();
@@ -976,9 +980,10 @@
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error || `HTTP ${response.status}`);
       }
-      state.apiSecurityNotice = "API-beveiliging is opgeslagen. OpenQuatt wordt opnieuw opgestart.";
+      await refreshApiSecurityStatus();
+      state.apiSecurityNotice = "API-beveiliging is opgeslagen. Kies daarna Opslaan en herstarten om dit toe te passen.";
+      state.apiSecurityError = "";
       render();
-      await restartForApiSecurityChange();
     } catch (error) {
       state.apiSecurityError = `Uitzetten is mislukt. ${error.message}`;
       render();
@@ -2419,6 +2424,11 @@
 
     if (action === "disable-api-security") {
       void commitDisableApiSecurity();
+      return;
+    }
+
+    if (action === "restart-api-security") {
+      void restartForApiSecurityChange();
       return;
     }
 

--- a/openquatt/web/js/src/10-settings.js
+++ b/openquatt/web/js/src/10-settings.js
@@ -1476,7 +1476,7 @@
     if (!status) {
       return "Laden...";
     }
-    if (status.enabled !== status.transport_active) {
+    if (status.pending_restart) {
       return "Herstart nodig";
     }
     if (status.transport_active === true) {
@@ -1493,7 +1493,7 @@
     if (!status) {
       return "API-encryptie wordt geladen.";
     }
-    if (status.enabled !== status.transport_active) {
+    if (status.pending_restart) {
       return status.key
         ? "Deze wijziging wordt actief na herstart. De sleutel blijft opgeslagen voor later gebruik."
         : "Deze wijziging wordt actief na herstart.";
@@ -1513,9 +1513,9 @@
       return "Laden...";
     }
     if (status.enabled) {
-      return "Uitschakelen en herstarten";
+      return "Uitschakelen";
     }
-    return status.key ? "Inschakelen en herstarten" : "Genereer en herstart";
+    return "Inschakelen";
   }
 
   function renderSettingsBackupSection() {

--- a/openquatt/web/js/src/10-settings.js
+++ b/openquatt/web/js/src/10-settings.js
@@ -1404,7 +1404,7 @@
     return renderSettingsSection(
       "Toegang",
       "Toegang & Beveiliging",
-      "Pas hier de web-login of de ESPHome API-sleutel aan.",
+      "Pas hier de web-login of de ESPHome API-sleutel aan. Deze wijziging wordt actief na herstart.",
       `
         <div class="oq-settings-access-security-shell">
           <div class="oq-settings-quickstart-status" data-oq-access-security-item="login">
@@ -1476,6 +1476,9 @@
     if (!status) {
       return "Laden...";
     }
+    if (status.enabled !== status.transport_active) {
+      return "Herstart nodig";
+    }
     if (status.transport_active === true) {
       return "Aan";
     }
@@ -1490,11 +1493,13 @@
     if (!status) {
       return "API-encryptie wordt geladen.";
     }
+    if (status.enabled !== status.transport_active) {
+      return status.key
+        ? "Deze wijziging wordt actief na herstart. De sleutel blijft opgeslagen voor later gebruik."
+        : "Deze wijziging wordt actief na herstart.";
+    }
     if (status.transport_active === true) {
       return "API-encryptie staat aan. Gebruik dezelfde sleutel in Home Assistant.";
-    }
-    if (status.enabled) {
-      return "API-encryptie wordt net aangepast. Wacht even tot de status is bijgewerkt.";
     }
     if (status.key) {
       return "De sleutel blijft opgeslagen, maar de native API staat nu open op je lokale netwerk.";
@@ -1508,9 +1513,9 @@
       return "Laden...";
     }
     if (status.enabled) {
-      return "Uitschakelen";
+      return "Uitschakelen en herstarten";
     }
-    return status.key ? "Inschakelen" : "Genereer en schakel in";
+    return status.key ? "Inschakelen en herstarten" : "Genereer en herstart";
   }
 
   function renderSettingsBackupSection() {


### PR DESCRIPTION
This PR makes API security changes apply through the existing restart flow instead of trying to keep live PSK state in sync.

What changed:
- API security changes are saved first, then the device restarts so the new state becomes active cleanly.
- The UI now makes that restart requirement explicit.
- The modal copy now includes the exact message: "Deze wijziging wordt actief na herstart."

Validation:
- `node --check openquatt/web/js/src/02-firmware-header.js`
- `node --check openquatt/web/js/src/03-entities-controls.js`
- `node --check openquatt/web/js/src/10-settings.js`
- `node openquatt/web/build-assets.mjs`
- `./scripts/validate_local.sh --config openquatt_duo_waveshare.yaml --jobs 1`