### PR TITLE
Refactor phase 8 flow-control boundary

### DIFF
--- a/docs/commissioning-autotune-contract.md
+++ b/docs/commissioning-autotune-contract.md
@@ -235,7 +235,11 @@ the live/persistent flow tuning numbers only when both suggestions are valid.
 
 ## Flow-Control Boundary
 
-Flow control owns pump iPWM in all non-CM0 modes. The autotune override has
+Flow control owns pump iPWM in all non-CM0 modes. The detailed phase-8
+mode-routing and PI boundary is tracked in
+[`docs/flow-control-contract.md`](flow-control-contract.md).
+
+The autotune override has
 priority only when:
 
 - `oq_flow_autotune_active == true`
@@ -296,6 +300,10 @@ Current phase-7 helper status:
 - centralized in `openquatt/includes/oq_boiler_task_logic.h`:
   boiler flow-valid/on-target checks, settle decisions, plateau-filtered
   measurement progression and result/confidence finalization
+- coordinated with `openquatt/includes/oq_flow_control_logic.h`:
+  non-CM0 route selection, AUTO start seed selection and pure flow PI/failsafe
+  decisions, while commissioning/autotune ownership and flow-control side
+  effects remain in YAML
 - still local in YAML:
   task timers, saved-flow ownership, number/entity writes, status publication,
   commissioning release semantics, logging and other side effects

--- a/docs/flow-control-contract.md
+++ b/docs/flow-control-contract.md
@@ -1,0 +1,179 @@
+# Flow Control Contract
+
+This document captures the phase-8 contract for the current boundary around
+`openquatt/oq_flow_control.yaml`.
+
+The goal is not to change hydraulic behavior in this phase. The goal is to
+make the current mode-routing, PI boundary, output ownership and runtime state
+explicit before later helper or C++ extraction.
+
+## Ownership Boundary
+
+Current control flow:
+
+```text
+mode selection -> selected flow mode -> control calculation -> pwm output/result
+```
+
+Flow control owns pump iPWM writes for all non-CM0 modes. Supervisory owns
+Control Mode selection and CM0 pump policy. Flow control does not decide heat
+production, compressor levels, boiler assist or whether CM100 is active.
+
+Flow control may:
+
+- publish `oq_flow_mode`
+- write `hp1_pump_speed`
+- write the secondary pump speed when `${flow_secondary_enabled}` is enabled
+- run AUTO PI against `flow_rate_selected`
+- apply fixed iPWM for manual and frost modes
+- apply a temporary autotune iPWM request while the CM100 flow-autotune task is active
+- update runtime PI memory and learned `oq_flow_last_good_pwm`
+
+Flow control must not:
+
+- write pump iPWM in CM0
+- own CM0 stop/sticky pump policy
+- select or change Control Mode
+- own commissioning task state
+- own flow autotune state progression
+- change `flow_rate_hp_avg`
+
+## Mode Selection Contract
+
+The current execution priority is:
+
+| Priority | Selected mode | Conditions | Output behavior |
+|---:|---|---|---|
+| 1 | `CM0` | `oq_control_mode_code == 0` | publish `CM0`, return without pump iPWM writes |
+| 2 | `AUTOTUNE` | `oq_flow_autotune_active == true`, CM100, task code `2` | write clamped `oq_flow_autotune_pwm`, publish `AUTOTUNE`, skip manual/frost/PI |
+| 3 | `CM98` | `oq_control_mode_code == 98` | write clamped frost iPWM, publish `CM98` |
+| 4 | `MANUAL` | flow control mode is `Manual PWM` and not CM98 | write clamped manual iPWM, publish `MANUAL` |
+| 5 | `AUTO (failsafe)` | AUTO path with invalid setpoint or invalid flow signal | write failsafe `iPWM=850`, publish `AUTO (failsafe)` |
+| 6 | `AUTO (starting)` | AUTO path while startup hold remains after the current tick | hold current start iPWM, publish `AUTO (starting)` |
+| 7 | `AUTO` | normal AUTO PI path | write PI result, publish `AUTO` |
+
+Important priority details:
+
+- CM0 is a hard early return. Even if manual or autotune state is present,
+  this loop does not write pump iPWM in CM0.
+- Autotune override is valid only for CM100 plus commissioning task code `2`.
+  A stale `oq_flow_autotune_active` flag outside that task is ignored by
+  flow control.
+- CM98 frost circulation takes fixed-output ownership before manual mode.
+  Selecting `Manual PWM` does not override frost iPWM.
+- AUTO failsafe status has priority over AUTO startup status.
+- The published `AUTO (starting)` label is based on the startup hold count
+  after the current AUTO tick has run.
+
+## PI Core Boundary
+
+The current AUTO PI core begins after mode routing has selected AUTO and ends
+when it returns a clamped iPWM value plus PI/failsafe state.
+
+Current AUTO PI inputs:
+
+- `oq_flow_setpoint_lph`
+- `flow_rate_selected`
+- `oq_flow_kp`
+- `oq_flow_ki`
+- previous `oq_flow_last_pwm`
+- runtime memory: setpoint filter, integral, last error, startup hold and stability counter
+
+Current AUTO PI outputs:
+
+- next pump iPWM
+- `oq_flow_i`
+- `oq_flow_last_pwm`
+- runtime setpoint filter and last error
+- `oq_flow_last_good_pwm` after stable tracking
+- mode status family: normal, starting or failsafe
+
+The PI core currently includes:
+
+- invalid-input failsafe to `iPWM=850`
+- startup hold with integrator freeze
+- setpoint ramping
+- deadband
+- proportional and integral action
+- anti-windup decay and clamping
+- asymmetric action limiting
+- final iPWM clamp to `50..850`
+- stable-flow tracking for learned `oq_flow_last_good_pwm`
+
+## State Contract
+
+Runtime-only state:
+
+- `oq_flow_i`
+- `oq_flow_last_pwm`
+- `oq_flow_last_mode`
+- `oq_flow_commissioning_start_pwm`
+- `oq_flow_control_mode_code`
+- `oq_flow_autotune_active`
+- `oq_flow_autotune_pwm`
+- lambda-local startup hold, stability counter, setpoint filter and previous PI error
+
+Persistent state:
+
+- `oq_flow_last_good_pwm`: learned AUTO restart seed
+- `oq_flow_setpoint_lph`: user setting
+- `oq_flow_manual_pwm`: user setting
+- `oq_flow_frost_pwm`: user setting
+- `oq_flow_auto_start_pwm`: user setting
+- `oq_flow_kp`: user setting
+- `oq_flow_ki`: user setting
+- `oq_flow_control_mode`: user setting
+
+Contractually visible outputs:
+
+- `oq_flow_mode`
+- pump iPWM number entities for HP1 and optional HP2
+- `oq_flow_mismatch`
+- `flow_rate_hp_avg`
+
+`flow_rate_hp_avg` and `oq_flow_mismatch` are diagnostics/sensor logic in the
+same package, but they are outside the phase-8 PI/mode-routing extraction
+scope unless explicitly covered first.
+
+## Extraction Rules
+
+Before moving any flow-control logic:
+
+- preserve the mode priority table above
+- add or keep regression scenarios for changed mode paths
+- keep CM0 pump policy in supervisory
+- keep ESPHome entity writes in YAML until a side-effect boundary is explicit
+- do not move PI/fallback logic without covering invalid-input, startup-hold,
+  clamp and `last_good_pwm` behavior
+- keep `flow_rate_hp_avg` unchanged
+
+## Current Phase-8 Helper Boundary
+
+The current phase-8 helper seam is centralized in
+`openquatt/includes/oq_flow_control_logic.h`.
+
+Centralized there:
+
+- mode-route selection (`CM0`, `AUTOTUNE`, `CM98`, `MANUAL`, `AUTO`)
+- execution-mode naming and AUTO status-family mapping
+- iPWM clamping
+- AUTO start seed selection for normal vs commissioning entry
+- pure AUTO PI arithmetic
+- startup-hold step behavior
+- invalid-input failsafe behavior
+- stable-flow tracking and `last_good_pwm` update decision
+
+YAML still owns:
+
+- ESPHome globals/statics and their storage locations
+- CM0 and manual edge bookkeeping
+- number/entity reads and writes
+- pump iPWM mirroring to HP1 and optional HP2
+- flow-mode text publication
+- logging
+- `flow_rate_hp_avg` and `oq_flow_mismatch` diagnostics
+
+That means the current phase-8 boundary is now:
+
+- helpers decide route, AUTO start seed and pure PI outputs
+- YAML applies side effects, stores runtime memory and publishes entities

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -283,8 +283,9 @@ Flow control execution priority:
 
 1. CM0 early return
 2. autotune override (CM100 commissioning task only)
