### PR TITLE
Refactor phase 7 commissioning task boundaries

### DIFF
--- a/docs/commissioning-autotune-contract.md
+++ b/docs/commissioning-autotune-contract.md
@@ -1,0 +1,314 @@
+# Commissioning And Flow Autotune Contract
+
+This document captures the phase-7 contract for the current boundary between
+`openquatt/oq_commissioning.yaml`, `openquatt/oq_flow_autotune.yaml` and
+`openquatt/oq_flow_control.yaml`.
+
+The goal is not to rewrite CM100 or autotune in one step. The goal is to make
+the current ownership, task interface, state, outputs and terminal paths
+explicit before later helper or C++ extraction.
+
+## Ownership Boundary
+
+Current control flow:
+
+```text
+commissioning supervisor -> selected task -> task state machine -> outputs/results
+```
+
+Commissioning owns the CM100 service container, task selection and shared task
+bookkeeping. Flow autotune owns the flow-identification and validation task.
+Flow control remains the only writer of non-CM0 pump iPWM; autotune only
+requests a temporary override through `oq_flow_autotune_active` and
+`oq_flow_autotune_pwm`.
+
+Supervisory owns whether CM100 becomes the active Control Mode. Commissioning
+may request or hold CM100, but it does not publish Control Mode directly.
+
+## Task Interface
+
+Current task codes:
+
+| Code | Meaning | Owner |
+|---:|---|---|
+| `0` | no selected task / neutral CM100 | commissioning |
+| `1` | boiler power test | commissioning |
+| `2` | flow autotune | flow autotune task inside commissioning container |
+
+Current commissioning state codes:
+
+| Code | Meaning |
+|---:|---|
+| `0` | idle / neutral |
+| `1` | requested |
+| `2` | flow settle |
+| `3` | boiler settle |
+| `4` | measure |
+| `5` | cooldown |
+| `6` | done |
+| `7` | abort |
+| `8` | failed |
+
+For flow autotune, `oq_commissioning_state_code` is currently only a coarse
+container marker. The detailed task state lives in `oq_flow_autotune_state`.
+
+## Commissioning Supervisor Contract
+
+Commissioning may:
+
+- accept a neutral CM100 request only while the override selector is Auto
+- refuse neutral CM100 start while another task is active
+- set `oq_commissioning_request_pending=true` for neutral CM100 start
+- mark `oq_commissioning_active=true` once supervisory has reached CM100
+- keep `oq_commissioning_active=true` after a task releases back to neutral
+  CM100
+- clear task state and return to `IDLE` when CM100 is stopped without an
+  active task
+- delegate abort to the selected task when a task is active
+
+Commissioning must not:
+
+- own flow PI calculations or pump iPWM writes
+- own autotune identification/validation state
+- change Control Mode directly
+- move the system out of CM100 after task success by default
+
+Current stop/abort nuance is part of the contract:
+
+- Active boiler task: `oq_commissioning_abort_requested=true`.
+- Active flow-autotune task: `oq_flow_autotune_abort=true` and
+  `oq_commissioning_abort_requested` stays false.
+- Pending flow-autotune request: both abort flags are set.
+
+## Boiler Power Test Task Contract
+
+Boiler power test may start only when:
+
+- current Control Mode is CM100
+- no other commissioning task is running
+- flow control mode is `Flow Setpoint`
+- `oq_flow_setpoint_lph` is available
+- boiler/CV assist is enabled
+
+On accepted start, the task claims code `1`, marks commissioning active,
+stores the previous flow setpoint, writes a temporary `800 L/h` flow target and
+enters commissioning state `2` (`FLOW_SETTLE`).
+
+Boiler-task ownership is currently split like this:
+
+- commissioning supervisor owns:
+  - CM100 container entry/exit
+  - saved/restored flow setpoint
+  - `oq_commissioning_boiler_request`
+  - task finish/release semantics
+  - status publication and entity writes
+- boiler task owns:
+  - flow-settle readiness
+  - boiler-settle readiness
+  - measurement plateau progression
+  - average/confidence result calculation
+
+Detailed task phases still use `oq_commissioning_state_code`:
+
+| State | Meaning | Primary effect |
+|---:|---|---|
+| `2` | flow settle | wait for stable flow before enabling boiler |
+| `3` | boiler settle | boiler relay requested, wait for stable active heat |
+| `4` | measure | accumulate plateau-filtered heat samples |
+| `5` | cooldown | boiler request released, result retained |
+| `6` | done | result visible, CM100 released to neutral |
+| `7` | abort | flow restored, result preserved |
+| `8` | failed | flow restored, result cleared |
+
+Boiler task abort/failure/success paths are currently:
+
+- abort:
+  - manual abort while task is active
+  - CM100 exited during task
+- failure:
+  - overall timeout
+  - hard trip active
+  - boiler inhibit active
+  - boiler/CV assist disabled during task
+  - boiler did not start within settle window
+- success:
+  - measurement window reached minimum time and sample count
+  - result publishes `DONE: <W> (conf <%%>)`
+  - commissioning releases back to neutral `CM100 READY`
+
+## Flow Autotune Task Contract
+
+Autotune may start only when:
+
+- current Control Mode is CM100
+- no commissioning task is running
+- `oq_flow_autotune_state == 0`
+- `oq_flow_autotune_active == false`
+- `oq_flow_autotune_req == false`
+
+On accepted start, autotune claims task code `2`, marks commissioning active,
+sets commissioning state code `1`, queues `oq_flow_autotune_req=true`, clears
+abort and measurement memory, and publishes:
+
+- commissioning status: `FLOW AUTOTUNE STARTED`
+- autotune status: `REQUESTED`
+
+The detailed autotune states are:
+
+| State | Meaning | Primary output |
+|---:|---|---|
+| `0` | idle | no override |
+| `1` | baseline arm/settle | baseline PWM override |
+| `2` | step 1 measure | step PWM override |
+| `3` | recover / step 2 arm | baseline PWM override |
+| `4` | step 2 measure | step PWM override |
+| `5` | closed-loop validation | normal PI, temporary seed gains/setpoint |
+| `6` | abort cleanup | restore saved values, release task |
+
+Autotune is valid only while `oq_control_mode_code == 100` and
+`oq_commissioning_task_code == 2`. Leaving that combination aborts the task.
+
+## Output Contract
+
+Contractually visible outputs:
+
+- `oq_commissioning_status`
+- `oq_boiler_power_test_status`
+- `oq_flow_autotune_status`
+- `oq_commissioning_result_w`
+- `oq_commissioning_result_confidence`
+- `oq_flow_kp_suggested`
+- `oq_flow_ki_suggested`
+- `oq_commissioning_cm100_active`
+- `oq_boiler_power_test_active`
+
+Runtime-only task state:
+
+- `oq_commissioning_request_pending`
+- `oq_commissioning_active`
+- `oq_commissioning_abort_requested`
+- `oq_commissioning_task_code`
+- `oq_commissioning_state_code`
+- `oq_commissioning_started_ms`
+- `oq_commissioning_state_since_ms`
+- all `oq_flow_at_*` measurement memory
+- `oq_flow_autotune_state`
+- `oq_flow_autotune_req`
+- `oq_flow_autotune_abort`
+- `oq_flow_autotune_active`
+- `oq_flow_autotune_pwm`
+
+These are intentionally `restore_value: false`.
+
+## Autotune Terminal Paths
+
+Abort paths end in state `6`, restore temporary runtime effects, publish
+`ABORTED`, clear task code and release back to neutral CM100:
+
+- abort button or CM100 stop
+- no longer in CM100/task 2
+- invalid flow during step or validation
+- no baseline/recovery flow by timeout
+- no steady-state response
+
+Failure/refusal paths still use the same state-6 cleanup path, but preserve
+the status text that explains the reason until cleanup publishes `ABORTED`:
+
+- `FAILED: INVALID_GAIN`
+- `FAILED: INVALID_VALIDATION_STEP`
+- `FAILED: INVALID_VALIDATION_STATE`
+- `REFUSED: STEP_HEADROOM`
+
+Successful validation:
+
+- computes suggested Kp/Ki
+- restores live `oq_flow_kp`, `oq_flow_ki` and `oq_flow_setpoint_lph`
+- clears temporary validation memory
+- publishes one of:
+  - `DONE (CLOSED-LOOP): ...`
+  - `DONE (CLAMPED): ...`
+  - `DONE (LIMITED): ...`
+- releases commissioning back to `CM100 READY`
+
+The apply button is separate from task success. It writes suggested values to
+the live/persistent flow tuning numbers only when both suggestions are valid.
+
+## Flow-Control Boundary
+
+Flow control owns pump iPWM in all non-CM0 modes. The autotune override has
+priority only when:
+
+- `oq_flow_autotune_active == true`
+- Control Mode is CM100
+- commissioning task code is `2`
+- frost mode is not active
+
+In that case flow control writes the requested autotune PWM, publishes flow
+mode `AUTOTUNE`, resets stability tracking and returns before manual/frost/PI
+paths run.
+
+When autotune disables `oq_flow_autotune_active` during validation, normal PI
+owns the pump again using the temporary seed gains and validation setpoint.
+
+## Regression Anchors
+
+The regression harness now covers these phase-7 anchors:
+
+- neutral CM100 start arms only the service container
+- CM100 start refuses while override is not Auto
+- active autotune abort is delegated to autotune
+- pending autotune abort marks both abort flags
+- autotune start claims task code 2 only in CM100
+- autotune start refuses outside CM100
+- queued autotune task enters baseline settling
+- autotune release clears the task while keeping CM100 ready
+- autotune abort restores saved PI gains and setpoint
+- invalid step gain remains a failed path
+- successful validation may scale gains up slightly
+- validation timeout publishes a limited done result
+- boiler flow-on-target uses the commissioning settle band
+- boiler settle requires both consecutive stable samples and minimum dwell time
+- boiler plateau gating delays sample accumulation until heat has stabilized
+- boiler measurement completion requires both minimum samples and minimum runtime
+- boiler finalize computes the published average and confidence
+
+## Extraction Path
+
+Safe phase-7 extraction should proceed in this order:
+
+1. Keep this contract and the harness green.
+2. Add a narrow task-interface helper for task codes, release semantics and
+   abort routing.
+3. Move only pure autotune calculations first: gain classification, validation
+   scaling and status-family selection.
+4. Move state transitions only after each transition has a scenario anchor.
+5. Leave ESPHome entity writes, number calls, status publication and interval
+   wiring in YAML until the helper boundary is proven stable.
+
+Current phase-7 helper status:
+
+- centralized in `openquatt/includes/oq_commissioning_logic.h`:
+  task codes, task state codes, CM100/task predicates and stop/abort routing
+- centralized in `openquatt/includes/oq_flow_autotune_logic.h`:
+  autotune state codes, iPWM clamp, rolling-window helpers, arm/recover/open-loop
+  step decisions, validation-settle/measure decisions, and validation
+  gain/status adjustment
+- centralized in `openquatt/includes/oq_boiler_task_logic.h`:
+  boiler flow-valid/on-target checks, settle decisions, plateau-filtered
+  measurement progression and result/confidence finalization
+- still local in YAML:
+  task timers, saved-flow ownership, number/entity writes, status publication,
+  commissioning release semantics, logging and other side effects
+
+This means the current phase-7 boundary is now:
+
+- helpers decide task-phase progression and pure task outputs
+- YAML applies side effects, persists runtime fields and publishes entities
+
+Out of scope for this phase:
+
+- no big-bang commissioning rewrite
+- no flow PI conversion to C++
+- no dashboard/UX work
+- no changes to `flow_rate_hp_avg`
+- no work in `oq_HP_io.yaml`

--- a/openquatt/includes/oq_boiler_task_logic.h
+++ b/openquatt/includes/oq_boiler_task_logic.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+
+namespace oq_boiler_task {
+
+struct MeasureState {
+  int sample_count;
+  float sum_w;
+  float min_w;
+  float max_w;
+  float peak_w;
+  int plateau_count;
+};
+
+struct MeasureResult {
+  bool ready;
+  float avg_w;
+  float confidence;
+  float min_w;
+  float max_w;
+  float spread_w;
+};
+
+struct SettleDecision {
+  int stable_count;
+  bool ready;
+};
+
+struct BoilerSettleDecision {
+  int stable_count;
+  bool ready;
+  bool boiler_timeout;
+};
+
+struct MeasureDecision {
+  MeasureState state;
+  bool window_complete;
+  MeasureResult result;
+};
+
+inline bool flow_valid(float flow_lph) {
+  return !isnan(flow_lph) && flow_lph > 0.0f;
+}
+
+inline bool flow_on_target(float flow_lph, float target_flow_lph, float band_lph) {
+  return flow_valid(flow_lph) && fabsf(flow_lph - target_flow_lph) <= band_lph;
+}
+
+inline int next_stable_count(bool stable_now, int stable_count) {
+  if (!stable_now) return 0;
+  return stable_count + 1;
+}
+
+inline SettleDecision evaluate_flow_settle(bool stable_now,
+                                           int stable_count,
+                                           int required_stable_samples,
+                                           uint32_t state_age_ms,
+                                           uint32_t settle_min_ms) {
+  const int next_count = next_stable_count(stable_now, stable_count);
+  return SettleDecision{
+      next_count,
+      next_count >= required_stable_samples && state_age_ms >= settle_min_ms,
+  };
+}
+
+inline bool settle_window_ready(int stable_count,
+                                int required_stable_samples,
+                                uint32_t state_age_ms,
+                                uint32_t settle_min_ms) {
+  return stable_count >= required_stable_samples && state_age_ms >= settle_min_ms;
+}
+
+inline BoilerSettleDecision evaluate_boiler_settle(bool stable_now,
+                                                   int stable_count,
+                                                   bool boiler_active,
+                                                   int required_stable_samples,
+                                                   uint32_t state_age_ms,
+                                                   uint32_t settle_min_ms) {
+  const int next_count = next_stable_count(stable_now, stable_count);
+  if (!boiler_active) {
+    return BoilerSettleDecision{
+        next_count,
+        false,
+        state_age_ms >= settle_min_ms,
+    };
+  }
+  return BoilerSettleDecision{
+      next_count,
+      next_count >= required_stable_samples && state_age_ms >= settle_min_ms,
+      false,
+  };
+}
+
+inline MeasureState reset_measurement() {
+  return MeasureState{0, 0.0f, NAN, NAN, NAN, 0};
+}
+
+inline MeasureState step_measurement(MeasureState state,
+                                     bool flow_stable_now,
+                                     bool heat_valid,
+                                     float heat_w,
+                                     float plateau_ratio,
+                                     int plateau_confirm_samples) {
+  if (!flow_stable_now || !heat_valid || !(heat_w > 0.0f)) {
+    return state;
+  }
+
+  if (isnan(state.peak_w) || heat_w > state.peak_w) {
+    state.peak_w = heat_w;
+    state.plateau_count = 0;
+  }
+
+  const float plateau_floor = isnan(state.peak_w) ? heat_w : state.peak_w * plateau_ratio;
+  if (heat_w >= plateau_floor) {
+    if (state.plateau_count < 1000) state.plateau_count++;
+  } else {
+    state.plateau_count = 0;
+  }
+
+  if (state.plateau_count < plateau_confirm_samples) {
+    return state;
+  }
+
+  state.sample_count++;
+  state.sum_w += heat_w;
+  if (isnan(state.min_w) || heat_w < state.min_w) state.min_w = heat_w;
+  if (isnan(state.max_w) || heat_w > state.max_w) state.max_w = heat_w;
+  return state;
+}
+
+inline bool measurement_window_complete(int sample_count,
+                                        int min_samples,
+                                        uint32_t state_age_ms,
+                                        uint32_t measure_min_ms) {
+  return sample_count >= min_samples && state_age_ms >= measure_min_ms;
+}
+
+inline MeasureResult finalize_measurement(const MeasureState &state) {
+  if (state.sample_count <= 0 || isnan(state.min_w) || isnan(state.max_w)) {
+    return MeasureResult{false, NAN, 0.0f, NAN, NAN, NAN};
+  }
+
+  const float sample_count_f = (float) state.sample_count;
+  const float avg_w = state.sum_w / sample_count_f;
+  const float spread_w = state.max_w - state.min_w;
+  float confidence = 100.0f;
+  if (sample_count_f < 10.0f) confidence -= (10.0f - sample_count_f) * 4.0f;
+  if (spread_w > avg_w * 0.05f) confidence -= 15.0f;
+  if (spread_w > avg_w * 0.10f) confidence -= 20.0f;
+  if (confidence < 0.0f) confidence = 0.0f;
+  if (confidence > 100.0f) confidence = 100.0f;
+
+  return MeasureResult{true, avg_w, confidence, state.min_w, state.max_w, spread_w};
+}
+
+inline MeasureDecision evaluate_measure_phase(MeasureState state,
+                                              bool flow_stable_now,
+                                              bool heat_valid,
+                                              float heat_w,
+                                              float plateau_ratio,
+                                              int plateau_confirm_samples,
+                                              int min_samples,
+                                              uint32_t state_age_ms,
+                                              uint32_t measure_min_ms) {
+  const MeasureState next_state = step_measurement(
+      state,
+      flow_stable_now,
+      heat_valid,
+      heat_w,
+      plateau_ratio,
+      plateau_confirm_samples);
+  const bool complete = measurement_window_complete(
+      next_state.sample_count, min_samples, state_age_ms, measure_min_ms);
+  const MeasureResult result = complete ? finalize_measurement(next_state)
+                                        : MeasureResult{false, NAN, 0.0f, NAN, NAN, NAN};
+  return MeasureDecision{next_state, complete, result};
+}
+
+}  // namespace oq_boiler_task

--- a/openquatt/includes/oq_commissioning_logic.h
+++ b/openquatt/includes/oq_commissioning_logic.h
@@ -1,0 +1,62 @@
+#pragma once
+
+namespace oq_commissioning {
+
+enum TaskCode {
+  TASK_NONE = 0,
+  TASK_BOILER_POWER_TEST = 1,
+  TASK_FLOW_AUTOTUNE = 2,
+};
+
+enum TaskStateCode {
+  TASK_STATE_IDLE = 0,
+  TASK_STATE_REQUESTED = 1,
+  TASK_STATE_FLOW_SETTLE = 2,
+  TASK_STATE_BOILER_SETTLE = 3,
+  TASK_STATE_MEASURE = 4,
+  TASK_STATE_COOLDOWN = 5,
+  TASK_STATE_DONE = 6,
+  TASK_STATE_ABORT = 7,
+  TASK_STATE_FAILED = 8,
+};
+
+inline bool is_cm100(int control_mode_code) {
+  return control_mode_code == 100;
+}
+
+inline bool task_selected(int task_code, TaskCode expected) {
+  return task_code == static_cast<int>(expected);
+}
+
+inline bool task_running(bool commissioning_active, int task_code) {
+  return commissioning_active && task_code != static_cast<int>(TASK_NONE);
+}
+
+inline bool task_active(bool commissioning_active, int task_code, TaskCode expected) {
+  return commissioning_active && task_selected(task_code, expected);
+}
+
+inline bool stop_routes_to_autotune_abort(bool commissioning_active,
+                                          int task_code,
+                                          bool flow_autotune_req) {
+  return task_active(commissioning_active, task_code, TASK_FLOW_AUTOTUNE) ||
+         task_selected(task_code, TASK_FLOW_AUTOTUNE) ||
+         flow_autotune_req;
+}
+
+inline bool stop_routes_to_commissioning_abort(bool commissioning_active,
+                                               int task_code) {
+  return task_running(commissioning_active, task_code) &&
+         !task_selected(task_code, TASK_FLOW_AUTOTUNE);
+}
+
+inline bool flow_autotune_mode_valid(int control_mode_code, int task_code) {
+  return is_cm100(control_mode_code) &&
+         task_selected(task_code, TASK_FLOW_AUTOTUNE);
+}
+
+inline bool neutral_cm100_requested(bool request_pending, int task_code) {
+  return request_pending && task_selected(task_code, TASK_NONE);
+}
+
+}  // namespace oq_commissioning

