### PR TITLE
Scope CiC compatibility to Q controller

### DIFF
--- a/configs/heatpump_controller_q/duo_eth.yaml
+++ b/configs/heatpump_controller_q/duo_eth.yaml
@@ -24,6 +24,8 @@ esphome:
 
 packages:
   openquatt_profile_heatpump_controller_q: !include ../../openquatt/profiles/heatpump_controller_q.yaml
+  openquatt_profile_heatpump_controller_q_cic_compatibility: !include ../../openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+  openquatt_profile_heatpump_controller_q_cic_compatibility_duo: !include ../../openquatt/profiles/heatpump_controller_q_cic_compatibility_duo.yaml
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_eth: !include ../../openquatt/connection/eth.yaml
   <<: !include ../../openquatt/oq_packages_common.yaml

--- a/configs/heatpump_controller_q/duo_wifi.yaml
+++ b/configs/heatpump_controller_q/duo_wifi.yaml
@@ -22,6 +22,8 @@ esphome:
 
 packages:
   openquatt_profile_heatpump_controller_q: !include ../../openquatt/profiles/heatpump_controller_q.yaml
+  openquatt_profile_heatpump_controller_q_cic_compatibility: !include ../../openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+  openquatt_profile_heatpump_controller_q_cic_compatibility_duo: !include ../../openquatt/profiles/heatpump_controller_q_cic_compatibility_duo.yaml
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_wifi: !include ../../openquatt/connection/wifi.yaml
   <<: !include ../../openquatt/oq_packages_common.yaml

--- a/configs/heatpump_controller_q/single_eth.yaml
+++ b/configs/heatpump_controller_q/single_eth.yaml
@@ -24,6 +24,7 @@ esphome:
 
 packages:
   openquatt_profile_heatpump_controller_q: !include ../../openquatt/profiles/heatpump_controller_q.yaml
+  openquatt_profile_heatpump_controller_q_cic_compatibility: !include ../../openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_eth: !include ../../openquatt/connection/eth.yaml
   <<: !include ../../openquatt/oq_packages_common.yaml

--- a/configs/heatpump_controller_q/single_wifi.yaml
+++ b/configs/heatpump_controller_q/single_wifi.yaml
@@ -22,6 +22,7 @@ esphome:
 
 packages:
   openquatt_profile_heatpump_controller_q: !include ../../openquatt/profiles/heatpump_controller_q.yaml
+  openquatt_profile_heatpump_controller_q_cic_compatibility: !include ../../openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_wifi: !include ../../openquatt/connection/wifi.yaml
   <<: !include ../../openquatt/oq_packages_common.yaml

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -153,26 +153,12 @@ uart:
     parity: EVEN
     rx_full_threshold: 1
     rx_timeout: 1
-  - id: cic_compat_uart_bus
-    tx_pin: ${cic_compat_uart_tx_pin}
-    rx_pin: ${cic_compat_uart_rx_pin}
-    baud_rate: 19200
-    data_bits: 8
-    stop_bits: 1
-    parity: EVEN
-    rx_full_threshold: 1
-    rx_timeout: 1
 
 modbus:
   - uart_id: uart_bus
     id: mod_bus
     flow_control_pin: ${uart_rts_pin}
     send_wait_time: 100ms
-  - uart_id: cic_compat_uart_bus
-    id: cic_compat_modbus
-    role: server
-    flow_control_pin: ${cic_compat_uart_rts_pin}
-    send_wait_time: 50ms
 
 # ==============================================================================
 # SHARED RUNTIME STATE

--- a/openquatt/oq_packages_common.yaml
+++ b/openquatt/oq_packages_common.yaml
@@ -12,16 +12,15 @@
 # 8) Flow/boiler and other actuation followers
 # 9) Aggregation/energy telemetry
 # 10) External inputs (CIC)
-# 11) CiC compatibility bridge
-# 12) External HA proxy inputs
-# 13) Local sensors
-# 14) Source selection and merged selected-source signals
-# 15) OpenTherm thermostat bridge
-# 16) Setup/status
-# 17) Web UI
-# 18) Web access runtime
-# 19) MQTT runtime/config
-# 20) Per-HP hardware adapters
+# 11) External HA proxy inputs
+# 12) Local sensors
+# 13) Source selection and merged selected-source signals
+# 14) OpenTherm thermostat bridge
+# 15) Setup/status
+# 16) Web UI
+# 17) Web access runtime
+# 18) MQTT runtime/config
+# 19) Per-HP hardware adapters
 # ==============================================================================
 # Shared modules use `*_secondary_*` template vars so topology wiring stays
 # centralized in topology substitutions and avoids duplicated module files.
