### PR TITLE
Refactor phase 5 thermal guards

### DIFF
--- a/docs/thermal-contract.md
+++ b/docs/thermal-contract.md
@@ -58,19 +58,15 @@ Guarded processing currently covers or prepares:
 
 Current guarded interface:
 
-- `oq_actuator_hp1_req`
-- `oq_actuator_hp2_req`
-- `oq_request_mode_code` as the mode carrier consumed by the actuator
-
-Important: `oq_actuator_hp*_req` is not applied state. It is a guarded request
-that can still be limited by actuator-local checks.
-
-Later naming direction:
-
 - `oq_guarded_mode_code`
 - `oq_guarded_hp1_level`
 - `oq_guarded_hp2_level`
-- optional `oq_guarded_reason`
+- `oq_guarded_hp1_keep_mode_active_on_zero`
+- `oq_guarded_hp2_keep_mode_active_on_zero`
+
+Important: `oq_guarded_*` is not applied state. It is guarded request state
+that can still be limited by actuator-local checks such as minimum off-time,
+mode confirmation and defrost retain.
 
 ### Applied
 
@@ -104,7 +100,9 @@ Later naming direction:
 | `oq_curve_dispatch_*` | strategy-local intent | Heating curve publishes dispatch/owner/topology. |
 | `oq_ph_request_*` | strategy-local intent | Power House publishes optimizer output. |
 | `oq_request_*` | intent | Explicit pre-guard/pre-actuator request interface. |
-| `oq_actuator_hp*_req` | guarded | Request-control output consumed by the actuator. |
+| `oq_guarded_mode_code` | guarded | Guard-owned mode carrier consumed by the actuator. |
+| `oq_guarded_hp*_level` | guarded | Guard-owned per-HP compressor request consumed by the actuator. |
+| `oq_guarded_hp*_keep_mode_active_on_zero` | guarded | Preserves thermal mode command when a guard soft-zeroes a request. |
 | `hp*_set_working_mode` | applied write | Only `oq_thermal_actuator` may write. |
 | `hp*_compressor_level` | applied write | Only `oq_thermal_actuator` may write. |
 | `hp*_last_applied_level` | applied state | Actuator-owned bookkeeping and guard input. |
@@ -122,13 +120,76 @@ order below is the behavior to preserve:
 6. Startup inhibit forces request levels to 0.
 7. Minimum runtime may re-arm a zero request to level 1, except during hard-trip
    and cooling floor trip.
-8. `oq_actuator_hp*_req` publishes guarded levels.
-9. The actuator applies min off-time, mode-confirmation gating, silent/day cap,
-   excluded-level cap and defrost retain around the actual writes.
+8. Silent/day cap is applied after runtime floor, with soft-zero semantics that
+   may keep the thermal mode command active.
+9. `oq_guarded_*` publishes guarded mode and levels.
+10. The actuator applies min off-time, mode-confirmation gating and defrost
+    retain around the actual writes.
 
 This split-location of guards is current semantics. Phase 3 may add tests and
 clarifying names/comments, but must not change this ordering without regression
 coverage.
+
+## Phase 5 Guard Boundary
+
+Phase 5 makes the guard boundary explicit before moving more behavior:
+
+```text
+strategy -> intent -> thermal guards -> guarded request -> actuator -> applied
+```
+
+Thermal guards are strategy-independent physical and safety constraints between
+intent and actuator input. They own the final guarded compressor request and the
+guard diagnostics that explain why intent changed.
+
+Guard-owned behavior:
+
+- final 0..10 level normalization
+- final excluded-level mapping
+- single topology HP2 force-zero
+- curve/cooling slew limiting and one-HP-per-cycle shaping
+- water hard-trip application
+- startup inhibit application
+- minimum runtime hold, including its priority against hard-trip, startup
+  inhibit and cooling floor trip
+- silent/day cap, including soft-zero mode preservation
+
+Strategy-owned behavior remains:
+
+- comfort, demand and target calculation
+- curve dispatch and Power House candidate scoring
+- strategy-specific topology preference
+- demand caps such as `oq_power_cap_f`
+- soft water-temperature limit factor as an input to strategy demand shaping
+
+Actuator-owned behavior remains:
+
+- hardware-facing working-mode and compressor-level writes
+- minimum off-time after a real stop
+- mode-confirmation gate around write latency
+- defrost retain / active mode hold around a zero request
+- applied state and runtime bookkeeping
+
+The first extraction target is a pure helper seam,
+`openquatt/includes/oq_thermal_guard_logic.h`. YAML should keep ESPHome state,
+timestamps, logging and publication while delegating pure guard decisions. A
+later `oq_thermal_guards.yaml` package can own guard wiring once behavior and
+diagnostics are stable.
+
+Current phase-5 implementation status:
+
+- guarded shaping is centralized in `openquatt/includes/oq_thermal_guard_logic.h`
+- `oq_thermal_request_control.yaml` now publishes explicit `oq_guarded_*`
+  actuator inputs after exclusions, slew, hard-trip, startup inhibit,
+  minimum-runtime and cap shaping
+- `oq_thermal_actuator.yaml` now consumes `oq_guarded_*` and focuses on write
+  path behavior, applied bookkeeping and runtime counters
+
+Important phase-5 nuance: current startup inhibit zeroes requests before the
+minimum runtime floor, so a compressor that is already measured active may still
+be re-armed to level 1 by minimum runtime. That behavior is explicitly covered
+and must not change unless the regression harness is updated with an intentional
+contract change.
 
 ## Topology Contract
 
@@ -190,7 +251,7 @@ Thermal scenarios for the regression harness:
 - defrost hold retains last non-zero applied level only outside cooling
 - cooling transition may apply level once target mode matches
 - excluded requested level searches down first, then up
