### PR TITLE
Cooling: dynamic dew stop + 30s confirm + restart hysteresis

### DIFF
--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -140,6 +140,11 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  - id: oq_cooling_dew_stop_candidate_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
   - id: oq_cooling_water_cycle_active
     type: bool
     restore_value: false
@@ -329,8 +334,9 @@ interval:
           // enough shape to behave across low-mass and high-mass water systems.
           const float filter_tau_s = 60.0f;
           const uint32_t rate_window_ms = 60000UL;
-          const float hard_dew_stop_gap_c = 0.30f;
-          const float hard_dew_restart_gap_c = 0.60f;
+          const float hard_dew_stop_base_gap_c = 0.15f;
+          const float hard_dew_stop_margin_gain_c = 0.30f;
+          const float hard_dew_restart_hyst_c = 0.20f;
           const float full_gap_c = 1.50f;
           const float cap2_gap_c = 0.60f;
           const float level2_release_rate_c_per_min = -0.12f;
@@ -382,6 +388,7 @@ interval:
             id(oq_cooling_buffer_gap_rate_ref_ms) = 0;
             id(oq_cooling_last_demand_change_ms) = 0;
             id(oq_cooling_stop_candidate_since_ms) = 0;
+            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
             return;
           }
 
@@ -432,6 +439,15 @@ interval:
               !dew_mode && id(cooling_fallback_active).has_state() && id(cooling_fallback_active).state;
           const float dew_gap_c = dew_mode ? (supply_c - id(cooling_dew_point_selected).state) : NAN;
           id(oq_cooling_dew_gap_c) = dew_gap_c;
+          float safety_margin_c = 0.0f;
+          if (id(cooling_safety_margin_selected).has_state() && !isnan(id(cooling_safety_margin_selected).state)) {
+            safety_margin_c = id(cooling_safety_margin_selected).state;
+          }
+          if (safety_margin_c < 0.0f) safety_margin_c = 0.0f;
+          if (safety_margin_c > 2.0f) safety_margin_c = 2.0f;
+          const float hard_dew_stop_gap_c =
+              hard_dew_stop_base_gap_c + (hard_dew_stop_margin_gain_c * safety_margin_c);
+          const float hard_dew_restart_gap_c = hard_dew_stop_gap_c + hard_dew_restart_hyst_c;
 
           bool trend_safe = id(oq_cooling_trend_safe);
           if (gap_rate_c_per_min > trend_safe_rate_c_per_min) trend_safe = true;
@@ -499,7 +515,19 @@ interval:
           int fallback_cap = demand_max;
           int mode_cap = demand_max;
           int reason_code = room_cap_active ? 9 : 1;
-          const bool dew_hard_stop = dew_mode && !isnan(dew_gap_c) && dew_gap_c <= hard_dew_stop_gap_c;
+          const bool dew_hard_stop_candidate =
+              dew_mode && !isnan(dew_gap_c) && dew_gap_c <= hard_dew_stop_gap_c;
+          bool dew_hard_stop = false;
+          if (dew_hard_stop_candidate) {
+            uint32_t dew_candidate_since_ms = id(oq_cooling_dew_stop_candidate_since_ms);
+            if (dew_candidate_since_ms == 0 || now_ms <= dew_candidate_since_ms) {
+              id(oq_cooling_dew_stop_candidate_since_ms) = now_ms;
+              dew_candidate_since_ms = now_ms;
+            }
+            dew_hard_stop = (uint32_t)(now_ms - dew_candidate_since_ms) >= limiter_stop_confirm_ms;
+          } else {
+            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
+          }
 
           // Build the limiter as independent caps and take the strictest one.
           // This keeps fallback, dew safety, trend and room overshoot from

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -343,7 +343,8 @@ interval:
           const float fallback_full_gap_c = 1.00f;
           const float fallback_cap1_gap_c = 0.30f;
           const float fallback_stop_gap_c = 0.00f;
-          const uint32_t limiter_stop_confirm_ms = 45000UL;
+          const uint32_t limiter_stop_confirm_ms =
+              (uint32_t) (${oq_cooling_limiter_stop_confirm_s} * 1000UL);
           const uint32_t upscale_dwell_ms = 90000UL;
           const uint32_t downscale_dwell_ms = 30000UL;
           const float simmer_room_error_min_c = 0.20f;

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -107,6 +107,7 @@ oq_outside_temp_stale_s: "1200"                       # Ignore a local outdoor r
 oq_heat_loop_tick_s: "5"                              # Scheduler tick for heat-control loop [s].
 oq_heat_loop_curve_s: "30"                            # Effective heat-control cadence in Heating Curve mode [s].
 oq_heat_loop_powerhouse_s: "60"                       # Effective heat-control cadence in Power House mode [s].
+oq_cooling_limiter_stop_confirm_s: "30"               # Confirm time before soft-stop near cooling target [s].
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
 oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -107,7 +107,7 @@ oq_outside_temp_stale_s: "1200"                       # Ignore a local outdoor r
 oq_heat_loop_tick_s: "5"                              # Scheduler tick for heat-control loop [s].
 oq_heat_loop_curve_s: "30"                            # Effective heat-control cadence in Heating Curve mode [s].
 oq_heat_loop_powerhouse_s: "60"                       # Effective heat-control cadence in Power House mode [s].
-oq_cooling_limiter_stop_confirm_s: "30"               # Confirm time before soft-stop near cooling target [s].
+oq_cooling_limiter_stop_confirm_s: "30"               # Confirm time before soft-stop and dew hard-stop take effect [s].
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
 oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].


### PR DESCRIPTION
## Summary
- implement updated cooling safety/modulation behavior without adding new user settings
- move cooling soft-stop confirm timing to a shared substitution with default 30s
- make dew hard-stop threshold dynamic from existing safety margin
- add confirm timing for dew hard-stop to avoid reacting to short spikes
- derive dew restart threshold from the effective hard-stop plus hysteresis
- keep level-1 hold behavior so demand does not drop to 0 while raw buffer gap is still positive (except real safety/fallback)

## Implemented Logic
- effective_hard_stop = 0.15 + 0.30 * clamp(safety_margin, 0..2)
- hard_dew_restart_gap = effective_hard_stop + 0.20
- hard dew stop is applied only when raw dew_gap stays below effective_hard_stop for the confirm window (30s default)
- soft-stop near target uses the same confirm window and remains substitution-driven

## Files
- openquatt/oq_cooling_strategy.yaml
  - dynamic dew hard-stop and restart thresholds
  - dew hard-stop confirmation state/timer
  - soft-stop confirm timer now substitution-driven
- openquatt/oq_substitutions_common.yaml
  - add oq_cooling_limiter_stop_confirm_s (default 30)

## Why
This reduces strict stop-restart chatter near dewpoint, especially at low safety margins, while preserving a clear condensation safety boundary.

## Validation
- local ESPHome upgraded to 2026.5.1
- local compile succeeded:
  - esphome compile configs/waveshare/duo_wifi.yaml
  - SUCCESS