### PR TITLE
Document PSRAM and flash storage expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ OpenQuatt richt zich nu bewust op drie hardwareprofielen:
 
 Voor nieuwe installaties is de Heatpump Controller Q-edition de voorkeursmodule.
 
+Alle ondersteunde OpenQuatt-profielen gebruiken PSRAM. De firmware zet `psram.ignore_not_found: false`, zodat ontbrekende PSRAM direct zichtbaar wordt als hardware- of profielprobleem in plaats van stil tot beperkte functionaliteit te leiden.
+
 ## Documentatie
 
 Belangrijkste pagina's voor gebruikers:

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -283,6 +283,25 @@ Shared non-hardware constants are in `openquatt/oq_substitutions_common.yaml`.
 
 Compile-time profile selection is done by choosing a matrix entrypoint from `build_targets.yaml`. Ethernet targets are enabled for the Heatpump Controller Q as separate Ethernet-only builds.
 
+### 9.1 Memory and flash expectations
+
+All active hardware profiles configure PSRAM with `ignore_not_found: false`. OpenQuatt therefore treats PSRAM as required hardware for supported profiles, not as an optional acceleration path. Missing PSRAM should surface as a hardware or profile mismatch instead of silently degrading Trends and LogHistory behavior.
+
+Trends uses a fixed flash archive inside the `openquatt_data` partition:
+
+- `components/openquatt_trends` reserves 90 flash sectors of 4 KiB.
+- Total Trends flash archive size is 360 KiB.
+- The archive stores 720 hourly blocks, covering up to 30 days.
+
+The custom partition tables leave different data headroom:
+
+| Partition table | `openquatt_data` size | Trends archive | Remaining data partition space |
+|---|---:|---:|---:|
+| `openquatt_8mb.csv` | 384 KiB | 360 KiB | 24 KiB |
+| `openquatt_16mb.csv` | 6016 KiB | 360 KiB | 5656 KiB |
+
+The 8 MB profile therefore has only a small `openquatt_data` margin after Trends flash history. Keep any future data-partition features explicit about their storage budget.
+
 
 ## 10. UI and Observability Organization
 

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -102,6 +102,8 @@ Zie je hier al vreemde waarden, ga dan niet meteen tunen. Controleer eerst de br
 
 Trendopslag kan onder `Instellingen -> Systeem` worden beheerd. Als trendopslag uit staat, kan de tab minder of geen historie tonen.
 
+OpenQuatt bewaart de korte trendhistorie in PSRAM en kan aanvullend tot 30 dagen trendhistorie in flash bewaren. Alle ondersteunde OpenQuatt-profielen gebruiken PSRAM; ontbrekende PSRAM wijst dus op een hardware- of profielprobleem. De flashhistorie reserveert 360 KiB in de `openquatt_data` partitie. Op het 8 MB hardwareprofiel is die partitie 384 KiB groot, waardoor na de trendhistorie nog 24 KiB overblijft voor andere data in dezelfde partitie.
+
 ## Energie
 
 `Energie` geeft inzicht in vermogen en rendement. Gebruik dit vooral om richting te krijgen, niet als gecertificeerde energiemeter.


### PR DESCRIPTION
## Summary

- Document that all supported OpenQuatt hardware profiles use PSRAM and that missing PSRAM should surface as a hardware/profile mismatch.
- Add architecture notes for the Trends flash archive size and remaining `openquatt_data` partition headroom.
- Add a user-facing Trends note in the web-app documentation.

## Details

The Trends flash archive reserves 90 sectors of 4 KiB, for a total of 360 KiB. On the 8 MB partition table, `openquatt_data` is 384 KiB, leaving 24 KiB after Trends history. On the 16 MB partition table, `openquatt_data` is 6016 KiB, leaving 5656 KiB after Trends history.

All active hardware profiles set `psram.ignore_not_found: false`, so PSRAM is documented as a required part of the supported profile set rather than an optional capability.

## Validation

- `./scripts/validate_local.sh --config-only`