--- a/openquatt/includes/oq_flow_autotune_logic.h
+++ b/openquatt/includes/oq_flow_autotune_logic.h
@@ -1,0 +1,843 @@
+#pragma once
+
+#include <math.h>
+
+namespace oq_flow_autotune {
+
+enum StateCode {
+  STATE_IDLE = 0,
+  STATE_ARM = 1,
+  STATE_STEP1 = 2,
+  STATE_RECOVER = 3,
+  STATE_STEP2 = 4,
+  STATE_VALIDATE = 5,
+  STATE_ABORT = 6,
+};
+
+struct WindowStats {
+  bool ready;
+  float mean;
+  float spread;
+  float slope01;
+  float slope12;
+};
+
+struct StepModel {
+  bool valid_gain;
+  float gain;
+  float tau_s;
+};
+
+struct RollingWindow {
+  float w0;
+  float w1;
+  float w2;
+};
+
+struct ValidationAdjustment {
+  float kp;
+  float ki;
+  float scale;
+  bool clamped;
+  const char *status_prefix;
+};
+
+enum StatusReason {
+  STATUS_NONE = 0,
+  STATUS_WAITING_FOR_CM100,
+  STATUS_WAITING_FOR_FLOW,
+  STATUS_SETTLING,
+  STATUS_STEP,
+  STATUS_STEP2,
+  STATUS_RECOVERING,
+  STATUS_VALIDATING_SETTLING,
+  STATUS_VALIDATING,
+  STATUS_ABORT_NOT_CM100,
+  STATUS_ABORT_NO_BASELINE_FLOW,
+  STATUS_ABORT_FLOW_INVALID,
+  STATUS_ABORT_NO_STEADY_STATE,
+  STATUS_REFUSED_STEP_HEADROOM,
+  STATUS_FAILED_INVALID_GAIN,
+  STATUS_FAILED_INVALID_VALIDATION_STEP,
+  STATUS_FAILED_INVALID_VALIDATION_STATE,
+};
+
+struct ArmDecision {
+  StateCode next_state;
+  StatusReason reason;
+  int next_t_s;
+  int pwm_step;
+  float pv0;
+  RollingWindow window;
+  int ss_confirm_cnt;
+};
+
+struct OpenLoopDecision {
+  StateCode next_state;
+  StatusReason reason;
+  int next_t_s;
+  RollingWindow window;
+  int ss_confirm_cnt;
+  float pv_ss;
+  float pv63_time_s;
+  StepModel model;
+  bool ready;
+};
+
+struct RecoveryDecision {
+  StateCode next_state;
+  StatusReason reason;
+  int next_t_s;
+  int pwm_step;
+  float pv0;
+  RollingWindow window;
+  int ss_confirm_cnt;
+};
+
+struct ValidationSeedPlan {
+  bool ready;
+  StatusReason reason;
+  float kp_seed;
+  float ki_seed;
+  float validate_sp1;
+  float combined_gain;
+  float combined_tau_s;
+  bool consistent;
+};
+
+struct ValidationSettleDecision {
+  StateCode next_state;
+  StatusReason reason;
+  int next_t_s;
+  RollingWindow window;
+  int confirm_cnt;
+  float peak_pv;
+  bool settle_ready;
+};
+
+struct ValidationMeasureDecision {
+  StateCode next_state;
+  StatusReason reason;
+  int next_t_s;
+  RollingWindow window;
+  int confirm_cnt;
+  float peak_pv;
+  bool done;
+  bool settled;
+  bool timed_out;
+  ValidationAdjustment adjustment;
+};
+
+inline bool baseline_window_ready(int elapsed_s,
+                                  int settle_s,
+                                  int wait_max_s,
+                                  const WindowStats &stats,
+                                  float stable_band_lph);
+
+inline ValidationAdjustment adjust_validation_gains(float seed_kp,
+                                                    float seed_ki,
+                                                    float overshoot,
+                                                    float settle_band,
+                                                    bool settled,
+                                                    bool timed_out,
+                                                    int elapsed_s,
+                                                    int sample_time_s,
+                                                    float kp_min,
+                                                    float kp_max,
+                                                    float ki_min,
+                                                    float ki_max);
+
+inline int clamp_ipwm(int value, int min_ipwm, int max_ipwm) {
+  if (value < min_ipwm) return min_ipwm;
+  if (value > max_ipwm) return max_ipwm;
+  return value;
+}
+
+inline RollingWindow push_window(float w0, float w1, float w2, float sample) {
+  return RollingWindow{w1, w2, sample};
+}
+
+inline WindowStats analyze_window(float w0, float w1, float w2) {
+  if (isnan(w0) || isnan(w1) || isnan(w2)) {
+    return WindowStats{false, NAN, NAN, NAN, NAN};
+  }
+  const float w_min = fminf(w0, fminf(w1, w2));
+  const float w_max = fmaxf(w0, fmaxf(w1, w2));
+  return WindowStats{
+      true,
+      (w0 + w1 + w2) / 3.0f,
+      w_max - w_min,
+      fabsf(w1 - w0),
+      fabsf(w2 - w1),
+  };
+}
+
+inline ArmDecision evaluate_arm_phase(bool valid_mode,
+                                      bool flow_valid_now,
+                                      int elapsed_s,
+                                      int sample_time_s,
+                                      float pv,
+                                      const RollingWindow &window,
+                                      int pwm0,
+                                      int pwm_min,
+                                      int pwm_max,
+                                      int min_step,
+                                      int settle_s,
+                                      int wait_max_s,
+                                      float stable_band_lph,
+                                      float step_frac,
+                                      int step_min_ipwm,
+                                      int step_max_ipwm,
+                                      StateCode hold_state,
+                                      StateCode success_state,
+                                      StatusReason success_reason) {
+  if (!valid_mode) {
+    return ArmDecision{
+        STATE_ABORT, STATUS_ABORT_NOT_CM100, elapsed_s, pwm0, NAN, window, 0};
+  }
+
+  const int next_t_s = elapsed_s + sample_time_s;
+  if (!flow_valid_now) {
+    if (elapsed_s >= wait_max_s) {
+      return ArmDecision{
+          STATE_ABORT,
+          STATUS_ABORT_NO_BASELINE_FLOW,
+          next_t_s,
+          pwm0,
+          NAN,
+          window,
+          0};
+    }
+    return ArmDecision{
+        hold_state,
+        STATUS_WAITING_FOR_FLOW,
+        next_t_s,
+        pwm0,
+        NAN,
+        window,
+        0};
+  }
+
+  const RollingWindow next_window = push_window(window.w0, window.w1, window.w2, pv);
+  const WindowStats stats = analyze_window(
+      next_window.w0, next_window.w1, next_window.w2);
+  if (baseline_window_ready(
+          elapsed_s, settle_s, wait_max_s, stats, stable_band_lph)) {
+    const int pwm_headroom = pwm0 - pwm_min;
+    if (pwm_headroom < min_step) {
+      return ArmDecision{
+          STATE_ABORT,
+          STATUS_REFUSED_STEP_HEADROOM,
+          next_t_s,
+          pwm0,
+          stats.mean,
+          next_window,
+          0};
+    }
+    int u_step = (int) roundf(step_frac * (float) pwm0);
+    if (u_step < step_min_ipwm) u_step = step_min_ipwm;
+    if (u_step > step_max_ipwm) u_step = step_max_ipwm;
+    if (u_step > pwm_headroom) u_step = pwm_headroom;
+    if (u_step < min_step) u_step = min_step;
+    const int pwm_step = clamp_ipwm(pwm0 - u_step, pwm_min, pwm_max);
+    return ArmDecision{
+        success_state,
+        success_reason,
+        0,
+        pwm_step,
+        stats.mean,
+        RollingWindow{NAN, NAN, NAN},
+        0};
+  }
+
+  if (elapsed_s >= wait_max_s) {
+    return ArmDecision{
+        STATE_ABORT,
+        STATUS_ABORT_NO_BASELINE_FLOW,
+        next_t_s,
+        pwm0,
+        NAN,
+        next_window,
+        0};
+  }
+
+  return ArmDecision{
+      hold_state,
+      STATUS_SETTLING,
+      next_t_s,
+      pwm0,
+      NAN,
+      next_window,
+      0};
+}
+
+inline bool baseline_window_ready(int elapsed_s,
+                                  int settle_s,
+                                  int wait_max_s,
+                                  const WindowStats &stats,
+                                  float stable_band_lph) {
+  return stats.ready &&
+         elapsed_s >= settle_s &&
+         elapsed_s <= wait_max_s &&
+         stats.spread <= stable_band_lph &&
+         stats.mean > 0.0f;
+}
+
+inline bool steady_state_window_ready(const WindowStats &stats,
+                                      float spread_limit_lph,
+                                      float slope_limit_lph) {
+  return stats.ready &&
+         stats.spread <= spread_limit_lph &&
+         stats.slope01 <= slope_limit_lph &&
+         stats.slope12 <= slope_limit_lph;
+}
+
+inline StepModel build_step_model(float pv0,
+                                  float pv_ss,
+                                  float t63_s,
+                                  float du,
+                                  float sample_time_s,
+                                  float tau_fallback_s) {
+  const float gain = (pv_ss - pv0) / du;
+  if (!(gain > 0.0f)) {
+    return StepModel{false, gain, NAN};
+  }
+  float tau_s = t63_s;
+  if (isnan(tau_s) || tau_s < sample_time_s) tau_s = tau_fallback_s;
+  return StepModel{true, gain, tau_s};
+}
+
+inline OpenLoopDecision evaluate_open_loop_measure(bool valid_mode,
+                                                   bool flow_valid_now,
+                                                   int elapsed_s,
+                                                   int sample_time_s,
+                                                   float pv,
+                                                   float pv0,
+                                                   float du,
+                                                   const RollingWindow &window,
+                                                   float pv_ss,
+                                                   float pv63_time_s,
+                                                   int ss_confirm_cnt,
+                                                   StateCode hold_state,
+                                                   int duration_s,
+                                                   float spread_limit_lph,
+                                                   float slope_limit_lph,
+                                                   float tau_fallback_s) {
+  if (!valid_mode) {
+    return OpenLoopDecision{
+        STATE_ABORT,
+        STATUS_ABORT_NOT_CM100,
+        elapsed_s,
+        window,
+        ss_confirm_cnt,
+        pv_ss,
+        pv63_time_s,
+        StepModel{false, NAN, NAN},
+        false};
+  }
+  if (!flow_valid_now) {
+    return OpenLoopDecision{
+        STATE_ABORT,
+        STATUS_ABORT_FLOW_INVALID,
+        elapsed_s,
+        window,
+        ss_confirm_cnt,
+        pv_ss,
+        pv63_time_s,
+        StepModel{false, NAN, NAN},
+        false};
+  }
+
+  const RollingWindow next_window = push_window(window.w0, window.w1, window.w2, pv);
+  const WindowStats stats = analyze_window(
+      next_window.w0, next_window.w1, next_window.w2);
+  float next_pv_ss = pv_ss;
+  int next_confirm_cnt = ss_confirm_cnt;
+  if (steady_state_window_ready(stats, spread_limit_lph, slope_limit_lph)) {
+    next_pv_ss = stats.mean;
+    if (next_confirm_cnt < 255) next_confirm_cnt++;
+  } else {
+    next_confirm_cnt = 0;
+  }
+
+  float next_pv63_time_s = pv63_time_s;
+  if (!isnan(next_pv_ss) && isnan(next_pv63_time_s)) {
+    const float dpv = next_pv_ss - pv0;
+    const float pv63 = pv0 + 0.632f * dpv;
+    if (dpv >= 0.0f) {
+      if (pv >= pv63) next_pv63_time_s = (float) elapsed_s;
+    } else {
+      if (pv <= pv63) next_pv63_time_s = (float) elapsed_s;
+    }
+  }
+
+  const bool early_done =
+      !isnan(next_pv_ss) &&
+      !isnan(next_pv63_time_s) &&
+      next_confirm_cnt >= 2;
+  const int next_t_s = elapsed_s + sample_time_s;
+  if (early_done || elapsed_s >= duration_s) {
+    if (isnan(next_pv_ss)) {
+      return OpenLoopDecision{
+          STATE_ABORT,
+          STATUS_ABORT_NO_STEADY_STATE,
+          next_t_s,
+          next_window,
+          next_confirm_cnt,
+          next_pv_ss,
+          next_pv63_time_s,
+          StepModel{false, NAN, NAN},
+          false};
+    }
+    const StepModel model = build_step_model(
+        pv0, next_pv_ss, next_pv63_time_s, du, (float) sample_time_s, tau_fallback_s);
+    if (!model.valid_gain) {
+      return OpenLoopDecision{
+          STATE_ABORT,
+          STATUS_FAILED_INVALID_GAIN,
+          next_t_s,
+          next_window,
+          next_confirm_cnt,
+          next_pv_ss,
+          next_pv63_time_s,
+          model,
+          false};
+    }
+    return OpenLoopDecision{
+        STATE_IDLE,
+        STATUS_NONE,
+        0,
+        RollingWindow{NAN, NAN, NAN},
+        0,
+        next_pv_ss,
+        next_pv63_time_s,
+        model,
+        true};
+  }
+
+  return OpenLoopDecision{
+      hold_state,
+      STATUS_NONE,
+      next_t_s,
+      next_window,
+      next_confirm_cnt,
+      next_pv_ss,
+      next_pv63_time_s,
+      StepModel{false, NAN, NAN},
+      false};
+}
+
+inline RecoveryDecision evaluate_recovery_phase(bool valid_mode,
+                                                bool flow_valid_now,
+                                                int elapsed_s,
+                                                int sample_time_s,
+                                                float pv,
+                                                const RollingWindow &window,
+                                                int pwm0,
+                                                int pwm_min,
+                                                int pwm_max,
+                                                int settle_s,
+                                                int wait_max_s,
+                                                float stable_band_lph,
+                                                float step_frac,
+                                                int step_min_ipwm,
+                                                int step_max_ipwm,
+                                                int step1_u,
+                                                StateCode hold_state,
+                                                StateCode success_state,
+                                                StatusReason success_reason) {
+  if (!valid_mode) {
+    return RecoveryDecision{
+        STATE_ABORT, STATUS_ABORT_NOT_CM100, elapsed_s, pwm0, NAN, window, 0};
+  }
+
+  const int next_t_s = elapsed_s + sample_time_s;
+  if (!flow_valid_now) {
+    if (elapsed_s >= wait_max_s) {
+      return RecoveryDecision{
+          STATE_ABORT,
+          STATUS_ABORT_NO_BASELINE_FLOW,
+          next_t_s,
+          pwm0,
+          NAN,
+          window,
+          0};
+    }
+    return RecoveryDecision{
+        hold_state,
+        STATUS_WAITING_FOR_FLOW,
+        next_t_s,
+        pwm0,
+        NAN,
+        window,
+        0};
+  }
+
+  const RollingWindow next_window = push_window(window.w0, window.w1, window.w2, pv);
+  const WindowStats stats = analyze_window(
+      next_window.w0, next_window.w1, next_window.w2);
+  if (baseline_window_ready(
+          elapsed_s, settle_s, wait_max_s, stats, stable_band_lph)) {
+    int u_step = (int) roundf(step_frac * (float) pwm0);
+    if (u_step < step_min_ipwm) u_step = step_min_ipwm;
+    if (u_step > step_max_ipwm) u_step = step_max_ipwm;
+    if (u_step <= step1_u) u_step = step1_u + 8;
+    if (u_step > pwm0 - pwm_min) u_step = pwm0 - pwm_min;
+    if (u_step <= step1_u) {
+      return RecoveryDecision{
+          STATE_ABORT,
+          STATUS_REFUSED_STEP_HEADROOM,
+          next_t_s,
+          pwm0,
+          stats.mean,
+          next_window,
+          0};
+    }
+    const int pwm_step = clamp_ipwm(pwm0 - u_step, pwm_min, pwm_max);
+    return RecoveryDecision{
+        success_state,
+        success_reason,
+        0,
+        pwm_step,
+        stats.mean,
+        RollingWindow{NAN, NAN, NAN},
+        0};
+  }
+
+  if (elapsed_s >= wait_max_s) {
+    return RecoveryDecision{
+        STATE_ABORT,
+        STATUS_ABORT_NO_BASELINE_FLOW,
+        next_t_s,
+        pwm0,
+        NAN,
+        next_window,
+        0};
+  }
+
+  return RecoveryDecision{
+      hold_state,
+      STATUS_SETTLING,
+      next_t_s,
+      pwm0,
+      NAN,
+      next_window,
+      0};
+}
+
+inline ValidationSeedPlan build_validation_seed(float K1,
+                                                float tau1,
+                                                float K2,
+                                                float tau2,
+                                                float du1,
+                                                float du2,
+                                                float sample_time_s,
+                                                float consistency_frac,
+                                                float seed_lambda_frac,
+                                                float seed_ti_frac,
+                                                float seed_min_lambda_s,
+                                                float seed_min_ti_s,
+                                                float kp_min,
+                                                float kp_max,
+                                                float ki_min,
+                                                float ki_max,
+                                                float sp0,
+                                                float validate_step_frac,
+                                                float validate_step_min_lph,
+                                                float validate_step_max_lph,
+                                                float pv0) {
+  if (!(K1 > 0.0f) || !(K2 > 0.0f) || isnan(tau1) || isnan(tau2)) {
+    return ValidationSeedPlan{
+        false,
+        STATUS_FAILED_INVALID_GAIN,
+        NAN,
+        NAN,
+        NAN,
+        NAN,
+        NAN,
+        false};
+  }
+
+  const float rel_k = fabsf(K1 - K2) / fmaxf(fmaxf(K1, K2), 1e-3f);
+  const float rel_tau =
+      fabsf(tau1 - tau2) / fmaxf(fmaxf(tau1, tau2), sample_time_s);
+  const bool consistent =
+      (rel_k <= consistency_frac) && (rel_tau <= 0.35f);
+
+  float K = consistent ? (K1 * du1 + K2 * du2) / fmaxf(du1 + du2, 1.0f)
+                       : fmaxf(K1, K2);
+  float tau = fmaxf(tau1, tau2);
+  if (isnan(tau) || tau < sample_time_s) tau = tau2;
+  if (isnan(tau) || tau < sample_time_s) {
+    return ValidationSeedPlan{
+        false,
+        STATUS_FAILED_INVALID_GAIN,
+        NAN,
+        NAN,
+        NAN,
+        K,
+        tau,
+        consistent};
+  }
+
+  float lambda_seed = seed_lambda_frac * tau;
+  if (lambda_seed < seed_min_lambda_s) lambda_seed = seed_min_lambda_s;
+  float Ti_seed = seed_ti_frac * tau;
+  if (Ti_seed < seed_min_ti_s) Ti_seed = seed_min_ti_s;
+
+  float kp_seed = tau / (K * (lambda_seed + sample_time_s));
+  float ki_seed = (Ti_seed > 1e-3f) ? (kp_seed / Ti_seed) : 0.0f;
+  if (kp_seed < kp_min) kp_seed = kp_min;
+  if (kp_seed > kp_max) kp_seed = kp_max;
+  if (ki_seed < ki_min) ki_seed = ki_min;
+  if (ki_seed > ki_max) ki_seed = ki_max;
+
+  float validate_step_lph = roundf(validate_step_frac * fmaxf(pv0, sp0));
+  if (validate_step_lph < validate_step_min_lph) validate_step_lph = validate_step_min_lph;
+  if (validate_step_lph > validate_step_max_lph) validate_step_lph = validate_step_max_lph;
+  const float validate_sp1 = sp0 + validate_step_lph;
+  if (!(validate_sp1 > sp0)) {
+    return ValidationSeedPlan{
+        false,
+        STATUS_FAILED_INVALID_VALIDATION_STEP,
+        kp_seed,
+        ki_seed,
+        validate_sp1,
+        K,
+        tau,
+        consistent};
+  }
+
+  return ValidationSeedPlan{
+      true,
+      STATUS_NONE,
+      kp_seed,
+      ki_seed,
+      validate_sp1,
+      K,
+      tau,
+      consistent};
+}
+
+inline ValidationSettleDecision evaluate_validation_settle(
+    bool valid_mode,
+    bool flow_valid_now,
+    int elapsed_s,
+    int sample_time_s,
+    float pv,
+    float sp1,
+    float settle_band,
+    int settle_grace_s,
+    int settle_max_s,
+    const RollingWindow &window,
+    int confirm_cnt,
+    float peak_pv) {
+  if (!valid_mode) {
+    return ValidationSettleDecision{
+        STATE_ABORT,
+        STATUS_ABORT_NOT_CM100,
+        elapsed_s,
+        window,
+        confirm_cnt,
+        peak_pv,
+        false};
+  }
+  if (!flow_valid_now) {
+    return ValidationSettleDecision{
+        STATE_ABORT,
+        STATUS_ABORT_FLOW_INVALID,
+        elapsed_s,
+        window,
+        confirm_cnt,
+        peak_pv,
+        false};
+  }
+
+  const float next_peak_pv = fmaxf(peak_pv, pv);
+  const RollingWindow next_window = push_window(window.w0, window.w1, window.w2, pv);
+  const WindowStats stats = analyze_window(
+      next_window.w0, next_window.w1, next_window.w2);
+  int next_confirm_cnt = confirm_cnt;
+  if (stats.ready) {
+    const bool settle_ready_now =
+        elapsed_s >= settle_grace_s &&
+        steady_state_window_ready(stats, settle_band, settle_band) &&
+        fabsf(pv - sp1) <= settle_band;
+    if (settle_ready_now) {
+      if (next_confirm_cnt < 255) next_confirm_cnt++;
+    } else {
+      next_confirm_cnt = 0;
+    }
+  }
+
+  if (next_confirm_cnt >= 2 || elapsed_s >= settle_max_s) {
+    return ValidationSettleDecision{
+        STATE_VALIDATE,
+        STATUS_VALIDATING,
+        0,
+        RollingWindow{NAN, NAN, NAN},
+        0,
+        sp1,
+        true};
+  }
+
+  return ValidationSettleDecision{
+      STATE_VALIDATE,
+      STATUS_VALIDATING_SETTLING,
+      elapsed_s + sample_time_s,
+      next_window,
+      next_confirm_cnt,
+      next_peak_pv,
+      false};
+}
+
+inline ValidationMeasureDecision evaluate_validation_measure(
+    bool valid_mode,
+    bool flow_valid_now,
+    int elapsed_s,
+    int sample_time_s,
+    float pv,
+    float sp1,
+    float settle_band,
+    float overshoot_band,
+    int duration_s,
+    const RollingWindow &window,
+    int confirm_cnt,
+    float peak_pv,
+    float seed_kp,
+    float seed_ki,
+    float kp_min,
+    float kp_max,
+    float ki_min,
+    float ki_max) {
+  if (!valid_mode) {
+    return ValidationMeasureDecision{
+        STATE_ABORT,
+        STATUS_ABORT_NOT_CM100,
+        elapsed_s,
+        window,
+        confirm_cnt,
+        peak_pv,
+        false,
+        false,
+        false,
+        ValidationAdjustment{NAN, NAN, NAN, false, ""}};
+  }
+  if (!flow_valid_now) {
+    return ValidationMeasureDecision{
+        STATE_ABORT,
+        STATUS_ABORT_FLOW_INVALID,
+        elapsed_s,
+        window,
+        confirm_cnt,
+        peak_pv,
+        false,
+        false,
+        false,
+        ValidationAdjustment{NAN, NAN, NAN, false, ""}};
+  }
+
+  const float next_peak_pv = fmaxf(peak_pv, pv);
+  const RollingWindow next_window = push_window(window.w0, window.w1, window.w2, pv);
+  const WindowStats stats = analyze_window(
+      next_window.w0, next_window.w1, next_window.w2);
+  int next_confirm_cnt = confirm_cnt;
+  if (stats.ready) {
+    const bool settled_now =
+        steady_state_window_ready(stats, settle_band, settle_band) &&
+        fabsf(pv - sp1) <= settle_band;
+    if (settled_now) {
+      if (next_confirm_cnt < 255) next_confirm_cnt++;
+    } else {
+      next_confirm_cnt = 0;
+    }
+  }
+
+  const float overshoot = next_peak_pv - sp1;
+  const bool overshot = overshoot > overshoot_band;
+  const bool settled =
+      next_confirm_cnt >= 2 && !overshot && fabsf(pv - sp1) <= settle_band;
+  const bool timed_out = elapsed_s >= duration_s;
+  if (settled || timed_out) {
+    return ValidationMeasureDecision{
+        STATE_VALIDATE,
+        STATUS_NONE,
+        elapsed_s + sample_time_s,
+        next_window,
+        next_confirm_cnt,
+        next_peak_pv,
+        true,
+        settled,
+        timed_out,
+        adjust_validation_gains(seed_kp,
+                                seed_ki,
+                                overshoot,
+                                settle_band,
+                                settled,
+                                timed_out,
+                                elapsed_s,
+                                sample_time_s,
+                                kp_min,
+                                kp_max,
+                                ki_min,
+                                ki_max)};
+  }
+
+  return ValidationMeasureDecision{
+      STATE_VALIDATE,
+      STATUS_VALIDATING,
+      elapsed_s + sample_time_s,
+      next_window,
+      next_confirm_cnt,
+      next_peak_pv,
+      false,
+      false,
+      false,
+      ValidationAdjustment{NAN, NAN, NAN, false, ""}};
+}
+
+inline ValidationAdjustment adjust_validation_gains(float seed_kp,
+                                                    float seed_ki,
+                                                    float overshoot,
+                                                    float settle_band,
+                                                    bool settled,
+                                                    bool timed_out,
+                                                    int elapsed_s,
+                                                    int sample_time_s,
+                                                    float kp_min,
+                                                    float kp_max,
+                                                    float ki_min,
+                                                    float ki_max) {
+  float scale = 1.0f;
+  if (overshoot > (2.0f * settle_band)) {
+    scale = 0.80f;
+  } else if (overshoot > settle_band) {
+    scale = 0.90f;
+  } else if (settled &&
+             elapsed_s <= (sample_time_s * 3) &&
+             overshoot <= (0.5f * settle_band)) {
+    scale = 1.05f;
+  }
+  if (timed_out && !settled) {
+    if (scale > 0.95f) scale = 0.95f;
+  }
+
+  const float raw_kp = seed_kp * scale;
+  const float raw_ki = seed_ki * scale;
+  float kp = raw_kp;
+  float ki = raw_ki;
+  if (kp < kp_min) kp = kp_min;
+  if (kp > kp_max) kp = kp_max;
+  if (ki < ki_min) ki = ki_min;
+  if (ki > ki_max) ki = ki_max;
+
+  const bool clamped =
+      fabsf(kp - raw_kp) > 1.0e-7f || fabsf(ki - raw_ki) > 1.0e-7f;
+  const char *status_prefix = "DONE (CLOSED-LOOP)";
+  if (timed_out && !settled) status_prefix = "DONE (LIMITED)";
+  else if (clamped) status_prefix = "DONE (CLAMPED)";
+
+  return ValidationAdjustment{kp, ki, scale, clamped, status_prefix};
+}
+
+}  // namespace oq_flow_autotune

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -86,9 +86,11 @@ sensor:
     lambda: |-
       const int cm_code = id(oq_control_mode_code);
       const bool commissioning_boiler =