-- silent/day cap can reduce applied level and can block to 0
+- silent/day cap can soft-zero a guarded request while preserving thermal mode intent
 - single topology never produces HP2 guarded/applied level
 - duo topology can arm single/duo hold on non-idle topology transition
 

--- a/openquatt/includes/oq_thermal_guard_logic.h
+++ b/openquatt/includes/oq_thermal_guard_logic.h
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <string>
+
+#include "oq_thermal_request_logic.h"
+
+namespace oq_guard {
+
+using oq_request::ExcludedLevels;
+
+struct GuardedLevel {
+  int level;
+  bool keep_mode_active_on_zero;
+};
+
+inline GuardedLevel from_intent_level(int intent_level,
+                                      int min_level,
+                                      int max_level,
+                                      const ExcludedLevels &excluded) {
+  return GuardedLevel{
+      oq_request::pick_allowed_level(intent_level, min_level, max_level, excluded),
+      false,
+  };
+}
+
+inline GuardedLevel limit_slew_level(GuardedLevel guarded,
+                                     uint32_t now_ms,
+                                     int previous_applied_level,
+                                     uint32_t last_level_change_ms,
+                                     int up_hold_s,
+                                     int down_hold_s) {
+  if (guarded.level == previous_applied_level) return guarded;
+
+  int limited = guarded.level;
+  if (limited > previous_applied_level + 1) limited = previous_applied_level + 1;
+  if (limited < previous_applied_level - 1) limited = previous_applied_level - 1;
+  if (limited == previous_applied_level) {
+    guarded.level = limited;
+    return guarded;
+  }
+
+  const bool moving_up = limited > previous_applied_level;
+  const uint32_t hold_ms =
+      (uint32_t) ((moving_up ? up_hold_s : down_hold_s) * 1000UL);
+  if (last_level_change_ms > 0 && now_ms > last_level_change_ms) {
+    const uint32_t dt_change_ms = now_ms - last_level_change_ms;
+    if (dt_change_ms < hold_ms) {
+      guarded.level = previous_applied_level;
+      return guarded;
+    }
+  }
+
+  guarded.level = limited;
+  return guarded;
+}
+
+inline void allow_only_one_hp_change(GuardedLevel &hp1_guarded,
+                                     GuardedLevel &hp2_guarded,
+                                     int previous_hp1_level,
+                                     int previous_hp2_level,
+                                     bool lead_is_hp1) {
+  const int d_hp1 = hp1_guarded.level - previous_hp1_level;
+  const int d_hp2 = hp2_guarded.level - previous_hp2_level;
+  if (d_hp1 == 0 || d_hp2 == 0) return;
+
+  bool apply_hp1_change = true;
+  if (d_hp1 > 0 && d_hp2 > 0) {
+    apply_hp1_change = lead_is_hp1;
+  } else if (d_hp1 < 0 && d_hp2 < 0) {
+    apply_hp1_change = !lead_is_hp1;
+  } else {
+    apply_hp1_change = (d_hp1 < 0);
+  }
+
+  if (apply_hp1_change) {
+    hp2_guarded.level = previous_hp2_level;
+    hp2_guarded.keep_mode_active_on_zero = false;
+  } else {
+    hp1_guarded.level = previous_hp1_level;
+    hp1_guarded.keep_mode_active_on_zero = false;
+  }
+}
+
+inline void apply_absolute_zero(GuardedLevel &guarded) {
+  guarded.level = 0;
+  guarded.keep_mode_active_on_zero = false;
+}
+
+inline bool min_runtime_hold_active(uint32_t now_ms,
+                                    uint32_t last_real_start_ms,
+                                    uint32_t min_runtime_ms,
+                                    bool cooling_floor_trip,
+                                    int previous_applied_level,
+                                    bool measured_thermal_active) {
+  if (cooling_floor_trip || min_runtime_ms == 0) return false;
+  if (!oq_request::min_runtime_window_active(now_ms, last_real_start_ms,
+                                             min_runtime_ms)) {
+    return false;
+  }
+  return previous_applied_level > 0 || measured_thermal_active;
+}
+
+inline GuardedLevel apply_min_runtime_floor(
+    GuardedLevel guarded,
+    uint32_t now_ms,
+    uint32_t last_real_start_ms,
+    uint32_t min_runtime_ms,
+    bool cooling_floor_trip,
+    int previous_applied_level,
+    bool measured_thermal_active,
+    int min_level,
+    int max_level,
+    const ExcludedLevels &excluded) {
+  if (guarded.level != 0) return guarded;
+  if (!min_runtime_hold_active(now_ms, last_real_start_ms, min_runtime_ms,
+                               cooling_floor_trip, previous_applied_level,
+                               measured_thermal_active)) {
+    return guarded;
+  }
+
+  guarded.level = oq_request::pick_allowed_level(1, min_level, max_level, excluded);
+  guarded.keep_mode_active_on_zero = false;
+  return guarded;
+}
+
+inline int clamp_cap_level(bool silent_active,
+                           float silent_cap_state,
+                           float day_cap_state,
+                           int min_level,
+                           int max_level) {
+  const float raw_cap = silent_active ? silent_cap_state : day_cap_state;
+  const int cap_level = (int) roundf(raw_cap);
+  return oq_request::clamp_level(cap_level, min_level, max_level);
+}
+
+inline GuardedLevel apply_capped_level(GuardedLevel guarded,
+                                       int min_level,
+                                       int max_level,
+                                       int cap_level,
+                                       const ExcludedLevels &excluded) {
+  if (guarded.level <= 0) return guarded;
+
+  const int capped_level = oq_request::pick_allowed_capped_level(
+      guarded.level, min_level, max_level, cap_level, excluded);
+  guarded.keep_mode_active_on_zero =
+      (guarded.keep_mode_active_on_zero || (guarded.level > 0 && capped_level == 0));
+  guarded.level = capped_level;
+  return guarded;
+}
+
+inline void force_single_topology_secondary_off(GuardedLevel &secondary_guarded) {
+  secondary_guarded.level = 0;
+  secondary_guarded.keep_mode_active_on_zero = false;
+}
+
+inline bool mode_should_stay_active_on_guarded_request(int mode_code,
+                                                       int guarded_level,
+                                                       bool keep_mode_active_on_zero) {
+  const bool request_thermal_active = (mode_code == 1 || mode_code == 2);
+  return request_thermal_active &&
+         (guarded_level > 0 || keep_mode_active_on_zero);
+}
+
+}  // namespace oq_guard

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -24,6 +24,7 @@ oq_timers_header: "openquatt/includes/oq_timers.h"       # Shared C++ helpers fo
 oq_cic_compatibility_logic_header: "openquatt/includes/oq_cic_compatibility_logic.h" # Shared helpers for CiC compatibility lambdas.
 oq_cic_compatibility_protocol_header: "openquatt/includes/oq_cic_compatibility_protocol.h" # Shared helpers for CiC compatibility protocol encoding.
 oq_supervisory_logic_header: "openquatt/includes/oq_supervisory_logic.h" # Shared supervisory helpers for CM naming and pure policy decisions.
