### PR TITLE
Refactor phase 3 thermal contract and harness

### DIFF
--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -216,15 +216,36 @@ Heating-curve stability guards around zero-demand edge:
 
 ## 6. Thermal Request Control Mechanics
 
-`oq_thermal_request_control` enforces, in order:
+The thermal chain is documented in more detail in
+[`docs/thermal-contract.md`](thermal-contract.md). The three contract layers are:
+
+- `intent`: what the active strategy wants thermally
+- `guarded`: what shared physical and safety guards allow downstream
+- `applied`: what the actuator actually writes to HP mode/level selects
+
+Current naming is still transitional:
+
+- `oq_request_*` is the explicit intent interface
+- `oq_actuator_hp*_req` is the guarded per-HP actuator request
+- `hp*_last_applied_level` plus HP select writes are actuator-owned applied state
+
+`oq_thermal_request_control` currently enforces or prepares, in order:
 
 1. demand filter and clamp
 2. power cap clamp (`oq_power_cap_f`)
-3. Control Mode gating (CM2/CM3 only)
+3. Control Mode gating (CM2/CM3/CM5 only)
 4. strategy-specific level logic
-5. allowed-level switch constraints
-6. min-runtime stop blocking (all strategies)
-7. write-on-change application and runtime counters
+5. `oq_request_*` intent publication
+6. allowed-level switch constraints
+7. slew limiting for non-Power-House modes
+8. water hard-trip and startup inhibit
+9. min-runtime stop blocking
+10. `oq_actuator_hp*_req` guarded request publication
+
+`oq_thermal_actuator` is the only package that writes HP working mode and
+compressor level selects. It also owns final actuator-local guards such as
+minimum off-time, mode-confirmation gating, silent/day cap application, defrost
+retain behavior, start/stop bookkeeping and runtime counters.
 
 Demand filter behavior is asymmetric:
 

--- a/docs/thermal-contract.md
+++ b/docs/thermal-contract.md
@@ -5,17 +5,6 @@ It is intentionally conservative: it documents current behavior and naming
 semantics before later refactors move logic between request control, guards and
 the actuator.
 
-## Model Work Split
-
-`gpt-5.5` owns the semantic contract: intent, guarded and applied definitions,
-current-name mapping, reason taxonomy, PR boundaries and high-risk review.
-
-`gpt-5.4` owns the concrete regression-harness expansion for thermal and
-supervisory scenarios.
-
-`gpt-5.3-codex` is reserved for narrow mechanical edits once names, helpers and
-test expectations are clear.
-
 ## Contract Layers
 
 The thermal chain is:

