### PR TITLE
Refactor phase 4 supervisory contract

### DIFF
--- a/docs/supervisory-contract.md
+++ b/docs/supervisory-contract.md
@@ -1,0 +1,242 @@
+# Supervisory Contract
+
+This document captures the phase-4 supervisory contract for
+`openquatt/oq_supervisory_controlmode.yaml`. It documents current behavior
+before later refactors move Control Mode logic into smaller C++ helpers.
+
+The goal is not to redesign the state machine in one step. The goal is to make
+its inputs, state, outputs, transition reasons and timer semantics explicit so
+future extraction can be tested and staged.
+
+## Ownership Boundary
+
+Supervisory is the single owner of Control Mode:
+
+```text
+strategy/thermal/cooling/commissioning inputs -> supervisory -> Control Mode + pump policy + diagnostics
+```
+
+Supervisory may read strategy, thermal, cooling, flow, HP feedback and
+commissioning state. It may publish the active Control Mode, pump on/off policy,
+CM0 sticky-pump PWM, silent-mode writes and supervisory diagnostics.
+
+Supervisory must not own compressor request generation. Compressor levels are
+selected by the strategy and thermal request chain, then applied by the thermal
+actuator. Flow-control owns non-CM0 pump PWM behavior. Commissioning owns task
+state inside CM100, but supervisory owns whether CM100 is the active container.
+
+## Control Modes
+
+| Mode | Meaning | Supervisory contract |
+|---|---|---|
+| `CM0` | idle/standby | No active thermal demand, no frost, no commissioning and no forced holding. CM0 owns pump stop PWM except during sticky circulation or HP-active failsafe. |
+| `CM1` | preflow/postflow/holding | Pump-on holding state used before CM2/CM5, after CM2/CM5, or while flow is insufficient for a thermal request. |
+| `CM2` | heating, heat pump only | Heating demand active and flow path acceptable. CM3 may demote back to CM2 without a CM1 detour. |
+| `CM3` | heating with boiler assist | Power House heating with boiler assist enabled and sustained thermal deficit. |
+| `CM5` | cooling | Cooling request active; cooling has priority over heating when both are present. |
+| `CM98` | frost circulation | Frost protection when no thermal request is active, or manual force override. |
+| `CM100` | commissioning/service container | Explicit commissioning request or active commissioning task while CM override remains Auto. |
+
+## Inputs
+
+Supervisory input categories:
+
+- Operator/service inputs: `oq_cm_override`, `oq_enabled`,
+  `oq_openquatt_resume_at`, `oq_boiler_assist_enabled`, silent schedule and
+  silent override.
+- Strategy demand inputs: `oq_strategy_active_code`,
+  `oq_strategy_heat_request_active`, `oq_strategy_requested_power_w`,
+  `oq_P_deficit_w`.
+- Cooling demand inputs: `cooling_enable_selected`, `cooling_request_active`,
+  `cooling_permitted_core`.
+- Flow inputs: `flow_rate_selected`, `oq_cm_min_flow_lph`,
+  `oq_cm_flow_fault_s`, `oq_cm_flow_recover_s`.
+- Frost inputs: `outside_temp_selected`, `oq_cm_frost_on_c`,
+  `oq_cm_frost_off_c`, `oq_cm_frost_nan_grace_s`.
+- HP feedback and target inputs: `hp*_working_mode`, `hp*_set_working_mode`,
+  `hp*_compressor_level`, `hp*_last_applied_level`, `hp*_defrost`.
+- Commissioning inputs: `oq_commissioning_request_pending`,
+  `oq_commissioning_active`, `oq_commissioning_task_code`.
+- Power limiter inputs: total electrical input power, HP generation, mains
+  voltage and configured cap timing.
+
+These inputs are sampled in the supervisory interval. Later extraction should
+copy them into a single input struct before making a CM decision.
+
+## Internal State
+
+Current supervisory state lives in ESPHome globals:
+
+| State | Purpose |
+|---|---|
+| `oq_control_mode_code` and `oq_control_mode` | Last published Control Mode. |
+| `oq_cm_frost_prev` | Frost hysteresis latch. |
+| `oq_cm1_until_ms`, `oq_cm1_next_after` | CM1 preflow/postflow window and intended next CM. |
+| `oq_lowflow_since_ms`, `oq_flow_recover_since_ms`, `oq_lowflow_fault_active` | Flow interlock fault and recovery timers. |
+| `oq_cm2_idle_since_ms`, `oq_cm2_reentry_block_until_ms`, `oq_cm2_entered_ms` | Power House CM2 idle-exit, startup grace and re-entry block state. |
+| `oq_lowload_heat_latch`, `oq_ph_start_confirm_since_ms` | Power House low-load and start-confirmation filters. |
+| `oq_cm_last_change_ms`, `oq_cm3_need_since_ms`, `oq_cm3_demote_since_ms` | CM dwell and CM2/CM3 hysteresis timers. |
+| `oq_cm0_since_ms`, `oq_sticky_until_ms` | CM0 sticky-pump protection. |
+| `oq_power_cap_f`, `oq_power_over_*_s`, `oq_power_under_ok_s` | Duo power safety cap state. |
+
+State is runtime-only. It must not be persisted across reboot unless a later
+phase explicitly documents a reboot-safe reason.
+
+## Decision Order
+
+Current CM selection order is part of the contract:
+
+1. Update duo power safety cap.
+2. Resolve raw heating/cooling demand, including OpenQuatt master enable.
+3. Apply Power House low-load latch, CM2 idle-exit, re-entry block and start
+   confirmation.
+4. Update flow interlock timers and low-flow fault state.
+5. Resolve frost with hysteresis and startup NaN grace.
+6. Resolve base target priority: cooling -> heating -> frost -> standby.
+7. Apply flow interlock: any active thermal request with low flow or low-flow
+   fault targets CM1.
+8. Apply supervisory override. Override beats commissioning.
+9. Apply commissioning container when override is Auto.
+10. Apply CM1 preflow/postflow timer semantics.
+11. Apply HP-active guard that holds CM1 instead of leaving to CM0 while a unit
+    still reports or targets thermal activity.
+12. Apply Power House CM2/CM3 promote/demote hysteresis.
+13. Publish CM, label and transition reason on actual CM changes.
+14. Apply silent window writes and CM0 sticky/pump policy.
+
+No later refactor should reorder these steps without targeted regression
+coverage and an explicit contract update.
+
+## Transition Reasons
+
+Transition reasons are diagnostics. They must not be control inputs.
+
+Current reason families:
+
+| Family | Current strings |
+|---|---|
+| Overrides | `supervisory override: Force CM0`, `supervisory override: Force CM1`, `supervisory override: Force CM98` |
+| Commissioning | `commissioning task active` |
+| CM1 window | `pre/postflow hold for heating`, `pre/postflow hold for cooling`, `pre/postflow hold for frost`, `postflow hold for standby`, `CM1 hold timer active` |
+| CM1 expiry | `CM1 hold expired -> heating`, `CM1 hold expired -> cooling`, `CM1 hold expired -> frost`, `CM1 hold expired -> standby` |
+| Demand/base target | `cooling request waiting for CM1 hold`, `cooling already active`, `cooling request held by flow interlock`, `heating request waiting for CM1 hold`, `heating already active`, `heating request held by flow interlock`, `postflow before standby`, `frost protection`, `no thermal demand` |
+| CM3 hysteresis | `power-house deficit promoted to CM3`, `power-house deficit cleared, demoting to CM2`, `Power House assist disabled, returning to CM2`, `boiler/CV assist disabled, returning to CM2` |
+
+The current code does not publish every hold reason as an entity; it logs the
+reason only when the published CM changes. A later helper may return a
+structured reason code plus stable text, but should keep existing text stable
+until UI/MQTT consumers are checked.
+
+## Timer And Hysteresis Semantics
+
+- CM1 pre/postflow: entering heating/cooling from a non-active state starts
+  CM1 for `oq_cm_prepost_s` and records `next_after` as CM2 or CM5. Leaving
+  CM2/CM5 to standby starts CM1 with `next_after=0`.
+- CM1 expiry: on expiry from CM1, `next_after` is revalidated against current
+  demand and base target. Heating-curve postflow may resume CM2 directly if
+  demand recovered; Power House postflow deliberately does not auto-resume CM2
+  through that path.
+- Flow interlock: while thermal demand exists, invalid or below-threshold flow
+  starts a low-flow timer. A latched fault clears only after flow has stayed OK
+  for `oq_cm_flow_recover_s`. Low flow or a latched fault forces CM1.
+- Frost: frost is considered only when there is no thermal request. Invalid
+  outside temperature becomes fail-safe frost after startup NaN grace. Frost
+  uses ON/OFF hysteresis through `oq_cm_frost_prev`.
+- Manual CM98 override: Force CM98 remains active until the operator returns
+  the override selector to Auto or chooses another override.
+- CM2/CM3: CM3 promotion requires Power House, boiler assist enabled, current
+  CM2 dwell >= `oq_cm2_min_run_s`, deficit >= ON threshold for
+  `oq_cm3_promote_s`. CM3 demotion requires CM3 dwell >= `oq_cm3_min_run_s` and
+  deficit <= OFF threshold or invalid for `oq_cm3_demote_s`.
+- CM2 idle-exit: Power House can drop heat demand when CM2 has demand but both
+  HPs are commanded/measured idle for `oq_cm2_idle_exit_s`, unless blocked by
+  curve mode, startup grace or high requested load.
+- CM0 sticky pump: after `oq_cm0_sticky_wait_s` in CM0, run sticky circulation
+  for `oq_cm0_sticky_run_s` using `oq_sticky_pwm`, then restart the CM0 wait.
+
+All timer comparisons are millis-based and should preserve unsigned rollover
+semantics.
+
+## Outputs
+
+Supervisory outputs:
+
+- `oq_control_mode` and `oq_control_mode_code`
+- `oq_control_mode_label`
+- low-flow, time, silent and sticky diagnostics
+- HP pump mode on/off writes
+- CM0 sticky/stop pump PWM writes
+- silent low-noise mode writes
+- low-flow emergency standby/level-zero writes, except when defrost stop-hold
+  says a unit must keep its non-zero command until defrost clears
+
+Pump ownership boundary:
+
+- In CM0, supervisory writes stop/sticky PWM.
+- In CM1/CM2/CM3/CM5/CM98, supervisory keeps pump mode on, while flow-control
+  owns non-CM0 PWM behavior.
+- In idle CM100, pump may be off. During a CM100 task, pump is on.
+- Pump remains on as a failsafe while any HP still reports or targets thermal
+  activity.
+
+## Extraction Path
+
+Safe extraction should proceed in small slices:
+
+1. Keep YAML as the wiring layer and copy all decision inputs into explicit
+   structs.
+2. Centralize CM enum/code/name/label helpers.
+3. Extract pure base-target and override/commissioning resolution first.
+4. Extract CM1 timer result calculation with regression coverage.
+5. Extract CM2/CM3 hysteresis with explicit timer state.
+6. Extract sticky pump policy as a separate output decision.
+7. Only after those helpers are covered, reduce the YAML lambda to input
+   collection, helper calls, writes and diagnostics publication.
+
+Current phase-4 helper status:
+
+- centralized in `openquatt/includes/oq_supervisory_logic.h`:
+  CM enum/code/name/label, frost computation, base-target resolution,
+  override-mode normalization, override/commissioning resolution, CM1 expiry
+  target resolution, normal transition resolution, standby-hold guard, CM3
+  transition resolution and pump-policy helpers
+- still local in YAML:
+  CM1 timer running/expired state ownership, CM1 start side effects, CM3 timer
+  accumulation/reason publication, silent window publication and sticky-timer
+  state
+
+Out of scope for phase 4:
+
+- no big-bang supervisory rewrite
+- no full C++ migration of `oq_supervisory_controlmode.yaml`
+- no thermal guard refactor
+- no flow PI conversion
+- no dashboard/UX work
+- no `flow_rate_hp_avg` changes
+- no work in `oq_HP_io.yaml`
+
+## Regression Anchors
+
+The current regression harness already covers the first supervisory anchors:
+
+- base target priority: cooling before heating before frost before standby
+- flow interlock forcing CM1
+- override priority over commissioning
+- CM100 selection from commissioning while override is Auto
+- CM1 preflow/postflow entry and selected expiry paths
+- CM1 timer running vs expired as explicit state
+- HP-active guard holding CM1 before standby
+- direct CM3 -> CM2 heating demotion without a CM1 detour
+- frost hysteresis and startup NaN grace in the CM target path
+- CM2/CM3 promote/demote hysteresis when timers are elapsed
+- CM2 idle-exit and Power House re-entry block interaction
+- sticky pump output policy
+- CM100 task-active pump policy
+
+Phase-4 status:
+
+- supervisory contract is documented
+- CM transition regressions run outside ESPHome
+- pure supervisory CM decision helpers live in shared C++
+- YAML remains the owner of ESPHome entity wiring, timer storage and
+  side-effectful publication

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -247,6 +247,21 @@ compressor level selects. It also owns final actuator-local guards such as
 minimum off-time, mode-confirmation gating, silent/day cap application, defrost
 retain behavior, start/stop bookkeeping and runtime counters.
 
