### PR TITLE
Rename trends FNV hash helper

### DIFF
--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -291,7 +291,7 @@ float OpenQuattTrends::decode_unsigned_(uint16_t value) {
   return value == UINT16_MAX ? NAN : static_cast<float>(value);
 }
 
-uint32_t OpenQuattTrends::crc32_(const uint8_t *data, size_t len) {
+uint32_t OpenQuattTrends::fnv1a_hash_(const uint8_t *data, size_t len) {
   uint32_t hash = 2166136261u;
   for (size_t i = 0; i < len; ++i) {
     hash ^= data[i];
@@ -574,7 +574,7 @@ bool OpenQuattTrends::write_flash_block_(const FlashBlockBuilder &builder) {
   header.sequence = builder.sequence;
   header.start_timestamp_ms = builder.start_timestamp_ms;
   header.payload_bytes = static_cast<uint32_t>(builder.sample_count * sizeof(TrendSample));
-  header.crc32 = crc32_(reinterpret_cast<const uint8_t *>(builder.samples.data()), header.payload_bytes);
+  header.crc32 = fnv1a_hash_(reinterpret_cast<const uint8_t *>(builder.samples.data()), header.payload_bytes);
   header.reserved = static_cast<uint32_t>(this->current_time_ms_() / 1000ULL);
   std::memcpy(slot_buffer.data(), &header, sizeof(header));
   std::memcpy(slot_buffer.data() + sizeof(header), builder.samples.data(), header.payload_bytes);
@@ -670,7 +670,7 @@ bool OpenQuattTrends::read_flash_block_(uint32_t slot_index, uint32_t expected_s
     return false;
   }
 
-  if (crc32_(reinterpret_cast<const uint8_t *>(samples->data()), header.payload_bytes) != header.crc32) {
+  if (fnv1a_hash_(reinterpret_cast<const uint8_t *>(samples->data()), header.payload_bytes) != header.crc32) {
     return false;
   }
 

--- a/components/openquatt_trends/OpenQuattTrends.h
+++ b/components/openquatt_trends/OpenQuattTrends.h
@@ -121,7 +121,7 @@ class OpenQuattTrends : public Component {
   static uint16_t encode_unsigned_(float value);
   static float decode_temp_(int16_t value);
   static float decode_unsigned_(uint16_t value);
-  static uint32_t crc32_(const uint8_t *data, size_t len);
+  static uint32_t fnv1a_hash_(const uint8_t *data, size_t len);
 
   TrendValues pack_values_(float outside_c, float supply_c, float room_c, float room_setpoint_c, float flow_lph,
                            float input_w, float output_w) const;


### PR DESCRIPTION
## Summary

- Rename the internal Trends hash helper from `crc32_()` to `fnv1a_hash_()`.
- Keep the existing flash header field name unchanged to avoid changing persisted flash data structures.

## Why

The helper implements FNV-1a, not CRC32. Renaming the helper makes the implementation clearer without changing behavior or the flash format.

## Stacked PR

This PR is stacked on top of #206 (`codex/review-auth-json-escaping`).

## Validation

- `./scripts/validate_local.sh`
  - style consistency ok
  - docs consistency ok
  - all config checks ok
  - all 8 profile compiles ok