--- a/docs/thermal-contract.md
+++ b/docs/thermal-contract.md
@@ -1,0 +1,227 @@
+# Thermal Contract
+
+This document captures the phase-3 thermal contract introduced after PR158.
+It is intentionally conservative: it documents current behavior and naming
+semantics before later refactors move logic between request control, guards and
+the actuator.
+
+## Model Work Split
+
+`gpt-5.5` owns the semantic contract: intent, guarded and applied definitions,
+current-name mapping, reason taxonomy, PR boundaries and high-risk review.
+
+`gpt-5.4` owns the concrete regression-harness expansion for thermal and
+supervisory scenarios.
+
+`gpt-5.3-codex` is reserved for narrow mechanical edits once names, helpers and
+test expectations are clear.
+
+## Contract Layers
+
+The thermal chain is:
+
+```text
+strategy-local output -> intent -> guarded -> applied
+```
+
+### Intent
+
+Intent is what the active strategy thermally wants.
+
+It contains the thermal mode, requested HP1/HP2 levels, owner/topology hints,
+strategy code and strategy reason. Intent does not imply that the request is
+safe or physically writeable.
+
+Current intent producers:
+
+- `oq_cooling_request_*`
+- `oq_curve_dispatch_*`
+- `oq_ph_request_*`
+
+Current shared intent interface:
+
+- `oq_request_mode_code`
+- `oq_request_hp1_level`
+- `oq_request_hp2_level`
+- `oq_request_owner_hp`
+- `oq_request_topology_code`
+- `oq_request_strategy_code`
+- `oq_request_reason`
+
+During phase 3 these names stay stable. Conceptually, `oq_request_*` means
+intent, even if a later refactor introduces `oq_intent_*` aliases or names.
+
+### Guarded
+
+Guarded is what shared physical and safety constraints allow downstream.
+
+Guarded processing currently covers or prepares:
+
+- Control Mode gating
+- startup inhibit after controller reboot
+- water-temperature hard trip
+- excluded compressor levels
+- slew limiting
+- minimum runtime floor
+- topology hold
+- silent/day cap where it affects request shaping
+- defrost stop-hold where a stop request cannot safely land immediately
+
+Current guarded interface:
+
+- `oq_actuator_hp1_req`
+- `oq_actuator_hp2_req`
+- `oq_request_mode_code` as the mode carrier consumed by the actuator
+
+Important: `oq_actuator_hp*_req` is not applied state. It is a guarded request
+that can still be limited by actuator-local checks.
+
+Later naming direction:
+
+- `oq_guarded_mode_code`
+- `oq_guarded_hp1_level`
+- `oq_guarded_hp2_level`
+- optional `oq_guarded_reason`
+
+### Applied
+
+Applied is what was actually commanded to the heat pump selects or stored as
+actuator-owned applied bookkeeping.
+
+Applied includes:
+
+- `hp*_set_working_mode` calls
+- `hp*_compressor_level` calls
+- `hp*_last_applied_level`
+- `hp*_last_start_ms`
+- `hp*_last_stop_ms`
+- runtime-minute bookkeeping
+
+Applied is owned by `oq_thermal_actuator`. Strategies and request-control logic
+may read applied state for guards, but must not directly write HP mode or level
+selects.
+
+Later naming direction:
+
+- `oq_applied_hp1_level`
+- `oq_applied_hp2_level`
+- optional applied mode diagnostics
+
+## Current Name Mapping
+
+| Current name | Contract layer | Note |
+|---|---|---|
+| `oq_cooling_request_*` | strategy-local intent | Cooling chooses owner and levels for CM5. |
+| `oq_curve_dispatch_*` | strategy-local intent | Heating curve publishes dispatch/owner/topology. |
+| `oq_ph_request_*` | strategy-local intent | Power House publishes optimizer output. |
+| `oq_request_*` | intent | Explicit pre-guard/pre-actuator request interface. |
+| `oq_actuator_hp*_req` | guarded | Request-control output consumed by the actuator. |
+| `hp*_set_working_mode` | applied write | Only `oq_thermal_actuator` may write. |
+| `hp*_compressor_level` | applied write | Only `oq_thermal_actuator` may write. |
+| `hp*_last_applied_level` | applied state | Actuator-owned bookkeeping and guard input. |
+
+## Current Guard Order
+
+The code is not yet split into pure layers. For regression tests, the current
+order below is the behavior to preserve:
+
+1. Strategy-local outputs are selected based on Control Mode and strategy.
+2. `oq_request_*` publishes intent.
+3. Excluded levels are mapped to an allowed alternative.
+4. Non-Power-House modes get slew limiting.
+5. Water hard-trip forces request levels to 0.
+6. Startup inhibit forces request levels to 0.
+7. Minimum runtime may re-arm a zero request to level 1, except during hard-trip
+   and cooling floor trip.
+8. `oq_actuator_hp*_req` publishes guarded levels.
+9. The actuator applies min off-time, mode-confirmation gating, silent/day cap,
+   excluded-level cap and defrost retain around the actual writes.
+
+This split-location of guards is current semantics. Phase 3 may add tests and
+clarifying names/comments, but must not change this ordering without regression
+coverage.
+
+## Topology Contract
+
+Single topology:
+
+- HP2 request, guarded and applied values are always 0 or diagnostic `NAN`.
+- Owner collapses to HP1 for non-zero single requests.
+- Duo optimizer reasons must not depend on HP2 state.
+
+Duo topology:
+
+- HP1 and HP2 can independently have intent, guarded and applied levels.
+- Topology transitions between single and duo may arm hold state.
+- Runtime lead may influence owner/topology, but applied writes remain
+  actuator-owned.
+
+## Reason Contract
+
+Reason strings are diagnostics, not control inputs. They must not be required
+for correct behavior.
+
+Current reason families:
+
+- Strategy request reasons: `cooling_*`, `curve_*`, `ph_*`
+- Duo optimizer reasons: `keep_current`, `hold_active`, `defrost_hold`,
+  `better_heat`, `soft_guard`, `less_power`, `no_candidate`,
+  `defrost_boost`, `runtime_lead`, `single_topology`, `oil_return_hold`
+- Guard/block reasons: startup inhibit, hard trip, min runtime, min off-time,
+  excluded levels, cap to zero, waiting for thermal mode confirmation,
+  defrost protect hold
+- Supervisory transition reasons: CM override, commissioning, CM1 hold,
+  flow interlock, cooling/heating demand, frost and CM3 promote/demote
+
+Phase-3 migration path:
+
+1. Keep existing strings stable for MQTT/UI compatibility.
+2. Centralize code-to-string mapping in a helper or explicit mapping table.
+3. Add mapping tests before moving switch-statements.
+4. Introduce new canonical reason codes only if existing consumers keep working.
+
+Current phase-3 status:
+
+- request-reason mapping is centralized in `openquatt/includes/oq_thermal_request_logic.h`
+- Power House optimizer-reason names are centralized in the same helper
+- regression coverage asserts the current string outputs
+- dynamic actuator block messages remain local to the actuator because they carry
+  runtime numbers and are not code-driven enums
+
+## Regression Anchors
+
+Thermal scenarios for the regression harness:
+
+- startup inhibit zeroes guarded request before later guard stages
+- startup inhibit currently does not suppress a later min-runtime hold re-arm
+- min-runtime re-arms level 1 after real measured thermal start
+- cooling floor trip blocks min-runtime re-arm
+- water hard-trip wins over min-runtime
+- min off-time blocks restart in the actuator from previous applied 0
+- defrost hold retains last non-zero applied level only outside cooling
+- cooling transition may apply level once target mode matches
+- excluded requested level searches down first, then up
+- silent/day cap can reduce applied level and can block to 0
+- single topology never produces HP2 guarded/applied level
+- duo topology can arm single/duo hold on non-idle topology transition
+
+Supervisory scenarios for the regression harness:
+
+- CM0 idle from no thermal demand
+- CM1 preflow/postflow expiry to CM0/CM2/CM5/CM98
+- CM2 heating when flow and heat demand are valid
+- CM3 promote/demote hysteresis from Power House deficit
+- CM5 cooling has priority over heating strategy dispatch
+- CM98 frost and diagnostic force expiry
+- CM100 commissioning entry/exit
+- flow interlock blocks heating/cooling into CM1
+
+## Out Of Scope For This PR
+
+- no big-bang thermal refactor
+- no Supervisory C++ extraction
+- no flow PI conversion to C++
+- no dashboard or UX work
+- no `flow_rate_hp_avg` changes
+- no work in `oq_HP_io.yaml`
+- no breaking rename of existing HA/MQTT-facing entities

--- a/openquatt/includes/oq_thermal_request_logic.h
+++ b/openquatt/includes/oq_thermal_request_logic.h
@@ -217,4 +217,83 @@ inline bool min_runtime_window_active(uint32_t now_ms,
          (uint32_t)(now_ms - last_real_start_ms) < min_runtime_ms;
 }
 
