### PR TITLE
Cache ESPHome dev profile builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -34,6 +34,7 @@ jobs:
     uses: ./.github/workflows/esphome-build.yml
     with:
       artifact_suffix: dev-release
+      cache_esphome_build: true
       project_version: ${{ needs.compute-meta.outputs.version }}
       release_channel: dev
       release_manifest_tag: dev-latest

--- a/.github/workflows/esphome-build.yml
+++ b/.github/workflows/esphome-build.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: boolean
         default: false
+      cache_esphome_build:
+        required: false
+        type: boolean
+        default: false
       project_version:
         required: false
         type: string
@@ -64,6 +68,13 @@ jobs:
           key: ${{ runner.os }}-platformio-${{ hashFiles('.github/requirements-esphome.txt') }}
           restore-keys: |
             ${{ runner.os }}-platformio-
+
+      - name: Cache ESPHome build
+        if: ${{ inputs.cache_esphome_build }}
+        uses: actions/cache@v5
+        with:
+          path: ${{ matrix.target.build_path }}
+          key: ${{ runner.os }}-esphome-build-v1-${{ hashFiles('.github/requirements-esphome.txt') }}-${{ matrix.target.id }}
 
       - name: Install ESPHome
         run: |


### PR DESCRIPTION
## Summary
- add an opt-in `cache_esphome_build` input to the reusable ESPHome profile workflow
- cache each target's `.esphome/build/<target>` directory independently
- enable the cache only for `Dev Build` while CI and release builds remain unchanged

## Why
Each GitHub-hosted runner currently recompiles its profile from scratch. The per-target cache provides a stable warm build baseline without allowing parallel matrix jobs to share mutable build directories.

The cache key is intentionally stable per OS, ESPHome requirements hash, cache schema version (`v1`), and target. This avoids creating eight fresh cache entries on every commit and keeps expected cache usage around 0.6-0.8 GB total based on local measurements.

## Validation
- `git diff --check`
- parsed `.github/workflows/esphome-build.yml` and `.github/workflows/dev-build.yml` as YAML
- confirmed the enabled build matrix still contains 8 targets

## Rollout
This is deliberately enabled only for `Dev Build` first. CI and release builds can opt in later after observing two successful warm dev runs.
