### PR TITLE
Flow: add separate cooling setpoint

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -843,7 +843,8 @@ views:
               Main flow-control settings:
 
               - `Flow control mode`: choose automatic flow control or manual behavior.
-              - `Flow setpoint`: target flow in L/h for automatic control.
+              - `Flow setpoint`: target flow in L/h for automatic control outside cooling.
+              - `Cooling flow setpoint`: target flow in L/h during cooling.
               - `Manual iPWM`: set iPWM value for manual control.
               </details>
             text_only: true
@@ -858,6 +859,16 @@ views:
             features_position: inline
           - type: tile
             entity: number.openquatt_flow_setpoint
+            name:
+              type: entity
+            hide_state: false
+            vertical: false
+            features:
+              - style: slider
+                type: numeric-input
+            features_position: inline
+          - type: tile
+            entity: number.openquatt_cooling_flow_setpoint
             name:
               type: entity
             hide_state: false
@@ -906,6 +917,8 @@ views:
                 name: Flowrate
               - entity: number.openquatt_flow_setpoint
                 name: Flow setpoint
+              - entity: number.openquatt_cooling_flow_setpoint
+                name: Cooling flow setpoint
             grid_options:
               columns: full
           - type: history-graph

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -884,7 +884,10 @@ views:
               - `Flow control mode`: kies automatische flowregeling of
               handmatige werking.
 
-              - `Flow setpoint`: doel-flow in L/h voor automatische regeling.
+              - `Flow setpoint`: doel-flow in L/h voor automatische regeling
+              buiten koelen.
+
+              - `Cooling flow setpoint`: doel-flow in L/h tijdens koelen.
 
               - `Handmatige iPWM`: stel iPWM waarde in voor handbediening.
 
@@ -901,6 +904,16 @@ views:
             features_position: inline
           - type: tile
             entity: number.openquatt_flow_setpoint
+            name:
+              type: entity
+            hide_state: false
+            vertical: false
+            features:
+              - style: slider
+                type: numeric-input
+            features_position: inline
+          - type: tile
+            entity: number.openquatt_cooling_flow_setpoint
             name:
               type: entity
             hide_state: false
@@ -948,6 +961,8 @@ views:
                 name: Flow
               - entity: number.openquatt_flow_setpoint
                 name: Flow setpoint
+              - entity: number.openquatt_cooling_flow_setpoint
+                name: Cooling flow setpoint
             grid_options:
               columns: full
           - type: history-graph

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -837,7 +837,8 @@ views:
               Main flow-control settings:
 
               - `Flow control mode`: choose automatic flow control or manual behavior.
-              - `Flow setpoint`: target flow in L/h for automatic control.
+              - `Flow setpoint`: target flow in L/h for automatic control outside cooling.
+              - `Cooling flow setpoint`: target flow in L/h during cooling.
               - `Manual iPWM`: set iPWM value for manual control.
               </details>
             text_only: true
@@ -852,6 +853,16 @@ views:
             features_position: inline
           - type: tile
             entity: number.openquatt_flow_setpoint
+            name:
+              type: entity
+            hide_state: false
+            vertical: false
+            features:
+              - style: slider
+                type: numeric-input
+            features_position: inline
+          - type: tile
+            entity: number.openquatt_cooling_flow_setpoint
             name:
               type: entity
             hide_state: false
@@ -900,6 +911,8 @@ views:
                 name: Flowrate
               - entity: number.openquatt_flow_setpoint
                 name: Flow setpoint
+              - entity: number.openquatt_cooling_flow_setpoint
+                name: Cooling flow setpoint
             grid_options:
               columns: full
           - type: history-graph

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -865,7 +865,10 @@ views:
               - `Flow control mode`: kies automatische flowregeling of
               handmatige werking.
 
-              - `Flow setpoint`: doel-flow in L/h voor automatische regeling.
+              - `Flow setpoint`: doel-flow in L/h voor automatische regeling
+              buiten koelen.
+
+              - `Cooling flow setpoint`: doel-flow in L/h tijdens koelen.
 
               - `Handmatige iPWM`: stel iPWM waarde in voor handbediening.
 