+oq_thermal_guard_logic_header: "openquatt/includes/oq_thermal_guard_logic.h" # Shared thermal guard helper seam for guarded-request shaping.
 oq_timezone: "Europe/Amsterdam"                         # SNTP timezone used by runtime timestamps.
 oq_webserver_css_url: ""                            # Optional external CSS for the ESPHome web UI.
 oq_webserver_js_url: ""                               # Custom OpenQuatt app is primary; load ESPHome fallback lazily on demand.

--- a/openquatt/oq_thermal_actuator.yaml
+++ b/openquatt/oq_thermal_actuator.yaml
@@ -7,14 +7,14 @@
 #   runtime bookkeeping.
 #
 # Ownership:
-#   - Consumes `oq_request_mode_code`
-#   - Consumes `oq_actuator_hp1_req` / `oq_actuator_hp2_req`
+#   - Consumes `oq_guarded_mode_code`
+#   - Consumes `oq_guarded_hp1_level` / `oq_guarded_hp2_level`
 #   - Is the only package that writes HP working mode and compressor levels
 #   - Owns applied state such as `hp*_last_applied_level`, start/stop
 #     timestamps, and runtime minute bookkeeping.
 #
-# Phase-3 contract terminology:
-#   - `oq_actuator_hp*_req` is guarded input, not applied state.
+# Phase-5 contract terminology:
+#   - `oq_guarded_*` is guarded input, not applied state.
 #   - Applied means the write path below has commanded HP mode/level selects or
 #     updated actuator-owned bookkeeping.
 # ==============================================================================
@@ -60,37 +60,6 @@ interval:
             #else
             (void) reason;
             #endif
-          };
-
-          auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
-            if (is_hp1) {
-              return oq_request::ExcludedLevels{
-                  id(hp1_excluded_level_a).has_state()
-                      ? id(hp1_excluded_level_a).current_option()
-                      : std::string("None"),
-                  id(hp1_excluded_level_b).has_state()
-                      ? id(hp1_excluded_level_b).current_option()
-                      : std::string("None"),
-              };
-            }
-            #if OQ_TOPOLOGY_DUO
-            return oq_request::ExcludedLevels{
-                id(${ta_secondary_excluded_level_a_id}).has_state()
-                    ? id(${ta_secondary_excluded_level_a_id}).current_option()
-                    : std::string("None"),
-                id(${ta_secondary_excluded_level_b_id}).has_state()
-                    ? id(${ta_secondary_excluded_level_b_id}).current_option()
-                    : std::string("None"),
-            };
-            #else
-            (void) is_hp1;
-            return oq_request::ExcludedLevels{"None", "None"};
-            #endif
-          };
-
-          auto pick_allowed_capped = [&](int req, bool is_hp1, int cap_level)->int {
-            return oq_request::pick_allowed_capped_level(
-                req, min_level, max_level, cap_level, excluded_levels(is_hp1));
           };
 
           auto hp_selected_level = [&](bool is_hp1)->int {
@@ -140,7 +109,7 @@ interval:
                 2);
           };
 
-          const int request_mode_code = id(oq_request_mode_code);
+          const int request_mode_code = id(oq_guarded_mode_code);
           const bool request_thermal_active = (request_mode_code == 1 || request_mode_code == 2);
           const char* request_thermal_mode_opt = oq_request::request_mode_option(request_mode_code);
 