-3. manual/frost fixed iPWM
-4. AUTO PI path
+3. CM98 frost fixed iPWM
+4. manual fixed iPWM
+5. AUTO PI path
 
 Key behaviors:
 
@@ -293,6 +294,10 @@ Key behaviors:
 - asymmetric action limits
 - validity-based failsafe (`iPWM=850`)
 - stable-flow tracking for `last_good_pwm`
+- helper seam for route selection, AUTO start seed and pure PI math
+
+The detailed phase-8 contract is in
+[`docs/flow-control-contract.md`](flow-control-contract.md).
 
 ## 9. Safety Model
 

--- a/openquatt/includes/oq_flow_control_logic.h
+++ b/openquatt/includes/oq_flow_control_logic.h
@@ -1,0 +1,317 @@
+#pragma once
+
+#include <math.h>
+#include <stdlib.h>
+
+namespace oq_flow_control {
+
+enum RouteKind {
+  ROUTE_CM0 = 0,
+  ROUTE_AUTOTUNE = 1,
+  ROUTE_FROST = 2,
+  ROUTE_MANUAL = 3,
+  ROUTE_AUTO = 4,
+};
+
+enum ExecMode {
+  EXEC_MODE_CM0 = 0,
+  EXEC_MODE_AUTOTUNE = 1,
+  EXEC_MODE_MANUAL = 2,
+  EXEC_MODE_FROST = 3,
+  EXEC_MODE_AUTO_STARTING = 4,
+  EXEC_MODE_AUTO = 5,
+  EXEC_MODE_AUTO_FAILSAFE = 6,
+};
+
+enum RuntimeModeStateCode {
+  RUNTIME_MODE_NORMAL = 0,
+  RUNTIME_MODE_FROST = 2,
+};
+
+struct RoutePlan {
+  RouteKind route_kind;
+  int runtime_mode_state_code;
+  bool early_return;
+  const char *mode_text;
+};
+
+struct AutoStartPlan {
+  int start_pwm;
+  int fallback_pwm;
+  bool commissioning_start;
+};
+
+struct AutoPiState {
+  float integral;
+  float setpoint_filtered;
+  float last_error;
+  int startup_hold;
+  int stable_count;
+};
+
+struct AutoPiConfig {
+  float dt_s;
+  int min_ipwm;
+  int max_ipwm;
+  int failsafe_ipwm;
+  float sp_ramp_up_lph_s;
+  float sp_ramp_down_lph_s;
+  float deadband_lph;
+  float i_active_band_lph;
+  float i_cross_keep;
+  float i_deadband_keep;
+  float i_large_err_keep;
+  float i_min;
+  float i_max;
+  float u_up_per_s;
+  float u_down_per_s;
+  float stable_err_lph;
+  int stable_time_ticks;
+  int good_pwm_step;
+};
+
+struct AutoPiInput {
+  int pwm_seed;
+  float setpoint_lph;
+  float flow_lph;
+  float kp;
+  float ki;
+  int last_good_pwm;
+};
+
+struct AutoPiResult {
+  int pwm;
+  AutoPiState state;
+  bool failsafe;
+  int last_good_pwm;
+};
+
+inline int clamp_ipwm(int value, int min_ipwm = 50, int max_ipwm = 850) {
+  if (value < min_ipwm) return min_ipwm;
+  if (value > max_ipwm) return max_ipwm;
+  return value;
+}
+
+inline int runtime_mode_state_code(int control_mode_code) {
+  return (control_mode_code == 98) ? RUNTIME_MODE_FROST : RUNTIME_MODE_NORMAL;
+}
+
+inline bool autotune_override_active(bool autotune_active,
+                                     int control_mode_code,
+                                     int commissioning_task_code) {
+  return autotune_active && control_mode_code == 100 && commissioning_task_code == 2;
+}
+
+inline RoutePlan select_route(int control_mode_code,
+                              bool want_manual,
+                              bool autotune_active,
+                              int commissioning_task_code) {
+  if (control_mode_code == 0) {
+    return RoutePlan{
+        ROUTE_CM0,
+        runtime_mode_state_code(control_mode_code),
+        true,
+        "CM0",
+    };
+  }
+
+  const bool is_frost = control_mode_code == 98;
+  if (autotune_override_active(
+          autotune_active, control_mode_code, commissioning_task_code) &&
+      !is_frost) {
+    return RoutePlan{
+        ROUTE_AUTOTUNE,
+        runtime_mode_state_code(control_mode_code),
+        false,
+        "AUTOTUNE",
+    };
+  }
+
+  if (is_frost) {
+    return RoutePlan{
+        ROUTE_FROST,
+        runtime_mode_state_code(control_mode_code),
+        false,
+        "CM98",
+    };
+  }
+
+  if (want_manual) {
+    return RoutePlan{
+        ROUTE_MANUAL,
+        runtime_mode_state_code(control_mode_code),
+        false,
+        "MANUAL",
+    };
+  }
+
+  return RoutePlan{
+      ROUTE_AUTO,
+      runtime_mode_state_code(control_mode_code),
+      false,
+      "AUTO",
+  };
+}
+
+inline ExecMode finalize_exec_mode(const RoutePlan &route,
+                                   bool pi_failsafe,
+                                   int startup_hold_after_tick) {
+  if (route.route_kind == ROUTE_CM0) return EXEC_MODE_CM0;
+  if (route.route_kind == ROUTE_AUTOTUNE) return EXEC_MODE_AUTOTUNE;
+  if (route.route_kind == ROUTE_MANUAL) return EXEC_MODE_MANUAL;
+  if (route.route_kind == ROUTE_FROST) return EXEC_MODE_FROST;
+  if (pi_failsafe) return EXEC_MODE_AUTO_FAILSAFE;
+  if (startup_hold_after_tick > 0) return EXEC_MODE_AUTO_STARTING;
+  return EXEC_MODE_AUTO;
+}
+
+inline const char *exec_mode_text(ExecMode exec_mode) {
+  if (exec_mode == EXEC_MODE_CM0) return "CM0";
+  if (exec_mode == EXEC_MODE_AUTOTUNE) return "AUTOTUNE";
+  if (exec_mode == EXEC_MODE_MANUAL) return "MANUAL";
+  if (exec_mode == EXEC_MODE_FROST) return "CM98";
+  if (exec_mode == EXEC_MODE_AUTO_FAILSAFE) return "AUTO (failsafe)";
+  if (exec_mode == EXEC_MODE_AUTO_STARTING) return "AUTO (starting)";
+  return "AUTO";
+}
+
+inline AutoStartPlan compute_auto_start_plan(int control_mode_code,
+                                             int commissioning_task_code,
+                                             int commissioning_start_pwm,
+                                             int last_good_pwm,
+                                             int fallback_pwm,
+                                             int min_ipwm = 50,
+                                             int max_ipwm = 850) {
+  const int clamped_fallback = clamp_ipwm(fallback_pwm, min_ipwm, max_ipwm);
+  const bool commissioning_start =
+      control_mode_code == 100 && commissioning_task_code != 0;
+
+  int start_pwm = commissioning_start
+                      ? clamp_ipwm(commissioning_start_pwm, min_ipwm, max_ipwm)
+                      : last_good_pwm;
+  if (!commissioning_start && (start_pwm < min_ipwm || start_pwm > max_ipwm)) {
+    start_pwm = clamped_fallback;
+  }
+
+  return AutoStartPlan{
+      start_pwm,
+      clamped_fallback,
+      commissioning_start,
+  };
+}
+
+inline AutoPiState reset_pi_tracking_keep_hold(const AutoPiState &state) {
+  return AutoPiState{
+      0.0f,
+      NAN,
+      0.0f,
+      state.startup_hold,
+      0,
+  };
+}
+
+inline AutoPiState enter_auto_transition(int startup_hold_ticks) {
+  return AutoPiState{
+      0.0f,
+      NAN,
+      0.0f,
+      startup_hold_ticks,
+      0,
+  };
+}
+
+inline AutoPiResult step_auto_pi(AutoPiState state,
+                                 const AutoPiInput &input,
+                                 const AutoPiConfig &cfg) {
+  int pwm_local = input.pwm_seed;
+  const bool flow_signal_valid = !isnan(input.flow_lph);
+  const bool failsafe =
+      isnan(input.setpoint_lph) || input.setpoint_lph <= 0.0f || !flow_signal_valid;
+
+  if (failsafe) {
+    return AutoPiResult{
+        cfg.failsafe_ipwm,
+        reset_pi_tracking_keep_hold(state),
+        true,
+        input.last_good_pwm,
+    };
+  }
+
+  if (state.startup_hold > 0) {
+    state.setpoint_filtered = input.flow_lph;
+    state.startup_hold--;
+    state.stable_count = 0;
+    return AutoPiResult{
+        clamp_ipwm(pwm_local, cfg.min_ipwm, cfg.max_ipwm),
+        state,
+        false,
+        input.last_good_pwm,
+    };
+  }
+
+  if (isnan(state.setpoint_filtered)) state.setpoint_filtered = input.flow_lph;
+
+  float d = input.setpoint_lph - state.setpoint_filtered;
+  float max_step =
+      ((d >= 0.0f) ? cfg.sp_ramp_up_lph_s : cfg.sp_ramp_down_lph_s) * cfg.dt_s;
+  if (d > max_step) d = max_step;
+  if (d < -max_step) d = -max_step;
+  state.setpoint_filtered += d;
+
+  float e = state.setpoint_filtered - input.flow_lph;
+  if (fabsf(e) < cfg.deadband_lph) e = 0.0f;
+
+  const bool have_e = e > 0.0f || e < 0.0f;
+  const bool have_last_e = state.last_error > 0.0f || state.last_error < 0.0f;
+  const bool sign_flip =
+      have_e && have_last_e && ((e > 0.0f) != (state.last_error > 0.0f));
+
+  if (sign_flip) {
+    state.integral *= cfg.i_cross_keep;
+  }
+
+  if (!have_e) {
+    state.integral *= cfg.i_deadband_keep;
+  } else if (fabsf(e) <= cfg.i_active_band_lph) {
+    state.integral += e * cfg.dt_s;
+  } else {
+    state.integral *= cfg.i_large_err_keep;
+  }
+
+  if (state.integral < cfg.i_min) state.integral = cfg.i_min;
+  if (state.integral > cfg.i_max) state.integral = cfg.i_max;
+  state.last_error = e;
+
+  float u = input.kp * e + input.ki * state.integral;
+  const float u_limit =
+      ((e >= 0.0f) ? cfg.u_up_per_s : cfg.u_down_per_s) * cfg.dt_s;
+  if (u < -u_limit) u = -u_limit;
+  if (u > u_limit) u = u_limit;
+
+  pwm_local = (int) roundf((float) pwm_local - u);
+  pwm_local = clamp_ipwm(pwm_local, cfg.min_ipwm, cfg.max_ipwm);
+
+  int next_last_good_pwm = input.last_good_pwm;
+  const float target_error = input.setpoint_lph - input.flow_lph;
+  if (fabsf(target_error) < cfg.stable_err_lph) {
+    state.stable_count++;
+  } else {
+    state.stable_count = 0;
+  }
+
+  if (state.stable_count >= cfg.stable_time_ticks) {
+    if (abs(next_last_good_pwm - pwm_local) >= cfg.good_pwm_step) {
+      next_last_good_pwm = pwm_local;
+    }
+    state.stable_count = cfg.stable_time_ticks;
+  }
+
+  return AutoPiResult{
+      pwm_local,
+      state,
+      false,
+      next_last_good_pwm,
+  };
+}
+
+}  // namespace oq_flow_control

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -48,7 +48,7 @@ globals:
   - id: oq_flow_last_mode
     type: int
     restore_value: false