@@ -882,6 +885,16 @@ views:
             features_position: inline
           - type: tile
             entity: number.openquatt_flow_setpoint
+            name:
+              type: entity
+            hide_state: false
+            vertical: false
+            features:
+              - style: slider
+                type: numeric-input
+            features_position: inline
+          - type: tile
+            entity: number.openquatt_cooling_flow_setpoint
             name:
               type: entity
             hide_state: false
@@ -929,6 +942,8 @@ views:
                 name: Flow
               - entity: number.openquatt_flow_setpoint
                 name: Flow setpoint
+              - entity: number.openquatt_cooling_flow_setpoint
+                name: Cooling flow setpoint
             grid_options:
               columns: full
           - type: history-graph

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -108,12 +108,15 @@ Deze groep bepaalt hoe de circulatiepomp wordt aangestuurd.
 Belangrijke instellingen:
 
 - `Flow Setpoint`
+- `Cooling Flow Setpoint`
 - `Flow Control Mode`
 - `Manual iPWM`
 - `Frost Circulation iPWM`
 - `Flow AUTO start iPWM`
 - `Flow PI Kp`
 - `Flow PI Ki`
+
+`Flow Setpoint` geldt voor verwarmen en normaal automatisch bedrijf. `Cooling Flow Setpoint` geldt alleen tijdens koelen, zodat koeling een eigen hydraulisch werkpunt kan hebben zonder de verwarmingsflow te veranderen.
 
 Gebruik deze groep voorzichtig. Bij verkeerde bronwaarden of hydraulische problemen maak je hier snel meer ruis dan winst.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -258,7 +258,8 @@ Key behaviors:
 - setpoint ramping
 - asymmetric action limits
 - validity-based failsafe (`iPWM=850`)
-- stable-flow tracking for `last_good_pwm`
+- automatic selection between the normal flow setpoint and the cooling flow setpoint in CM5
+- separate stable-flow tracking for normal and cooling `last_good_pwm`
 
 ## 8. Safety Model
 

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -23,7 +23,7 @@
 #   - Pump output is correctly configured for PWM
 #
 # Interaction with Control Modes:
-#   - Active in CM1/CM2/CM3/CM100 (AUTO=PI, MANUAL=fixed iPWM)
+#   - Active in CM1/CM2/CM3/CM5/CM100 (AUTO=PI, MANUAL=fixed iPWM)
 #   - CM0: early return (supervisory owns pump state in idle)
 #   - CM98: fixed frost PWM path
 #
@@ -53,6 +53,14 @@ globals:
     type: int
     restore_value: true
     initial_value: "440"
+  - id: oq_flow_last_good_pwm_cooling
+    type: int
+    restore_value: true
+    initial_value: "440"
+  - id: oq_flow_cooling_settings_migrated
+    type: bool
+    restore_value: true
+    initial_value: 'false'
   - id: oq_flow_commissioning_start_pwm
     type: int
     restore_value: false
@@ -78,6 +86,21 @@ number:
     id: oq_flow_setpoint_lph
     name: "Flow Setpoint"
     icon: mdi:waves-arrow-right
+    unit_of_measurement: "L/h"
+    mode: slider
+    web_server:
+      sorting_group_id: oq_control
+    min_value: 0
+    max_value: 1500
+    step: 10
+    restore_value: true
+    optimistic: true
+    initial_value: 800
+
+  - platform: template
+    id: oq_cooling_flow_setpoint_lph
+    name: "Cooling Flow Setpoint"
+    icon: mdi:snowflake-thermometer
     unit_of_measurement: "L/h"
     mode: slider
     web_server:
@@ -341,6 +364,7 @@ interval:
           static bool was_flow_idle = true;
           static int last_cm_code = 0;
           static int last_commissioning_task_code = oq_commissioning::TASK_NONE;
+          static bool last_auto_target_is_cooling = false;
 
           // One central hold time for all start transitions.
           // During this window we keep start iPWM fixed to let hydraulics settle.
@@ -385,20 +409,39 @@ interval:
               c.perform();
             }
           };