@@ -222,7 +191,9 @@ interval:
           };
 
           auto set_mode = [&](bool is_hp1, bool active) {
-            const char* opt = (active && request_thermal_active) ? request_thermal_mode_opt : oq_request::request_mode_option(0);
+            const char* opt = (active && request_thermal_active)
+                ? request_thermal_mode_opt
+                : oq_request::request_mode_option(0);
             if (is_hp1) {
               if (id(hp1_set_working_mode).current_option() != opt) {
                 auto c = id(hp1_set_working_mode).make_call();
@@ -261,7 +232,9 @@ interval:
           // Note: options must exactly match the options map in oq_HP_io.yaml (levels 0..10)
           const char* lvl_opts[11] = {"0","1","2","3","4","5","6","7","8","9","10"};
 
-          auto apply_level = [&](bool is_hp1, int req_level)->int {
+          auto apply_level = [&](bool is_hp1,
+                                 int req_level,
+                                 bool keep_mode_active_on_zero)->int {
             req_level = std::max(min_level, std::min(max_level, req_level));
             const int requested_level = req_level;
             const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${ta_secondary_last_applied_level_id});
@@ -279,6 +252,8 @@ interval:
             }
 
             // Hard guardrail: after stop, enforce a universal per-HP minimum off-time before restart.
+            bool mode_request_active = oq_guard::mode_should_stay_active_on_guarded_request(
+                request_mode_code, req_level, keep_mode_active_on_zero);
             if (req_level > 0 && prev_applied == 0) {
               int min_off_s = (int) ${oq_hp_min_off_s};
               if (min_off_s < 0) min_off_s = 0;
@@ -289,6 +264,7 @@ interval:
                 const uint32_t min_off_ms = (uint32_t) min_off_s * 1000UL;
                 if (elapsed_off_ms < min_off_ms) req_level = 0;
                 if (req_level == 0) {
+                  mode_request_active = false;
                   const uint32_t remaining_s = (min_off_ms > elapsed_off_ms) ? ((min_off_ms - elapsed_off_ms + 999UL) / 1000UL) : 0;
                   char reason_buf[144];
                   snprintf(reason_buf, sizeof(reason_buf),
@@ -300,18 +276,9 @@ interval:
               }
             }
 
-            if (req_level > 0) set_mode(is_hp1, true);
-            else set_mode(is_hp1, false);
+            set_mode(is_hp1, mode_request_active);
 
             int applied = req_level;
-
-            // Silent/day cap
-            const bool silent_active = id(oq_silent_active).state;
-            int cap = silent_active ? (int) roundf(id(oq_silent_max_level).state)
-                                    : (int) roundf(id(oq_day_max_level).state);
-            cap = std::max(min_level, std::min(max_level, cap));
-            if (applied > cap) applied = cap;
-            applied = pick_allowed_capped(applied, is_hp1, cap);
 
             // Normative rule: compressor >0 only when the active thermal mode is measured
             // or the command target is already on that mode. This avoids losing a full
@@ -323,17 +290,7 @@ interval:
             }
 
             if (applied == 0 && req_level > 0) {
-              if (block_reason.empty() && req_level > cap) {
-                char reason_buf[128];
-                snprintf(reason_buf, sizeof(reason_buf), "silent/day cap limited request to 0 (cap=%d, requested=%d)", cap, requested_level);
-                block_reason = reason_buf;
-                log_hp_block_change(is_hp1, reason_buf);
-              } else if (block_reason.empty() && !oq_request::level_allowed_for_excluded_levels(excluded_levels(is_hp1), requested_level)) {
-                char reason_buf[128];
-                snprintf(reason_buf, sizeof(reason_buf), "excluded compressor levels blocked request %d", requested_level);
-                block_reason = reason_buf;
-                log_hp_block_change(is_hp1, reason_buf);
-              } else if (block_reason.empty() && retained_level == 0) {
+              if (block_reason.empty() && retained_level == 0) {
                 block_reason = "actuator gating held request at 0";
                 log_hp_block_change(is_hp1, "actuator gating held request at 0");
               }
@@ -368,11 +325,13 @@ interval:
             return applied;
           };
 
-          const int hp1_req = id(oq_actuator_hp1_req);
-          const int hp2_req = id(oq_actuator_hp2_req);
-          const int hp1_applied = apply_level(true, hp1_req);
+          const int hp1_req = id(oq_guarded_hp1_level);
+          const int hp2_req = id(oq_guarded_hp2_level);
+          const bool hp1_keep_mode_active_on_zero = id(oq_guarded_hp1_keep_mode_active_on_zero);
+          const bool hp2_keep_mode_active_on_zero = id(oq_guarded_hp2_keep_mode_active_on_zero);
+          const int hp1_applied = apply_level(true, hp1_req, hp1_keep_mode_active_on_zero);
           #if OQ_TOPOLOGY_DUO
-          const int hp2_applied = apply_level(false, hp2_req);
+          const int hp2_applied = apply_level(false, hp2_req, hp2_keep_mode_active_on_zero);
           const int prev_topology_count =
               (id(hp1_last_applied_level) > 0 ? 1 : 0) + (id(${ta_secondary_last_applied_level_id}) > 0 ? 1 : 0);
           const int new_topology_count = (hp1_applied > 0 ? 1 : 0) + (hp2_applied > 0 ? 1 : 0);

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -16,8 +16,8 @@
 #   - Applies demand filtering to damp noise/jitter in heat demand
 #   - Applies caps/limits on `f` before split
 #   - Publishes `oq_request_*` as the explicit pre-actuator request interface
-#   - Publishes finalized actuator requests for the downstream thermal actuator
-#   - Owns shared request filtering, caps, guards, and actuator input logic
+#   - Publishes finalized guarded requests for the downstream thermal actuator
+#   - Owns shared request filtering, caps, guards, and guarded-request shaping
 #   - Consumes shared HP capacity/deficit (`oq_P_hp_cap_w`, `oq_P_deficit_w`) for supervisory/debug logic
 #
 # What this package DOES NOT do:
@@ -49,7 +49,7 @@
 #     * strategy-local outputs (`oq_cooling_request_*`, `oq_curve_dispatch_*`,
 #       `oq_ph_request_*`) are producer intent.
 #     * `oq_request_*` is the current shared intent interface.
-#     * `oq_actuator_hp*_req` is the current guarded request consumed by
+#     * `oq_guarded_*` is the current guarded request interface consumed by
 #       `oq_thermal_actuator`; it is not applied hardware state.
 #
 # ==============================================================================
@@ -89,16 +89,31 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # Final per-HP requests consumed by oq_thermal_actuator.
-  - id: oq_actuator_hp1_req
+  # Final per-HP guarded requests consumed by oq_thermal_actuator.
+  - id: oq_guarded_mode_code
     type: int
     restore_value: false
     initial_value: '0'
 
-  - id: oq_actuator_hp2_req
+  - id: oq_guarded_hp1_level
     type: int
     restore_value: false
     initial_value: '0'
+
+  - id: oq_guarded_hp2_level
+    type: int
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_guarded_hp1_keep_mode_active_on_zero
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_guarded_hp2_keep_mode_active_on_zero
+    type: bool
+    restore_value: false
+    initial_value: 'false'
 
   # Shared filtered demand owned by the active strategy module.
   - id: oq_demand_filtered
@@ -933,6 +948,41 @@ interval:
             return 1;
           };
 
+          auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
+            if (is_hp1) {
+              return oq_request::ExcludedLevels{
+                  id(hp1_excluded_level_a).has_state()
+                      ? id(hp1_excluded_level_a).current_option()
+                      : std::string("None"),
+                  id(hp1_excluded_level_b).has_state()
+                      ? id(hp1_excluded_level_b).current_option()
+                      : std::string("None"),
+              };
+            }
+            #if OQ_TOPOLOGY_DUO
+            return oq_request::ExcludedLevels{
+                id(${hc_secondary_excluded_level_a_id}).has_state()
+                    ? id(${hc_secondary_excluded_level_a_id}).current_option()
+                    : std::string("None"),
+                id(${hc_secondary_excluded_level_b_id}).has_state()
+                    ? id(${hc_secondary_excluded_level_b_id}).current_option()
+                    : std::string("None"),
+            };
+            #else
+            (void) is_hp1;
+            return oq_request::ExcludedLevels{"None", "None"};
+            #endif
+          };
+
+          const int min_level = 0;
+          const int max_level = 10;
+          const int level_cap = oq_guard::clamp_cap_level(
+              id(oq_silent_active).state,
+              id(oq_silent_max_level).state,
+              id(oq_day_max_level).state,
+              min_level,
+              max_level);
+
           // =========================
           // 1d) Inactive-CM fast exit
           // Shared standby/hold behavior runs before any request-selection logic.
@@ -971,6 +1021,22 @@ interval:
                                                         : oq_request::optimizer_reason_inactive());
             #endif
             const int hold_mode_code = hold_request_mode_code(hp1_hold_level, hp2_hold_level);
+            auto hp1_guarded = oq_guard::apply_capped_level(
+                oq_guard::GuardedLevel{hp1_hold_level, false},
+                min_level,
+                max_level,
+                level_cap,
+                excluded_levels(true));
+            #if OQ_TOPOLOGY_DUO
+            auto hp2_guarded = oq_guard::apply_capped_level(
+                oq_guard::GuardedLevel{hp2_hold_level, false},
+                min_level,
+                max_level,
+                level_cap,
+                excluded_levels(false));
+            #else
+            auto hp2_guarded = oq_guard::GuardedLevel{0, false};
+            #endif
             publish_request(
               any_hold ? hold_mode_code : 0,
               hp1_hold_level,
@@ -978,14 +1044,17 @@ interval:
               request_strategy_inactive,
               0,
               any_hold ? "inactive_cm_hold" : "inactive_cm");
-            id(oq_actuator_hp1_req) = hp1_hold_level;
-            id(oq_actuator_hp2_req) = hp2_hold_level;
+            id(oq_guarded_mode_code) = any_hold ? hold_mode_code : 0;
+            id(oq_guarded_hp1_level) = hp1_guarded.level;
+            id(oq_guarded_hp2_level) = hp2_guarded.level;
+            id(oq_guarded_hp1_keep_mode_active_on_zero) = hp1_guarded.keep_mode_active_on_zero;
+            id(oq_guarded_hp2_keep_mode_active_on_zero) = hp2_guarded.keep_mode_active_on_zero;
             #if OQ_TOPOLOGY_DUO
             const int debug_hp2_applied = id(${hc_secondary_last_applied_level_id});
             #else
             const int debug_hp2_applied = 0;
             #endif
-            publish_debug(hp1_hold_level, hp2_hold_level, id(hp1_last_applied_level), debug_hp2_applied);
+            publish_debug(id(oq_guarded_hp1_level), id(oq_guarded_hp2_level), id(hp1_last_applied_level), debug_hp2_applied);
             return;
           }
           // =========================