-    initial_value: '0'   # 0=AUTO, 1=MANUAL, 2=FROST
+    initial_value: '0'   # 0=NON_FROST, 2=FROST
   - id: oq_flow_last_good_pwm
     type: int
     # persistent: learned_value - remembers the last stable AUTO seed across reboots.
@@ -336,8 +336,9 @@ interval:
           // Priority (highest -> lowest):
           // 1) CM0 early return (no writes from this loop)
           // 2) AUTOTUNE override (CM100 commissioning task only)
-          // 3) MANUAL / FROST fixed iPWM
-          // 4) AUTO PI path (with startup-hold + failsafe)
+          // 3) CM98 frost fixed iPWM
+          // 4) MANUAL fixed iPWM
+          // 5) AUTO PI path (with startup-hold + failsafe)
           //
           // iPWM semantics:
           // - 50..850 = pump running (lower means harder)
@@ -362,26 +363,7 @@ interval:
           static float sp_f = NAN;
           static float last_pi_e = 0.0f;
 
-          // Explicit execution mode keeps the control flow readable and makes
-          // status publishing deterministic.
-          enum FlowExecMode {
-            FLOW_MODE_CM0 = 0,
-            FLOW_MODE_AUTOTUNE = 1,
-            FLOW_MODE_MANUAL = 2,
-            FLOW_MODE_FROST = 3,
-            FLOW_MODE_AUTO_STARTING = 4,
-            FLOW_MODE_AUTO = 5,
-            FLOW_MODE_AUTO_FAILSAFE = 6
-          };
-
           // --- helpers ---
