### PR TITLE
Tighten small MQTT and log writer paths

### DIFF
--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -144,10 +144,6 @@ class ChunkedJsonWriter {
       this->used_ += to_copy;
       cursor += to_copy;
       remaining -= to_copy;
-
-      if (this->used_ == BUFFER_SIZE && !this->flush()) {
-        return false;
-      }
     }
 
     return true;

--- a/components/openquatt_mqtt_publisher/OpenQuattMqttPublisher.cpp
+++ b/components/openquatt_mqtt_publisher/OpenQuattMqttPublisher.cpp
@@ -265,12 +265,24 @@ std::string OpenQuattMqttPublisher::build_config_signature_() const {
   if (this->config_ == nullptr) {
     return std::string();
   }
-  return this->config_->get_base_topic() + "|" + this->config_->get_publish_profile_name() + "|" +
-         std::to_string(this->config_->get_essential_interval_s()) + "|" +
-         std::to_string(this->config_->get_standard_interval_s()) + "|" +
-         std::to_string(this->config_->get_diagnostic_interval_s()) + "|" +
-         (this->config_->get_retain_snapshots() ? "retain" : "volatile") + "|" +
-         (this->config_->is_enabled() ? "enabled" : "disabled");
+  const std::string base_topic = this->config_->get_base_topic();
+  const std::string profile_name = this->config_->get_publish_profile_name();
+  std::string out;
+  out.reserve(base_topic.size() + profile_name.size() + 48);
+  out += base_topic;
+  out += "|";
+  out += profile_name;
+  out += "|";
+  out += std::to_string(this->config_->get_essential_interval_s());
+  out += "|";
+  out += std::to_string(this->config_->get_standard_interval_s());
+  out += "|";
+  out += std::to_string(this->config_->get_diagnostic_interval_s());
+  out += "|";
+  out += this->config_->get_retain_snapshots() ? "retain" : "volatile";
+  out += "|";
+  out += this->config_->is_enabled() ? "enabled" : "disabled";
+  return out;
 }
 
 static inline void append_sensor_signature_(std::string &out, const sensor::Sensor *sensor) {


### PR DESCRIPTION
## Summary

- Build the MQTT config signature into a reserved string instead of chained temporary concatenations.
- Leave existing reserved state/heat-pump/diagnostics signature builders unchanged.
- Remove the redundant post-copy flush check from `ChunkedJsonWriter::write_bytes_()`.

## Validation

- `./scripts/validate_local.sh --config-only`
- `./scripts/validate_local.sh`