@@ -1027,38 +1096,6 @@ interval:
           const char* request_reason =
               is_cooling_mode ? "cooling_idle"
                               : (is_power_house ? "ph_idle" : "curve_idle");
-          const int min_level = 0;
-          const int max_level = 10;
-
-          auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
-            if (is_hp1) {
-              return oq_request::ExcludedLevels{
-                  id(hp1_excluded_level_a).has_state()
-                      ? id(hp1_excluded_level_a).current_option()
-                      : std::string("None"),
-                  id(hp1_excluded_level_b).has_state()
-                      ? id(hp1_excluded_level_b).current_option()
-                      : std::string("None"),
-              };
-            }
-            #if OQ_TOPOLOGY_DUO
-            return oq_request::ExcludedLevels{
-                id(${hc_secondary_excluded_level_a_id}).has_state()
-                    ? id(${hc_secondary_excluded_level_a_id}).current_option()
-                    : std::string("None"),
-                id(${hc_secondary_excluded_level_b_id}).has_state()
-                    ? id(${hc_secondary_excluded_level_b_id}).current_option()
-                    : std::string("None"),
-            };
-            #else
-            (void) is_hp1;
-            return oq_request::ExcludedLevels{"None", "None"};
-            #endif
-          };
-          int level_cap = (int) roundf(id(oq_day_max_level).state);
-          if (id(oq_silent_active).state) level_cap = (int) roundf(id(oq_silent_max_level).state);
-          if (level_cap < 0) level_cap = 0;
-          if (level_cap > max_level) level_cap = max_level;
           const bool hp1_valve_def = valve_defrost_active(true);
           #if OQ_TOPOLOGY_DUO
           const bool hp2_valve_def = valve_defrost_active(false);
@@ -1137,26 +1174,13 @@ interval:
           hp1_req = id(oq_request_hp1_level);
           hp2_req = id(oq_request_hp2_level);
 
