### PR TITLE
Refactor phase 2 persistence audit

### DIFF
--- a/openquatt/includes/oq_cic_compatibility_protocol.h
+++ b/openquatt/includes/oq_cic_compatibility_protocol.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+namespace oq_cic_compat_protocol {
+
+constexpr uint16_t kPumpModeOnMask = 0x1000u;
+constexpr uint16_t kUnavailableWord = 0xFFFFu;
+constexpr uint16_t kFallbackPcbFirmwareRaw = 0x011Eu;
+constexpr float kDeciScale = 10.0f;
+constexpr float kCentiScale = 100.0f;
+constexpr float kTempOffset = 3000.0f;
+constexpr float kFlowLphToCompatUnits = (1.0f / 0.618f);
+
+inline uint16_t encode_deci(float value) {
+  return std::isnan(value) ? 0u : static_cast<uint16_t>(lroundf(value * kDeciScale));
+}
+
+inline uint16_t encode_offset_centi_c(float value) {
+  return std::isnan(value)
+      ? 0u
+      : static_cast<uint16_t>(lroundf((value * kCentiScale) + kTempOffset));
+}
+
+inline uint16_t encode_flow_lph(float value) {
+  return std::isnan(value)
+      ? 0u
+      : static_cast<uint16_t>(lroundf(value * kFlowLphToCompatUnits));
+}
+
+}  // namespace oq_cic_compat_protocol

--- a/openquatt/oq_cic.yaml
+++ b/openquatt/oq_cic.yaml
@@ -31,6 +31,7 @@ switch:
     name: "CIC - Enable polling"
     icon: mdi:cloud-sync
     optimistic: true
+    # persistent: user_setting - retains whether CIC polling stays enabled.
     restore_mode: ${oq_cic_restore_mode_default}
     web_server:
       sorting_group_id: oq_cic
@@ -45,6 +46,7 @@ text:
     icon: mdi:link-variant
     mode: text
     optimistic: true
+    # persistent: user_setting - retains the configured CIC feed endpoint.
     restore_value: true
     initial_value: "http://192.168.2.117:8080/beta/feed/data.json"
     web_server:

--- a/openquatt/oq_cic_compatibility.yaml
+++ b/openquatt/oq_cic_compatibility.yaml
@@ -27,6 +27,7 @@ switch:
     icon: mdi:transit-connection-variant
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains whether the CiC compatibility server stays enabled.
     restore_mode: ${oq_cic_compat_restore_mode_default}
     web_server:
       sorting_group_id: oq_cic_compatibility

--- a/openquatt/oq_cic_compatibility_server.yaml
+++ b/openquatt/oq_cic_compatibility_server.yaml
@@ -45,7 +45,9 @@ modbus_controller:
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
-          return id(${cic_compat_hp_id}_set_pump_mode).current_option() == "On" ? 4096 : 0;
+          return id(${cic_compat_hp_id}_set_pump_mode).current_option() == "On"
+              ? oq_cic_compat_protocol::kPumpModeOnMask
+              : 0;
       - address: 2015
         value_type: U_WORD
         read_lambda: |-
@@ -80,7 +82,7 @@ modbus_controller:
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_current).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+          return oq_cic_compat_protocol::encode_deci(v);
       - address: 2102
         value_type: U_WORD
         read_lambda: |-
@@ -139,25 +141,25 @@ modbus_controller:
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_outside_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2111
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_evaporator_coil_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2112
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_gas_discharge_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2113
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_gas_return_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2114
         value_type: U_WORD
         read_lambda: |-
@@ -168,13 +170,13 @@ modbus_controller:
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_evaporator_pressure).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+          return oq_cic_compat_protocol::encode_deci(v);
       - address: 2117
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_condenser_pressure).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+          return oq_cic_compat_protocol::encode_deci(v);
       - address: 2118
         value_type: U_WORD
         read_lambda: |-