+inline const char *cooling_request_reason(int reason_code) {
+  switch (reason_code) {
+    case 1: return "cooling_owner_hp1";
+    case 2: return "cooling_owner_hp2";
+    default: return "cooling_idle";
+  }
+}
+
+inline const char *optimizer_reason_inactive() {
+  return "inactive";
+}
+
+inline const char *optimizer_reason_curve_mode() {
+  return "curve_mode";
+}
+
+inline const char *optimizer_reason_single_topology() {
+  return "single_topology";
+}
+
+inline const char *optimizer_reason_defrost_protect_hold() {
+  return "defrost_protect_hold";
+}
+
+inline const char *curve_request_reason(int hp1_level,
+                                        int hp2_level,
+                                        int owner_hp,
+                                        int capacity_mode_code) {
+  if ((hp1_level + hp2_level) <= 0) return "curve_idle";
+  if (capacity_mode_code == 2) return "curve_dual";
+  if (owner_hp == 1) return "curve_single_hp1";
+  if (owner_hp == 2) return "curve_single_hp2";
+  return "curve_single";
+}
+
+inline const char *power_house_request_reason(int reason_code, bool duo_topology) {
+  if (duo_topology) {
+    switch (reason_code) {
+      case 1: return "ph_fallback_idle";
+      case 2: return "ph_fallback_single_hp1";
+      case 3: return "ph_fallback_single_hp2";
+      case 4: return "ph_fallback_duo";
+      case 5: return "keep_current";
+      case 6: return "hold_active";
+      case 7: return "defrost_hold";
+      case 8: return "better_heat";
+      case 9: return "soft_guard";
+      case 10: return "less_power";
+      case 11: return "no_candidate";
+      case 12: return "defrost_boost";
+      case 13: return "runtime_lead";
+      default: return "ph_idle";
+    }
+  }
+
+  switch (reason_code) {
+    case 1: return "ph_fallback_idle";
+    case 2: return "ph_fallback_single_hp1";
+    case 14: return "ph_single_topology";
+    default: return "ph_idle";
+  }
+}
+
+inline const char *power_house_optimizer_reason(int reason_code) {
+  switch (reason_code) {
+    case 5: return "keep_current";
+    case 6: return "hold_active";
+    case 7: return "defrost_hold";
+    case 8: return "better_heat";
+    case 9: return "soft_guard";
+    case 10: return "less_power";
+    case 11: return "no_candidate";
+    case 12: return "defrost_boost";
+    case 13: return "runtime_lead";
+    case 15: return "oil_return_hold";
+    default: return nullptr;
+  }
+}
+
 }  // namespace oq_request

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -986,16 +986,8 @@ interval:
             hp2_req = chosen_candidate.valid ? chosen_candidate.l2 : 0;
             request_reason_code = optimizer_reason_code;
 
-            switch (optimizer_reason_code) {
-              case 5: publish_optimizer_reason("keep_current"); break;
-              case 6: publish_optimizer_reason("hold_active"); break;
-              case 7: publish_optimizer_reason("defrost_hold"); break;
-              case 8: publish_optimizer_reason("better_heat"); break;
-              case 9: publish_optimizer_reason("soft_guard"); break;
-              case 10: publish_optimizer_reason("less_power"); break;
-              case 11: publish_optimizer_reason("no_candidate"); break;
-              case 15: publish_optimizer_reason("oil_return_hold"); break;
-              default: break;
+            if (const char* optimizer_reason = oq_request::power_house_optimizer_reason(optimizer_reason_code)) {
+              publish_optimizer_reason(optimizer_reason);
             }
 
             int def_comp_min_f = (int) roundf(${oq_defrost_comp_min_f});
@@ -1016,12 +1008,14 @@ interval:
               if (hp1_valve_def && !hp2_valve_def && hp2_req > 0) {
                 hp2_req = std::min(level_cap, hp2_req + def_comp_boost);
                 request_reason_code = 12;
-                publish_optimizer_reason("defrost_boost");
+                publish_optimizer_reason(
+                    oq_request::power_house_optimizer_reason(request_reason_code));
               }
               if (hp2_valve_def && !hp1_valve_def && hp1_req > 0) {
                 hp1_req = std::min(level_cap, hp1_req + def_comp_boost);
                 request_reason_code = 12;
-                publish_optimizer_reason("defrost_boost");
+                publish_optimizer_reason(
+                    oq_request::power_house_optimizer_reason(request_reason_code));
               }
             }
             if (hp1_req > 0 && hp2_req == 0) request_owner_hp = 1;
@@ -1045,12 +1039,13 @@ interval:
                   request_owner_hp = 2;
                 }
                 request_reason_code = 13;
-                publish_optimizer_reason("runtime_lead");
+                publish_optimizer_reason(
+                    oq_request::power_house_optimizer_reason(request_reason_code));
               }
             }
           }
           #else
-          publish_optimizer_reason("single_topology");
+          publish_optimizer_reason(oq_request::optimizer_reason_single_topology());
           const float Pr = id(house_rated_power_w).state;
           float P_req_total = id(oq_phouse_req_w);
           float P_cap = NAN;

--- a/openquatt/oq_thermal_actuator.yaml
+++ b/openquatt/oq_thermal_actuator.yaml
@@ -10,6 +10,13 @@
 #   - Consumes `oq_request_mode_code`
 #   - Consumes `oq_actuator_hp1_req` / `oq_actuator_hp2_req`
 #   - Is the only package that writes HP working mode and compressor levels
+#   - Owns applied state such as `hp*_last_applied_level`, start/stop
+#     timestamps, and runtime minute bookkeeping.
+#
+# Phase-3 contract terminology:
+#   - `oq_actuator_hp*_req` is guarded input, not applied state.
+#   - Applied means the write path below has commanded HP mode/level selects or
+#     updated actuator-owned bookkeeping.
 # ==============================================================================
 
 # ----------------------------
@@ -267,7 +274,7 @@ interval:
               block_reason = reason_buf;
               log_hp_block_change(is_hp1, reason_buf);
               apply_active_mode_hold(is_hp1, retained_level);
