### PR TITLE
Keep settings backup configuration in sync

### DIFF
--- a/openquatt/web/build-assets.mjs
+++ b/openquatt/web/build-assets.mjs
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { checkSettingsBackupConfig } from "./check-settings-backup.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -84,4 +85,5 @@ async function buildBundle(bundle) {
   console.log(`${bundle.label} bundle rebuilt: ${path.relative(__dirname, bundle.output)}`);
 }
 
+await checkSettingsBackupConfig();
 await Promise.all(bundles.map(buildBundle));

--- a/openquatt/web/check-settings-backup.mjs
+++ b/openquatt/web/check-settings-backup.mjs
@@ -1,0 +1,166 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_CONFIG_PATH = path.join(__dirname, "js", "src", "00-config.js");
+
+function formatList(values) {
+  return values.length ? values.join(", ") : "none";
+}
+
+function sorted(values) {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+function collectDuplicateBackupKeys(sections) {
+  const seen = new Map();
+  const duplicates = new Map();
+
+  sections.forEach((section) => {
+    section.keys.forEach((key) => {
+      const locations = seen.get(key) || [];
+      locations.push(section.id);
+      seen.set(key, locations);
+      if (locations.length > 1) {
+        duplicates.set(key, locations);
+      }
+    });
+  });
+
+  return sorted([...duplicates.entries()].map(([key, locations]) => `${key} (${locations.join(", ")})`));
+}
+
+function validateSectionShape(section) {
+  return section
+    && typeof section.id === "string"
+    && section.id.trim()
+    && typeof section.label === "string"
+    && section.label.trim()
+    && Array.isArray(section.keys);
+}
+
+async function loadConfig(configPath) {
+  const source = await readFile(configPath, "utf8");
+  const sandbox = {};
+  vm.runInNewContext(
+    `${source}
+
+globalThis.__settingsBackupCheckConfig = {
+  ENTITY_DEFS,
+  SETTINGS_KEYS,
+  SETTINGS_BACKUP_SECTIONS,
+  SETTINGS_BACKUP_KEYS,
+  SETTINGS_BACKUP_WRITABLE_DOMAINS: [...SETTINGS_BACKUP_WRITABLE_DOMAINS],
+  SETTINGS_BACKUP_EXPECTED_EXTRA_KEYS: [...SETTINGS_BACKUP_EXPECTED_EXTRA_KEYS],
+  SETTINGS_BACKUP_EXCLUDED_KEYS: [...SETTINGS_BACKUP_EXCLUDED_KEYS],
+};`,
+    sandbox,
+    { filename: configPath },
+  );
+  return sandbox.__settingsBackupCheckConfig;
+}
+
+export async function checkSettingsBackupConfig(configPath = DEFAULT_CONFIG_PATH) {
+  const config = await loadConfig(configPath);
+  const {
+    ENTITY_DEFS,
+    SETTINGS_KEYS,
+    SETTINGS_BACKUP_SECTIONS,
+    SETTINGS_BACKUP_KEYS,
+    SETTINGS_BACKUP_WRITABLE_DOMAINS,
+    SETTINGS_BACKUP_EXPECTED_EXTRA_KEYS,
+    SETTINGS_BACKUP_EXCLUDED_KEYS,
+  } = config;
+
+  const errors = [];
+  const entityDefs = ENTITY_DEFS || {};
+  const settingsKeys = SETTINGS_KEYS || [];
+  const backupSections = SETTINGS_BACKUP_SECTIONS || [];
+  const backupKeys = SETTINGS_BACKUP_KEYS || [];
+  const writableDomains = new Set(SETTINGS_BACKUP_WRITABLE_DOMAINS || []);
+  const expectedExtraKeys = new Set(SETTINGS_BACKUP_EXPECTED_EXTRA_KEYS || []);
+  const excludedKeys = new Set(SETTINGS_BACKUP_EXCLUDED_KEYS || []);
+  const backupKeySet = new Set(backupKeys);
+
+  const invalidSections = backupSections
+    .filter((section) => !validateSectionShape(section))
+    .map((section) => String(section?.id || section?.label || "<unknown>"));
+  if (invalidSections.length) {
+    errors.push(`invalid backup sections: ${formatList(invalidSections)}`);
+  }
+
+  const sectionIds = backupSections.map((section) => section.id);
+  const duplicateSectionIds = sorted(sectionIds.filter((id, index) => sectionIds.indexOf(id) !== index));
+  if (duplicateSectionIds.length) {
+    errors.push(`duplicate backup section ids: ${formatList(duplicateSectionIds)}`);
+  }
+
+  const duplicateBackupKeys = collectDuplicateBackupKeys(backupSections.filter(validateSectionShape));
+  if (duplicateBackupKeys.length) {
+    errors.push(`duplicate backup keys: ${formatList(duplicateBackupKeys)}`);
+  }
+
+  const flattenedBackupKeys = backupSections.flatMap((section) => section.keys || []);
+  const derivedBackupKeys = [...new Set(flattenedBackupKeys)];
+  if (derivedBackupKeys.length !== backupKeys.length || derivedBackupKeys.some((key) => !backupKeySet.has(key))) {
+    errors.push("SETTINGS_BACKUP_KEYS does not match SETTINGS_BACKUP_SECTIONS");
+  }
+
+  const settingsKeysWithoutEntity = sorted(settingsKeys.filter((key) => !entityDefs[key]));
+  if (settingsKeysWithoutEntity.length) {
+    errors.push(`settings keys without entity definition: ${formatList(settingsKeysWithoutEntity)}`);
+  }
+
+  const backupKeysWithoutEntity = sorted(backupKeys.filter((key) => !entityDefs[key]));
+  if (backupKeysWithoutEntity.length) {
+    errors.push(`backup keys without entity definition: ${formatList(backupKeysWithoutEntity)}`);
+  }
+
+  const expectedBackupKeys = new Set();
+  settingsKeys.forEach((key) => {
+    const entity = entityDefs[key];
+    if (!entity || excludedKeys.has(key)) {
+      return;
+    }
+    if (writableDomains.has(entity.domain)) {
+      expectedBackupKeys.add(key);
+    }
+  });
+  expectedExtraKeys.forEach((key) => expectedBackupKeys.add(key));
+
+  const excludedKeysInBackup = sorted(backupKeys.filter((key) => excludedKeys.has(key)));
+  if (excludedKeysInBackup.length) {
+    errors.push(`excluded keys are still in backup: ${formatList(excludedKeysInBackup)}`);
+  }
+
+  const missingExpectedKeys = sorted([...expectedBackupKeys].filter((key) => !backupKeySet.has(key)));
+  if (missingExpectedKeys.length) {
+    errors.push(`backup is missing expected settings: ${formatList(missingExpectedKeys)}`);
+  }
+
+  const unexpectedBackupKeys = sorted(backupKeys.filter((key) => !expectedBackupKeys.has(key)));
+  if (unexpectedBackupKeys.length) {
+    errors.push(`backup contains unexpected keys: ${formatList(unexpectedBackupKeys)}`);
+  }
+
+  const nonWritableBackupKeys = sorted(backupKeys.filter((key) => {
+    const entity = entityDefs[key];
+    return entity && !writableDomains.has(entity.domain) && !expectedExtraKeys.has(key);
+  }));
+  if (nonWritableBackupKeys.length) {
+    errors.push(`backup contains non-writable keys: ${formatList(nonWritableBackupKeys)}`);
+  }
+
+  if (errors.length) {
+    throw new Error(`Settings backup config is out of sync:\n- ${errors.join("\n- ")}`);
+  }
+
+  console.log(`Settings backup config ok: ${backupKeys.length} keys across ${backupSections.length} sections`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  await checkSettingsBackupConfig();
+}

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -767,22 +767,33 @@ const LOGO_MARKUP = `
     ...COMPRESSOR_SETTING_KEYS,
     ...SILENT_SETTING_KEYS,
   ];
+  const SETTINGS_BACKUP_WRITABLE_DOMAINS = new Set(["number", "select", "switch", "time", "datetime"]);
+  const SETTINGS_BACKUP_EXPECTED_EXTRA_KEYS = new Set(["setupComplete", "openquattResumeAt", "firmwareUpdateChannel"]);
+  const SETTINGS_BACKUP_EXCLUDED_KEYS = new Set([
+    "installationTopology",
+    ...COMMISSIONING_STATE_KEYS,
+    "trendHistoryFlashAvailable",
+    "trendHistoryFlashOldest",
+    "trendHistoryFlashNewest",
+    "trendHistoryFlashLastFlush",
+    "trendHistoryFlashSize",
+    "trendHistoryFlashWrites",
+    "coolingGuardMode",
+    "coolingFallbackNightMinOutdoorTemp",
+    "coolingFallbackMinSupplyTemp",
+    "coolingEffectiveMinSupplyTemp",
+  ]);
+  // Keep this aligned with persisted UI settings. The build checks that new
+  // writable settings are backed up or explicitly excluded above.
   const SETTINGS_BACKUP_SECTIONS = [
     {
       id: "installation",
       label: "Installatie",
       keys: [
         "setupComplete",
-        "installationTopology",
         "hpGeneration",
         "boilerCvAssistEnabled",
         "boilerRatedHeatPower",
-        "flowControlMode",
-        "flowSetpoint",
-        "manualIpwm",
-        "flowKp",
-        "flowKi",
-        "firmwareUpdateChannel",
       ],
     },
     {
@@ -791,26 +802,21 @@ const LOGO_MARKUP = `
       keys: [
         "strategy",
         "openquattEnabled",
-        "boilerCvAssistEnabled",
         "manualCoolingEnable",
         "cicCompatibilityMode",
-        "trendHistoryEnabled",
-        "trendHistoryFlashEnabled",
-        "webServerLogHistoryEnabled",
         "silentModeOverride",
         "openquattResumeAt",
       ],
     },
     {
-      id: "limits",
-      label: "Limieten",
+      id: "comfort",
+      label: "Comfort",
       keys: [
         "silentStartTime",
         "silentEndTime",
         "dayMax",
         "silentMax",
         "maxWater",
-        "minRuntime",
       ],
     },
     {
@@ -840,17 +846,34 @@ const LOGO_MARKUP = `
     {
       id: "flow",
       label: "Flow",
-      keys: ["flowControlMode", "flowSetpoint", "manualIpwm"],
+      keys: ["flowControlMode", "flowSetpoint", "manualIpwm", "flowKp", "flowKi"],
     },
     {
       id: "cooling",
       label: "Koeling",
-      keys: ["coolingWithoutDewPointMode"],
+      keys: [
+        "coolingMinimumSupplyTemp",
+        "coolingDemandMax",
+        "coolingRequestOnDelta",
+        "coolingRequestOffDelta",
+        "coolingSafetyMargin",
+        "coolingWithoutDewPointMode",
+      ],
     },
     {
       id: "compressor",
       label: "Compressor",
-      keys: ["hp1ExcludedA", "hp1ExcludedB", "hp2ExcludedA", "hp2ExcludedB"],
+      keys: ["minRuntime", "hp1ExcludedA", "hp1ExcludedB", "hp2ExcludedA", "hp2ExcludedB"],
+    },
+    {
+      id: "system",
+      label: "Systeem",
+      keys: [
+        "trendHistoryEnabled",
+        "trendHistoryFlashEnabled",
+        "webServerLogHistoryEnabled",
+        "firmwareUpdateChannel",
+      ],
     },
   ];
   const SETTINGS_BACKUP_SCHEMA_VERSION = 1;
@@ -9548,7 +9571,7 @@ function renderWebServerLogsModal() {
     return `
       <div class="${escapeHtml(className)}">
         ${renderSettingsNumberField("houseOutdoorMax", "Maximum heating outdoor temperature", "Bij deze buitentemperatuur is verwarmen meestal niet meer nodig.")}
-        ${renderSettingsNumberField("housePower", "Rated maximum house power", "Hoeveel warmte je woning ongeveer nodig heeft op een koude dag.")}
+        ${renderSettingsNumberField("housePower", "Rated maximum house power", "Hoeveel warmte je woning ongeveer nodig heeft wanneer het -10°C buiten is.")}
         ${renderPowerHouseResponseProfilesField()}
       </div>
     `;

--- a/openquatt/web/js/src/00-config.js
+++ b/openquatt/web/js/src/00-config.js
@@ -763,22 +763,33 @@ const LOGO_MARKUP = `
     ...COMPRESSOR_SETTING_KEYS,
     ...SILENT_SETTING_KEYS,
   ];
+  const SETTINGS_BACKUP_WRITABLE_DOMAINS = new Set(["number", "select", "switch", "time", "datetime"]);
+  const SETTINGS_BACKUP_EXPECTED_EXTRA_KEYS = new Set(["setupComplete", "openquattResumeAt", "firmwareUpdateChannel"]);
+  const SETTINGS_BACKUP_EXCLUDED_KEYS = new Set([
+    "installationTopology",
+    ...COMMISSIONING_STATE_KEYS,
+    "trendHistoryFlashAvailable",
+    "trendHistoryFlashOldest",
+    "trendHistoryFlashNewest",
+    "trendHistoryFlashLastFlush",
+    "trendHistoryFlashSize",
+    "trendHistoryFlashWrites",
+    "coolingGuardMode",
+    "coolingFallbackNightMinOutdoorTemp",
+    "coolingFallbackMinSupplyTemp",
+    "coolingEffectiveMinSupplyTemp",
+  ]);
+  // Keep this aligned with persisted UI settings. The build checks that new
+  // writable settings are backed up or explicitly excluded above.
   const SETTINGS_BACKUP_SECTIONS = [
     {
       id: "installation",
       label: "Installatie",
       keys: [
         "setupComplete",
-        "installationTopology",
         "hpGeneration",
         "boilerCvAssistEnabled",
         "boilerRatedHeatPower",
-        "flowControlMode",
-        "flowSetpoint",
-        "manualIpwm",
-        "flowKp",
-        "flowKi",
-        "firmwareUpdateChannel",
       ],
     },
     {
@@ -787,26 +798,21 @@ const LOGO_MARKUP = `
       keys: [
         "strategy",
         "openquattEnabled",
-        "boilerCvAssistEnabled",
         "manualCoolingEnable",
         "cicCompatibilityMode",
-        "trendHistoryEnabled",
-        "trendHistoryFlashEnabled",
-        "webServerLogHistoryEnabled",
         "silentModeOverride",
         "openquattResumeAt",
       ],
     },
     {
-      id: "limits",
-      label: "Limieten",
+      id: "comfort",
+      label: "Comfort",
       keys: [
         "silentStartTime",
         "silentEndTime",
         "dayMax",
         "silentMax",
         "maxWater",
-        "minRuntime",
       ],
     },
     {
@@ -836,17 +842,34 @@ const LOGO_MARKUP = `
     {
       id: "flow",
       label: "Flow",
-      keys: ["flowControlMode", "flowSetpoint", "manualIpwm"],
+      keys: ["flowControlMode", "flowSetpoint", "manualIpwm", "flowKp", "flowKi"],
     },
     {
       id: "cooling",
       label: "Koeling",
-      keys: ["coolingWithoutDewPointMode"],
+      keys: [
+        "coolingMinimumSupplyTemp",
+        "coolingDemandMax",
+        "coolingRequestOnDelta",
+        "coolingRequestOffDelta",
+        "coolingSafetyMargin",
+        "coolingWithoutDewPointMode",
+      ],
     },
     {
       id: "compressor",
       label: "Compressor",
-      keys: ["hp1ExcludedA", "hp1ExcludedB", "hp2ExcludedA", "hp2ExcludedB"],
+      keys: ["minRuntime", "hp1ExcludedA", "hp1ExcludedB", "hp2ExcludedA", "hp2ExcludedB"],
+    },
+    {
+      id: "system",
+      label: "Systeem",
+      keys: [
+        "trendHistoryEnabled",
+        "trendHistoryFlashEnabled",
+        "webServerLogHistoryEnabled",
+        "firmwareUpdateChannel",
+      ],
     },
   ];
   const SETTINGS_BACKUP_SCHEMA_VERSION = 1;

--- a/openquatt/web/js/src/10-settings.js
+++ b/openquatt/web/js/src/10-settings.js
@@ -1052,7 +1052,7 @@
     return `
       <div class="${escapeHtml(className)}">
         ${renderSettingsNumberField("houseOutdoorMax", "Maximum heating outdoor temperature", "Bij deze buitentemperatuur is verwarmen meestal niet meer nodig.")}
-        ${renderSettingsNumberField("housePower", "Rated maximum house power", "Hoeveel warmte je woning ongeveer nodig heeft op een koude dag.")}
+        ${renderSettingsNumberField("housePower", "Rated maximum house power", "Hoeveel warmte je woning ongeveer nodig heeft wanneer het -10°C buiten is.")}
         ${renderPowerHouseResponseProfilesField()}
       </div>
     `;


### PR DESCRIPTION
## Summary
- Add a build-time settings backup validation script.
- Run the validation before rebuilding web assets.
- Update the backup sections to cover the current writable settings and exclude read-only/status fields explicitly.
- Clarify that rated maximum house power is the heat demand at -10°C outside.

## Why
The settings backup can drift when new UI-managed settings are added. The build now fails when a persistent writable setting is missing from the backup configuration, duplicated, unknown, or explicitly excluded while still present in backup.

## Validation
- `node openquatt/web/check-settings-backup.mjs`
- `node openquatt/web/build-assets.mjs`
- `node --check openquatt/web/js/openquatt-app.js`
- `git diff --check`