@@ -185,37 +187,37 @@ modbus_controller:
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_pcb_firmware_raw).state;
-          return isnan(v) ? 0x011Eu : static_cast<uint16_t>(lroundf(v));
+          return isnan(v) ? oq_cic_compat_protocol::kFallbackPcbFirmwareRaw : static_cast<uint16_t>(lroundf(v));
       - address: 2131
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_condensing_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2132
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_evaporating_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2133
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_water_in_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2134
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_water_out_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2135
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_inner_coil_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+          return oq_cic_compat_protocol::encode_offset_centi_c(v);
       - address: 2136
         value_type: U_WORD
         read_lambda: |-
@@ -226,58 +228,58 @@ modbus_controller:
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_pump_power).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+          return oq_cic_compat_protocol::encode_deci(v);
       - address: 2138
         value_type: U_WORD
         read_lambda: |-
           if (!oq_cic_compat::touch_and_enabled(id(cic_compatibility_last_request_ms), id(cic_compatibility_enable).state, millis())) return 0;
           const float v = id(${cic_compat_hp_id}_flow).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v / 0.618f));
+          return oq_cic_compat_protocol::encode_flow_lph(v);
       - address: 11160
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11161
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11162
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11163
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11164
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11165
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11166
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11167
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11168
         value_type: U_WORD
         read_lambda: |-
           oq_cic_compat::touch(id(cic_compatibility_last_request_ms), millis());
-          return 0xFFFFu;
+          return oq_cic_compat_protocol::kUnavailableWord;
       - address: 11169
         value_type: U_WORD
         read_lambda: |-

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -349,6 +349,7 @@ number:
     min_value: 1000
     max_value: 20000
     step: 10
+    # persistent: learned_value - keeps the commissioning-applied boiler rating across reboots.
     restore_value: true
     optimistic: true
     initial_value: 6000

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -262,6 +262,7 @@ select:
       sorting_group_id: oq_system_diagnostics
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the preferred firmware release channel.
     restore_value: true
     options: ["main", "dev"]
     initial_option: "${release_channel}"
@@ -298,6 +299,7 @@ select:
       sorting_group_id: oq_heating_strategy
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the installed Quatt hardware generation.
     restore_value: true
     options: ["V1", "V1.5", "V2"]
     initial_option: V1.5
@@ -311,6 +313,7 @@ select:
       sorting_group_id: oq_system_diagnostics
     entity_category: diagnostic
     optimistic: true
+    # persistent: diagnostic_cache - keeps the requested runtime log verbosity across reboot.
     restore_value: true
     options: [NONE, ERROR, WARN, INFO, CONFIG, DEBUG]
     initial_option: INFO
@@ -387,6 +390,7 @@ switch:
     icon: mdi:chart-line
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains whether RAM trend capture stays enabled.
     restore_mode: RESTORE_DEFAULT_ON
     turn_on_action:
       - script.execute: oq_capture_overview_trend_sample
@@ -402,6 +406,7 @@ switch:
     icon: mdi:database
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains whether trend history is flushed to flash.
     restore_mode: RESTORE_DEFAULT_OFF
     turn_on_action:
       - lambda: |-

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -29,10 +29,12 @@ globals:
     initial_value: '-1'
   - id: oq_cooling_fallback_night_min_last_c
     type: float
+    # persistent: learned_value - keeps the last completed fallback night minimum across reboots.
     restore_value: true
     initial_value: 'NAN'
   - id: oq_cooling_fallback_night_min_last_day_key
     type: int
+    # persistent: learned_value - remembers which completed night window produced the cached minimum.
     restore_value: true
     initial_value: '-1'
 
@@ -60,6 +62,7 @@ number:
     step: 0.1
     mode: box
     optimistic: true
+    # persistent: user_setting - retains the configured dew point safety margin.
     restore_value: true
     initial_value: 2.0
     entity_category: config
@@ -77,6 +80,7 @@ number:
     step: 0.1
     mode: slider
     optimistic: true