-              publish_optimizer_reason("defrost_protect_hold");
+              publish_optimizer_reason(oq_request::optimizer_reason_defrost_protect_hold());
               return retained_level;
             }
 
@@ -336,7 +343,7 @@ interval:
 
             if (applied == 0 && retained_level > 0) {
               apply_active_mode_hold(is_hp1, retained_level);
-              publish_optimizer_reason("defrost_protect_hold");
+              publish_optimizer_reason(oq_request::optimizer_reason_defrost_protect_hold());
               return retained_level;
             }
 

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -45,6 +45,12 @@
 #     1) shared gating / runtime anchors
 #     2) explicit request-interface publication
 #     3) final actuator-request preparation and safety gating
+#   - Phase-3 contract terminology:
+#     * strategy-local outputs (`oq_cooling_request_*`, `oq_curve_dispatch_*`,
+#       `oq_ph_request_*`) are producer intent.
+#     * `oq_request_*` is the current shared intent interface.
+#     * `oq_actuator_hp*_req` is the current guarded request consumed by
+#       `oq_thermal_actuator`; it is not applied hardware state.
 #
 # ==============================================================================
 
@@ -958,9 +964,11 @@ interval:
                 id(oq_duo_request_hold_until_ms),
                 0);
             #if OQ_TOPOLOGY_DUO
-            publish_optimizer_reason(any_hold ? "keep_current" : "inactive");
+            publish_optimizer_reason(any_hold ? oq_request::power_house_optimizer_reason(5)
+                                              : oq_request::optimizer_reason_inactive());
             #else
-            publish_optimizer_reason(hp1_hold_level > 0 ? "keep_current" : "inactive");
+            publish_optimizer_reason(hp1_hold_level > 0 ? oq_request::power_house_optimizer_reason(5)
+                                                        : oq_request::optimizer_reason_inactive());
             #endif
             const int hold_mode_code = hold_request_mode_code(hp1_hold_level, hp2_hold_level);
             publish_request(
@@ -1061,47 +1069,27 @@ interval:
           #if OQ_TOPOLOGY_DUO
           if (!is_power_house) {
             id(oq_duo_request_hold_until_ms) = 0;
-            publish_optimizer_reason("curve_mode");
+            publish_optimizer_reason(oq_request::optimizer_reason_curve_mode());
             if (is_cooling_mode) {
               hp1_req = id(oq_cooling_request_hp1_level);
               hp2_req = id(oq_cooling_request_hp2_level);
               request_owner_hp = id(oq_cooling_request_owner_hp);
-              switch (id(oq_cooling_request_reason_code)) {
-                case 1: request_reason = "cooling_owner_hp1"; break;
-                case 2: request_reason = "cooling_owner_hp2"; break;
-                default: request_reason = "cooling_idle"; break;
-              }
+              request_reason = oq_request::cooling_request_reason(
+                  id(oq_cooling_request_reason_code));
             } else {
               hp1_req = id(oq_curve_dispatch_hp1_level);
               hp2_req = id(oq_curve_dispatch_hp2_level);
               request_owner_hp = id(oq_curve_request_owner_hp);
-              if ((hp1_req + hp2_req) <= 0) request_reason = "curve_idle";
-              else if (id(oq_curve_capacity_mode_code) == 2) request_reason = "curve_dual";
-              else if (request_owner_hp == 1) request_reason = "curve_single_hp1";
-              else if (request_owner_hp == 2) request_reason = "curve_single_hp2";
-              else request_reason = "curve_single";
+              request_reason = oq_request::curve_request_reason(
+                  hp1_req, hp2_req, request_owner_hp, id(oq_curve_capacity_mode_code));
             }
 
           } else {
             hp1_req = id(oq_ph_request_hp1_level);
             hp2_req = id(oq_ph_request_hp2_level);
             request_owner_hp = id(oq_ph_request_owner_hp);
-            switch (id(oq_ph_request_reason_code)) {
-              case 1: request_reason = "ph_fallback_idle"; break;
-              case 2: request_reason = "ph_fallback_single_hp1"; break;
-              case 3: request_reason = "ph_fallback_single_hp2"; break;
-              case 4: request_reason = "ph_fallback_duo"; break;
-              case 5: request_reason = "keep_current"; break;
-              case 6: request_reason = "hold_active"; break;
-              case 7: request_reason = "defrost_hold"; break;
-              case 8: request_reason = "better_heat"; break;
-              case 9: request_reason = "soft_guard"; break;
-              case 10: request_reason = "less_power"; break;
-              case 11: request_reason = "no_candidate"; break;
-              case 12: request_reason = "defrost_boost"; break;
-              case 13: request_reason = "runtime_lead"; break;
-              default: request_reason = "ph_idle"; break;
-            }
+            request_reason = oq_request::power_house_request_reason(
+                id(oq_ph_request_reason_code), true);
           }
           #else
           oq_request::reset_dual_runtime_state(
@@ -1116,21 +1104,19 @@ interval:
             if (is_cooling_mode) {
               hp1_req = id(oq_cooling_request_hp1_level);
               request_owner_hp = id(oq_cooling_request_owner_hp);
-              request_reason = (request_owner_hp > 0) ? "cooling_owner_hp1" : "cooling_idle";
+              request_reason = oq_request::cooling_request_reason(
+                  id(oq_cooling_request_reason_code));
             } else {
               hp1_req = id(oq_curve_dispatch_hp1_level);
               request_owner_hp = id(oq_curve_request_owner_hp);
-              request_reason = (hp1_req > 0) ? "curve_single_hp1" : "curve_idle";
+              request_reason = oq_request::curve_request_reason(
+                  hp1_req, 0, request_owner_hp, id(oq_curve_capacity_mode_code));
             }
           } else {
             hp1_req = id(oq_ph_request_hp1_level);
             request_owner_hp = id(oq_ph_request_owner_hp);
-            switch (id(oq_ph_request_reason_code)) {
-              case 1: request_reason = "ph_fallback_idle"; break;
-              case 2: request_reason = "ph_fallback_single_hp1"; break;
-              case 14: request_reason = "ph_single_topology"; break;
-              default: request_reason = "ph_idle"; break;
-            }
+            request_reason = oq_request::power_house_request_reason(
+                id(oq_ph_request_reason_code), false);
           }
           hp2_req = 0;
           #endif

--- a/scripts/simulate_thermal_refactor_regressions.py
+++ b/scripts/simulate_thermal_refactor_regressions.py
@@ -179,6 +179,282 @@ def topology_hold_arms(previous_topology_count: int, new_topology_count: int) ->
     )
 
 