-          // =========================
-          // 4) Allowed levels after applying up to two explicit exclusions per HP.
-          //    - level 0 always allowed
-          //    - if requested level is excluded: search down first, then up
-          // =========================
-          auto pick_allowed = [&](int req, bool is_hp1)->int {
-            return oq_request::pick_allowed_level(req, 1, max_level, excluded_levels(is_hp1));
-          };
-
-          // Like pick_allowed(), but never returns above cap_level.
-          auto pick_allowed_capped = [&](int req, bool is_hp1, int cap_level)->int {
-            return oq_request::pick_allowed_capped_level(
-                req, min_level, max_level, cap_level, excluded_levels(is_hp1));
-          };
-
-          hp1_req = pick_allowed(hp1_req, true);
+          auto hp1_guarded = oq_guard::from_intent_level(
+              hp1_req, 1, max_level, excluded_levels(true));
           #if OQ_TOPOLOGY_DUO
-          hp2_req = pick_allowed(hp2_req, false);
+          auto hp2_guarded = oq_guard::from_intent_level(
+              hp2_req, 1, max_level, excluded_levels(false));
           #else
-          hp2_req = 0;
+          auto hp2_guarded = oq_guard::GuardedLevel{0, false};
           #endif
 
           // =========================
@@ -1176,54 +1200,32 @@ interval:
             int down_hold_s = tuning.steady_down_hold_s;
             if (curve_regime == 1) up_hold_s = tuning.recovery_up_hold_s;
 
-            auto limit_slew = [&](bool is_hp1, int req_level)->int {
-              const int prev = is_hp1 ? id(hp1_last_applied_level) : id(${hc_secondary_last_applied_level_id});
-              uint32_t &last_change_ms = is_hp1 ? id(hp1_last_level_change_ms) : id(hp2_last_level_change_ms);
-
-              if (req_level == prev) return req_level;
-
-              int limited = req_level;
-              if (limited > prev + 1) limited = prev + 1;
-              if (limited < prev - 1) limited = prev - 1;
-              if (limited == prev) return limited;
-
-              const bool moving_up = limited > prev;
-              const uint32_t hold_ms = (uint32_t) ((moving_up ? up_hold_s : down_hold_s) * 1000UL);
-              if (last_change_ms > 0 && now_ms > last_change_ms) {
-                const uint32_t dt_change_ms = now_ms - last_change_ms;
-                if (dt_change_ms < hold_ms) return prev;
-              }
-              return limited;
-            };
-
-            hp1_req = limit_slew(true, hp1_req);
+            hp1_guarded = oq_guard::limit_slew_level(
+                hp1_guarded,
+                now_ms,
+                id(hp1_last_applied_level),
+                id(hp1_last_level_change_ms),
+                up_hold_s,
+                down_hold_s);
             #if OQ_TOPOLOGY_DUO
-            hp2_req = limit_slew(false, hp2_req);
+            hp2_guarded = oq_guard::limit_slew_level(
+                hp2_guarded,
+                now_ms,
+                id(${hc_secondary_last_applied_level_id}),
+                id(hp2_last_level_change_ms),
+                up_hold_s,
+                down_hold_s);
 
             // Global guardrail: in curve mode allow at most one HP level change per cycle.
             // This avoids tandem jumps like 1+1 -> 2+2 that create thermal overshoot.
-            const int prev1 = id(hp1_last_applied_level);
-            const int prev2 = id(${hc_secondary_last_applied_level_id});
-            const int d_hp1 = hp1_req - prev1;
-            const int d_hp2 = hp2_req - prev2;
-            if (d_hp1 != 0 && d_hp2 != 0) {
-              bool apply_hp1_change = true;
-              if (d_hp1 > 0 && d_hp2 > 0) {
-                // Ramp-up: prioritize runtime lead.
-                apply_hp1_change = lead_is_hp1;
-              } else if (d_hp1 < 0 && d_hp2 < 0) {
-                // Ramp-down: shed lag first.
-                apply_hp1_change = !lead_is_hp1;
-              } else {
-                // Mixed direction: prioritize the downward correction.
-                apply_hp1_change = (d_hp1 < 0);
-              }
-
-              if (apply_hp1_change) hp2_req = prev2;
-              else hp1_req = prev1;
-            }
+            oq_guard::allow_only_one_hp_change(
+                hp1_guarded,
+                hp2_guarded,
+                id(hp1_last_applied_level),
+                id(${hc_secondary_last_applied_level_id}),
+                lead_is_hp1);
             #else
-            hp2_req = 0;
+            hp2_guarded.level = 0;
             #endif
           }
 
@@ -1233,23 +1235,15 @@ interval:
           // higher priority than compressor minimum runtime.
           // =========================
           if (id(oq_water_temp_hard_trip_active)) {
-            hp1_req = 0;
-            #if OQ_TOPOLOGY_DUO
-            hp2_req = 0;
-            #else
-            hp2_req = 0;
-            #endif
+            oq_guard::apply_absolute_zero(hp1_guarded);
+            oq_guard::apply_absolute_zero(hp2_guarded);
           }
 
           // Absolute boot-time startup inhibit: after a controller reboot, keep compressors
           // at level 0 until the configured compressor minimum off-time has elapsed.
           if (startup_inhibit_active) {
-            hp1_req = 0;
-            #if OQ_TOPOLOGY_DUO
-            hp2_req = 0;
-            #else
-            hp2_req = 0;
-            #endif
+            oq_guard::apply_absolute_zero(hp1_guarded);
+            oq_guard::apply_absolute_zero(hp2_guarded);
           }
 
           // =========================
@@ -1274,11 +1268,19 @@ interval:
                 (now_ms > id(hp1_last_real_heat_start_ms)) &&
                 ((uint32_t)(now_ms - id(hp1_last_real_heat_start_ms)) < min_rt_ms);
             const bool hp1_min_runtime_hold =