+          if (!id(oq_flow_cooling_settings_migrated) && !isnan(id(oq_flow_setpoint_lph).state)) {
+            const float current_flow_setpoint = id(oq_flow_setpoint_lph).state;
+            if (!isnan(current_flow_setpoint)) {
+              auto c = id(oq_cooling_flow_setpoint_lph).make_call();
+              c.set_value(current_flow_setpoint);
+              c.perform();
+            }
+            id(oq_flow_last_good_pwm_cooling) = id(oq_flow_last_good_pwm);
+            id(oq_flow_cooling_settings_migrated) = true;
+            ESP_LOGI(
+                "flow",
+                "Initialized cooling flow settings from current flow setpoint: sp=%.0f L/h last_good=%d",
+                current_flow_setpoint,
+                id(oq_flow_last_good_pwm_cooling));
+          }
           // Common AUTO-entry init used for CM0->* and MANUAL->AUTO edges.
           auto start_auto_transition = [&](const char *tag) {
             int fallback = (int) roundf(id(oq_flow_auto_start_pwm).state);
             fallback = clamp_iPWM(fallback);
 
             const int cm_code = id(oq_control_mode_code);
+            const bool cooling_target = (cm_code == 5);
             const bool commissioning_start = (cm_code == 100) && (id(oq_commissioning_task_code) != 0);
+            const int last_good_pwm =
+              cooling_target ? id(oq_flow_last_good_pwm_cooling) : id(oq_flow_last_good_pwm);
             int start_pwm = commissioning_start
               ? clamp_iPWM(id(oq_flow_commissioning_start_pwm))
-              : (int) id(oq_flow_last_good_pwm);
+              : last_good_pwm;
             if (!commissioning_start && (start_pwm < 50 || start_pwm > 850)) start_pwm = fallback;
 
-            ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d fallback=%d commissioning=%s hold %ds, fixed iPWM)",
-                     tag, start_pwm, (int)id(oq_flow_last_good_pwm), fallback, commissioning_start ? "yes" : "no", STARTUP_HOLD_S);
+            ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d bank=%s fallback=%d commissioning=%s hold %ds, fixed iPWM)",
+                     tag, start_pwm, last_good_pwm, cooling_target ? "cooling" : "normal",
+                     fallback, commissioning_start ? "yes" : "no", STARTUP_HOLD_S);
 
             id(oq_flow_last_pwm) = start_pwm;
             id(oq_flow_i) = 0.0f;
@@ -410,7 +453,10 @@ interval:
           // AUTO PI path only: setpoint ramp, PI, startup-hold, and last_good tracking.
           auto run_auto_pi = [&](int pwm_seed) -> int {
             int pwm_local = pwm_seed;
-            float sp_target = id(oq_flow_setpoint_lph).state;
+            const bool cooling_target = (id(oq_control_mode_code) == 5);
+            float sp_target = cooling_target
+              ? id(oq_cooling_flow_setpoint_lph).state
+              : id(oq_flow_setpoint_lph).state;
             float pv = id(flow_rate_selected).state;
 
             // Treat 0 L/h as a valid measurement (no-flow state), not as sensor failure.
@@ -511,9 +557,15 @@ interval:
               }
 
               if (stable_cnt >= stable_time_ticks) {
-                const int prev = id(oq_flow_last_good_pwm);
+                const int prev = cooling_target
+                  ? id(oq_flow_last_good_pwm_cooling)
+                  : id(oq_flow_last_good_pwm);
                 if (abs(prev - pwm_local) >= good_pwm_step) {
-                  id(oq_flow_last_good_pwm) = pwm_local;
+                  if (cooling_target) {
+                    id(oq_flow_last_good_pwm_cooling) = pwm_local;
+                  } else {
+                    id(oq_flow_last_good_pwm) = pwm_local;
+                  }
                 }
                 stable_cnt = stable_time_ticks;
               }
@@ -532,6 +584,7 @@ interval:
           id(oq_flow_control_mode_code) = flow_mode_code;
           const bool want_manual = (flow_mode_code == 1);
           static bool was_manual = false;