-          (cm_code == 100) &&
-          id(oq_commissioning_active) &&
-          (id(oq_commissioning_task_code) == 1) &&
+          oq_commissioning::is_cm100(cm_code) &&
+          oq_commissioning::task_active(
+              id(oq_commissioning_active),
+              id(oq_commissioning_task_code),
+              oq_commissioning::TASK_BOILER_POWER_TEST) &&
           id(oq_commissioning_boiler_request);
       const bool in_cm3 = (cm_code == 3);
       if (!id(oq_boiler_assist_enabled).state) return 0.0f;
@@ -119,9 +121,11 @@ interval:
       - lambda: |-
           const int cm_code = id(oq_control_mode_code);
           const bool commissioning_boiler =
-              (cm_code == 100) &&
-              id(oq_commissioning_active) &&
-              (id(oq_commissioning_task_code) == 1) &&
+              oq_commissioning::is_cm100(cm_code) &&
+              oq_commissioning::task_active(
+                  id(oq_commissioning_active),
+                  id(oq_commissioning_task_code),
+                  oq_commissioning::TASK_BOILER_POWER_TEST) &&
               id(oq_commissioning_boiler_request);
           // Boiler follows Control Mode CM3, but the shared water-temperature model
           // may block it independently from CM ownership.
@@ -137,9 +141,11 @@ interval:
             boiler_block_reason = "water temperature boiler inhibit active";
           } else if (id(oq_water_temp_hard_trip_active)) {
             boiler_block_reason = "water temperature hard trip active";
-          } else if ((cm_code == 100) &&
-                     id(oq_commissioning_active) &&
-                     (id(oq_commissioning_task_code) == 1) &&
+          } else if (oq_commissioning::is_cm100(cm_code) &&
+                     oq_commissioning::task_active(
+                         id(oq_commissioning_active),
+                         id(oq_commissioning_task_code),
+                         oq_commissioning::TASK_BOILER_POWER_TEST) &&
                      !id(oq_commissioning_boiler_request)) {
             boiler_block_reason = "CM100 boiler commissioning waiting for flow settle";
           } else if (!in_cm3 && !commissioning_boiler) {

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -141,23 +141,23 @@ button:
                    id(oq_commissioning_task_code),
                    (int) id(oq_commissioning_active),
                    (int) id(oq_commissioning_request_pending));