+    # persistent: user_setting - retains the cooling request on-hysteresis.
     restore_value: true
     initial_value: 0.4
     entity_category: config
@@ -94,6 +98,7 @@ number:
     step: 0.1
     mode: slider
     optimistic: true
+    # persistent: user_setting - retains the cooling request off-hysteresis.
     restore_value: true
     initial_value: 0.1
     entity_category: config
@@ -107,6 +112,7 @@ select:
     icon: mdi:water-alert
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains whether fallback cooling is allowed without dew point input.
     restore_value: true
     options:
       - Dew point required

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -79,6 +79,7 @@ number:
     step: 0.5
     mode: slider
     optimistic: true
+    # persistent: user_setting - retains the installer-selected cooling floor.
     restore_value: true
     initial_value: 18.0
     entity_category: config
@@ -95,6 +96,7 @@ number:
     step: 1
     mode: slider
     optimistic: true
+    # persistent: user_setting - retains the cooling demand ceiling.
     restore_value: true
     initial_value: 4
     entity_category: config
@@ -110,6 +112,7 @@ number:
     step: 0.1
     mode: slider
     optimistic: true
+    # persistent: user_setting - retains cooling PID proportional tuning.
     restore_value: true
     initial_value: 3.0
     entity_category: config
@@ -125,6 +128,7 @@ number:
     step: 0.01
     mode: slider
     optimistic: true
+    # persistent: user_setting - retains cooling PID integral tuning.
     restore_value: true
     initial_value: 0.12
     entity_category: config
@@ -140,6 +144,7 @@ number:
     step: 0.01
     mode: slider
     optimistic: true
+    # persistent: user_setting - retains cooling PID derivative tuning.
     restore_value: true
     initial_value: 0.0
     entity_category: config

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -51,6 +51,7 @@ globals:
     initial_value: '0'   # 0=AUTO, 1=MANUAL, 2=FROST
   - id: oq_flow_last_good_pwm
     type: int
+    # persistent: learned_value - remembers the last stable AUTO seed across reboots.
     restore_value: true
     initial_value: "440"
   - id: oq_flow_commissioning_start_pwm
@@ -85,6 +86,7 @@ number:
     min_value: 0
     max_value: 1500
     step: 10
+    # persistent: user_setting - retains the selected flow target.
     restore_value: true
     optimistic: true
     initial_value: 800
@@ -99,6 +101,7 @@ number:
     max_value: 850
     step: 1
     initial_value: 400
+    # persistent: user_setting - retains the manual iPWM override.
     restore_value: true
     optimistic: true
     web_server:
@@ -116,6 +119,7 @@ number:
     min_value: 50
     max_value: 850
     step: 10
+    # persistent: user_setting - retains frost circulation tuning.
     restore_value: true
     optimistic: true
     initial_value: 800
@@ -132,6 +136,7 @@ number:
     min_value: 50
     max_value: 850
     step: 1
+    # persistent: user_setting - retains the AUTO restart fallback seed.
     restore_value: true
     optimistic: true
     initial_value: 440
@@ -147,6 +152,7 @@ number:
     min_value: ${oq_flow_kp_min}
     max_value: ${oq_flow_kp_max}
     step: 0.001
+    # persistent: user_setting - retains flow PI proportional tuning.
     restore_value: true
     optimistic: true
     # Default increased for more robust control in the current hydraulic setup.
@@ -162,6 +168,7 @@ number:
     min_value: ${oq_flow_ki_min}
     max_value: ${oq_flow_ki_max}
     step: 0.0001
+    # persistent: user_setting - retains flow PI integral tuning.
     restore_value: true
     optimistic: true
     initial_value: 0.0008
@@ -180,6 +187,7 @@ select:
       - Flow Setpoint
       - Manual PWM
     initial_option: Flow Setpoint
