### PR TITLE
Add logger controls and reduce text sensor heap churn

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -1160,12 +1160,21 @@ text_sensor:
       sorting_group_id: oq_hp_diagnostics
     icon: mdi:alert-circle-outline
     lambda: |-
-      std::string s;
-      s.reserve(384);
+      char s[384];
+      size_t used = 0;
+      s[0] = '\0';
 
       auto add = [&](const char *name) -> void {
-        if (!s.empty()) s += ", ";
-        s += name;
+        if (name == nullptr || name[0] == '\0' || used >= (sizeof(s) - 1)) {
+          return;
+        }
+        const char *separator = used == 0 ? "" : ", ";
+        const int written = snprintf(s + used, sizeof(s) - used, "%s%s", separator, name);
+        if (written <= 0) {
+          return;
+        }
+        const size_t appended = static_cast<size_t>(written);
+        used = appended >= (sizeof(s) - used) ? (sizeof(s) - 1) : (used + appended);
       };
 
       auto has_bit = [](float raw, uint16_t bitmask) -> bool {
@@ -1224,7 +1233,7 @@ text_sensor:
       if (has_bit(status_2121, 0x1000u)) add("Reserved temp sensor failure");
       if (has_bit(status_2121, 0x2000u)) add("DC water pump failure");
 
-      return s.empty() ? std::string("None") : s;
+      return std::string(used == 0 ? "None" : s);
 
 
   - platform: template

--- a/openquatt/oq_cic_compatibility_server.yaml
+++ b/openquatt/oq_cic_compatibility_server.yaml
@@ -13,17 +13,15 @@
 #
 # ==============================================================================
 
-modbus_controller:
+modbus_server:
   - id: ${cic_compat_hp_id}_cic_compat_server
     address: ${cic_compat_device_address}
     modbus_id: cic_compat_modbus
-    setup_priority: -100
-    update_interval: never
-    server_courtesy_response:
+    courtesy_response:
       enabled: true
       register_last_address: 5000
       register_value: 0
-    server_registers:
+    registers:
       - address: 1999
         value_type: U_WORD
         read_lambda: |-

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -19,6 +19,19 @@ esphome:
       - lambda: |-
           // Always start from a clean paused state after reboot or OTA.
           id(oq_runtime_polling_paused).publish_state(false);
+          id(oq_ota_phase_code) = 0;
+          id(oq_ota_progress_pct) = 0.0f;
+          id(oq_firmware_update_status).publish_state("Idle");
+          id(oq_firmware_update_progress).publish_state(0.0f);
+          id(oq_project_version_text).publish_state("${project_version}");
+          id(oq_release_channel_text).publish_state("${release_channel}");
+          #if OQ_TOPOLOGY_DUO
+          id(oq_installation_topology_text).publish_state("duo");
+          #else
+          id(oq_installation_topology_text).publish_state("single");
+          #endif
+          id(oq_hardware_profile_text).publish_state("${oq_hardware_profile}");
+          id(oq_connection_text).publish_state("${oq_connection}");
 
 logger:
   level: DEBUG
@@ -600,7 +613,7 @@ text_sensor:
     name: Firmware Update Status
     icon: mdi:upload-network-outline
     entity_category: diagnostic
-    update_interval: 1s
+    update_interval: never
     lambda: |-
       // Expose a compact OTA phase label for dashboards and the local web UI.
       switch (id(oq_ota_phase_code)) {
@@ -675,7 +688,7 @@ text_sensor:
     name: OpenQuatt Version
     icon: mdi:tag-text-outline
     entity_category: diagnostic
-    update_interval: 60s
+    update_interval: never
     lambda: |-
       return {"${project_version}"};
     web_server:
@@ -685,7 +698,7 @@ text_sensor:
     name: OpenQuatt Installation Topology
     icon: mdi:home-analytics
     entity_category: diagnostic
-    update_interval: 60s
+    update_interval: never
     lambda: |-
       #if OQ_TOPOLOGY_DUO
       return {"duo"};
@@ -699,7 +712,7 @@ text_sensor:
     name: OpenQuatt Hardware Profile
     icon: mdi:developer-board
     entity_category: diagnostic
-    update_interval: 60s
+    update_interval: never
     lambda: |-
       return {"${oq_hardware_profile}"};
     web_server:
@@ -709,7 +722,7 @@ text_sensor:
     name: OpenQuatt Connection
     icon: mdi:lan-connect
     entity_category: diagnostic
-    update_interval: 60s
+    update_interval: never
     lambda: |-
       return {"${oq_connection}"};
     web_server:
@@ -719,7 +732,7 @@ text_sensor:
     name: OpenQuatt Release Channel
     icon: mdi:source-branch
     entity_category: diagnostic
-    update_interval: 60s
+    update_interval: never
     lambda: |-
       return {"${release_channel}"};
     web_server:

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -220,7 +220,7 @@ text_sensor:
     disabled_by_default: true
     icon: mdi:shield-half-full
     entity_category: diagnostic
-    update_interval: 10s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       if (id(cooling_dew_point_available).state) {
         return {"Dew point"};
@@ -238,7 +238,7 @@ text_sensor:
     disabled_by_default: true
     icon: mdi:information-outline
     entity_category: diagnostic
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       // Report the first blocking condition in operator-friendly terms.
       if (!id(cooling_enable_selected).has_state() || !id(cooling_enable_selected).state) {

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -831,7 +831,7 @@ text_sensor:
     id: oq_curve_phase_sensor
     name: "Curve Phase"
     icon: mdi:state-machine
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -844,7 +844,7 @@ text_sensor:
     id: oq_curve_regime_sensor
     name: "Curve operating regime"
     icon: mdi:state-machine
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:
@@ -860,7 +860,7 @@ text_sensor:
     id: oq_curve_capacity_mode_sensor
     name: "Curve capacity mode"
     icon: mdi:state-machine
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
     web_server:

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -266,7 +266,7 @@ text_sensor:
     disabled_by_default: true
     icon: mdi:timer-sand
     entity_category: diagnostic
-    update_interval: 5s
+    update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       // Report which selected-source inputs are currently being held through source dropouts.
       std::string active;

--- a/openquatt/web/css/openquatt-app.css
+++ b/openquatt/web/css/openquatt-app.css
@@ -3281,6 +3281,25 @@ body.oq-surface-native {
   flex: 1;
 }
 
+.oq-webserver-log-history-shell {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
+  align-items: stretch;
+  gap: 12px;
+}
+
+.oq-webserver-log-level-control {
+  position: relative;
+  display: block;
+  flex: 0 0 220px;
+  width: min(220px, 100%);
+}
+
+.oq-webserver-log-level-control .oq-helper-select {
+  min-height: 46px;
+  padding-right: 40px;
+}
+
 .oq-webserver-log-modal .oq-helper-modal-copy code,
 .oq-webserver-log-modal .oq-helper-modal-note code {
   padding: 0 0.35em;
@@ -7923,6 +7942,11 @@ esp-app.oq-native-app.oq-native-app--collapsed {
 
   .oq-settings-installation-summary button,
   .oq-settings-system-row button {
+    width: 100%;
+  }
+
+  .oq-webserver-log-level-control {
+    flex-basis: auto;
     width: 100%;
   }
 

--- a/openquatt/web/css/src/10-settings.css
+++ b/openquatt/web/css/src/10-settings.css
@@ -1058,6 +1058,25 @@
   flex: 1;
 }
 
+.oq-webserver-log-history-shell {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
+  align-items: stretch;
+  gap: 12px;
+}
+
+.oq-webserver-log-level-control {
+  position: relative;
+  display: block;
+  flex: 0 0 220px;
+  width: min(220px, 100%);
+}
+
+.oq-webserver-log-level-control .oq-helper-select {
+  min-height: 46px;
+  padding-right: 40px;
+}
+
 .oq-webserver-log-modal .oq-helper-modal-copy code,
 .oq-webserver-log-modal .oq-helper-modal-note code {
   padding: 0 0.35em;

--- a/openquatt/web/css/src/90-responsive.css
+++ b/openquatt/web/css/src/90-responsive.css
@@ -223,6 +223,11 @@ esp-app.oq-native-app.oq-native-app--collapsed {
     width: 100%;
   }
 
+  .oq-webserver-log-level-control {
+    flex-basis: auto;
+    width: 100%;
+  }
+
   .oq-helper-hub-switches,
   .oq-helper-hub-actions,
   .oq-helper-hub-dev-grid,

--- a/openquatt/web/dev.html
+++ b/openquatt/web/dev.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>OpenQuatt UI Preview</title>
-    <link rel="stylesheet" href="./css/openquatt-app.css?v=q-connection-switch-v3">
+    <link rel="stylesheet" href="./css/openquatt-app.css?v=q-logger-level-select-v1">
     <style>
       :root {
         color-scheme: light;
@@ -35,7 +35,7 @@
     <script>
       window.__OQ_DEV_LOAD_DELAY_MS = 2000;
     </script>
-    <script src="./js/mock-device.js?v=q-connection-switch-v3"></script>
-    <script src="./js/openquatt-app.js?v=q-connection-switch-v3"></script>
+    <script src="./js/mock-device.js?v=q-logger-level-select-v1"></script>
+    <script src="./js/openquatt-app.js?v=q-logger-level-select-v1"></script>
   </body>
 </html>

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -178,6 +178,13 @@
     state.logHistoryEntries = source.map((entry, index) => parseDemoLogEntry(entry, index, source.length));
   }
 
+  function appendLogHistoryEntry(raw) {
+    const entry = parseDemoLogEntry(raw, state.logHistoryEntries.length, state.logHistoryEntries.length + 1);
+    entry.seq = state.logHistoryEntries.length + 1;
+    entry.ts = Date.now();
+    state.logHistoryEntries = [...state.logHistoryEntries, entry].slice(-250);
+  }
+
   function isSwitchEnabled(name) {
     return Boolean(getEntity("switch", name)?.value);
   }
@@ -624,6 +631,11 @@
     setEntity("switch", "Trendopslag", { value: true, state: true });
     setEntity("switch", "Trendhistorie opslaan in flash", { value: true, state: true });
     setEntity("switch", "RAM log history", { value: true, state: true });
+    setEntity("select", "Debug Level", {
+      value: "INFO",
+      state: "INFO",
+      option: ["NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG"],
+    });
     setEntity("select", "Silent Mode Override", {
       value: "Schedule",
       state: "Schedule",
@@ -1581,6 +1593,8 @@
           ? "Alternatieve verbindingsbuild geselecteerd voor deze preview."
           : "Normale firmware-update geselecteerd voor deze preview.";
       }
+    } else if (name === "Debug Level") {
+      appendLogHistoryEntry(`[I][oq_fw:376]: Runtime logger level updated to ${value}`);
     } else if (name === "Power House response profile") {
       if (value === "Calm") {
         setNumber("Power House demand rise time", 12);

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -199,6 +199,7 @@ const LOGO_MARKUP = `
     trendHistoryEnabled: { domain: "switch", name: "Trendopslag", optional: true },
     trendHistoryFlashEnabled: { domain: "switch", name: "Trendhistorie opslaan in flash", optional: true },
     webServerLogHistoryEnabled: { domain: "switch", name: "RAM log history", optional: true },
+    debugLevel: { domain: "select", name: "Debug Level", optional: true },
     trendHistoryFlush: { domain: "button", name: "Trendhistorie nu opslaan", optional: true },
     trendHistoryFlashAvailable: { domain: "text_sensor", name: "Trendhistorie beschikbaar", optional: true },
     trendHistoryFlashOldest: { domain: "text_sensor", name: "Trendhistorie oudste punt", optional: true },
@@ -4103,6 +4104,7 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
       "trendHistoryEnabled",
       "trendHistoryFlashEnabled",
       "webServerLogHistoryEnabled",
+      "debugLevel",
       "trendHistoryFlashAvailable",
       "trendHistoryFlashOldest",
       "trendHistoryFlashNewest",
@@ -6870,6 +6872,11 @@ const OPENQUATT_RESUME_CLEAR_VALUE = "2000-01-01 00:00:00";
         render();
         await pollFirmwareUpdateState();
         state.controlNotice = "Releasekanaal bijgewerkt.";
+      } else if (key === "debugLevel") {
+        state.controlNotice = "Logger level bijgewerkt.";
+        if (state.systemModal === "webserver-logs") {
+          void refreshWebServerLogHistory();
+        }
       } else if (key === "webServerLogHistoryEnabled") {
         if (enabled) {
           state.webServerLogHistoryLoaded = false;
@@ -8025,6 +8032,25 @@ function getWebServerLogHistoryInfoCopy() {
   return "Slaat de laatste firmwarelogs tijdelijk op in RAM. De viewer leest die buffer bij openen en blijft daarna live /events volgen.";
 }
 
+function getWebServerLoggerLevelEntity() {
+  return state.entities?.debugLevel || null;
+}
+
+function getWebServerLoggerLevelOptions(entity = getWebServerLoggerLevelEntity()) {
+  const options = Array.isArray(entity?.option)
+    ? entity.option
+    : Array.isArray(entity?.options)
+      ? entity.options
+      : [];
+  return options.length ? options : ["NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG"];
+}
+
+function getWebServerLoggerLevelValue(entity = getWebServerLoggerLevelEntity()) {
+  const value = String(entity?.value ?? entity?.state ?? "").trim();
+  const options = getWebServerLoggerLevelOptions(entity);
+  return options.includes(value) ? value : (options.includes("INFO") ? "INFO" : options[0] || "");
+}
+
 function getWebServerLogEntryKey(entry) {
   if (!entry || typeof entry !== "object") {
     return "";
@@ -8360,6 +8386,7 @@ function openWebServerLogsModal() {
   state.webServerLogCopyError = "";
   state.systemModal = "webserver-logs";
   render();
+  void refreshEntities(["webServerLogHistoryEnabled", "debugLevel"], "all", { forceFast: true });
   scrollWebServerLogToBottom();
   if (!state.webServerLogHistoryLoaded || state.webServerLogEntries.length === 0) {
     void refreshWebServerLogHistory();
@@ -8732,6 +8759,7 @@ function renderWebServerLogHistoryControls() {
   const busy = state.loadingEntities || state.busyAction === "switch-webServerLogHistoryEnabled";
   const label = getWebServerLogHistoryStatusLabel();
   const copy = getWebServerLogHistoryInfoCopy();
+  const loggerLevelControl = renderWebServerLoggerLevelControl();
 
   return `
     <div class="oq-webserver-log-history-shell">
@@ -8753,6 +8781,34 @@ function renderWebServerLogHistoryControls() {
           ${enabled ? "Uitschakelen" : "Inschakelen"}
         </button>
       </div>
+      ${loggerLevelControl}
+    </div>
+  `;
+}
+
+function renderWebServerLoggerLevelControl() {
+  const entity = getWebServerLoggerLevelEntity();
+  if (!entity) {
+    return "";
+  }
+
+  const options = getWebServerLoggerLevelOptions(entity);
+  const value = getWebServerLoggerLevelValue(entity);
+  const busy = state.loadingEntities || state.busyAction === "save-debugLevel";
+
+  return `
+    <div class="oq-settings-system-row oq-settings-system-row--with-action" data-oq-diagnostics-row="debugLevel">
+      <div class="oq-settings-system-row-copy">
+        <p class="oq-settings-system-row-label">Logger level</p>
+        <strong class="oq-settings-system-row-value">${escapeHtml(value || "Onbekend")}</strong>
+        <p class="oq-settings-system-row-note">Past het runtime logniveau aan voor nieuwe firmwaremeldingen.</p>
+      </div>
+      <label class="oq-webserver-log-level-control" aria-label="Logger level">
+        <select class="oq-helper-select" data-oq-field="debugLevel" ${busy ? "disabled" : ""}>
+          ${options.map((option) => `<option value="${escapeHtml(option)}" ${option === value ? "selected" : ""}>${escapeHtml(option)}</option>`).join("")}
+        </select>
+        <span class="oq-settings-select-caret" aria-hidden="true"></span>
+      </label>
     </div>
   `;
 }

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -8386,7 +8386,14 @@ function openWebServerLogsModal() {
   state.webServerLogCopyError = "";
   state.systemModal = "webserver-logs";
   render();
-  void refreshEntities(["webServerLogHistoryEnabled", "debugLevel"], "all", { forceFast: true });
+  void refreshEntities(["webServerLogHistoryEnabled", "debugLevel"], "all", { forceFast: true }).then(() => {
+    if (state.systemModal !== "webserver-logs") {
+      return;
+    }
+    const scrollState = captureWebServerLogScrollState();
+    render();
+    queueWebServerLogScrollRestore(scrollState);
+  });
   scrollWebServerLogToBottom();
   if (!state.webServerLogHistoryLoaded || state.webServerLogEntries.length === 0) {
     void refreshWebServerLogHistory();

--- a/openquatt/web/js/src/00-config.js
+++ b/openquatt/web/js/src/00-config.js
@@ -195,6 +195,7 @@ const LOGO_MARKUP = `
     trendHistoryEnabled: { domain: "switch", name: "Trendopslag", optional: true },
     trendHistoryFlashEnabled: { domain: "switch", name: "Trendhistorie opslaan in flash", optional: true },
     webServerLogHistoryEnabled: { domain: "switch", name: "RAM log history", optional: true },
+    debugLevel: { domain: "select", name: "Debug Level", optional: true },
     trendHistoryFlush: { domain: "button", name: "Trendhistorie nu opslaan", optional: true },
     trendHistoryFlashAvailable: { domain: "text_sensor", name: "Trendhistorie beschikbaar", optional: true },
     trendHistoryFlashOldest: { domain: "text_sensor", name: "Trendhistorie oudste punt", optional: true },

--- a/openquatt/web/js/src/03-entities-controls.js
+++ b/openquatt/web/js/src/03-entities-controls.js
@@ -320,6 +320,7 @@
       "trendHistoryEnabled",
       "trendHistoryFlashEnabled",
       "webServerLogHistoryEnabled",
+      "debugLevel",
       "trendHistoryFlashAvailable",
       "trendHistoryFlashOldest",
       "trendHistoryFlashNewest",
@@ -3087,6 +3088,11 @@
         render();
         await pollFirmwareUpdateState();
         state.controlNotice = "Releasekanaal bijgewerkt.";
+      } else if (key === "debugLevel") {
+        state.controlNotice = "Logger level bijgewerkt.";
+        if (state.systemModal === "webserver-logs") {
+          void refreshWebServerLogHistory();
+        }
       } else if (key === "webServerLogHistoryEnabled") {
         if (enabled) {
           state.webServerLogHistoryLoaded = false;

--- a/openquatt/web/js/src/06-webserver-logs.js
+++ b/openquatt/web/js/src/06-webserver-logs.js
@@ -482,7 +482,14 @@ function openWebServerLogsModal() {
   state.webServerLogCopyError = "";
   state.systemModal = "webserver-logs";
   render();
-  void refreshEntities(["webServerLogHistoryEnabled", "debugLevel"], "all", { forceFast: true });
+  void refreshEntities(["webServerLogHistoryEnabled", "debugLevel"], "all", { forceFast: true }).then(() => {
+    if (state.systemModal !== "webserver-logs") {
+      return;
+    }
+    const scrollState = captureWebServerLogScrollState();
+    render();
+    queueWebServerLogScrollRestore(scrollState);
+  });
   scrollWebServerLogToBottom();
   if (!state.webServerLogHistoryLoaded || state.webServerLogEntries.length === 0) {
     void refreshWebServerLogHistory();

--- a/openquatt/web/js/src/06-webserver-logs.js
+++ b/openquatt/web/js/src/06-webserver-logs.js
@@ -128,6 +128,25 @@ function getWebServerLogHistoryInfoCopy() {
   return "Slaat de laatste firmwarelogs tijdelijk op in RAM. De viewer leest die buffer bij openen en blijft daarna live /events volgen.";
 }
 
+function getWebServerLoggerLevelEntity() {
+  return state.entities?.debugLevel || null;
+}
+
+function getWebServerLoggerLevelOptions(entity = getWebServerLoggerLevelEntity()) {
+  const options = Array.isArray(entity?.option)
+    ? entity.option
+    : Array.isArray(entity?.options)
+      ? entity.options
+      : [];
+  return options.length ? options : ["NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG"];
+}
+
+function getWebServerLoggerLevelValue(entity = getWebServerLoggerLevelEntity()) {
+  const value = String(entity?.value ?? entity?.state ?? "").trim();
+  const options = getWebServerLoggerLevelOptions(entity);
+  return options.includes(value) ? value : (options.includes("INFO") ? "INFO" : options[0] || "");
+}
+
 function getWebServerLogEntryKey(entry) {
   if (!entry || typeof entry !== "object") {
     return "";
@@ -463,6 +482,7 @@ function openWebServerLogsModal() {
   state.webServerLogCopyError = "";
   state.systemModal = "webserver-logs";
   render();
+  void refreshEntities(["webServerLogHistoryEnabled", "debugLevel"], "all", { forceFast: true });
   scrollWebServerLogToBottom();
   if (!state.webServerLogHistoryLoaded || state.webServerLogEntries.length === 0) {
     void refreshWebServerLogHistory();
@@ -835,6 +855,7 @@ function renderWebServerLogHistoryControls() {
   const busy = state.loadingEntities || state.busyAction === "switch-webServerLogHistoryEnabled";
   const label = getWebServerLogHistoryStatusLabel();
   const copy = getWebServerLogHistoryInfoCopy();
+  const loggerLevelControl = renderWebServerLoggerLevelControl();
 
   return `
     <div class="oq-webserver-log-history-shell">
@@ -856,6 +877,34 @@ function renderWebServerLogHistoryControls() {
           ${enabled ? "Uitschakelen" : "Inschakelen"}
         </button>
       </div>
+      ${loggerLevelControl}
+    </div>
+  `;
+}
+
+function renderWebServerLoggerLevelControl() {
+  const entity = getWebServerLoggerLevelEntity();
+  if (!entity) {
+    return "";
+  }
+
+  const options = getWebServerLoggerLevelOptions(entity);
+  const value = getWebServerLoggerLevelValue(entity);
+  const busy = state.loadingEntities || state.busyAction === "save-debugLevel";
+
+  return `
+    <div class="oq-settings-system-row oq-settings-system-row--with-action" data-oq-diagnostics-row="debugLevel">
+      <div class="oq-settings-system-row-copy">
+        <p class="oq-settings-system-row-label">Logger level</p>
+        <strong class="oq-settings-system-row-value">${escapeHtml(value || "Onbekend")}</strong>
+        <p class="oq-settings-system-row-note">Past het runtime logniveau aan voor nieuwe firmwaremeldingen.</p>
+      </div>
+      <label class="oq-webserver-log-level-control" aria-label="Logger level">
+        <select class="oq-helper-select" data-oq-field="debugLevel" ${busy ? "disabled" : ""}>
+          ${options.map((option) => `<option value="${escapeHtml(option)}" ${option === value ? "selected" : ""}>${escapeHtml(option)}</option>`).join("")}
+        </select>
+        <span class="oq-settings-select-caret" aria-hidden="true"></span>
+      </label>
     </div>
   `;
 }


### PR DESCRIPTION
## Summary
- Add the optional `Debug Level` select entity to the web app entity map.
- Show a logger level select next to the RAM log history control in the OpenQuatt log modal.
- Update the mock preview and rebuilt bundled JS/CSS assets.
- Reduce periodic template text-sensor churn by publishing static firmware/device labels at boot and making OTA status event-driven.
- Slow disabled diagnostic text sensors to the shared diagnostic cadence and build HP active-failure summaries with a fixed stack buffer instead of repeated `std::string` growth.
- Migrate the CiC compatibility register map from deprecated `modbus_controller` server options to the ESPHome `modbus_server` component.

## Why
The recent heap history did not show a clear leak, but it did show short-lived internal heap pressure and fragmentation. These changes remove avoidable periodic string work from low-value text sensors while preserving the visible states used by HA and the local web UI.

The full local validation also exposed an ESPHome 2026.5.0 compatibility break: `server_courtesy_response` and `server_registers` are no longer accepted on `modbus_controller`. The CiC compatibility layer now uses the replacement `modbus_server` schema while keeping the existing register lambdas intact.

## Validation
- `node --check openquatt/web/js/src/00-config.js`
- `node --check openquatt/web/js/src/03-entities-controls.js`
- `node --check openquatt/web/js/src/06-webserver-logs.js`
- `node --check openquatt/web/js/mock-device.js`
- `node openquatt/web/build-assets.mjs`
- `git diff --check`
- `./scripts/validate_local.sh --config configs/waveshare/single_wifi.yaml --config-only`
- `./scripts/validate_local.sh`