### PR TITLE
Add Q controller PT1000 and flow inputs

### DIFF
--- a/configs/heatpump_controller_q/duo_eth.yaml
+++ b/configs/heatpump_controller_q/duo_eth.yaml
@@ -8,6 +8,8 @@ substitutions:
   <<: !include ../../openquatt/topology/duo.yaml
   oq_hardware_profile: "heatpump_controller_q"
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
+  oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000"
+  oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=1"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-duo-eth-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-duo-eth-ota.manifest.json"

--- a/configs/heatpump_controller_q/duo_eth.yaml
+++ b/configs/heatpump_controller_q/duo_eth.yaml
@@ -6,6 +6,8 @@
 substitutions:
   <<: !include ../../openquatt/oq_substitutions_common.yaml
   <<: !include ../../openquatt/topology/duo.yaml
+  oq_hardware_profile: "heatpump_controller_q"
+  oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=1"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-duo-eth-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-duo-eth-ota.manifest.json"

--- a/configs/heatpump_controller_q/duo_eth.yaml
+++ b/configs/heatpump_controller_q/duo_eth.yaml
@@ -9,6 +9,7 @@ substitutions:
   oq_hardware_profile: "heatpump_controller_q"
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
   oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000"
+  oq_local_supply_temp_selector_id: "oq_local_supply_temp_source"
   oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=1"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-duo-eth-ota.manifest.json"

--- a/configs/heatpump_controller_q/duo_wifi.yaml
+++ b/configs/heatpump_controller_q/duo_wifi.yaml
@@ -6,6 +6,8 @@ substitutions:
   <<: !include ../../openquatt/topology/duo.yaml
   oq_hardware_profile: "heatpump_controller_q"
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
+  oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000"
+  oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=1"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-duo-wifi-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-duo-wifi-ota.manifest.json"

--- a/configs/heatpump_controller_q/duo_wifi.yaml
+++ b/configs/heatpump_controller_q/duo_wifi.yaml
@@ -4,6 +4,8 @@
 substitutions:
   <<: !include ../../openquatt/oq_substitutions_common.yaml
   <<: !include ../../openquatt/topology/duo.yaml
+  oq_hardware_profile: "heatpump_controller_q"
+  oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=1"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-duo-wifi-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-duo-wifi-ota.manifest.json"

--- a/configs/heatpump_controller_q/duo_wifi.yaml
+++ b/configs/heatpump_controller_q/duo_wifi.yaml
@@ -7,6 +7,7 @@ substitutions:
   oq_hardware_profile: "heatpump_controller_q"
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
   oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000"
+  oq_local_supply_temp_selector_id: "oq_local_supply_temp_source"
   oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=1"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-duo-wifi-ota.manifest.json"

--- a/configs/heatpump_controller_q/single_eth.yaml
+++ b/configs/heatpump_controller_q/single_eth.yaml
@@ -9,6 +9,7 @@ substitutions:
   oq_hardware_profile: "heatpump_controller_q"
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
   oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000"
+  oq_local_supply_temp_selector_id: "oq_local_supply_temp_source"
   oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=0"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-eth-ota.manifest.json"

--- a/configs/heatpump_controller_q/single_eth.yaml
+++ b/configs/heatpump_controller_q/single_eth.yaml
@@ -8,6 +8,8 @@ substitutions:
   <<: !include ../../openquatt/topology/single.yaml
   oq_hardware_profile: "heatpump_controller_q"
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
+  oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000"
+  oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=0"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-eth-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-single-eth-ota.manifest.json"

--- a/configs/heatpump_controller_q/single_eth.yaml
+++ b/configs/heatpump_controller_q/single_eth.yaml
@@ -6,6 +6,8 @@
 substitutions:
   <<: !include ../../openquatt/oq_substitutions_common.yaml
   <<: !include ../../openquatt/topology/single.yaml
+  oq_hardware_profile: "heatpump_controller_q"
+  oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=0"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-eth-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-single-eth-ota.manifest.json"

--- a/configs/heatpump_controller_q/single_wifi.yaml
+++ b/configs/heatpump_controller_q/single_wifi.yaml
@@ -4,6 +4,8 @@
 substitutions:
   <<: !include ../../openquatt/oq_substitutions_common.yaml
   <<: !include ../../openquatt/topology/single.yaml
