### PR TITLE
Add a GitHub Pages demo for the web app

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -7,6 +7,7 @@ on:
       - "README.md"
       - "build_targets.yaml"
       - "docs/**"
+      - "openquatt/web/**"
       - "scripts/dev.py"
       - "scripts/build_targets.py"
       - "scripts/build_pages_docs.py"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Voor de volledige installatiestappen en eerste controle:
 
 - [Installatie en ingebruikname](docs/installatie-en-ingebruikname.md)
 - [Web-app gebruiken](docs/web-app.md)
+- [Web-app demo](demo/)
 - [Dashboard installeren](docs/dashboard/README.md)
 - [Dashboard gebruiken](docs/dashboardoverzicht.md)
 - [Problemen oplossen](docs/problemen-oplossen.md)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Voor de volledige installatiestappen en eerste controle:
 
 - [Installatie en ingebruikname](docs/installatie-en-ingebruikname.md)
 - [Web-app gebruiken](docs/web-app.md)
-- [Web-app demo](demo/)
+- [Web-app demo](https://jeroen85.github.io/OpenQuatt/demo/)
 - [Dashboard installeren](docs/dashboard/README.md)
 - [Dashboard gebruiken](docs/dashboardoverzicht.md)
 - [Problemen oplossen](docs/problemen-oplossen.md)

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -44,6 +44,8 @@ http://<ip-adres>
 
 De web-app draait lokaal op je eigen netwerk. Je gebruikt dus geen cloudaccount en hoeft niets externs open te zetten.
 
+Wil je de interface eerst rustig bekijken zonder echte hardware, open dan de [web-app demo op GitHub Pages](demo/). Die gebruikt dezelfde look-and-feel in mockmodus.
+
 ## Eerste keer: Quick Start
 
 Na de eerste installatie opent de web-app Quick Start zolang de basisinstallatie nog niet is afgerond.

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -44,7 +44,7 @@ http://<ip-adres>
 
 De web-app draait lokaal op je eigen netwerk. Je gebruikt dus geen cloudaccount en hoeft niets externs open te zetten.
 
-Wil je de interface eerst rustig bekijken zonder echte hardware, open dan de [web-app demo op GitHub Pages](demo/). Die gebruikt dezelfde look-and-feel in mockmodus.
+Wil je de interface eerst rustig bekijken zonder echte hardware, open dan de [web-app demo op GitHub Pages](https://jeroen85.github.io/OpenQuatt/demo/). Die gebruikt dezelfde look-and-feel in mockmodus.
 
 ## Eerste keer: Quick Start
 

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -15106,8 +15106,38 @@ function renderSettingsView() {
     `;
   }
 
+  function getActiveDevControlSelect() {
+    const active = typeof document !== "undefined" ? document.activeElement : null;
+    if (!active || typeof active.matches !== "function") {
+      return null;
+    }
+    return active.matches('select[data-oq-dev-control]') ? active : null;
+  }
+
+  function deferRenderUntilDevControlSelectSettles(select) {
+    if (!select || state.deferDevControlSelectRender) {
+      return;
+    }
+
+    state.deferDevControlSelectRender = true;
+    const flush = () => {
+      select.removeEventListener("blur", flush);
+      select.removeEventListener("change", flush);
+      state.deferDevControlSelectRender = false;
+      window.setTimeout(() => render(), 0);
+    };
+    select.addEventListener("blur", flush, { once: true });
+    select.addEventListener("change", flush, { once: true });
+  }
+
   function render() {
     if (!state.root) {
+      return;
+    }
+
+    const activeDevControlSelect = getActiveDevControlSelect();
+    if (activeDevControlSelect) {
+      deferRenderUntilDevControlSelectSettles(activeDevControlSelect);
       return;
     }
 

--- a/openquatt/web/js/src/90-shell.js
+++ b/openquatt/web/js/src/90-shell.js
@@ -33,8 +33,38 @@ function renderSettingsView() {
     `;
   }
 
+  function getActiveDevControlSelect() {
+    const active = typeof document !== "undefined" ? document.activeElement : null;
+    if (!active || typeof active.matches !== "function") {
+      return null;
+    }
+    return active.matches('select[data-oq-dev-control]') ? active : null;
+  }
+
+  function deferRenderUntilDevControlSelectSettles(select) {
+    if (!select || state.deferDevControlSelectRender) {
+      return;
+    }
+
+    state.deferDevControlSelectRender = true;
+    const flush = () => {
+      select.removeEventListener("blur", flush);
+      select.removeEventListener("change", flush);
+      state.deferDevControlSelectRender = false;
+      window.setTimeout(() => render(), 0);
+    };
+    select.addEventListener("blur", flush, { once: true });
+    select.addEventListener("change", flush, { once: true });
+  }
+
   function render() {
     if (!state.root) {
+      return;
+    }
+
+    const activeDevControlSelect = getActiveDevControlSelect();
+    if (activeDevControlSelect) {
+      deferRenderUntilDevControlSelectSettles(activeDevControlSelect);
       return;
     }
 

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -477,6 +477,8 @@ def build_pages_site(site_dir: Path, factory_dir: Path, helper_python: Sequence[
         shutil.rmtree(site_dir)
 
     (site_dir / "firmware" / "main").mkdir(parents=True, exist_ok=True)
+    (site_dir / "css").mkdir(parents=True, exist_ok=True)
+    (site_dir / "js").mkdir(parents=True, exist_ok=True)
     shutil.copytree(root_dir / "docs", site_dir, dirs_exist_ok=True)
 
     for stale_file in ("onderhoudsgids.md", "releaseproces.md"):
@@ -488,6 +490,19 @@ def build_pages_site(site_dir: Path, factory_dir: Path, helper_python: Sequence[
         [*helper_python, str(root_dir / "scripts" / "build_pages_docs.py"), str(site_dir)],
         cwd=root_dir,
     )
+
+    shutil.copy2(root_dir / "openquatt" / "web" / "css" / "openquatt-app.css", site_dir / "css" / "openquatt-app.css")
+    shutil.copy2(root_dir / "openquatt" / "web" / "js" / "mock-device.js", site_dir / "js" / "mock-device.js")
+    shutil.copy2(root_dir / "openquatt" / "web" / "js" / "openquatt-app.js", site_dir / "js" / "openquatt-app.js")
+
+    demo_html = (root_dir / "openquatt" / "web" / "dev.html").read_text(encoding="utf-8")
+    demo_html = demo_html.replace("<title>OpenQuatt UI Preview</title>", "<title>OpenQuatt web-app demo</title>")
+    demo_html = demo_html.replace("./css/openquatt-app.css?v=q-connection-switch-v3", "../css/openquatt-app.css?v=q-pages-demo")
+    demo_html = demo_html.replace("./js/mock-device.js?v=q-connection-switch-v3", "../js/mock-device.js?v=q-pages-demo")
+    demo_html = demo_html.replace("./js/openquatt-app.js?v=q-connection-switch-v3", "../js/openquatt-app.js?v=q-pages-demo")
+    demo_dir = site_dir / "demo"
+    demo_dir.mkdir(parents=True, exist_ok=True)
+    (demo_dir / "index.html").write_text(demo_html, encoding="utf-8")
 
     (site_dir / ".nojekyll").touch()
 


### PR DESCRIPTION
## Summary
- Add a `/demo/` GitHub Pages route that serves the web-app preview shell used by `openquatt/web/dev.html`.
- Copy the bundled web-app assets into the Pages site during `prepare-pages-site`.
- Make Pages rebuild whenever files under `openquatt/web/**` change.
- Add links to the demo from the project README and the web-app guide.
- Keep the select dropdown render fix in the same PR so it is not split away from the Pages work.

## Why
The current Pages site only covers documentation. This change makes the web-app demo directly available from GitHub Pages, so people can inspect the UI without a local checkout or a live device.

## Validation
- `./scripts/preview_pages_local.sh --no-serve --keep`
- `python3 -m py_compile scripts/dev.py`
- `node --check openquatt/web/js/openquatt-app.js`
- `git diff --check`