+    # persistent: user_setting - retains the chosen flow operating mode.
     restore_value: true
     optimistic: true
     web_server:

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -118,6 +118,7 @@ select:
     name: "Heating Curve Control Profile"
     icon: mdi:tune-variant
     optimistic: true
+    # persistent: user_setting - retains the chosen curve response profile.
     restore_value: true
     options:
       - Comfort
@@ -171,6 +172,7 @@ number:
     min_value: 20
     max_value: 70
     step: 0.5
+    # persistent: user_setting - retains the heating curve anchor at -20 C.
     restore_value: true
     optimistic: true
     initial_value: 55
@@ -185,6 +187,7 @@ number:
     min_value: 20
     max_value: 70
     step: 0.5
+    # persistent: user_setting - retains the heating curve anchor at -10 C.
     restore_value: true
     optimistic: true
     initial_value: 50
@@ -199,6 +202,7 @@ number:
     min_value: 20
     max_value: 70
     step: 0.5
+    # persistent: user_setting - retains the heating curve anchor at 0 C.
     restore_value: true
     optimistic: true
     initial_value: 45
@@ -213,6 +217,7 @@ number:
     min_value: 20
     max_value: 70
     step: 0.5
+    # persistent: user_setting - retains the heating curve anchor at 5 C.
     restore_value: true
     optimistic: true
     initial_value: 40
@@ -227,6 +232,7 @@ number:
     min_value: 20
     max_value: 70
     step: 0.5
+    # persistent: user_setting - retains the heating curve anchor at 10 C.
     restore_value: true
     optimistic: true
     initial_value: 35
@@ -241,6 +247,7 @@ number:
     min_value: 20
     max_value: 70
     step: 0.5
+    # persistent: user_setting - retains the heating curve anchor at 15 C.
     restore_value: true
     optimistic: true
     initial_value: 30
@@ -255,6 +262,7 @@ number:
     max_value: 0.800
     step: 0.010
     mode: slider
+    # persistent: user_setting - retains curve PID proportional tuning.
     restore_value: true
     optimistic: true
     initial_value: 0.280
@@ -277,6 +285,7 @@ number:
     max_value: 0.00300
     step: 0.00010
     mode: slider
+    # persistent: user_setting - retains curve PID integral tuning.
     restore_value: true
     optimistic: true
     initial_value: 0.00060
@@ -299,6 +308,7 @@ number:
     max_value: 0.400
     step: 0.010
     mode: slider
+    # persistent: user_setting - retains curve PID derivative tuning.
     restore_value: true
     optimistic: true
     initial_value: 0.200
@@ -321,6 +331,7 @@ number:
     min_value: 25
     max_value: 70
     step: 0.5
+    # persistent: user_setting - retains the fallback target without outside temperature.
     restore_value: true
     optimistic: true
     initial_value: 40

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -132,6 +132,7 @@ number:
     min_value: -25
     max_value: 5
     step: 0.5
+    # persistent: user_setting - retains the cold-end outdoor design point.
     restore_value: true
     optimistic: true
     initial_value: -10
@@ -147,6 +148,7 @@ number:
     min_value: 1000
     max_value: 15000
     step: 10
+    # persistent: user_setting - retains the rated house heat-loss estimate.
     restore_value: true
     optimistic: true
     initial_value: 7020
@@ -162,6 +164,7 @@ number:
     min_value: 5
     max_value: 25
     step: 0.5
+    # persistent: user_setting - retains the no-heat outdoor balance point.
     restore_value: true
     optimistic: true
     initial_value: 16
@@ -177,6 +180,7 @@ number:
     min_value: 0
     max_value: 4000
     step: 10
+    # persistent: user_setting - retains the room-error reaction gain.
     restore_value: true
     optimistic: true
     initial_value: 3000
@@ -192,6 +196,7 @@ number:
     min_value: 0
     max_value: 2.0
     step: 0.05
+    # persistent: user_setting - retains the cold-side comfort band.
     restore_value: true
     optimistic: true
     initial_value: 0.1
