### PR TITLE
Refactor phase 6 strategy cleanup

### DIFF
--- a/openquatt/includes/oq_power_house_logic.h
+++ b/openquatt/includes/oq_power_house_logic.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <math.h>
+
+namespace oq_ph {
+
+struct DuoCandidate {
+  bool valid = false;
+  int l1 = 0;
+  int l2 = 0;
+  float p_th_w = 0.0f;
+  float p_el_w = 0.0f;
+  float err_w = 1.0e9f;
+  float over_soft_w = 0.0f;
+  int level_moves = 0;
+  int active_hp_count = 0;
+  int balance_steps = 0;
+  bool single_on_lead = false;
+};
+
+inline DuoCandidate invalid_duo_candidate() {
+  return DuoCandidate{};
+}
+
+inline bool better_duo_candidate(const DuoCandidate &a, const DuoCandidate &b) {
+  const float soft_eps_w = 1.0f;
+  const float pel_eps_w = 1.0f;
+  const float err_eps_w = 1.0f;
+  if (fabsf(a.over_soft_w - b.over_soft_w) > soft_eps_w) return a.over_soft_w < b.over_soft_w;
+  if (fabsf(a.p_el_w - b.p_el_w) > pel_eps_w) return a.p_el_w < b.p_el_w;
+  if (fabsf(a.err_w - b.err_w) > err_eps_w) return a.err_w < b.err_w;
+  if (a.level_moves != b.level_moves) return a.level_moves < b.level_moves;
+  if (a.active_hp_count == 2 && b.active_hp_count == 2 && a.balance_steps != b.balance_steps) {
+    return a.balance_steps < b.balance_steps;
+  }
+  if (a.active_hp_count == 1 && b.active_hp_count == 1) {
+    const int a_single = (a.l1 > 0) ? a.l1 : a.l2;
+    const int b_single = (b.l1 > 0) ? b.l1 : b.l2;
+    if (a_single == b_single && a.single_on_lead != b.single_on_lead) return a.single_on_lead;
+  }
+  if (a.l1 != b.l1) return a.l1 < b.l1;
+  return a.l2 < b.l2;
+}
+
+inline bool choose_preferred_candidate(const DuoCandidate &best_single,
+                                       bool have_best_single,
+                                       const DuoCandidate &best_duo,
+                                       bool have_best_duo,
+                                       float topology_heat_advantage_w,
+                                       DuoCandidate &best_candidate) {
+  if (have_best_single && have_best_duo) {
+    const DuoCandidate *preferred_candidate = &best_single;
+    const DuoCandidate *alternate_candidate = &best_duo;
+    if (best_duo.p_el_w < best_single.p_el_w) {
+      preferred_candidate = &best_duo;
+      alternate_candidate = &best_single;
+    }
+    best_candidate = *preferred_candidate;
+    if (alternate_candidate->err_w + topology_heat_advantage_w < preferred_candidate->err_w) {
+      best_candidate = *alternate_candidate;
+    }
+    return true;
+  }
+  if (have_best_single) {
+    best_candidate = best_single;
+    return true;
+  }
+  if (have_best_duo) {
+    best_candidate = best_duo;
+    return true;
+  }
+  best_candidate = invalid_duo_candidate();
+  return false;
+}
+
+inline int request_owner_hp(int hp1_req, int hp2_req) {
+  if (hp1_req > 0 && hp2_req == 0) return 1;
+  if (hp2_req > 0 && hp1_req == 0) return 2;
+  return 0;
+}
+
+inline bool runtime_lead_override_allowed(bool single_req,
+                                          bool both_idle_prev,
+                                          bool hp1_def,
+                                          bool hp2_def,
+                                          bool hp1_valve_def,
+                                          bool hp2_valve_def,
+                                          bool lead_can,
+                                          bool lag_can) {
+  return single_req &&
+         both_idle_prev &&
+         !hp1_def &&
+         !hp2_def &&
+         !hp1_valve_def &&
+         !hp2_valve_def &&
+         lead_can &&
+         lag_can;
+}
+
+inline void assign_single_owner_request(int req_single,
+                                        bool lead_is_hp1,
+                                        int &hp1_req,
+                                        int &hp2_req,
+                                        int &request_owner_hp) {
+  if (lead_is_hp1) {
+    hp1_req = req_single;
+    hp2_req = 0;
+    request_owner_hp = 1;
+  } else {
+    hp2_req = req_single;
+    hp1_req = 0;
+    request_owner_hp = 2;
+  }
+}
+
+}  // namespace oq_ph