+## 7. Supervisory Control Mode Contract
+
+The Control Mode state machine is documented in
+[`docs/supervisory-contract.md`](supervisory-contract.md). Supervisory owns
+`CM0/CM1/CM2/CM3/CM5/CM98/CM100`, but it does not own compressor request
+generation or flow PI output.
+
+Current CM decision order is part of the contract: base demand resolution,
+Power House low-load/start filters, flow interlock, frost hysteresis, base
+target priority, override, commissioning, CM1 pre/postflow, HP-active standby
+hold, CM2/CM3 hysteresis and finally pump policy publication.
+
+Transition reasons are diagnostics, not control inputs. They should stay stable
+until UI/MQTT consumers are checked.
+
 Demand filter behavior is asymmetric:
 
 - downward path follows demand immediately
@@ -262,7 +277,7 @@ Power House duo request selection works in simple steps:
 - if two single-HP options are equally good, choose the runtime lead HP
 - defrost derating now follows the real `4-Way valve` phase, and extra compensation is only added if the chosen combination would otherwise still underdeliver
 
-## 7. Flow Control Mechanics
+## 8. Flow Control Mechanics
 
 Flow control execution priority:
 
@@ -279,7 +294,7 @@ Key behaviors:
 - validity-based failsafe (`iPWM=850`)
 - stable-flow tracking for `last_good_pwm`
 
-## 8. Safety Model
+## 9. Safety Model
 
 Safety is distributed but coordinated:
 
@@ -289,7 +304,7 @@ Safety is distributed but coordinated:
 - stale feed invalidation in CIC ingest
 - conservative fallback on invalid numeric inputs
 
-## 9. Hardware Profiles and Pin Strategy
+## 10. Hardware Profiles and Pin Strategy
 
 Hardware profile substitutions are split into dedicated files:
 
@@ -305,7 +320,7 @@ Compile-time profile selection is done by choosing the firmware entrypoint:
 - `openquatt_single_waveshare.yaml`
 - `openquatt_single_heatpump_listener.yaml`
 
-## 10. UI and Observability Organization
+## 11. UI and Observability Organization
 
 `oq_webserver.yaml` defines stable sorting groups used across packages:
 
@@ -318,7 +333,7 @@ Compile-time profile selection is done by choosing the firmware entrypoint:
 
 This keeps ESPHome web UI and Home Assistant mapping coherent.
 
-## 11. Engineering Notes
+## 12. Engineering Notes
 
 - Keep ownership boundaries intact when refactoring.
 - Preserve entity IDs unless migration is documented.

--- a/openquatt/includes/oq_supervisory_logic.h
+++ b/openquatt/includes/oq_supervisory_logic.h
@@ -1,8 +1,19 @@
 #pragma once
 
 #include <math.h>