@@ -207,6 +212,7 @@ number:
     min_value: 0
     max_value: 2.0
     step: 0.05
+    # persistent: user_setting - retains the warm-side comfort band.
     restore_value: true
     optimistic: true
     initial_value: 0.3
@@ -222,6 +228,7 @@ number:
     min_value: 2
     max_value: 20
     step: 1
+    # persistent: user_setting - retains demand ramp-up response timing.
     restore_value: true
     optimistic: true
     initial_value: 8
@@ -237,6 +244,7 @@ number:
     min_value: 1
     max_value: 10
     step: 1
+    # persistent: user_setting - retains demand ramp-down response timing.
     restore_value: true
     optimistic: true
     initial_value: 3
@@ -254,6 +262,7 @@ number:
     max_value: 20
     step: 1
     mode: slider
+    # persistent: user_setting - retains the demand ramp-up limiter.
     restore_value: true
     optimistic: true
     initial_value: 1

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -74,6 +74,7 @@ select:
     icon: mdi:source-branch
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the selected water supply source.
     restore_value: true
     options:
       - Local
@@ -89,6 +90,7 @@ select:
     icon: mdi:source-branch
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the selected flow source.
     restore_value: true
     options:
       - Outdoor unit
@@ -104,6 +106,7 @@ select:
     icon: mdi:call-split
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the selected duo flow aggregation mode.
     restore_value: true
     options:
       - Flowmeter HP1
@@ -119,6 +122,7 @@ select:
     icon: mdi:source-branch
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the selected outside temperature source.
     restore_value: true
     options:
       - Auto
@@ -134,6 +138,7 @@ select:
     icon: mdi:source-branch
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the selected room temperature source.
     restore_value: true
     options:
       - CIC
@@ -149,6 +154,7 @@ select:
     icon: mdi:source-branch
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the selected room setpoint source.
     restore_value: true
     options:
       - CIC
@@ -164,6 +170,7 @@ select:
     icon: mdi:source-branch
     entity_category: config
     optimistic: true
+    # persistent: user_setting - retains the selected cooling enable source.
     restore_value: true
     options:
       - CIC
@@ -178,6 +185,7 @@ switch:
     id: oq_manual_cooling_enable
     name: "Manual Cooling Enable"
     icon: mdi:snowflake-check
+    # persistent: user_setting - retains the manual cooling enable override.
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     web_server:

--- a/openquatt/oq_setup_status.yaml
+++ b/openquatt/oq_setup_status.yaml
@@ -15,6 +15,7 @@
 globals:
   - id: oq_setup_complete
     type: bool
+    # persistent: diagnostic_cache - keeps the local quick-start completion state for the web app.
     restore_value: true
     initial_value: 'false'
 

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -79,6 +79,7 @@ select:
     name: "Heating Control Mode"
     icon: mdi:tune-variant
     optimistic: true
+    # persistent: user_setting - retains the chosen heating strategy.
     restore_value: true
     options:
       - Power House

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -22,6 +22,7 @@ heating_curve_logic_header: "openquatt/includes/oq_heating_curve_logic.h" # Shar
 oq_psram_buffer_header: "components/openquatt_common/PsramBuffer.h" # Shared PSRAM-backed buffer helper for custom components.
 oq_timers_header: "openquatt/includes/oq_timers.h"       # Shared C++ helpers for millis()/elapsed timer patterns.
 oq_cic_compatibility_logic_header: "openquatt/includes/oq_cic_compatibility_logic.h" # Shared helpers for CiC compatibility lambdas.
+oq_cic_compatibility_protocol_header: "openquatt/includes/oq_cic_compatibility_protocol.h" # Shared helpers for CiC compatibility protocol encoding.
 oq_timezone: "Europe/Amsterdam"                         # SNTP timezone used by runtime timestamps.
 oq_webserver_css_url: ""                            # Optional external CSS for the ESPHome web UI.
 oq_webserver_js_url: ""                               # Custom OpenQuatt app is primary; load ESPHome fallback lazily on demand.

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -57,7 +57,7 @@ globals:
   # Frost hysteresis state for CM98 selection
   - id: oq_cm_frost_prev
     type: bool