+  oq_hardware_profile: "heatpump_controller_q"
+  oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=0"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-wifi-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-single-wifi-ota.manifest.json"

--- a/configs/heatpump_controller_q/single_wifi.yaml
+++ b/configs/heatpump_controller_q/single_wifi.yaml
@@ -7,6 +7,7 @@ substitutions:
   oq_hardware_profile: "heatpump_controller_q"
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
   oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000"
+  oq_local_supply_temp_selector_id: "oq_local_supply_temp_source"
   oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=0"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-wifi-ota.manifest.json"

--- a/configs/heatpump_controller_q/single_wifi.yaml
+++ b/configs/heatpump_controller_q/single_wifi.yaml
@@ -6,6 +6,8 @@ substitutions:
   <<: !include ../../openquatt/topology/single.yaml
   oq_hardware_profile: "heatpump_controller_q"
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1"
+  oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000"
+  oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=0"
   main_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-wifi-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/jeroen85/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-single-wifi-ota.manifest.json"

--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -30,6 +30,7 @@ esphome:
     build_flags:
       # Hard-pinned by the topology entrypoint to prevent accidental topology drift.
       - ${oq_topology_build_flag}
+      - ${oq_hardware_build_flag}
   on_boot:
     priority: -100
     then:

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -225,6 +225,15 @@ sensor:
     accuracy_decimals: 0
     update_interval: 1s
     lambda: |-
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+      // On the Heatpump Controller Q, V1 uses the central controller flowmeter.
+      // V1.5/V2 keep using the outdoor-unit Modbus flowmeters.
+      if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V1") {
+        if (id(flow_rate_controller).has_state()) return id(flow_rate_controller).state;
+        return NAN;
+      }
+      #endif
+
       const bool secondary_enabled = (${flow_secondary_enabled} != 0);
       float f1 = id(hp1_flow).state;
       float f2 = secondary_enabled ? id(${flow_secondary_flow_sensor_id}).state : NAN;
@@ -275,6 +284,15 @@ binary_sensor:
       static bool state = false;
       static bool mismatch_timer_running = false;
       static uint32_t mismatch_start_ms = 0;
+
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+      if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V1") {
+        state = false;
+        mismatch_timer_running = false;
+        mismatch_start_ms = 0;
+        return false;
+      }
+      #endif
 
       const bool secondary_enabled = (${flow_secondary_enabled} != 0);
       if (!secondary_enabled) {

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -229,7 +229,7 @@ sensor:
       // On the Heatpump Controller Q, V1 uses the central controller flowmeter.
       // V1.5/V2 keep using the outdoor-unit Modbus flowmeters.
       if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V1") {
-        if (id(flow_rate_controller).has_state()) return id(flow_rate_controller).state;
+        if (id(${oq_controller_flow_sensor_id}).has_state()) return id(${oq_controller_flow_sensor_id}).state;
         return NAN;
       }
       #endif

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -225,18 +225,17 @@ sensor:
     accuracy_decimals: 0
     update_interval: 1s
     lambda: |-
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      // On the Heatpump Controller Q, V1 uses the central controller flowmeter.
-      // V1.5/V2 keep using the outdoor-unit Modbus flowmeters.
-      if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V1") {
-        if (id(${oq_controller_flow_sensor_id}).has_state()) return id(${oq_controller_flow_sensor_id}).state;
-        return NAN;
-      }
-      #endif
-
       const bool secondary_enabled = (${flow_secondary_enabled} != 0);
       float f1 = id(hp1_flow).state;
       float f2 = secondary_enabled ? id(${flow_secondary_flow_sensor_id}).state : NAN;
+
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+      // Q-edition V1 uses the central controller meter as its primary local flow.
+      // In a mixed V1/V1.5 Duo, keep aggregating the secondary outdoor-unit meter.
+      if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V1") {
+        f1 = id(${oq_controller_flow_sensor_id}).has_state() ? id(${oq_controller_flow_sensor_id}).state : NAN;
+      }
+      #endif
 
       const bool v1 = !isnan(f1);
       const bool v2 = !isnan(f2);