--- a/openquatt/includes/oq_strategy_logic.h
+++ b/openquatt/includes/oq_strategy_logic.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace oq_strategy {
+
+inline void update_lead_hp(int &last_lead_hp, bool lead_is_hp1) {
+  const int lead_code = lead_is_hp1 ? 1 : 2;
+  if (last_lead_hp != lead_code) last_lead_hp = lead_code;
+}
+
+}  // namespace oq_strategy
+
+namespace oq_cooling {
+
+inline void reset_request_state(uint32_t &request_last_loop_ms,
+                                int &request_hp1_level,
+                                int &request_hp2_level,
+                                int &request_owner_hp,
+                                int &owner_hp,
+                                int &request_reason_code) {
+  request_last_loop_ms = 0;
+  request_hp1_level = 0;
+  request_hp2_level = 0;
+  request_owner_hp = 0;
+  owner_hp = 0;
+  request_reason_code = 0;
+}
+
+inline int pick_owner_hp(int stored_owner,
+                         bool demand_active,
+                         bool prev_hp1_on,
+                         bool prev_hp2_on,
+                         bool hp1_can_start,
+                         bool hp2_can_start,
+                         int recent_owner,
+                         bool lead_is_hp1) {
+  if (!demand_active) return 0;
+  if (prev_hp1_on && !prev_hp2_on) return 1;
+  if (prev_hp2_on && !prev_hp1_on) return 2;
+
+  const bool owner_ok =
+      (stored_owner == 1 && hp1_can_start) ||
+      (stored_owner == 2 && hp2_can_start);
+  if (owner_ok) return stored_owner;
+  if (recent_owner == 1 && hp1_can_start) return 1;
+  if (recent_owner == 2 && hp2_can_start) return 2;
+  if (lead_is_hp1 && hp1_can_start) return 1;
+  if (!lead_is_hp1 && hp2_can_start) return 2;
+  if (hp1_can_start && !hp2_can_start) return 1;
+  if (hp2_can_start && !hp1_can_start) return 2;
+  if (hp1_can_start && hp2_can_start) return lead_is_hp1 ? 1 : 2;
+  return 0;
+}
+
+}  // namespace oq_cooling
+
+namespace oq_ph {
+
+inline void reset_request_state(uint32_t &request_last_loop_ms,
+                                int &request_hp1_level,
+                                int &request_hp2_level,
+                                int &request_owner_hp,
+                                int &request_reason_code) {
+  request_last_loop_ms = 0;
+  request_hp1_level = 0;
+  request_hp2_level = 0;
+  request_owner_hp = 0;
+  request_reason_code = 0;
+}
+
+}  // namespace oq_ph

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -339,12 +339,13 @@ interval:
           // Cooling strategy: owns single-owner cooling requests for CM5.
           const int cm_code = id(oq_control_mode_code);
           if (cm_code != 5) {
-            id(oq_cooling_request_last_loop_ms) = 0;
-            id(oq_cooling_request_hp1_level) = 0;
-            id(oq_cooling_request_hp2_level) = 0;
-            id(oq_cooling_request_owner_hp) = 0;
-            id(oq_cooling_owner_hp) = 0;
-            id(oq_cooling_request_reason_code) = 0;
+            oq_cooling::reset_request_state(
+                id(oq_cooling_request_last_loop_ms),
+                id(oq_cooling_request_hp1_level),
+                id(oq_cooling_request_hp2_level),
+                id(oq_cooling_request_owner_hp),
+                id(oq_cooling_owner_hp),
+                id(oq_cooling_request_reason_code));
             return;
           }
 
@@ -359,7 +360,7 @@ interval:
           constexpr int max_level = 10;
           const int demand_max_f = (int) ${oq_strategy_demand_max_f};
           int raw = id(oq_cooling_demand_raw);
-          raw = std::max(0, std::min(demand_max_f, raw));
+          raw = oq_request::clamp_level(raw, 0, demand_max_f);
 
           id(oq_demand_filtered_prev) = id(oq_demand_filtered);
           id(oq_demand_filtered) = raw;
@@ -367,7 +368,7 @@ interval:
 
           int f = raw;
           int f_cap = id(oq_power_cap_f);
-          f_cap = std::max(0, std::min(demand_max_f, f_cap));
+          f_cap = oq_request::clamp_level(f_cap, 0, demand_max_f);
           if (f > f_cap) f = f_cap;
 
           #if OQ_TOPOLOGY_DUO
@@ -375,9 +376,7 @@ interval:
           #else
           const bool lead_is_hp1 = true;
           #endif
-
-          const int lead_code = lead_is_hp1 ? 1 : 2;
-          if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
+          oq_strategy::update_lead_hp(id(oq_last_lead_hp), lead_is_hp1);
 
           auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
             if (is_hp1) {
@@ -492,28 +491,15 @@ interval:
               (hp1_last_active_ms > hp2_last_active_ms) ? 1 :
               (hp2_last_active_ms > hp1_last_active_ms) ? 2 : 0;
 
-          owner = id(oq_cooling_owner_hp);
-          if (!demand_active) {
-            owner = 0;
-          } else if (prev_hp1_on && !prev_hp2_on) {
-            owner = 1;
-          } else if (prev_hp2_on && !prev_hp1_on) {
-            owner = 2;
-          } else {
-            const bool owner_ok =
-                (owner == 1 && hp1_can_start_cooling) ||
-                (owner == 2 && hp2_can_start_cooling);
-            if (!owner_ok) {
-              if (recent_owner == 1 && hp1_can_start_cooling) owner = 1;
-              else if (recent_owner == 2 && hp2_can_start_cooling) owner = 2;
-              else if (lead_is_hp1 && hp1_can_start_cooling) owner = 1;
-              else if (!lead_is_hp1 && hp2_can_start_cooling) owner = 2;
-              else if (hp1_can_start_cooling && !hp2_can_start_cooling) owner = 1;
-              else if (hp2_can_start_cooling && !hp1_can_start_cooling) owner = 2;
-              else if (hp1_can_start_cooling && hp2_can_start_cooling) owner = lead_is_hp1 ? 1 : 2;
-              else owner = 0;
-            }
-          }
+          owner = oq_cooling::pick_owner_hp(
+              id(oq_cooling_owner_hp),
+              demand_active,
+              prev_hp1_on,
+              prev_hp2_on,
+              hp1_can_start_cooling,
+              hp2_can_start_cooling,
+              recent_owner,
+              lead_is_hp1);
 
           static bool last_cooling_start_blocked = false;
           const bool cooling_start_blocked = demand_active && owner == 0 && !hp1_can_start_cooling && !hp2_can_start_cooling;

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -890,11 +890,6 @@ interval:
           // curve path must go fully inactive there even when curve mode remains selected.
           const bool active = (id(oq_control_mode_code) != 5) && (id(oq_heat_mode_code) == 1);
           const int demand_max = (int) ${oq_strategy_demand_max_f};
-          auto clamp_demand = [&](int demand)->int {
-            if (demand < 0) return 0;
-            if (demand > demand_max) return demand_max;
-            return demand;
-          };
 
           if (active) {
             const float spw = id(oq_supply_target_temp).state;
@@ -922,7 +917,7 @@ interval:
               }
             }
 
-            int d_out = clamp_demand(id(oq_demand_curve));
+            int d_out = oq_request::clamp_level(id(oq_demand_curve), 0, demand_max);
             if (id(oq_water_temp_hard_trip_active)) d_out = 0;
             id(oq_demand_raw) = d_out;
 