+def clamp_level(level: int, min_level: int, max_level: int) -> int:
+    return max(min_level, min(max_level, level))
+
+
+def excluded_option_matches_level(option: str, level: int) -> bool:
+    return {
+        1: "L1 (H30/C30)",
+        2: "L2 (H39/C36)",
+        3: "L3 (H49/C42)",
+        4: "L4 (H55/C47)",
+        5: "L5 (H61/C52)",
+        6: "L6 (H67/C56)",
+        7: "L7 (H72/C61)",
+        8: "L8 (H79/C66)",
+        9: "L9 (H85/C71)",
+        10: "L10 (H90/C74)",
+    }.get(level) == option
+
+
+def level_allowed_for_excluded_levels(excluded: tuple[str, str], level: int) -> bool:
+    if level <= 0 or level > 10:
+        return True
+    return (
+        not excluded_option_matches_level(excluded[0], level)
+        and not excluded_option_matches_level(excluded[1], level)
+    )
+
+
+def pick_allowed_level(
+    request_level: int,
+    min_level: int,
+    max_level: int,
+    excluded: tuple[str, str],
+) -> int:
+    if request_level <= 0:
+        return 0
+    request_level = clamp_level(request_level, min_level, max_level)
+    if request_level <= 0:
+        return 0
+    if level_allowed_for_excluded_levels(excluded, request_level):
+        return request_level
+
+    for level in range(request_level - 1, min_level - 1, -1):
+        if level > 0 and level_allowed_for_excluded_levels(excluded, level):
+            return level
+    for level in range(request_level + 1, max_level + 1):
+        if level > 0 and level_allowed_for_excluded_levels(excluded, level):
+            return level
+    return 0
+
+
+def pick_allowed_capped_level(
+    request_level: int,
+    min_level: int,
+    max_level: int,
+    cap_level: int,
+    excluded: tuple[str, str],
+) -> int:
+    if request_level <= 0:
+        return 0
+    cap_level = clamp_level(cap_level, min_level, max_level)
+    if cap_level <= 0:
+        return 0
+    request_level = clamp_level(request_level, min_level, cap_level)
+    if request_level <= 0:
+        return 0
+    if level_allowed_for_excluded_levels(excluded, request_level):
+        return request_level
+
+    for level in range(request_level - 1, min_level - 1, -1):
+        if level > 0 and level_allowed_for_excluded_levels(excluded, level):
+            return level
+    for level in range(request_level + 1, cap_level + 1):
+        if level > 0 and level_allowed_for_excluded_levels(excluded, level):
+            return level
+    return 0
+
+
+def guarded_request_after_runtime_floor(
+    request_level: int,
+    *,
+    hard_trip_active: bool,
+    startup_inhibit_active: bool,
+    min_runtime_active: bool,
+    cooling_floor_trip: bool,
+    measured_or_previously_active: bool,
+) -> int:
+    guarded_hp1_level, _ = apply_request_guards(
+        request_level,
+        0,
+        hard_trip_active=hard_trip_active,
+        startup_inhibit_active=startup_inhibit_active,
+    )
+    if not hard_trip_active:
+        guarded_hp1_level = runtime_floor_request(
+            guarded_hp1_level,
+            min_runtime_active=min_runtime_active,
+            cooling_floor_trip=cooling_floor_trip,
+            measured_or_previously_active=measured_or_previously_active,
+        )
+    return guarded_hp1_level
+
+
+def topology_guarded_requests(
+    hp1_request: int,
+    hp2_request: int,
+    *,
+    duo_topology: bool,
+) -> tuple[int, int]:
+    return hp1_request, hp2_request if duo_topology else 0
+
+
+def supervisory_base_target(
+    *,
+    cooling_request_active: bool,
+    heating_request_active: bool,
+    frost_active: bool,
+    lowflow_fault_active: bool,
+    flow_low: bool,
+) -> int:
+    thermal_request_active = cooling_request_active or heating_request_active
+    if cooling_request_active:
+        base_target = 5
+    elif heating_request_active:
+        base_target = 2
+    elif frost_active:
+        base_target = 98
+    else:
+        base_target = 0
+
+    if thermal_request_active and (lowflow_fault_active or flow_low):
+        return 1
+    return base_target
+
+
+def supervisory_override_or_commissioning(
+    *,
+    override_mode: int,
+    commissioning_in_progress: bool,
+) -> int | None:
+    if override_mode == 1:
+        return 0
+    if override_mode == 2:
+        return 1
+    if override_mode == 3:
+        return 98
+    if commissioning_in_progress:
+        return 100
+    return None
+
+
+def supervisory_normal_transition(
+    current_mode: int,
+    *,
+    cooling_request_active: bool,
+    heating_request_active: bool,
+    base_target: int,
+) -> int:
+    if cooling_request_active:
+        if base_target == 5:
+            return 5 if current_mode == 5 else 1
+        return 1
+    if heating_request_active:
+        if base_target == 2:
+            return 2 if current_mode in (2, 3) else 1
+        return 1
+    if current_mode in (2, 5):
+        return 1
+    return 98 if base_target == 98 else 0
+
+
+def supervisory_cm3_transition(
+    current_mode: int,
+    *,
+    power_house_active: bool,
+    boiler_assist_enabled: bool,
+    heating_request_active: bool,
+    base_target: int,
+    need_on: bool = False,
+    ok_off: bool = False,
+    min_cm2_elapsed: bool = False,
+    min_cm3_elapsed: bool = False,
+    promote_elapsed: bool = False,
+    demote_elapsed: bool = False,
+) -> int:
+    desired_mode = current_mode
+    if power_house_active and boiler_assist_enabled:
+        if current_mode == 2 and min_cm2_elapsed and need_on and promote_elapsed:
+            desired_mode = 3
+        elif current_mode == 3 and min_cm3_elapsed and ok_off and demote_elapsed:
+            desired_mode = 2
+    elif current_mode == 3 and heating_request_active and base_target == 2:
+        desired_mode = 2
+    return desired_mode
+
+
+def cooling_request_reason(reason_code: int) -> str:
+    return {
+        1: "cooling_owner_hp1",
+        2: "cooling_owner_hp2",
+    }.get(reason_code, "cooling_idle")
+
+
+def optimizer_reason_inactive() -> str:
+    return "inactive"
+
+
+def optimizer_reason_curve_mode() -> str:
+    return "curve_mode"
+
+
+def optimizer_reason_single_topology() -> str:
+    return "single_topology"
+
+
+def optimizer_reason_defrost_protect_hold() -> str:
+    return "defrost_protect_hold"
+
+
+def curve_request_reason(
+    hp1_level: int,
+    hp2_level: int,
+    owner_hp: int,
+    capacity_mode_code: int,
+) -> str:
+    if (hp1_level + hp2_level) <= 0:
+        return "curve_idle"
+    if capacity_mode_code == 2:
+        return "curve_dual"
+    if owner_hp == 1:
+        return "curve_single_hp1"
+    if owner_hp == 2:
+        return "curve_single_hp2"
+    return "curve_single"
+
+
+def power_house_request_reason(reason_code: int, *, duo_topology: bool) -> str:
+    if duo_topology:
+        return {
+            1: "ph_fallback_idle",
+            2: "ph_fallback_single_hp1",
+            3: "ph_fallback_single_hp2",
+            4: "ph_fallback_duo",
+            5: "keep_current",
+            6: "hold_active",
+            7: "defrost_hold",
+            8: "better_heat",
+            9: "soft_guard",
+            10: "less_power",
+            11: "no_candidate",
+            12: "defrost_boost",
+            13: "runtime_lead",
+        }.get(reason_code, "ph_idle")
+
+    return {
+        1: "ph_fallback_idle",
+        2: "ph_fallback_single_hp1",
+        14: "ph_single_topology",
+    }.get(reason_code, "ph_idle")
+
+
+def power_house_optimizer_reason(reason_code: int) -> str | None:
+    return {
+        5: "keep_current",
+        6: "hold_active",
+        7: "defrost_hold",
+        8: "better_heat",
+        9: "soft_guard",
+        10: "less_power",
+        11: "no_candidate",
+        12: "defrost_boost",
+        13: "runtime_lead",
+        15: "oil_return_hold",
+    }.get(reason_code)
+
+
 def run_scenarios() -> list[ScenarioResult]:
     results: list[ScenarioResult] = []
 