@@ -285,15 +284,6 @@ binary_sensor:
       static bool mismatch_timer_running = false;
       static uint32_t mismatch_start_ms = 0;
 
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V1") {
-        state = false;
-        mismatch_timer_running = false;
-        mismatch_start_ms = 0;
-        return false;
-      }
-      #endif
-
       const bool secondary_enabled = (${flow_secondary_enabled} != 0);
       if (!secondary_enabled) {
         state = false;
@@ -304,6 +294,13 @@ binary_sensor:
 
       float f1 = id(hp1_flow).state;
       float f2 = id(${flow_secondary_flow_sensor_id}).state;
+
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+      // Compare the Q-edition V1 controller meter with a secondary V1.5 meter when present.
+      if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V1") {
+        f1 = id(${oq_controller_flow_sensor_id}).has_state() ? id(${oq_controller_flow_sensor_id}).state : NAN;
+      }
+      #endif
 
       // Evaluate only when both are valid; otherwise reset indication.
       if (isnan(f1) || isnan(f2)) {

--- a/openquatt/oq_local_sensors.yaml
+++ b/openquatt/oq_local_sensors.yaml
@@ -43,8 +43,8 @@ sensor:
     update_interval: 5s
     lambda: |-
       #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (id(water_supply_temp_pt1000).has_state() && !isnan(id(water_supply_temp_pt1000).state)) {
-        return id(water_supply_temp_pt1000).state;
+      if (id(${oq_local_supply_temp_sensor_id}).has_state() && !isnan(id(${oq_local_supply_temp_sensor_id}).state)) {
+        return id(${oq_local_supply_temp_sensor_id}).state;
       }
       #endif
       if (id(water_supply_temp_ds18b20).has_state() && !isnan(id(water_supply_temp_ds18b20).state)) {

--- a/openquatt/oq_local_sensors.yaml
+++ b/openquatt/oq_local_sensors.yaml
@@ -7,6 +7,7 @@
 #
 # Current scope:
 #   - DS18B20 local water supply temperature (1-Wire on configured GPIO)
+#   - Heatpump Controller Q PT1000/MAX31865 local water supply temperature
 #
 # ==============================================================================
 
@@ -17,15 +18,38 @@ one_wire:
 
 sensor:
   - platform: dallas_temp
+    id: water_supply_temp_ds18b20
+    name: "Water Supply Temp (DS18B20)"
+    icon: mdi:thermometer
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+    disabled_by_default: true
+    accuracy_decimals: 2
+    update_interval: 5s
+    one_wire_id: oq_local_temp_bus
+    index: 0
+    web_server:
+      sorting_group_id: oq_temperatures
+
+  - platform: template
     id: water_supply_temp_esp
     name: "Water Supply Temp"
-    icon: mdi:thermometer
+    icon: mdi:water-thermometer
     unit_of_measurement: "°C"
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 5s
-    one_wire_id: oq_local_temp_bus
-    index: 0
+    lambda: |-
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+      if (id(water_supply_temp_pt1000).has_state() && !isnan(id(water_supply_temp_pt1000).state)) {
+        return id(water_supply_temp_pt1000).state;
+      }
+      #endif
+      if (id(water_supply_temp_ds18b20).has_state() && !isnan(id(water_supply_temp_ds18b20).state)) {
+        return id(water_supply_temp_ds18b20).state;
+      }
+      return NAN;
     web_server:
       sorting_group_id: oq_temperatures

--- a/openquatt/oq_local_sensors.yaml
+++ b/openquatt/oq_local_sensors.yaml
@@ -43,8 +43,11 @@ sensor:
     update_interval: 5s
     lambda: |-
       #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (id(${oq_local_supply_temp_sensor_id}).has_state() && !isnan(id(${oq_local_supply_temp_sensor_id}).state)) {
-        return id(${oq_local_supply_temp_sensor_id}).state;
+      if (id(${oq_local_supply_temp_selector_id}).current_option() == "PT1000") {
+        if (id(${oq_local_supply_temp_sensor_id}).has_state() && !isnan(id(${oq_local_supply_temp_sensor_id}).state)) {
+          return id(${oq_local_supply_temp_sensor_id}).state;
+        }
+        return NAN;
       }
       #endif
       if (id(water_supply_temp_ds18b20).has_state() && !isnan(id(water_supply_temp_ds18b20).state)) {

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -361,8 +361,15 @@ sensor:
         //   (normally average, but with mismatch guard inside flow_rate_hp_avg)
         // This keeps the main flow source selector compact while still allowing
         // per-flowmeter inspection and explicit selection for local Duo flow.
+        // On Q-edition V1, the controller flowmeter is the primary local meter.
         const auto local_mode = id(oq_duo_outdoor_flow_mode).current_option();
         if (local_mode == "Flowmeter HP1") {
+          #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+          if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V1") {
+            if (id(${oq_controller_flow_sensor_id}).has_state()) return id(${oq_controller_flow_sensor_id}).state;
+            return NAN;
+          }
+          #endif
           if (id(hp1_flow).has_state()) return id(hp1_flow).state;
           return NAN;
         }

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -16,6 +16,7 @@ project_name: "openquatt.openquatt"                   # ESPHome project identifi
 project_version: "v0.32.0"                            # ESPHome project version shown in firmware metadata.
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 oq_hardware_profile: "unknown"                        # Compile-time hardware profile id.
+oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=0" # Hardware capability flag for C++ lambdas.
 oq_connection: "unknown"                              # Compile-time connection profile id (`wifi` or `eth`).
 alternate_connection: ""                              # Optional connection target used for controlled Wi-Fi/Ethernet switching.
 alternate_main_release_manifest_url: ""               # Optional main-channel OTA manifest for the alternate connection target.

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -17,6 +17,8 @@ project_version: "v0.32.0"                            # ESPHome project version 
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 oq_hardware_profile: "unknown"                        # Compile-time hardware profile id.
 oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=0" # Hardware capability flag for C++ lambdas.
+oq_local_supply_temp_sensor_id: "water_supply_temp_ds18b20" # Profile-safe local supply-temperature source used by shared lambdas.
+oq_controller_flow_sensor_id: "hp1_flow"              # Profile-safe controller-flow source used by shared lambdas.
 oq_connection: "unknown"                              # Compile-time connection profile id (`wifi` or `eth`).
 alternate_connection: ""                              # Optional connection target used for controlled Wi-Fi/Ethernet switching.
 alternate_main_release_manifest_url: ""               # Optional main-channel OTA manifest for the alternate connection target.

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -17,7 +17,8 @@ project_version: "v0.32.0"                            # ESPHome project version 
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 oq_hardware_profile: "unknown"                        # Compile-time hardware profile id.
 oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=0" # Hardware capability flag for C++ lambdas.
-oq_local_supply_temp_sensor_id: "water_supply_temp_ds18b20" # Profile-safe local supply-temperature source used by shared lambdas.
+oq_local_supply_temp_sensor_id: "water_supply_temp_ds18b20" # Profile-safe local supply-temperature sensor used by shared lambdas.
+oq_local_supply_temp_selector_id: "water_supply_source"     # Validation-safe placeholder outside Q profiles.
 oq_controller_flow_sensor_id: "hp1_flow"              # Profile-safe controller-flow source used by shared lambdas.
 oq_connection: "unknown"                              # Compile-time connection profile id (`wifi` or `eth`).
 alternate_connection: ""                              # Optional connection target used for controlled Wi-Fi/Ethernet switching.

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -85,7 +85,7 @@ sensor:
     filters:
       - lambda: |-
           if (isnan(x)) return x;
-          if (x < -10.0f || x > 100.0f) return {};
+          if (x < -10.0f || x > 100.0f) return NAN;
           return x;
     web_server:
       sorting_group_id: oq_temperatures

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -67,10 +67,10 @@ sensor:
     rtd_wires: ${hpcq_pt1000_rtd_wires}
     mains_filter: "50 Hz"
     filters:
-      - clamp:
-          min_value: -10
-          max_value: 100
-          ignore_out_of_range: true
+      - lambda: |-
+          if (isnan(x)) return x;
+          if (x < -10.0f || x > 100.0f) return {};
+          return x;
     web_server:
       sorting_group_id: oq_temperatures
 

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -4,6 +4,8 @@
 substitutions:
   oq_hardware_profile: "heatpump_controller_q"         # Compile-time hardware profile id.
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1" # Enable Q-only local sensor paths.
+  oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000" # Prefer the controller PT1000 over the DS18B20 fallback.
+  oq_controller_flow_sensor_id: "flow_rate_controller" # Use the controller pulse meter for V1 flow.
   esp_board: "esp32-s3-devkitc-1"                       # PlatformIO board shared with the Waveshare S3 build.
   esp_flash_size: "16MB"                                # Active ESP flash size.
   esp_variant: "esp32s3"                                # Active ESP variant.

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -3,6 +3,7 @@
 # ==============================================================================
 substitutions:
   oq_hardware_profile: "heatpump_controller_q"         # Compile-time hardware profile id.
+  oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1" # Enable Q-only local sensor paths.
   esp_board: "esp32-s3-devkitc-1"                       # PlatformIO board shared with the Waveshare S3 build.
   esp_flash_size: "16MB"                                # Active ESP flash size.
   esp_variant: "esp32s3"                                # Active ESP variant.
@@ -23,8 +24,77 @@ substitutions:
   eth_miso_pin: "GPIO11"                                # W5500 SPI MISO.
   eth_clk_pin: "GPIO12"                                 # W5500 SPI CLK.
   eth_cs_pin: "GPIO13"                                  # W5500 SPI CS.
+  hpcq_pt1000_mosi_pin: "GPIO5"                         # MAX31865 MOSI / SDI.
+  hpcq_pt1000_miso_pin: "GPIO2"                         # MAX31865 MISO / SDO.
+  hpcq_pt1000_clk_pin: "GPIO4"                          # MAX31865 SPI clock.
+  hpcq_pt1000_cs_pin: "GPIO3"                           # MAX31865 chip select.
+  hpcq_pt1000_drdy_pin: "GPIO1"                         # MAX31865 DRDY/RDY pin; ESPHome MAX31865 does not use it.
+  hpcq_pt1000_reference_resistance_ohm: "4300"          # PT1000 MAX31865 reference resistor.
+  hpcq_pt1000_nominal_resistance_ohm: "1000"            # PT1000 nominal resistance at 0 degrees C.
+  hpcq_pt1000_rtd_wires: "2"                            # Probe wiring mode; board jumpers must match.
+  hpcq_flow_pin: "GPIO6"                                # V1 central flowmeter pulse input.
+  hpcq_flow_kf_lpm_per_hz: "0.1836"                     # Flow coefficient: Qv[l/min] = Kf * f[Hz] + Q0.
+  hpcq_flow_q0_lpm: "-0.2"                              # Flow intercept [l/min].
 
 psram:
   mode: octal
   speed: 80MHz
   ignore_not_found: false
+
+spi:
+  - id: oq_hpcq_pt1000_spi
+    mosi_pin: ${hpcq_pt1000_mosi_pin}
+    miso_pin: ${hpcq_pt1000_miso_pin}
+    clk_pin: ${hpcq_pt1000_clk_pin}
+    interface: spi3
+
+sensor:
+  - platform: max31865
+    id: water_supply_temp_pt1000
+    name: "Water Supply Temp (PT1000)"
+    icon: mdi:thermometer
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+    accuracy_decimals: 2
+    update_interval: 5s
+    spi_id: oq_hpcq_pt1000_spi
+    cs_pin: ${hpcq_pt1000_cs_pin}
+    reference_resistance: ${hpcq_pt1000_reference_resistance_ohm}
+    rtd_nominal_resistance: ${hpcq_pt1000_nominal_resistance_ohm}
+    rtd_wires: ${hpcq_pt1000_rtd_wires}
+    mains_filter: "50 Hz"
+    filters:
+      - clamp:
+          min_value: -10
+          max_value: 100
+          ignore_out_of_range: true
+    web_server:
+      sorting_group_id: oq_temperatures
+
+  - platform: pulse_meter
+    id: flow_rate_controller
+    name: "Controller Flow"
+    icon: mdi:waves
+    unit_of_measurement: "L/h"
+    device_class: volume_flow_rate
+    state_class: measurement
+    accuracy_decimals: 1
+    timeout: 5s
+    internal_filter: 100us
+    pin:
+      number: ${hpcq_flow_pin}
+      mode:
+        input: true
+        pullup: true
+    filters:
+      - lambda: |-
+          // pulse_meter publishes pulses/minute. Convert to Hz first:
+          // Qv[l/min] = Kf * f[Hz] + Q0, then convert to l/h.
+          const float hz = x / 60.0f;
+          const float lpm = (${hpcq_flow_kf_lpm_per_hz}f * hz) + (${hpcq_flow_q0_lpm}f);
+          if (isnan(lpm)) return NAN;
+          const float lph = lpm * 60.0f;
+          return lph > 0.0f ? lph : 0.0f;
+    web_server:
+      sorting_group_id: oq_hydraulics

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -4,7 +4,8 @@
 substitutions:
   oq_hardware_profile: "heatpump_controller_q"         # Compile-time hardware profile id.
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1" # Enable Q-only local sensor paths.
-  oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000" # Prefer the controller PT1000 over the DS18B20 fallback.
+  oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000" # Q-edition local PT1000 source.
+  oq_local_supply_temp_selector_id: "oq_local_supply_temp_source" # Explicit local physical-sensor selection.
   oq_controller_flow_sensor_id: "flow_rate_controller" # Use the controller pulse meter for V1 flow.
   esp_board: "esp32-s3-devkitc-1"                       # PlatformIO board shared with the Waveshare S3 build.
   esp_flash_size: "16MB"                                # Active ESP flash size.
@@ -42,6 +43,21 @@ psram:
   mode: octal
   speed: 80MHz
   ignore_not_found: false
+
+select:
+  - platform: template
+    id: oq_local_supply_temp_source
+    name: "Local Water Supply Temp Source"
+    icon: mdi:thermometer-check
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - PT1000
+      - DS18B20
+    initial_option: PT1000
+    web_server:
+      sorting_group_id: oq_sensor_selection
 
 spi:
   - id: oq_hpcq_pt1000_spi


### PR DESCRIPTION
## Summary
- Add Heatpump Controller Q pins and sensors for the MAX31865/PT1000 supply-temperature input and GPIO6 pulse-flow input.
- Add an explicit Q-edition local supply-temperature selector with `PT1000` and `DS18B20` options. Q builds default to `PT1000`; other hardware profiles continue to use DS18B20.
- Keep `Water Supply Temp` as the local selected-source input without silent physical-sensor fallback. If the selected PT1000 is invalid, the local value becomes `NAN` until the sensor recovers or the user explicitly selects DS18B20.
- Invalidate MAX31865 faults and implausible finite PT1000 readings outside `-10..100 °C` so stale valid readings are not retained.
- Treat the controller flowmeter as the primary local meter for Q builds when `Quatt Hybrid version` is `V1`. Single V1 uses that meter directly; a mixed V1/V1.5 Duo aggregates it with the secondary outdoor-unit meter using the existing fallback and mismatch safeguards. V1.5/V2 continue to use outdoor-unit Modbus flow.
- Route Q-only sensor IDs through profile-safe substitutions so shared lambdas validate for Q, Waveshare and listener profiles.

## Notes
- MAX31865 DRDY is captured as a pin substitution but not wired into ESPHome because the MAX31865 component does not use DRDY.
- Q Ethernet builds require the PT1000 SPI bus to use `spi3`, leaving W5500 Ethernet on its existing SPI interface.
- DS18B20 remains available on Q hardware as an explicit alternative local source; it is not used as an automatic fallback.
- For Q/V1 Duo diagnostics, `Flowmeter HP1` maps to the controller meter, `Flowmeter HP2` remains the secondary outdoor-unit meter and `Local aggregate HP1/HP2` remains the recommended regulation path.

## Validation
- `git diff --check`
- `esphome config configs/heatpump_controller_q/single_wifi.yaml`
- `esphome config configs/heatpump_controller_q/duo_wifi.yaml`
- `esphome config configs/heatpump_controller_q/single_eth.yaml`
- `esphome config configs/heatpump_controller_q/duo_eth.yaml`
- `esphome config configs/waveshare/duo_wifi.yaml`
- `esphome config configs/heatpump_listener/duo_wifi.yaml`
- `esphome compile configs/heatpump_controller_q/single_wifi.yaml`
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`
- `esphome compile configs/waveshare/duo_wifi.yaml`

Local validation and all three representative full compiles pass. Known GPIO strapping-pin warnings remain unchanged. GitHub CI runs again for the latest commit.