+          const bool auto_target_is_cooling = (cm_code == 5);
 
           const bool is_cm100_idle =
               (cm_code == 100) &&
@@ -555,6 +608,7 @@ interval:
           if (flow_idle) {
             // Keep manual-edge memory synchronized while idle.
             was_manual = want_manual;
+            last_auto_target_is_cooling = auto_target_is_cooling;
             stable_cnt = 0;
             startup_hold = 0;
             sp_f = NAN;
@@ -572,6 +626,11 @@ interval:
             last_pi_e = 0.0f;
             stable_cnt = 0;
           }
+          if (!want_manual && !is_frost && auto_target_is_cooling != last_auto_target_is_cooling) {
+            ESP_LOGI("flow", "AUTO target switched to %s flow setpoint", auto_target_is_cooling ? "cooling" : "normal");
+            start_auto_transition(auto_target_is_cooling ? "AUTO->cooling" : "AUTO->normal");
+          }
+          last_auto_target_is_cooling = auto_target_is_cooling;
           id(oq_flow_last_mode) = mode;
 
           // Autotune temporarily overrides PWM (flow_control remains output owner).

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -720,6 +720,7 @@
 
     [
       ["Flow Setpoint", 800, 0, 1500, 10, "L/h"],
+      ["Cooling Flow Setpoint", 800, 0, 1500, 10, "L/h"],
       ["Manual iPWM", 400, 50, 850, 1, "iPWM"],
       ["Flow PI Kp", 0.35, 0, 5, 0.01, ""],
       ["Flow PI Ki", 0.05, 0, 5, 0.01, ""],

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -165,6 +165,7 @@ coolingRequestOffDelta: { domain: "number", name: "Cooling Request Off Delta", o
 coolingWithoutDewPointMode: { domain: "select", name: "Cooling Without Dew Point", optional: true },
 flowControlMode: { domain: "select", name: "Flow Control Mode" },
 flowSetpoint: { domain: "number", name: "Flow Setpoint" },
+coolingFlowSetpoint: { domain: "number", name: "Cooling Flow Setpoint", optional: true },
 manualIpwm: { domain: "number", name: "Manual iPWM" },
 flowKp: { domain: "number", name: "Flow PI Kp", optional: true },
 flowKi: { domain: "number", name: "Flow PI Ki", optional: true },
@@ -413,7 +414,7 @@ const POWER_HOUSE_KEYS = [
 "phDemandFallTime",
 ];
 const LIMIT_KEYS = ["dayMax", "silentMax", "maxWater"];
-const FLOW_SETTING_KEYS = ["flowControlMode", "flowSetpoint", "manualIpwm"];
+const FLOW_SETTING_KEYS = ["flowControlMode", "flowSetpoint", "coolingFlowSetpoint", "manualIpwm"];
 const FLOW_TUNING_KEYS = ["flowKp", "flowKi"];
 const COMMISSIONING_STATE_KEYS = [
 "commissioningStatus",
@@ -859,7 +860,7 @@ keys: [
 {
 id: "flow",
 label: "Flow",
-keys: ["flowControlMode", "flowSetpoint", "manualIpwm", "flowKp", "flowKi"],
+keys: ["flowControlMode", "flowSetpoint", "coolingFlowSetpoint", "manualIpwm", "flowKp", "flowKi"],
 },
 {
 id: "cooling",
@@ -9104,12 +9105,16 @@ ${renderSettingsSelectField("strategy", "Verwarmingsstrategie", "Kies tussen aut
 `;
 }
 function renderFlowSettingsFields(className = "oq-settings-grid") {
+const autoFields = [
+renderSettingsNumberField("flowSetpoint", "Gewenste flow verwarmen", "De flow die OpenQuatt zoveel mogelijk probeert vast te houden buiten koeling."),
+renderSettingsNumberField("coolingFlowSetpoint", "Gewenste flow koelen", "De flow die OpenQuatt gebruikt tijdens actieve koeling."),
+].filter(Boolean).join("");
 return `
 <div class="${escapeHtml(className)}">
 ${renderSettingsSelectField("flowControlMode", "Regelmodus", "Kies tussen automatische flowregeling en een vaste pompstand.")}
 ${isManualFlowMode()
 ? renderSettingsNumberField("manualIpwm", "Vaste pompstand", "Deze pompstand wordt gebruikt zolang de regeling op handmatig staat.")
-: renderSettingsNumberField("flowSetpoint", "Gewenste flow", "De flow die OpenQuatt zoveel mogelijk probeert vast te houden.")}
+: autoFields}
 </div>
 `;
 }

--- a/openquatt/web/js/src/00-config.js
+++ b/openquatt/web/js/src/00-config.js
@@ -165,6 +165,7 @@ const LOGO_MARKUP = `
     coolingWithoutDewPointMode: { domain: "select", name: "Cooling Without Dew Point", optional: true },
     flowControlMode: { domain: "select", name: "Flow Control Mode" },
     flowSetpoint: { domain: "number", name: "Flow Setpoint" },
+    coolingFlowSetpoint: { domain: "number", name: "Cooling Flow Setpoint", optional: true },
     manualIpwm: { domain: "number", name: "Manual iPWM" },
     flowKp: { domain: "number", name: "Flow PI Kp", optional: true },
     flowKi: { domain: "number", name: "Flow PI Ki", optional: true },
@@ -416,7 +417,7 @@ const LOGO_MARKUP = `
     "phDemandFallTime",
   ];
   const LIMIT_KEYS = ["dayMax", "silentMax", "maxWater"];
-  const FLOW_SETTING_KEYS = ["flowControlMode", "flowSetpoint", "manualIpwm"];
+  const FLOW_SETTING_KEYS = ["flowControlMode", "flowSetpoint", "coolingFlowSetpoint", "manualIpwm"];
   const FLOW_TUNING_KEYS = ["flowKp", "flowKi"];
   const COMMISSIONING_STATE_KEYS = [
     "commissioningStatus",
@@ -864,7 +865,7 @@ const LOGO_MARKUP = `
     {
       id: "flow",
       label: "Flow",
-      keys: ["flowControlMode", "flowSetpoint", "manualIpwm", "flowKp", "flowKi"],
+      keys: ["flowControlMode", "flowSetpoint", "coolingFlowSetpoint", "manualIpwm", "flowKp", "flowKi"],
     },
     {
       id: "cooling",

--- a/openquatt/web/js/src/10-settings.js
+++ b/openquatt/web/js/src/10-settings.js
@@ -910,12 +910,16 @@
   }
 
   function renderFlowSettingsFields(className = "oq-settings-grid") {
+    const autoFields = [
+      renderSettingsNumberField("flowSetpoint", "Gewenste flow verwarmen", "De flow die OpenQuatt zoveel mogelijk probeert vast te houden buiten koeling."),
+      renderSettingsNumberField("coolingFlowSetpoint", "Gewenste flow koelen", "De flow die OpenQuatt gebruikt tijdens actieve koeling."),
+    ].filter(Boolean).join("");
     return `
       <div class="${escapeHtml(className)}">
         ${renderSettingsSelectField("flowControlMode", "Regelmodus", "Kies tussen automatische flowregeling en een vaste pompstand.")}
         ${isManualFlowMode()
           ? renderSettingsNumberField("manualIpwm", "Vaste pompstand", "Deze pompstand wordt gebruikt zolang de regeling op handmatig staat.")
-          : renderSettingsNumberField("flowSetpoint", "Gewenste flow", "De flow die OpenQuatt zoveel mogelijk probeert vast te houden.")}
+          : autoFields}
       </div>
     `;
   }


### PR DESCRIPTION
## Summary
- add Cooling Flow Setpoint as a separate automatic flow target for CM5 cooling
- keep Flow Setpoint for heating/normal automatic flow control
- add separate restored last-good pump PWM memory for cooling starts and live target switches
- migrate the initial cooling flow setpoint and cooling last-good PWM from the current normal flow settings once
- update web app, mock device, HA dashboards, and docs

## Validation
- node --check openquatt/web/js/openquatt-app.js
- esphome config configs/waveshare/single_wifi.yaml
- esphome config configs/waveshare/duo_wifi.yaml
- git diff --check