@@ -137,13 +136,6 @@ oq_cic: !include
   vars:
     cic_secondary_enabled: "${cic_secondary_enabled}"
     cic_hp2_sensor_internal: "${cic_hp2_sensor_internal}"
-oq_cic_compatibility: !include oq_cic_compatibility.yaml
-oq_cic_compatibility_hp1: !include
-  file: oq_cic_compatibility_server.yaml
-  vars:
-    cic_compat_hp_id: "hp1"
-    cic_compat_label: "HP1"
-    cic_compat_device_address: "${cic_compat_modbus_address_hp1}"
 oq_ha_inputs: !include oq_ha_inputs.yaml
 oq_local_sensors: !include oq_local_sensors.yaml
 oq_sensor_sources: !include

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -177,13 +177,6 @@ cic_feed_error_trip_n: "3"                            # Feed OK becomes false af
 oq_cic_restore_mode_default: "RESTORE_DEFAULT_OFF"    # Default CIC polling state.
 
 # ----------------------------
-# CIC COMPATIBILITY
-# ----------------------------
-cic_compat_modbus_address_hp1: "0x01"                 # CiC-facing Modbus address for HP1 compatibility data.
-cic_compat_modbus_address_hp2: "0x02"                 # CiC-facing Modbus address for HP2 compatibility data.
-oq_cic_compat_restore_mode_default: "RESTORE_DEFAULT_OFF" # Default CiC compatibility mode state.
-
-# ----------------------------
 # HA INPUT ENTITY MAPPING
 # ----------------------------
 ha_outside_temp_entity_id: "sensor.openquatt_ext_outdoor_temperature"      # HA proxy entity for outside temperature [degC].

--- a/openquatt/oq_webserver.yaml
+++ b/openquatt/oq_webserver.yaml
@@ -45,9 +45,6 @@ web_server:
     - id: oq_boiler
       name: "Boiler"
       sorting_weight: 50
-    - id: oq_cic_compatibility
-      name: "CiC Compatibility"
-      sorting_weight: 52
     - id: oq_cic
       name: "CIC Feed"
       sorting_weight: 55

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -14,9 +14,6 @@ substitutions:
   uart_tx_pin: "GPIO42"                                 # Modbus 1 TX; primary heat-pump bus.
   uart_rx_pin: "GPIO45"                                 # Modbus 1 RX; primary heat-pump bus.
   uart_rts_pin: "GPIO41"                                # Modbus 1 DE/RE; primary heat-pump bus.
-  cic_compat_uart_tx_pin: "GPIO40"                      # Modbus 2 TX; CiC compatibility / extra bus.
-  cic_compat_uart_rx_pin: "GPIO39"                      # Modbus 2 RX; CiC compatibility / extra bus.
-  cic_compat_uart_rts_pin: "GPIO38"                     # Modbus 2 DE/RE; CiC compatibility / extra bus.
   oq_ot_thermostat_in_pin: "GPIO16"                     # OpenTherm thermostat input.
   oq_ot_thermostat_out_pin: "GPIO15"                    # OpenTherm thermostat output.
   ds18b20_pin: "GPIO14"                                 # Dallas DS18B20 1-Wire input.

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
@@ -1,0 +1,47 @@
+# ==============================================================================
+# OpenQuatt - Heatpump Controller Q-edition CiC compatibility port
+# ==============================================================================
+#
+# The secondary RS485 port is physically available only on the Q-edition
+# controller. Listener and Waveshare builds must not initialize dummy pins.
+# ==============================================================================
+substitutions:
+  cic_compat_uart_tx_pin: "GPIO40"                      # Modbus 2 TX; CiC compatibility port.
+  cic_compat_uart_rx_pin: "GPIO39"                      # Modbus 2 RX; CiC compatibility port.
+  cic_compat_uart_rts_pin: "GPIO38"                     # Modbus 2 DE/RE; CiC compatibility port.
+  cic_compat_modbus_address_hp1: "0x01"                 # CiC-facing Modbus address for HP1 data.
+  cic_compat_modbus_address_hp2: "0x02"                 # CiC-facing Modbus address for HP2 data.
+  oq_cic_compat_restore_mode_default: "RESTORE_DEFAULT_OFF" # Default compatibility mode state.
+
+uart:
+  - id: cic_compat_uart_bus
+    tx_pin: ${cic_compat_uart_tx_pin}
+    rx_pin: ${cic_compat_uart_rx_pin}
+    baud_rate: 19200
+    data_bits: 8
+    stop_bits: 1
+    parity: EVEN
+    rx_full_threshold: 1
+    rx_timeout: 1
+
+modbus:
+  - uart_id: cic_compat_uart_bus
+    id: cic_compat_modbus
+    role: server
+    flow_control_pin: ${cic_compat_uart_rts_pin}
+    send_wait_time: 50ms
+
+packages:
+  oq_cic_compatibility: !include ../oq_cic_compatibility.yaml
+  oq_cic_compatibility_hp1: !include
+    file: ../oq_cic_compatibility_server.yaml
+    vars:
+      cic_compat_hp_id: "hp1"
+      cic_compat_label: "HP1"
+      cic_compat_device_address: "${cic_compat_modbus_address_hp1}"
+
+web_server:
+  sorting_groups:
+    - id: oq_cic_compatibility
+      name: "CiC Compatibility"
+      sorting_weight: 52

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility_duo.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility_duo.yaml
@@ -1,0 +1,10 @@
+# ==============================================================================
+# OpenQuatt - Heatpump Controller Q-edition Duo CiC compatibility registers
+# ==============================================================================
+packages:
+  oq_cic_compatibility_hp2: !include
+    file: ../oq_cic_compatibility_server.yaml
+    vars:
+      cic_compat_hp_id: "hp2"
+      cic_compat_label: "HP2"
+      cic_compat_device_address: "${cic_compat_modbus_address_hp2}"