-          auto clamp_iPWM = [](int value) -> int {
-            constexpr int kMinIpwm = 50;
-            constexpr int kMaxIpwm = 850;
-            if (value < kMinIpwm) return kMinIpwm;
-            if (value > kMaxIpwm) return kMaxIpwm;
-            return value;
-          };
           auto write_pump_pwm_if_changed = [](auto *num, int value) {
             if (num == nullptr) return;
             const float cur = num->state;
@@ -391,145 +373,93 @@ interval:
               c.perform();
             }
           };
-          // Common AUTO-entry init used for CM0->* and MANUAL->AUTO edges.
-          auto start_auto_transition = [&](const char *tag) {
-            int fallback = (int) roundf(id(oq_flow_auto_start_pwm).state);
-            fallback = clamp_iPWM(fallback);
-
-            const int cm_code = id(oq_control_mode_code);
-            const bool commissioning_start = (cm_code == 100) && (id(oq_commissioning_task_code) != 0);
-            int start_pwm = commissioning_start
-              ? clamp_iPWM(id(oq_flow_commissioning_start_pwm))
-              : (int) id(oq_flow_last_good_pwm);
-            if (!commissioning_start && (start_pwm < 50 || start_pwm > 850)) start_pwm = fallback;
-
-            ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d fallback=%d commissioning=%s hold %ds, fixed iPWM)",
-                     tag, start_pwm, (int)id(oq_flow_last_good_pwm), fallback, commissioning_start ? "yes" : "no", STARTUP_HOLD_S);
-
-            id(oq_flow_last_pwm) = start_pwm;
-            id(oq_flow_i) = 0.0f;
-            startup_hold = STARTUP_HOLD_TICKS;
-            sp_f = NAN;
-            last_pi_e = 0.0f;
-            stable_cnt = 0;
+          auto current_auto_state = [&]() -> oq_flow_control::AutoPiState {
+            return oq_flow_control::AutoPiState{
+              id(oq_flow_i),
+              sp_f,
+              last_pi_e,
+              startup_hold,
+              stable_cnt,
+            };
           };