+#include <string.h>
 
 namespace oq_supervisory {
+
+enum ControlModeCode {
+  CONTROL_MODE_CM0 = 0,
+  CONTROL_MODE_CM1 = 1,
+  CONTROL_MODE_CM2 = 2,
+  CONTROL_MODE_CM3 = 3,
+  CONTROL_MODE_CM5 = 5,
+  CONTROL_MODE_CM98 = 98,
+  CONTROL_MODE_CM100 = 100,
+};
 
 struct PowerCapState {
   int cap_f;
@@ -27,6 +38,68 @@ struct FrostConfig {
   float on_c;
   float off_c;
 };
+
+struct NormalTransitionInput {
+  int current_mode;
+  bool cooling_request_active;
+  bool heating_request_active;
+  int base_target;
+};
+
+struct NormalTransitionResult {
+  int desired_mode;
+  int start_cm1_next_after;
+};
+
+struct Cm3TransitionInput {
+  int current_mode;
+  bool power_house_active;
+  bool boiler_assist_enabled;
+  bool heating_request_active;
+  int base_target;
+  bool need_on;
+  bool ok_off;
+  bool min_cm2_elapsed;
+  bool min_cm3_elapsed;
+  bool promote_elapsed;
+  bool demote_elapsed;
+};
+
+inline int normalize_override_mode(int override_mode) {
+  if (override_mode < 0 || override_mode > 3) return 0;
+  return override_mode;
+}
+
+inline int control_mode_id_to_code(const char *cm_id) {
+  if (cm_id == nullptr) return CONTROL_MODE_CM0;
+  if (strcmp(cm_id, "CM100") == 0) return CONTROL_MODE_CM100;
+  if (strcmp(cm_id, "CM98") == 0) return CONTROL_MODE_CM98;
+  if (strcmp(cm_id, "CM5") == 0) return CONTROL_MODE_CM5;
+  if (strcmp(cm_id, "CM3") == 0) return CONTROL_MODE_CM3;
+  if (strcmp(cm_id, "CM2") == 0) return CONTROL_MODE_CM2;
+  if (strcmp(cm_id, "CM1") == 0) return CONTROL_MODE_CM1;
+  return CONTROL_MODE_CM0;
+}
+
+inline const char *control_mode_code_to_id(int cm) {
+  if (cm == CONTROL_MODE_CM100) return "CM100";
+  if (cm == CONTROL_MODE_CM98) return "CM98";
+  if (cm == CONTROL_MODE_CM5) return "CM5";
+  if (cm == CONTROL_MODE_CM3) return "CM3";
+  if (cm == CONTROL_MODE_CM2) return "CM2";
+  if (cm == CONTROL_MODE_CM1) return "CM1";
+  return "CM0";
+}
+
+inline const char *control_mode_code_to_label(int cm) {
+  if (cm == CONTROL_MODE_CM100) return "CM100 - Commissioning";
+  if (cm == CONTROL_MODE_CM98) return "CM98 - Anti-Freeze Protection - Water Circulation";
+  if (cm == CONTROL_MODE_CM5) return "CM5 - Cooling";
+  if (cm == CONTROL_MODE_CM3) return "CM3 - Heating - Heat Pump + Boiler";
+  if (cm == CONTROL_MODE_CM2) return "CM2 - Heating - Heat Pump Only";
+  if (cm == CONTROL_MODE_CM1) return "CM1 - Preflow/Postflow";
+  return "CM0 - Standby";
+}
 
 inline PowerCapState step_power_cap(PowerCapState state, float power_w, const PowerCapConfig &cfg) {
   if (isnan(power_w)) {
@@ -72,6 +145,141 @@ inline bool compute_frost(bool heating_req, float outside_c, bool prev_frost, bo
   if (isnan(outside_c)) return !frost_nan_grace_active;
   if (prev_frost) return outside_c < cfg.off_c;
   return outside_c < cfg.on_c;
+}
+
+inline int compute_base_target(bool cooling_request_active,
+                               bool heating_request_active,
+                               bool frost_active,
+                               bool lowflow_fault_active,
+                               bool flow_low) {
+  const bool thermal_request_active = cooling_request_active || heating_request_active;
+  int base_target = CONTROL_MODE_CM0;
+  if (cooling_request_active) base_target = CONTROL_MODE_CM5;
+  else if (heating_request_active) base_target = CONTROL_MODE_CM2;
+  else if (frost_active) base_target = CONTROL_MODE_CM98;
+
+  if (thermal_request_active && (lowflow_fault_active || flow_low)) {
+    return CONTROL_MODE_CM1;
+  }
+  return base_target;
+}
+
+inline int resolve_override_or_commissioning(int override_mode, bool commissioning_in_progress) {
+  if (override_mode == 1) return CONTROL_MODE_CM0;
+  if (override_mode == 2) return CONTROL_MODE_CM1;
+  if (override_mode == 3) return CONTROL_MODE_CM98;
+  if (commissioning_in_progress) return CONTROL_MODE_CM100;
+  return -1;
+}
+
+inline int resolve_cm1_expiry_target(int cm1_next_after,
+                                     bool cooling_request_active,
+                                     bool heating_request_active,
+                                     int base_target,
+                                     int strategy_active_code) {
+  if (cm1_next_after == CONTROL_MODE_CM2) {
+    if (heating_request_active && base_target == CONTROL_MODE_CM2) return CONTROL_MODE_CM2;
+    if (base_target == CONTROL_MODE_CM98) return CONTROL_MODE_CM98;
+    return CONTROL_MODE_CM0;
+  }
+  if (cm1_next_after == CONTROL_MODE_CM5) {
+    if (cooling_request_active && base_target == CONTROL_MODE_CM5) return CONTROL_MODE_CM5;
+    if (base_target == CONTROL_MODE_CM98) return CONTROL_MODE_CM98;
+    return CONTROL_MODE_CM0;
+  }
+  if (cm1_next_after == CONTROL_MODE_CM0) {
+    if (cooling_request_active && base_target == CONTROL_MODE_CM5) return CONTROL_MODE_CM5;
+    if (strategy_active_code == 2 && heating_request_active && base_target == CONTROL_MODE_CM2) {
+      return CONTROL_MODE_CM2;
+    }
+    if (base_target == CONTROL_MODE_CM98) return CONTROL_MODE_CM98;
+    return CONTROL_MODE_CM0;
+  }
+  if (cm1_next_after == CONTROL_MODE_CM98) return CONTROL_MODE_CM98;
+  if (base_target == CONTROL_MODE_CM5) return CONTROL_MODE_CM5;
+  if (base_target == CONTROL_MODE_CM2) return CONTROL_MODE_CM2;
+  if (base_target == CONTROL_MODE_CM98) return CONTROL_MODE_CM98;
+  return CONTROL_MODE_CM0;
+}
+
+inline NormalTransitionResult resolve_normal_transition(const NormalTransitionInput &input) {
+  if (input.cooling_request_active) {
+    if (input.base_target == CONTROL_MODE_CM5) {
+      if (input.current_mode == CONTROL_MODE_CM5) {
+        return NormalTransitionResult{CONTROL_MODE_CM5, -1};
+      }
+      return NormalTransitionResult{CONTROL_MODE_CM1, CONTROL_MODE_CM5};
+    }
+    return NormalTransitionResult{CONTROL_MODE_CM1, -1};
+  }
+
+  if (input.heating_request_active) {
+    if (input.base_target == CONTROL_MODE_CM2) {
+      if (input.current_mode == CONTROL_MODE_CM2 || input.current_mode == CONTROL_MODE_CM3) {
+        return NormalTransitionResult{CONTROL_MODE_CM2, -1};
+      }
+      return NormalTransitionResult{CONTROL_MODE_CM1, CONTROL_MODE_CM2};
+    }
+    return NormalTransitionResult{CONTROL_MODE_CM1, -1};
+  }
+
+  if (input.current_mode == CONTROL_MODE_CM2 || input.current_mode == CONTROL_MODE_CM5) {
+    return NormalTransitionResult{CONTROL_MODE_CM1, CONTROL_MODE_CM0};
+  }
+  if (input.base_target == CONTROL_MODE_CM98) {
+    return NormalTransitionResult{CONTROL_MODE_CM98, -1};
+  }
+  return NormalTransitionResult{CONTROL_MODE_CM0, -1};
+}
+
+inline int apply_standby_hold_guard(int current_mode,
+                                    bool thermal_request_active,
+                                    int base_target,
+                                    bool any_hp_active_guard,
+                                    int desired_mode) {
+  if (current_mode == CONTROL_MODE_CM1 &&
+      !thermal_request_active &&
+      base_target == CONTROL_MODE_CM0 &&
+      any_hp_active_guard) {
+    return CONTROL_MODE_CM1;
+  }
+  return desired_mode;
+}
+
+inline int resolve_cm3_transition(const Cm3TransitionInput &input) {
+  int desired_mode = input.current_mode;
+  if (input.power_house_active && input.boiler_assist_enabled) {
+    if (input.current_mode == CONTROL_MODE_CM2 &&
+        input.min_cm2_elapsed &&
+        input.need_on &&
+        input.promote_elapsed) {
+      desired_mode = CONTROL_MODE_CM3;
+    } else if (input.current_mode == CONTROL_MODE_CM3 &&
+               input.min_cm3_elapsed &&
+               input.ok_off &&
+               input.demote_elapsed) {
+      desired_mode = CONTROL_MODE_CM2;
+    }
+  } else if (input.current_mode == CONTROL_MODE_CM3 &&
+             input.heating_request_active &&
+             input.base_target == CONTROL_MODE_CM2) {
+    desired_mode = CONTROL_MODE_CM2;
+  }
+  return desired_mode;
+}
+
+inline bool pump_should_run(int desired_cm,
+                            bool commissioning_task_active,
+                            bool sticky_active,
+                            bool any_hp_active_guard) {
+  return (desired_cm != CONTROL_MODE_CM0 && desired_cm != CONTROL_MODE_CM100) ||
+         commissioning_task_active ||
+         sticky_active ||
+         any_hp_active_guard;
+}
+
+inline float cm0_pump_target_pwm(bool sticky_active, float stop_pwm, float sticky_pwm) {
+  return sticky_active ? sticky_pwm : stop_pwm;
 }
 
 }  // namespace oq_supervisory

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -23,6 +23,7 @@ oq_psram_buffer_header: "components/openquatt_common/PsramBuffer.h" # Shared PSR
 oq_timers_header: "openquatt/includes/oq_timers.h"       # Shared C++ helpers for millis()/elapsed timer patterns.
 oq_cic_compatibility_logic_header: "openquatt/includes/oq_cic_compatibility_logic.h" # Shared helpers for CiC compatibility lambdas.
 oq_cic_compatibility_protocol_header: "openquatt/includes/oq_cic_compatibility_protocol.h" # Shared helpers for CiC compatibility protocol encoding.
+oq_supervisory_logic_header: "openquatt/includes/oq_supervisory_logic.h" # Shared supervisory helpers for CM naming and pure policy decisions.
 oq_timezone: "Europe/Amsterdam"                         # SNTP timezone used by runtime timestamps.
 oq_webserver_css_url: ""                            # Optional external CSS for the ESPHome web UI.
 oq_webserver_js_url: ""                               # Custom OpenQuatt app is primary; load ESPHome fallback lazily on demand.
@@ -73,7 +74,6 @@ oq_ph_start_confirm_s: "30"                           # Power House start confir
 oq_cm_frost_on_c: "5.0"                               # Frost protection enable threshold [°C].
 oq_cm_frost_off_c: "6.0"                              # Frost protection disable threshold (hysteresis) [°C].
 oq_cm_frost_nan_grace_s: "30"                         # Startup grace before NaN outside temp triggers frost fail-safe [s].
-oq_cm98_diag_max_s: "1800"                            # Maximum duration of diagnostic Force CM98 override [s].
 oq_cm3_promote_s: "300"                               # Required deficit duration for CM2 -> CM3 promotion [s].
 oq_cm3_demote_s: "120"                                # Required low-deficit duration for CM3 -> CM2 demotion [s].
 oq_cm3_min_run_s: "300"                               # Minimum dwell time in CM3 before demotion [s].

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -4,6 +4,7 @@
 #
 # Goal:
 #   Determines the active Control Mode (CM) as central state machine and publishes the system decision to the other packages.
+#   The phase-4 contract for inputs, state, outputs, reasons and timer semantics is documented in docs/supervisory-contract.md.
 #
 # Role in architecture:
 #   Single owner of Control Mode; coordinates subsystems by selecting CM (CM0/CM1/CM2/CM3/CM5/CM98/CM100).
@@ -11,7 +12,7 @@
 # What this package DOES do:
 #   - Determines base mode (idle / heating / cooling / frost) based on demand and conditions
 #   - Applies flow override: with insufficient flow -> CM1 (holding)
-#   - Supports test override: Force CM0/CM1 and Diagnostic Force CM98 (auto-expire)
+#   - Supports test override: Force CM0/CM1/CM98
 #   - Exposes CM100 commissioning when a service task is explicitly requested
 #   - Automatically switches CM2 <-> CM3 based on thermal deficit (`oq_P_deficit_w`) with timers/hysteresis
 #   - Publishes current CM as text_sensor (for example 'CM2', 'CM3', 'CM5', 'CM100')
@@ -131,15 +132,7 @@ globals:
 
   # ----------------------------
   # Supervisory override (test/commissioning)
-  # AUTO / FORCE_CM0 / FORCE_CM1 / FORCE_CM98_DIAG (auto-expire)
-  - id: oq_override_last_mode
-    type: int
-    restore_value: false
-    initial_value: '0'  # 0=AUTO,1=CM0,2=CM1,3=CM98_DIAG
-  - id: oq_override_cm98_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
+  # AUTO / FORCE_CM0 / FORCE_CM1 / FORCE_CM98
   - id: oq_control_mode_code
     type: int
     restore_value: false
@@ -708,26 +701,6 @@ interval:
               last_value = value;
             }
           };
-          auto cm_code_to_id = [](int cm) -> const char* {
-            if (cm == 100) return "CM100";
-            if (cm == 98) return "CM98";
-            if (cm == 5) return "CM5";
-            if (cm == 3) return "CM3";
-            if (cm == 2) return "CM2";
-            if (cm == 1) return "CM1";
-            return "CM0";
-          };
-          auto cm_code_to_label = [&](int cm) -> std::string {
-            const char* cm_id = cm_code_to_id(cm);
-            if (strcmp(cm_id, "CM100") == 0) return std::string("CM100 - Commissioning");
-            if (strcmp(cm_id, "CM0") == 0) return std::string("CM0 - Standby");
-            if (strcmp(cm_id, "CM1") == 0) return std::string("CM1 - Preflow/Postflow");
-            if (strcmp(cm_id, "CM2") == 0) return std::string("CM2 - Heating - Heat Pump Only");
-            if (strcmp(cm_id, "CM3") == 0) return std::string("CM3 - Heating - Heat Pump + Boiler");
-            if (strcmp(cm_id, "CM5") == 0) return std::string("CM5 - Cooling");
-            if (strcmp(cm_id, "CM98") == 0) return std::string("CM98 - Anti-Freeze Protection - Water Circulation");
-            return std::string("Unknown");
-          };
           auto ms_window_active = [&](uint32_t until_ms)->bool {
             if (until_ms == 0) return false;
             return static_cast<uint32_t>(until_ms - now_ms) < 0x80000000UL;
@@ -1049,24 +1022,23 @@ interval:
           // -------------------------------------------------
           const float outside_c = id(outside_temp_selected).state;
 
-          bool frost = false;
-          if (!thermal_req) {
-            if (isnan(outside_c)) {
-              frost = !frost_nan_grace_active; // fail-safe after startup grace
-            } else {
-              if (id(oq_cm_frost_prev)) {
-                frost = (outside_c < ${oq_cm_frost_off_c});
-              } else {
-                frost = (outside_c < ${oq_cm_frost_on_c});
-              }
-            }
-          }
+          const oq_supervisory::FrostConfig frost_cfg{
+            .on_c = ${oq_cm_frost_on_c},
+            .off_c = ${oq_cm_frost_off_c},
+          };
+          const bool frost = oq_supervisory::compute_frost(
+              thermal_req,
+              outside_c,
+              id(oq_cm_frost_prev),
+              frost_nan_grace_active,
+              frost_cfg);
           id(oq_cm_frost_prev) = frost;
 
           // -------------------------------------------------
           // 4) CM selection with CM1 timer (pre/postflow) + flow interlock
           // -------------------------------------------------
           const char* cur_cm = id(oq_control_mode).state.c_str();
+          const int cur_cm_code = oq_supervisory::control_mode_id_to_code(cur_cm);
           std::string cm_transition_reason = "control decision updated";
           auto resolve_desired_cm = [&]() -> int {
             // Helper: start CM1 window
@@ -1083,16 +1055,12 @@ interval:
             };
 
             // Determine base target (without CM1 timer)
-            int base_target = 0; // CM0
-            if (cooling_req) base_target = 5;     // CM5 desired
-            else if (heating_req) base_target = 2; // CM2 desired
-            else if (frost)  base_target = 98;     // CM98 desired
-            else             base_target = 0;      // CM0
-
-            // Apply flow interlock: if thermal output is requested but low-flow fault => hold in CM1.
-            if (thermal_req && (id(oq_lowflow_fault_active) || flow_low)) {
-              base_target = 1; // force CM1 as safe holding state
-            }
+            const int base_target = oq_supervisory::compute_base_target(
+                cooling_req,
+                heating_req,
+                frost,
+                id(oq_lowflow_fault_active),
+                flow_low);
 
             // Handle CM1 window:
             // - If we're currently in CM1 and timer is running, keep CM1 until expiry.
@@ -1102,57 +1070,33 @@ interval:
             // Supervisory override (test/commissioning)
             // - Auto (normal logic)
             // - Force CM0 / Force CM1
-            // - Force CM98 (auto-expire after 30 min)
-            int override_mode = id(oq_cm_override).active_index().value_or(0); // 0=AUTO,1=CM0,2=CM1,3=CM98_DIAG
-            if (override_mode < 0 || override_mode > 3) override_mode = 0;
-            // Track entry into CM98 diagnostic override for auto-expire
-            if (override_mode != id(oq_override_last_mode)) {
-              id(oq_override_last_mode) = override_mode;
-              id(oq_override_cm98_since_ms) = (override_mode == 3) ? now_ms : 0;
-            }
-            // Auto-expire Diagnostic CM98 after 30 minutes
-            if (override_mode == 3) {
-              const uint32_t MAX_MS = (uint32_t)(${oq_cm98_diag_max_s}UL * 1000UL);
-              if (id(oq_override_cm98_since_ms) != 0 && (uint32_t)(now_ms - id(oq_override_cm98_since_ms)) >= MAX_MS) {
-                ESP_LOGI("supervisory", "CM98 diagnostic override expired after %u s; returning to Auto.",
-                         (unsigned int) ${oq_cm98_diag_max_s});
-                auto call = id(oq_cm_override).make_call();
-                call.set_option("Auto");
-                call.perform();
-                override_mode = 0;
-                id(oq_override_last_mode) = 0;
-                id(oq_override_cm98_since_ms) = 0;
-              }
-            }
+            // - Force CM98
+            int override_mode = oq_supervisory::normalize_override_mode(
+                id(oq_cm_override).active_index().value_or(0)); // 0=AUTO,1=CM0,2=CM1,3=CM98
 
-            int desired_local = 0;
-            if (override_mode != 0) {
+            int desired_local = oq_supervisory::CONTROL_MODE_CM0;
+            const bool commissioning_in_progress =
+                id(oq_commissioning_request_pending) || id(oq_commissioning_active);
+            const int override_or_commissioning = oq_supervisory::resolve_override_or_commissioning(
+                override_mode,
+                commissioning_in_progress);
+            if (override_or_commissioning >= 0) {
               // Clear transition timers to avoid surprises when returning to Auto
               id(oq_cm1_until_ms) = 0;
               id(oq_cm1_next_after) = 0;
               id(oq_cm3_need_since_ms) = 0;
               id(oq_cm3_demote_since_ms) = 0;
+              desired_local = override_or_commissioning;
               if (override_mode == 1) {
-                desired_local = 0;       // CM0
                 cm_transition_reason = "supervisory override: Force CM0";
               } else if (override_mode == 2) {
-                desired_local = 1;  // CM1
                 cm_transition_reason = "supervisory override: Force CM1";
               } else if (override_mode == 3) {
-                desired_local = 98; // CM98
                 cm_transition_reason = "supervisory override: Force CM98";
+              } else {
+                cm_transition_reason = "commissioning task active";
               }
             } else {
-              const bool commissioning_in_progress =
-                  id(oq_commissioning_request_pending) || id(oq_commissioning_active);
-              if (commissioning_in_progress) {
-                id(oq_cm1_until_ms) = 0;
-                id(oq_cm1_next_after) = 0;
-                id(oq_cm3_need_since_ms) = 0;
-                id(oq_cm3_demote_since_ms) = 0;
-                desired_local = 100;
-                cm_transition_reason = "commissioning task active";
-              } else {
               // Snapshot CM1 timer state (before we touch globals)
               const bool cm1_timer_active  = (id(oq_cm1_until_ms) != 0);
               const bool cm1_timer_running = cm1_timer_active && now_before_until;
@@ -1160,35 +1104,18 @@ interval:
               const int  cm1_next_after    = id(oq_cm1_next_after);
 
               // 1) If we're in CM1 and timer is still running -> stay CM1
-              if (cm1_timer_running && strcmp(cur_cm, "CM1") == 0) {
-                desired_local = 1;
+              if (cm1_timer_running && cur_cm_code == oq_supervisory::CONTROL_MODE_CM1) {
+                desired_local = oq_supervisory::CONTROL_MODE_CM1;
                 cm_transition_reason = "CM1 hold timer active";
 
                   // 2) If we're in CM1 and timer just expired -> advance to next_after
-                  } else if (cm1_timer_expired && strcmp(cur_cm, "CM1") == 0) {
-                    if (cm1_next_after == 2) {
-                      if (heating_req && base_target == 2) desired_local = 2;
-                      else if (base_target == 98)          desired_local = 98;
-                      else                                 desired_local = 0;
-                    } else if (cm1_next_after == 5) {
-                      if (cooling_req && base_target == 5) desired_local = 5;
-                      else if (base_target == 98)          desired_local = 98;
-                      else                                 desired_local = 0;
-                    } else if (cm1_next_after == 0) {
-                      // Re-evaluate heating/frost when postflow expires.
-                      // If demand recovered during CM1-postflow, resume CM2/CM5 directly
-                      // instead of forcing an avoidable CM0 hop (anti-flip/chatter).
-                      // Scope this behavior to heating-curve strategy only; keep
-                      // Power House behavior unchanged.
-                      if (cooling_req && base_target == 5) desired_local = 5;
-                      else if (strategy_active_code == 2 && heating_req && base_target == 2) desired_local = 2;
-                      else if (base_target == 98)          desired_local = 98;
-                      else                                 desired_local = 0;
-                    } else if (cm1_next_after == 98) {
-                      desired_local = 98;
-                    } else {
-                      desired_local = (base_target == 5) ? 5 : ((base_target == 2) ? 2 : (base_target == 98 ? 98 : 0));
-                    }
+                  } else if (cm1_timer_expired && cur_cm_code == oq_supervisory::CONTROL_MODE_CM1) {
+                    desired_local = oq_supervisory::resolve_cm1_expiry_target(
+                        cm1_next_after,
+                        cooling_req,
+                        heating_req,
+                        base_target,
+                        strategy_active_code);
 
                     cm_transition_reason =
                         (desired_local == 2) ? "CM1 hold expired -> heating" :
@@ -1208,62 +1135,56 @@ interval:
                   id(oq_cm1_next_after) = 0;
                 }
 
+                const auto normal_result = oq_supervisory::resolve_normal_transition(
+                    oq_supervisory::NormalTransitionInput{
+                        .current_mode = cur_cm_code,
+                        .cooling_request_active = cooling_req,
+                        .heating_request_active = heating_req,
+                        .base_target = base_target,
+                    });
+                desired_local = normal_result.desired_mode;
+
+                if (normal_result.start_cm1_next_after >= 0) {
+                  start_cm1(normal_result.start_cm1_next_after);
+                }
+
                 if (cooling_req) {
-                  if (base_target == 5) {
-                    if (strcmp(cur_cm, "CM5") == 0) {
-                      desired_local = 5;
-                      cm_transition_reason = "cooling already active";
-                    } else {
-                      start_cm1(5);
-                      desired_local = 1;
-                      cm_transition_reason = "cooling request waiting for CM1 hold";
-                    }
-                  } else {
-                    desired_local = 1; // flow interlock holding state
-                    cm_transition_reason = "cooling request held by flow interlock";
-                  }
+                  cm_transition_reason =
+                      (base_target == oq_supervisory::CONTROL_MODE_CM5 && cur_cm_code == oq_supervisory::CONTROL_MODE_CM5)
+                          ? "cooling already active"
+                          : (base_target == oq_supervisory::CONTROL_MODE_CM5)
+                                ? "cooling request waiting for CM1 hold"
+                                : "cooling request held by flow interlock";
                 } else if (heating_req) {
-                  if (base_target == 2) {
-                    // Keep active heating transitions inside the heating states. CM3 -> CM2
-                    // should not force an artificial CM1 detour that drops compressor requests.
-                    if (strcmp(cur_cm, "CM2") == 0 || strcmp(cur_cm, "CM3") == 0) {
-                      desired_local = 2;
-                      cm_transition_reason = "heating already active";
-                    } else {
-                      start_cm1(2);
-                      desired_local = 1;
-                      cm_transition_reason = "heating request waiting for CM1 hold";
-                    }
-                  } else {
-                    desired_local = 1; // flow interlock holding state
-                    cm_transition_reason = "heating request held by flow interlock";
-                  }
+                  cm_transition_reason =
+                      (base_target == oq_supervisory::CONTROL_MODE_CM2 &&
+                       (cur_cm_code == oq_supervisory::CONTROL_MODE_CM2 || cur_cm_code == oq_supervisory::CONTROL_MODE_CM3))
+                          ? "heating already active"
+                          : (base_target == oq_supervisory::CONTROL_MODE_CM2)
+                                ? "heating request waiting for CM1 hold"
+                                : "heating request held by flow interlock";
                 } else {
-                  if (strcmp(cur_cm, "CM2") == 0 || strcmp(cur_cm, "CM5") == 0) {
-                    start_cm1(0); // postflow to CM0
-                    desired_local = 1;
-                    cm_transition_reason = "postflow before standby";
-                  } else {
-                    desired_local = (base_target == 98) ? 98 : 0;
-                    cm_transition_reason = (desired_local == 98) ? "frost protection" : "no thermal demand";
-                  }
+                  cm_transition_reason =
+                      (normal_result.start_cm1_next_after == oq_supervisory::CONTROL_MODE_CM0)
+                          ? "postflow before standby"
+                          : (desired_local == oq_supervisory::CONTROL_MODE_CM98)
+                                ? "frost protection"
+                                : "no thermal demand";
                 }
               }
 
               // Safety: never leave CM1 to CM0 while any HP still reports/targets activity.
               // Keep CM1 (pump-on holding state) until both HPs are effectively idle.
-                  if (strcmp(cur_cm, "CM1") == 0 && !thermal_req && base_target == 0 && any_hp_active_guard) {
-                    desired_local = 1;
-                  }
+              desired_local = oq_supervisory::apply_standby_hold_guard(
+                  cur_cm_code,
+                  thermal_req,
+                  base_target,
+                  any_hp_active_guard,
+                  desired_local);
 
               // CM3 (boiler assist) is a Power House-only feature and only applies
               // when the installation has explicit boiler/CV assist enabled.
-              const int cm_now =
-                  (strcmp(cur_cm, "CM3") == 0) ? 3 :
-                  (strcmp(cur_cm, "CM2") == 0) ? 2 :
-                  (strcmp(cur_cm, "CM5") == 0) ? 5 :
-                  (strcmp(cur_cm, "CM1") == 0) ? 1 :
-                  (strcmp(cur_cm, "CM98") == 0) ? 98 : 0;
+              const int cm_now = cur_cm_code;
               const bool boiler_assist_enabled = id(oq_boiler_assist_enabled).state;
               if (power_house_active && boiler_assist_enabled) {
                 // CM3 (boiler assist) auto-switching
@@ -1282,8 +1203,23 @@ interval:
                   if (now_ms - id(oq_cm_last_change_ms) >= MIN_CM2_MS) {
                     if (need_on) {
                       if (id(oq_cm3_need_since_ms) == 0) id(oq_cm3_need_since_ms) = now_ms;
-                      if (now_ms - id(oq_cm3_need_since_ms) >= T_ON_MS) {
-                        desired_local = 3;
+                      const bool promote_elapsed = (now_ms - id(oq_cm3_need_since_ms) >= T_ON_MS);
+                      const int cm3_desired = oq_supervisory::resolve_cm3_transition(
+                          oq_supervisory::Cm3TransitionInput{
+                              .current_mode = cm_now,
+                              .power_house_active = power_house_active,
+                              .boiler_assist_enabled = boiler_assist_enabled,
+                              .heating_request_active = heating_req,
+                              .base_target = base_target,
+                              .need_on = need_on,
+                              .ok_off = ok_off,
+                              .min_cm2_elapsed = true,
+                              .min_cm3_elapsed = false,
+                              .promote_elapsed = promote_elapsed,
+                              .demote_elapsed = false,
+                          });
+                      if (cm3_desired == oq_supervisory::CONTROL_MODE_CM3) {
+                        desired_local = oq_supervisory::CONTROL_MODE_CM3;
                         cm_transition_reason = "power-house deficit promoted to CM3";
                       }
                     } else {
@@ -1294,8 +1230,23 @@ interval:
                   if (now_ms - id(oq_cm_last_change_ms) >= MIN_CM3_MS) {
                     if (ok_off) {
                       if (id(oq_cm3_demote_since_ms) == 0) id(oq_cm3_demote_since_ms) = now_ms;
-                      if (now_ms - id(oq_cm3_demote_since_ms) >= T_OFF_MS) {
-                        desired_local = 2;
+                      const bool demote_elapsed = (now_ms - id(oq_cm3_demote_since_ms) >= T_OFF_MS);
+                      const int cm3_desired = oq_supervisory::resolve_cm3_transition(
+                          oq_supervisory::Cm3TransitionInput{
+                              .current_mode = cm_now,
+                              .power_house_active = power_house_active,
+                              .boiler_assist_enabled = boiler_assist_enabled,
+                              .heating_request_active = heating_req,
+                              .base_target = base_target,
+                              .need_on = need_on,
+                              .ok_off = ok_off,
+                              .min_cm2_elapsed = false,
+                              .min_cm3_elapsed = true,
+                              .promote_elapsed = false,
+                              .demote_elapsed = demote_elapsed,
+                          });
+                      if (cm3_desired == oq_supervisory::CONTROL_MODE_CM2) {
+                        desired_local = oq_supervisory::CONTROL_MODE_CM2;
                         cm_transition_reason = "power-house deficit cleared, demoting to CM2";
                       }
                     } else {
@@ -1309,19 +1260,32 @@ interval:
               } else {
                 id(oq_cm3_need_since_ms) = 0;
                 id(oq_cm3_demote_since_ms) = 0;
-                if (cm_now == 3 && heating_req && base_target == 2) {
-                  desired_local = 2;
+                const int cm3_desired = oq_supervisory::resolve_cm3_transition(
+                    oq_supervisory::Cm3TransitionInput{
+                        .current_mode = cm_now,
+                        .power_house_active = power_house_active,
+                        .boiler_assist_enabled = boiler_assist_enabled,
+                        .heating_request_active = heating_req,
+                        .base_target = base_target,
+                        .need_on = false,
+                        .ok_off = false,
+                        .min_cm2_elapsed = false,
+                        .min_cm3_elapsed = false,
+                        .promote_elapsed = false,
+                        .demote_elapsed = false,
+                    });
+                if (cm3_desired == oq_supervisory::CONTROL_MODE_CM2 && cm_now == oq_supervisory::CONTROL_MODE_CM3) {
+                  desired_local = oq_supervisory::CONTROL_MODE_CM2;
                   cm_transition_reason = boiler_assist_enabled
                       ? "Power House assist disabled, returning to CM2"
                       : "boiler/CV assist disabled, returning to CM2";
                 }
               }
-              }
             }
             return desired_local;
           };
           const int desired = resolve_desired_cm();
-          const char* desired_cm = cm_code_to_id(desired);
+          const char* desired_cm = oq_supervisory::control_mode_code_to_id(desired);
           id(oq_control_mode_code) = desired;
           // -------------------------------------------------
           // 5) Publish CM (writes-only-on-change)
@@ -1340,7 +1304,10 @@ interval:
             }
           }
           static std::string last_control_mode_label;
-          publish_text_if_changed(id(oq_control_mode_label), cm_code_to_label(desired), last_control_mode_label);
+          publish_text_if_changed(
+              id(oq_control_mode_label),
+              std::string(oq_supervisory::control_mode_code_to_label(desired)),
+              last_control_mode_label);
 
           auto apply_silent_window = [&]() -> void {
             // Silent window + diagnostics + low-noise mode selection.
@@ -1461,19 +1428,23 @@ interval:
                 (id(oq_commissioning_task_code) != 0);
             // Pump failsafe: never stop circulation while any HP is still active.
             // CM100 idle is a service stand, not an active circulation mode.
-            const bool pump_on = (strcmp(desired_cm, "CM0") != 0 && strcmp(desired_cm, "CM100") != 0) ||
-                                 cm100_task_active ||
-                                 sticky_active ||
-                                 any_hp_active_guard;
+            const bool pump_on = oq_supervisory::pump_should_run(
+                desired,
+                cm100_task_active,
+                sticky_active,
+                any_hp_active_guard);
             set_select_option(id(hp1_set_pump_mode), pump_on ? "On" : "Off");
             #if OQ_TOPOLOGY_DUO
             set_select_option(id(${supervisory_secondary_set_pump_mode_id}), pump_on ? "On" : "Off");
             #endif
 
-            if (strcmp(desired_cm, "CM0") == 0) {
+            if (desired == oq_supervisory::CONTROL_MODE_CM0) {
               const float stop_pwm = ${oq_cm0_pump_stop_ipwm};
               const float sticky_pwm = ${oq_sticky_pwm};
-              const float target_pwm = sticky_active ? sticky_pwm : stop_pwm;
+              const float target_pwm = oq_supervisory::cm0_pump_target_pwm(
+                  sticky_active,
+                  stop_pwm,
+                  sticky_pwm);
               set_number_value(id(hp1_pump_speed), target_pwm, 1.0f);
               #if OQ_TOPOLOGY_DUO
               set_number_value(id(${supervisory_secondary_pump_speed_id}), target_pwm, 1.0f);

--- a/openquatt_base_common.yaml
+++ b/openquatt_base_common.yaml
@@ -22,6 +22,7 @@ esphome:
     - ${oq_timers_header}
     - ${oq_cic_compatibility_logic_header}
     - ${oq_cic_compatibility_protocol_header}
+    - ${oq_supervisory_logic_header}
   platformio_options:
     extra_scripts:
       - pre:../../../scripts/normalize_factory_merge_inputs.py

--- a/scripts/simulate_thermal_refactor_regressions.py
+++ b/scripts/simulate_thermal_refactor_regressions.py
@@ -110,6 +110,32 @@ def cm1_expiry_resume(
     return 0
 
 
+def supervisory_cm1_timer_transition(
+    current_mode: int,
+    *,
+    cm1_timer_running: bool,
+    cm1_timer_expired: bool,
+    cm1_next_after: int,
+    cooling_request_active: bool,
+    heating_request_active: bool,
+    base_target: int,
+    strategy_active_code: int,
+) -> int | None:
+    if current_mode != 1:
+        return None
+    if cm1_timer_running:
+        return 1
+    if cm1_timer_expired:
+        return cm1_expiry_resume(
+            cm1_next_after,
+            cooling_request_active,
+            heating_request_active,
+            base_target,
+            strategy_active_code,
+        )
+    return None
+
+
 def apply_request_guards(
     hp1_request: int,
     hp2_request: int,
@@ -350,6 +376,19 @@ def supervisory_normal_transition(
     return 98 if base_target == 98 else 0
 
 
+def supervisory_cm1_standby_guard(
+    current_mode: int,
+    *,
+    thermal_request_active: bool,
+    base_target: int,
+    any_hp_active_guard: bool,
+    desired_mode: int,
+) -> int:
+    if current_mode == 1 and not thermal_request_active and base_target == 0 and any_hp_active_guard:
+        return 1
+    return desired_mode
+
+
 def supervisory_cm3_transition(
     current_mode: int,
     *,
@@ -373,6 +412,75 @@ def supervisory_cm3_transition(
     elif current_mode == 3 and heating_request_active and base_target == 2:
         desired_mode = 2
     return desired_mode
+
+
+def supervisory_frost_active(
+    *,
+    thermal_request_active: bool,
+    outside_temp_c: float | None,
+    prev_frost: bool,
+    frost_nan_grace_active: bool,
+    frost_on_c: float = 5.0,
+    frost_off_c: float = 6.0,
+) -> bool:
+    if thermal_request_active:
+        return False
+    if outside_temp_c is None:
+        return not frost_nan_grace_active
+    if prev_frost:
+        return outside_temp_c < frost_off_c
+    return outside_temp_c < frost_on_c
+
+
+def supervisory_cm2_idle_exit_heating_request(
+    *,
+    in_cm2: bool,
+    heating_request_active: bool,
+    curve_mode_active: bool,
+    both_levels_off: bool,
+    both_units_idle: bool,
+    startup_grace_active: bool,
+    ph_high_load_idle_exit_block: bool,
+    idle_exit_elapsed: bool,
+    power_house_active: bool,
+    reentry_block_active: bool,
+) -> bool:
+    cm2_idle_exit_trip = (
+        in_cm2
+        and heating_request_active
+        and not curve_mode_active
+        and both_levels_off
+        and both_units_idle
+        and not startup_grace_active
+        and not ph_high_load_idle_exit_block
+        and idle_exit_elapsed
+    )
+    next_heating_request = heating_request_active and not cm2_idle_exit_trip
+    if power_house_active and not in_cm2 and reentry_block_active:
+        return False
+    return next_heating_request
+
+
+def supervisory_pump_on(
+    desired_mode: int,
+    *,
+    commissioning_task_active: bool,
+    sticky_active: bool,
+    any_hp_active_guard: bool,
+) -> bool:
+    return desired_mode not in (0, 100) or commissioning_task_active or sticky_active or any_hp_active_guard
+
+
+def supervisory_cm0_pump_pwm(
+    desired_mode: int,
+    *,
+    sticky_active: bool,
+    stop_pwm: float,
+    sticky_pwm: float,
+) -> float | None:
+    if desired_mode != 0:
+        return None
+    return sticky_pwm if sticky_active else stop_pwm
 
 
 def cooling_request_reason(reason_code: int) -> str:
@@ -558,6 +666,42 @@ def run_scenarios() -> list[ScenarioResult]:
         "CM1 expiry resumes CM5 when cooling demand recovered",
         cm1_expiry_resume(0, True, False, 5, 1) == 5,
         f"cm1_expiry_resume(...) -> {cm1_expiry_resume(0, True, False, 5, 1)}",
+    )
+    add(
+        "CM1 timer running keeps CM1 active",
+        supervisory_cm1_timer_transition(
+            1,
+            cm1_timer_running=True,
+            cm1_timer_expired=False,
+            cm1_next_after=2,
+            cooling_request_active=False,
+            heating_request_active=True,
+            base_target=2,
+            strategy_active_code=2,
+        )
+        == 1,
+        (
+            "supervisory_cm1_timer_transition(...) -> "
+            f"{supervisory_cm1_timer_transition(1, cm1_timer_running=True, cm1_timer_expired=False, cm1_next_after=2, cooling_request_active=False, heating_request_active=True, base_target=2, strategy_active_code=2)}"
+        ),
+    )
+    add(
+        "CM1 timer expiry may resolve directly to frost",
+        supervisory_cm1_timer_transition(
+            1,
+            cm1_timer_running=False,
+            cm1_timer_expired=True,
+            cm1_next_after=2,
+            cooling_request_active=False,
+            heating_request_active=False,
+            base_target=98,
+            strategy_active_code=2,
+        )
+        == 98,
+        (
+            "supervisory_cm1_timer_transition(...) -> "
+            f"{supervisory_cm1_timer_transition(1, cm1_timer_running=False, cm1_timer_expired=True, cm1_next_after=2, cooling_request_active=False, heating_request_active=False, base_target=98, strategy_active_code=2)}"
+        ),
     )
 
     add(
@@ -907,6 +1051,21 @@ def run_scenarios() -> list[ScenarioResult]:
         ),
     )
     add(
+        "CM1 stays active before standby while any HP still reports activity",
+        supervisory_cm1_standby_guard(
+            1,
+            thermal_request_active=False,
+            base_target=0,
+            any_hp_active_guard=True,
+            desired_mode=0,
+        )
+        == 1,
+        (
+            "supervisory_cm1_standby_guard(...) -> "
+            f"{supervisory_cm1_standby_guard(1, thermal_request_active=False, base_target=0, any_hp_active_guard=True, desired_mode=0)}"
+        ),
+    )
+    add(
         "Power House deficit may promote CM2 to CM3 after timers elapse",
         supervisory_cm3_transition(
             2,
@@ -955,6 +1114,125 @@ def run_scenarios() -> list[ScenarioResult]:
         (
             "supervisory_cm3_transition(...) -> "
             f"{supervisory_cm3_transition(3, power_house_active=False, boiler_assist_enabled=False, heating_request_active=True, base_target=2)}"
+        ),
+    )
+    add(
+        "Frost stays off during startup NaN grace and turns on after grace",
+        supervisory_frost_active(
+            thermal_request_active=False,
+            outside_temp_c=None,
+            prev_frost=False,
+            frost_nan_grace_active=True,
+        )
+        is False
+        and supervisory_frost_active(
+            thermal_request_active=False,
+            outside_temp_c=None,
+            prev_frost=False,
+            frost_nan_grace_active=False,
+        )
+        is True,
+        (
+            "supervisory_frost_active(...) -> "
+            f"{supervisory_frost_active(thermal_request_active=False, outside_temp_c=None, prev_frost=False, frost_nan_grace_active=False)}"
+        ),
+    )
+    add(
+        "Frost hysteresis holds CM98 until outside temperature reaches the off threshold",
+        supervisory_frost_active(
+            thermal_request_active=False,
+            outside_temp_c=5.5,
+            prev_frost=True,
+            frost_nan_grace_active=False,
+        )
+        is True
+        and supervisory_frost_active(
+            thermal_request_active=False,
+            outside_temp_c=6.1,
+            prev_frost=True,
+            frost_nan_grace_active=False,
+        )
+        is False,
+        (
+            "supervisory_frost_active(...) -> "
+            f"{supervisory_frost_active(thermal_request_active=False, outside_temp_c=5.5, prev_frost=True, frost_nan_grace_active=False)}"
+        ),
+    )
+    add(
+        "CM2 idle-exit can drop heating demand and re-entry block keeps it suppressed outside CM2",
+        supervisory_cm2_idle_exit_heating_request(
+            in_cm2=True,
+            heating_request_active=True,
+            curve_mode_active=False,
+            both_levels_off=True,
+            both_units_idle=True,
+            startup_grace_active=False,
+            ph_high_load_idle_exit_block=False,
+            idle_exit_elapsed=True,
+            power_house_active=True,
+            reentry_block_active=False,
+        )
+        is False
+        and supervisory_cm2_idle_exit_heating_request(
+            in_cm2=False,
+            heating_request_active=True,
+            curve_mode_active=False,
+            both_levels_off=True,
+            both_units_idle=True,
+            startup_grace_active=False,
+            ph_high_load_idle_exit_block=False,
+            idle_exit_elapsed=False,
+            power_house_active=True,
+            reentry_block_active=True,
+        )
+        is False,
+        (
+            "supervisory_cm2_idle_exit_heating_request(...) -> "
+            f"{supervisory_cm2_idle_exit_heating_request(in_cm2=False, heating_request_active=True, curve_mode_active=False, both_levels_off=True, both_units_idle=True, startup_grace_active=False, ph_high_load_idle_exit_block=False, idle_exit_elapsed=False, power_house_active=True, reentry_block_active=True)}"
+        ),
+    )
+    add(
+        "CM0 sticky run keeps pump on and uses sticky PWM",
+        supervisory_pump_on(
+            0,
+            commissioning_task_active=False,
+            sticky_active=True,
+            any_hp_active_guard=False,
+        )
+        is True
+        and supervisory_cm0_pump_pwm(
+            0,
+            sticky_active=True,
+            stop_pwm=1000.0,
+            sticky_pwm=850.0,
+        )
+        == 850.0,
+        (
+            "supervisory_pump_on/supervisory_cm0_pump_pwm -> "
+            f"{supervisory_pump_on(0, commissioning_task_active=False, sticky_active=True, any_hp_active_guard=False)}, "
+            f"{supervisory_cm0_pump_pwm(0, sticky_active=True, stop_pwm=1000.0, sticky_pwm=850.0)}"
+        ),
+    )
+    add(
+        "CM100 idle may stop the pump while a CM100 task keeps it on",
+        supervisory_pump_on(
+            100,
+            commissioning_task_active=False,
+            sticky_active=False,
+            any_hp_active_guard=False,
+        )
+        is False
+        and supervisory_pump_on(
+            100,
+            commissioning_task_active=True,
+            sticky_active=False,
+            any_hp_active_guard=False,
+        )
+        is True,
+        (
+            "supervisory_pump_on(...) -> "
+            f"{supervisory_pump_on(100, commissioning_task_active=False, sticky_active=False, any_hp_active_guard=False)}, "
+            f"{supervisory_pump_on(100, commissioning_task_active=True, sticky_active=False, any_hp_active_guard=False)}"
         ),
     )
 


### PR DESCRIPTION
## What changed

This PR is the phase-4 follow-up stacked on top of PR159. It finishes the supervisory-contract part of the refactor plan by making the supervisory contract explicit, expanding regression coverage for control-mode behavior, and moving the pure supervisory CM decision helpers into shared C++ seams.

The PR adds a tracked supervisory contract document and system-overview references, expands the regression harness around CM1/CM2/CM3/CM98/CM100 behavior, and centralizes pure supervisory helpers in `openquatt/includes/oq_supervisory_logic.h`.

It also removes the automatic expiry of manual `Force CM98` because that behavior turned out not to be useful.

## Scope

This is intentionally the next stacked step after PR159:
- PR159 established the thermal contract, naming cleanup and regression anchors
- this PR builds on that by making supervisory behavior explicit and more verifiable
- the runtime orchestration stays in YAML while pure CM decision logic moves into small shared helpers

Included here:
- tracked supervisory contract document in `docs/supervisory-contract.md`
- system overview references aligned with the supervisory contract
- regression harness growth from 55 to 63 scenarios for supervisory behavior
- centralized pure supervisory helpers for CM naming, frost, base-target resolution, override/commissioning resolution, CM1 expiry handling, CM2/CM3 transition logic and pump policy
- removal of `Force CM98` automatic expiry so manual CM98 stays active until the override returns to `Auto`

Not included here:
- no big-bang supervisory refactor
- no full C++ migration of `oq_supervisory_controlmode.yaml`
- no new thermal guard refactor in this phase
- no flow PI conversion to C++
- no UX/dashboard work
- no `oq_HP_io.yaml` work

## Why it changed

Phase 4 was about making supervisory behavior visible and verifiable before any larger extraction work. The previous YAML held a lot of decision logic inline, which made it harder to reason about control-mode transitions and safer follow-up refactors.

This PR separates pure CM decision logic from ESPHome runtime wiring so later changes can build on explicit contracts and regression anchors instead of implicit behavior.

## Impact

- Supervisory behavior is now documented in `docs/supervisory-contract.md`.
- The regression harness now locks in the current supervisory contract outside ESPHome.
- `oq_supervisory_controlmode.yaml` keeps timer state, side effects and publication, while shared helpers now own pure CM decision rules.
- Manual `Force CM98` stays active until the operator returns the override to `Auto`.

## Validation

- `uv run python scripts/simulate_thermal_refactor_regressions.py` -> `63/63`
- `./scripts/validate_local.sh`
  - style consistency
  - docs consistency
  - config validation for all 4 firmware profiles
  - compile validation for all 4 firmware profiles
- `git diff --check`