--- a/openquatt/profiles/heatpump_listener.yaml
+++ b/openquatt/profiles/heatpump_listener.yaml
@@ -10,9 +10,6 @@ substitutions:
   uart_tx_pin: "GPIO33"                                 # Active RS485 TX pin.
   uart_rx_pin: "GPIO32"                                 # Active RS485 RX pin.
   uart_rts_pin: "GPIO21"                                # Active RS485 DE/RE (flow control) pin.
-  cic_compat_uart_tx_pin: "GPIO15"                      # Secondary CiC Modbus TX pin.
-  cic_compat_uart_rx_pin: "GPIO16"                      # Secondary CiC Modbus RX pin.
-  cic_compat_uart_rts_pin: "GPIO19"                     # Secondary CiC Modbus DE/RE pin.
   oq_ot_thermostat_in_pin: "GPIO25"                     # Reserved OT thermostat RX pin placeholder for future wiring.
   oq_ot_thermostat_out_pin: "GPIO26"                    # Reserved OT thermostat TX pin placeholder for future wiring.
   listener_temp_t1_pin: "GPIO4"                         # Optional external temperature sensor input T1.

--- a/openquatt/profiles/waveshare.yaml
+++ b/openquatt/profiles/waveshare.yaml
@@ -10,9 +10,6 @@ substitutions:
   uart_tx_pin: "GPIO17"                                 # Active RS485 TX pin.
   uart_rx_pin: "GPIO18"                                 # Active RS485 RX pin.
   uart_rts_pin: "GPIO21"                                # Active RS485 DE/RE (flow control) pin.
-  cic_compat_uart_tx_pin: "GPIO15"                      # Secondary CiC Modbus TX pin.
-  cic_compat_uart_rx_pin: "GPIO16"                      # Secondary CiC Modbus RX pin.
-  cic_compat_uart_rts_pin: "GPIO19"                     # Secondary CiC Modbus DE/RE pin.
   oq_ot_thermostat_in_pin: "GPIO14"                     # OpenTherm thermostat input on header pin GPIO14.
   oq_ot_thermostat_out_pin: "GPIO13"                    # OpenTherm thermostat output on header pin GPIO13.
   ds18b20_pin: "GPIO2"                                  # Active DS18B20 1-Wire pin.

--- a/openquatt/topology/duo_packages.yaml
+++ b/openquatt/topology/duo_packages.yaml
@@ -8,9 +8,3 @@ heatpump2: !include
     prefix: "HP2 - "
     device_address: 0x02
     oq_modbus_startup_delay_ms: "2500"