@@ -294,6 +570,38 @@ def run_scenarios() -> list[ScenarioResult]:
         apply_request_guards(4, 3, hard_trip_active=False, startup_inhibit_active=True) == (0, 0),
         f"apply_request_guards(...) -> {apply_request_guards(4, 3, hard_trip_active=False, startup_inhibit_active=True)}",
     )
+    add(
+        "Startup inhibit still allows runtime floor re-arm in current order",
+        guarded_request_after_runtime_floor(
+            4,
+            hard_trip_active=False,
+            startup_inhibit_active=True,
+            min_runtime_active=True,
+            cooling_floor_trip=False,
+            measured_or_previously_active=True,
+        )
+        == 1,
+        (
+            "guarded_request_after_runtime_floor(...) -> "
+            f"{guarded_request_after_runtime_floor(4, hard_trip_active=False, startup_inhibit_active=True, min_runtime_active=True, cooling_floor_trip=False, measured_or_previously_active=True)}"
+        ),
+    )
+    add(
+        "Hard trip suppresses runtime floor re-arm",
+        guarded_request_after_runtime_floor(
+            4,
+            hard_trip_active=True,
+            startup_inhibit_active=False,
+            min_runtime_active=True,
+            cooling_floor_trip=False,
+            measured_or_previously_active=True,
+        )
+        == 0,
+        (
+            "guarded_request_after_runtime_floor(...) -> "
+            f"{guarded_request_after_runtime_floor(4, hard_trip_active=True, startup_inhibit_active=False, min_runtime_active=True, cooling_floor_trip=False, measured_or_previously_active=True)}"
+        ),
+    )
 
     add(
         "Runtime floor can keep HP alive at level 1",
@@ -322,6 +630,67 @@ def run_scenarios() -> list[ScenarioResult]:
             "runtime_floor_request(...) -> "
             f"{runtime_floor_request(0, min_runtime_active=True, cooling_floor_trip=True, measured_or_previously_active=True)}"
         ),