-    restore_value: true
+    restore_value: false
     initial_value: 'false'
 
   # Pre/Postflow timer (CM1)
@@ -222,6 +222,7 @@ select:
       - "On"
       - "Off"
     initial_option: "Schedule"
+    # persistent: user_setting - retains the silent mode override choice.
     restore_value: true
     optimistic: true
     web_server:
@@ -232,6 +233,7 @@ switch:
     id: oq_boiler_assist_enabled
     name: "Boiler assist enabled"
     icon: mdi:water-boiler
+    # persistent: user_setting - retains whether boiler assist is enabled.
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
     entity_category: config
@@ -242,6 +244,7 @@ switch:
     id: oq_enabled
     name: "OpenQuatt Enabled"
     icon: mdi:power-standby
+    # persistent: user_setting - retains the master enable switch across reboot.
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
     on_turn_on:
@@ -264,6 +267,7 @@ number:
     max_value: 10
     step: 1
     optimistic: true
+    # persistent: user_setting - retains the night-time compressor cap.
     restore_value: true
     initial_value: 6
     entity_category: config
@@ -278,6 +282,7 @@ number:
     max_value: 10
     step: 1
     optimistic: true
+    # persistent: user_setting - retains the daytime compressor cap.
     restore_value: true
     initial_value: 10
     entity_category: config
@@ -293,6 +298,7 @@ number:
     max_value: 10000
     step: 50
     optimistic: true
+    # persistent: user_setting - retains the CM3 promotion threshold.
     restore_value: true
     initial_value: 1000
     entity_category: config
@@ -308,6 +314,7 @@ number:
     max_value: 10000
     step: 50
     optimistic: true
+    # persistent: user_setting - retains the CM3 demotion threshold.
     restore_value: true
     initial_value: 400
     entity_category: config
@@ -323,6 +330,7 @@ number:
     max_value: 0.90
     step: 0.05
     optimistic: true
+    # persistent: user_setting - retains low-load dynamic OFF tuning.
     restore_value: true
     initial_value: 0.75
     entity_category: config
@@ -338,6 +346,7 @@ number:
     max_value: 1.10
     step: 0.05
     optimistic: true
+    # persistent: user_setting - retains low-load dynamic ON tuning.
     restore_value: true
     initial_value: 1.0
     entity_category: config
@@ -354,6 +363,7 @@ number:
     max_value: 400
     step: 25
     optimistic: true
+    # persistent: user_setting - retains the minimum low-load hysteresis.
     restore_value: true
     initial_value: 200
     entity_category: config
@@ -370,6 +380,7 @@ number:
     max_value: 900
     step: 5
     optimistic: true
+    # persistent: user_setting - retains the CM2 re-entry block after low load.
     restore_value: true
     initial_value: 300
     entity_category: config
@@ -384,6 +395,7 @@ datetime:
     name: "Silent start time"
     type: time
     optimistic: true
+    # persistent: user_setting - retains the silent schedule start time.
     restore_value: true
     initial_value: "19:00:00"
     entity_category: config
@@ -395,6 +407,7 @@ datetime:
     name: "Silent end time"
     type: time
     optimistic: true
+    # persistent: user_setting - retains the silent schedule end time.
     restore_value: true
     initial_value: "07:00:00"
     entity_category: config
@@ -406,6 +419,7 @@ datetime:
     name: "OpenQuatt resume at"
     type: datetime
     optimistic: true
+    # persistent: user_setting - keeps deferred resume requests across reboot.
     restore_value: true
     initial_value: "2000-01-01 00:00:00"
     entity_category: config

--- a/openquatt/oq_thermal_limits.yaml
+++ b/openquatt/oq_thermal_limits.yaml
@@ -56,6 +56,7 @@ number:
     min_value: 25
     max_value: 75
     step: 0.5