-oq_cic_compatibility_hp2: !include
-  file: ../oq_cic_compatibility_server.yaml
-  vars:
-    cic_compat_hp_id: "hp2"
-    cic_compat_label: "HP2"
-    cic_compat_device_address: "${cic_compat_modbus_address_hp2}"

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -111,8 +111,6 @@ STRICT_TOP_LEVEL_ORDER_RULES = {
         "oq_boiler_control",
         "oq_energy",
         "oq_cic",
-        "oq_cic_compatibility",
-        "oq_cic_compatibility_hp1",
         "oq_ha_inputs",
         "oq_local_sensors",
         "oq_sensor_sources",
@@ -138,7 +136,6 @@ STRICT_TOP_LEVEL_ORDER_RULES = {
     ),
     "openquatt/topology/duo_packages.yaml": (
         "heatpump2",
-        "oq_cic_compatibility_hp2",
     ),
     "openquatt/topology/single.yaml": (
         "secondary_hp_id",
@@ -153,9 +150,46 @@ STRICT_TOP_LEVEL_ORDER_RULES = {
         "sensor_sources_duo_flow_internal",
         "ot_secondary_present",
     ),
+    "openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml": (
+        "substitutions",
+        "uart",
+        "modbus",
+        "packages",
+        "web_server",
+    ),
+    "openquatt/profiles/heatpump_controller_q_cic_compatibility_duo.yaml": (
+        "packages",
+    ),
 }
 
-NESTED_KEY_ORDER_RULES = {}
+NESTED_KEY_ORDER_RULES = {
+    ("configs/heatpump_controller_q/single_wifi.yaml", "packages"): (
+        "openquatt_profile_heatpump_controller_q",
+        "openquatt_profile_heatpump_controller_q_cic_compatibility",
+        "openquatt_base_common",
+        "openquatt_connection_wifi",
+    ),
+    ("configs/heatpump_controller_q/single_eth.yaml", "packages"): (
+        "openquatt_profile_heatpump_controller_q",
+        "openquatt_profile_heatpump_controller_q_cic_compatibility",
+        "openquatt_base_common",
+        "openquatt_connection_eth",
+    ),
+    ("configs/heatpump_controller_q/duo_wifi.yaml", "packages"): (
+        "openquatt_profile_heatpump_controller_q",
+        "openquatt_profile_heatpump_controller_q_cic_compatibility",
+        "openquatt_profile_heatpump_controller_q_cic_compatibility_duo",
+        "openquatt_base_common",
+        "openquatt_connection_wifi",
+    ),
+    ("configs/heatpump_controller_q/duo_eth.yaml", "packages"): (
+        "openquatt_profile_heatpump_controller_q",
+        "openquatt_profile_heatpump_controller_q_cic_compatibility",
+        "openquatt_profile_heatpump_controller_q_cic_compatibility_duo",
+        "openquatt_base_common",
+        "openquatt_connection_eth",
+    ),
+}
 
 SUBSTITUTION_SECTION_ORDER_RULES = {
     "openquatt/oq_substitutions_common.yaml": (
@@ -168,7 +202,6 @@ SUBSTITUTION_SECTION_ORDER_RULES = {
         "FLOW AUTOTUNE",
         "BOILER CONTROL",
         "CIC FEED",
-        "CIC COMPATIBILITY",
         "HA INPUT ENTITY MAPPING",
         "HP IO (MODBUS POLLING)",
     ),


### PR DESCRIPTION
## Summary
- move the secondary CiC compatibility UART, Modbus server, switch, and web grouping out of shared firmware packages
- include the compatibility port only for Heatpump Controller Q builds, with HP2 registers only for Q duo builds
- remove dummy CiC UART pin substitutions from Listener and Waveshare profiles while keeping Listener PSRAM enabled
- extend style checks to enforce the Q-only package layout

## Why
Listener hardware uses an ESP32 N8R8. Its PSRAM remains enabled and uses GPIO16 as PSRAM CS. The shared dummy CiC UART previously initialized GPIO16 as RX on Listener builds even though that second bus is not present there. CiC compatibility belongs to the Q-edition controller capability instead of the shared firmware layer.

## Validation
- `git diff --cached --check`
- `python3 scripts/check_style_consistency.py`
- `esphome config` for all 8 Listener, Waveshare, and Q single/duo Wi-Fi/Ethernet variants
- `esphome compile --only-generate` for Listener single, Waveshare single, Q single Wi-Fi, and Q duo Wi-Fi
- generated Listener and Waveshare sources contain no CiC compatibility UART/Modbus/switch symbols
- generated Q single source initializes CiC UART GPIO40/39/38
- generated Q duo source registers CiC HP1 at `0x01` and HP2 at `0x02`
- generated Listener sdkconfig still contains `CONFIG_SPIRAM=y`, PSRAM CS GPIO16, and CLK GPIO17

## Local build note
`./scripts/validate_local.sh` was also run before publication. Listener and Waveshare firmware builds passed. The four Q firmware compile targets hit an existing local PlatformIO ESP-IDF cache conflict where `system_time.c.o` is offered by both `esp_system/system_time.c` and `esp_timer/src/system_time.c`; their config validation and source generation passed.