-          // AUTO PI path only: setpoint ramp, PI, startup-hold, and last_good tracking.
-          auto run_auto_pi = [&](int pwm_seed) -> int {
-            int pwm_local = pwm_seed;
-            float sp_target = id(oq_flow_setpoint_lph).state;
-            float pv = id(flow_rate_selected).state;
-
-            // Treat 0 L/h as a valid measurement (no-flow state), not as sensor failure.
-            // This prevents an AUTO(start) deadlock where PI would stay in failsafe and never build flow.
-            const bool flow_signal_valid = !isnan(pv);
-            pi_failsafe = (isnan(sp_target) || sp_target <= 0.0f || !flow_signal_valid);
-
-            if (pi_failsafe) {
-              constexpr int kFailsafeIpwm = 850;
-              pwm_local = kFailsafeIpwm;
-              ESP_LOGW("flow", "Flow PI failsafe engaged: sp=%0.1f pv=%0.1f -> forcing iPWM=%d", sp_target, pv, kFailsafeIpwm);
-              id(oq_flow_i) = 0.0f;
-              last_pi_e = 0.0f;
-              stable_cnt = 0;
-              sp_f = NAN;
-              return pwm_local;
-            }
-
-            const bool in_startup_hold = (startup_hold > 0);
-            if (in_startup_hold) {
-              // True startup settle: keep iPWM fixed for a short hydraulic delay window.
-              // Keep SP filter aligned to PV so PI starts without a large instantaneous kick.
-              sp_f = pv;
-              startup_hold--;
-              stable_cnt = 0;
-              return clamp_iPWM(pwm_local);
-            }
-
-            const float sp_ramp_up = 25.0f;   // L/h per second up
-            const float sp_ramp_dn = 15.0f;   // L/h per second down
-            if (isnan(sp_f)) sp_f = flow_signal_valid ? pv : sp_target;
-
-            float d = sp_target - sp_f;
-            float max_step = ((d >= 0.0f) ? sp_ramp_up : sp_ramp_dn) * dt;
-            if (d >  max_step) d =  max_step;
-            if (d < -max_step) d = -max_step;
-            sp_f += d;
-
-            float e = sp_f - pv;  // positive => more flow needed
-
-            constexpr float deadband_lph = 10.0f;
-            if (fabsf(e) < deadband_lph) e = 0.0f;
-
-            const float kp = id(oq_flow_kp).state;
-            const float ki = id(oq_flow_ki).state;
-
-            // Anti-windup:
-            // - keep I inactive during large setpoint / plant transients
-            // - quickly bleed stored I when we cross the setpoint
-            // - slowly unwind I inside the deadband so it cannot keep pushing past target
-            constexpr float i_active_band_lph = 60.0f;
-            constexpr float i_cross_keep = 0.25f;
-            constexpr float i_deadband_keep = 0.60f;
-            constexpr float i_large_err_keep = 0.35f;
-            const bool have_e = (e > 0.0f) || (e < 0.0f);
-            const bool have_last_e = (last_pi_e > 0.0f) || (last_pi_e < 0.0f);
-            const bool sign_flip = have_e && have_last_e && ((e > 0.0f) != (last_pi_e > 0.0f));
-
-            if (sign_flip) {
-              id(oq_flow_i) *= i_cross_keep;
-            }
-
-            if (!have_e) {
-              id(oq_flow_i) *= i_deadband_keep;
-            } else if (fabsf(e) <= i_active_band_lph) {
-              id(oq_flow_i) += e * dt;
-            } else {
-              id(oq_flow_i) *= i_large_err_keep;
-            }
-
-            id(oq_flow_i) = fmaxf(-4000.0f, fminf(4000.0f, id(oq_flow_i)));
-            last_pi_e = e;
-
-            float u = kp * e + ki * id(oq_flow_i);
-            // Asymmetric action limit: allow faster "pump harder" corrections (u_up)
-            // than "pump softer" corrections (u_down) to recover low-flow sooner.
-            const float u_up_s = 12.0f;
-            const float u_down_s = 8.0f;
-            const float u_up = u_up_s * dt;
-            const float u_down = u_down_s * dt;
-            const float u_lim = (e >= 0.0f) ? u_up : u_down;
-            u = fmaxf(-u_lim, fminf(u_lim, u));
-
-            pwm_local = (int) roundf((float)pwm_local - u);
-            pwm_local = clamp_iPWM(pwm_local);
-
-            const float stable_err_lph = 15.0f;
-            constexpr int stable_time_s = 60;
-            const int stable_time_ticks = (stable_time_s <= 0) ? 0 : (int) roundf((float)stable_time_s / dt);
-            constexpr int good_pwm_step = 10;
-
-            if (startup_hold <= 0 && !pi_failsafe) {
-              const float e_target = sp_target - pv;
-              if (fabsf(e_target) < stable_err_lph) {
-                stable_cnt++;
-              } else {
-                stable_cnt = 0;
-              }
-
-              if (stable_cnt >= stable_time_ticks) {
-                const int prev = id(oq_flow_last_good_pwm);
-                if (abs(prev - pwm_local) >= good_pwm_step) {
-                  id(oq_flow_last_good_pwm) = pwm_local;
-                }
-                stable_cnt = stable_time_ticks;
-              }
-            } else {
-              stable_cnt = 0;
-            }
-            return pwm_local;
+          auto apply_auto_state = [&](const oq_flow_control::AutoPiState &state) {
+            id(oq_flow_i) = state.integral;
+            sp_f = state.setpoint_filtered;
+            last_pi_e = state.last_error;
+            startup_hold = state.startup_hold;
+            stable_cnt = state.stable_count;
+          };
+          const oq_flow_control::AutoPiConfig auto_pi_cfg{
+            dt,
+            50,
+            850,
+            850,
+            25.0f,
+            15.0f,
+            10.0f,
+            60.0f,
+            0.25f,
+            0.60f,
+            0.35f,
+            -4000.0f,
+            4000.0f,
+            12.0f,
+            8.0f,
+            15.0f,
+            (int) roundf(60.0f / dt),
+            10,
           };
 
           const int cm_code = id(oq_control_mode_code);
+          const int commissioning_task_code = id(oq_commissioning_task_code);
+
+          // Common AUTO-entry init used for CM0->* and MANUAL->AUTO edges.
+          auto start_auto_transition = [&](const char *tag) {
+            const auto start_plan = oq_flow_control::compute_auto_start_plan(
+              cm_code,
+              commissioning_task_code,
+              id(oq_flow_commissioning_start_pwm),
+              (int) id(oq_flow_last_good_pwm),
+              (int) roundf(id(oq_flow_auto_start_pwm).state));
+            ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d fallback=%d commissioning=%s hold %ds, fixed iPWM)",
+                     tag,
+                     start_plan.start_pwm,
+                     (int) id(oq_flow_last_good_pwm),
+                     start_plan.fallback_pwm,
+                     start_plan.commissioning_start ? "yes" : "no",
+                     STARTUP_HOLD_S);
+
+            id(oq_flow_last_pwm) = start_plan.start_pwm;
+            apply_auto_state(
+              oq_flow_control::enter_auto_transition(STARTUP_HOLD_TICKS));
+          };
+          auto run_auto_pi = [&](int pwm_seed) -> int {
+            const auto pi_result = oq_flow_control::step_auto_pi(
+              current_auto_state(),
+              oq_flow_control::AutoPiInput{
+                pwm_seed,
+                id(oq_flow_setpoint_lph).state,
+                id(flow_rate_selected).state,
+                id(oq_flow_kp).state,
+                id(oq_flow_ki).state,
+                (int) id(oq_flow_last_good_pwm),
+              },
+              auto_pi_cfg);
+
+            pi_failsafe = pi_result.failsafe;
+            apply_auto_state(pi_result.state);
+            id(oq_flow_last_good_pwm) = pi_result.last_good_pwm;
+
+            if (pi_result.failsafe) {
+              ESP_LOGW("flow", "Flow PI failsafe engaged: sp=%0.1f pv=%0.1f -> forcing iPWM=%d",
+                       id(oq_flow_setpoint_lph).state,
+                       id(flow_rate_selected).state,
+                       pi_result.pwm);
+              return pi_result.pwm;
+            }
+            return pi_result.pwm;
+          };
+
           const bool is_cm0 = (cm_code == 0);
 
           // Flow submode select (within CM1/CM2/CM3): AUTO vs MANUAL PWM
@@ -537,6 +467,11 @@ interval:
           id(oq_flow_control_mode_code) = flow_mode_code;
           const bool want_manual = (flow_mode_code == 1);
           static bool was_manual = false;
+          const auto route = oq_flow_control::select_route(
+            cm_code,
+            want_manual,
+            id(oq_flow_autotune_active),
+            commissioning_task_code);
 
           // Edge 1: entering active control from CM0
           if (was_cm0 && !is_cm0) {
@@ -544,27 +479,22 @@ interval:
           }
           was_cm0 = is_cm0;
 