+    # persistent: user_setting - retains the installer-selected maximum water temperature.
     restore_value: true
     optimistic: true
     initial_value: 60

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -238,6 +238,7 @@ number:
     max_value: 3600
     step: 30
     mode: slider
+    # persistent: user_setting - retains the minimum runtime floor.
     restore_value: true
     optimistic: true
     initial_value: 300
@@ -256,6 +257,7 @@ number:
     max_value: 60
     step: 1
     mode: slider
+    # persistent: user_setting - retains the curve-mode dual-HP enable hold.
     restore_value: true
     optimistic: true
     initial_value: 3
@@ -274,6 +276,7 @@ number:
     max_value: 60
     step: 1
     mode: slider
+    # persistent: user_setting - retains the curve-mode dual-HP disable hold.
     restore_value: true
     optimistic: true
     initial_value: 5

--- a/openquatt/oq_web_access.yaml
+++ b/openquatt/oq_web_access.yaml
@@ -30,6 +30,7 @@ switch:
     icon: mdi:memory
     entity_category: config
     optimistic: true
+    # persistent: diagnostic_cache - retains whether in-memory log history capture is enabled.
     restore_mode: RESTORE_DEFAULT_ON
     turn_on_action:
       - lambda: |-

--- a/openquatt_base_common.yaml
+++ b/openquatt_base_common.yaml
@@ -21,6 +21,7 @@ esphome:
     - ${oq_psram_buffer_header}
     - ${oq_timers_header}
     - ${oq_cic_compatibility_logic_header}
+    - ${oq_cic_compatibility_protocol_header}
   platformio_options:
     extra_scripts:
       - pre:../../../scripts/normalize_factory_merge_inputs.py

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -35,6 +35,12 @@ PACKAGE_ORDER_PATTERNS = (
     "openquatt/*.yaml",
 )
 