-          if (id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0) {
+          if (oq_commissioning::task_running(id(oq_commissioning_active), id(oq_commissioning_task_code))) {
             id(oq_commissioning_status).publish_state("REFUSED: BUSY");
             return;
           }
 
-          id(oq_commissioning_task_code) = 0;
+          id(oq_commissioning_task_code) = oq_commissioning::TASK_NONE;
           id(oq_commissioning_request_pending) = true;
           id(oq_commissioning_active) = false;
           id(oq_commissioning_abort_requested) = false;
-          id(oq_commissioning_state_code) = 0;
+          id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_IDLE;
           id(oq_commissioning_started_ms) = 0;
           id(oq_commissioning_state_since_ms) = 0;
           id(oq_commissioning_boiler_request) = false;
           id(oq_flow_autotune_req) = false;
           id(oq_flow_autotune_abort) = false;
           id(oq_flow_autotune_active) = false;
-          id(oq_flow_autotune_state) = 0;
+          id(oq_flow_autotune_state) = oq_flow_autotune::STATE_IDLE;
           id(oq_commissioning_result_peak_w) = NAN;
           id(oq_commissioning_result_plateau_count) = 0;
           id(oq_commissioning_status).publish_state("CM100 REQUESTED");
@@ -171,18 +171,21 @@ button:
     on_press:
       - lambda: |-
           // Stop CM100 immediately when no task is active; otherwise abort the running task.
-          const int cm_code = id(oq_control_mode_code);
           const int task_code = id(oq_commissioning_task_code);
-          if (id(oq_commissioning_active) && task_code != 0) {
-            if (task_code == 2) {
+          if (oq_commissioning::task_running(id(oq_commissioning_active), task_code)) {
+            if (oq_commissioning::stop_routes_to_autotune_abort(
+                    id(oq_commissioning_active), task_code, id(oq_flow_autotune_req))) {
               id(oq_flow_autotune_abort) = true;
-            } else {
+            }
+            if (oq_commissioning::stop_routes_to_commissioning_abort(
+                    id(oq_commissioning_active), task_code)) {
               id(oq_commissioning_abort_requested) = true;
             }
             id(oq_commissioning_status).publish_state("ABORT REQUESTED");
             return;
           }
-          if (task_code == 2 || id(oq_flow_autotune_req)) {
+          if (oq_commissioning::stop_routes_to_autotune_abort(
+                  id(oq_commissioning_active), task_code, id(oq_flow_autotune_req))) {
             id(oq_flow_autotune_abort) = true;
             id(oq_commissioning_abort_requested) = true;
             id(oq_commissioning_status).publish_state("ABORT REQUESTED");
@@ -191,15 +194,15 @@ button:
           id(oq_commissioning_request_pending) = false;
           id(oq_commissioning_active) = false;
           id(oq_commissioning_abort_requested) = false;
-          id(oq_commissioning_task_code) = 0;
-          id(oq_commissioning_state_code) = 0;
+          id(oq_commissioning_task_code) = oq_commissioning::TASK_NONE;
+          id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_IDLE;
           id(oq_commissioning_started_ms) = 0;
           id(oq_commissioning_state_since_ms) = 0;
           id(oq_commissioning_boiler_request) = false;
           id(oq_flow_autotune_req) = false;
           id(oq_flow_autotune_abort) = false;
           id(oq_flow_autotune_active) = false;
-          id(oq_flow_autotune_state) = 0;
+          id(oq_flow_autotune_state) = oq_flow_autotune::STATE_IDLE;
           id(oq_commissioning_result_peak_w) = NAN;
           id(oq_commissioning_result_plateau_count) = 0;
           id(oq_commissioning_status).publish_state("IDLE");
@@ -215,8 +218,9 @@ button:
       - lambda: |-
           // Boiler test may only start while the system is already in CM100.
           const int cm_code = id(oq_control_mode_code);
-          const bool cm100_ready = (cm_code == 100);
-          const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0;
+          const bool cm100_ready = oq_commissioning::is_cm100(cm_code);
+          const bool task_running = oq_commissioning::task_running(
+              id(oq_commissioning_active), id(oq_commissioning_task_code));
           if (!id(oq_boiler_assist_enabled).state) {
             id(oq_boiler_power_test_status).publish_state("REFUSED: boiler/CV assist disabled");
             return;
@@ -245,11 +249,11 @@ button:
                    id(oq_commissioning_task_code),
                    (int) id(oq_commissioning_active));
 
-          id(oq_commissioning_task_code) = 1;
+          id(oq_commissioning_task_code) = oq_commissioning::TASK_BOILER_POWER_TEST;
           id(oq_commissioning_request_pending) = false;
           id(oq_commissioning_active) = true;
           id(oq_commissioning_abort_requested) = false;
-          id(oq_commissioning_state_code) = 2;
+          id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_FLOW_SETTLE;
           id(oq_commissioning_started_ms) = (uint32_t) millis();
           id(oq_commissioning_state_since_ms) = (uint32_t) millis();
           id(oq_commissioning_boiler_request) = false;
@@ -287,17 +291,22 @@ button:
       - lambda: |-
           // Abort the running commissioning task, or clear a pending CM100 request.
           const int task_code = id(oq_commissioning_task_code);
-          const bool task_running = id(oq_commissioning_active) && task_code != 0;
+          const bool task_running = oq_commissioning::task_running(
+              id(oq_commissioning_active), task_code);
           if (task_running) {
-            if (task_code == 2) {
+            if (oq_commissioning::stop_routes_to_autotune_abort(
+                    id(oq_commissioning_active), task_code, id(oq_flow_autotune_req))) {
               id(oq_flow_autotune_abort) = true;
-            } else {
+            }
+            if (oq_commissioning::stop_routes_to_commissioning_abort(
+                    id(oq_commissioning_active), task_code)) {
               id(oq_commissioning_abort_requested) = true;
             }
             id(oq_commissioning_status).publish_state("ABORT REQUESTED");
             return;
           }
-          if (task_code == 2 || id(oq_flow_autotune_req)) {
+          if (oq_commissioning::stop_routes_to_autotune_abort(
+                  id(oq_commissioning_active), task_code, id(oq_flow_autotune_req))) {
             id(oq_flow_autotune_abort) = true;
             id(oq_commissioning_abort_requested) = true;
             id(oq_commissioning_status).publish_state("ABORT REQUESTED");
@@ -306,15 +315,15 @@ button:
           id(oq_commissioning_request_pending) = false;
           id(oq_commissioning_active) = false;
           id(oq_commissioning_abort_requested) = false;
-          id(oq_commissioning_task_code) = 0;
-          id(oq_commissioning_state_code) = 0;
+          id(oq_commissioning_task_code) = oq_commissioning::TASK_NONE;
+          id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_IDLE;
           id(oq_commissioning_started_ms) = 0;
           id(oq_commissioning_state_since_ms) = 0;
           id(oq_commissioning_boiler_request) = false;
           id(oq_flow_autotune_req) = false;
           id(oq_flow_autotune_abort) = false;
           id(oq_flow_autotune_active) = false;
-          id(oq_flow_autotune_state) = 0;
+          id(oq_flow_autotune_state) = oq_flow_autotune::STATE_IDLE;
           id(oq_commissioning_status).publish_state("IDLE");
   - platform: template
     id: oq_boiler_power_test_apply
@@ -405,7 +414,10 @@ binary_sensor:
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      return id(oq_commissioning_active) && id(oq_commissioning_task_code) == 1;
+      return oq_commissioning::task_active(
+          id(oq_commissioning_active),
+          id(oq_commissioning_task_code),
+          oq_commissioning::TASK_BOILER_POWER_TEST);
 
 text_sensor:
   - platform: template
@@ -446,14 +458,20 @@ interval:
           const uint32_t now_ms = (uint32_t) millis();
           const int cm_code = id(oq_control_mode_code);
           const bool in_cm3 = (cm_code == 3);
-          const bool in_cm100 = (cm_code == 100);
-          const bool task_is_none = (id(oq_commissioning_task_code) == 0);
-          const bool task_is_boiler = (id(oq_commissioning_task_code) == 1);
-          const bool task_is_flow_autotune = (id(oq_commissioning_task_code) == 2);
-          const bool boiler_test_running = id(oq_commissioning_active) && task_is_boiler;
+          const bool in_cm100 = oq_commissioning::is_cm100(cm_code);
+          const bool task_is_none = oq_commissioning::task_selected(
+              id(oq_commissioning_task_code), oq_commissioning::TASK_NONE);
+          const bool task_is_boiler = oq_commissioning::task_selected(
+              id(oq_commissioning_task_code), oq_commissioning::TASK_BOILER_POWER_TEST);
+          const bool task_is_flow_autotune = oq_commissioning::task_selected(
+              id(oq_commissioning_task_code), oq_commissioning::TASK_FLOW_AUTOTUNE);
+          const bool boiler_test_running = oq_commissioning::task_active(
+              id(oq_commissioning_active),
+              id(oq_commissioning_task_code),
+              oq_commissioning::TASK_BOILER_POWER_TEST);
           const float flow_lph = id(flow_rate_selected).state;
-          const bool flow_valid = !isnan(flow_lph) && flow_lph > 0.0f;
-          const bool flow_on_target = flow_valid && fabsf(flow_lph - kTargetFlowLph) <= kFlowBandLph;
+          const bool flow_on_target = oq_boiler_task::flow_on_target(
+              flow_lph, kTargetFlowLph, kFlowBandLph);
           const bool flow_stable_now = flow_on_target;
           const float heat_w = id(boiler_heat_power).state;
           const bool heat_valid = !isnan(heat_w) && heat_w >= 0.0f;
@@ -515,13 +533,14 @@ interval:
           };
 
           auto reset_measurement = [&]() {
-            id(oq_commissioning_sample_count) = 0;
+            const auto state = oq_boiler_task::reset_measurement();
+            id(oq_commissioning_sample_count) = state.sample_count;
             id(oq_commissioning_flow_stable_count) = 0;
-            id(oq_commissioning_result_sum_w) = 0.0f;
-            id(oq_commissioning_result_min_w) = NAN;
-            id(oq_commissioning_result_max_w) = NAN;
-            id(oq_commissioning_result_peak_w) = NAN;
-            id(oq_commissioning_result_plateau_count) = 0;
+            id(oq_commissioning_result_sum_w) = state.sum_w;
+            id(oq_commissioning_result_min_w) = state.min_w;
+            id(oq_commissioning_result_max_w) = state.max_w;
+            id(oq_commissioning_result_peak_w) = state.peak_w;
+            id(oq_commissioning_result_plateau_count) = state.plateau_count;
           };
 
           auto finish_task = [&](const char *status, int next_state, bool keep_result, bool keep_cm100) {
@@ -530,7 +549,7 @@ interval:
             id(oq_commissioning_request_pending) = false;
             id(oq_commissioning_active) = keep_cm100;
             id(oq_commissioning_abort_requested) = false;
-            id(oq_commissioning_task_code) = 0;
+            id(oq_commissioning_task_code) = oq_commissioning::TASK_NONE;
             id(oq_commissioning_state_code) = next_state;
             if (!keep_result) {
           id(oq_commissioning_result_w) = NAN;
@@ -546,7 +565,7 @@ interval:
             ESP_LOGW("quatt.cm100.boiler", "Boiler test abort requested (state=%d cm=%d active=%d pending=%d)",
                      id(oq_commissioning_state_code), cm_code,
                      (int) id(oq_commissioning_active), (int) id(oq_commissioning_request_pending));
-            finish_task("ABORTED", 7, true, true);
+            finish_task("ABORTED", oq_commissioning::TASK_STATE_ABORT, true, true);
             return;
           }
 
@@ -593,7 +612,7 @@ interval:
                 id(oq_commissioning_request_pending) = false;
                 id(oq_commissioning_started_ms) = now_ms;
                 id(oq_commissioning_state_since_ms) = now_ms;
-                id(oq_commissioning_state_code) = 2;
+                id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_FLOW_SETTLE;
                 publish_status("FLOW_SETTLING");
               }
             }
@@ -601,7 +620,7 @@ interval:
           }
 
           if (!in_cm100) {
-            finish_task("ABORTED: CM100 exited", 7, true, false);
+            finish_task("ABORTED: CM100 exited", oq_commissioning::TASK_STATE_ABORT, true, false);
             return;
           }
 
@@ -612,34 +631,38 @@ interval:
 
           const uint32_t elapsed_ms = now_ms - id(oq_commissioning_started_ms);
           if (elapsed_ms >= kMaxRuntimeMs) {
-            finish_task("FAILED: timeout", 8, false, true);
+            finish_task("FAILED: timeout", oq_commissioning::TASK_STATE_FAILED, false, true);
             return;
           }
 
           if (id(oq_water_temp_hard_trip_active)) {
             ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: hard trip active");
-            finish_task("FAILED: hard trip active", 8, false, true);
+            finish_task("FAILED: hard trip active", oq_commissioning::TASK_STATE_FAILED, false, true);
             return;
           }
           if (id(oq_water_temp_boiler_inhibit_active)) {
             ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: boiler inhibit active");
-            finish_task("FAILED: boiler inhibit active", 8, false, true);
+            finish_task("FAILED: boiler inhibit active", oq_commissioning::TASK_STATE_FAILED, false, true);
             return;
           }
           if (!id(oq_boiler_assist_enabled).state) {
             ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: boiler/CV assist disabled");
-            finish_task("FAILED: boiler/CV assist disabled", 8, false, true);
+            finish_task("FAILED: boiler/CV assist disabled", oq_commissioning::TASK_STATE_FAILED, false, true);
             return;
           }
 
-          if (id(oq_commissioning_state_code) == 2) {
-            if (flow_stable_now) id(oq_commissioning_flow_stable_count)++;
-            else id(oq_commissioning_flow_stable_count) = 0;
+          if (id(oq_commissioning_state_code) == oq_commissioning::TASK_STATE_FLOW_SETTLE) {
+            const auto flow_settle = oq_boiler_task::evaluate_flow_settle(
+                flow_stable_now,
+                id(oq_commissioning_flow_stable_count),
+                kStableFlowSamples,
+                now_ms - id(oq_commissioning_state_since_ms),
+                kFlowSettleMinMs);
+            id(oq_commissioning_flow_stable_count) = flow_settle.stable_count;
 
-            if (id(oq_commissioning_flow_stable_count) >= kStableFlowSamples &&
-                (now_ms - id(oq_commissioning_state_since_ms)) >= kFlowSettleMinMs) {
+            if (flow_settle.ready) {
               id(oq_commissioning_boiler_request) = true;
-              id(oq_commissioning_state_code) = 3;
+              id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_BOILER_SETTLE;
               id(oq_commissioning_state_since_ms) = now_ms;
               id(oq_commissioning_flow_stable_count) = 0;
               ESP_LOGI("quatt.cm100.boiler",
@@ -653,27 +676,32 @@ interval:
             return;
           }
 
-          if (id(oq_commissioning_state_code) == 3) {
-            if (flow_stable_now) id(oq_commissioning_flow_stable_count)++;
-            else id(oq_commissioning_flow_stable_count) = 0;
+          if (id(oq_commissioning_state_code) == oq_commissioning::TASK_STATE_BOILER_SETTLE) {
+            const auto boiler_settle = oq_boiler_task::evaluate_boiler_settle(
+                flow_stable_now,
+                id(oq_commissioning_flow_stable_count),
+                id(boiler_active).state,
+                kStableFlowSamples,
+                now_ms - id(oq_commissioning_state_since_ms),
+                kBoilerSettleMinMs);
+            id(oq_commissioning_flow_stable_count) = boiler_settle.stable_count;
 
             if (!id(boiler_active).state) {
-              if ((now_ms - id(oq_commissioning_state_since_ms)) >= kBoilerSettleMinMs) {
+              if (boiler_settle.boiler_timeout) {
                 ESP_LOGW("quatt.cm100.boiler",
                          "Boiler did not start in time (flow=%.0fL/h boiler_req=%d elapsed=%lus)",
                          flow_lph,
                          (int) id(oq_commissioning_boiler_request),
                          (unsigned long) ((now_ms - id(oq_commissioning_state_since_ms)) / 1000UL));
-                finish_task("FAILED: boiler did not start", 8, false, true);
+                finish_task("FAILED: boiler did not start", oq_commissioning::TASK_STATE_FAILED, false, true);
                 return;
               }
               publish_status("BOILER_SETTLING");
               return;
             }
 
-            if (id(oq_commissioning_flow_stable_count) >= kStableFlowSamples &&
-                (now_ms - id(oq_commissioning_state_since_ms)) >= kBoilerSettleMinMs) {
-              id(oq_commissioning_state_code) = 4;
+            if (boiler_settle.ready) {
+              id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_MEASURE;
               id(oq_commissioning_state_since_ms) = now_ms;
               reset_measurement();
               ESP_LOGI("quatt.cm100.boiler",
@@ -686,63 +714,49 @@ interval:
             return;
           }
 
-          if (id(oq_commissioning_state_code) == 4) {
-            if (flow_stable_now && heat_valid && heat_w > 0.0f) {
-              constexpr float kPlateauRatio = 0.95f;
-              constexpr int kPlateauConfirmSamples = 4;
-              if (isnan(id(oq_commissioning_result_peak_w)) || heat_w > id(oq_commissioning_result_peak_w)) {
-                id(oq_commissioning_result_peak_w) = heat_w;
-                id(oq_commissioning_result_plateau_count) = 0;
+          if (id(oq_commissioning_state_code) == oq_commissioning::TASK_STATE_MEASURE) {
+            constexpr float kPlateauRatio = 0.95f;
+            constexpr int kPlateauConfirmSamples = 4;
+            const auto measure_phase = oq_boiler_task::evaluate_measure_phase(
+                oq_boiler_task::MeasureState{
+                    id(oq_commissioning_sample_count),
+                    id(oq_commissioning_result_sum_w),
+                    id(oq_commissioning_result_min_w),
+                    id(oq_commissioning_result_max_w),
+                    id(oq_commissioning_result_peak_w),
+                    id(oq_commissioning_result_plateau_count),
+                },
+                flow_stable_now,
+                heat_valid,
+                heat_w,
+                kPlateauRatio,
+                kPlateauConfirmSamples,
+                kMeasureMinSamples,
+                now_ms - id(oq_commissioning_state_since_ms),
+                kMeasureMinMs);
+            id(oq_commissioning_sample_count) = measure_phase.state.sample_count;
+            id(oq_commissioning_result_sum_w) = measure_phase.state.sum_w;
+            id(oq_commissioning_result_min_w) = measure_phase.state.min_w;
+            id(oq_commissioning_result_max_w) = measure_phase.state.max_w;
+            id(oq_commissioning_result_peak_w) = measure_phase.state.peak_w;
+            id(oq_commissioning_result_plateau_count) = measure_phase.state.plateau_count;
+            if (measure_phase.window_complete) {
+              if (!measure_phase.result.ready) {
+                finish_task("FAILED: invalid measurement", oq_commissioning::TASK_STATE_FAILED, false, true);
+                return;
               }
-
-              const float plateau_floor = isnan(id(oq_commissioning_result_peak_w))
-                  ? heat_w
-                  : id(oq_commissioning_result_peak_w) * kPlateauRatio;
-              if (heat_w >= plateau_floor) {
-                if (id(oq_commissioning_result_plateau_count) < 1000) {
-                  id(oq_commissioning_result_plateau_count)++;
-                }
-              } else {
-                id(oq_commissioning_result_plateau_count) = 0;
-              }
-
-              if (id(oq_commissioning_result_plateau_count) >= kPlateauConfirmSamples) {
-                id(oq_commissioning_sample_count)++;
-                id(oq_commissioning_result_sum_w) += heat_w;
-                if (isnan(id(oq_commissioning_result_min_w)) || heat_w < id(oq_commissioning_result_min_w)) {
-                  id(oq_commissioning_result_min_w) = heat_w;
-                }
-                if (isnan(id(oq_commissioning_result_max_w)) || heat_w > id(oq_commissioning_result_max_w)) {
-                  id(oq_commissioning_result_max_w) = heat_w;
-                }
-              }
-            }
-
-            const uint32_t measure_age_ms = now_ms - id(oq_commissioning_state_since_ms);
-            const bool enough_samples = id(oq_commissioning_sample_count) >= kMeasureMinSamples;
-            const bool enough_time = measure_age_ms >= kMeasureMinMs;
-
-            if (enough_samples && enough_time) {
-              const float sample_count_f = (float) id(oq_commissioning_sample_count);
-              const float avg_w = id(oq_commissioning_result_sum_w) / sample_count_f;
-              const float min_w = id(oq_commissioning_result_min_w);
-              const float max_w = id(oq_commissioning_result_max_w);
-              const float spread_w = max_w - min_w;
-              float confidence = 100.0f;
-              if (sample_count_f < 10.0f) confidence -= (10.0f - sample_count_f) * 4.0f;
-              if (spread_w > avg_w * 0.05f) confidence -= 15.0f;
-              if (spread_w > avg_w * 0.10f) confidence -= 20.0f;
-              if (confidence < 0.0f) confidence = 0.0f;
-              if (confidence > 100.0f) confidence = 100.0f;
-
-              id(oq_commissioning_result_w) = avg_w;
-              id(oq_commissioning_result_confidence) = confidence;
-              id(oq_commissioning_state_code) = 5;
+              id(oq_commissioning_result_w) = measure_phase.result.avg_w;
+              id(oq_commissioning_result_confidence) = measure_phase.result.confidence;
+              id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_COOLDOWN;
               id(oq_commissioning_state_since_ms) = now_ms;
               id(oq_commissioning_boiler_request) = false;
               ESP_LOGI("quatt.cm100.boiler",
                        "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%",
-                       avg_w, min_w, max_w, (unsigned int) id(oq_commissioning_sample_count), confidence);
+                       measure_phase.result.avg_w,
+                       measure_phase.result.min_w,
+                       measure_phase.result.max_w,
+                       (unsigned int) id(oq_commissioning_sample_count),
+                       measure_phase.result.confidence);
               restore_flow_setpoint();
               publish_status("COOLDOWN");
             } else {
@@ -751,7 +765,7 @@ interval:
             return;
           }
 
-          if (id(oq_commissioning_state_code) == 5) {
+          if (id(oq_commissioning_state_code) == oq_commissioning::TASK_STATE_COOLDOWN) {
             if ((now_ms - id(oq_commissioning_state_since_ms)) >= kCooldownMs) {
               char msg[128];
               snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)",
@@ -759,14 +773,14 @@ interval:
               ESP_LOGI("quatt.cm100.boiler",
                        "Cooldown complete; CM100 idle after boiler test (flow restored, boiler off, %s)",
                        msg);
-              finish_task(msg, 6, true, true);
+              finish_task(msg, oq_commissioning::TASK_STATE_DONE, true, true);
             } else {
               publish_status("COOLDOWN");
             }
             return;
           }
 
-          if (id(oq_commissioning_state_code) == 6) {
+          if (id(oq_commissioning_state_code) == oq_commissioning::TASK_STATE_DONE) {
             char msg[128];
             snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)",
                      id(oq_commissioning_result_w), id(oq_commissioning_result_confidence));

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -156,9 +156,10 @@ button:
       - lambda: |-
           // Start autotune only when the system is already in CM100.
           const int cm_code = id(oq_control_mode_code);
-          const bool cm100_ready = (cm_code == 100);
-          const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != 0;
-          if (id(oq_flow_autotune_state) != 0 ||
+          const bool cm100_ready = oq_commissioning::is_cm100(cm_code);
+          const bool task_running = oq_commissioning::task_running(
+              id(oq_commissioning_active), id(oq_commissioning_task_code));
+          if (id(oq_flow_autotune_state) != oq_flow_autotune::STATE_IDLE ||
               id(oq_flow_autotune_active) ||
               id(oq_flow_autotune_req) ||
               task_running) {
@@ -178,16 +179,16 @@ button:
                    400,
                    (int) id(oq_flow_autotune_active),
                    (int) id(oq_flow_autotune_state));
-          id(oq_commissioning_task_code) = 2;
+          id(oq_commissioning_task_code) = oq_commissioning::TASK_FLOW_AUTOTUNE;
           id(oq_commissioning_request_pending) = false;
           id(oq_commissioning_active) = true;
           id(oq_commissioning_abort_requested) = false;
-          id(oq_commissioning_state_code) = 1;
+          id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_REQUESTED;
           id(oq_commissioning_started_ms) = (uint32_t) millis();
           id(oq_commissioning_state_since_ms) = (uint32_t) millis();
           id(oq_flow_autotune_req) = true;
           id(oq_flow_autotune_abort) = false;
-          id(oq_flow_autotune_state) = 0;
+          id(oq_flow_autotune_state) = oq_flow_autotune::STATE_IDLE;
           id(oq_flow_at_t) = 0;
           id(oq_flow_at_pwm0) = 850;
           id(oq_flow_at_pwm_step) = 850;
@@ -326,12 +327,12 @@ interval:
           constexpr float kAutotuneStepConsistencyFrac = 0.20f;
 
           auto clamp_ipwm = [](int value) -> int {
-            if (value < ${oq_flow_pwm_min}) return ${oq_flow_pwm_min};
-            if (value > ${oq_flow_pwm_max}) return ${oq_flow_pwm_max};
-            return value;
+            return oq_flow_autotune::clamp_ipwm(
+                value, ${oq_flow_pwm_min}, ${oq_flow_pwm_max});
           };
           auto in_valid_autotune_mode = []() -> bool {
-            return id(oq_control_mode_code) == 100 && id(oq_commissioning_task_code) == 2;
+            return oq_commissioning::flow_autotune_mode_valid(
+                id(oq_control_mode_code), id(oq_commissioning_task_code));
           };
           auto release_commissioning = [&](bool keep_cm100 = true) {
             id(oq_flow_autotune_active) = false;
@@ -340,8 +341,8 @@ interval:
             id(oq_commissioning_request_pending) = false;
             id(oq_commissioning_active) = keep_cm100;
             id(oq_commissioning_abort_requested) = false;
-            id(oq_commissioning_task_code) = 0;
-            id(oq_commissioning_state_code) = 0;
+            id(oq_commissioning_task_code) = oq_commissioning::TASK_NONE;
+            id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_IDLE;
             id(oq_commissioning_started_ms) = 0;
             id(oq_commissioning_state_since_ms) = 0;
             id(oq_commissioning_status).publish_state(keep_cm100 ? "CM100 READY" : "IDLE");
@@ -351,11 +352,66 @@ interval:
             call.set_value(value);
             call.perform();
           };
+          auto publish_reason = [&](oq_flow_autotune::StatusReason reason) {
+            switch (reason) {
+              case oq_flow_autotune::STATUS_WAITING_FOR_CM100:
+                id(oq_flow_autotune_status).publish_state("WAITING_FOR_CM100");
+                break;
+              case oq_flow_autotune::STATUS_WAITING_FOR_FLOW:
+                id(oq_flow_autotune_status).publish_state("WAITING_FOR_FLOW");
+                break;
+              case oq_flow_autotune::STATUS_SETTLING:
+                id(oq_flow_autotune_status).publish_state("SETTLING");
+                break;
+              case oq_flow_autotune::STATUS_STEP:
+                id(oq_flow_autotune_status).publish_state("STEP");
+                break;
+              case oq_flow_autotune::STATUS_STEP2:
+                id(oq_flow_autotune_status).publish_state("STEP2");
+                break;
+              case oq_flow_autotune::STATUS_RECOVERING:
+                id(oq_flow_autotune_status).publish_state("RECOVERING");
+                break;
+              case oq_flow_autotune::STATUS_VALIDATING_SETTLING:
+                id(oq_flow_autotune_status).publish_state("VALIDATING_SETTLING");
+                break;
+              case oq_flow_autotune::STATUS_VALIDATING:
+                id(oq_flow_autotune_status).publish_state("VALIDATING");
+                break;
+              case oq_flow_autotune::STATUS_ABORT_NOT_CM100:
+                id(oq_flow_autotune_status).publish_state("ABORT: not CM100");
+                break;
+              case oq_flow_autotune::STATUS_ABORT_NO_BASELINE_FLOW:
+                id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
+                break;
+              case oq_flow_autotune::STATUS_ABORT_FLOW_INVALID:
+                id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID");
+                break;
+              case oq_flow_autotune::STATUS_ABORT_NO_STEADY_STATE:
+                id(oq_flow_autotune_status).publish_state("ABORT: NO_STEADY_STATE");
+                break;
+              case oq_flow_autotune::STATUS_REFUSED_STEP_HEADROOM:
+                id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
+                break;
+              case oq_flow_autotune::STATUS_FAILED_INVALID_GAIN:
+                id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
+                break;
+              case oq_flow_autotune::STATUS_FAILED_INVALID_VALIDATION_STEP:
+                id(oq_flow_autotune_status).publish_state("FAILED: INVALID_VALIDATION_STEP");
+                break;
+              case oq_flow_autotune::STATUS_FAILED_INVALID_VALIDATION_STATE:
+                id(oq_flow_autotune_status).publish_state("FAILED: INVALID_VALIDATION_STATE");
+                break;
+              case oq_flow_autotune::STATUS_NONE:
+              default:
+                break;
+            }
+          };
 
           // Abort button always works
           if (id(oq_flow_autotune_abort)) {
             id(oq_flow_autotune_abort) = false;
-            id(oq_flow_autotune_state) = 6;
+            id(oq_flow_autotune_state) = oq_flow_autotune::STATE_ABORT;
           }
 
           const float pv = id(flow_rate_selected).state;
@@ -364,13 +420,13 @@ interval:
           int st = id(oq_flow_autotune_state);
 
           // Never queue a second start while a run is active.
-          if (st != 0 && id(oq_flow_autotune_req)) {
+          if (st != oq_flow_autotune::STATE_IDLE && id(oq_flow_autotune_req)) {
             id(oq_flow_autotune_req) = false;
             id(oq_flow_autotune_status).publish_state("REFUSED: BUSY");
           }
 
           // IDLE
-          if (st == 0) {
+          if (st == oq_flow_autotune::STATE_IDLE) {
             if (id(oq_flow_autotune_req)) {
               if (!in_valid_autotune_mode()) {
                 id(oq_commissioning_request_pending) = true;
@@ -408,671 +464,426 @@ interval:
                        (unsigned int) ${oq_flow_autotune_settle_s},
                        (float) ${oq_flow_autotune_stable_band_lph});
               id(oq_flow_autotune_status).publish_state(flow_valid ? "SETTLING" : "WAITING_FOR_FLOW");
-              id(oq_flow_autotune_state) = 1;
+              id(oq_flow_autotune_state) = oq_flow_autotune::STATE_ARM;
             }
             return;
           }
 
           // ARM
-          if (st == 1) {
-            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else {
-              // Keep baseline override active while settling.
-              const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
-              id(oq_flow_autotune_pwm) = pwm0;
-              id(oq_flow_autotune_active) = true;
-              const int t = id(oq_flow_at_t);
-              id(oq_flow_at_t) = t + (int) sample_time_s;
-
-              if (!flow_valid) {
-                if (t >= kAutotuneBaselineWaitMaxS) {
-                  st = 6;
-                  ESP_LOGW("quatt.cm100.autotune",
-                           "Autotune aborted: baseline flow never became valid (pwm0=%d pv=%.1f t=%ds)",
-                           pwm0, pv, t);
-                  id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
-                } else {
-                  id(oq_flow_at_ss_confirm_cnt) = 0;
-                  id(oq_flow_autotune_status).publish_state("WAITING_FOR_FLOW");
-                }
-                id(oq_flow_autotune_state) = st;
-                return;
-              }
-
-              id(oq_flow_at_ss_confirm_cnt) = 0;
-
-              // Baseline stability check on rolling 3-sample window.
-              id(oq_flow_at_w0) = id(oq_flow_at_w1);
-              id(oq_flow_at_w1) = id(oq_flow_at_w2);
-              id(oq_flow_at_w2) = pv;
-
-              const bool win_ready = !isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2));
-              if (win_ready) {
-                const float w0 = id(oq_flow_at_w0);
-                const float w1 = id(oq_flow_at_w1);
-                const float w2 = id(oq_flow_at_w2);
-                const float w_min = fminf(w0, fminf(w1, w2));
-                const float w_max = fmaxf(w0, fmaxf(w1, w2));
-                const float spread = w_max - w_min;
-                const float mean = (w0 + w1 + w2) / 3.0f;
-
-                if (t >= ${oq_flow_autotune_settle_s} &&
-                    t <= kAutotuneBaselineWaitMaxS &&
-                    spread <= ${oq_flow_autotune_stable_band_lph} &&
-                    mean > 0.0f) {
-                  id(oq_flow_at_pv0) = mean;
-                  ESP_LOGI("quatt.cm100.autotune",
-                           "Baseline stable (pv0=%.1f pwm0=%d spread=%.1f t=%ds)",
-                           mean, pwm0, spread, t);
-
-                  const int pwm_headroom = pwm0 - ${oq_flow_pwm_min};
-                  if (pwm_headroom < ${oq_flow_autotune_min_step}) {
-                    st = 6;
-                    ESP_LOGW("quatt.cm100.autotune",
-                             "Autotune refused: insufficient step headroom (pwm0=%d min=%d headroom=%d required=%d)",
-                             pwm0, ${oq_flow_pwm_min}, pwm_headroom, ${oq_flow_autotune_min_step});
-                    id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
-                  } else {
-                    int u_step = (int) roundf(kAutotuneStep1Frac * (float) pwm0);
-                    if (u_step < kAutotuneStep1MinIpwm) u_step = kAutotuneStep1MinIpwm;
-                    if (u_step > kAutotuneStep1MaxIpwm) u_step = kAutotuneStep1MaxIpwm;
-                    if (u_step > pwm_headroom) u_step = pwm_headroom;
-                    if (u_step < ${oq_flow_autotune_min_step}) u_step = ${oq_flow_autotune_min_step};
-
-                    const int pwm_step = clamp_ipwm(pwm0 - u_step);
-                    id(oq_flow_at_pwm_step) = pwm_step;
-                    id(oq_flow_at_t) = 0;
-                    id(oq_flow_at_w0) = NAN;
-                    id(oq_flow_at_w1) = NAN;
-                    id(oq_flow_at_w2) = NAN;
-                    id(oq_flow_at_ss_confirm_cnt) = 0;
-
-                    id(oq_flow_autotune_pwm) = pwm_step;
-                    ESP_LOGI("quatt.cm100.autotune",
-                             "Step applied (pwm0=%d step=%d pwm_step=%d pv0=%.1f)",
-                             pwm0, u_step, pwm_step, mean);
-                    id(oq_flow_autotune_status).publish_state("STEP");
-                    st = 2;
-                  }
-                } else if (t >= kAutotuneBaselineWaitMaxS) {
-                  st = 6;
-                  ESP_LOGW("quatt.cm100.autotune",
-                           "Autotune aborted: baseline never stabilized (pwm0=%d pv=%.1f spread=%.1f t=%ds)",
-                           pwm0, pv, spread, t);
-                  id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
-                }
+          if (st == oq_flow_autotune::STATE_ARM) {
+            const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
+            id(oq_flow_autotune_pwm) = pwm0;
+            id(oq_flow_autotune_active) = true;
+            const int t = id(oq_flow_at_t);
+            const auto arm = oq_flow_autotune::evaluate_arm_phase(
+                in_valid_autotune_mode(),
+                flow_valid,
+                t,
+                (int) sample_time_s,
+                pv,
+                oq_flow_autotune::RollingWindow{
+                    id(oq_flow_at_w0),
+                    id(oq_flow_at_w1),
+                    id(oq_flow_at_w2),
+                },
+                pwm0,
+                ${oq_flow_pwm_min},
+                ${oq_flow_pwm_max},
+                ${oq_flow_autotune_min_step},
+                ${oq_flow_autotune_settle_s},
+                kAutotuneBaselineWaitMaxS,
+                ${oq_flow_autotune_stable_band_lph},
+                kAutotuneStep1Frac,
+                kAutotuneStep1MinIpwm,
+                kAutotuneStep1MaxIpwm,
+                oq_flow_autotune::STATE_ARM,
+                oq_flow_autotune::STATE_STEP1,
+                oq_flow_autotune::STATUS_STEP);
+            id(oq_flow_at_t) = arm.next_t_s;
+            id(oq_flow_at_w0) = arm.window.w0;
+            id(oq_flow_at_w1) = arm.window.w1;
+            id(oq_flow_at_w2) = arm.window.w2;
+            id(oq_flow_at_ss_confirm_cnt) = arm.ss_confirm_cnt;
+            st = arm.next_state;
+            if (arm.next_state == oq_flow_autotune::STATE_STEP1) {
+              id(oq_flow_at_pv0) = arm.pv0;
+              id(oq_flow_at_pwm_step) = arm.pwm_step;
+              id(oq_flow_autotune_pwm) = arm.pwm_step;
+              ESP_LOGI("quatt.cm100.autotune",
+                       "Baseline stable -> step1 (pwm0=%d pwm_step=%d pv0=%.1f t=%ds)",
+                       pwm0, arm.pwm_step, arm.pv0, t);
+            } else if (arm.next_state == oq_flow_autotune::STATE_ABORT) {
+              if (arm.reason == oq_flow_autotune::STATUS_REFUSED_STEP_HEADROOM) {
+                const int pwm_headroom = pwm0 - ${oq_flow_pwm_min};
+                ESP_LOGW("quatt.cm100.autotune",
+                         "Autotune refused: insufficient step headroom (pwm0=%d min=%d headroom=%d required=%d)",
+                         pwm0, ${oq_flow_pwm_min}, pwm_headroom, ${oq_flow_autotune_min_step});
+              } else {
+                ESP_LOGW("quatt.cm100.autotune",
+                         "Autotune aborted in baseline settle (reason=%d pwm0=%d pv=%.1f t=%ds)",
+                         (int) arm.reason, pwm0, pv, t);
               }
             }
+            publish_reason(arm.reason);
             id(oq_flow_autotune_state) = st;
             return;
           }
 
           // STEP 1 / MEASURE
-          if (st == 2) {
-            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else if (!flow_valid) { st = 6; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during step1 (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
-            else {
-              const float pv0 = id(oq_flow_at_pv0);
-              const int t = id(oq_flow_at_t);
-              const int max_s = kAutotuneDurationS;
-
-              // Rolling window for ss-estimate.
-              id(oq_flow_at_w0) = id(oq_flow_at_w1);
-              id(oq_flow_at_w1) = id(oq_flow_at_w2);
-              id(oq_flow_at_w2) = pv;
-              if (!isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2)) && ${oq_flow_autotune_ss_window} == 3) {
-                const float w0 = id(oq_flow_at_w0);
-                const float w1 = id(oq_flow_at_w1);
-                const float w2 = id(oq_flow_at_w2);
-                const float w_min = fminf(w0, fminf(w1, w2));
-                const float w_max = fmaxf(w0, fmaxf(w1, w2));
-                const float spread = w_max - w_min;
-                const float slope01 = fabsf(w1 - w0);
-                const float slope12 = fabsf(w2 - w1);
-                const bool ss_ready = (spread <= 6.0f) && (slope01 <= 2.0f) && (slope12 <= 2.0f);
-                if (ss_ready) {
-                  id(oq_flow_at_pv_ss) = (w0 + w1 + w2) / 3.0f;
-                  if (id(oq_flow_at_ss_confirm_cnt) < 255) id(oq_flow_at_ss_confirm_cnt)++;
-                  if (id(oq_flow_at_ss_confirm_cnt) == 1) {
-                    ESP_LOGI("quatt.cm100.autotune",
-                             "Step1 steady-state candidate locked (pv_ss=%.1f t=%ds spread=%.1f slopes=%.1f/%.1f)",
-                             id(oq_flow_at_pv_ss), t, spread, slope01, slope12);
-                  }
-                } else {
-                  id(oq_flow_at_ss_confirm_cnt) = 0;
-                }
+          if (st == oq_flow_autotune::STATE_STEP1) {
+            const float pv0 = id(oq_flow_at_pv0);
+            const int t = id(oq_flow_at_t);
+            const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
+            const int pwm_step1 = clamp_ipwm(id(oq_flow_at_pwm_step));
+            const auto step1 = oq_flow_autotune::evaluate_open_loop_measure(
+                in_valid_autotune_mode(),
+                flow_valid,
+                t,
+                (int) sample_time_s,
+                pv,
+                pv0,
+                (float) (pwm0 - pwm_step1),
+                oq_flow_autotune::RollingWindow{
+                    id(oq_flow_at_w0),
+                    id(oq_flow_at_w1),
+                    id(oq_flow_at_w2),
+                },
+                id(oq_flow_at_pv_ss),
+                id(oq_flow_at_pv63_time_s),
+                id(oq_flow_at_ss_confirm_cnt),
+                oq_flow_autotune::STATE_STEP1,
+                kAutotuneDurationS,
+                6.0f,
+                2.0f,
+                ${oq_flow_autotune_tau_fallback_s});
+            id(oq_flow_at_t) = step1.next_t_s;
+            id(oq_flow_at_w0) = step1.window.w0;
+            id(oq_flow_at_w1) = step1.window.w1;
+            id(oq_flow_at_w2) = step1.window.w2;
+            id(oq_flow_at_ss_confirm_cnt) = step1.ss_confirm_cnt;
+            id(oq_flow_at_pv_ss) = step1.pv_ss;
+            id(oq_flow_at_pv63_time_s) = step1.pv63_time_s;
+            if (step1.ready) {
+              id(oq_flow_at_step1_pv0) = pv0;
+              id(oq_flow_at_step1_pv_ss) = step1.pv_ss;
+              id(oq_flow_at_step1_pv63_time_s) = step1.pv63_time_s;
+              id(oq_flow_at_step1_k) = step1.model.gain;
+              id(oq_flow_at_step1_tau) = step1.model.tau_s;
+              id(oq_flow_at_step1_pwm_step) = pwm_step1;
+              id(oq_flow_autotune_pwm) = pwm0;
+              id(oq_flow_at_t) = 0;
+              id(oq_flow_at_w0) = NAN;
+              id(oq_flow_at_w1) = NAN;
+              id(oq_flow_at_w2) = NAN;
+              id(oq_flow_at_ss_confirm_cnt) = 0;
+              id(oq_flow_at_pv0) = NAN;
+              id(oq_flow_at_pv_ss) = NAN;
+              id(oq_flow_at_pv63_time_s) = NAN;
+              ESP_LOGI("quatt.cm100.autotune",
+                       "Step1 captured (pwm0=%d step=%d pv0=%.1f pv_ss=%.1f t63=%.1f K1=%.3f tau1=%.0fs) -> recover",
+                       pwm0, pwm_step1, pv0, step1.pv_ss, step1.pv63_time_s, step1.model.gain, step1.model.tau_s);
+              publish_reason(oq_flow_autotune::STATUS_RECOVERING);
+              st = oq_flow_autotune::STATE_RECOVER;
+            } else {
+              st = step1.next_state;
+              if (st == oq_flow_autotune::STATE_ABORT) {
+                ESP_LOGW("quatt.cm100.autotune",
+                         "Autotune step1 ended in abort/fail (reason=%d pv=%.1f t=%ds)",
+                         (int) step1.reason, pv, t);
               }
-
-              const float pv_ss_est = id(oq_flow_at_pv_ss);
-              if (!isnan(pv_ss_est) && isnan(id(oq_flow_at_pv63_time_s))) {
-                const float dpv = pv_ss_est - pv0;
-                const float pv63 = pv0 + 0.632f * dpv;
-                if (dpv >= 0.0f) {
-                  if (pv >= pv63) id(oq_flow_at_pv63_time_s) = (float) t;
-                } else {
-                  if (pv <= pv63) id(oq_flow_at_pv63_time_s) = (float) t;
-                }
-              }
-
-              const bool early_done =
-                  !isnan(id(oq_flow_at_pv_ss)) &&
-                  !isnan(id(oq_flow_at_pv63_time_s)) &&
-                  (id(oq_flow_at_ss_confirm_cnt) >= 2);
-
-              id(oq_flow_at_t) = t + (int) sample_time_s;
-
-              if (early_done || t >= max_s) {
-                if (isnan(id(oq_flow_at_pv_ss))) {
-                  st = 6;
-                  ESP_LOGW("quatt.cm100.autotune", "Autotune aborted: no step1 steady-state response (t=%ds pv=%.1f)", t, pv);
-                  id(oq_flow_autotune_status).publish_state("ABORT: NO_STEADY_STATE");
-                } else {
-                  const float pv_ss1 = id(oq_flow_at_pv_ss);
-                  const float t63_1 = id(oq_flow_at_pv63_time_s);
-                  const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
-                  const int pwm_step1 = clamp_ipwm(id(oq_flow_at_pwm_step));
-                  const float du1 = (float)(pwm0 - pwm_step1); // >0
-                  const float dpv1 = pv_ss1 - pv0;
-                  const float K1 = dpv1 / du1;
-                  if (!(K1 > 0.0f)) {
-                    st = 6;
-                    ESP_LOGW("quatt.cm100.autotune",
-                             "Autotune failed: invalid step1 gain (pv0=%.1f pv_ss=%.1f du=%.1f)",
-                             pv0, pv_ss1, du1);
-                    id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
-                  } else {
-                    float tau1 = t63_1;
-                    if (isnan(tau1) || tau1 < sample_time_s) tau1 = ${oq_flow_autotune_tau_fallback_s};
-                    id(oq_flow_at_step1_pv0) = pv0;
-                    id(oq_flow_at_step1_pv_ss) = pv_ss1;
-                    id(oq_flow_at_step1_pv63_time_s) = t63_1;
-                    id(oq_flow_at_step1_k) = K1;
-                    id(oq_flow_at_step1_tau) = tau1;
-                    id(oq_flow_at_step1_pwm_step) = pwm_step1;
-
-                    const int pwm_headroom = pwm0 - ${oq_flow_pwm_min};
-                    if (pwm_headroom < ${oq_flow_autotune_min_step}) {
-                      st = 6;
-                      ESP_LOGW("quatt.cm100.autotune",
-                               "Autotune refused: insufficient recovery headroom (pwm0=%d min=%d headroom=%d required=%d)",
-                               pwm0, ${oq_flow_pwm_min}, pwm_headroom, ${oq_flow_autotune_min_step});
-                      id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
-                    } else {
-                      id(oq_flow_autotune_pwm) = pwm0;
-                      id(oq_flow_at_t) = 0;
-                      id(oq_flow_at_w0) = NAN;
-                      id(oq_flow_at_w1) = NAN;
-                      id(oq_flow_at_w2) = NAN;
-                      id(oq_flow_at_ss_confirm_cnt) = 0;
-                      id(oq_flow_at_pv0) = NAN;
-                      id(oq_flow_at_pv_ss) = NAN;
-                      id(oq_flow_at_pv63_time_s) = NAN;
-                      ESP_LOGI("quatt.cm100.autotune",
-                               "Step1 captured (pwm0=%d step=%d pv0=%.1f pv_ss=%.1f t63=%.1f K1=%.3f tau1=%.0fs) -> recover",
-                               pwm0, pwm_step1, pv0, pv_ss1, tau1, K1);
-                      id(oq_flow_autotune_status).publish_state("RECOVERING");
-                      st = 3;
-                    }
-                  }
-                }
-              } else {
-                st = 2;
-              }
-              id(oq_flow_autotune_state) = st;
-              return;
+              publish_reason(step1.reason);
             }
             id(oq_flow_autotune_state) = st;
+            return;
           }
 
           // RECOVER / STEP 2 ARM
-          if (st == 3) {
-            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else {
-              const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
-              id(oq_flow_autotune_pwm) = pwm0;
-              id(oq_flow_autotune_active) = true;
-              const int t = id(oq_flow_at_t);
-              id(oq_flow_at_t) = t + (int) sample_time_s;
-
-              if (!flow_valid) {
-                if (t >= kAutotuneBaselineWaitMaxS) {
-                  st = 6;
-                  ESP_LOGW("quatt.cm100.autotune",
-                           "Autotune aborted: recovery flow never became valid (pwm0=%d pv=%.1f t=%ds)",
-                           pwm0, pv, t);
-                  id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
-                } else {
-                  id(oq_flow_at_ss_confirm_cnt) = 0;
-                  id(oq_flow_autotune_status).publish_state("WAITING_FOR_FLOW");
-                }
-                id(oq_flow_autotune_state) = st;
-                return;
-              }
-
-              id(oq_flow_at_ss_confirm_cnt) = 0;
-              id(oq_flow_at_w0) = id(oq_flow_at_w1);
-              id(oq_flow_at_w1) = id(oq_flow_at_w2);
-              id(oq_flow_at_w2) = pv;
-              const bool win_ready = !isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2));
-              if (win_ready) {
-                const float w0 = id(oq_flow_at_w0);
-                const float w1 = id(oq_flow_at_w1);
-                const float w2 = id(oq_flow_at_w2);
-                const float w_min = fminf(w0, fminf(w1, w2));
-                const float w_max = fmaxf(w0, fmaxf(w1, w2));
-                const float spread = w_max - w_min;
-                const float mean = (w0 + w1 + w2) / 3.0f;
-
-                if (t >= ${oq_flow_autotune_settle_s} &&
-                    t <= kAutotuneBaselineWaitMaxS &&
-                    spread <= ${oq_flow_autotune_stable_band_lph} &&
-                    mean > 0.0f) {
-                  ESP_LOGI("quatt.cm100.autotune",
-                           "Recovery stable (pv=%.1f pwm0=%d spread=%.1f t=%ds)",
-                           mean, pwm0, spread, t);
-
-                  int u_step = (int) roundf(kAutotuneStep2Frac * (float) pwm0);
-                  if (u_step < kAutotuneStep2MinIpwm) u_step = kAutotuneStep2MinIpwm;
-                  if (u_step > kAutotuneStep2MaxIpwm) u_step = kAutotuneStep2MaxIpwm;
-                  const int step1_u = pwm0 - clamp_ipwm(id(oq_flow_at_step1_pwm_step));
-                  if (u_step <= step1_u) u_step = step1_u + 8;
-                  if (u_step > pwm0 - ${oq_flow_pwm_min}) u_step = pwm0 - ${oq_flow_pwm_min};
-                  if (u_step <= step1_u) {
-                    st = 6;
-                    ESP_LOGW("quatt.cm100.autotune",
-                             "Autotune refused: insufficient distinct step2 headroom (step1=%d step2=%d pwm0=%d)",
-                             step1_u, u_step, pwm0);
-                    id(oq_flow_autotune_status).publish_state("REFUSED: STEP_HEADROOM");
-                  } else {
-                    const int pwm_step2 = clamp_ipwm(pwm0 - u_step);
-                    id(oq_flow_at_pv0) = mean;
-                    id(oq_flow_at_pwm_step) = pwm_step2;
-                    id(oq_flow_at_t) = 0;
-                    id(oq_flow_at_w0) = NAN;
-                    id(oq_flow_at_w1) = NAN;
-                    id(oq_flow_at_w2) = NAN;
-                    id(oq_flow_at_ss_confirm_cnt) = 0;
-                    id(oq_flow_autotune_pwm) = pwm_step2;
-                    ESP_LOGI("quatt.cm100.autotune",
-                             "Step2 applied (pwm0=%d step=%d pwm_step=%d pv0=%.1f)",
-                             pwm0, u_step, pwm_step2, mean);
-                    id(oq_flow_autotune_status).publish_state("STEP2");
-                    st = 4;
-                  }
-                } else if (t >= kAutotuneBaselineWaitMaxS) {
-                  st = 6;
-                  ESP_LOGW("quatt.cm100.autotune",
-                           "Autotune aborted: recovery never stabilized (pwm0=%d pv=%.1f spread=%.1f t=%ds)",
-                           pwm0, pv, spread, t);
-                  id(oq_flow_autotune_status).publish_state("ABORT: NO_BASELINE_FLOW");
-                }
-              }
+          if (st == oq_flow_autotune::STATE_RECOVER) {
+            const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
+            id(oq_flow_autotune_pwm) = pwm0;
+            id(oq_flow_autotune_active) = true;
+            const int t = id(oq_flow_at_t);
+            const int step1_u = pwm0 - clamp_ipwm(id(oq_flow_at_step1_pwm_step));
+            const auto recover = oq_flow_autotune::evaluate_recovery_phase(
+                in_valid_autotune_mode(),
+                flow_valid,
+                t,
+                (int) sample_time_s,
+                pv,
+                oq_flow_autotune::RollingWindow{
+                    id(oq_flow_at_w0),
+                    id(oq_flow_at_w1),
+                    id(oq_flow_at_w2),
+                },
+                pwm0,
+                ${oq_flow_pwm_min},
+                ${oq_flow_pwm_max},
+                ${oq_flow_autotune_settle_s},
+                kAutotuneBaselineWaitMaxS,
+                ${oq_flow_autotune_stable_band_lph},
+                kAutotuneStep2Frac,
+                kAutotuneStep2MinIpwm,
+                kAutotuneStep2MaxIpwm,
+                step1_u,
+                oq_flow_autotune::STATE_RECOVER,
+                oq_flow_autotune::STATE_STEP2,
+                oq_flow_autotune::STATUS_STEP2);
+            id(oq_flow_at_t) = recover.next_t_s;
+            id(oq_flow_at_w0) = recover.window.w0;
+            id(oq_flow_at_w1) = recover.window.w1;
+            id(oq_flow_at_w2) = recover.window.w2;
+            id(oq_flow_at_ss_confirm_cnt) = recover.ss_confirm_cnt;
+            st = recover.next_state;
+            if (st == oq_flow_autotune::STATE_STEP2) {
+              id(oq_flow_at_pv0) = recover.pv0;
+              id(oq_flow_at_pwm_step) = recover.pwm_step;
+              id(oq_flow_autotune_pwm) = recover.pwm_step;
+              ESP_LOGI("quatt.cm100.autotune",
+                       "Recovery stable -> step2 (pwm0=%d pwm_step=%d pv0=%.1f t=%ds)",
+                       pwm0, recover.pwm_step, recover.pv0, t);
+            } else if (st == oq_flow_autotune::STATE_ABORT) {
+              ESP_LOGW("quatt.cm100.autotune",
+                       "Autotune recovery ended in abort/fail (reason=%d pwm0=%d pv=%.1f t=%ds)",
+                       (int) recover.reason, pwm0, pv, t);
             }
+            publish_reason(recover.reason);
             id(oq_flow_autotune_state) = st;
             return;
           }
 
           // STEP 2 / MEASURE
-          if (st == 4) {
-            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else if (!flow_valid) { st = 6; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during step2 (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
-            else {
-              const float pv0 = id(oq_flow_at_pv0);
-              const int t = id(oq_flow_at_t);
-              const int max_s = kAutotuneDurationS;
-
-              // Rolling window for ss-estimate.
-              id(oq_flow_at_w0) = id(oq_flow_at_w1);
-              id(oq_flow_at_w1) = id(oq_flow_at_w2);
-              id(oq_flow_at_w2) = pv;
-              if (!isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2)) && ${oq_flow_autotune_ss_window} == 3) {
-                const float w0 = id(oq_flow_at_w0);
-                const float w1 = id(oq_flow_at_w1);
-                const float w2 = id(oq_flow_at_w2);
-                const float w_min = fminf(w0, fminf(w1, w2));
-                const float w_max = fmaxf(w0, fmaxf(w1, w2));
-                const float spread = w_max - w_min;
-                const float slope01 = fabsf(w1 - w0);
-                const float slope12 = fabsf(w2 - w1);
-                const bool ss_ready = (spread <= 6.0f) && (slope01 <= 2.0f) && (slope12 <= 2.0f);
-                if (ss_ready) {
-                  id(oq_flow_at_pv_ss) = (w0 + w1 + w2) / 3.0f;
-                  if (id(oq_flow_at_ss_confirm_cnt) < 255) id(oq_flow_at_ss_confirm_cnt)++;
-                  if (id(oq_flow_at_ss_confirm_cnt) == 1) {
-                    ESP_LOGI("quatt.cm100.autotune",
-                             "Step2 steady-state candidate locked (pv_ss=%.1f t=%ds spread=%.1f slopes=%.1f/%.1f)",
-                             id(oq_flow_at_pv_ss), t, spread, slope01, slope12);
-                  }
-                } else {
-                  id(oq_flow_at_ss_confirm_cnt) = 0;
-                }
-              }
-
-              const float pv_ss_est = id(oq_flow_at_pv_ss);
-              if (!isnan(pv_ss_est) && isnan(id(oq_flow_at_pv63_time_s))) {
-                const float dpv = pv_ss_est - pv0;
-                const float pv63 = pv0 + 0.632f * dpv;
-                if (dpv >= 0.0f) {
-                  if (pv >= pv63) id(oq_flow_at_pv63_time_s) = (float) t;
-                } else {
-                  if (pv <= pv63) id(oq_flow_at_pv63_time_s) = (float) t;
-                }
-              }
-
-              const bool early_done =
-                  !isnan(id(oq_flow_at_pv_ss)) &&
-                  !isnan(id(oq_flow_at_pv63_time_s)) &&
-                  (id(oq_flow_at_ss_confirm_cnt) >= 2);
-
-              id(oq_flow_at_t) = t + (int) sample_time_s;
-
-              if (early_done || t >= max_s) {
-                if (isnan(id(oq_flow_at_pv_ss))) {
-                  st = 6;
-                  ESP_LOGW("quatt.cm100.autotune", "Autotune aborted: no step2 steady-state response (t=%ds pv=%.1f)", t, pv);
-                  id(oq_flow_autotune_status).publish_state("ABORT: NO_STEADY_STATE");
-                } else {
-                  const float pv_ss2 = id(oq_flow_at_pv_ss);
-                  const float t63_2 = id(oq_flow_at_pv63_time_s);
-                  const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
-                  const int pwm_step2 = clamp_ipwm(id(oq_flow_at_pwm_step));
-                  const float du2 = (float)(pwm0 - pwm_step2); // >0
-                  const float dpv2 = pv_ss2 - pv0;
-                  const float K2 = dpv2 / du2;
-                  const float K1 = id(oq_flow_at_step1_k);
-                  const float tau1 = id(oq_flow_at_step1_tau);
-                  if (!(K2 > 0.0f) || !(K1 > 0.0f) || isnan(tau1)) {
-                    st = 6;
-                    ESP_LOGW("quatt.cm100.autotune",
-                             "Autotune failed: invalid step2 gain (pv0=%.1f pv_ss=%.1f du=%.1f step1_k=%.3f tau1=%.1f)",
-                             pv0, pv_ss2, du2, K1, tau1);
-                    id(oq_flow_autotune_status).publish_state("FAILED: INVALID_GAIN");
-                  } else {
-                    float tau2 = t63_2;
-                    if (isnan(tau2) || tau2 < sample_time_s) tau2 = ${oq_flow_autotune_tau_fallback_s};
-                    const float rel_k = fabsf(K1 - K2) / fmaxf(fmaxf(K1, K2), 1e-3f);
-                    const float rel_tau = fabsf(tau1 - tau2) / fmaxf(fmaxf(tau1, tau2), sample_time_s);
-                    const bool consistent = (rel_k <= kAutotuneStepConsistencyFrac) && (rel_tau <= 0.35f);
-
-                    const float du1 = (float)(pwm0 - clamp_ipwm(id(oq_flow_at_step1_pwm_step)));
-                    float K = 0.0f;
-                    if (consistent) {
-                      K = (K1 * du1 + K2 * du2) / fmaxf(du1 + du2, 1.0f);
-                    } else {
-                      K = fmaxf(K1, K2);
-                    }
-                    float tau = fmaxf(tau1, tau2);
-                    if (isnan(tau) || tau < sample_time_s) tau = ${oq_flow_autotune_tau_fallback_s};
-
-                    const float theta = sample_time_s;
-                    const float lambda_raw = 0.5f * tau;
-                    const float Kp_raw = tau / (K * (lambda_raw + theta));
-                    const float Ti_raw = tau;
-                    const float Ki_raw = (Ti_raw > 1e-3f) ? (Kp_raw / Ti_raw) : 0.0f;
-
-                    float lambda_seed = kAutotuneValidateSeedLambdaFrac * tau;
-                    if (lambda_seed < kAutotuneValidateSeedMinLambdaS) lambda_seed = kAutotuneValidateSeedMinLambdaS;
-                    float Ti_seed = kAutotuneValidateSeedTiFrac * tau;
-                    if (Ti_seed < kAutotuneValidateSeedMinTiS) Ti_seed = kAutotuneValidateSeedMinTiS;
-
-                    float Kp_seed = tau / (K * (lambda_seed + theta));
-                    float Ki_seed = (Ti_seed > 1e-3f) ? (Kp_seed / Ti_seed) : 0.0f;
-
-                    const float Kp_min = ${oq_flow_kp_min};
-                    const float Kp_max = ${oq_flow_kp_max};
-                    const float Ki_min = ${oq_flow_ki_min};
-                    const float Ki_max = ${oq_flow_ki_max};
-                    if (Kp_seed < Kp_min) Kp_seed = Kp_min;
-                    if (Kp_seed > Kp_max) Kp_seed = Kp_max;
-                    if (Ki_seed < Ki_min) Ki_seed = Ki_min;
-                    if (Ki_seed > Ki_max) Ki_seed = Ki_max;
-
-                    const float sp0 = id(oq_flow_setpoint_lph).state;
-                    float validate_step_lph = roundf(kAutotuneValidateStepFrac * fmaxf(pv0, sp0));
-                    if (validate_step_lph < kAutotuneValidateStepMinLph) validate_step_lph = kAutotuneValidateStepMinLph;
-                    if (validate_step_lph > kAutotuneValidateStepMaxLph) validate_step_lph = kAutotuneValidateStepMaxLph;
-                    float validate_sp1 = sp0 + validate_step_lph;
-                    if (!(validate_sp1 > sp0)) {
-                      st = 6;
-                      ESP_LOGW("quatt.cm100.autotune",
-                               "Autotune failed: invalid validation setpoint (sp0=%.1f step=%.1f)",
-                               sp0, validate_step_lph);
-                      id(oq_flow_autotune_status).publish_state("FAILED: INVALID_VALIDATION_STEP");
-                    } else {
-                      id(oq_flow_at_saved_kp) = id(oq_flow_kp).state;
-                      id(oq_flow_at_saved_ki) = id(oq_flow_ki).state;
-                      id(oq_flow_at_validate_sp0) = sp0;
-                      id(oq_flow_at_validate_sp1) = validate_sp1;
-                      id(oq_flow_at_validate_peak_pv) = validate_sp1;
-                      id(oq_flow_at_validate_confirm_cnt) = 0;
-                      id(oq_flow_at_validate_settle_ready) = false;
-                      id(oq_flow_at_t) = 0;
-                      id(oq_flow_at_w0) = NAN;
-                      id(oq_flow_at_w1) = NAN;
-                      id(oq_flow_at_w2) = NAN;
-
-                      set_number_value(id(oq_flow_kp), Kp_seed);
-                      set_number_value(id(oq_flow_ki), Ki_seed);
-                      set_number_value(id(oq_flow_setpoint_lph), validate_sp1);
-                      id(oq_flow_autotune_active) = false;
-
-                      const char *consistency_tag = consistent ? "2STEP" : "2STEP (LIMITED)";
-                      ESP_LOGI("quatt.cm100.autotune",
-                               "Open-loop captured (%s) step1: pv0=%.1f pv_ss=%.1f t63=%.1f K=%.3f tau=%.0fs | step2: pv0=%.1f pv_ss=%.1f t63=%.1f K=%.3f tau=%.0fs | combined: K=%.3f tau=%.0fs raw=%.3f/%.4f seed=%.3f/%.4f validate_sp=%.1f->%.1f",
-                               consistency_tag,
-                               id(oq_flow_at_step1_pv0), id(oq_flow_at_step1_pv_ss), id(oq_flow_at_step1_pv63_time_s), K1, tau1,
-                               pv0, pv_ss2, t63_2, K2, tau2,
-                               K, tau, Kp_raw, Ki_raw, Kp_seed, Ki_seed, sp0, validate_sp1);
-                      id(oq_flow_autotune_status).publish_state("VALIDATING_SETTLING");
-                      st = 5;
-                    }
-                  }
-                }
-              } else {
-                st = 4;
-              }
-              id(oq_flow_autotune_state) = st;
-              return;
-            }
-            id(oq_flow_autotune_state) = st;
-          }
-
-          // VALIDATION
-          if (id(oq_flow_autotune_state) == 5) {
-            if (!in_valid_autotune_mode()) { st = 6; id(oq_flow_autotune_status).publish_state("ABORT: not CM100"); }
-            else if (!flow_valid) { st = 6; ESP_LOGW("quatt.cm100.autotune", "Autotune abort: flow invalid during validation (pv=%.1f)", pv); id(oq_flow_autotune_status).publish_state("ABORT: FLOW_INVALID"); }
-            else {
-              const float sp0 = id(oq_flow_at_validate_sp0);
-              const float sp1 = id(oq_flow_at_validate_sp1);
-              if (isnan(sp0) || isnan(sp1) || !(sp1 > sp0)) {
-                st = 6;
+          if (st == oq_flow_autotune::STATE_STEP2) {
+            const float pv0 = id(oq_flow_at_pv0);
+            const int t = id(oq_flow_at_t);
+            const int pwm0 = clamp_ipwm(id(oq_flow_at_pwm0));
+            const int pwm_step2 = clamp_ipwm(id(oq_flow_at_pwm_step));
+            const auto step2 = oq_flow_autotune::evaluate_open_loop_measure(
+                in_valid_autotune_mode(),
+                flow_valid,
+                t,
+                (int) sample_time_s,
+                pv,
+                pv0,
+                (float) (pwm0 - pwm_step2),
+                oq_flow_autotune::RollingWindow{
+                    id(oq_flow_at_w0),
+                    id(oq_flow_at_w1),
+                    id(oq_flow_at_w2),
+                },
+                id(oq_flow_at_pv_ss),
+                id(oq_flow_at_pv63_time_s),
+                id(oq_flow_at_ss_confirm_cnt),
+                oq_flow_autotune::STATE_STEP2,
+                kAutotuneDurationS,
+                6.0f,
+                2.0f,
+                ${oq_flow_autotune_tau_fallback_s});
+            id(oq_flow_at_t) = step2.next_t_s;
+            id(oq_flow_at_w0) = step2.window.w0;
+            id(oq_flow_at_w1) = step2.window.w1;
+            id(oq_flow_at_w2) = step2.window.w2;
+            id(oq_flow_at_ss_confirm_cnt) = step2.ss_confirm_cnt;
+            id(oq_flow_at_pv_ss) = step2.pv_ss;
+            id(oq_flow_at_pv63_time_s) = step2.pv63_time_s;
+            if (step2.ready) {
+              const float K1 = id(oq_flow_at_step1_k);
+              const float tau1 = id(oq_flow_at_step1_tau);
+              const float du1 = (float) (pwm0 - clamp_ipwm(id(oq_flow_at_step1_pwm_step)));
+              const float sp0 = id(oq_flow_setpoint_lph).state;
+              const auto validate_seed = oq_flow_autotune::build_validation_seed(
+                  K1,
+                  tau1,
+                  step2.model.gain,
+                  step2.model.tau_s,
+                  du1,
+                  (float) (pwm0 - pwm_step2),
+                  sample_time_s,
+                  kAutotuneStepConsistencyFrac,
+                  kAutotuneValidateSeedLambdaFrac,
+                  kAutotuneValidateSeedTiFrac,
+                  kAutotuneValidateSeedMinLambdaS,
+                  kAutotuneValidateSeedMinTiS,
+                  ${oq_flow_kp_min},
+                  ${oq_flow_kp_max},
+                  ${oq_flow_ki_min},
+                  ${oq_flow_ki_max},
+                  sp0,
+                  kAutotuneValidateStepFrac,
+                  kAutotuneValidateStepMinLph,
+                  kAutotuneValidateStepMaxLph,
+                  pv0);
+              if (!validate_seed.ready) {
+                st = oq_flow_autotune::STATE_ABORT;
+                publish_reason(validate_seed.reason);
                 ESP_LOGW("quatt.cm100.autotune",
-                         "Autotune failed: invalid validation state (sp0=%.1f sp1=%.1f)",
-                         sp0, sp1);
-                id(oq_flow_autotune_status).publish_state("FAILED: INVALID_VALIDATION_STATE");
+                         "Autotune step2/validate preparation failed (reason=%d pv0=%.1f pv_ss=%.1f)",
+                         (int) validate_seed.reason, pv0, step2.pv_ss);
               } else {
-                const float step_lph = sp1 - sp0;
-                const float settle_band = fmaxf(kAutotuneValidateBandFloorLph, kAutotuneValidateBandFrac * step_lph);
-                const float overshoot_band = fmaxf(settle_band, kAutotuneValidateOvershootFrac * step_lph);
-                constexpr int kAutotuneValidateSettleGraceS = 20;
-                constexpr int kAutotuneValidateSettleMaxS = 60;
+                id(oq_flow_at_saved_kp) = id(oq_flow_kp).state;
+                id(oq_flow_at_saved_ki) = id(oq_flow_ki).state;
+                id(oq_flow_at_validate_sp0) = sp0;
+                id(oq_flow_at_validate_sp1) = validate_seed.validate_sp1;
+                id(oq_flow_at_validate_peak_pv) = validate_seed.validate_sp1;
+                id(oq_flow_at_validate_confirm_cnt) = 0;
+                id(oq_flow_at_validate_settle_ready) = false;
+                id(oq_flow_at_t) = 0;
+                id(oq_flow_at_w0) = NAN;
+                id(oq_flow_at_w1) = NAN;
+                id(oq_flow_at_w2) = NAN;
 
-                if (!id(oq_flow_at_validate_settle_ready)) {
-                  id(oq_flow_at_validate_peak_pv) = fmaxf(id(oq_flow_at_validate_peak_pv), pv);
-                  id(oq_flow_at_w0) = id(oq_flow_at_w1);
-                  id(oq_flow_at_w1) = id(oq_flow_at_w2);
-                  id(oq_flow_at_w2) = pv;
-
-                  const int t = id(oq_flow_at_t);
-                  id(oq_flow_at_t) = t + (int) sample_time_s;
-
-                  const bool win_ready = !isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2));
-                  if (win_ready) {
-                    const float w0 = id(oq_flow_at_w0);
-                    const float w1 = id(oq_flow_at_w1);
-                    const float w2 = id(oq_flow_at_w2);
-                    const float w_min = fminf(w0, fminf(w1, w2));
-                    const float w_max = fmaxf(w0, fmaxf(w1, w2));
-                    const float spread = w_max - w_min;
-                    const float slope01 = fabsf(w1 - w0);
-                    const float slope12 = fabsf(w2 - w1);
-                    const bool settle_ready_now = (t >= kAutotuneValidateSettleGraceS) &&
-                                                  (spread <= settle_band) &&
-                                                  (slope01 <= settle_band) &&
-                                                  (slope12 <= settle_band) &&
-                                                  (fabsf(pv - sp1) <= settle_band);
-                    if (settle_ready_now) {
-                      if (id(oq_flow_at_validate_confirm_cnt) < 255) id(oq_flow_at_validate_confirm_cnt)++;
-                    } else {
-                      id(oq_flow_at_validate_confirm_cnt) = 0;
-                    }
-                  }
-
-                  if (id(oq_flow_at_validate_confirm_cnt) >= 2 || t >= kAutotuneValidateSettleMaxS) {
-                    if (t >= kAutotuneValidateSettleMaxS && id(oq_flow_at_validate_confirm_cnt) < 2) {
-                      ESP_LOGW("quatt.cm100.autotune",
-                               "Validation settle timeout; starting measurement anyway (sp0=%.1f sp1=%.1f t=%ds)",
-                               sp0, sp1, t);
-                    } else {
-                      ESP_LOGI("quatt.cm100.autotune",
-                               "Validation settle done (sp0=%.1f sp1=%.1f t=%ds)",
-                               sp0, sp1, t);
-                    }
-                    id(oq_flow_at_validate_settle_ready) = true;
-                    id(oq_flow_at_validate_confirm_cnt) = 0;
-                    id(oq_flow_at_validate_peak_pv) = sp1;
-                    id(oq_flow_at_w0) = NAN;
-                    id(oq_flow_at_w1) = NAN;
-                    id(oq_flow_at_w2) = NAN;
-                    id(oq_flow_at_t) = 0;
-                    id(oq_flow_autotune_status).publish_state("VALIDATING");
-                  } else {
-                    id(oq_flow_autotune_status).publish_state("VALIDATING_SETTLING");
-                  }
-                  id(oq_flow_autotune_state) = st;
-                  return;
-                }
-
-                id(oq_flow_at_validate_peak_pv) = fmaxf(id(oq_flow_at_validate_peak_pv), pv);
-                id(oq_flow_at_w0) = id(oq_flow_at_w1);
-                id(oq_flow_at_w1) = id(oq_flow_at_w2);
-                id(oq_flow_at_w2) = pv;
-
-                const int t = id(oq_flow_at_t);
-                id(oq_flow_at_t) = t + (int) sample_time_s;
-
-                const bool win_ready = !isnan(id(oq_flow_at_w0)) && !isnan(id(oq_flow_at_w1)) && !isnan(id(oq_flow_at_w2));
-                if (win_ready) {
-                  const float w0 = id(oq_flow_at_w0);
-                  const float w1 = id(oq_flow_at_w1);
-                  const float w2 = id(oq_flow_at_w2);
-                  const float w_min = fminf(w0, fminf(w1, w2));
-                  const float w_max = fmaxf(w0, fmaxf(w1, w2));
-                  const float spread = w_max - w_min;
-                  const float slope01 = fabsf(w1 - w0);
-                  const float slope12 = fabsf(w2 - w1);
-                  const bool settled_now = (spread <= settle_band) &&
-                                           (slope01 <= settle_band) &&
-                                           (slope12 <= settle_band) &&
-                                           (fabsf(pv - sp1) <= settle_band);
-                  if (settled_now) {
-                    if (id(oq_flow_at_validate_confirm_cnt) < 255) id(oq_flow_at_validate_confirm_cnt)++;
-                  } else {
-                    id(oq_flow_at_validate_confirm_cnt) = 0;
-                  }
-                }
-
-                const float peak_pv = id(oq_flow_at_validate_peak_pv);
-                const float overshoot = peak_pv - sp1;
-                const bool overshot = overshoot > overshoot_band;
-                const bool settled = (id(oq_flow_at_validate_confirm_cnt) >= 2) &&
-                                     !overshot &&
-                                     (fabsf(pv - sp1) <= settle_band);
-                const bool timed_out = t >= kAutotuneValidateDurationS;
-
-                if (settled || timed_out) {
-                  const float seed_kp = id(oq_flow_kp).state;
-                  const float seed_ki = id(oq_flow_ki).state;
-                  float scale = 1.0f;
-                  if (overshoot > (2.0f * settle_band)) {
-                    scale = 0.80f;
-                  } else if (overshoot > settle_band) {
-                    scale = 0.90f;
-                  } else if (settled && t <= ((int) sample_time_s * 3) && overshoot <= (0.5f * settle_band)) {
-                    scale = 1.05f;
-                  }
-                  if (timed_out && !settled) {
-                    scale = fminf(scale, 0.95f);
-                  }
-
-                  float Kp = seed_kp * scale;
-                  float Ki = seed_ki * scale;
-                  const float Kp_min = ${oq_flow_kp_min};
-                  const float Kp_max = ${oq_flow_kp_max};
-                  const float Ki_min = ${oq_flow_ki_min};
-                  const float Ki_max = ${oq_flow_ki_max};
-                  if (Kp < Kp_min) Kp = Kp_min;
-                  if (Kp > Kp_max) Kp = Kp_max;
-                  if (Ki < Ki_min) Ki = Ki_min;
-                  if (Ki > Ki_max) Ki = Ki_max;
-                  const bool clamped = (fabsf(Kp - (seed_kp * scale)) > 1e-7f) || (fabsf(Ki - (seed_ki * scale)) > 1e-7f);
-
-                  auto ckp = id(oq_flow_kp_suggested).make_call();
-                  ckp.set_value(Kp);
-                  ckp.perform();
-                  auto cki = id(oq_flow_ki_suggested).make_call();
-                  cki.set_value(Ki);
-                  cki.perform();
-
-                  const float saved_kp = id(oq_flow_at_saved_kp);
-                  const float saved_ki = id(oq_flow_at_saved_ki);
-                  const float saved_sp = id(oq_flow_at_validate_sp0);
-                  set_number_value(id(oq_flow_kp), saved_kp);
-                  set_number_value(id(oq_flow_ki), saved_ki);
-                  set_number_value(id(oq_flow_setpoint_lph), saved_sp);
-                  id(oq_flow_autotune_active) = false;
-                  id(oq_flow_at_saved_kp) = NAN;
-                  id(oq_flow_at_saved_ki) = NAN;
-                  id(oq_flow_at_validate_sp0) = NAN;
-                  id(oq_flow_at_validate_sp1) = NAN;
-                  id(oq_flow_at_validate_peak_pv) = NAN;
-                  id(oq_flow_at_w0) = NAN;
-                  id(oq_flow_at_w1) = NAN;
-                  id(oq_flow_at_w2) = NAN;
-                  id(oq_flow_at_validate_confirm_cnt) = 0;
-                  id(oq_flow_at_validate_settle_ready) = false;
-
-                  char msg[220];
-                  if (timed_out && !settled) {
-                    snprintf(msg, sizeof(msg),
-                             "DONE (LIMITED): seed=%.3f/%.4f -> Kp=%.3f Ki=%.4f peak=%.1f target=%.1f",
-                             seed_kp, seed_ki, Kp, Ki, peak_pv, sp1);
-                  } else if (clamped) {
-                    snprintf(msg, sizeof(msg),
-                             "DONE (CLAMPED): seed=%.3f/%.4f -> Kp=%.3f Ki=%.4f peak=%.1f target=%.1f",
-                             seed_kp, seed_ki, Kp, Ki, peak_pv, sp1);
-                  } else {
-                    snprintf(msg, sizeof(msg),
-                             "DONE (CLOSED-LOOP): seed=%.3f/%.4f -> Kp=%.3f Ki=%.4f peak=%.1f target=%.1f",
-                             seed_kp, seed_ki, Kp, Ki, peak_pv, sp1);
-                  }
-                  ESP_LOGI("quatt.cm100.autotune",
-                           "Validation done: seed=%.3f/%.4f scale=%.2f peak=%.1f sp0=%.1f sp1=%.1f band=%.1f t=%ds settled=%d timed_out=%d",
-                           seed_kp, seed_ki, scale, peak_pv, sp0, sp1, settle_band, t, (int) settled, (int) timed_out);
-                  id(oq_flow_autotune_status).publish_state(msg);
-
-                  release_commissioning();
-                  id(oq_flow_autotune_state) = 0;
-                  return;
-                }
+                set_number_value(id(oq_flow_kp), validate_seed.kp_seed);
+                set_number_value(id(oq_flow_ki), validate_seed.ki_seed);
+                set_number_value(id(oq_flow_setpoint_lph), validate_seed.validate_sp1);
+                id(oq_flow_autotune_active) = false;
+                ESP_LOGI("quatt.cm100.autotune",
+                         "Step2 captured -> validation (%s) step1 K=%.3f tau=%.0fs step2 K=%.3f tau=%.0fs combined K=%.3f tau=%.0fs seed=%.3f/%.4f sp=%.1f->%.1f",
+                         validate_seed.consistent ? "2STEP" : "2STEP (LIMITED)",
+                         K1, tau1, step2.model.gain, step2.model.tau_s,
+                         validate_seed.combined_gain, validate_seed.combined_tau_s,
+                         validate_seed.kp_seed, validate_seed.ki_seed, sp0, validate_seed.validate_sp1);
+                publish_reason(oq_flow_autotune::STATUS_VALIDATING_SETTLING);
+                st = oq_flow_autotune::STATE_VALIDATE;
               }
+            } else {
+              st = step2.next_state;
+              if (st == oq_flow_autotune::STATE_ABORT) {
+                ESP_LOGW("quatt.cm100.autotune",
+                         "Autotune step2 ended in abort/fail (reason=%d pv=%.1f t=%ds)",
+                         (int) step2.reason, pv, t);
+              }
+              publish_reason(step2.reason);
             }
             id(oq_flow_autotune_state) = st;
             return;
           }
 
+          // VALIDATION
+          if (id(oq_flow_autotune_state) == oq_flow_autotune::STATE_VALIDATE) {
+            const float sp0 = id(oq_flow_at_validate_sp0);
+            const float sp1 = id(oq_flow_at_validate_sp1);
+            if (isnan(sp0) || isnan(sp1) || !(sp1 > sp0)) {
+              st = oq_flow_autotune::STATE_ABORT;
+              publish_reason(oq_flow_autotune::STATUS_FAILED_INVALID_VALIDATION_STATE);
+              ESP_LOGW("quatt.cm100.autotune",
+                       "Autotune failed: invalid validation state (sp0=%.1f sp1=%.1f)",
+                       sp0, sp1);
+              id(oq_flow_autotune_state) = st;
+              return;
+            }
+            const float step_lph = sp1 - sp0;
+            const float settle_band = fmaxf(kAutotuneValidateBandFloorLph, kAutotuneValidateBandFrac * step_lph);
+            const float overshoot_band = fmaxf(settle_band, kAutotuneValidateOvershootFrac * step_lph);
+            constexpr int kAutotuneValidateSettleGraceS = 20;
+            constexpr int kAutotuneValidateSettleMaxS = 60;
+            const int t = id(oq_flow_at_t);
+            if (!id(oq_flow_at_validate_settle_ready)) {
+              const auto settle = oq_flow_autotune::evaluate_validation_settle(
+                  in_valid_autotune_mode(),
+                  flow_valid,
+                  t,
+                  (int) sample_time_s,
+                  pv,
+                  sp1,
+                  settle_band,
+                  kAutotuneValidateSettleGraceS,
+                  kAutotuneValidateSettleMaxS,
+                  oq_flow_autotune::RollingWindow{
+                      id(oq_flow_at_w0),
+                      id(oq_flow_at_w1),
+                      id(oq_flow_at_w2),
+                  },
+                  id(oq_flow_at_validate_confirm_cnt),
+                  id(oq_flow_at_validate_peak_pv));
+              id(oq_flow_at_t) = settle.next_t_s;
+              id(oq_flow_at_w0) = settle.window.w0;
+              id(oq_flow_at_w1) = settle.window.w1;
+              id(oq_flow_at_w2) = settle.window.w2;
+              id(oq_flow_at_validate_confirm_cnt) = settle.confirm_cnt;
+              id(oq_flow_at_validate_peak_pv) = settle.peak_pv;
+              id(oq_flow_at_validate_settle_ready) = settle.settle_ready;
+              st = settle.next_state;
+              publish_reason(settle.reason);
+              id(oq_flow_autotune_state) = st;
+              return;
+            }
+
+            const auto validate = oq_flow_autotune::evaluate_validation_measure(
+                in_valid_autotune_mode(),
+                flow_valid,
+                t,
+                (int) sample_time_s,
+                pv,
+                sp1,
+                settle_band,
+                overshoot_band,
+                kAutotuneValidateDurationS,
+                oq_flow_autotune::RollingWindow{
+                    id(oq_flow_at_w0),
+                    id(oq_flow_at_w1),
+                    id(oq_flow_at_w2),
+                },
+                id(oq_flow_at_validate_confirm_cnt),
+                id(oq_flow_at_validate_peak_pv),
+                id(oq_flow_kp).state,
+                id(oq_flow_ki).state,
+                ${oq_flow_kp_min},
+                ${oq_flow_kp_max},
+                ${oq_flow_ki_min},
+                ${oq_flow_ki_max});
+            id(oq_flow_at_t) = validate.next_t_s;
+            id(oq_flow_at_w0) = validate.window.w0;
+            id(oq_flow_at_w1) = validate.window.w1;
+            id(oq_flow_at_w2) = validate.window.w2;
+            id(oq_flow_at_validate_confirm_cnt) = validate.confirm_cnt;
+            id(oq_flow_at_validate_peak_pv) = validate.peak_pv;
+            st = validate.next_state;
+            if (validate.done) {
+              const float seed_kp = id(oq_flow_kp).state;
+              const float seed_ki = id(oq_flow_ki).state;
+              auto ckp = id(oq_flow_kp_suggested).make_call();
+              ckp.set_value(validate.adjustment.kp);
+              ckp.perform();
+              auto cki = id(oq_flow_ki_suggested).make_call();
+              cki.set_value(validate.adjustment.ki);
+              cki.perform();
+
+              const float saved_kp = id(oq_flow_at_saved_kp);
+              const float saved_ki = id(oq_flow_at_saved_ki);
+              const float saved_sp = id(oq_flow_at_validate_sp0);
+              set_number_value(id(oq_flow_kp), saved_kp);
+              set_number_value(id(oq_flow_ki), saved_ki);
+              set_number_value(id(oq_flow_setpoint_lph), saved_sp);
+              id(oq_flow_autotune_active) = false;
+              id(oq_flow_at_saved_kp) = NAN;
+              id(oq_flow_at_saved_ki) = NAN;
+              id(oq_flow_at_validate_sp0) = NAN;
+              id(oq_flow_at_validate_sp1) = NAN;
+              id(oq_flow_at_validate_peak_pv) = NAN;
+              id(oq_flow_at_w0) = NAN;
+              id(oq_flow_at_w1) = NAN;
+              id(oq_flow_at_w2) = NAN;
+              id(oq_flow_at_validate_confirm_cnt) = 0;
+              id(oq_flow_at_validate_settle_ready) = false;
+
+              char msg[220];
+              snprintf(msg, sizeof(msg),
+                       "%s: seed=%.3f/%.4f -> Kp=%.3f Ki=%.4f peak=%.1f target=%.1f",
+                       validate.adjustment.status_prefix,
+                       seed_kp, seed_ki,
+                       validate.adjustment.kp, validate.adjustment.ki,
+                       validate.peak_pv, sp1);
+              id(oq_flow_autotune_status).publish_state(msg);
+              release_commissioning();
+              id(oq_flow_autotune_state) = oq_flow_autotune::STATE_IDLE;
+              return;
+            }
+            publish_reason(validate.reason);
+            id(oq_flow_autotune_state) = st;
+            return;
+          }
+
           // ABORT
-          if (id(oq_flow_autotune_state) == 6) {
+          if (id(oq_flow_autotune_state) == oq_flow_autotune::STATE_ABORT) {
             id(oq_flow_autotune_active) = false;
             id(oq_flow_autotune_pwm) = clamp_ipwm((int) id(oq_flow_last_pwm));
             if (!isnan(id(oq_flow_at_saved_kp)) && !isnan(id(oq_flow_at_saved_ki))) {
@@ -1096,6 +907,6 @@ interval:
             ESP_LOGW("quatt.cm100.autotune", "Autotune aborted; restoring last PWM=%d", (int) id(oq_flow_last_pwm));
             release_commissioning();
             id(oq_flow_autotune_status).publish_state("ABORTED");
-            id(oq_flow_autotune_state) = 0;
+            id(oq_flow_autotune_state) = oq_flow_autotune::STATE_IDLE;
             return;
           }

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -27,6 +27,9 @@ oq_cic_compatibility_logic_header: "openquatt/includes/oq_cic_compatibility_logi
 oq_cic_compatibility_protocol_header: "openquatt/includes/oq_cic_compatibility_protocol.h" # Shared helpers for CiC compatibility protocol encoding.
 oq_supervisory_logic_header: "openquatt/includes/oq_supervisory_logic.h" # Shared supervisory helpers for CM naming and pure policy decisions.
 oq_thermal_guard_logic_header: "openquatt/includes/oq_thermal_guard_logic.h" # Shared thermal guard helper seam for guarded-request shaping.
+oq_commissioning_logic_header: "openquatt/includes/oq_commissioning_logic.h" # Shared commissioning/task helper seam for task codes and abort routing.
+oq_flow_autotune_logic_header: "openquatt/includes/oq_flow_autotune_logic.h" # Shared autotune helper seam for state names and pure validation math.
+oq_boiler_task_logic_header: "openquatt/includes/oq_boiler_task_logic.h" # Shared boiler-task helper seam for settle/measurement/result math.
 oq_timezone: "Europe/Amsterdam"                         # SNTP timezone used by runtime timestamps.
 oq_webserver_css_url: ""                            # Optional external CSS for the ESPHome web UI.
 oq_webserver_js_url: ""                               # Custom OpenQuatt app is primary; load ESPHome fallback lazily on demand.

--- a/openquatt_base_common.yaml
+++ b/openquatt_base_common.yaml
@@ -26,6 +26,9 @@ esphome:
     - ${oq_cic_compatibility_protocol_header}
     - ${oq_supervisory_logic_header}
     - ${oq_thermal_guard_logic_header}
+    - ${oq_commissioning_logic_header}
+    - ${oq_flow_autotune_logic_header}
+    - ${oq_boiler_task_logic_header}
   platformio_options:
     extra_scripts:
       - pre:../../../scripts/normalize_factory_merge_inputs.py

--- a/scripts/simulate_thermal_refactor_regressions.py
+++ b/scripts/simulate_thermal_refactor_regressions.py
@@ -41,6 +41,380 @@ class PhDuoCandidate:
     single_on_lead: bool = False
 
 
+@dataclass(frozen=True)
+class CommissioningActionResult:
+    status: str
+    accepted: bool = False
+    task_code: int = 0
+    request_pending: bool = False
+    active: bool = False
+    abort_requested: bool = False
+    state_code: int = 0
+    flow_autotune_req: bool = False
+    flow_autotune_abort: bool = False
+    flow_autotune_active: bool = False
+    flow_autotune_state: int = 0
+
+
+@dataclass(frozen=True)
+class FlowAutotuneValidationResult:
+    status_family: str
+    kp: float
+    ki: float
+    scale: float
+    clamped: bool
+
+
+@dataclass(frozen=True)
+class BoilerMeasureState:
+    sample_count: int = 0
+    sum_w: float = 0.0
+    min_w: float | None = None
+    max_w: float | None = None
+    peak_w: float | None = None
+    plateau_count: int = 0
+
+
+@dataclass(frozen=True)
+class BoilerMeasureResult:
+    ready: bool
+    avg_w: float | None
+    confidence: float
+    min_w: float | None
+    max_w: float | None
+    spread_w: float | None
+
+
+@dataclass(frozen=True)
+class FlowArmResult:
+    state: str
+    status: str
+    pwm_step: int | None = None
+    pv0: float | None = None
+
+
+@dataclass(frozen=True)
+class FlowValidationSettleResult:
+    settle_ready: bool
+    status: str
+    confirm_cnt: int
+    peak_pv: float
+
+
+def commissioning_cm100_start_result(
+    *,
+    override_auto: bool,
+    active: bool,
+    task_code: int,
+) -> CommissioningActionResult:
+    if not override_auto:
+        return CommissioningActionResult("REFUSED: CM Override must be Auto")
+    if active and task_code != 0:
+        return CommissioningActionResult("REFUSED: BUSY")
+    return CommissioningActionResult(
+        "CM100 REQUESTED",
+        accepted=True,
+        task_code=0,
+        request_pending=True,
+    )
+
+
+def commissioning_stop_result(
+    *,
+    active: bool,
+    task_code: int,
+    flow_autotune_req: bool,
+) -> CommissioningActionResult:
+    if active and task_code != 0:
+        return CommissioningActionResult(
+            "ABORT REQUESTED",
+            task_code=task_code,
+            active=active,
+            abort_requested=task_code != 2,
+            flow_autotune_abort=task_code == 2,
+        )
+    if task_code == 2 or flow_autotune_req:
+        return CommissioningActionResult(
+            "ABORT REQUESTED",
+            task_code=task_code,
+            abort_requested=True,
+            flow_autotune_req=flow_autotune_req,
+            flow_autotune_abort=True,
+        )
+    return CommissioningActionResult("IDLE")
+
+
+def flow_autotune_start_result(
+    *,
+    cm_code: int,
+    task_running: bool,
+    autotune_state: int,
+    autotune_active: bool,
+    autotune_req: bool,
+) -> CommissioningActionResult:
+    if autotune_state != 0 or autotune_active or autotune_req or task_running:
+        return CommissioningActionResult("REFUSED: BUSY")
+    if cm_code != 100:
+        return CommissioningActionResult("REFUSED: not CM100")
+    return CommissioningActionResult(
+        "REQUESTED",
+        accepted=True,
+        task_code=2,
+        active=True,
+        state_code=1,
+        flow_autotune_req=True,
+    )
+
+
+def flow_autotune_idle_tick_result(
+    *,
+    cm_code: int,
+    task_code: int,
+    autotune_req: bool,
+    flow_valid: bool,
+) -> CommissioningActionResult:
+    if task_code != 2 or not autotune_req:
+        return CommissioningActionResult("IDLE")
+    if cm_code != 100:
+        return CommissioningActionResult(
+            "WAITING_FOR_CM100",
+            task_code=2,
+            request_pending=True,
+        )
+    return CommissioningActionResult(
+        "SETTLING" if flow_valid else "WAITING_FOR_FLOW",
+        accepted=True,
+        task_code=2,
+        active=True,
+        state_code=1,
+        flow_autotune_active=True,
+        flow_autotune_state=1,
+    )
+
+
+def flow_autotune_release_result(*, keep_cm100: bool = True) -> CommissioningActionResult:
+    return CommissioningActionResult(
+        "CM100 READY" if keep_cm100 else "IDLE",
+        active=keep_cm100,
+    )
+
+
+def flow_autotune_abort_result(
+    *,
+    saved_kp: float | None,
+    saved_ki: float | None,
+    saved_sp: float | None,
+    current_kp: float,
+    current_ki: float,
+    current_sp: float,
+) -> tuple[CommissioningActionResult, float, float, float]:
+    restored_kp = current_kp if saved_kp is None or saved_ki is None else saved_kp
+    restored_ki = current_ki if saved_kp is None or saved_ki is None else saved_ki
+    restored_sp = current_sp if saved_sp is None else saved_sp
+    return (
+        flow_autotune_release_result(keep_cm100=True),
+        restored_kp,
+        restored_ki,
+        restored_sp,
+    )
+
+
+def flow_autotune_step_gain_status(pv0: float, pv_ss: float, du: float) -> str:
+    gain = (pv_ss - pv0) / du
+    return "OK" if gain > 0.0 else "FAILED: INVALID_GAIN"
+
+
+def flow_autotune_validation_result(
+    *,
+    seed_kp: float,
+    seed_ki: float,
+    overshoot: float,
+    settle_band: float,
+    settled: bool,
+    timed_out: bool,
+    elapsed_s: int,
+    sample_time_s: int,
+    kp_min: float,
+    kp_max: float,
+    ki_min: float,
+    ki_max: float,
+) -> FlowAutotuneValidationResult:
+    scale = 1.0
+    if overshoot > (2.0 * settle_band):
+        scale = 0.80
+    elif overshoot > settle_band:
+        scale = 0.90
+    elif settled and elapsed_s <= (sample_time_s * 3) and overshoot <= (0.5 * settle_band):
+        scale = 1.05
+    if timed_out and not settled:
+        scale = min(scale, 0.95)
+
+    raw_kp = seed_kp * scale
+    raw_ki = seed_ki * scale
+    kp = max(kp_min, min(kp_max, raw_kp))
+    ki = max(ki_min, min(ki_max, raw_ki))
+    clamped = abs(kp - raw_kp) > 1.0e-7 or abs(ki - raw_ki) > 1.0e-7
+    if timed_out and not settled:
+        status_family = "DONE (LIMITED)"
+    elif clamped:
+        status_family = "DONE (CLAMPED)"
+    else:
+        status_family = "DONE (CLOSED-LOOP)"
+    return FlowAutotuneValidationResult(status_family, kp, ki, scale, clamped)
+
+
+def boiler_flow_valid(flow_lph: float | None) -> bool:
+    return flow_lph is not None and flow_lph > 0.0
+
+
+def boiler_flow_on_target(
+    flow_lph: float | None, target_flow_lph: float, band_lph: float
+) -> bool:
+    return boiler_flow_valid(flow_lph) and abs(flow_lph - target_flow_lph) <= band_lph
+
+
+def boiler_next_stable_count(stable_now: bool, stable_count: int) -> int:
+    return stable_count + 1 if stable_now else 0
+
+
+def boiler_settle_window_ready(
+    stable_count: int,
+    required_stable_samples: int,
+    state_age_ms: int,
+    settle_min_ms: int,
+) -> bool:
+    return stable_count >= required_stable_samples and state_age_ms >= settle_min_ms
+
+
+def boiler_reset_measurement() -> BoilerMeasureState:
+    return BoilerMeasureState()
+
+
+def boiler_step_measurement(
+    state: BoilerMeasureState,
+    *,
+    flow_stable_now: bool,
+    heat_valid: bool,
+    heat_w: float,
+    plateau_ratio: float,
+    plateau_confirm_samples: int,
+) -> BoilerMeasureState:
+    if not flow_stable_now or not heat_valid or not (heat_w > 0.0):
+        return state
+
+    peak_w = state.peak_w
+    plateau_count = state.plateau_count
+    if peak_w is None or heat_w > peak_w:
+        peak_w = heat_w
+        plateau_count = 0
+
+    plateau_floor = heat_w if peak_w is None else peak_w * plateau_ratio
+    plateau_count = min(1000, plateau_count + 1) if heat_w >= plateau_floor else 0
+    if plateau_count < plateau_confirm_samples:
+        return BoilerMeasureState(
+            sample_count=state.sample_count,
+            sum_w=state.sum_w,
+            min_w=state.min_w,
+            max_w=state.max_w,
+            peak_w=peak_w,
+            plateau_count=plateau_count,
+        )
+
+    min_w = heat_w if state.min_w is None else min(state.min_w, heat_w)
+    max_w = heat_w if state.max_w is None else max(state.max_w, heat_w)
+    return BoilerMeasureState(
+        sample_count=state.sample_count + 1,
+        sum_w=state.sum_w + heat_w,
+        min_w=min_w,
+        max_w=max_w,
+        peak_w=peak_w,
+        plateau_count=plateau_count,
+    )
+
+
+def boiler_measurement_window_complete(
+    sample_count: int,
+    min_samples: int,
+    state_age_ms: int,
+    measure_min_ms: int,
+) -> bool:
+    return sample_count >= min_samples and state_age_ms >= measure_min_ms
+
+
+def boiler_finalize_measurement(state: BoilerMeasureState) -> BoilerMeasureResult:
+    if state.sample_count <= 0 or state.min_w is None or state.max_w is None:
+        return BoilerMeasureResult(False, None, 0.0, None, None, None)
+
+    avg_w = state.sum_w / state.sample_count
+    spread_w = state.max_w - state.min_w
+    confidence = 100.0
+    if state.sample_count < 10:
+        confidence -= (10 - state.sample_count) * 4.0
+    if spread_w > avg_w * 0.05:
+        confidence -= 15.0
+    if spread_w > avg_w * 0.10:
+        confidence -= 20.0
+    confidence = max(0.0, min(100.0, confidence))
+    return BoilerMeasureResult(True, avg_w, confidence, state.min_w, state.max_w, spread_w)
+
+
+def flow_autotune_arm_result(
+    *,
+    valid_mode: bool,
+    flow_valid: bool,
+    elapsed_s: int,
+    pwm0: int,
+    pwm_min: int,
+    min_step: int,
+    baseline_ready: bool,
+) -> FlowArmResult:
+    if not valid_mode:
+        return FlowArmResult("ABORT", "ABORT: not CM100")
+    if not flow_valid:
+        return FlowArmResult(
+            "ABORT" if elapsed_s >= 60 else "ARM",
+            "ABORT: NO_BASELINE_FLOW" if elapsed_s >= 60 else "WAITING_FOR_FLOW",
+        )
+    if not baseline_ready:
+        return FlowArmResult(
+            "ABORT" if elapsed_s >= 60 else "ARM",
+            "ABORT: NO_BASELINE_FLOW" if elapsed_s >= 60 else "SETTLING",
+        )
+    pwm_headroom = pwm0 - pwm_min
+    if pwm_headroom < min_step:
+        return FlowArmResult("ABORT", "REFUSED: STEP_HEADROOM")
+    u_step = max(10, min(28, round(0.06 * pwm0)))
+    u_step = max(min_step, min(u_step, pwm_headroom))
+    return FlowArmResult("STEP1", "STEP", pwm0 - u_step, 500.0)
+
+
+def flow_autotune_validation_settle_result(
+    *,
+    valid_mode: bool,
+    flow_valid: bool,
+    elapsed_s: int,
+    confirm_cnt: int,
+    peak_pv: float,
+    pv: float,
+    sp1: float,
+    settle_band: float,
+    window_ready: bool,
+    settled_now: bool,
+) -> FlowValidationSettleResult:
+    if not valid_mode:
+        return FlowValidationSettleResult(False, "ABORT: not CM100", confirm_cnt, peak_pv)
+    if not flow_valid:
+        return FlowValidationSettleResult(False, "ABORT: FLOW_INVALID", confirm_cnt, peak_pv)
+    peak_pv = max(peak_pv, pv)
+    if window_ready and elapsed_s >= 20 and settled_now:
+        confirm_cnt = min(255, confirm_cnt + 1)
+    else:
+        confirm_cnt = 0
+    if confirm_cnt >= 2 or elapsed_s >= 60:
+        return FlowValidationSettleResult(True, "VALIDATING", 0, sp1)
+    return FlowValidationSettleResult(False, "VALIDATING_SETTLING", confirm_cnt, peak_pv)
+
+
 def hold_request_mode_code(
     hp1_hold: int,
     hp2_hold: int,
@@ -1691,6 +2065,307 @@ def run_scenarios() -> list[ScenarioResult]:
             f"{supervisory_pump_on(100, commissioning_task_active=False, sticky_active=False, any_hp_active_guard=False)}, "
             f"{supervisory_pump_on(100, commissioning_task_active=True, sticky_active=False, any_hp_active_guard=False)}"
         ),
+    )
+    cm100_start = commissioning_cm100_start_result(
+        override_auto=True,
+        active=False,
+        task_code=0,
+    )
+    add(
+        "Commissioning CM100 start only arms the neutral service container",
+        cm100_start.accepted
+        and cm100_start.request_pending
+        and not cm100_start.active
+        and cm100_start.task_code == 0
+        and cm100_start.status == "CM100 REQUESTED",
+        f"commissioning_cm100_start_result(...) -> {cm100_start}",
+    )
+    add(
+        "Commissioning CM100 start refuses while override is not Auto",
+        commissioning_cm100_start_result(
+            override_auto=False,
+            active=False,
+            task_code=0,
+        ).status
+        == "REFUSED: CM Override must be Auto",
+        (
+            "commissioning_cm100_start_result(...) -> "
+            f"{commissioning_cm100_start_result(override_auto=False, active=False, task_code=0).status}"
+        ),
+    )
+    active_autotune_stop = commissioning_stop_result(
+        active=True,
+        task_code=2,
+        flow_autotune_req=False,
+    )
+    add(
+        "Commissioning stop delegates active flow-autotune abort to the task",
+        active_autotune_stop.status == "ABORT REQUESTED"
+        and active_autotune_stop.flow_autotune_abort
+        and not active_autotune_stop.abort_requested,
+        f"commissioning_stop_result(...) -> {active_autotune_stop}",
+    )
+    pending_autotune_stop = commissioning_stop_result(
+        active=False,
+        task_code=2,
+        flow_autotune_req=True,
+    )
+    add(
+        "Commissioning stop marks both abort flags for a pending flow-autotune request",
+        pending_autotune_stop.status == "ABORT REQUESTED"
+        and pending_autotune_stop.flow_autotune_abort
+        and pending_autotune_stop.abort_requested,
+        f"commissioning_stop_result(...) -> {pending_autotune_stop}",
+    )
+    autotune_start = flow_autotune_start_result(
+        cm_code=100,
+        task_running=False,
+        autotune_state=0,
+        autotune_active=False,
+        autotune_req=False,
+    )
+    add(
+        "Flow autotune start claims commissioning task 2 only when CM100 is ready",
+        autotune_start.accepted
+        and autotune_start.task_code == 2
+        and autotune_start.active
+        and autotune_start.state_code == 1
+        and autotune_start.flow_autotune_req,
+        f"flow_autotune_start_result(...) -> {autotune_start}",
+    )
+    add(
+        "Flow autotune start refuses outside CM100",
+        flow_autotune_start_result(
+            cm_code=2,
+            task_running=False,
+            autotune_state=0,
+            autotune_active=False,
+            autotune_req=False,
+        ).status
+        == "REFUSED: not CM100",
+        (
+            "flow_autotune_start_result(...) -> "
+            f"{flow_autotune_start_result(cm_code=2, task_running=False, autotune_state=0, autotune_active=False, autotune_req=False).status}"
+        ),
+    )
+    autotune_idle = flow_autotune_idle_tick_result(
+        cm_code=100,
+        task_code=2,
+        autotune_req=True,
+        flow_valid=True,
+    )
+    add(
+        "Flow autotune idle tick turns a queued task into baseline settling",
+        autotune_idle.status == "SETTLING"
+        and autotune_idle.active
+        and autotune_idle.flow_autotune_active
+        and autotune_idle.flow_autotune_state == 1,
+        f"flow_autotune_idle_tick_result(...) -> {autotune_idle}",
+    )
+    add(
+        "Flow autotune release keeps CM100 ready and clears the selected task",
+        flow_autotune_release_result(keep_cm100=True).status == "CM100 READY"
+        and flow_autotune_release_result(keep_cm100=True).active
+        and flow_autotune_release_result(keep_cm100=True).task_code == 0,
+        f"flow_autotune_release_result(...) -> {flow_autotune_release_result(keep_cm100=True)}",
+    )
+    abort_result, restored_kp, restored_ki, restored_sp = flow_autotune_abort_result(
+        saved_kp=0.03,
+        saved_ki=0.0008,
+        saved_sp=650.0,
+        current_kp=0.05,
+        current_ki=0.0012,
+        current_sp=690.0,
+    )
+    add(
+        "Flow autotune abort restores saved PI gains and setpoint before releasing CM100",
+        abort_result.status == "CM100 READY"
+        and restored_kp == 0.03
+        and restored_ki == 0.0008
+        and restored_sp == 650.0,
+        (
+            "flow_autotune_abort_result(...) -> "
+            f"{abort_result}, kp={restored_kp}, ki={restored_ki}, sp={restored_sp}"
+        ),
+    )
+    add(
+        "Flow autotune invalid step gain is a FAILED path, not an ABORT path",
+        flow_autotune_step_gain_status(500.0, 490.0, 20.0) == "FAILED: INVALID_GAIN",
+        (
+            "flow_autotune_step_gain_status(...) -> "
+            f"{flow_autotune_step_gain_status(500.0, 490.0, 20.0)}"
+        ),
+    )
+    validation_fast = flow_autotune_validation_result(
+        seed_kp=0.03,
+        seed_ki=0.0008,
+        overshoot=2.0,
+        settle_band=8.0,
+        settled=True,
+        timed_out=False,
+        elapsed_s=5,
+        sample_time_s=5,
+        kp_min=0.001,
+        kp_max=0.2,
+        ki_min=0.0,
+        ki_max=0.01,
+    )
+    add(
+        "Flow autotune successful validation may gently increase fast stable gains",
+        validation_fast.status_family == "DONE (CLOSED-LOOP)"
+        and validation_fast.scale == 1.05
+        and round(validation_fast.kp, 5) == 0.0315
+        and round(validation_fast.ki, 6) == 0.00084,
+        f"flow_autotune_validation_result(...) -> {validation_fast}",
+    )
+    validation_timeout = flow_autotune_validation_result(
+        seed_kp=0.03,
+        seed_ki=0.0008,
+        overshoot=4.0,
+        settle_band=8.0,
+        settled=False,
+        timed_out=True,
+        elapsed_s=180,
+        sample_time_s=5,
+        kp_min=0.001,
+        kp_max=0.2,
+        ki_min=0.0,
+        ki_max=0.01,
+    )
+    add(
+        "Flow autotune validation timeout publishes a limited DONE result",
+        validation_timeout.status_family == "DONE (LIMITED)"
+        and validation_timeout.scale == 0.95,
+        f"flow_autotune_validation_result(...) -> {validation_timeout}",
+    )
+    arm_ready = flow_autotune_arm_result(
+        valid_mode=True,
+        flow_valid=True,
+        elapsed_s=30,
+        pwm0=400,
+        pwm_min=50,
+        min_step=5,
+        baseline_ready=True,
+    )
+    add(
+        "Flow autotune arm helper turns a stable baseline into the first step request",
+        arm_ready.state == "STEP1"
+        and arm_ready.status == "STEP"
+        and arm_ready.pwm_step == 376,
+        f"flow_autotune_arm_result(...) -> {arm_ready}",
+    )
+    arm_wait = flow_autotune_arm_result(
+        valid_mode=True,
+        flow_valid=False,
+        elapsed_s=25,
+        pwm0=400,
+        pwm_min=50,
+        min_step=5,
+        baseline_ready=False,
+    )
+    add(
+        "Flow autotune arm helper stays in waiting-for-flow before the baseline timeout",
+        arm_wait.state == "ARM" and arm_wait.status == "WAITING_FOR_FLOW",
+        f"flow_autotune_arm_result(...) -> {arm_wait}",
+    )
+    validation_settle = flow_autotune_validation_settle_result(
+        valid_mode=True,
+        flow_valid=True,
+        elapsed_s=25,
+        confirm_cnt=1,
+        peak_pv=710.0,
+        pv=705.0,
+        sp1=700.0,
+        settle_band=8.0,
+        window_ready=True,
+        settled_now=True,
+    )
+    add(
+        "Flow autotune validation-settle helper releases into measurement after two confirmations",
+        validation_settle.settle_ready
+        and validation_settle.status == "VALIDATING"
+        and validation_settle.confirm_cnt == 0
+        and validation_settle.peak_pv == 700.0,
+        f"flow_autotune_validation_settle_result(...) -> {validation_settle}",
+    )
+    add(
+        "Boiler task flow-on-target helper accepts stable flow inside the commissioning band",
+        boiler_flow_on_target(782.0, 800.0, 40.0)
+        and not boiler_flow_on_target(855.0, 800.0, 40.0),
+        (
+            "boiler_flow_on_target(...) -> "
+            f"{boiler_flow_on_target(782.0, 800.0, 40.0)}, "
+            f"{boiler_flow_on_target(855.0, 800.0, 40.0)}"
+        ),
+    )
+    add(
+        "Boiler task settle helper keeps only consecutive stable samples",
+        boiler_next_stable_count(True, 3) == 4
+        and boiler_next_stable_count(False, 3) == 0,
+        (
+            "boiler_next_stable_count(...) -> "
+            f"{boiler_next_stable_count(True, 3)}, {boiler_next_stable_count(False, 3)}"
+        ),
+    )
+    add(
+        "Boiler task settle gate requires both enough stable samples and minimum dwell time",
+        boiler_settle_window_ready(4, 4, 120000, 120000)
+        and not boiler_settle_window_ready(3, 4, 120000, 120000)
+        and not boiler_settle_window_ready(4, 4, 119000, 120000),
+        (
+            "boiler_settle_window_ready(...) -> "
+            f"{boiler_settle_window_ready(4, 4, 120000, 120000)}, "
+            f"{boiler_settle_window_ready(3, 4, 120000, 120000)}, "
+            f"{boiler_settle_window_ready(4, 4, 119000, 120000)}"
+        ),
+    )
+    boiler_measure_state = boiler_reset_measurement()
+    for heat_w in (4000.0, 4100.0, 4300.0, 4300.0, 4300.0, 4300.0, 4250.0, 4250.0):
+        boiler_measure_state = boiler_step_measurement(
+            boiler_measure_state,
+            flow_stable_now=True,
+            heat_valid=True,
+            heat_w=heat_w,
+            plateau_ratio=0.95,
+            plateau_confirm_samples=4,
+        )
+    add(
+        "Boiler task measurement helper waits for plateau confirmation before counting samples",
+        boiler_measure_state.sample_count == 3
+        and round(boiler_measure_state.sum_w, 1) == 12800.0
+        and boiler_measure_state.min_w == 4250.0
+        and boiler_measure_state.max_w == 4300.0,
+        f"boiler_step_measurement(...) -> {boiler_measure_state}",
+    )
+    add(
+        "Boiler task measurement window closes only after both sample and runtime thresholds",
+        boiler_measurement_window_complete(8, 8, 180000, 180000)
+        and not boiler_measurement_window_complete(7, 8, 180000, 180000)
+        and not boiler_measurement_window_complete(8, 8, 179000, 180000),
+        (
+            "boiler_measurement_window_complete(...) -> "
+            f"{boiler_measurement_window_complete(8, 8, 180000, 180000)}, "
+            f"{boiler_measurement_window_complete(7, 8, 180000, 180000)}, "
+            f"{boiler_measurement_window_complete(8, 8, 179000, 180000)}"
+        ),
+    )
+    boiler_result = boiler_finalize_measurement(
+        BoilerMeasureState(
+            sample_count=8,
+            sum_w=34000.0,
+            min_w=4200.0,
+            max_w=4300.0,
+            peak_w=4300.0,
+            plateau_count=6,
+        )
+    )
+    add(
+        "Boiler task finalize helper computes average and confidence from the measurement spread",
+        boiler_result.ready
+        and boiler_result.avg_w == 4250.0
+        and boiler_result.spread_w == 100.0
+        and boiler_result.confidence == 92.0,
+        f"boiler_finalize_measurement(...) -> {boiler_result}",
     )
 
     return results


### PR DESCRIPTION
## What changed

This PR completes phase 7 on top of PR #162 by making the commissioning/task boundary explicit and moving commissioning boiler-test and flow-autotune phase decisions behind shared helper seams.

The main changes are:
- added a tracked contract document in `docs/commissioning-autotune-contract.md`
- added `openquatt/includes/oq_commissioning_logic.h` for shared task codes, task-state codes, task predicates, and stop/abort routing
- added `openquatt/includes/oq_flow_autotune_logic.h` for autotune phase decisions, rolling-window helpers, open-loop step decisions, validation settle/measure decisions, and validation gain adjustment
- added `openquatt/includes/oq_boiler_task_logic.h` for boiler flow-settle, boiler-settle, plateau-window measurement, and result/confidence decisions
- updated `oq_commissioning.yaml`, `oq_flow_autotune.yaml`, and `oq_boiler_control.yaml` so YAML now mostly applies side effects while helper code decides phase progression
- expanded the regression harness with explicit commissioning/autotune/boiler task anchors

## Scope

This is intentionally stacked on PR #162.

Included here:
- commissioning/task contract documentation
- explicit shared task semantics for CM100 work
- helper-driven phase decisions for flow autotune and boiler power test
- regression coverage for new task-step boundaries

Not included here:
- no big-bang commissioning rewrite
- no supervisory redesign
- no flow PI conversion to C++
- no dashboard or UX work
- no `flow_rate_hp_avg` changes
- no `oq_HP_io.yaml` work
- no intentional commissioning or autotune behavior change

## Why it changed

Phase 7 is about making CM100 work safer to read, test, and evolve before any later relocation into heavier helpers or custom components.

Before this step, boiler power test and flow autotune were still tightly expressed as long YAML state machines. This PR makes their ownership and task progression explicit, keeps behavioral anchors green, and narrows YAML more toward orchestration and side effects.

## Impact

- commissioning now reads more clearly as a supervisor/task-runner
- boiler power test and flow autotune have more explicit task ownership boundaries
- current abort/failure/success behavior is documented and regression-anchored
- later helper or C++ extraction work has a safer boundary to build on

## Validation

- `uv run python scripts/simulate_thermal_refactor_regressions.py` -> `119/119`
- `uv run python scripts/check_style_consistency.py`
- `git diff --check`
- `./scripts/validate_local.sh`
  - style consistency
  - docs consistency
  - config validation for all 4 firmware profiles
  - compile validation for all 4 firmware profiles