+    )
+    add(
+        "Excluded level search prefers lower allowed level first",
+        pick_allowed_level(5, 1, 10, ("L5 (H61/C52)", "None")) == 4,
+        f"pick_allowed_level(...) -> {pick_allowed_level(5, 1, 10, ('L5 (H61/C52)', 'None'))}",
+    )
+    add(
+        "Excluded level search falls upward when no lower level exists",
+        pick_allowed_level(1, 1, 10, ("L1 (H30/C30)", "None")) == 2,
+        f"pick_allowed_level(...) -> {pick_allowed_level(1, 1, 10, ('L1 (H30/C30)', 'None'))}",
+    )
+    add(
+        "Silent or day cap may reduce a guarded request to zero",
+        pick_allowed_capped_level(4, 0, 10, 0, ("None", "None")) == 0,
+        f"pick_allowed_capped_level(...) -> {pick_allowed_capped_level(4, 0, 10, 0, ('None', 'None'))}",
+    )
+    add(
+        "Cooling request reason maps owner code 2 consistently",
+        cooling_request_reason(2) == "cooling_owner_hp2",
+        f"cooling_request_reason(2) -> {cooling_request_reason(2)}",
+    )
+    add(
+        "Curve request reason maps dual-capacity path consistently",
+        curve_request_reason(3, 3, 0, 2) == "curve_dual",
+        f"curve_request_reason(...) -> {curve_request_reason(3, 3, 0, 2)}",
+    )
+    add(
+        "Single-topology Power House request reason maps code 14 consistently",
+        power_house_request_reason(14, duo_topology=False) == "ph_single_topology",
+        (
+            "power_house_request_reason(...) -> "
+            f"{power_house_request_reason(14, duo_topology=False)}"
+        ),
+    )
+    add(
+        "Power House optimizer reason maps code 15 consistently",
+        power_house_optimizer_reason(15) == "oil_return_hold",
+        f"power_house_optimizer_reason(15) -> {power_house_optimizer_reason(15)}",
+    )
+    add(
+        "Shared inactive optimizer reason stays stable",
+        optimizer_reason_inactive() == "inactive",
+        f"optimizer_reason_inactive() -> {optimizer_reason_inactive()}",
+    )
+    add(
+        "Shared curve-mode optimizer reason stays stable",
+        optimizer_reason_curve_mode() == "curve_mode",
+        f"optimizer_reason_curve_mode() -> {optimizer_reason_curve_mode()}",
+    )
+    add(
+        "Shared defrost-protect optimizer reason stays stable",
+        optimizer_reason_defrost_protect_hold() == "defrost_protect_hold",
+        (
+            "optimizer_reason_defrost_protect_hold() -> "
+            f"{optimizer_reason_defrost_protect_hold()}"
+        ),
+    )
+    add(
+        "Shared single-topology optimizer reason stays stable",
+        optimizer_reason_single_topology() == "single_topology",
+        f"optimizer_reason_single_topology() -> {optimizer_reason_single_topology()}",
     )
 
     mode_command, applied_level = actuator_mode_and_level(
@@ -366,6 +735,20 @@ def run_scenarios() -> list[ScenarioResult]:
         applied_level == 5,
         f"mode_command={mode_command}, applied_level={applied_level}",
     )