-                (hp1_req == 0 && !cooling_floor_trip && hp1_min_runtime_active &&
+                (hp1_guarded.level == 0 && !cooling_floor_trip && hp1_min_runtime_active &&
                  (id(hp1_last_applied_level) > 0 || hp1_measured_thermal));
-            if (hp1_min_runtime_hold) {
-              hp1_req = pick_allowed(1, true);
-            }
+            hp1_guarded = oq_guard::apply_min_runtime_floor(
+                hp1_guarded,
+                now_ms,
+                id(hp1_last_real_heat_start_ms),
+                min_rt_ms,
+                cooling_floor_trip,
+                id(hp1_last_applied_level),
+                hp1_measured_thermal,
+                1,
+                max_level,
+                excluded_levels(true));
             static bool last_hp1_min_runtime_hold = false;
             if (hp1_min_runtime_hold != last_hp1_min_runtime_hold) {
               if (hp1_min_runtime_hold) {
@@ -1299,11 +1301,19 @@ interval:
                 (now_ms > id(hp2_last_real_heat_start_ms)) &&
                 ((uint32_t)(now_ms - id(hp2_last_real_heat_start_ms)) < min_rt_ms);
             const bool hp2_min_runtime_hold =
-                (hp2_req == 0 && !cooling_floor_trip && hp2_min_runtime_active &&
+                (hp2_guarded.level == 0 && !cooling_floor_trip && hp2_min_runtime_active &&
                  (id(${hc_secondary_last_applied_level_id}) > 0 || hp2_measured_thermal));
-            if (hp2_min_runtime_hold) {
-              hp2_req = pick_allowed(1, false);
-            }
+            hp2_guarded = oq_guard::apply_min_runtime_floor(
+                hp2_guarded,
+                now_ms,
+                id(hp2_last_real_heat_start_ms),
+                min_rt_ms,
+                cooling_floor_trip,
+                id(${hc_secondary_last_applied_level_id}),
+                hp2_measured_thermal,
+                1,
+                max_level,
+                excluded_levels(false));
             static bool last_hp2_min_runtime_hold = false;
             if (hp2_min_runtime_hold != last_hp2_min_runtime_hold) {
               if (hp2_min_runtime_hold) {
@@ -1318,20 +1328,41 @@ interval:
               last_hp2_min_runtime_hold = hp2_min_runtime_hold;
             }
             #else
-            hp2_req = 0;
+            hp2_guarded.level = 0;
+            hp2_guarded.keep_mode_active_on_zero = false;
             #endif
           }
+
+          hp1_guarded = oq_guard::apply_capped_level(
+              hp1_guarded,
+              min_level,
+              max_level,
+              level_cap,
+              excluded_levels(true));
+          #if OQ_TOPOLOGY_DUO
+          hp2_guarded = oq_guard::apply_capped_level(
+              hp2_guarded,
+              min_level,
+              max_level,
+              level_cap,
+              excluded_levels(false));
+          #else
+          oq_guard::force_single_topology_secondary_off(hp2_guarded);
+          #endif
 
           // =========================
           // 7) Thermal actuator input
           // oq_thermal_actuator is now the only package that writes working mode
           // and compressor levels, and owns the post-apply bookkeeping.
           // =========================
-          id(oq_actuator_hp1_req) = hp1_req;
-          id(oq_actuator_hp2_req) = hp2_req;
+          id(oq_guarded_mode_code) = active_thermal_mode_code;
+          id(oq_guarded_hp1_level) = hp1_guarded.level;
+          id(oq_guarded_hp2_level) = hp2_guarded.level;
+          id(oq_guarded_hp1_keep_mode_active_on_zero) = hp1_guarded.keep_mode_active_on_zero;
+          id(oq_guarded_hp2_keep_mode_active_on_zero) = hp2_guarded.keep_mode_active_on_zero;
           #if OQ_TOPOLOGY_DUO
           const int debug_hp2_applied = id(${hc_secondary_last_applied_level_id});
           #else
           const int debug_hp2_applied = 0;
           #endif
-          publish_debug(hp1_req, hp2_req, id(hp1_last_applied_level), debug_hp2_applied);
+          publish_debug(id(oq_guarded_hp1_level), id(oq_guarded_hp2_level), id(hp1_last_applied_level), debug_hp2_applied);

--- a/openquatt_base_common.yaml
+++ b/openquatt_base_common.yaml
@@ -23,6 +23,7 @@ esphome:
     - ${oq_cic_compatibility_logic_header}
     - ${oq_cic_compatibility_protocol_header}
     - ${oq_supervisory_logic_header}
+    - ${oq_thermal_guard_logic_header}
   platformio_options:
     extra_scripts:
       - pre:../../../scripts/normalize_factory_merge_inputs.py

--- a/scripts/simulate_thermal_refactor_regressions.py
+++ b/scripts/simulate_thermal_refactor_regressions.py
@@ -173,9 +173,8 @@ def actuator_mode_and_level(
     min_off_blocked: bool,
     measured_mode_matches: bool,
     target_mode_matches: bool,
+    keep_mode_active_on_zero: bool = False,
     retained_level: int = 0,
-    silent_cap: int = 10,
-    level_allowed: bool = True,
 ) -> tuple[str, int]:
     request_mode_name = {0: "Standby", 1: "Cooling", 2: "Heating"}[request_mode_code]
     request_thermal_active = request_mode_code in (1, 2)
@@ -183,13 +182,15 @@ def actuator_mode_and_level(
     if request_level == 0 and retained_level > 0:
         return request_mode_name if request_thermal_active else "Hold", retained_level
 
+    mode_request_active = request_thermal_active and (
+        request_level > 0 or keep_mode_active_on_zero
+    )
     if request_level > 0 and previous_applied_level == 0 and min_off_blocked:
         request_level = 0
+        mode_request_active = False
 
-    mode_command = request_mode_name if (request_level > 0 and request_thermal_active) else "Standby"
-    applied_level = min(request_level, silent_cap)
-    if applied_level > 0 and not level_allowed:
-        applied_level = 0
+    mode_command = request_mode_name if mode_request_active else "Standby"
+    applied_level = request_level
     if request_level > 0 and not measured_mode_matches and not target_mode_matches:
         applied_level = 0
     if applied_level == 0 and retained_level > 0:
@@ -281,6 +282,22 @@ def pick_allowed_capped_level(
         if level > 0 and level_allowed_for_excluded_levels(excluded, level):
             return level
     return 0
+
+
+def apply_guard_cap(
+    request_level: int,
+    *,
+    min_level: int,
+    max_level: int,
+    cap_level: int,
+    excluded: tuple[str, str],
+) -> tuple[int, bool]:
+    if request_level <= 0:
+        return request_level, False
+    capped_level = pick_allowed_capped_level(
+        request_level, min_level, max_level, cap_level, excluded
+    )
+    return capped_level, capped_level == 0 and request_level > 0
 
 
 def guarded_request_after_runtime_floor(
@@ -790,6 +807,18 @@ def run_scenarios() -> list[ScenarioResult]:
         pick_allowed_capped_level(4, 0, 10, 0, ("None", "None")) == 0,
         f"pick_allowed_capped_level(...) -> {pick_allowed_capped_level(4, 0, 10, 0, ('None', 'None'))}",
     )
+    guarded_level, keep_mode = apply_guard_cap(
+        4,
+        min_level=0,
+        max_level=10,
+        cap_level=0,
+        excluded=("None", "None"),
+    )
+    add(
+        "Guard cap may soft-zero a request while preserving thermal mode intent",
+        guarded_level == 0 and keep_mode,
+        f"guarded_level={guarded_level}, keep_mode={keep_mode}",
+    )
     add(
         "Cooling request reason maps owner code 2 consistently",
         cooling_request_reason(2) == "cooling_owner_hp2",
@@ -880,16 +909,16 @@ def run_scenarios() -> list[ScenarioResult]:
         f"mode_command={mode_command}, applied_level={applied_level}",
     )
     mode_command, applied_level = actuator_mode_and_level(
-        4,
+        0,
         request_mode_code=2,
         previous_applied_level=2,
         min_off_blocked=False,
         measured_mode_matches=True,
         target_mode_matches=True,
-        silent_cap=0,
+        keep_mode_active_on_zero=True,
     )
     add(
-        "Actuator may keep heating mode command while cap drops applied level to zero",
+        "Actuator preserves heating mode command on guarded soft-zero request",
         (mode_command == "Heating") and (applied_level == 0),
         f"mode_command={mode_command}, applied_level={applied_level}",
     )


### PR DESCRIPTION
## What changed

This PR is the phase-5 follow-up stacked on top of PR160. It introduces an explicit thermal guard layer between strategy intent and actuator writes, then moves the shared guarded-request shaping into that layer without doing a big-bang thermal rewrite.

The PR adds a new shared helper `openquatt/includes/oq_thermal_guard_logic.h`, introduces an explicit `oq_guarded_*` interface between `oq_thermal_request_control.yaml` and `oq_thermal_actuator.yaml`, centralizes the guarded request shaping, and narrows the actuator to hardware-facing write-path behavior plus applied bookkeeping.

It also updates the tracked thermal contract doc and extends the regression harness with the new guarded soft-zero semantics.

## Scope

This is intentionally the next stacked step after PR160:
- PR160 made the supervisory contract explicit and moved pure supervisory helpers into shared seams
- this PR builds on that by making the thermal guard boundary explicit and centralizing shared guard behavior before later strategy cleanup
- the runtime orchestration stays in YAML while the pure guard decisions move into a small shared helper seam

Included here:
- new guard helper seam in `openquatt/includes/oq_thermal_guard_logic.h`
- explicit guarded interface via `oq_guarded_mode_code`, `oq_guarded_hp1_level`, `oq_guarded_hp2_level` and soft-zero mode-hold flags
- centralization of final excluded-level mapping, silent/day cap shaping and non-Power-House slew limiting
- centralization of hard-trip, startup inhibit and minimum-runtime floor decisions before actuator input publication
- actuator narrowed to min-off, mode-confirmation, defrost retain, applied state and runtime bookkeeping
- tracked updates to `docs/thermal-contract.md`
- regression harness growth from 63 to 64 scenarios to lock in the guarded soft-zero behavior

Not included here:
- no big-bang rewrite of `oq_thermal_request_control.yaml`
- no new supervisory refactor
- no flow PI conversion to C++
- no commissioning or autotune refactor
- no UX/dashboard work
- no `oq_HP_io.yaml` work

## Why it changed

Phase 5 is about separating strategy intent from physical and safety constraints before doing deeper thermal refactors. The previous request-control and actuator split still mixed guard logic and write-path logic in a way that made the thermal chain harder to reason about and riskier to change.

This PR makes the guard boundary explicit, gives the actuator a cleaner contract, and moves the strategy-independent guarded shaping into a dedicated helper seam so later extractions can build on a clearer contract and existing regression anchors.

## Impact

- The thermal chain is now explicitly `strategy -> intent -> guards -> actuator` in both code and docs.
- `oq_thermal_request_control.yaml` publishes explicit guarded requests instead of implicit actuator-facing request globals.
- Shared guard semantics are centralized for excluded levels, cap shaping, slew limiting, hard-trip, startup inhibit and minimum-runtime floor.
- `oq_thermal_actuator.yaml` now focuses on write-path-only behavior and applied bookkeeping.
- Guard cap-to-zero semantics are now explicit: a guard may soft-zero a request while preserving thermal mode intent.

## Validation

- `uv run python scripts/simulate_thermal_refactor_regressions.py` -> `64/64`
- `uv run python scripts/check_style_consistency.py`
- `./scripts/validate_local.sh`
  - style consistency
  - docs consistency
  - config validation for all 4 firmware profiles
  - compile validation for all 4 firmware profiles
- `git diff --check`