-          if (is_cm0) {
+          if (route.early_return) {
             // Keep manual-edge memory synchronized while idle.
             was_manual = want_manual;
-            id(oq_flow_mode).publish_state("CM0");
+            id(oq_flow_mode).publish_state(route.mode_text);
             return;
           }
 
-          const bool is_frost = (cm_code == 98);
-
-          int mode = is_frost ? 2 : 0; // 0=AUTO, 2=FROST
-          if (mode != id(oq_flow_last_mode)) {
-            id(oq_flow_i) = 0.0f;
-            sp_f = NAN;
-            last_pi_e = 0.0f;
-            stable_cnt = 0;
+          if (route.runtime_mode_state_code != id(oq_flow_last_mode)) {
+            apply_auto_state(
+              oq_flow_control::reset_pi_tracking_keep_hold(current_auto_state()));
           }
-          id(oq_flow_last_mode) = mode;
+          id(oq_flow_last_mode) = route.runtime_mode_state_code;
 
           // Autotune temporarily overrides PWM (flow_control remains output owner).
-          if (id(oq_flow_autotune_active) && (cm_code == 100) && (id(oq_commissioning_task_code) == 2) && !is_frost) {
-            int at_pwm = clamp_iPWM((int) id(oq_flow_autotune_pwm));
+          if (route.route_kind == oq_flow_control::ROUTE_AUTOTUNE) {
+            int at_pwm = oq_flow_control::clamp_ipwm((int) id(oq_flow_autotune_pwm));
             id(oq_flow_last_pwm) = at_pwm;
             stable_cnt = 0;
             pi_failsafe = false;
@@ -572,9 +502,9 @@ interval:
             if (${flow_secondary_enabled} != 0) {
               write_pump_pwm_if_changed(id(${flow_secondary_pump_speed_id}), at_pwm);
             }
-            if (last_mode != "AUTOTUNE") {
-              id(oq_flow_mode).publish_state("AUTOTUNE");
-              last_mode = "AUTOTUNE";
+            if (last_mode != route.mode_text) {
+              id(oq_flow_mode).publish_state(route.mode_text);
+              last_mode = route.mode_text;
             }
             return;
           }
@@ -585,37 +515,31 @@ interval:
           }
           was_manual = want_manual;
 
-          int pwm = clamp_iPWM((int) id(oq_flow_last_pwm));
-          FlowExecMode exec_mode = FLOW_MODE_AUTO;
+          int pwm = oq_flow_control::clamp_ipwm((int) id(oq_flow_last_pwm));
+          oq_flow_control::ExecMode exec_mode = oq_flow_control::EXEC_MODE_AUTO;
 
           // Fixed-output modes first, AUTO PI as fallback.
-          if (want_manual && !is_frost) {
+          if (route.route_kind == oq_flow_control::ROUTE_MANUAL) {
             pwm = (int) roundf(id(oq_flow_manual_pwm).state);
-            pwm = clamp_iPWM(pwm);
+            pwm = oq_flow_control::clamp_ipwm(pwm);
             stable_cnt = 0;
             pi_failsafe = false;
             sp_f = NAN;
             last_pi_e = 0.0f;
-            exec_mode = FLOW_MODE_MANUAL;
-          } else if (is_frost) {
+            exec_mode = oq_flow_control::finalize_exec_mode(route, false, startup_hold);
+          } else if (route.route_kind == oq_flow_control::ROUTE_FROST) {
             pwm = (int) roundf(id(oq_flow_frost_pwm).state);
-            pwm = clamp_iPWM(pwm);
+            pwm = oq_flow_control::clamp_ipwm(pwm);
             stable_cnt = 0;
             pi_failsafe = false;
             last_pi_e = 0.0f;
-            exec_mode = FLOW_MODE_FROST;
+            exec_mode = oq_flow_control::finalize_exec_mode(route, false, startup_hold);
           } else {
             pwm = run_auto_pi(pwm);
-            if (pi_failsafe) {
-              exec_mode = FLOW_MODE_AUTO_FAILSAFE;
-            } else if (startup_hold > 0) {
-              exec_mode = FLOW_MODE_AUTO_STARTING;
-            } else {
-              exec_mode = FLOW_MODE_AUTO;
-            }
+            exec_mode = oq_flow_control::finalize_exec_mode(route, pi_failsafe, startup_hold);
           }
 
-          pwm = clamp_iPWM(pwm);
+          pwm = oq_flow_control::clamp_ipwm(pwm);
           id(oq_flow_last_pwm) = pwm;
 
           write_pump_pwm_if_changed(id(hp1_pump_speed), pwm);
@@ -624,14 +548,7 @@ interval:
           }
 
           // External mode text has explicit priority and updates only on change.
-          std::string mode_txt;
-          switch (exec_mode) {
-            case FLOW_MODE_FROST: mode_txt = "CM98"; break;
-            case FLOW_MODE_MANUAL: mode_txt = "MANUAL"; break;
-            case FLOW_MODE_AUTO_FAILSAFE: mode_txt = "AUTO (failsafe)"; break;
-            case FLOW_MODE_AUTO_STARTING: mode_txt = "AUTO (starting)"; break;
-            default: mode_txt = "AUTO"; break;
-          }
+          const std::string mode_txt = oq_flow_control::exec_mode_text(exec_mode);
           if (mode_txt != last_mode) {
             id(oq_flow_mode).publish_state(mode_txt.c_str());
             ESP_LOGI("flow", "Flow mode changed: %s (cm=%s manual=%d failsafe=%d hold=%d pwm=%d)",

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -28,6 +28,7 @@ oq_cic_compatibility_protocol_header: "openquatt/includes/oq_cic_compatibility_p
 oq_supervisory_logic_header: "openquatt/includes/oq_supervisory_logic.h" # Shared supervisory helpers for CM naming and pure policy decisions.
 oq_thermal_guard_logic_header: "openquatt/includes/oq_thermal_guard_logic.h" # Shared thermal guard helper seam for guarded-request shaping.
 oq_commissioning_logic_header: "openquatt/includes/oq_commissioning_logic.h" # Shared commissioning/task helper seam for task codes and abort routing.
+oq_flow_control_logic_header: "openquatt/includes/oq_flow_control_logic.h" # Shared flow-control helper seam for route selection and pure PI math.
 oq_flow_autotune_logic_header: "openquatt/includes/oq_flow_autotune_logic.h" # Shared autotune helper seam for state names and pure validation math.
 oq_boiler_task_logic_header: "openquatt/includes/oq_boiler_task_logic.h" # Shared boiler-task helper seam for settle/measurement/result math.
 oq_timezone: "Europe/Amsterdam"                         # SNTP timezone used by runtime timestamps.

--- a/openquatt_base_common.yaml
+++ b/openquatt_base_common.yaml
@@ -27,6 +27,7 @@ esphome:
     - ${oq_supervisory_logic_header}
     - ${oq_thermal_guard_logic_header}
     - ${oq_commissioning_logic_header}
+    - ${oq_flow_control_logic_header}
     - ${oq_flow_autotune_logic_header}
     - ${oq_boiler_task_logic_header}
   platformio_options:

--- a/scripts/simulate_thermal_refactor_regressions.py
+++ b/scripts/simulate_thermal_refactor_regressions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from dataclasses import asdict, dataclass
 from typing import Sequence
@@ -99,6 +100,191 @@ class FlowValidationSettleResult:
     status: str
     confirm_cnt: int
     peak_pv: float
+
+
+@dataclass(frozen=True)
+class FlowControlRouteResult:
+    mode: str
+    writes_pwm: bool
+    source: str
+
+
+@dataclass(frozen=True)
+class FlowAutoStartResult:
+    start_pwm: int
+    fallback_pwm: int
+    commissioning_start: bool
+
+
+@dataclass(frozen=True)
+class FlowAutoPiState:
+    integral: float = 0.0
+    setpoint_filtered: float | None = None
+    last_error: float = 0.0
+    startup_hold: int = 0
+    stable_count: int = 0
+
+
+@dataclass(frozen=True)
+class FlowAutoPiResult:
+    pwm: int
+    state: FlowAutoPiState
+    failsafe: bool
+    last_good_pwm: int
+
+
+def clamp_ipwm(value: int, min_ipwm: int = 50, max_ipwm: int = 850) -> int:
+    return max(min_ipwm, min(max_ipwm, value))
+
+
+def flow_control_route_result(
+    *,
+    cm_code: int,
+    want_manual: bool,
+    autotune_active: bool,
+    commissioning_task_code: int,
+    pi_failsafe: bool = False,
+    startup_hold_after_tick: int = 0,
+) -> FlowControlRouteResult:
+    if cm_code == 0:
+        return FlowControlRouteResult("CM0", False, "supervisory_cm0_policy")
+
+    is_frost = cm_code == 98
+    if autotune_active and cm_code == 100 and commissioning_task_code == 2 and not is_frost:
+        return FlowControlRouteResult("AUTOTUNE", True, "oq_flow_autotune_pwm")
+
+    if is_frost:
+        return FlowControlRouteResult("CM98", True, "oq_flow_frost_pwm")
+
+    if want_manual:
+        return FlowControlRouteResult("MANUAL", True, "oq_flow_manual_pwm")
+
+    if pi_failsafe:
+        return FlowControlRouteResult("AUTO (failsafe)", True, "auto_failsafe_850")
+
+    if startup_hold_after_tick > 0:
+        return FlowControlRouteResult("AUTO (starting)", True, "auto_start_hold_pwm")
+
+    return FlowControlRouteResult("AUTO", True, "auto_pi")
+
+
+def flow_auto_start_result(
+    *,
+    control_mode_code: int,
+    commissioning_task_code: int,
+    commissioning_start_pwm: int,
+    last_good_pwm: int,
+    fallback_pwm: int,
+) -> FlowAutoStartResult:
+    fallback = clamp_ipwm(fallback_pwm)
+    commissioning_start = control_mode_code == 100 and commissioning_task_code != 0
+    start_pwm = clamp_ipwm(commissioning_start_pwm) if commissioning_start else last_good_pwm
+    if not commissioning_start and not (50 <= start_pwm <= 850):
+        start_pwm = fallback
+    return FlowAutoStartResult(start_pwm, fallback, commissioning_start)
+
+
+def flow_auto_pi_result(
+    *,
+    state: FlowAutoPiState,
+    pwm_seed: int,
+    setpoint_lph: float | None,
+    flow_lph: float | None,
+    kp: float,
+    ki: float,
+    last_good_pwm: int,
+    dt_s: float = 5.0,
+) -> FlowAutoPiResult:
+    failsafe = (
+        setpoint_lph is None
+        or setpoint_lph <= 0.0
+        or flow_lph is None
+        or math.isnan(setpoint_lph)
+        or math.isnan(flow_lph)
+    )
+    if failsafe:
+        return FlowAutoPiResult(
+            pwm=850,
+            state=FlowAutoPiState(
+                integral=0.0,
+                setpoint_filtered=None,
+                last_error=0.0,
+                startup_hold=state.startup_hold,
+                stable_count=0,
+            ),
+            failsafe=True,
+            last_good_pwm=last_good_pwm,
+        )
+
+    if state.startup_hold > 0:
+        return FlowAutoPiResult(
+            pwm=clamp_ipwm(pwm_seed),
+            state=FlowAutoPiState(
+                integral=state.integral,
+                setpoint_filtered=flow_lph,
+                last_error=state.last_error,
+                startup_hold=state.startup_hold - 1,
+                stable_count=0,
+            ),
+            failsafe=False,
+            last_good_pwm=last_good_pwm,
+        )
+
+    sp_f = flow_lph if state.setpoint_filtered is None else state.setpoint_filtered
+    delta = setpoint_lph - sp_f
+    max_step = (25.0 if delta >= 0.0 else 15.0) * dt_s
+    if delta > max_step:
+        delta = max_step
+    if delta < -max_step:
+        delta = -max_step
+    sp_f += delta
+
+    error = sp_f - flow_lph
+    if abs(error) < 10.0:
+        error = 0.0
+
+    integral = state.integral
+    have_error = error > 0.0 or error < 0.0
+    have_last_error = state.last_error > 0.0 or state.last_error < 0.0
+    sign_flip = have_error and have_last_error and ((error > 0.0) != (state.last_error > 0.0))
+
+    if sign_flip:
+        integral *= 0.25
+
+    if not have_error:
+        integral *= 0.60
+    elif abs(error) <= 60.0:
+        integral += error * dt_s
+    else:
+        integral *= 0.35
+
+    integral = max(-4000.0, min(4000.0, integral))
+
+    control = (kp * error) + (ki * integral)
+    limit = (12.0 if error >= 0.0 else 8.0) * dt_s
+    control = max(-limit, min(limit, control))
+
+    pwm = clamp_ipwm(round(pwm_seed - control))
+    stable_count = state.stable_count + 1 if abs(setpoint_lph - flow_lph) < 15.0 else 0
+    stable_time_ticks = round(60.0 / dt_s)
+    next_last_good_pwm = last_good_pwm
+    if stable_count >= stable_time_ticks:
+        if abs(next_last_good_pwm - pwm) >= 10:
+            next_last_good_pwm = pwm
+        stable_count = stable_time_ticks
+
+    return FlowAutoPiResult(
+        pwm=pwm,
+        state=FlowAutoPiState(
+            integral=integral,
+            setpoint_filtered=sp_f,
+            last_error=error,
+            startup_hold=state.startup_hold,
+            stable_count=stable_count,
+        ),
+        failsafe=False,
+        last_good_pwm=next_last_good_pwm,
+    )
 
 
 def commissioning_cm100_start_result(
@@ -2065,6 +2251,194 @@ def run_scenarios() -> list[ScenarioResult]:
             f"{supervisory_pump_on(100, commissioning_task_active=False, sticky_active=False, any_hp_active_guard=False)}, "
             f"{supervisory_pump_on(100, commissioning_task_active=True, sticky_active=False, any_hp_active_guard=False)}"
         ),
+    )
+    flow_cm0 = flow_control_route_result(
+        cm_code=0,
+        want_manual=True,
+        autotune_active=True,
+        commissioning_task_code=2,
+    )
+    add(
+        "Flow control CM0 is a hard early return with no pump iPWM write",
+        flow_cm0.mode == "CM0" and not flow_cm0.writes_pwm,
+        f"flow_control_route_result(...) -> {flow_cm0}",
+    )
+    flow_autotune_manual = flow_control_route_result(
+        cm_code=100,
+        want_manual=True,
+        autotune_active=True,
+        commissioning_task_code=2,
+    )
+    add(
+        "Flow control AUTOTUNE override wins over manual during CM100 task 2",
+        flow_autotune_manual.mode == "AUTOTUNE"
+        and flow_autotune_manual.writes_pwm
+        and flow_autotune_manual.source == "oq_flow_autotune_pwm",
+        f"flow_control_route_result(...) -> {flow_autotune_manual}",
+    )
+    flow_frost_manual = flow_control_route_result(
+        cm_code=98,
+        want_manual=True,
+        autotune_active=True,
+        commissioning_task_code=2,
+    )
+    add(
+        "Flow control CM98 frost fixed PWM has priority over manual selection",
+        flow_frost_manual.mode == "CM98"
+        and flow_frost_manual.source == "oq_flow_frost_pwm",
+        f"flow_control_route_result(...) -> {flow_frost_manual}",
+    )
+    stale_autotune = flow_control_route_result(
+        cm_code=100,
+        want_manual=False,
+        autotune_active=True,
+        commissioning_task_code=0,
+    )
+    add(
+        "Flow control ignores stale autotune-active state outside task 2",
+        stale_autotune.mode == "AUTO" and stale_autotune.source == "auto_pi",
+        f"flow_control_route_result(...) -> {stale_autotune}",
+    )
+    auto_status_priority = flow_control_route_result(
+        cm_code=2,
+        want_manual=False,
+        autotune_active=False,
+        commissioning_task_code=0,
+        pi_failsafe=True,
+        startup_hold_after_tick=3,
+    )
+    add(
+        "Flow control AUTO failsafe status has priority over startup-hold status",
+        auto_status_priority.mode == "AUTO (failsafe)"
+        and auto_status_priority.source == "auto_failsafe_850",
+        f"flow_control_route_result(...) -> {auto_status_priority}",
+    )
+    auto_starting = flow_control_route_result(
+        cm_code=2,
+        want_manual=False,
+        autotune_active=False,
+        commissioning_task_code=0,
+        startup_hold_after_tick=3,
+    )
+    add(
+        "Flow control AUTO startup status is published while hold remains after the tick",
+        auto_starting.mode == "AUTO (starting)"
+        and auto_starting.source == "auto_start_hold_pwm",
+        f"flow_control_route_result(...) -> {auto_starting}",
+    )
+    normal_auto_start = flow_auto_start_result(
+        control_mode_code=2,
+        commissioning_task_code=0,
+        commissioning_start_pwm=400,
+        last_good_pwm=999,
+        fallback_pwm=440,
+    )
+    add(
+        "Flow control normal AUTO start falls back to configured start PWM when last_good is invalid",
+        normal_auto_start.start_pwm == 440
+        and normal_auto_start.fallback_pwm == 440
+        and not normal_auto_start.commissioning_start,
+        f"flow_auto_start_result(...) -> {normal_auto_start}",
+    )
+    commissioning_auto_start = flow_auto_start_result(
+        control_mode_code=100,
+        commissioning_task_code=1,
+        commissioning_start_pwm=20,
+        last_good_pwm=430,
+        fallback_pwm=500,
+    )
+    add(
+        "Flow control commissioning AUTO start uses the commissioning seed and clamps it into iPWM range",
+        commissioning_auto_start.start_pwm == 50
+        and commissioning_auto_start.commissioning_start,
+        f"flow_auto_start_result(...) -> {commissioning_auto_start}",
+    )
+    auto_pi_failsafe = flow_auto_pi_result(
+        state=FlowAutoPiState(
+            integral=120.0,
+            setpoint_filtered=700.0,
+            last_error=25.0,
+            startup_hold=3,
+            stable_count=4,
+        ),
+        pwm_seed=420,
+        setpoint_lph=None,
+        flow_lph=650.0,
+        kp=0.03,
+        ki=0.0008,
+        last_good_pwm=440,
+    )
+    add(
+        "Flow control AUTO PI failsafe resets PI memory but preserves the remaining startup hold",
+        auto_pi_failsafe.failsafe
+        and auto_pi_failsafe.pwm == 850
+        and auto_pi_failsafe.state.integral == 0.0
+        and auto_pi_failsafe.state.setpoint_filtered is None
+        and auto_pi_failsafe.state.startup_hold == 3
+        and auto_pi_failsafe.state.stable_count == 0,
+        f"flow_auto_pi_result(...) -> {auto_pi_failsafe}",
+    )
+    auto_pi_start_hold = flow_auto_pi_result(
+        state=FlowAutoPiState(
+            integral=0.0,
+            setpoint_filtered=None,
+            last_error=0.0,
+            startup_hold=2,
+            stable_count=5,
+        ),
+        pwm_seed=430,
+        setpoint_lph=800.0,
+        flow_lph=520.0,
+        kp=0.03,
+        ki=0.0008,
+        last_good_pwm=440,
+    )
+    add(
+        "Flow control AUTO startup hold keeps the seed PWM, aligns the SP filter to PV and counts down",
+        not auto_pi_start_hold.failsafe
+        and auto_pi_start_hold.pwm == 430
+        and auto_pi_start_hold.state.setpoint_filtered == 520.0
+        and auto_pi_start_hold.state.startup_hold == 1
+        and auto_pi_start_hold.state.stable_count == 0,
+        f"flow_auto_pi_result(...) -> {auto_pi_start_hold}",
+    )
+    auto_pi_zero_flow = flow_auto_pi_result(
+        state=FlowAutoPiState(),
+        pwm_seed=400,
+        setpoint_lph=800.0,
+        flow_lph=0.0,
+        kp=1.0,
+        ki=0.0008,
+        last_good_pwm=440,
+    )
+    add(
+        "Flow control treats 0 L/h as a valid AUTO PI measurement rather than a sensor-failsafe input",
+        not auto_pi_zero_flow.failsafe
+        and auto_pi_zero_flow.pwm == 340
+        and auto_pi_zero_flow.state.last_error == 125.0,
+        f"flow_auto_pi_result(...) -> {auto_pi_zero_flow}",
+    )
+    auto_pi_last_good = flow_auto_pi_result(
+        state=FlowAutoPiState(
+            integral=0.0,
+            setpoint_filtered=790.0,
+            last_error=0.0,
+            startup_hold=0,
+            stable_count=11,
+        ),
+        pwm_seed=410,
+        setpoint_lph=800.0,
+        flow_lph=798.0,
+        kp=0.03,
+        ki=0.0008,
+        last_good_pwm=440,
+    )
+    add(
+        "Flow control updates last_good_pwm only after the stable-flow window closes",
+        not auto_pi_last_good.failsafe
+        and auto_pi_last_good.last_good_pwm == 410
+        and auto_pi_last_good.state.stable_count == 12,
+        f"flow_auto_pi_result(...) -> {auto_pi_last_good}",
     )
     cm100_start = commissioning_cm100_start_result(
         override_auto=True,


### PR DESCRIPTION
## Summary
- add a tracked phase-8 flow-control contract and document the explicit mode/output priority
- centralize flow route selection, AUTO start seed logic and pure AUTO PI/failsafe math in `oq_flow_control_logic.h`
- reduce `oq_flow_control.yaml` to clearer runtime state, writes, logging and publication glue while extending regression anchors

## Validation
- `uv run python scripts/simulate_thermal_refactor_regressions.py`
- `uv run python scripts/check_style_consistency.py`
- `uv run python scripts/check_docs_consistency.py`
- `./scripts/validate_local.sh`