@@ -1025,7 +1020,7 @@ interval:
           constexpr int max_level = 10;
           const int demand_max_f = (int) ${oq_strategy_demand_max_f};
           int raw = id(oq_demand_raw);
-          raw = std::max(0, std::min(demand_max_f, raw));
+          raw = oq_request::clamp_level(raw, 0, demand_max_f);
 
           id(oq_demand_filtered_prev) = id(oq_demand_filtered);
           id(oq_demand_filtered) = raw;
@@ -1033,7 +1028,7 @@ interval:
 
           int f = raw;
           int f_cap = id(oq_power_cap_f);
-          f_cap = std::max(0, std::min(demand_max_f, f_cap));
+          f_cap = oq_request::clamp_level(f_cap, 0, demand_max_f);
           if (f > f_cap) f = f_cap;
 
           #if OQ_TOPOLOGY_DUO
@@ -1041,8 +1036,7 @@ interval:
           #else
           const bool lead_is_hp1 = true;
           #endif
-          const int lead_code = lead_is_hp1 ? 1 : 2;
-          if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
+          oq_strategy::update_lead_hp(id(oq_last_lead_hp), lead_is_hp1);
 
           auto excluded_levels = [&](bool is_hp1)->oq_request::ExcludedLevels {
             if (is_hp1) {

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -376,11 +376,12 @@ interval:
           const int cm_code = id(oq_control_mode_code);
           const bool active = (cm_code != 5) && (id(oq_heat_mode_code) != 1);
           if (!active) {
-            id(oq_ph_request_last_loop_ms) = 0;
-            id(oq_ph_request_hp1_level) = 0;
-            id(oq_ph_request_hp2_level) = 0;
-            id(oq_ph_request_owner_hp) = 0;
-            id(oq_ph_request_reason_code) = 0;
+            oq_ph::reset_request_state(
+                id(oq_ph_request_last_loop_ms),
+                id(oq_ph_request_hp1_level),
+                id(oq_ph_request_hp2_level),
+                id(oq_ph_request_owner_hp),
+                id(oq_ph_request_reason_code));
             id(oq_phouse_last_ms) = 0;
             id(oq_phouse_last_w) = 0.0f;
             id(oq_phouse_comfort_memory_c) = 0.0f;
@@ -410,11 +411,6 @@ interval:
             if (v < lo) return lo;
             if (v > hi) return hi;
             return v;
-          };
-          auto clamp_demand = [&](int demand)->int {
-            if (demand < 0) return 0;
-            if (demand > demand_max_f) return demand_max_f;
-            return demand;
           };
 
           const float Tout = id(outside_temp_selected).state;
@@ -502,18 +498,20 @@ interval:
             id(oq_phouse_req_w) = P_effective;
             id(oq_phouse_last_w) = P_effective;
             id(oq_phouse_last_ms) = now_ms;
-            id(oq_demand_raw) = clamp_demand((int) lroundf(${oq_strategy_demand_max_f} * (P_effective / house_power_rating_w)));
+            id(oq_demand_raw) = oq_request::clamp_level(
+                (int) lroundf(${oq_strategy_demand_max_f} * (P_effective / house_power_rating_w)),
+                0,
+                demand_max_f);
           }
 
           int raw = id(oq_demand_raw);
-          raw = std::max(0, std::min(demand_max_f, raw));
+          raw = oq_request::clamp_level(raw, 0, demand_max_f);
 
           int ramp_up_step_min = (int) lroundf(id(oq_demand_filter_ramp_up_step_min).state);
-          if (ramp_up_step_min < 1) ramp_up_step_min = 1;
-          if (ramp_up_step_min > demand_max_f) ramp_up_step_min = demand_max_f;
+          ramp_up_step_min = oq_request::clamp_level(ramp_up_step_min, 1, demand_max_f);
 
           int f = id(oq_demand_filtered);
-          f = std::max(0, std::min(demand_max_f, f));
+          f = oq_request::clamp_level(f, 0, demand_max_f);
           id(oq_demand_filtered_prev) = f;
 
           float ramp_budget = id(oq_demand_filter_ramp_up_budget) + (((float) ramp_up_step_min) / 60.0f) * dt_s;
@@ -530,12 +528,12 @@ interval:
             f = raw;
           }
 
-          f = std::max(0, std::min(demand_max_f, f));
+          f = oq_request::clamp_level(f, 0, demand_max_f);
           id(oq_demand_filtered) = f;
           id(oq_heating_demand_filtered) = f;
 
           int f_cap = id(oq_power_cap_f);
-          f_cap = std::max(0, std::min(demand_max_f, f_cap));
+          f_cap = oq_request::clamp_level(f_cap, 0, demand_max_f);
           if (f > f_cap) f = f_cap;
 
           #if OQ_TOPOLOGY_DUO
@@ -543,8 +541,7 @@ interval:
           #else
           const bool lead_is_hp1 = true;
           #endif