+PERSISTENCE_REASON_PATTERNS = (
+    "openquatt/*.yaml",
+    "openquatt/profiles/*.yaml",
+    "openquatt_*.yaml",
+)
+
 STRICT_TOP_LEVEL_ORDER_RULES = {
     "openquatt_base.yaml": (
         "substitutions",
@@ -180,6 +186,12 @@ TOP_LEVEL_KEY_RE = re.compile(r"^([a-z_][a-z0-9_]*):(?:\s|$)")
 NESTED_KEY_RE = re.compile(r"^(?P<indent>\s+)(?P<key>[a-z_][a-z0-9_]*):(?:\s|$)")
 LAMBDA_LINE_RE = re.compile(r"^(?P<indent>\s*)(?:-\s+)?lambda:(?P<tail>.*)$")
 LAMBDA_BLOCK_RE = re.compile(r"^(?P<indent>\s*)(?:-\s+)?lambda:\s*\|-\s*$")
+PERSISTENCE_REASON_RE = re.compile(
+    r"^\s*#\s*persistent:\s*(user_setting|learned_value|runtime_state|diagnostic_cache)\b"
+)
+PERSISTENCE_REASON_EXCLUDED_FILES = {
+    "openquatt/oq_HP_io.yaml",
+}
 PACKAGE_GROUP_BY_KEY = {
     "logger": 0,
     "api": 0,
@@ -436,6 +448,27 @@ def check_package_group_order(path: Path, findings: list[Finding]) -> None:
         previous_line = current_line
 
 
+def check_persistence_reason_comments(path: Path, findings: list[Finding]) -> None:
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    if rel in PERSISTENCE_REASON_EXCLUDED_FILES:
+        return
+
+    lines = read_lines(path)
+    for idx, line in enumerate(lines, start=1):
+        if "restore_value: true" not in line and "restore_mode: RESTORE_" not in line:
+            continue
+
+        if any(PERSISTENCE_REASON_RE.match(lines[cursor]) for cursor in range(max(0, idx - 3), idx - 1)):
+            continue
+
+        add(
+            findings,
+            rel,
+            idx,
+            "Add `# persistent: <category> - reason` above `restore_value: true`.",
+        )
+
+
 def iter_lambda_blocks(path: Path) -> list[tuple[int, int, int, list[tuple[int, str]]]]:
     lines = read_lines(path)
     blocks: list[tuple[int, int, int, list[tuple[int, str]]]] = []
@@ -532,6 +565,9 @@ def main() -> int:
 
     for path in expand_patterns(PACKAGE_ORDER_PATTERNS):
         check_package_group_order(path, findings)
+
+    for path in expand_patterns(PERSISTENCE_REASON_PATTERNS):
+        check_persistence_reason_comments(path, findings)
 
     for rel_path in sorted(set(STRICT_TOP_LEVEL_ORDER_RULES)):
         check_strict_top_level_order(REPO_ROOT / rel_path, findings)


### PR DESCRIPTION
## Summary
This stacked phase-2 PR audits persistent state in the current control/config surface and makes persistence choices explicit.

Concretely this PR:
- classifies phase-2 `restore_value: true` entries with inline `# persistent:` annotations
- extends the style check so new persisted settings must carry an explicit persistence reason
- fixes one clear runtime-state restore hazard by making `oq_cm_frost_prev` runtime-only again
- names CiC compatibility protocol encodings in a dedicated helper header instead of repeating raw literals
- adds the same persistence reasoning to the relevant `restore_mode` switches found in the follow-up audit

## Why
The goal of phase 2 is to reduce reboot-sensitive behavior without accidentally wiping real installer or user configuration.

Before this change, persistence intent was spread across YAML without a consistent explanation of whether a value was:
- a real user setting
- a learned value worth keeping
- runtime state that should reset on boot
- or a diagnostic/UI cache

That made review harder and increased the risk of subtle restore regressions when touching control logic later.

## What changed
### Explicit persistence categories
Across the phase-2 scope, persisted values are now annotated inline as one of:
- `user_setting`
- `learned_value`
- `runtime_state`
- `diagnostic_cache`

This keeps the reasoning close to the actual entity/global and makes future review much easier.

### Style-check enforcement
`scripts/check_style_consistency.py` now flags:
- `restore_value: true`
- `restore_mode: RESTORE_...`

when they do not have a nearby `# persistent:` reason comment.

This turns the audit outcome into an ongoing guardrail instead of a one-off cleanup.

### Conservative runtime-state correction
The only clear phase-2 runtime restore issue found in scope was:
- `oq_cm_frost_prev`

That value is a supervisory hysteresis latch and should be recomputed after boot instead of restored from NVS. It now uses `restore_value: false`.

Other borderline cases were intentionally left persistent where they are better understood as:
- learned startup seeds or commissioning-derived values
- stable user/installer configuration
- low-risk UI/diagnostic cache

### Named protocol constants
The CiC compatibility server previously repeated protocol encodings such as:
- pump-mode bit masks
- deci-unit scaling
- offset centi-degree temperature encoding
- fallback raw values
- unavailable register words

Those encodings now live in `openquatt/includes/oq_cic_compatibility_protocol.h`, which makes the protocol intent easier to read and reduces repeated raw literals.

## Explicitly out of scope
Per the phase-2 work agreement, this PR does not:
- touch `flow_rate_hp_avg`
- change the HA dashboard
- modify `openquatt/oq_HP_io.yaml`
- attempt a larger control/state-machine refactor

## Validation
Ran locally:
- `git diff --check`
- `uv run python scripts/check_style_consistency.py`
- `./scripts/validate_local.sh`

Validation result: all green, including config validation and the four firmware profile compiles.

## Stacking / notes
- This PR is stacked on top of PR #157.
- Local tracker updates were made in `docs/_local_reference/code-review-refactor-plan.md`, but that path is gitignored in this repo, so those notes are intentionally not part of the committed diff.
