### PR TITLE
Address factory repair review feedback

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -657,8 +657,6 @@ def validate_command(args: argparse.Namespace) -> int:
                             check=False,
                             heartbeat_label=label,
                         )
-                        if exit_code == 0:
-                            return config, exit_code, log_path
                         tail = tail_lines(log_path, limit=160)
 
                 if cache_race:

--- a/scripts/repair_factory_bin.py
+++ b/scripts/repair_factory_bin.py
@@ -82,9 +82,17 @@ def infer_role(offset: int, path: Path) -> str:
         return "partition-table"
     if offset in (0xE000, 0xF000) or "ota_data" in name:
         return "otadata"
-    if offset >= 0x10000 and is_app_image_name(name):
+    if offset >= 0x10000 and has_esp_image_magic(path):
         return "app"
     return ""
+
+
+def has_esp_image_magic(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            return handle.read(1) == bytes([ESP_IMAGE_MAGIC])
+    except OSError:
+        return False
 
 
 def is_app_image_name(name: str) -> bool:

--- a/scripts/repair_factory_bin.py
+++ b/scripts/repair_factory_bin.py
@@ -68,9 +68,7 @@ def fallback_candidates(raw_path: str, build_dir: Path, role: str, offset: int) 
         )
     if role == "otadata":
         candidates.append(build_dir / "ota_data_initial.bin")
-    if role == "app":
-        candidates.append(build_dir / "firmware.bin")
-    if not role and offset >= 0x10000:
+    if role == "app" or (not role and is_app_image_name(raw_name)):
         candidates.append(build_dir / "firmware.bin")
 
     return candidates
@@ -84,9 +82,14 @@ def infer_role(offset: int, path: Path) -> str:
         return "partition-table"
     if offset in (0xE000, 0xF000) or "ota_data" in name:
         return "otadata"
-    if name.endswith(".bin") and offset >= 0x10000:
+    if offset >= 0x10000 and is_app_image_name(name):
         return "app"
     return ""
+
+
+def is_app_image_name(name: str) -> bool:
+    normalized = name.lower()
+    return normalized == "firmware.bin" or normalized.startswith("openquatt_")
 
 
 def resolve_flash_file(raw_path: str, build_dir: Path, role: str, offset: int) -> Path:

--- a/scripts/repair_factory_bin.py
+++ b/scripts/repair_factory_bin.py
@@ -9,7 +9,12 @@ from typing import Iterable
 ESP_IMAGE_MAGIC = 0xE9
 PARTITION_TABLE_MAGIC = b"\xaa\x50"
 
-ROLE_ORDER = ("bootloader", "partition-table", "otadata", "app")
+ROLE_KEYS = (
+    ("bootloader", ("bootloader",)),
+    ("partition-table", ("partition-table", "partition_table")),
+    ("otadata", ("otadata",)),
+    ("app", ("app",)),
+)
 
 
 class FactoryBinError(RuntimeError):
@@ -65,8 +70,23 @@ def fallback_candidates(raw_path: str, build_dir: Path, role: str, offset: int) 
         candidates.append(build_dir / "ota_data_initial.bin")
     if role == "app":
         candidates.append(build_dir / "firmware.bin")
+    if not role and offset >= 0x10000:
+        candidates.append(build_dir / "firmware.bin")
 
     return candidates
+
+
+def infer_role(offset: int, path: Path) -> str:
+    name = path.name.lower()
+    if offset in (0x0, 0x1000, 0x2000) or "bootloader" in name:
+        return "bootloader"
+    if offset == 0x8000 or "partition" in name or name == "partitions.bin":
+        return "partition-table"
+    if offset in (0xE000, 0xF000) or "ota_data" in name:
+        return "otadata"
+    if name.endswith(".bin") and offset >= 0x10000:
+        return "app"
+    return ""
 
 
 def resolve_flash_file(raw_path: str, build_dir: Path, role: str, offset: int) -> Path:
@@ -85,9 +105,12 @@ def collect_sections(build_dir: Path, flasher_args: dict) -> tuple[list[tuple[in
     sections: dict[int, Path] = {}
     role_offsets: dict[str, int] = {}
 
-    for role in ROLE_ORDER:
-        entry = flasher_args.get(role)
-        if not isinstance(entry, dict):
+    for role, metadata_keys in ROLE_KEYS:
+        entry = next(
+            (flasher_args[key] for key in metadata_keys if isinstance(flasher_args.get(key), dict)),
+            None,
+        )
+        if entry is None:
             continue
         offset = parse_offset(entry.get("offset", ""))
         raw_file = str(entry.get("file", "")).strip()
@@ -99,8 +122,15 @@ def collect_sections(build_dir: Path, flasher_args: dict) -> tuple[list[tuple[in
     for raw_offset, raw_file in flasher_args.get("flash_files", {}).items():
         offset = parse_offset(raw_offset)
         if offset in sections:
+            role = infer_role(offset, sections[offset])
+            if role and role not in role_offsets:
+                role_offsets[role] = offset
             continue
-        sections[offset] = resolve_flash_file(str(raw_file), build_dir, "", offset)
+        path = resolve_flash_file(str(raw_file), build_dir, "", offset)
+        sections[offset] = path
+        role = infer_role(offset, path)
+        if role and role not in role_offsets:
+            role_offsets[role] = offset
 
     if not sections:
         raise FactoryBinError(f"No flash sections found in {build_dir / 'flasher_args.json'}")


### PR DESCRIPTION
## Summary
- Derive bootloader, partition-table, otadata, and app roles from `flash_files` when top-level ESP-IDF metadata is absent.
- Accept both `partition-table` and ESP-IDF's `partition_table` metadata spelling for partition validation.
- Ensure local validation still runs factory repair after a successful efuse retry compile.

## Validation
- `python3 -m py_compile scripts/repair_factory_bin.py scripts/dev.py`
- `./scripts/validate_local.sh --config-only`
- Rebuilt flash-files-only and `partition_table` alias fixtures; verified bootloader/app/partition magic bytes.