+    mode_command, applied_level = actuator_mode_and_level(
+        4,
+        request_mode_code=2,
+        previous_applied_level=2,
+        min_off_blocked=False,
+        measured_mode_matches=True,
+        target_mode_matches=True,
+        silent_cap=0,
+    )
+    add(
+        "Actuator may keep heating mode command while cap drops applied level to zero",
+        (mode_command == "Heating") and (applied_level == 0),
+        f"mode_command={mode_command}, applied_level={applied_level}",
+    )
 
     add(
         "Topology hold arms on single-dual transition",
@@ -381,6 +764,198 @@ def run_scenarios() -> list[ScenarioResult]:
         "Topology hold does not arm when topology count is unchanged",
         topology_hold_arms(2, 2) is False,
         f"topology_hold_arms(2, 2) -> {topology_hold_arms(2, 2)}",
+    )
+    add(
+        "Single topology always forces HP2 guarded request to zero",
+        topology_guarded_requests(4, 3, duo_topology=False) == (4, 0),
+        f"topology_guarded_requests(...) -> {topology_guarded_requests(4, 3, duo_topology=False)}",
+    )
+    add(
+        "Duo topology preserves both guarded requests",
+        topology_guarded_requests(4, 3, duo_topology=True) == (4, 3),
+        f"topology_guarded_requests(...) -> {topology_guarded_requests(4, 3, duo_topology=True)}",
+    )
+    add(
+        "Cooling demand wins base target priority over heating demand",
+        supervisory_base_target(
+            cooling_request_active=True,
+            heating_request_active=True,
+            frost_active=False,
+            lowflow_fault_active=False,
+            flow_low=False,
+        )
+        == 5,
+        (
+            "supervisory_base_target(...) -> "
+            f"{supervisory_base_target(cooling_request_active=True, heating_request_active=True, frost_active=False, lowflow_fault_active=False, flow_low=False)}"
+        ),
+    )
+    add(
+        "Frost becomes base target when there is no thermal demand",
+        supervisory_base_target(
+            cooling_request_active=False,
+            heating_request_active=False,
+            frost_active=True,
+            lowflow_fault_active=False,
+            flow_low=False,
+        )
+        == 98,
+        (
+            "supervisory_base_target(...) -> "
+            f"{supervisory_base_target(cooling_request_active=False, heating_request_active=False, frost_active=True, lowflow_fault_active=False, flow_low=False)}"
+        ),
+    )
+    add(
+        "Flow interlock forces CM1 even when heating demand exists",
+        supervisory_base_target(
+            cooling_request_active=False,
+            heating_request_active=True,
+            frost_active=False,
+            lowflow_fault_active=True,
+            flow_low=False,
+        )
+        == 1,
+        (
+            "supervisory_base_target(...) -> "
+            f"{supervisory_base_target(cooling_request_active=False, heating_request_active=True, frost_active=False, lowflow_fault_active=True, flow_low=False)}"
+        ),
+    )
+    add(
+        "Supervisory override beats commissioning when both are present",
+        supervisory_override_or_commissioning(override_mode=3, commissioning_in_progress=True) == 98,
+        (
+            "supervisory_override_or_commissioning(...) -> "
+            f"{supervisory_override_or_commissioning(override_mode=3, commissioning_in_progress=True)}"
+        ),
+    )
+    add(
+        "Commissioning selects CM100 when override is Auto",
+        supervisory_override_or_commissioning(override_mode=0, commissioning_in_progress=True) == 100,
+        (
+            "supervisory_override_or_commissioning(...) -> "
+            f"{supervisory_override_or_commissioning(override_mode=0, commissioning_in_progress=True)}"
+        ),
+    )
+    add(
+        "Heating request from standby waits in CM1 preflow first",
+        supervisory_normal_transition(
+            0,
+            cooling_request_active=False,
+            heating_request_active=True,
+            base_target=2,
+        )
+        == 1,
+        (
+            "supervisory_normal_transition(...) -> "
+            f"{supervisory_normal_transition(0, cooling_request_active=False, heating_request_active=True, base_target=2)}"
+        ),
+    )
+    add(
+        "Active heating can move from CM3 back to CM2 without CM1 detour",
+        supervisory_normal_transition(
+            3,
+            cooling_request_active=False,
+            heating_request_active=True,
+            base_target=2,
+        )
+        == 2,
+        (
+            "supervisory_normal_transition(...) -> "
+            f"{supervisory_normal_transition(3, cooling_request_active=False, heating_request_active=True, base_target=2)}"
+        ),
+    )
+    add(
+        "Cooling request from standby waits in CM1 preflow first",
+        supervisory_normal_transition(
+            0,
+            cooling_request_active=True,
+            heating_request_active=False,
+            base_target=5,
+        )
+        == 1,
+        (
+            "supervisory_normal_transition(...) -> "
+            f"{supervisory_normal_transition(0, cooling_request_active=True, heating_request_active=False, base_target=5)}"
+        ),
+    )
+    add(
+        "No thermal demand from CM2 enters CM1 postflow before standby",
+        supervisory_normal_transition(
+            2,
+            cooling_request_active=False,
+            heating_request_active=False,
+            base_target=0,
+        )
+        == 1,
+        (
+            "supervisory_normal_transition(...) -> "
+            f"{supervisory_normal_transition(2, cooling_request_active=False, heating_request_active=False, base_target=0)}"
+        ),
+    )
+    add(
+        "No thermal demand from standby can resolve directly to frost",
+        supervisory_normal_transition(
+            0,
+            cooling_request_active=False,
+            heating_request_active=False,
+            base_target=98,
+        )
+        == 98,
+        (
+            "supervisory_normal_transition(...) -> "
+            f"{supervisory_normal_transition(0, cooling_request_active=False, heating_request_active=False, base_target=98)}"
+        ),
+    )
+    add(
+        "Power House deficit may promote CM2 to CM3 after timers elapse",
+        supervisory_cm3_transition(
+            2,
+            power_house_active=True,
+            boiler_assist_enabled=True,
+            heating_request_active=True,
+            base_target=2,
+            need_on=True,
+            min_cm2_elapsed=True,
+            promote_elapsed=True,
+        )
+        == 3,
+        (
+            "supervisory_cm3_transition(...) -> "
+            f"{supervisory_cm3_transition(2, power_house_active=True, boiler_assist_enabled=True, heating_request_active=True, base_target=2, need_on=True, min_cm2_elapsed=True, promote_elapsed=True)}"
+        ),
+    )
+    add(
+        "Power House deficit clear may demote CM3 to CM2 after timers elapse",
+        supervisory_cm3_transition(
+            3,
+            power_house_active=True,
+            boiler_assist_enabled=True,
+            heating_request_active=True,
+            base_target=2,
+            ok_off=True,
+            min_cm3_elapsed=True,
+            demote_elapsed=True,
+        )
+        == 2,
+        (
+            "supervisory_cm3_transition(...) -> "
+            f"{supervisory_cm3_transition(3, power_house_active=True, boiler_assist_enabled=True, heating_request_active=True, base_target=2, ok_off=True, min_cm3_elapsed=True, demote_elapsed=True)}"
+        ),
+    )
+    add(
+        "Disabled boiler assist collapses CM3 back to CM2 during heating",
+        supervisory_cm3_transition(
+            3,
+            power_house_active=False,
+            boiler_assist_enabled=False,
+            heating_request_active=True,
+            base_target=2,
+        )
+        == 2,
+        (
+            "supervisory_cm3_transition(...) -> "
+            f"{supervisory_cm3_transition(3, power_house_active=False, boiler_assist_enabled=False, heating_request_active=True, base_target=2)}"
+        ),
     )
 
     return results


### PR DESCRIPTION
## Summary
- document the phase-3 thermal contract with explicit `intent`, `guarded` and `applied` layers
- make the current `oq_request_*`, `oq_actuator_*` and applied actuator state mapping explicit in repo docs and code comments
- expand the regression harness for thermal guards, topology differences and supervisory transitions
- centralize request-reason and Power House optimizer-reason mapping without changing runtime behavior

## Scope
This PR is the phase-3 safety rail above PR158. It is intentionally focused on proof, naming clarity and regression coverage before phase 4 starts moving supervisory logic.

Included here:
- tracked thermal contract document in `docs/thermal-contract.md`
- architecture and package comments aligned with the contract
- regression harness growth from 26 to 55 scenarios
- centralized helper mapping for cooling, curve and Power House request reasons
- centralized helper mapping for Power House optimizer reasons and shared optimizer-reason literals

Not included here:
- no big-bang thermal refactor
- no Supervisory C++ extractie
- no flow PI conversion to C++
- no UX/dashboard work
- no `oq_HP_io.yaml` work
- no deliberate runtime behavior change

## Important Current-Behavior Note
The new harness now locks in an important existing nuance: startup inhibit currently zeros the request first, but it does **not** suppress a later minimum-runtime re-arm in the present guard ordering. That is documented on purpose so a later change can be reviewed as an intentional behavior change instead of an accidental one.

## Why
This keeps phase 3 reviewable on its own:
- contract first
- regression proof second
- logic movement later

That separation should make the next supervisory refactor safer and much easier to review as a stacked follow-up.

## Validation
- `uv run python scripts/simulate_thermal_refactor_regressions.py` (`55/55`)
- `uv run python scripts/check_style_consistency.py`
- `git diff --check`
- `./scripts/validate_local.sh`