-          const int lead_code = lead_is_hp1 ? 1 : 2;
-          if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
+          oq_strategy::update_lead_hp(id(oq_last_lead_hp), lead_is_hp1);
 
           auto publish_optimizer_reason = [&](const char* reason)->void {
             #if OQ_TOPOLOGY_DUO
@@ -761,23 +758,8 @@ interval:
             if (isnan(topology_heat_advantage_w) || topology_heat_advantage_w < 0.0f) topology_heat_advantage_w = 450.0f;
             const float pel_switch_margin_w = 150.0f;
             const float soft_switch_margin_w = 40.0f;
-            struct DuoCandidate {
-              bool valid;
-              int l1;
-              int l2;
-              float p_th_w;
-              float p_el_w;
-              float err_w;
-              float over_soft_w;
-              int level_moves;
-              int active_hp_count;
-              int balance_steps;
-              bool single_on_lead;
-            };
-
-            auto build_duo_candidate = [&](int l1, int l2)->DuoCandidate {
-              DuoCandidate c{};
-              c.valid = false;
+            auto build_duo_candidate = [&](int l1, int l2)->oq_ph::DuoCandidate {
+              oq_ph::DuoCandidate c = oq_ph::invalid_duo_candidate();
               c.l1 = l1;
               c.l2 = l2;
 
@@ -818,33 +800,13 @@ interval:
               return c;
             };
 
-            auto better_duo_candidate = [&](const DuoCandidate &a, const DuoCandidate &b)->bool {
-              const float soft_eps_w = 1.0f;
-              const float pel_eps_w = 1.0f;
-              const float err_eps_w = 1.0f;
-              if (fabsf(a.over_soft_w - b.over_soft_w) > soft_eps_w) return a.over_soft_w < b.over_soft_w;
-              if (fabsf(a.p_el_w - b.p_el_w) > pel_eps_w) return a.p_el_w < b.p_el_w;
-              if (fabsf(a.err_w - b.err_w) > err_eps_w) return a.err_w < b.err_w;
-              if (a.level_moves != b.level_moves) return a.level_moves < b.level_moves;
-              if (a.active_hp_count == 2 && b.active_hp_count == 2 && a.balance_steps != b.balance_steps) {
-                return a.balance_steps < b.balance_steps;
-              }
-              if (a.active_hp_count == 1 && b.active_hp_count == 1) {
-                const int a_single = (a.l1 > 0) ? a.l1 : a.l2;
-                const int b_single = (b.l1 > 0) ? b.l1 : b.l2;
-                if (a_single == b_single && a.single_on_lead != b.single_on_lead) return a.single_on_lead;
-              }
-              if (a.l1 != b.l1) return a.l1 < b.l1;
-              return a.l2 < b.l2;
-            };
-
-            const DuoCandidate current_candidate = build_duo_candidate(last1, last2);
-            auto pick_topology_candidate = [&](int active_hp_count, DuoCandidate &chosen)->bool {
+            const oq_ph::DuoCandidate current_candidate = build_duo_candidate(last1, last2);
+            auto pick_topology_candidate = [&](int active_hp_count, oq_ph::DuoCandidate &chosen)->bool {
               float topology_best_err_w = 1e12f;
               bool have_topology_candidate = false;
               for (int l1 = 0; l1 <= level_cap; l1++) {
                 for (int l2 = 0; l2 <= level_cap; l2++) {
-                  const DuoCandidate c = build_duo_candidate(l1, l2);
+                  const oq_ph::DuoCandidate c = build_duo_candidate(l1, l2);
                   if (!c.valid || c.active_hp_count != active_hp_count) continue;
                   have_topology_candidate = true;
                   if (c.err_w < topology_best_err_w) topology_best_err_w = c.err_w;
@@ -855,10 +817,10 @@ interval:
               bool have_chosen = false;
               for (int l1 = 0; l1 <= level_cap; l1++) {
                 for (int l2 = 0; l2 <= level_cap; l2++) {
-                  const DuoCandidate c = build_duo_candidate(l1, l2);
+                  const oq_ph::DuoCandidate c = build_duo_candidate(l1, l2);
                   if (!c.valid || c.active_hp_count != active_hp_count) continue;
                   if (c.err_w > (topology_best_err_w + thermal_tie_band_w)) continue;
-                  if (!have_chosen || better_duo_candidate(c, chosen)) {
+                  if (!have_chosen || oq_ph::better_duo_candidate(c, chosen)) {
                     chosen = c;
                     have_chosen = true;
                   }
@@ -867,36 +829,23 @@ interval:
               return have_chosen;
             };
 
-            DuoCandidate best_single_candidate{};
+            oq_ph::DuoCandidate best_single_candidate = oq_ph::invalid_duo_candidate();
             const bool have_best_single = pick_topology_candidate(1, best_single_candidate);
-            DuoCandidate best_duo_candidate{};
+            oq_ph::DuoCandidate best_duo_candidate = oq_ph::invalid_duo_candidate();
             const bool have_best_duo = pick_topology_candidate(2, best_duo_candidate);
             const bool valve_defrost_any = hp1_valve_def || hp2_valve_def;
             const bool hp1_single_active = (last1 > 0) && (last2 <= 0);
             const bool hp2_single_active = (last1 <= 0) && (last2 > 0);
             const bool single_topology_active = hp1_single_active || hp2_single_active;
 
-            DuoCandidate best_candidate{};
-            bool have_best_candidate = false;
-            if (have_best_single && have_best_duo) {
-              const DuoCandidate *preferred_candidate = &best_single_candidate;
-              const DuoCandidate *alternate_candidate = &best_duo_candidate;
-              if (best_duo_candidate.p_el_w < best_single_candidate.p_el_w) {
-                preferred_candidate = &best_duo_candidate;
-                alternate_candidate = &best_single_candidate;
-              }
-              best_candidate = *preferred_candidate;
-              if (alternate_candidate->err_w + topology_heat_advantage_w < preferred_candidate->err_w) {
-                best_candidate = *alternate_candidate;
-              }
-              have_best_candidate = true;
-            } else if (have_best_single) {
-              best_candidate = best_single_candidate;
-              have_best_candidate = true;
-            } else if (have_best_duo) {
-              best_candidate = best_duo_candidate;
-              have_best_candidate = true;
-            }
+            oq_ph::DuoCandidate best_candidate = oq_ph::invalid_duo_candidate();
+            const bool have_best_candidate = oq_ph::choose_preferred_candidate(
+                best_single_candidate,
+                have_best_single,
+                best_duo_candidate,
+                have_best_duo,
+                topology_heat_advantage_w,
+                best_candidate);
 
             if (valve_defrost_any && single_topology_active && have_best_single &&
                 have_best_candidate && (best_candidate.active_hp_count == 2)) {
@@ -980,7 +929,7 @@ interval:
               optimizer_reason_code = 8;
             }
 
-            const DuoCandidate chosen_candidate =
+            const oq_ph::DuoCandidate chosen_candidate =
                 (keep_current && current_candidate.valid) ? current_candidate : best_candidate;
             hp1_req = chosen_candidate.valid ? chosen_candidate.l1 : 0;
             hp2_req = chosen_candidate.valid ? chosen_candidate.l2 : 0;
@@ -1018,30 +967,25 @@ interval:
                     oq_request::power_house_optimizer_reason(request_reason_code));
               }
             }
-            if (hp1_req > 0 && hp2_req == 0) request_owner_hp = 1;
-            else if (hp2_req > 0 && hp1_req == 0) request_owner_hp = 2;
-            else request_owner_hp = 0;
+            request_owner_hp = oq_ph::request_owner_hp(hp1_req, hp2_req);
 
             const bool single_req = ((hp1_req > 0) != (hp2_req > 0));
             const bool both_idle_prev = (id(hp1_last_applied_level) <= 0 && id(${ph_secondary_last_applied_level_id}) <= 0);
-            if (single_req && both_idle_prev && !(hp1_def || hp2_def) && !(hp1_valve_def || hp2_valve_def)) {
+            if (oq_ph::runtime_lead_override_allowed(
+                    single_req,
+                    both_idle_prev,
+                    hp1_def,
+                    hp2_def,
+                    hp1_valve_def,
+                    hp2_valve_def,
+                    level_allowed(lead_is_hp1, (hp1_req > 0) ? hp1_req : hp2_req),
+                    level_allowed(!lead_is_hp1, (hp1_req > 0) ? hp1_req : hp2_req))) {
               const int req_single = (hp1_req > 0) ? hp1_req : hp2_req;
-              const bool lead_can = level_allowed(lead_is_hp1, req_single);
-              const bool lag_can = level_allowed(!lead_is_hp1, req_single);
-              if (lead_can && lag_can) {
-                if (lead_is_hp1) {
-                  hp1_req = req_single;
-                  hp2_req = 0;
-                  request_owner_hp = 1;
-                } else {
-                  hp2_req = req_single;
-                  hp1_req = 0;
-                  request_owner_hp = 2;
-                }
-                request_reason_code = 13;
-                publish_optimizer_reason(
-                    oq_request::power_house_optimizer_reason(request_reason_code));
-              }
+              oq_ph::assign_single_owner_request(
+                  req_single, lead_is_hp1, hp1_req, hp2_req, request_owner_hp);
+              request_reason_code = 13;
+              publish_optimizer_reason(
+                  oq_request::power_house_optimizer_reason(request_reason_code));
             }
           }
           #else

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -19,6 +19,8 @@ hp_perf_map_header: "openquatt/includes/hp_perf_map.h" # C++ performance-map hea
 hp_perf_map_v2_high_header: "openquatt/includes/hp_perf_map_v2_high.h" # C++ V2 high-temperature continuation header.
 thermal_request_logic_header: "openquatt/includes/oq_thermal_request_logic.h" # Shared C++ helper include for request/control glue.
 heating_curve_logic_header: "openquatt/includes/oq_heating_curve_logic.h" # Shared C++ helper include for curve runtime state and naming.
+oq_strategy_logic_header: "openquatt/includes/oq_strategy_logic.h" # Shared strategy-only helper include for lead-owner and request-state plumbing.
+oq_power_house_logic_header: "openquatt/includes/oq_power_house_logic.h" # Power House-only helper include for pure optimizer/candidate plumbing.
 oq_psram_buffer_header: "components/openquatt_common/PsramBuffer.h" # Shared PSRAM-backed buffer helper for custom components.
 oq_timers_header: "openquatt/includes/oq_timers.h"       # Shared C++ helpers for millis()/elapsed timer patterns.
 oq_cic_compatibility_logic_header: "openquatt/includes/oq_cic_compatibility_logic.h" # Shared helpers for CiC compatibility lambdas.

--- a/openquatt_base_common.yaml
+++ b/openquatt_base_common.yaml
@@ -18,6 +18,8 @@ esphome:
     - ${hp_perf_map_v2_high_header}
     - ${thermal_request_logic_header}
     - ${heating_curve_logic_header}
+    - ${oq_strategy_logic_header}
+    - ${oq_power_house_logic_header}
     - ${oq_psram_buffer_header}
     - ${oq_timers_header}
     - ${oq_cic_compatibility_logic_header}

--- a/scripts/simulate_thermal_refactor_regressions.py
+++ b/scripts/simulate_thermal_refactor_regressions.py
@@ -15,6 +15,32 @@ class ScenarioResult:
     details: str
 
 
+@dataclass(frozen=True)
+class CurveDispatchCandidate:
+    valid: bool = False
+    hp1_level: int = 0
+    hp2_level: int = 0
+    power_w: float = 0.0
+    error_w: float = 1.0e9
+    active_hp_count: int = 0
+    balance_gap: int = 0
+
+
+@dataclass(frozen=True)
+class PhDuoCandidate:
+    valid: bool = False
+    l1: int = 0
+    l2: int = 0
+    p_th_w: float = 0.0
+    p_el_w: float = 0.0
+    err_w: float = 1.0e9
+    over_soft_w: float = 0.0
+    level_moves: int = 0
+    active_hp_count: int = 0
+    balance_steps: int = 0
+    single_on_lead: bool = False
+
+
 def hold_request_mode_code(
     hp1_hold: int,
     hp2_hold: int,
@@ -507,6 +533,101 @@ def cooling_request_reason(reason_code: int) -> str:
     }.get(reason_code, "cooling_idle")
 
 
+def cooling_owner_choice(
+    *,
+    stored_owner: int,
+    demand_active: bool,
+    prev_hp1_on: bool,
+    prev_hp2_on: bool,
+    hp1_can_start: bool,
+    hp2_can_start: bool,
+    recent_owner: int,
+    lead_is_hp1: bool,
+) -> int:
+    owner = stored_owner
+    if not demand_active:
+        return 0
+    if prev_hp1_on and not prev_hp2_on:
+        return 1
+    if prev_hp2_on and not prev_hp1_on:
+        return 2
+
+    owner_ok = (owner == 1 and hp1_can_start) or (owner == 2 and hp2_can_start)
+    if owner_ok:
+        return owner
+    if recent_owner == 1 and hp1_can_start:
+        return 1
+    if recent_owner == 2 and hp2_can_start:
+        return 2
+    if lead_is_hp1 and hp1_can_start:
+        return 1
+    if (not lead_is_hp1) and hp2_can_start:
+        return 2
+    if hp1_can_start and not hp2_can_start:
+        return 1
+    if hp2_can_start and not hp1_can_start:
+        return 2
+    if hp1_can_start and hp2_can_start:
+        return 1 if lead_is_hp1 else 2
+    return 0
+
+
+def curve_pick_single_owner(
+    demand_active: bool,
+    stored_owner_hp: int,
+    prev_hp1_on: bool,
+    prev_hp2_on: bool,
+    lead_is_hp1: bool,
+) -> int:
+    if not demand_active:
+        return 0
+    if prev_hp1_on != prev_hp2_on:
+        return 1 if prev_hp1_on else 2
+    if stored_owner_hp in (1, 2):
+        return stored_owner_hp
+    return 1 if lead_is_hp1 else 2
+
+
+def curve_better_dispatch_candidate(
+    candidate: CurveDispatchCandidate,
+    best: CurveDispatchCandidate,
+    prev_hp1_level: int,
+    prev_hp2_level: int,
+) -> bool:
+    if not candidate.valid:
+        return False
+    if not best.valid:
+        return True
+    if abs(candidate.error_w - best.error_w) > 50.0:
+        return candidate.error_w < best.error_w
+
+    candidate_starts = (
+        (1 if prev_hp1_level == 0 and candidate.hp1_level > 0 else 0)
+        + (1 if prev_hp2_level == 0 and candidate.hp2_level > 0 else 0)
+    )
+    best_starts = (
+        (1 if prev_hp1_level == 0 and best.hp1_level > 0 else 0)
+        + (1 if prev_hp2_level == 0 and best.hp2_level > 0 else 0)
+    )
+    if candidate_starts != best_starts:
+        return candidate_starts < best_starts
+
+    candidate_moves = abs(candidate.hp1_level - prev_hp1_level) + abs(
+        candidate.hp2_level - prev_hp2_level
+    )
+    best_moves = abs(best.hp1_level - prev_hp1_level) + abs(
+        best.hp2_level - prev_hp2_level
+    )
+    if candidate_moves != best_moves:
+        return candidate_moves < best_moves
+
+    if candidate.active_hp_count != best.active_hp_count:
+        return candidate.active_hp_count < best.active_hp_count
+    if candidate.balance_gap != best.balance_gap:
+        return candidate.balance_gap < best.balance_gap
+    return candidate.power_w < best.power_w
+
+
 def optimizer_reason_inactive() -> str:
     return "inactive"
 
@@ -578,6 +699,85 @@ def power_house_optimizer_reason(reason_code: int) -> str | None:
         13: "runtime_lead",
         15: "oil_return_hold",
     }.get(reason_code)
+
+
+def ph_better_duo_candidate(a: PhDuoCandidate, b: PhDuoCandidate) -> bool:
+    soft_eps_w = 1.0
+    pel_eps_w = 1.0
+    err_eps_w = 1.0
+    if abs(a.over_soft_w - b.over_soft_w) > soft_eps_w:
+        return a.over_soft_w < b.over_soft_w
+    if abs(a.p_el_w - b.p_el_w) > pel_eps_w:
+        return a.p_el_w < b.p_el_w
+    if abs(a.err_w - b.err_w) > err_eps_w:
+        return a.err_w < b.err_w
+    if a.level_moves != b.level_moves:
+        return a.level_moves < b.level_moves
+    if a.active_hp_count == 2 and b.active_hp_count == 2 and a.balance_steps != b.balance_steps:
+        return a.balance_steps < b.balance_steps
+    if a.active_hp_count == 1 and b.active_hp_count == 1:
+        a_single = a.l1 if a.l1 > 0 else a.l2
+        b_single = b.l1 if b.l1 > 0 else b.l2
+        if a_single == b_single and a.single_on_lead != b.single_on_lead:
+            return a.single_on_lead
+    if a.l1 != b.l1:
+        return a.l1 < b.l1
+    return a.l2 < b.l2
+
+
+def ph_choose_preferred_candidate(
+    best_single: PhDuoCandidate,
+    have_best_single: bool,
+    best_duo: PhDuoCandidate,
+    have_best_duo: bool,
+    topology_heat_advantage_w: float,
+) -> tuple[bool, PhDuoCandidate]:
+    if have_best_single and have_best_duo:
+        preferred = best_single
+        alternate = best_duo
+        if best_duo.p_el_w < best_single.p_el_w:
+            preferred = best_duo
+            alternate = best_single
+        best_candidate = preferred
+        if alternate.err_w + topology_heat_advantage_w < preferred.err_w:
+            best_candidate = alternate
+        return True, best_candidate
+    if have_best_single:
+        return True, best_single
+    if have_best_duo:
+        return True, best_duo
+    return False, PhDuoCandidate()
+
+
+def ph_request_owner_hp(hp1_req: int, hp2_req: int) -> int:
+    if hp1_req > 0 and hp2_req == 0:
+        return 1
+    if hp2_req > 0 and hp1_req == 0:
+        return 2
+    return 0
+
+
+def ph_runtime_lead_override_allowed(
+    *,
+    single_req: bool,
+    both_idle_prev: bool,
+    hp1_def: bool,
+    hp2_def: bool,
+    hp1_valve_def: bool,
+    hp2_valve_def: bool,
+    lead_can: bool,
+    lag_can: bool,
+) -> bool:
+    return (
+        single_req
+        and both_idle_prev
+        and not hp1_def
+        and not hp2_def
+        and not hp1_valve_def
+        and not hp2_valve_def
+        and lead_can
+        and lag_can
+    )
 
 
 def run_scenarios() -> list[ScenarioResult]:
@@ -825,6 +1025,119 @@ def run_scenarios() -> list[ScenarioResult]:
         f"cooling_request_reason(2) -> {cooling_request_reason(2)}",
     )
     add(
+        "Cooling owner keeps HP1 while it is already active",
+        cooling_owner_choice(
+            stored_owner=2,
+            demand_active=True,
+            prev_hp1_on=True,
+            prev_hp2_on=False,
+            hp1_can_start=True,
+            hp2_can_start=True,
+            recent_owner=2,
+            lead_is_hp1=False,
+        )
+        == 1,
+        (
+            "cooling_owner_choice(...) -> "
+            f"{cooling_owner_choice(stored_owner=2, demand_active=True, prev_hp1_on=True, prev_hp2_on=False, hp1_can_start=True, hp2_can_start=True, recent_owner=2, lead_is_hp1=False)}"
+        ),
+    )
+    add(
+        "Cooling owner prefers recent owner when stored owner is blocked",
+        cooling_owner_choice(
+            stored_owner=1,
+            demand_active=True,
+            prev_hp1_on=False,
+            prev_hp2_on=False,
+            hp1_can_start=False,
+            hp2_can_start=True,
+            recent_owner=2,
+            lead_is_hp1=True,
+        )
+        == 2,
+        (
+            "cooling_owner_choice(...) -> "
+            f"{cooling_owner_choice(stored_owner=1, demand_active=True, prev_hp1_on=False, prev_hp2_on=False, hp1_can_start=False, hp2_can_start=True, recent_owner=2, lead_is_hp1=True)}"
+        ),
+    )
+    add(
+        "Cooling owner falls back to lead HP when neither owner nor recent owner applies",
+        cooling_owner_choice(
+            stored_owner=0,
+            demand_active=True,
+            prev_hp1_on=False,
+            prev_hp2_on=False,
+            hp1_can_start=True,
+            hp2_can_start=True,
+            recent_owner=0,
+            lead_is_hp1=False,
+        )
+        == 2,
+        (
+            "cooling_owner_choice(...) -> "
+            f"{cooling_owner_choice(stored_owner=0, demand_active=True, prev_hp1_on=False, prev_hp2_on=False, hp1_can_start=True, hp2_can_start=True, recent_owner=0, lead_is_hp1=False)}"
+        ),
+    )
+    add(
+        "Cooling owner drops to idle when both HP starts are blocked",
+        cooling_owner_choice(
+            stored_owner=1,
+            demand_active=True,
+            prev_hp1_on=False,
+            prev_hp2_on=False,
+            hp1_can_start=False,
+            hp2_can_start=False,
+            recent_owner=1,
+            lead_is_hp1=True,
+        )
+        == 0,
+        (
+            "cooling_owner_choice(...) -> "
+            f"{cooling_owner_choice(stored_owner=1, demand_active=True, prev_hp1_on=False, prev_hp2_on=False, hp1_can_start=False, hp2_can_start=False, recent_owner=1, lead_is_hp1=True)}"
+        ),
+    )
+    add(
+        "Curve owner keeps previous active HP over lead preference",
+        curve_pick_single_owner(
+            demand_active=True,
+            stored_owner_hp=1,
+            prev_hp1_on=False,
+            prev_hp2_on=True,
+            lead_is_hp1=True,
+        )
+        == 2,
+        (
+            "curve_pick_single_owner(...) -> "
+            f"{curve_pick_single_owner(demand_active=True, stored_owner_hp=1, prev_hp1_on=False, prev_hp2_on=True, lead_is_hp1=True)}"
+        ),
+    )
+    add(
+        "Curve dispatch tie-break prefers fewer starts before lower power",
+        curve_better_dispatch_candidate(
+            CurveDispatchCandidate(
+                valid=True,
+                hp1_level=3,
+                hp2_level=0,
+                power_w=3200.0,
+                error_w=30.0,
+                active_hp_count=1,
+                balance_gap=3,
+            ),
+            CurveDispatchCandidate(
+                valid=True,
+                hp1_level=2,
+                hp2_level=2,
+                power_w=3100.0,
+                error_w=30.0,
+                active_hp_count=2,
+                balance_gap=0,
+            ),
+            prev_hp1_level=3,
+            prev_hp2_level=0,
+        ),
+        "curve_better_dispatch_candidate(...) -> True",
+    )
+    add(
         "Curve request reason maps dual-capacity path consistently",
         curve_request_reason(3, 3, 0, 2) == "curve_dual",
         f"curve_request_reason(...) -> {curve_request_reason(3, 3, 0, 2)}",
@@ -837,11 +1150,126 @@ def run_scenarios() -> list[ScenarioResult]:
             f"{power_house_request_reason(14, duo_topology=False)}"
         ),
     )
+    for code, expected in {
+        0: "ph_idle",
+        1: "ph_fallback_idle",
+        2: "ph_fallback_single_hp1",
+        3: "ph_fallback_single_hp2",
+        4: "ph_fallback_duo",
+        5: "keep_current",
+        6: "hold_active",
+        7: "defrost_hold",
+        8: "better_heat",
+        9: "soft_guard",
+        10: "less_power",
+        11: "no_candidate",
+        12: "defrost_boost",
+        13: "runtime_lead",
+    }.items():
+        actual = power_house_request_reason(code, duo_topology=True)
+        add(
+            f"Duo Power House request reason code {code} stays stable",
+            actual == expected,
+            f"power_house_request_reason({code}, duo_topology=True) -> {actual}",
+        )
     add(
         "Power House optimizer reason maps code 15 consistently",
         power_house_optimizer_reason(15) == "oil_return_hold",
         f"power_house_optimizer_reason(15) -> {power_house_optimizer_reason(15)}",
     )
+    add(
+        "Power House candidate tie-break prefers lower soft-limit overshoot first",
+        ph_better_duo_candidate(
+            PhDuoCandidate(
+                valid=True,
+                l1=3,
+                l2=3,
+                p_el_w=2500.0,
+                err_w=40.0,
+                over_soft_w=10.0,
+                level_moves=2,
+                active_hp_count=2,
+                balance_steps=0,
+            ),
+            PhDuoCandidate(
+                valid=True,
+                l1=4,
+                l2=2,
+                p_el_w=2300.0,
+                err_w=20.0,
+                over_soft_w=30.0,
+                level_moves=2,
+                active_hp_count=2,
+                balance_steps=2,
+            ),
+        ),
+        "ph_better_duo_candidate(...) -> True",
+    )
+    have_best_candidate, best_candidate = ph_choose_preferred_candidate(
+        PhDuoCandidate(valid=True, l1=4, l2=0, p_el_w=1800.0, err_w=600.0, active_hp_count=1),
+        True,
+        PhDuoCandidate(valid=True, l1=2, l2=2, p_el_w=2000.0, err_w=60.0, active_hp_count=2),
+        True,
+        450.0,
+    )
+    add(
+        "Power House topology chooser may prefer better heat when advantage beats margin",
+        have_best_candidate and best_candidate.active_hp_count == 2,
+        (
+            "ph_choose_preferred_candidate(...) -> "
+            f"have_best_candidate={have_best_candidate}, active_hp_count={best_candidate.active_hp_count}"
+        ),
+    )
+    add(
+        "Power House runtime-lead override requires both sides to be startable and no defrost",
+        ph_runtime_lead_override_allowed(
+            single_req=True,
+            both_idle_prev=True,
+            hp1_def=False,
+            hp2_def=False,
+            hp1_valve_def=False,
+            hp2_valve_def=False,
+            lead_can=True,
+            lag_can=True,
+        )
+        and not ph_runtime_lead_override_allowed(
+            single_req=True,
+            both_idle_prev=True,
+            hp1_def=False,
+            hp2_def=False,
+            hp1_valve_def=True,
+            hp2_valve_def=False,
+            lead_can=True,
+            lag_can=True,
+        ),
+        "ph_runtime_lead_override_allowed(...) -> True/False as expected",
+    )
+    add(
+        "Power House request owner stays zero for duo requests",
+        ph_request_owner_hp(3, 3) == 0 and ph_request_owner_hp(4, 0) == 1,
+        (
+            "ph_request_owner_hp(...) -> "
+            f"{ph_request_owner_hp(3, 3)}, {ph_request_owner_hp(4, 0)}"
+        ),
+    )
+    for code, expected in {
+        5: "keep_current",
+        6: "hold_active",
+        7: "defrost_hold",
+        8: "better_heat",
+        9: "soft_guard",
+        10: "less_power",
+        11: "no_candidate",
+        12: "defrost_boost",
+        13: "runtime_lead",
+        15: "oil_return_hold",
+    }.items():
+        actual = power_house_optimizer_reason(code)
+        add(
+            f"Power House optimizer reason code {code} stays stable",
+            actual == expected,
+            f"power_house_optimizer_reason({code}) -> {actual}",
+        )
     add(
         "Shared inactive optimizer reason stays stable",
         optimizer_reason_inactive() == "inactive",


### PR DESCRIPTION
## What changed

This PR completes phase 6 on top of PR161 by narrowing the strategy layer without changing request-output behavior.

The strategy packages are smaller and more explicit about ownership:
- `openquatt/includes/oq_strategy_logic.h` now holds only shared strategy plumbing helpers such as lead-owner updates, cooling/PH request resets, and cooling owner selection
- `openquatt/includes/oq_power_house_logic.h` now holds pure Power House optimizer plumbing helpers such as candidate comparison, preferred-candidate selection, request-owner mapping, and runtime-lead override helpers
- `oq_heating_curve_strategy.yaml`, `oq_cooling_strategy.yaml`, and `oq_power_house_strategy.yaml` now reuse those helpers and keep strategy-specific decision-making local
- curve/cooling/PH demand and cap clamps now consistently use the existing shared request clamp helper

The regression harness was expanded to lock in the current strategy semantics before and during these extractions:
- cooling owner selection semantics
- curve owner and dispatch tie-break basics
- Power House request reason mappings
- Power House optimizer reason mappings
- Power House candidate-selection and runtime-lead helper semantics

## Scope

This is intentionally the next stacked step after PR161:
- PR161 made the thermal guard boundary explicit and narrowed the actuator to write-path behavior
- this PR keeps that guard/actuator split intact and cleans up the upstream strategy layer so it is easier to evolve later

Included here:
- new strategy-only helper seam in `openquatt/includes/oq_strategy_logic.h`
- new PH-only helper seam in `openquatt/includes/oq_power_house_logic.h`
- smaller strategy YAMLs through helper reuse and plumbing extraction
- broader regression coverage for strategy request/reason semantics

Not included here:
- no thermal guard redesign
- no supervisory redesign
- no commissioning or autotune refactor
- no flow PI conversion to C++
- no dashboard or UX work
- no `oq_HP_io.yaml` work
- no intentional request-output behavior change

## Why it changed

Phase 6 is about making the strategy layer easier to read and maintain now that the downstream chain is explicitly `strategy -> intent -> guards -> actuator`.

Before this step, the three strategy packages still contained a mix of real strategy choices and repeated plumbing. This PR reduces that duplication, keeps shared helpers in clearly named strategy- or PH-specific seams, and preserves the boundary that phase 5 established.

## Impact

- Strategies are narrower and more obviously focused on intent production and strategy-specific choices
- shared plumbing no longer needs to live in multiple YAML lambdas
- Power House optimizer behavior remains strategy-owned rather than drifting back into request-control or actuator layers
- later commissioning/autotune and flow work now has a cleaner strategy boundary to build on

## Validation

- `uv run python scripts/simulate_thermal_refactor_regressions.py` -> `98/98`
- `uv run python scripts/check_style_consistency.py`
- `./scripts/validate_local.sh`
  - style consistency
  - docs consistency
  - config validation for all 4 firmware profiles
  - compile validation for all 4 firmware profiles
- `git diff --check`