### PR TITLE
Hide service entities from Home Assistant

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -32,8 +32,7 @@ views:
 
               - `Outside temp`: selected outdoor temperature source used in control.
 
-              - `Supply temperature`: selected source for current water supply
-              temperature.
+              - `Supply temperature`: selected source for current water supply temperature.
 
 
               </details>
@@ -147,19 +146,13 @@ views:
 
               Use these controls for direct runtime interaction:
 
-              - `OpenQuatt regulation`: temporarily disables or re-enables
-              automatic heating and cooling control. Safety monitoring and
-              freeze protection stay active.
+              - `OpenQuatt regulation`: temporarily disables or re-enables automatic heating and cooling control. Safety monitoring and freeze protection stay active.
 
-              - `Resume automatically`: choose the date and time when the
-              regulation should turn itself back on after being temporarily
-              disabled.
+              - `Resume automatically`: choose the date and time when the regulation should turn itself back on after being temporarily disabled.
 
-              - `Manual cooling`: adds an extra cooling permission on top of
-              CIC and/or HA input.
+              - `Manual cooling`: adds an extra cooling permission on top of CIC and/or HA input.
 
-              - `Silent mode override`: sets silent mode to `Schedule`, `On`
-              or `Off`.
+              - `Silent mode override`: sets silent mode to `Schedule`, `On` or `Off`.
 
 
               </details>
@@ -200,8 +193,7 @@ views:
               <details>
 
               <summary><strong>Explanation</strong></summary><ha-alert
-              alert-type="warning">Pas op, dit overruled de ControlMode van
-              OpenQuatt!</ha-alert>
+              alert-type="warning">Pas op, dit overruled de ControlMode van OpenQuatt!</ha-alert>
 
 
               `CM override`: handmatige mode-override; normaal op `Auto` laten.
@@ -899,8 +891,7 @@ views:
 
               <summary><strong>Explanation</strong></summary>
 
-              - `Flow measurements` compares actual flow versus setpoint over
-              time.
+              - `Flow measurements` compares actual flow versus setpoint over time.
 
               - `Pump control` shows iPWM command output for HP1 and HP2.
 
@@ -1926,8 +1917,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:heat-pump-outline"></ha-icon> Overview HP1&HP2
 
-          This tab shows a per-HP technical snapshot of refrigerant/water-side
-          behavior. Use it mainly for diagnostics and HP1 vs HP2 comparison.
+          This tab shows a per-HP technical snapshot of refrigerant/water-side behavior. Use it mainly for diagnostics and HP1 vs HP2 comparison.
 
           For settings, use `Flow`, `Heat control`, and `Advanced settings`.
   - title: Sensor Configuration
@@ -1947,25 +1937,18 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              Select which source OpenQuatt should use per signal.
-              The `Selected` value should directly follow the chosen source.
-              This makes it easy to verify that the effective control input matches your expectation.
+              Select which source OpenQuatt should use per signal. The `Selected` value should directly follow the chosen source. This makes it easy to verify that the effective control input matches your expectation.
 
               Use this block for:
               - source selection during tuning
               - quick comparison between CIC, local, and HA Input
               - validation of the effective control input
               - in Duo, `Flow source = Outdoor unit` reveals an extra choice for
-                `Flowmeter HP1`, `Flowmeter HP2`, or the existing local HP1/HP2
-                aggregate
+                `Flowmeter HP1`, `Flowmeter HP2`, or the existing local HP1/HP2 aggregate
 
               The local `HP1/HP2` aggregate is, in principle, the average of both flowmeters.
 
-              For `Outside temperature source`, `Auto` is the recommended mode.
-              OpenQuatt then picks the lowest valid source between the local
-              Duo aggregate and HA outside temperature, when HA is configured
-              and valid. This keeps control robust when one source is
-              temporarily biased warm by sun or local heat.
+              For `Outside temperature source`, `Auto` is the recommended mode. OpenQuatt then picks the lowest valid source between the local Duo aggregate and HA outside temperature, when HA is configured and valid. This keeps control robust when one source is temporarily biased warm by sun or local heat.
 
               </details>
             text_only: true
@@ -2129,8 +2112,7 @@ views:
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  Enter the entity IDs for the sources that must feed the OpenQuatt HA
-                  proxy sensors.
+                  Enter the entity IDs for the sources that must feed the OpenQuatt HA proxy sensors.
 
                   Example values:
                   - `sensor.outdoor_temperature`
@@ -2142,8 +2124,7 @@ views:
                   - `climate.living_room | hvac_mode`
 
                   Optional attribute format:
-                  - `entity_id|attribute_name`
-                  Spaces around `|` are ignored.
+                  - `entity_id|attribute_name` Spaces around `|` are ignored.
 
                   If a source is invalid, the proxy value becomes `Unavailable`.
                   </details>
@@ -2172,13 +2153,9 @@ views:
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  These are the stable HA proxy entities used as the contract towards
-                  OpenQuatt.
+                  These are the stable HA proxy entities used as the contract towards OpenQuatt.
 
-                  `Valid` should be `on` for all five signals.
-                  If `Valid` is `off`, the current source is not numeric.
-                  In that case the proxy value is `Unavailable` until the source
-                  becomes valid again.
+                  `Valid` should be `on` for all five signals. If `Valid` is `off`, the current source is not numeric. In that case the proxy value is `Unavailable` until the source becomes valid again.
                   </details>
                 text_only: true
               - type: entities
@@ -2215,11 +2192,9 @@ views:
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  These are the five HA input signals as received by OpenQuatt.
-                  They should follow the proxy values shown in the middle panel.
+                  These are the five HA input signals as received by OpenQuatt. They should follow the proxy values shown in the middle panel.
 
-                  If a value stays `Unknown`, first check whether the matching
-                  `... source valid` sensor is `on`.
+                  If a value stays `Unknown`, first check whether the matching `... source valid` sensor is `on`.
 
                   </details>
                 text_only: true
@@ -2288,18 +2263,13 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              Configure the dew point, temperature, and humidity source per room
-              for cooling.
+              Configure the dew point, temperature, and humidity source per room for cooling.
 
-              Prefer a direct dew point entity per room. If you do not have one,
-              enter temperature and relative humidity instead.
+              Prefer a direct dew point entity per room. If you do not have one, enter temperature and relative humidity instead.
 
-              OpenQuatt prefers the direct dew point per room and otherwise
-              computes dew point from temperature + RH. For system safety it
-              then uses the highest valid room value.
+              OpenQuatt prefers the direct dew point per room and otherwise computes dew point from temperature + RH. For system safety it then uses the highest valid room value.
 
-              Increase `Number of rooms` first; the input fields per room will
-              appear below.
+              Increase `Number of rooms` first; the input fields per room will appear below.
               </details>
             text_only: true
             grid_options:
@@ -2484,9 +2454,7 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              This block shows the direct OpenTherm thermostat link.
-              Use it to verify that OpenQuatt sees thermostat heat/cooling intent
-              and room values without going through CIC or Home Assistant.
+              This block shows the direct OpenTherm thermostat link. Use it to verify that OpenQuatt sees thermostat heat/cooling intent and room values without going through CIC or Home Assistant.
 
               Check these first when OT behavior looks wrong:
               - `OpenTherm Enabled`
@@ -2526,9 +2494,7 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              This block shows CiC feed health.
-              If feed health degrades or data becomes stale, CIC-backed sources
-              may become unusable for selected signals.
+              This block shows CiC feed health. If feed health degrades or data becomes stale, CIC-backed sources may become unusable for selected signals.
 
               Check these first when values look wrong:
               - `JSON feed OK`
@@ -2555,8 +2521,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensor configuration
 
-          Configure source selection and source mapping, then verify per signal
-          the selected value and source status.
+          Configure source selection and source mapping, then verify per signal the selected value and source status.
     top_margin: false
     dense_section_placement: false
   - title: Tuning
@@ -2577,8 +2542,7 @@ views:
 
               <summary><strong>Explanation</strong></summary>
 
-              Choose which Quatt Hybrid you have. OpenQuatt uses this setting
-              to apply the correct model rules and limits.
+              Choose which Quatt Hybrid you have. OpenQuatt uses this setting to apply the correct model rules and limits.
 
               </details>
             text_only: true
@@ -2600,11 +2564,9 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Day max level / Silent max level** limit the maximum
-              compressor level during normal or silent hours.
+              - **Day max level / Silent max level** limit the maximum compressor level during normal or silent hours.
 
-              - **Silent start/end time** defines the time window in which the
-              silent cap is active.
+              - **Silent start/end time** defines the time window in which the silent cap is active.
 
               </details>
             text_only: true
@@ -2632,37 +2594,23 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **House cold temp** and **Rated maximum house power (Pr)**
-              together define heat-demand scale at cold conditions.
+              - **House cold temp** and **Rated maximum house power (Pr)** together define heat-demand scale at cold conditions.
 
-              - **Maximum heating outdoor temperature** is the point where model
-              heat demand approaches ~0.
+              - **Maximum heating outdoor temperature** is the point where model heat demand approaches ~0.
 
-              - **PH temperature reaction** defines how strongly Power House
-              adds heat below the cold comfort edge and how strongly it starts
-              pulling heat back again above room setpoint.
+              - **PH temperature reaction** defines how strongly Power House adds heat below the cold comfort edge and how strongly it starts pulling heat back again above room setpoint.
 
-              - **Comfort above setpoint** defines the acceptable upper side of
-              the comfort band.
+              - **Comfort above setpoint** defines the acceptable upper side of the comfort band.
 
-              - **Comfort below setpoint** is the cold-side margin below
-              setpoint before extra heating correction starts.
+              - **Comfort below setpoint** is the cold-side margin below setpoint before extra heating correction starts.
 
-              - If the room stays too cold for longer, Power House keeps some
-              extra heat demand active for longer. This helps the room stay
-              within the configured comfort band.
+              - If the room stays too cold for longer, Power House keeps some extra heat demand active for longer. This helps the room stay within the configured comfort band.
 
-              - **Response profile** is a quick preset for calmer, balanced, or
-              more responsive Power House behavior. As soon as rise and fall
-              time no longer match a preset, the profile automatically shows
-              `Custom`.
+              - **Response profile** is a quick preset for calmer, balanced, or more responsive Power House behavior. As soon as rise and fall time no longer match a preset, the profile automatically shows `Custom`.
 
-              - **Demand rise time** is the approximate time `P_req` may take
-              to move from `0` to `Pr`. Lower = faster ramp-up.
+              - **Demand rise time** is the approximate time `P_req` may take to move from `0` to `Pr`. Lower = faster ramp-up.
 
-              - **Demand fall time** is the approximate time `P_req` may take
-              to move from `Pr` back to `0`. Lower = faster pullback on
-              overshoot.
+              - **Demand fall time** is the approximate time `P_req` may take to move from `Pr` back to `0`. Lower = faster pullback on overshoot.
 
               </details>
             text_only: true
@@ -2700,19 +2648,15 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Supply points** form the heating curve: desired supply
-              temperature for different outdoor temperatures.
+              - **Supply points** form the heating curve: desired supply temperature for different outdoor temperatures.
 
               - First tune curve points for baseline comfort, then fine-tune PID.
 
-              - **Fallback supply** is used when outdoor temperature is
-              temporarily unavailable.
+              - **Fallback supply** is used when outdoor temperature is temporarily unavailable.
 
-              - `Heating Curve Control Profile` selects the built-in control
-              behavior for stability (including smoothing/hysteresis behavior).
+              - `Heating Curve Control Profile` selects the built-in control behavior for stability (including smoothing/hysteresis behavior).
 
-              - **PID Kp/Ki/Kd** defines correction on system supply
-              temperature:
+              - **PID Kp/Ki/Kd** defines correction on system supply temperature:
                 - Kp too high: fast but nervous response.
                 - Ki too high: slow oscillation/overshoot.
                 - Keep Kd low in slow hydraulic systems.
@@ -2760,12 +2704,9 @@ views:
 
               - Uses `Water Supply Temp (Selected)` as the measured limit source.
 
-              - **Maximum water temperature** is the normal ceiling for measured
-              supply temperature.
+              - **Maximum water temperature** is the normal ceiling for measured supply temperature.
 
-              - OpenQuatt derives an internal rollback band and a hard trip at
-              `max + 5°C` from that setting. In `CM3` the boiler drops out
-              first; a hard HP stop follows only if the overshoot persists.
+              - OpenQuatt derives an internal rollback band and a hard trip at `max + 5°C` from that setting. In `CM3` the boiler drops out first; a hard HP stop follows only if the overshoot persists.
 
 
               </details>
@@ -2835,12 +2776,9 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Minimum runtime** keeps a started compressor on for at least
-              `300 s`. You can lengthen this runtime, but not lower it.
+              - **Minimum runtime** keeps a started compressor on for at least `300 s`. You can lengthen this runtime, but not lower it.
 
-              - In heating-curve mode, PID demand is passed through directly;
-              allocation is single-HP-first with dual-enable hysteresis and
-              sequential level steps.
+              - In heating-curve mode, PID demand is passed through directly; allocation is single-HP-first with dual-enable hysteresis and sequential level steps.
 
 
               </details>
@@ -2863,8 +2801,7 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Flow PI Kp/Ki** defines flow-control dynamics; adjust in small
-              steps.
+              - **Flow PI Kp/Ki** defines flow-control dynamics; adjust in small steps.
 
 
               </details>
@@ -2888,23 +2825,17 @@ views:
 
               <summary><strong>Parameter explanation</strong></summary>
 
-              - **Boiler rated power** is the reference for boiler assist and
-              the boiler power test.
+              - **Boiler rated power** is the reference for boiler assist and the boiler power test.
 
-              - **Boiler assist enabled** must be on before OpenQuatt may
-              use CM3 or run the boiler power test.
+              - **Boiler assist enabled** must be on before OpenQuatt may use CM3 or run the boiler power test.
 
-              - The **CM3 deficit turn-on and turn-off thresholds** define
-              when boiler assist may switch on/off.
+              - The **CM3 deficit turn-on and turn-off thresholds** define when boiler assist may switch on/off.
 
-              - Boiler assist is still blocked by the water temperature limit
-              when measured supply temperature gets too high.
+              - Boiler assist is still blocked by the water temperature limit when measured supply temperature gets too high.
 
-              - Keep the turn-on threshold clearly higher than the turn-off
-              threshold to reduce toggling around the boundary.
+              - Keep the turn-on threshold clearly higher than the turn-off threshold to reduce toggling around the boundary.
 
-              - If behavior is too aggressive: increase the turn-on threshold
-              or decrease the turn-off threshold.
+              - If behavior is too aggressive: increase the turn-on threshold or decrease the turn-off threshold.
 
 
               </details>
@@ -2934,19 +2865,15 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - Select up to two compressor levels per HP that allocation logic
-              should skip.
+              - Select up to two compressor levels per HP that allocation logic should skip.
 
               - `None` means: no exclusion for that slot.
 
-              - If a requested level is excluded, OpenQuatt searches down first
-              and only then up.
+              - If a requested level is excluded, OpenQuatt searches down first and only then up.
 
-              - Usually you keep both slots on `None`; only exclude levels for
-              testing, noise, or specific constraints.
+              - Usually you keep both slots on `None`; only exclude levels for testing, noise, or specific constraints.
 
-              - If both slots point to the same level, that still counts as a
-              single exclusion.
+              - If both slots point to the same level, that still counts as a single exclusion.
 
 
               </details>
@@ -2980,8 +2907,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:tune-vertical"></ha-icon> Tuning
 
-          Structural control tuning for limits, house model, heating curve, heat
-          allocation, and flow.
+          Structural control tuning for limits, house model, heating curve, heat allocation, and flow.
     cards: []
   - title: Service & Test
     path: service-test
@@ -3002,17 +2928,13 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Reset runtime counters**. Note: it can take up to 1 minute
-              before the effect is visible.
+              - **Reset runtime counters**. Note: it can take up to 1 minute before the effect is visible.
 
-              - **Reset cumulative energy counters** sets cumulative electricity
-              and thermal energy counters back to 0.
+              - **Reset cumulative energy counters** sets cumulative electricity and thermal energy counters back to 0.
 
-              - **HP1/HP2 Runtime counters** show the current counters used for
-              runtime balancing.
+              - **HP1/HP2 Runtime counters** show the current counters used for runtime balancing.
 
-              - **Runtime lead HP** shows which unit is currently selected as
-              lead based on the lowest runtime.
+              - **Runtime lead HP** shows which unit is currently selected as lead based on the lowest runtime.
 
 
               </details>
@@ -3030,134 +2952,6 @@ views:
                 name: HP2 Runtime
               - entity: sensor.openquatt_runtime_lead_hp
                 name: Runtime lead HP
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: CM100 commissioning
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Start **CM100** first. In this mode nothing happens yet: no
-              flow, no boiler, and no autotune.
-
-              - Then choose exactly one commissioning task: **Boiler power
-              test** or **Flow autotune**.
-
-              - Start **CM100** first. Only then can you start exactly one
-              commissioning task.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_cm100_start
-                name: Start CM100
-              - entity: button.openquatt_cm100_stop
-                name: Stop CM100
-              - entity: sensor.openquatt_control_mode_label
-                name: ControlMode
-              - entity: binary_sensor.openquatt_cm100_active
-                name: CM100 active
-              - entity: sensor.openquatt_commissioning_status
-                name: CM100 status
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: CM100 - Flow autotune
-            heading_style: title
-            grid_options:
-              columns: 12
-              rows: 1
-          - type: heading
-            icon: mdi:water-boiler
-            heading: CM100 - Boiler power test
-            heading_style: title
-            grid_options:
-              columns: 12
-              rows: auto
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Start **Flow autotune** only while **CM100** is already
-              active.
-
-              - In CM100, autotune starts the flow itself and then measures
-              the response.
-
-              - Autotune uses a fixed duration and an adaptive step preset.
-
-              - Apply `Apply autotune Kp/Ki` only if suggested values are
-              sensible.
-
-
-              </details>
-            text_only: true
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Measures the effective boiler output at stable flow.
-
-              - Start the test only while **CM100** is already active.
-
-              - Apply the measured value only if it looks sensible.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_flow_autotune_start
-                name: Flow autotune start
-              - entity: button.openquatt_flow_autotune_abort
-                name: Flow autotune abort
-              - entity: button.openquatt_apply_flow_autotune_kp_ki
-                name: Apply autotune Kp/Ki
-              - entity: number.openquatt_flow_autotune_kp_suggested
-                name: Autotune Kp suggested
-              - entity: number.openquatt_flow_autotune_ki_suggested
-                name: Autotune Ki suggested
-              - entity: sensor.openquatt_flow_autotune_status
-                name: Autotune status
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_boiler_power_test_start
-                name: Start boiler power test
-              - entity: button.openquatt_boiler_power_test_abort
-                name: Abort boiler power test
-              - entity: button.openquatt_boiler_power_test_apply
-                name: Apply boiler power
-              - entity: number.openquatt_boiler_rated_heat_power
-                name: Boiler rated power
-              - entity: sensor.openquatt_boiler_power_test_result
-                name: Boiler power test result
-              - entity: sensor.openquatt_boiler_power_test_confidence
-                name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
-                name: Boiler power test status
-        visibility:
-          - condition: state
-            entity: binary_sensor.openquatt_cm100_active
-            state: 'on'
-        column_span: 2
     header:
       card:
         type: markdown
@@ -3186,19 +2980,13 @@ views:
 
               This block shows firmware version and OTA update status:
 
-              - `OpenQuatt Version`: version currently running on the ESP
-              (from build-time `project_version`).
-              - `OpenQuatt Release Channel`: build channel currently running
-              on the ESP (`main` or `dev`).
-              - `Firmware Update Channel`: selects which OTA track the update
-              entity follows next (`main` or `dev`).
-              - `Firmware Update`: compares your installed firmware with the
-              latest GitHub release and indicates if an update is available.
-              - `Check Firmware Updates`: forces an immediate update check
-              (without waiting for the next scheduled poll).
+              - `OpenQuatt Version`: version currently running on the ESP (from build-time `project_version`).
+              - `OpenQuatt Release Channel`: build channel currently running on the ESP (`main` or `dev`).
+              - `Firmware Update Channel`: selects which OTA track the update entity follows next (`main` or `dev`).
+              - `Firmware Update`: compares your installed firmware with the latest GitHub release and indicates if an update is available.
+              - `Check Firmware Updates`: forces an immediate update check (without waiting for the next scheduled poll).
 
-              Note: after a new release, the update entity may take a short
-              time to reflect the latest version (cache/refresh interval).
+              Note: after a new release, the update entity may take a short time to reflect the latest version (cache/refresh interval).
 
               </details>
             text_only: true
@@ -3281,11 +3069,9 @@ views:
 
               - `P_house` is the model estimate based on outdoor temperature.
 
-              - `P_req` is the limited heat request after comfort band,
-              temperature reaction and ramp limiting.
+              - `P_req` is the limited heat request after comfort band, temperature reaction and ramp limiting.
 
-              If `P_req` looks unexpectedly high/low: check outside source, room
-              setpoint/temp, comfort band and response settings.
+              If `P_req` looks unexpectedly high/low: check outside source, room setpoint/temp, comfort band and response settings.
 
 
               </details>
@@ -3322,14 +3108,11 @@ views:
 
               - This section is most relevant when heating-curve control is active.
 
-              - First compare `Supply target` and `Supply actual` to see control
-              error.
+              - First compare `Supply target` and `Supply actual` to see control error.
 
-              - Use `Heating Curve PID` for fine tuning when response is too
-              slow or too nervous.
+              - Use `Heating Curve PID` for fine tuning when response is too slow or too nervous.
 
-              - `Outside temp (selected)` helps explain why `Supply target`
-              rises or drops.
+              - `Outside temp (selected)` helps explain why `Supply target` rises or drops.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -22,21 +22,17 @@ views:
 
               Deze waarden geven live de belangrijkste systeemprestatie:
 
-              - `Power E`: totaal elektrisch ingangsvermogen van de
-              warmtepomp(en).
+              - `Power E`: totaal elektrisch ingangsvermogen van de warmtepomp(en).
 
               - `Power H`: totaal thermisch afgegeven vermogen.
 
               - `COP`: verhouding `Power H / Power E` (momentane efficientie).
 
-              - `Flow`: actuele volumestroom die als basis dient voor
-              flowbewaking.
+              - `Flow`: actuele volumestroom die als basis dient voor flowbewaking.
 
-              - `Buitentemp`: geselecteerde bron voor buitentemperatuur in de
-              regeling.
+              - `Buitentemp`: geselecteerde bron voor buitentemperatuur in de regeling.
 
-              - `Aanvoertemperatuur`: geselecteerde bron voor actuele
-              watersupply.
+              - `Aanvoertemperatuur`: geselecteerde bron voor actuele watersupply.
 
 
               </details>
@@ -102,13 +98,11 @@ views:
 
               - `Flow mode`: manier waarop de pomp/flowregeling momenteel werkt.
 
-              - `Verwarmingsstrategie`: bron van de warmtevraag (bijv. Power
-              House/curve).
+              - `Verwarmingsstrategie`: bron van de warmtevraag (bijv. Power House/curve).
 
               - `Ketel actief`: geeft aan of ketelondersteuning actief is.
 
-              - `Stille modus actief`: toont of het stil-venster nu van kracht
-              is.
+              - `Stille modus actief`: toont of het stil-venster nu van kracht is.
 
 
               </details>
@@ -152,19 +146,13 @@ views:
 
               Gebruik deze schakelaars voor directe runtime-bediening:
 
-              - `OpenQuatt regeling`: schakelt de automatische verwarmings- en
-              koelregeling tijdelijk uit of weer in. Bewaking en
-              vorstbeveiliging blijven actief.
+              - `OpenQuatt regeling`: schakelt de automatische verwarmings- en koelregeling tijdelijk uit of weer in. Bewaking en vorstbeveiliging blijven actief.
 
-              - `Hervat automatisch`: kies een datum en tijd waarop de
-              regeling vanzelf weer wordt ingeschakeld nadat je haar tijdelijk
-              hebt uitgezet.
+              - `Hervat automatisch`: kies een datum en tijd waarop de regeling vanzelf weer wordt ingeschakeld nadat je haar tijdelijk hebt uitgezet.
 
-              - `Handmatige koeling`: telt mee als extra koeltoestemming,
-              bovenop CIC en/of HA-invoer.
+              - `Handmatige koeling`: telt mee als extra koeltoestemming, bovenop CIC en/of HA-invoer.
 
-              - `Stille modus override`: zet stille modus op `Schema`, `Aan`
-              of `Uit`.
+              - `Stille modus override`: zet stille modus op `Schema`, `Aan` of `Uit`.
 
 
               </details>
@@ -205,8 +193,7 @@ views:
               <details>
 
               <summary><strong>Uitleg</strong></summary><ha-alert
-              alert-type="warning">Pas op, dit overruled de ControlMode van
-              OpenQuatt!</ha-alert>
+              alert-type="warning">Pas op, dit overruled de ControlMode van OpenQuatt!</ha-alert>
 
 
               `CM override`: handmatige mode-override; normaal op `Auto` laten.
@@ -242,8 +229,7 @@ views:
 
               - `Huidige temperatuur`: gemeten ruimtetemperatuur.
 
-              Het verschil tussen deze twee bepaalt hoe sterk de warmtevraag
-              oploopt.
+              Het verschil tussen deze twee bepaalt hoe sterk de warmtevraag oploopt.
 
 
               </details>
@@ -287,8 +273,7 @@ views:
 
               - `Day max level`: bovengrens compressorlevel buiten silent-uren.
 
-              - `Silent max level`: bovengrens compressorlevel tijdens
-              silent-uren.
+              - `Silent max level`: bovengrens compressorlevel tijdens silent-uren.
 
 
               </details>
@@ -347,8 +332,7 @@ views:
               - `COP`: efficientieverhouding (`Power H / Power E`).
 
 
-              Gebruik dit om te controleren of warmteafgifte het opgenomen
-              vermogen volgt en of COP realistisch blijft.
+              Gebruik dit om te controleren of warmteafgifte het opgenomen vermogen volgt en of COP realistisch blijft.
 
               </details>
             text_only: true
@@ -626,8 +610,7 @@ views:
 
               Dagaggregatie voor energie:
 
-              - Elektriciteit en warmte als dagelijkse kWh (afgeleid uit
-              cumulatieve sensoren)
+              - Elektriciteit en warmte als dagelijkse kWh (afgeleid uit cumulatieve sensoren)
 
               - `COP vandaag` als daggemiddelde
 
@@ -797,8 +780,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energie
 
-          Energie-overzicht van Warmtepomp, boiler en totaal systeem (dag +
-          cumulatief).
+          Energie-overzicht van Warmtepomp, boiler en totaal systeem (dag + cumulatief).
   - title: Flow
     path: flow
     icon: mdi:waves
@@ -831,11 +813,9 @@ views:
 
               - `Low flow alarm`: beveiligingsalarm bij te lage flow.
 
-              - `Flow (gemiddeld)`: geselecteerde gemiddelde flow voor
-              regeling/beveiliging.
+              - `Flow (gemiddeld)`: geselecteerde gemiddelde flow voor regeling/beveiliging.
 
-              - `Flow mismatch`: signaleert hydraulische onbalans tussen HP1 en
-              HP2.
+              - `Flow mismatch`: signaleert hydraulische onbalans tussen HP1 en HP2.
 
               </details>
             text_only: true
@@ -881,11 +861,9 @@ views:
               Belangrijkste flowinstellingen:
 
 
-              - `Flow control mode`: kies automatische flowregeling of
-              handmatige werking.
+              - `Flow control mode`: kies automatische flowregeling of handmatige werking.
 
-              - `Flow setpoint`: doel-flow in L/h voor automatische regeling
-              buiten koelen.
+              - `Flow setpoint`: doel-flow in L/h voor automatische regeling buiten koelen.
 
               - `Cooling flow setpoint`: doel-flow in L/h tijdens koelen.
 
@@ -1011,14 +989,11 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              - `ControlMode`: kiest welke strategie de warmtevraag opbouwt
-              (bijv. Stooklijn of PH).
+              - `ControlMode`: kiest welke strategie de warmtevraag opbouwt (bijv. Stooklijn of PH).
 
-              - Bij stooklijnregeling verschijnt ook `Heating Curve Control
-              Profile` voor de ingebouwde regelkarakteristiek.
+              - Bij stooklijnregeling verschijnt ook `Heating Curve Control Profile` voor de ingebouwde regelkarakteristiek.
 
-              - Controleer daarna bij `Kern KPI` hoe dit doorwerkt in `P_req`,
-              `P_house` en `Tekort`.
+              - Controleer daarna bij `Kern KPI` hoe dit doorwerkt in `P_req`, `P_house` en `Tekort`.
 
               </details>
             text_only: true
@@ -1058,8 +1033,7 @@ views:
               Kernindicatoren voor warmtebalans:
 
 
-              - Vergelijk `P_req` (gevraagd vermogen) met `P_house`
-              (modelschatting).
+              - Vergelijk `P_req` (gevraagd vermogen) met `P_house` (modelschatting).
 
               - `P_req`: gevraagde verwarmingspower na filtering/ramp-limiet.
 
@@ -1067,11 +1041,9 @@ views:
 
               - `Max HP capaciteit`: geschatte beschikbare warmtepompcapaciteit.
 
-              - `Tekort`: positieve waarde betekent dat vraag boven
-              beschikbare/geleverde warmte ligt.
+              - `Tekort`: positieve waarde betekent dat vraag boven beschikbare/geleverde warmte ligt.
 
-              - Richtlijn: bij `Tekort > 0 W` vraagt het systeem meer dan nu
-              geleverd wordt.
+              - Richtlijn: bij `Tekort > 0 W` vraagt het systeem meer dan nu geleverd wordt.
 
               - Gebruik `Trends` voor het gedrag over tijd.
 
@@ -1155,14 +1127,11 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              - `Warmtevraag` vergelijkt gevraagde (`P_req`) met geleverde
-              warmte.
+              - `Warmtevraag` vergelijkt gevraagde (`P_req`) met geleverde warmte.
 
-              - `HP powerinput` en `HP heat output` tonen elektrisch in versus
-              thermisch uit.
+              - `HP powerinput` en `HP heat output` tonen elektrisch in versus thermisch uit.
 
-              - `Temperatuurregeling` toont buiten-, supply- en kamertemperatuur
-              tegen targets.
+              - `Temperatuurregeling` toont buiten-, supply- en kamertemperatuur tegen targets.
 
 
               </details>
@@ -2032,12 +2001,9 @@ views:
       card:
         type: markdown
         content: |-
-          # <ha-icon icon="mdi:heat-pump-outline"></ha-icon> Overzicht HP1 en
-          HP2
+          # <ha-icon icon="mdi:heat-pump-outline"></ha-icon> Overzicht HP1 en HP2
 
-          Deze tab toont per HP een technische momentopname van
-          koudemiddel/waterzijde. Gebruik dit vooral voor diagnose en
-          vergelijking tussen HP1 en HP2.
+          Deze tab toont per HP een technische momentopname van koudemiddel/waterzijde. Gebruik dit vooral voor diagnose en vergelijking tussen HP1 en HP2.
 
           Voor instellingen: gebruik `Flow`, `Warmteregeling` en `Instellingen`.
   - title: Sensorconfiguratie
@@ -2063,8 +2029,7 @@ views:
 
               De `Geselecteerde` waarde hoort de gekozen bron direct te volgen.
 
-              Zo zie je snel of de effectieve regelinput overeenkomt met wat je
-              verwacht.
+              Zo zie je snel of de effectieve regelinput overeenkomt met wat je verwacht.
 
 
               Gebruik dit blok voor:
@@ -2074,21 +2039,14 @@ views:
               - snelle vergelijking tussen CIC, lokaal en HA input
 
               - validatie van de effectieve regelinput
-              - bij `Flow bron = Outdoor unit` in een Duo-opstelling verschijnt
-              een extra
-                keuze voor `Flowmeter HP1`, `Flowmeter HP2` of de bestaande lokale
-                aggregatie van HP1/HP2
+              - bij `Flow bron = Outdoor unit` in een Duo-opstelling verschijnt een extra
+                keuze voor `Flowmeter HP1`, `Flowmeter HP2` of de bestaande lokale aggregatie van HP1/HP2
 
-              De lokale aggregatie van `HP1/HP2` is in principe het gemiddelde
-              van beide
+              De lokale aggregatie van `HP1/HP2` is in principe het gemiddelde van beide
 
               flowmeters.
 
-              Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand.
-              OpenQuatt kiest dan de laagste geldige bron tussen de lokale
-              Duo-aggregatie en de HA-buitentemperatuur, als die bron is
-              geconfigureerd en geldig is. Dat houdt de regeling robuust als
-              een bron tijdelijk te warm uitvalt door zon of lokale opwarming.
+              Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand. OpenQuatt kiest dan de laagste geldige bron tussen de lokale Duo-aggregatie en de HA-buitentemperatuur, als die bron is geconfigureerd en geldig is. Dat houdt de regeling robuust als een bron tijdelijk te warm uitvalt door zon of lokale opwarming.
 
 
               </details>
@@ -2255,8 +2213,7 @@ views:
                   <details>
                   <summary><strong>Uitleg</strong></summary>
 
-                  Vul hier de entity IDs in van de bronnen die de OpenQuatt HA
-                  proxy-sensoren moeten voeden.
+                  Vul hier de entity IDs in van de bronnen die de OpenQuatt HA proxy-sensoren moeten voeden.
 
                   Voorbeelden:
                   - `sensor.outdoor_temperature`
@@ -2268,8 +2225,7 @@ views:
                   - `climate.woonkamer | hvac_mode`
 
                   Optioneel attribuutformaat:
-                  - `entity_id|attribute_name`
-                  Spaties rond `|` worden genegeerd.
+                  - `entity_id|attribute_name` Spaties rond `|` worden genegeerd.
 
                   Is een bron ongeldig, dan wordt de proxywaarde `Unavailable`.
                   </details>
@@ -2305,13 +2261,11 @@ views:
                   OpenQuatt dienen.
 
 
-                  De status `Valid` hoort voor alle vijf signalen op `on` te
-                  staan.
+                  De status `Valid` hoort voor alle vijf signalen op `on` te staan.
 
                   Als `Valid` op `off` staat, is de huidige bron niet numeriek.
 
-                  Dan wordt de proxywaarde `Unavailable` totdat de bron weer
-                  geldig
+                  Dan wordt de proxywaarde `Unavailable` totdat de bron weer geldig
 
                   is.
 
@@ -2351,11 +2305,9 @@ views:
                   <details>
                   <summary><strong>Uitleg</strong></summary>
 
-                  Dit zijn de vijf HA-invoerwaarden zoals OpenQuatt ze ontvangt.
-                  Deze horen de proxywaarden uit het middelste blok te volgen.
+                  Dit zijn de vijf HA-invoerwaarden zoals OpenQuatt ze ontvangt. Deze horen de proxywaarden uit het middelste blok te volgen.
 
-                  Blijft een waarde op `Unknown`, controleer dan eerst of de
-                  bijbehorende `... bron valid` op `on` staat.
+                  Blijft een waarde op `Unknown`, controleer dan eerst of de bijbehorende `... bron valid` op `on` staat.
 
                   </details>
                 text_only: true
@@ -2424,18 +2376,13 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Configureer hier per kamer de dauwpunt-, temperatuur- en
-              luchtvochtigheidsbron voor cooling.
+              Configureer hier per kamer de dauwpunt-, temperatuur- en luchtvochtigheidsbron voor cooling.
 
-              Gebruik per kamer bij voorkeur een directe dauwpuntentity. Heb je
-              die niet, vul dan temperatuur en relatieve luchtvochtigheid in.
+              Gebruik per kamer bij voorkeur een directe dauwpuntentity. Heb je die niet, vul dan temperatuur en relatieve luchtvochtigheid in.
 
-              OpenQuatt gebruikt per kamer eerst het directe dauwpunt en
-              berekent anders zelf het dauwpunt uit temperatuur + RH. Voor de
-              systeembeveiliging telt daarna de hoogste geldige kamerwaarde.
+              OpenQuatt gebruikt per kamer eerst het directe dauwpunt en berekent anders zelf het dauwpunt uit temperatuur + RH. Voor de systeembeveiliging telt daarna de hoogste geldige kamerwaarde.
 
-              Verhoog eerst `Aantal kamers`; daarna verschijnen de invoervelden
-              per kamer.
+              Verhoog eerst `Aantal kamers`; daarna verschijnen de invoervelden per kamer.
               </details>
             text_only: true
             grid_options:
@@ -2620,10 +2567,7 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Dit blok toont de directe OpenTherm-thermostaatkoppeling.
-              Gebruik het om te controleren dat OpenQuatt warmtevraag,
-              koelvraag en kamerwaarden rechtstreeks van de thermostaat ziet,
-              dus buiten CIC of Home Assistant om.
+              Dit blok toont de directe OpenTherm-thermostaatkoppeling. Gebruik het om te controleren dat OpenQuatt warmtevraag, koelvraag en kamerwaarden rechtstreeks van de thermostaat ziet, dus buiten CIC of Home Assistant om.
 
               Controleer bij afwijkingen eerst:
               - `OpenTherm Enabled`
@@ -2663,9 +2607,7 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Dit blok toont de status van de CiC-feed.
-              Als de feed niet OK is of data stale wordt, kunnen CIC-bronnen
-              onbruikbaar worden voor de geselecteerde signalen.
+              Dit blok toont de status van de CiC-feed. Als de feed niet OK is of data stale wordt, kunnen CIC-bronnen onbruikbaar worden voor de geselecteerde signalen.
 
               Controleer bij afwijkingen:
               - `JSON feed OK`
@@ -2693,8 +2635,7 @@ views:
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensorconfiguratie
 
 
-          Configureer bronkeuze en bronkoppeling, en verifieer daarna per
-          signaal
+          Configureer bronkeuze en bronkoppeling, en verifieer daarna per signaal
 
           de geselecteerde waarde en bronstatus.
     top_margin: false
@@ -2717,8 +2658,7 @@ views:
 
               <summary><strong>Uitleg</strong></summary>
 
-              Kies hier welke Quatt Hybrid je hebt. OpenQuatt gebruikt deze
-              keuze om de juiste modelregels en limieten toe te passen.
+              Kies hier welke Quatt Hybrid je hebt. OpenQuatt gebruikt deze keuze om de juiste modelregels en limieten toe te passen.
 
               </details>
             text_only: true
@@ -2740,11 +2680,9 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Day max level / Silent max level** begrenzen het maximale
-              compressorlevel in normale of stille uren.
+              - **Day max level / Silent max level** begrenzen het maximale compressorlevel in normale of stille uren.
 
-              - **Silent start/end time** definieert het tijdvenster waarin de
-              silent-begrenzing actief is.
+              - **Silent start/end time** definieert het tijdvenster waarin de silent-begrenzing actief is.
 
 
               </details>
@@ -2773,38 +2711,23 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **House cold temp** en **Rated maximum house power (Pr)**
-              bepalen samen de schaal van de warmtevraag bij koude condities.
+              - **House cold temp** en **Rated maximum house power (Pr)** bepalen samen de schaal van de warmtevraag bij koude condities.
 
-              - **Maximum heating outdoor temperature** is het punt waar
-              modelmatig de warmtevraag naar ~0 gaat.
+              - **Maximum heating outdoor temperature** is het punt waar modelmatig de warmtevraag naar ~0 gaat.
 
-              - **PH temperatuurreactie** bepaalt hoe sterk Power House extra
-              warmtevraag toevoegt onder de koude comfortgrens en hoe sterk het
-              boven het kamer-setpoint weer gas terugneemt.
+              - **PH temperatuurreactie** bepaalt hoe sterk Power House extra warmtevraag toevoegt onder de koude comfortgrens en hoe sterk het boven het kamer-setpoint weer gas terugneemt.
 
-              - **Comfort above setpoint** bepaalt de acceptabele bovenkant van
-              de comfortband.
+              - **Comfort above setpoint** bepaalt de acceptabele bovenkant van de comfortband.
 
-              - **Comfort below setpoint** bepaalt hoeveel ruimte onder
-              setpoint nog acceptabel is voordat extra opwarming begint.
+              - **Comfort below setpoint** bepaalt hoeveel ruimte onder setpoint nog acceptabel is voordat extra opwarming begint.
 
-              - Als de kamer langere tijd te koud blijft, houdt Power House
-              wat langer extra warmtevraag vast. Daardoor blijft de kamer
-              beter binnen de ingestelde comfortband.
+              - Als de kamer langere tijd te koud blijft, houdt Power House wat langer extra warmtevraag vast. Daardoor blijft de kamer beter binnen de ingestelde comfortband.
 
-              - **Response profile** is een snelle voorkeuze voor rustige,
-              gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd en
-              afbouwtijd niet meer bij een preset horen, toont het profiel
-              automatisch `Custom`.
+              - **Response profile** is een snelle voorkeuze voor rustige, gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd en afbouwtijd niet meer bij een preset horen, toont het profiel automatisch `Custom`.
 
-              - **Demand rise time** geeft ongeveer aan hoe lang `P_req` nodig
-              mag hebben om van `0` naar `Pr` te lopen. Lager = sneller
-              opschakelen.
+              - **Demand rise time** geeft ongeveer aan hoe lang `P_req` nodig mag hebben om van `0` naar `Pr` te lopen. Lager = sneller opschakelen.
 
-              - **Demand fall time** geeft ongeveer aan hoe lang `P_req` nodig
-              mag hebben om van `Pr` naar `0` te zakken. Lager = sneller
-              terugregelen bij overshoot.
+              - **Demand fall time** geeft ongeveer aan hoe lang `P_req` nodig mag hebben om van `Pr` naar `0` te zakken. Lager = sneller terugregelen bij overshoot.
 
               </details>
             text_only: true
@@ -2842,20 +2765,15 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - De **aanvoerpunten** vormen de stooklijn: gewenste
-              aanvoertemperatuur bij verschillende buitentemperaturen.
+              - De **aanvoerpunten** vormen de stooklijn: gewenste aanvoertemperatuur bij verschillende buitentemperaturen.
 
-              - Pas eerst de curvepunten aan voor het juiste basiscomfort,
-              daarna pas PID finetunen.
+              - Pas eerst de curvepunten aan voor het juiste basiscomfort, daarna pas PID finetunen.
 
-              - **Fallback-aanvoer** wordt gebruikt als buitentemperatuur
-              tijdelijk ontbreekt.
+              - **Fallback-aanvoer** wordt gebruikt als buitentemperatuur tijdelijk ontbreekt.
 
-              - `Heating Curve Control Profile` kiest het ingebouwde regelgedrag
-              voor stabiliteit (o.a. smoothing/hysterese).
+              - `Heating Curve Control Profile` kiest het ingebouwde regelgedrag voor stabiliteit (o.a. smoothing/hysterese).
 
-              - **PID Kp/Ki/Kd** bepaalt de correctie op de
-              systeem-aanvoertemperatuur:
+              - **PID Kp/Ki/Kd** bepaalt de correctie op de systeem-aanvoertemperatuur:
                 - Kp te hoog: snelle maar nerveuze reactie.
                 - Ki te hoog: traag pendelen/overshoot.
                 - Kd meestal laag houden in trage hydraulische systemen.
@@ -2901,16 +2819,11 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - Gebruikt `Water Supply Temp (Selected)` als gemeten
-              begrenzingsbron.
+              - Gebruikt `Water Supply Temp (Selected)` als gemeten begrenzingsbron.
 
-              - **Maximum water temperature** is het normale plafond voor de
-              gemeten aanvoertemperatuur.
+              - **Maximum water temperature** is het normale plafond voor de gemeten aanvoertemperatuur.
 
-              - OpenQuatt leidt uit die instelling intern zelf een
-              terugregelband en een harde trip op `max + 5°C` af. In `CM3`
-              valt eerst de boiler weg; alleen bij aanhoudende overshoot volgt
-              daarna een harde HP-stop.
+              - OpenQuatt leidt uit die instelling intern zelf een terugregelband en een harde trip op `max + 5°C` af. In `CM3` valt eerst de boiler weg; alleen bij aanhoudende overshoot volgt daarna een harde HP-stop.
 
 
               </details>
@@ -2994,13 +2907,9 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Minimum runtime** houdt een al gestarte compressor minimaal
-              `300 s` aan. Je kunt deze runtime verlengen, maar niet lager
-              zetten.
+              - **Minimum runtime** houdt een al gestarte compressor minimaal `300 s` aan. Je kunt deze runtime verlengen, maar niet lager zetten.
 
-              - In heating-curve mode wordt PID-demand direct doorgezet; de
-              allocatie is single-HP-first met dual-enable hysterese en
-              sequentiële levelstappen.
+              - In heating-curve mode wordt PID-demand direct doorgezet; de allocatie is single-HP-first met dual-enable hysterese en sequentiële levelstappen.
 
 
               </details>
@@ -3023,8 +2932,7 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Flow PI Kp/Ki** bepaalt de dynamiek van flowregeling; wijzig
-              in kleine stappen.
+              - **Flow PI Kp/Ki** bepaalt de dynamiek van flowregeling; wijzig in kleine stappen.
 
 
               </details>
@@ -3048,24 +2956,17 @@ views:
 
               <summary><strong>Uitleg parameters</strong></summary>
 
-              - **Nominaal ketelvermogen** is de referentie voor
-              boilerondersteuning en de boiler power test.
+              - **Nominaal ketelvermogen** is de referentie voor boilerondersteuning en de boiler power test.
 
-              - **CV-ketel/boiler aanwezig** moet aan staan voordat
-              OpenQuatt de ketel/boiler als ondersteuning of de boiler power
-              test mag gebruiken.
+              - **CV-ketel/boiler aanwezig** moet aan staan voordat OpenQuatt de ketel/boiler als ondersteuning of de boiler power test mag gebruiken.
 
-              - De **CM3-tekort inschakel- en uitschakeldrempels** bepalen
-              wanneer boilerondersteuning mag inschakelen/uitschakelen.
+              - De **CM3-tekort inschakel- en uitschakeldrempels** bepalen wanneer boilerondersteuning mag inschakelen/uitschakelen.
 
-              - Boilerondersteuning wordt daarnaast geblokkeerd door de
-              watertempbegrenzing als de gemeten aanvoer te hoog wordt.
+              - Boilerondersteuning wordt daarnaast geblokkeerd door de watertempbegrenzing als de gemeten aanvoer te hoog wordt.
 
-              - Houd de inschakeldrempel duidelijk hoger dan de
-              uitschakeldrempel om schakelen rond de grens te beperken.
+              - Houd de inschakeldrempel duidelijk hoger dan de uitschakeldrempel om schakelen rond de grens te beperken.
 
-              - Bij te agressief gedrag: inschakeldrempel verhogen of
-              uitschakeldrempel verlagen.
+              - Bij te agressief gedrag: inschakeldrempel verhogen of uitschakeldrempel verlagen.
 
 
               </details>
@@ -3095,19 +2996,15 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - Kies hier maximaal twee compressorlevels per HP die de
-              verdelingslogica moet overslaan.
+              - Kies hier maximaal twee compressorlevels per HP die de verdelingslogica moet overslaan.
 
               - `None` betekent: geen uitsluiting in dat slot.
 
-              - Als een gevraagd level is uitgesloten, zoekt OpenQuatt eerst een
-              lager level en daarna pas een hoger level.
+              - Als een gevraagd level is uitgesloten, zoekt OpenQuatt eerst een lager level en daarna pas een hoger level.
 
-              - Meestal laat je beide slots op `None`; gebruik uitsluitingen
-              alleen voor testen, geluid of specifieke beperkingen.
+              - Meestal laat je beide slots op `None`; gebruik uitsluitingen alleen voor testen, geluid of specifieke beperkingen.
 
-              - Als beide slots hetzelfde level kiezen, telt dat gewoon als
-              een enkele uitsluiting.
+              - Als beide slots hetzelfde level kiezen, telt dat gewoon als een enkele uitsluiting.
 
 
               </details>
@@ -3141,8 +3038,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:tune-vertical"></ha-icon> Instellingen
 
-          Structurele regelinstellingen voor limieten, huismodel, stooklijn,
-          heat-allocation en flow.
+          Structurele regelinstellingen voor limieten, huismodel, stooklijn, heat-allocation en flow.
     cards: []
   - title: Service en test
     path: service-test
@@ -3163,17 +3059,13 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Reset draaitellers**. Let op: het kan maximaal 1 minuut duren
-              voordat je effect ziet.
+              - **Reset draaitellers**. Let op: het kan maximaal 1 minuut duren voordat je effect ziet.
 
-              - **Reset cumulatieve energietellers** zet cumulatieve
-              elektriciteits- en warmte-energiemeters terug naar 0.
+              - **Reset cumulatieve energietellers** zet cumulatieve elektriciteits- en warmte-energiemeters terug naar 0.
 
-              - **HP1/HP2 draaitijd counters** tonen de actuele teller waarop de
-              runtime-balans wordt gebaseerd.
+              - **HP1/HP2 draaitijd counters** tonen de actuele teller waarop de runtime-balans wordt gebaseerd.
 
-              - **Leidende HP** toont welke unit momenteel lead is op basis van
-              de laagste runtime.
+              - **Leidende HP** toont welke unit momenteel lead is op basis van de laagste runtime.
 
 
               </details>
@@ -3192,134 +3084,6 @@ views:
               - entity: sensor.openquatt_runtime_lead_hp
                 name: Leidende HP
         column_span: 1
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: CM100 commissioning
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Start eerst **CM100**. In deze stand gebeurt nog niets: geen
-              flow, geen boiler en geen autotune.
-
-              - Kies daarna precies één commissioningtaak: **Boiler power test**
-              of **Flow autotune**.
-
-              - Start eerst **CM100**. Pas daarna kun je precies één
-              commissioningtaak starten.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_cm100_start
-                name: CM100 starten
-              - entity: button.openquatt_cm100_stop
-                name: CM100 stoppen
-              - entity: sensor.openquatt_control_mode_label
-                name: ControlMode
-              - entity: binary_sensor.openquatt_cm100_active
-                name: CM100 actief
-              - entity: sensor.openquatt_commissioning_status
-                name: CM100 status
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: CM100 - Flow autotune
-            heading_style: title
-            grid_options:
-              columns: 12
-              rows: 1
-          - type: heading
-            icon: mdi:water-boiler
-            heading: CM100 - Boiler power test
-            heading_style: title
-            grid_options:
-              columns: 12
-              rows: auto
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Start **Flow autotune** alleen terwijl **CM100** al actief is.
-
-              - In CM100 start autotune zelf de flow op en meet daarna de
-              respons.
-
-              - Autotune gebruikt een vaste duur en een adaptieve stap-preset.
-              starten.
-
-              - `Apply autotune Kp/Ki` alleen toepassen als de voorgestelde
-              waarden logisch zijn.
-
-
-              </details>
-            text_only: true
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Meet het effectieve ketelvermogen bij stabiele flow.
-
-              - Start de test alleen terwijl **CM100** al actief is.
-
-              - Pas de gemeten waarde toe als die logisch oogt.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_flow_autotune_start
-                name: Flow autotune starten
-              - entity: button.openquatt_flow_autotune_abort
-                name: Flow autotune afbreken
-              - entity: button.openquatt_apply_flow_autotune_kp_ki
-                name: Pas autotune Kp/Ki toe
-              - entity: number.openquatt_flow_autotune_kp_suggested
-                name: Autotune Kp voorstel
-              - entity: number.openquatt_flow_autotune_ki_suggested
-                name: Autotune Ki voorstel
-              - entity: sensor.openquatt_flow_autotune_status
-                name: Autotune status
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_boiler_power_test_start
-                name: Boiler power test starten
-              - entity: button.openquatt_boiler_power_test_abort
-                name: Boiler power test afbreken
-              - entity: button.openquatt_boiler_power_test_apply
-                name: Pas boilervermogen toe
-              - entity: number.openquatt_boiler_rated_heat_power
-                name: Nominaal ketelvermogen
-              - entity: sensor.openquatt_boiler_power_test_result
-                name: Boiler power test resultaat
-              - entity: sensor.openquatt_boiler_power_test_confidence
-                name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
-                name: Boiler power test status
-        visibility:
-          - condition: state
-            entity: binary_sensor.openquatt_cm100_active
-            state: 'on'
-        column_span: 2
     header:
       card:
         type: markdown
@@ -3366,8 +3130,7 @@ views:
 
               laatste GitHub release en toont of er een update beschikbaar is.
 
-              - `Controleer firmware-updates`: forceert direct een nieuwe
-              updatecheck
+              - `Controleer firmware-updates`: forceert direct een nieuwe updatecheck
 
               (zonder te wachten op de volgende automatische poll).
 
@@ -3470,11 +3233,9 @@ views:
 
               - `P_house` is de modelschatting op basis van buitentemperatuur.
 
-              - `P_req` is de begrensde warmtevraag na comfortband,
-              temperatuurreactie en ramp-limiter.
+              - `P_req` is de begrensde warmtevraag na comfortband, temperatuurreactie en ramp-limiter.
 
-              Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
-              setpoint/temp, comfortband en responsinstellingen.
+              Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer setpoint/temp, comfortband en responsinstellingen.
 
 
               </details>
@@ -3506,20 +3267,16 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              Gebruik dit blok om de curve-regeling stap voor stap te
-              controleren.
+              Gebruik dit blok om de curve-regeling stap voor stap te controleren.
 
 
               - Deze sectie is vooral relevant bij actieve stooklijnregeling.
 
-              - Vergelijk eerst `Aanvoerdoel` met `Werkelijke aanvoer (gekozen)`
-              om de regelafwijking te zien.
+              - Vergelijk eerst `Aanvoerdoel` met `Werkelijke aanvoer (gekozen)` om de regelafwijking te zien.
 
-              - Gebruik `Stooklijn-PID` bij finetuning als de regeling te
-              traag of te nerveus reageert.
+              - Gebruik `Stooklijn-PID` bij finetuning als de regeling te traag of te nerveus reageert.
 
-              - `Buitentemp (gekozen)` helpt verklaren waarom het `Supply
-              target` stijgt of daalt.
+              - `Buitentemp (gekozen)` helpt verklaren waarom het `Supply target` stijgt of daalt.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -32,8 +32,7 @@ views:
 
               - `Outside temp`: selected outdoor temperature source used in control.
 
-              - `Supply temperature`: selected source for current water supply
-              temperature.
+              - `Supply temperature`: selected source for current water supply temperature.
 
 
               </details>
@@ -147,19 +146,13 @@ views:
 
               Use these controls for direct runtime interaction:
 
-              - `OpenQuatt regulation`: temporarily disables or re-enables
-              automatic heating and cooling control. Safety monitoring and
-              freeze protection stay active.
+              - `OpenQuatt regulation`: temporarily disables or re-enables automatic heating and cooling control. Safety monitoring and freeze protection stay active.
 
-              - `Resume automatically`: choose the date and time when the
-              regulation should turn itself back on after being temporarily
-              disabled.
+              - `Resume automatically`: choose the date and time when the regulation should turn itself back on after being temporarily disabled.
 
-              - `Manual cooling`: adds an extra cooling permission on top of
-              CIC and/or HA input.
+              - `Manual cooling`: adds an extra cooling permission on top of CIC and/or HA input.
 
-              - `Silent mode override`: sets silent mode to `Schedule`, `On`
-              or `Off`.
+              - `Silent mode override`: sets silent mode to `Schedule`, `On` or `Off`.
 
 
               </details>
@@ -200,8 +193,7 @@ views:
               <details>
 
               <summary><strong>Explanation</strong></summary><ha-alert
-              alert-type="warning">Pas op, dit overruled de ControlMode van
-              OpenQuatt!</ha-alert>
+              alert-type="warning">Pas op, dit overruled de ControlMode van OpenQuatt!</ha-alert>
 
 
               `CM override`: handmatige mode-override; normaal op `Auto` laten.
@@ -893,8 +885,7 @@ views:
 
               <summary><strong>Explanation</strong></summary>
 
-              - `Flow measurements` compares actual flow versus setpoint over
-              time.
+              - `Flow measurements` compares actual flow versus setpoint over time.
 
               - `Pump control` shows iPWM command output for HP1.
 
@@ -1605,20 +1596,14 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              Select which source OpenQuatt should use per signal.
-              The `Selected` value should directly follow the chosen source.
-              This makes it easy to verify that the effective control input matches your expectation.
+              Select which source OpenQuatt should use per signal. The `Selected` value should directly follow the chosen source. This makes it easy to verify that the effective control input matches your expectation.
 
               Use this block for:
               - source selection during tuning
               - quick comparison between CIC, local, and HA Input
               - validation of the effective control input
 
-              For `Outside temperature source`, `Auto` is the recommended mode.
-              OpenQuatt then picks the lowest valid source between the local
-              outdoor-unit reading and HA outside temperature, when HA is
-              configured and valid. This keeps control robust when one source
-              is temporarily biased warm by sun or local heat.
+              For `Outside temperature source`, `Auto` is the recommended mode. OpenQuatt then picks the lowest valid source between the local outdoor-unit reading and HA outside temperature, when HA is configured and valid. This keeps control robust when one source is temporarily biased warm by sun or local heat.
 
               </details>
             text_only: true
@@ -1774,8 +1759,7 @@ views:
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  Enter the entity IDs for the sources that must feed the OpenQuatt HA
-                  proxy sensors.
+                  Enter the entity IDs for the sources that must feed the OpenQuatt HA proxy sensors.
 
                   Example values:
                   - `sensor.outdoor_temperature`
@@ -1787,8 +1771,7 @@ views:
                   - `climate.living_room | hvac_mode`
 
                   Optional attribute format:
-                  - `entity_id|attribute_name`
-                  Spaces around `|` are ignored.
+                  - `entity_id|attribute_name` Spaces around `|` are ignored.
 
                   If a source is invalid, the proxy value becomes `Unavailable`.
                   </details>
@@ -1817,13 +1800,9 @@ views:
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  These are the stable HA proxy entities used as the contract towards
-                  OpenQuatt.
+                  These are the stable HA proxy entities used as the contract towards OpenQuatt.
 
-                  `Valid` should be `on` for all five signals.
-                  If `Valid` is `off`, the current source is not numeric.
-                  In that case the proxy value is `Unavailable` until the source
-                  becomes valid again.
+                  `Valid` should be `on` for all five signals. If `Valid` is `off`, the current source is not numeric. In that case the proxy value is `Unavailable` until the source becomes valid again.
                   </details>
                 text_only: true
               - type: entities
@@ -1860,11 +1839,9 @@ views:
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  These are the five HA input signals as received by OpenQuatt.
-                  They should follow the proxy values shown in the middle panel.
+                  These are the five HA input signals as received by OpenQuatt. They should follow the proxy values shown in the middle panel.
 
-                  If a value stays `Unknown`, first check whether the matching
-                  `... source valid` sensor is `on`.
+                  If a value stays `Unknown`, first check whether the matching `... source valid` sensor is `on`.
 
                   </details>
                 text_only: true
@@ -1933,18 +1910,13 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              Configure the dew point, temperature, and humidity source per room
-              for cooling.
+              Configure the dew point, temperature, and humidity source per room for cooling.
 
-              Prefer a direct dew point entity per room. If you do not have one,
-              enter temperature and relative humidity instead.
+              Prefer a direct dew point entity per room. If you do not have one, enter temperature and relative humidity instead.
 
-              OpenQuatt prefers the direct dew point per room and otherwise
-              computes dew point from temperature + RH. For system safety it
-              then uses the highest valid room value.
+              OpenQuatt prefers the direct dew point per room and otherwise computes dew point from temperature + RH. For system safety it then uses the highest valid room value.
 
-              Increase `Number of rooms` first; the input fields per room will
-              appear below.
+              Increase `Number of rooms` first; the input fields per room will appear below.
               </details>
             text_only: true
             grid_options:
@@ -2129,9 +2101,7 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              This block shows the direct OpenTherm thermostat link.
-              Use it to verify that OpenQuatt sees thermostat heat/cooling intent
-              and room values without going through CIC or Home Assistant.
+              This block shows the direct OpenTherm thermostat link. Use it to verify that OpenQuatt sees thermostat heat/cooling intent and room values without going through CIC or Home Assistant.
 
               Check these first when OT behavior looks wrong:
               - `OpenTherm Enabled`
@@ -2171,9 +2141,7 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              This block shows CiC feed health.
-              If feed health degrades or data becomes stale, CIC-backed sources
-              may become unusable for selected signals.
+              This block shows CiC feed health. If feed health degrades or data becomes stale, CIC-backed sources may become unusable for selected signals.
 
               Check these first when values look wrong:
               - `JSON feed OK`
@@ -2200,8 +2168,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensor configuration
 
-          Configure source selection and source mapping, then verify per signal
-          the selected value and source status.
+          Configure source selection and source mapping, then verify per signal the selected value and source status.
     top_margin: false
     dense_section_placement: false
   - title: Tuning
@@ -2222,8 +2189,7 @@ views:
 
               <summary><strong>Explanation</strong></summary>
 
-              Choose which Quatt Hybrid you have. OpenQuatt uses this setting
-              to apply the correct model rules and limits.
+              Choose which Quatt Hybrid you have. OpenQuatt uses this setting to apply the correct model rules and limits.
 
               </details>
             text_only: true
@@ -2245,11 +2211,9 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Day max level / Silent max level** limit the maximum
-              compressor level during normal or silent hours.
+              - **Day max level / Silent max level** limit the maximum compressor level during normal or silent hours.
 
-              - **Silent start/end time** defines the time window in which the
-              silent cap is active.
+              - **Silent start/end time** defines the time window in which the silent cap is active.
 
               </details>
             text_only: true
@@ -2277,37 +2241,23 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **House cold temp** and **Rated maximum house power (Pr)**
-              together define heat-demand scale at cold conditions.
+              - **House cold temp** and **Rated maximum house power (Pr)** together define heat-demand scale at cold conditions.
 
-              - **Maximum heating outdoor temperature** is the point where model
-              heat demand approaches ~0.
+              - **Maximum heating outdoor temperature** is the point where model heat demand approaches ~0.
 
-              - **PH temperature reaction** defines how strongly Power House
-              adds heat below the cold comfort edge and how strongly it starts
-              pulling heat back again above room setpoint.
+              - **PH temperature reaction** defines how strongly Power House adds heat below the cold comfort edge and how strongly it starts pulling heat back again above room setpoint.
 
-              - **Comfort above setpoint** defines the acceptable upper side of
-              the comfort band.
+              - **Comfort above setpoint** defines the acceptable upper side of the comfort band.
 
-              - **Comfort below setpoint** is the cold-side margin below
-              setpoint before extra heating correction starts.
+              - **Comfort below setpoint** is the cold-side margin below setpoint before extra heating correction starts.
 
-              - If the room stays too cold for longer, Power House keeps some
-              extra heat demand active for longer. This helps the room stay
-              within the configured comfort band.
+              - If the room stays too cold for longer, Power House keeps some extra heat demand active for longer. This helps the room stay within the configured comfort band.
 
-              - **Response profile** is a quick preset for calmer, balanced, or
-              more responsive Power House behavior. As soon as rise and fall
-              time no longer match a preset, the profile automatically shows
-              `Custom`.
+              - **Response profile** is a quick preset for calmer, balanced, or more responsive Power House behavior. As soon as rise and fall time no longer match a preset, the profile automatically shows `Custom`.
 
-              - **Demand rise time** is the approximate time `P_req` may take
-              to move from `0` to `Pr`. Lower = faster ramp-up.
+              - **Demand rise time** is the approximate time `P_req` may take to move from `0` to `Pr`. Lower = faster ramp-up.
 
-              - **Demand fall time** is the approximate time `P_req` may take
-              to move from `Pr` back to `0`. Lower = faster pullback on
-              overshoot.
+              - **Demand fall time** is the approximate time `P_req` may take to move from `Pr` back to `0`. Lower = faster pullback on overshoot.
 
               </details>
             text_only: true
@@ -2345,19 +2295,15 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Supply points** form the heating curve: desired supply
-              temperature for different outdoor temperatures.
+              - **Supply points** form the heating curve: desired supply temperature for different outdoor temperatures.
 
               - First tune curve points for baseline comfort, then fine-tune PID.
 
-              - **Fallback supply** is used when outdoor temperature is
-              temporarily unavailable.
+              - **Fallback supply** is used when outdoor temperature is temporarily unavailable.
 
-              - `Heating Curve Control Profile` selects the built-in control
-              behavior for stability (including smoothing/hysteresis behavior).
+              - `Heating Curve Control Profile` selects the built-in control behavior for stability (including smoothing/hysteresis behavior).
 
-              - **PID Kp/Ki/Kd** defines correction on system supply
-              temperature:
+              - **PID Kp/Ki/Kd** defines correction on system supply temperature:
                 - Kp too high: fast but nervous response.
                 - Ki too high: slow oscillation/overshoot.
                 - Keep Kd low in slow hydraulic systems.
@@ -2405,12 +2351,9 @@ views:
 
               - Uses `Water Supply Temp (Selected)` as the measured limit source.
 
-              - **Maximum water temperature** is the normal ceiling for measured
-              supply temperature.
+              - **Maximum water temperature** is the normal ceiling for measured supply temperature.
 
-              - OpenQuatt derives an internal rollback band and a hard trip at
-              `max + 5°C` from that setting. In `CM3` the boiler drops out
-              first; a hard HP stop follows only if the overshoot persists.
+              - OpenQuatt derives an internal rollback band and a hard trip at `max + 5°C` from that setting. In `CM3` the boiler drops out first; a hard HP stop follows only if the overshoot persists.
 
 
               </details>
@@ -2480,8 +2423,7 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Minimum runtime** keeps a started compressor on for at least
-              `300 s`. You can lengthen this runtime, but not lower it.
+              - **Minimum runtime** keeps a started compressor on for at least `300 s`. You can lengthen this runtime, but not lower it.
 
               </details>
             text_only: true
@@ -2503,8 +2445,7 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Flow PI Kp/Ki** defines flow-control dynamics; adjust in small
-              steps.
+              - **Flow PI Kp/Ki** defines flow-control dynamics; adjust in small steps.
 
 
               </details>
@@ -2528,23 +2469,17 @@ views:
 
               <summary><strong>Parameter explanation</strong></summary>
 
-              - **Boiler rated power** is the reference for boiler assist and
-              the boiler power test.
+              - **Boiler rated power** is the reference for boiler assist and the boiler power test.
 
-              - **Boiler assist enabled** must be on before OpenQuatt may
-              use CM3 or run the boiler power test.
+              - **Boiler assist enabled** must be on before OpenQuatt may use CM3 or run the boiler power test.
 
-              - The **CM3 deficit turn-on and turn-off thresholds** define
-              when boiler assist may switch on/off.
+              - The **CM3 deficit turn-on and turn-off thresholds** define when boiler assist may switch on/off.
 
-              - Boiler assist is still blocked by the water temperature limit
-              when measured supply temperature gets too high.
+              - Boiler assist is still blocked by the water temperature limit when measured supply temperature gets too high.
 
-              - Keep the turn-on threshold clearly higher than the turn-off
-              threshold to reduce toggling around the boundary.
+              - Keep the turn-on threshold clearly higher than the turn-off threshold to reduce toggling around the boundary.
 
-              - If behavior is too aggressive: increase the turn-on threshold
-              or decrease the turn-off threshold.
+              - If behavior is too aggressive: increase the turn-on threshold or decrease the turn-off threshold.
 
 
               </details>
@@ -2574,19 +2509,15 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - Select up to two compressor levels per HP that allocation logic
-              should skip.
+              - Select up to two compressor levels per HP that allocation logic should skip.
 
               - `None` means: no exclusion for that slot.
 
-              - If a requested level is excluded, OpenQuatt searches down first
-              and only then up.
+              - If a requested level is excluded, OpenQuatt searches down first and only then up.
 
-              - Usually you keep both slots on `None`; only exclude levels for
-              testing, noise, or specific constraints.
+              - Usually you keep both slots on `None`; only exclude levels for testing, noise, or specific constraints.
 
-              - If both slots point to the same level, that still counts as a
-              single exclusion.
+              - If both slots point to the same level, that still counts as a single exclusion.
 
 
               </details>
@@ -2610,8 +2541,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:tune-vertical"></ha-icon> Tuning
 
-          Structural control tuning for limits, house model, heating curve, heat
-          allocation, and flow.
+          Structural control tuning for limits, house model, heating curve, heat allocation, and flow.
     cards: []
   - title: Service & Test
     path: service-test
@@ -2632,16 +2562,12 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Reset runtime counters**. Note: it can take up to 1 minute
-              before the effect is visible.
+              - **Reset runtime counters**. Note: it can take up to 1 minute before the effect is visible.
 
-              - **Reset cumulative energy counters** sets cumulative electricity
-              and thermal energy counters back to 0.
-              - **HP1 Runtime counter** shows the current counter used for
-              runtime balancing.
+              - **Reset cumulative energy counters** sets cumulative electricity and thermal energy counters back to 0.
+              - **HP1 Runtime counter** shows the current counter used for runtime balancing.
 
-              - **Runtime lead HP** shows which unit is currently selected as
-              lead based on the lowest runtime.
+              - **Runtime lead HP** shows which unit is currently selected as lead based on the lowest runtime.
 
 
               </details>
@@ -2657,134 +2583,6 @@ views:
                 name: HP1 Runtime
               - entity: sensor.openquatt_runtime_lead_hp
                 name: Runtime lead HP
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: CM100 commissioning
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Start **CM100** first. In this mode nothing happens yet: no
-              flow, no boiler, and no autotune.
-
-              - Then choose exactly one commissioning task: **Boiler power
-              test** or **Flow autotune**.
-
-              - Start **CM100** first. Only then can you start exactly one
-              commissioning task.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_cm100_start
-                name: Start CM100
-              - entity: button.openquatt_cm100_stop
-                name: Stop CM100
-              - entity: sensor.openquatt_control_mode_label
-                name: ControlMode
-              - entity: binary_sensor.openquatt_cm100_active
-                name: CM100 active
-              - entity: sensor.openquatt_commissioning_status
-                name: CM100 status
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: CM100 - Flow autotune
-            heading_style: title
-            grid_options:
-              columns: 12
-              rows: 1
-          - type: heading
-            icon: mdi:water-boiler
-            heading: CM100 - Boiler power test
-            heading_style: title
-            grid_options:
-              columns: 12
-              rows: auto
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Start **Flow autotune** only while **CM100** is already
-              active.
-
-              - In CM100, autotune starts the flow itself and then measures
-              the response.
-
-              - Autotune uses a fixed duration and an adaptive step preset.
-
-              - Apply `Apply autotune Kp/Ki` only if suggested values are
-              sensible.
-
-
-              </details>
-            text_only: true
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Parameter explanation</strong></summary>
-
-
-              - Measures the effective boiler output at stable flow.
-
-              - Start the test only while **CM100** is already active.
-
-              - Apply the measured value only if it looks sensible.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_flow_autotune_start
-                name: Flow autotune start
-              - entity: button.openquatt_flow_autotune_abort
-                name: Flow autotune abort
-              - entity: button.openquatt_apply_flow_autotune_kp_ki
-                name: Apply autotune Kp/Ki
-              - entity: number.openquatt_flow_autotune_kp_suggested
-                name: Autotune Kp suggested
-              - entity: number.openquatt_flow_autotune_ki_suggested
-                name: Autotune Ki suggested
-              - entity: sensor.openquatt_flow_autotune_status
-                name: Autotune status
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_boiler_power_test_start
-                name: Start boiler power test
-              - entity: button.openquatt_boiler_power_test_abort
-                name: Abort boiler power test
-              - entity: button.openquatt_boiler_power_test_apply
-                name: Apply boiler power
-              - entity: number.openquatt_boiler_rated_heat_power
-                name: Boiler rated power
-              - entity: sensor.openquatt_boiler_power_test_result
-                name: Boiler power test result
-              - entity: sensor.openquatt_boiler_power_test_confidence
-                name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
-                name: Boiler power test status
-        visibility:
-          - condition: state
-            entity: binary_sensor.openquatt_cm100_active
-            state: 'on'
-        column_span: 2
     header:
       card:
         type: markdown
@@ -2813,19 +2611,13 @@ views:
 
               This block shows firmware version and OTA update status:
 
-              - `OpenQuatt Version`: version currently running on the ESP
-              (from build-time `project_version`).
-              - `OpenQuatt Release Channel`: build channel currently running
-              on the ESP (`main` or `dev`).
-              - `Firmware Update Channel`: selects which OTA track the update
-              entity follows next (`main` or `dev`).
-              - `Firmware Update`: compares your installed firmware with the
-              latest GitHub release and indicates if an update is available.
-              - `Check Firmware Updates`: forces an immediate update check
-              (without waiting for the next scheduled poll).
+              - `OpenQuatt Version`: version currently running on the ESP (from build-time `project_version`).
+              - `OpenQuatt Release Channel`: build channel currently running on the ESP (`main` or `dev`).
+              - `Firmware Update Channel`: selects which OTA track the update entity follows next (`main` or `dev`).
+              - `Firmware Update`: compares your installed firmware with the latest GitHub release and indicates if an update is available.
+              - `Check Firmware Updates`: forces an immediate update check (without waiting for the next scheduled poll).
 
-              Note: after a new release, the update entity may take a short
-              time to reflect the latest version (cache/refresh interval).
+              Note: after a new release, the update entity may take a short time to reflect the latest version (cache/refresh interval).
 
               </details>
             text_only: true
@@ -2908,11 +2700,9 @@ views:
 
               - `P_house` is the model estimate based on outdoor temperature.
 
-              - `P_req` is the limited heat request after comfort band,
-              temperature reaction and ramp limiting.
+              - `P_req` is the limited heat request after comfort band, temperature reaction and ramp limiting.
 
-              If `P_req` looks unexpectedly high/low: check outside source, room
-              setpoint/temp, comfort band and response settings.
+              If `P_req` looks unexpectedly high/low: check outside source, room setpoint/temp, comfort band and response settings.
 
 
               </details>
@@ -2949,14 +2739,11 @@ views:
 
               - This section is most relevant when heating-curve control is active.
 
-              - First compare `Supply target` and `Supply actual` to see control
-              error.
+              - First compare `Supply target` and `Supply actual` to see control error.
 
-              - Use `Heating Curve PID` for fine tuning when response is too
-              slow or too nervous.
+              - Use `Heating Curve PID` for fine tuning when response is too slow or too nervous.
 
-              - `Outside temp (selected)` helps explain why `Supply target`
-              rises or drops.
+              - `Outside temp (selected)` helps explain why `Supply target` rises or drops.
 
 
               </details>

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -22,21 +22,17 @@ views:
 
               Deze waarden geven live de belangrijkste systeemprestatie:
 
-              - `Power E`: totaal elektrisch ingangsvermogen van de
-              warmtepomp(en).
+              - `Power E`: totaal elektrisch ingangsvermogen van de warmtepomp(en).
 
               - `Power H`: totaal thermisch afgegeven vermogen.
 
               - `COP`: verhouding `Power H / Power E` (momentane efficientie).
 
-              - `Flow`: actuele volumestroom die als basis dient voor
-              flowbewaking.
+              - `Flow`: actuele volumestroom die als basis dient voor flowbewaking.
 
-              - `Buitentemp`: geselecteerde bron voor buitentemperatuur in de
-              regeling.
+              - `Buitentemp`: geselecteerde bron voor buitentemperatuur in de regeling.
 
-              - `Aanvoertemperatuur`: geselecteerde bron voor actuele
-              watersupply.
+              - `Aanvoertemperatuur`: geselecteerde bron voor actuele watersupply.
 
 
               </details>
@@ -102,8 +98,7 @@ views:
 
               - `Flow mode`: manier waarop de pomp/flowregeling momenteel werkt.
 
-              - `Verwarmingsstrategie`: bron van de warmtevraag (bijv. Power
-              House/curve).
+              - `Verwarmingsstrategie`: bron van de warmtevraag (bijv. Power House/curve).
 
               - `Ketel actief`: geeft aan of ketelondersteuning actief is.
 
@@ -151,19 +146,13 @@ views:
 
               Gebruik deze schakelaars voor directe runtime-bediening:
 
-              - `OpenQuatt regeling`: schakelt de automatische verwarmings- en
-              koelregeling tijdelijk uit of weer in. Bewaking en
-              vorstbeveiliging blijven actief.
+              - `OpenQuatt regeling`: schakelt de automatische verwarmings- en koelregeling tijdelijk uit of weer in. Bewaking en vorstbeveiliging blijven actief.
 
-              - `Hervat automatisch`: kies een datum en tijd waarop de
-              regeling vanzelf weer wordt ingeschakeld nadat je haar tijdelijk
-              hebt uitgezet.
+              - `Hervat automatisch`: kies een datum en tijd waarop de regeling vanzelf weer wordt ingeschakeld nadat je haar tijdelijk hebt uitgezet.
 
-              - `Handmatige koeling`: telt mee als extra koeltoestemming,
-              bovenop CIC en/of HA-invoer.
+              - `Handmatige koeling`: telt mee als extra koeltoestemming, bovenop CIC en/of HA-invoer.
 
-              - `Stille modus override`: zet stille modus op `Schema`, `Aan`
-              of `Uit`.
+              - `Stille modus override`: zet stille modus op `Schema`, `Aan` of `Uit`.
 
 
               </details>
@@ -204,8 +193,7 @@ views:
               <details>
 
               <summary><strong>Uitleg</strong></summary><ha-alert
-              alert-type="warning">Pas op, dit overruled de ControlMode van
-              OpenQuatt!</ha-alert>
+              alert-type="warning">Pas op, dit overruled de ControlMode van OpenQuatt!</ha-alert>
 
 
               `CM override`: handmatige mode-override; normaal op `Auto` laten.
@@ -241,8 +229,7 @@ views:
 
               - `Huidige temperatuur`: gemeten ruimtetemperatuur.
 
-              Het verschil tussen deze twee bepaalt hoe sterk de warmtevraag
-              oploopt.
+              Het verschil tussen deze twee bepaalt hoe sterk de warmtevraag oploopt.
 
 
               </details>
@@ -286,8 +273,7 @@ views:
 
               - `Day max level`: bovengrens compressorlevel buiten silent-uren.
 
-              - `Silent max level`: bovengrens compressorlevel tijdens
-              silent-uren.
+              - `Silent max level`: bovengrens compressorlevel tijdens silent-uren.
 
 
               </details>
@@ -346,8 +332,7 @@ views:
               - `COP`: efficientieverhouding (`Power H / Power E`).
 
 
-              Gebruik dit om te controleren of warmteafgifte het opgenomen
-              vermogen volgt en of COP realistisch blijft.
+              Gebruik dit om te controleren of warmteafgifte het opgenomen vermogen volgt en of COP realistisch blijft.
 
               </details>
             text_only: true
@@ -615,8 +600,7 @@ views:
 
               Dagaggregatie voor energie:
 
-              - Elektriciteit en warmte als dagelijkse kWh (afgeleid uit
-              cumulatieve sensoren)
+              - Elektriciteit en warmte als dagelijkse kWh (afgeleid uit cumulatieve sensoren)
 
               - `COP vandaag` als daggemiddelde
 
@@ -786,8 +770,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:lightning-bolt-circle"></ha-icon> Energie
 
-          Energie-overzicht van Warmtepomp, boiler en totaal systeem (dag +
-          cumulatief).
+          Energie-overzicht van Warmtepomp, boiler en totaal systeem (dag + cumulatief).
   - title: Flow
     path: flow
     icon: mdi:waves
@@ -820,8 +803,7 @@ views:
 
               - `Low flow alarm`: beveiligingsalarm bij te lage flow.
 
-              - `Flow (gemiddeld)`: geselecteerde gemiddelde flow voor
-              regeling/beveiliging.
+              - `Flow (gemiddeld)`: geselecteerde gemiddelde flow voor regeling/beveiliging.
 
               </details>
             text_only: true
@@ -862,11 +844,9 @@ views:
               Belangrijkste flowinstellingen:
 
 
-              - `Flow control mode`: kies automatische flowregeling of
-              handmatige werking.
+              - `Flow control mode`: kies automatische flowregeling of handmatige werking.
 
-              - `Flow setpoint`: doel-flow in L/h voor automatische regeling
-              buiten koelen.
+              - `Flow setpoint`: doel-flow in L/h voor automatische regeling buiten koelen.
 
               - `Cooling flow setpoint`: doel-flow in L/h tijdens koelen.
 
@@ -990,14 +970,11 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              - `ControlMode`: kiest welke strategie de warmtevraag opbouwt
-              (bijv. Stooklijn of PH).
+              - `ControlMode`: kiest welke strategie de warmtevraag opbouwt (bijv. Stooklijn of PH).
 
-              - Bij stooklijnregeling verschijnt ook `Heating Curve Control
-              Profile` voor de ingebouwde regelkarakteristiek.
+              - Bij stooklijnregeling verschijnt ook `Heating Curve Control Profile` voor de ingebouwde regelkarakteristiek.
 
-              - Controleer daarna bij `Kern KPI` hoe dit doorwerkt in `P_req`,
-              `P_house` en `Tekort`.
+              - Controleer daarna bij `Kern KPI` hoe dit doorwerkt in `P_req`, `P_house` en `Tekort`.
 
               </details>
             text_only: true
@@ -1037,8 +1014,7 @@ views:
               Kernindicatoren voor warmtebalans:
 
 
-              - Vergelijk `P_req` (gevraagd vermogen) met `P_house`
-              (modelschatting).
+              - Vergelijk `P_req` (gevraagd vermogen) met `P_house` (modelschatting).
 
               - `P_req`: gevraagde verwarmingspower na filtering/ramp-limiet.
 
@@ -1046,11 +1022,9 @@ views:
 
               - `Max HP capaciteit`: geschatte beschikbare warmtepompcapaciteit.
 
-              - `Tekort`: positieve waarde betekent dat vraag boven
-              beschikbare/geleverde warmte ligt.
+              - `Tekort`: positieve waarde betekent dat vraag boven beschikbare/geleverde warmte ligt.
 
-              - Richtlijn: bij `Tekort > 0 W` vraagt het systeem meer dan nu
-              geleverd wordt.
+              - Richtlijn: bij `Tekort > 0 W` vraagt het systeem meer dan nu geleverd wordt.
 
               - Gebruik `Trends` voor het gedrag over tijd.
 
@@ -1134,14 +1108,11 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              - `Warmtevraag` vergelijkt gevraagde (`P_req`) met geleverde
-              warmte.
+              - `Warmtevraag` vergelijkt gevraagde (`P_req`) met geleverde warmte.
 
-              - `HP powerinput` en `HP heat output` tonen elektrisch in versus
-              thermisch uit.
+              - `HP powerinput` en `HP heat output` tonen elektrisch in versus thermisch uit.
 
-              - `Temperatuurregeling` toont buiten-, supply- en kamertemperatuur
-              tegen targets.
+              - `Temperatuurregeling` toont buiten-, supply- en kamertemperatuur tegen targets.
 
 
               </details>
@@ -1650,8 +1621,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:heat-pump-outline"></ha-icon> Overzicht HP1
 
-          Deze tab toont een technische momentopname van HP1 op
-          koudemiddel/waterzijde. Gebruik dit vooral voor diagnose.
+          Deze tab toont een technische momentopname van HP1 op koudemiddel/waterzijde. Gebruik dit vooral voor diagnose.
 
           Voor instellingen: gebruik `Flow`, `Warmteregeling` en `Instellingen`.
   - title: Sensorconfiguratie
@@ -1671,20 +1641,14 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Kies per signaal de bron die OpenQuatt gebruikt.
-              De `Geselecteerde` waarde hoort de gekozen bron direct te volgen.
-              Zo zie je snel of de effectieve regelinput overeenkomt met wat je verwacht.
+              Kies per signaal de bron die OpenQuatt gebruikt. De `Geselecteerde` waarde hoort de gekozen bron direct te volgen. Zo zie je snel of de effectieve regelinput overeenkomt met wat je verwacht.
 
               Gebruik dit blok voor:
               - bronkeuze tijdens tuning
               - snelle vergelijking tussen CIC, lokaal en HA input
               - validatie van de effectieve regelinput
 
-              Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand.
-              OpenQuatt kiest dan de laagste geldige bron tussen de lokale
-              buitenunitmeting en de HA-buitentemperatuur, als die bron is
-              geconfigureerd en geldig is. Dat houdt de regeling robuust als
-              een bron tijdelijk te warm uitvalt door zon of lokale opwarming.
+              Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand. OpenQuatt kiest dan de laagste geldige bron tussen de lokale buitenunitmeting en de HA-buitentemperatuur, als die bron is geconfigureerd en geldig is. Dat houdt de regeling robuust als een bron tijdelijk te warm uitvalt door zon of lokale opwarming.
 
               </details>
             text_only: true
@@ -1842,8 +1806,7 @@ views:
                   <details>
                   <summary><strong>Uitleg</strong></summary>
 
-                  Vul hier de entity IDs in van de bronnen die de OpenQuatt HA
-                  proxy-sensoren moeten voeden.
+                  Vul hier de entity IDs in van de bronnen die de OpenQuatt HA proxy-sensoren moeten voeden.
 
                   Voorbeelden:
                   - `sensor.outdoor_temperature`
@@ -1855,8 +1818,7 @@ views:
                   - `climate.woonkamer | hvac_mode`
 
                   Optioneel attribuutformaat:
-                  - `entity_id|attribute_name`
-                  Spaties rond `|` worden genegeerd.
+                  - `entity_id|attribute_name` Spaties rond `|` worden genegeerd.
 
                   Is een bron ongeldig, dan wordt de proxywaarde `Unavailable`.
                   </details>
@@ -1892,13 +1854,11 @@ views:
                   OpenQuatt dienen.
 
 
-                  De status `Valid` hoort voor alle vijf signalen op `on` te
-                  staan.
+                  De status `Valid` hoort voor alle vijf signalen op `on` te staan.
 
                   Als `Valid` op `off` staat, is de huidige bron niet numeriek.
 
-                  Dan wordt de proxywaarde `Unavailable` totdat de bron weer
-                  geldig
+                  Dan wordt de proxywaarde `Unavailable` totdat de bron weer geldig
 
                   is.
 
@@ -1938,11 +1898,9 @@ views:
                   <details>
                   <summary><strong>Uitleg</strong></summary>
 
-                  Dit zijn de vijf HA-invoerwaarden zoals OpenQuatt ze ontvangt.
-                  Deze horen de proxywaarden uit het middelste blok te volgen.
+                  Dit zijn de vijf HA-invoerwaarden zoals OpenQuatt ze ontvangt. Deze horen de proxywaarden uit het middelste blok te volgen.
 
-                  Blijft een waarde op `Unknown`, controleer dan eerst of de
-                  bijbehorende `... bron valid` op `on` staat.
+                  Blijft een waarde op `Unknown`, controleer dan eerst of de bijbehorende `... bron valid` op `on` staat.
 
                   </details>
                 text_only: true
@@ -2012,18 +1970,13 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Configureer hier per kamer de dauwpunt-, temperatuur- en
-              luchtvochtigheidsbron voor cooling.
+              Configureer hier per kamer de dauwpunt-, temperatuur- en luchtvochtigheidsbron voor cooling.
 
-              Gebruik per kamer bij voorkeur een directe dauwpuntentity. Heb je
-              die niet, vul dan temperatuur en relatieve luchtvochtigheid in.
+              Gebruik per kamer bij voorkeur een directe dauwpuntentity. Heb je die niet, vul dan temperatuur en relatieve luchtvochtigheid in.
 
-              OpenQuatt gebruikt per kamer eerst het directe dauwpunt en
-              berekent anders zelf het dauwpunt uit temperatuur + RH. Voor de
-              systeembeveiliging telt daarna de hoogste geldige kamerwaarde.
+              OpenQuatt gebruikt per kamer eerst het directe dauwpunt en berekent anders zelf het dauwpunt uit temperatuur + RH. Voor de systeembeveiliging telt daarna de hoogste geldige kamerwaarde.
 
-              Verhoog eerst `Aantal kamers`; daarna verschijnen de invoervelden
-              per kamer.
+              Verhoog eerst `Aantal kamers`; daarna verschijnen de invoervelden per kamer.
               </details>
             text_only: true
             grid_options:
@@ -2208,10 +2161,7 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Dit blok toont de directe OpenTherm-thermostaatkoppeling.
-              Gebruik het om te controleren dat OpenQuatt warmtevraag,
-              koelvraag en kamerwaarden rechtstreeks van de thermostaat ziet,
-              dus buiten CIC of Home Assistant om.
+              Dit blok toont de directe OpenTherm-thermostaatkoppeling. Gebruik het om te controleren dat OpenQuatt warmtevraag, koelvraag en kamerwaarden rechtstreeks van de thermostaat ziet, dus buiten CIC of Home Assistant om.
 
               Controleer bij afwijkingen eerst:
               - `OpenTherm Enabled`
@@ -2251,9 +2201,7 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Dit blok toont de status van de CiC-feed.
-              Als de feed niet OK is of data stale wordt, kunnen CIC-bronnen
-              onbruikbaar worden voor de geselecteerde signalen.
+              Dit blok toont de status van de CiC-feed. Als de feed niet OK is of data stale wordt, kunnen CIC-bronnen onbruikbaar worden voor de geselecteerde signalen.
 
               Controleer bij afwijkingen:
               - `JSON feed OK`
@@ -2281,8 +2229,7 @@ views:
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensorconfiguratie
 
 
-          Configureer bronkeuze en bronkoppeling, en verifieer daarna per
-          signaal
+          Configureer bronkeuze en bronkoppeling, en verifieer daarna per signaal
 
           de geselecteerde waarde en bronstatus.
     top_margin: false
@@ -2305,8 +2252,7 @@ views:
 
               <summary><strong>Uitleg</strong></summary>
 
-              Kies hier welke Quatt Hybrid je hebt. OpenQuatt gebruikt deze
-              keuze om de juiste modelregels en limieten toe te passen.
+              Kies hier welke Quatt Hybrid je hebt. OpenQuatt gebruikt deze keuze om de juiste modelregels en limieten toe te passen.
 
               </details>
             text_only: true
@@ -2328,11 +2274,9 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Day max level / Silent max level** begrenzen het maximale
-              compressorlevel in normale of stille uren.
+              - **Day max level / Silent max level** begrenzen het maximale compressorlevel in normale of stille uren.
 
-              - **Silent start/end time** definieert het tijdvenster waarin de
-              silent-begrenzing actief is.
+              - **Silent start/end time** definieert het tijdvenster waarin de silent-begrenzing actief is.
 
 
               </details>
@@ -2361,38 +2305,23 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **House cold temp** en **Rated maximum house power (Pr)**
-              bepalen samen de schaal van de warmtevraag bij koude condities.
+              - **House cold temp** en **Rated maximum house power (Pr)** bepalen samen de schaal van de warmtevraag bij koude condities.
 
-              - **Maximum heating outdoor temperature** is het punt waar
-              modelmatig de warmtevraag naar ~0 gaat.
+              - **Maximum heating outdoor temperature** is het punt waar modelmatig de warmtevraag naar ~0 gaat.
 
-              - **PH temperatuurreactie** bepaalt hoe sterk Power House extra
-              warmtevraag toevoegt onder de koude comfortgrens en hoe sterk het
-              boven het kamer-setpoint weer gas terugneemt.
+              - **PH temperatuurreactie** bepaalt hoe sterk Power House extra warmtevraag toevoegt onder de koude comfortgrens en hoe sterk het boven het kamer-setpoint weer gas terugneemt.
 
-              - **Comfort above setpoint** bepaalt de acceptabele bovenkant van
-              de comfortband.
+              - **Comfort above setpoint** bepaalt de acceptabele bovenkant van de comfortband.
 
-              - **Comfort below setpoint** bepaalt hoeveel ruimte onder
-              setpoint nog acceptabel is voordat extra opwarming begint.
+              - **Comfort below setpoint** bepaalt hoeveel ruimte onder setpoint nog acceptabel is voordat extra opwarming begint.
 
-              - Als de kamer langere tijd te koud blijft, houdt Power House
-              wat langer extra warmtevraag vast. Daardoor blijft de kamer
-              beter binnen de ingestelde comfortband.
+              - Als de kamer langere tijd te koud blijft, houdt Power House wat langer extra warmtevraag vast. Daardoor blijft de kamer beter binnen de ingestelde comfortband.
 
-              - **Response profile** is een snelle voorkeuze voor rustige,
-              gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd
-              en afbouwtijd niet meer bij een preset horen, toont het profiel
-              automatisch `Custom`.
+              - **Response profile** is een snelle voorkeuze voor rustige, gebalanceerde of vlottere Power House-reactie. Zodra opbouwtijd en afbouwtijd niet meer bij een preset horen, toont het profiel automatisch `Custom`.
 
-              - **Demand rise time** geeft ongeveer aan hoe lang `P_req` nodig
-              mag hebben om van `0` naar `Pr` te lopen. Lager = sneller
-              opschakelen.
+              - **Demand rise time** geeft ongeveer aan hoe lang `P_req` nodig mag hebben om van `0` naar `Pr` te lopen. Lager = sneller opschakelen.
 
-              - **Demand fall time** geeft ongeveer aan hoe lang `P_req` nodig
-              mag hebben om van `Pr` naar `0` te zakken. Lager = sneller
-              terugregelen bij overshoot.
+              - **Demand fall time** geeft ongeveer aan hoe lang `P_req` nodig mag hebben om van `Pr` naar `0` te zakken. Lager = sneller terugregelen bij overshoot.
 
               </details>
             text_only: true
@@ -2430,20 +2359,15 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - De **aanvoerpunten** vormen de stooklijn: gewenste
-              aanvoertemperatuur bij verschillende buitentemperaturen.
+              - De **aanvoerpunten** vormen de stooklijn: gewenste aanvoertemperatuur bij verschillende buitentemperaturen.
 
-              - Pas eerst de curvepunten aan voor het juiste basiscomfort,
-              daarna pas PID finetunen.
+              - Pas eerst de curvepunten aan voor het juiste basiscomfort, daarna pas PID finetunen.
 
-              - **Fallback-aanvoer** wordt gebruikt als buitentemperatuur
-              tijdelijk ontbreekt.
+              - **Fallback-aanvoer** wordt gebruikt als buitentemperatuur tijdelijk ontbreekt.
 
-              - `Heating Curve Control Profile` kiest het ingebouwde regelgedrag
-              voor stabiliteit (o.a. smoothing/hysterese).
+              - `Heating Curve Control Profile` kiest het ingebouwde regelgedrag voor stabiliteit (o.a. smoothing/hysterese).
 
-              - **PID Kp/Ki/Kd** bepaalt de correctie op de
-              systeem-aanvoertemperatuur:
+              - **PID Kp/Ki/Kd** bepaalt de correctie op de systeem-aanvoertemperatuur:
                 - Kp te hoog: snelle maar nerveuze reactie.
                 - Ki te hoog: traag pendelen/overshoot.
                 - Kd meestal laag houden in trage hydraulische systemen.
@@ -2491,13 +2415,9 @@ views:
 
               - Gebruikt `Water Supply Temp (Selected)` als gemeten begrenzingsbron.
 
-              - **Maximum water temperature** is het normale plafond voor de
-              gemeten aanvoertemperatuur.
+              - **Maximum water temperature** is het normale plafond voor de gemeten aanvoertemperatuur.
 
-              - OpenQuatt leidt uit die instelling intern zelf een
-              terugregelband en een harde trip op `max + 5°C` af. In `CM3`
-              valt eerst de boiler weg; alleen bij aanhoudende overshoot volgt
-              daarna een harde HP-stop.
+              - OpenQuatt leidt uit die instelling intern zelf een terugregelband en een harde trip op `max + 5°C` af. In `CM3` valt eerst de boiler weg; alleen bij aanhoudende overshoot volgt daarna een harde HP-stop.
 
 
               </details>
@@ -2567,12 +2487,9 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Minimum runtime** houdt een al gestarte compressor minimaal
-              `300 s` aan. Je kunt deze runtime verlengen, maar niet lager
-              zetten.
+              - **Minimum runtime** houdt een al gestarte compressor minimaal `300 s` aan. Je kunt deze runtime verlengen, maar niet lager zetten.
 
-              - In heating-curve mode wordt PID-demand direct doorgezet en
-              vertaald naar sequentiële levelstappen op HP1.
+              - In heating-curve mode wordt PID-demand direct doorgezet en vertaald naar sequentiële levelstappen op HP1.
 
 
               </details>
@@ -2595,8 +2512,7 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Flow PI Kp/Ki** bepaalt de dynamiek van flowregeling; wijzig
-              in kleine stappen.
+              - **Flow PI Kp/Ki** bepaalt de dynamiek van flowregeling; wijzig in kleine stappen.
 
 
               </details>
@@ -2620,24 +2536,17 @@ views:
 
               <summary><strong>Uitleg parameters</strong></summary>
 
-              - **Nominaal ketelvermogen** is de referentie voor
-              boilerondersteuning en de boiler power test.
+              - **Nominaal ketelvermogen** is de referentie voor boilerondersteuning en de boiler power test.
 
-              - **CV-ketel/boiler aanwezig** moet aan staan voordat
-              OpenQuatt de ketel/boiler als ondersteuning of de boiler power
-              test mag gebruiken.
+              - **CV-ketel/boiler aanwezig** moet aan staan voordat OpenQuatt de ketel/boiler als ondersteuning of de boiler power test mag gebruiken.
 
-              - De **CM3-tekort inschakel- en uitschakeldrempels** bepalen
-              wanneer boilerondersteuning mag inschakelen/uitschakelen.
+              - De **CM3-tekort inschakel- en uitschakeldrempels** bepalen wanneer boilerondersteuning mag inschakelen/uitschakelen.
 
-              - Boilerondersteuning wordt daarnaast geblokkeerd door de
-              watertempbegrenzing als de gemeten aanvoer te hoog wordt.
+              - Boilerondersteuning wordt daarnaast geblokkeerd door de watertempbegrenzing als de gemeten aanvoer te hoog wordt.
 
-              - Houd de inschakeldrempel duidelijk hoger dan de
-              uitschakeldrempel om schakelen rond de grens te beperken.
+              - Houd de inschakeldrempel duidelijk hoger dan de uitschakeldrempel om schakelen rond de grens te beperken.
 
-              - Bij te agressief gedrag: inschakeldrempel verhogen of
-              uitschakeldrempel verlagen.
+              - Bij te agressief gedrag: inschakeldrempel verhogen of uitschakeldrempel verlagen.
 
 
               </details>
@@ -2667,19 +2576,15 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - Kies hier maximaal twee compressorlevels per HP die de
-              verdelingslogica moet overslaan.
+              - Kies hier maximaal twee compressorlevels per HP die de verdelingslogica moet overslaan.
 
               - `None` betekent: geen uitsluiting in dat slot.
 
-              - Als een gevraagd level is uitgesloten, zoekt OpenQuatt eerst een
-              lager level en daarna pas een hoger level.
+              - Als een gevraagd level is uitgesloten, zoekt OpenQuatt eerst een lager level en daarna pas een hoger level.
 
-              - Meestal laat je beide slots op `None`; gebruik uitsluitingen
-              alleen voor testen, geluid of specifieke beperkingen.
+              - Meestal laat je beide slots op `None`; gebruik uitsluitingen alleen voor testen, geluid of specifieke beperkingen.
 
-              - Als beide slots hetzelfde level kiezen, telt dat gewoon als
-              een enkele uitsluiting.
+              - Als beide slots hetzelfde level kiezen, telt dat gewoon als een enkele uitsluiting.
 
 
               </details>
@@ -2703,8 +2608,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:tune-vertical"></ha-icon> Instellingen
 
-          Structurele regelinstellingen voor limieten, huismodel, stooklijn,
-          heat-allocation en flow.
+          Structurele regelinstellingen voor limieten, huismodel, stooklijn, heat-allocation en flow.
     cards: []
   - title: Service en test
     path: service-test
@@ -2725,17 +2629,13 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Reset draaitellers**. Let op: het kan maximaal 1 minuut
-              duren voordat je effect ziet.
+              - **Reset draaitellers**. Let op: het kan maximaal 1 minuut duren voordat je effect ziet.
 
-              - **Reset cumulatieve energietellers** zet cumulatieve elektriciteits-
-              en warmte-energiemeters terug naar 0.
+              - **Reset cumulatieve energietellers** zet cumulatieve elektriciteits-en warmte-energiemeters terug naar 0.
 
-              - **HP1 draaitijd counter** toont de actuele teller waarop de
-              runtime-balans wordt gebaseerd.
+              - **HP1 draaitijd counter** toont de actuele teller waarop de runtime-balans wordt gebaseerd.
 
-              - **Leidende HP** toont welke unit momenteel lead is op basis
-              van de laagste runtime.
+              - **Leidende HP** toont welke unit momenteel lead is op basis van de laagste runtime.
 
 
               </details>
@@ -2751,134 +2651,6 @@ views:
                 name: HP1 draaitijd
               - entity: sensor.openquatt_runtime_lead_hp
                 name: Leidende HP
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: CM100 commissioning
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Start eerst **CM100**. In deze stand gebeurt nog niets: geen
-              flow, geen boiler en geen autotune.
-
-              - Kies daarna precies één commissioningtaak: **Boiler power test**
-              of **Flow autotune**.
-
-              - Start eerst **CM100**. Pas daarna kun je precies één
-              commissioningtaak starten.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_cm100_start
-                name: CM100 starten
-              - entity: button.openquatt_cm100_stop
-                name: CM100 stoppen
-              - entity: sensor.openquatt_control_mode_label
-                name: ControlMode
-              - entity: binary_sensor.openquatt_cm100_active
-                name: CM100 actief
-              - entity: sensor.openquatt_commissioning_status
-                name: CM100 status
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:tools
-            heading: CM100 - Flow autotune
-            heading_style: title
-            grid_options:
-              columns: 12
-              rows: 1
-          - type: heading
-            icon: mdi:water-boiler
-            heading: CM100 - Boiler power test
-            heading_style: title
-            grid_options:
-              columns: 12
-              rows: auto
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Start **Flow autotune** alleen terwijl **CM100** al actief is.
-
-              - In CM100 start autotune zelf de flow op en meet daarna de
-              respons.
-
-              - Autotune gebruikt een vaste duur en een adaptieve stap-preset.
-              starten.
-
-              - `Apply autotune Kp/Ki` alleen toepassen als de voorgestelde
-              waarden logisch zijn.
-
-
-              </details>
-            text_only: true
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg parameters</strong></summary>
-
-
-              - Meet het effectieve ketelvermogen bij stabiele flow.
-
-              - Start de test alleen terwijl **CM100** al actief is.
-
-              - Pas de gemeten waarde toe als die logisch oogt.
-
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_flow_autotune_start
-                name: Flow autotune starten
-              - entity: button.openquatt_flow_autotune_abort
-                name: Flow autotune afbreken
-              - entity: button.openquatt_apply_flow_autotune_kp_ki
-                name: Pas autotune Kp/Ki toe
-              - entity: number.openquatt_flow_autotune_kp_suggested
-                name: Autotune Kp voorstel
-              - entity: number.openquatt_flow_autotune_ki_suggested
-                name: Autotune Ki voorstel
-              - entity: sensor.openquatt_flow_autotune_status
-                name: Autotune status
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: button.openquatt_boiler_power_test_start
-                name: Boiler power test starten
-              - entity: button.openquatt_boiler_power_test_abort
-                name: Boiler power test afbreken
-              - entity: button.openquatt_boiler_power_test_apply
-                name: Pas boilervermogen toe
-              - entity: number.openquatt_boiler_rated_heat_power
-                name: Nominaal ketelvermogen
-              - entity: sensor.openquatt_boiler_power_test_result
-                name: Boiler power test resultaat
-              - entity: sensor.openquatt_boiler_power_test_confidence
-                name: Boiler power test confidence
-              - entity: sensor.openquatt_boiler_power_test_status
-                name: Boiler power test status
-        visibility:
-          - condition: state
-            entity: binary_sensor.openquatt_cm100_active
-            state: 'on'
-        column_span: 2
     header:
       card:
         type: markdown
@@ -2906,19 +2678,13 @@ views:
 
               Dit blok toont firmwareversie en OTA-update-status:
 
-              - `OpenQuatt-versie`: versie die lokaal op de ESP draait
-              (uit `project_version` in de build).
-              - `OpenQuatt-releasekanaal`: buildkanaal dat nu op de ESP draait
-              (`main` of `dev`).
-              - `Firmware-updatekanaal`: kiest welk OTA-kanaal de update-
-              entiteit hierna volgt (`main` of `dev`).
-              - `Firmware-update`: vergelijkt jouw huidige firmware met de
-              laatste GitHub release en toont of er een update beschikbaar is.
-              - `Controleer firmware-updates`: forceert direct een nieuwe updatecheck
-              (zonder te wachten op de volgende automatische poll).
+              - `OpenQuatt-versie`: versie die lokaal op de ESP draait (uit `project_version` in de build).
+              - `OpenQuatt-releasekanaal`: buildkanaal dat nu op de ESP draait (`main` of `dev`).
+              - `Firmware-updatekanaal`: kiest welk OTA-kanaal de update-entiteit hierna volgt (`main` of `dev`).
+              - `Firmware-update`: vergelijkt jouw huidige firmware met de laatste GitHub release en toont of er een update beschikbaar is.
+              - `Controleer firmware-updates`: forceert direct een nieuwe updatecheck (zonder te wachten op de volgende automatische poll).
 
-              Let op: bij een nieuwe release kan het kort duren voordat de
-              update-entiteit de nieuwe versie toont (cache/refresh interval).
+              Let op: bij een nieuwe release kan het kort duren voordat de update-entiteit de nieuwe versie toont (cache/refresh interval).
 
               </details>
             text_only: true
@@ -3001,11 +2767,9 @@ views:
 
               - `P_house` is de modelschatting op basis van buitentemperatuur.
 
-              - `P_req` is de begrensde warmtevraag na comfortband,
-              temperatuurreactie en ramp-limiter.
+              - `P_req` is de begrensde warmtevraag na comfortband, temperatuurreactie en ramp-limiter.
 
-              Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer
-              setpoint/temp, comfortband en responsinstellingen.
+              Als `P_req` onverwacht hoog/laag is: controleer buitenbron, kamer setpoint/temp, comfortband en responsinstellingen.
 
 
               </details>
@@ -3037,20 +2801,16 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              Gebruik dit blok om de curve-regeling stap voor stap te
-              controleren.
+              Gebruik dit blok om de curve-regeling stap voor stap te controleren.
 
 
               - Deze sectie is vooral relevant bij actieve stooklijnregeling.
 
-              - Vergelijk eerst `Aanvoerdoel` met `Werkelijke aanvoer (gekozen)` om de
-              regelafwijking te zien.
+              - Vergelijk eerst `Aanvoerdoel` met `Werkelijke aanvoer (gekozen)` om de regelafwijking te zien.
 
-              - Gebruik `Stooklijn-PID` bij finetuning als de regeling te
-              traag of te nerveus reageert.
+              - Gebruik `Stooklijn-PID` bij finetuning als de regeling te traag of te nerveus reageert.
 
-              - `Buitentemp (gekozen)` helpt verklaren waarom het `Supply
-              target` stijgt of daalt.
+              - `Buitentemp (gekozen)` helpt verklaren waarom het `Supply target` stijgt of daalt.
 
 
               </details>

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -101,6 +101,7 @@ select:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_set_working_mode
     name: "${prefix}Set Working Mode"
+    internal: true
     disabled_by_default: true
     icon: "mdi:heat-pump-outline"
     address: 3999
@@ -118,6 +119,7 @@ select:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_compressor_level
     name: "${prefix}Set Compressor Level"
+    internal: true
     disabled_by_default: true
     icon: "mdi:sine-wave"
     address: 1999
@@ -143,6 +145,7 @@ select:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_low_noise_mode
     name: "${prefix}Silent Mode"
+    internal: true
     disabled_by_default: true
     icon: mdi:weather-night
     address: 2006
@@ -159,6 +162,7 @@ select:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_set_pump_mode
     name: "${prefix}Set Pump Mode"
+    internal: true
     disabled_by_default: true
     icon: "mdi:pump"
     address: 2010
@@ -630,6 +634,7 @@ sensor:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_water_in_temp_raw
     name: "${prefix}Water in temperature raw"
+    internal: true
     disabled_by_default: true
     icon: mdi:thermometer-water
     register_type: holding
@@ -655,6 +660,7 @@ sensor:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_water_out_temp_raw
     name: "${prefix}Water out temperature raw"
+    internal: true
     disabled_by_default: true
     icon: mdi:thermometer-water
     register_type: holding

--- a/openquatt/oq_air_purge.yaml
+++ b/openquatt/oq_air_purge.yaml
@@ -54,6 +54,7 @@ button:
   - platform: template
     id: oq_air_purge_start
     name: "Air Purge Start"
+    internal: true
     icon: mdi:water-pump
     entity_category: config
     web_server:
@@ -67,6 +68,7 @@ button:
   - platform: template
     id: oq_air_purge_abort_btn
     name: "Air Purge Abort"
+    internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
     web_server:
@@ -79,6 +81,7 @@ switch:
   - platform: template
     id: oq_air_purge_return_to_auto
     name: "Air purge return to Auto"
+    internal: true
     icon: mdi:backup-restore
     entity_category: config
     optimistic: true
@@ -93,6 +96,7 @@ binary_sensor:
   - platform: template
     id: oq_air_purge_active_sensor
     name: "Air purge active"
+    internal: true
     icon: mdi:water-pump
     entity_category: diagnostic
     web_server:
@@ -104,6 +108,7 @@ sensor:
   - platform: template
     id: oq_air_purge_remaining_sensor
     name: "Air purge remaining"
+    internal: true
     icon: mdi:timer-outline
     unit_of_measurement: "s"
     state_class: measurement
@@ -117,6 +122,7 @@ sensor:
   - platform: template
     id: oq_air_purge_phase_sensor
     name: "Air purge phase"
+    internal: true
     icon: mdi:timeline-clock-outline
     state_class: measurement
     accuracy_decimals: 0
@@ -129,6 +135,7 @@ sensor:
   - platform: template
     id: oq_air_purge_target_ipwm_sensor
     name: "Air purge target iPWM"
+    internal: true
     icon: mdi:fan-speed-3
     unit_of_measurement: "iPWM"
     state_class: measurement
@@ -143,6 +150,7 @@ text_sensor:
   - platform: template
     id: oq_air_purge_status
     name: "Air purge status"
+    internal: true
     icon: mdi:information-outline
     update_interval: never
     web_server:

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -51,6 +51,7 @@ switch:
   - platform: output
     id: boiler_relay
     name: "Boiler relay"
+    internal: true
     disabled_by_default: true
     output: boiler_relay_out
     icon: mdi:water-boiler

--- a/openquatt/oq_boiler_test.yaml
+++ b/openquatt/oq_boiler_test.yaml
@@ -34,6 +34,7 @@ button:
   - platform: template
     id: oq_boiler_power_test_start
     name: "Boiler Power Test Start"
+    internal: true
     icon: mdi:play-circle-outline
     entity_category: config
     web_server:
@@ -45,6 +46,7 @@ button:
   - platform: template
     id: oq_boiler_power_test_abort
     name: "Boiler Power Test Abort"
+    internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
     web_server:
@@ -56,6 +58,7 @@ button:
   - platform: template
     id: oq_boiler_power_test_apply
     name: "Boiler Power Test Apply"
+    internal: true
     icon: mdi:check-circle-outline
     entity_category: config
     web_server:
@@ -97,6 +100,7 @@ sensor:
   - platform: template
     id: oq_boiler_power_test_result
     name: "Boiler power test result"
+    internal: true
     icon: mdi:chart-line
     unit_of_measurement: "W"
     device_class: power
@@ -111,6 +115,7 @@ sensor:
   - platform: template
     id: oq_boiler_power_test_confidence
     name: "Boiler power test confidence"
+    internal: true
     icon: mdi:percent-outline
     unit_of_measurement: "%"
     state_class: measurement
@@ -125,6 +130,7 @@ binary_sensor:
   - platform: template
     id: oq_boiler_power_test_active
     name: "Boiler power test active"
+    internal: true
     icon: mdi:test-tube
     entity_category: diagnostic
     web_server:
@@ -136,6 +142,7 @@ text_sensor:
   - platform: template
     id: oq_boiler_power_test_status
     name: "Boiler power test status"
+    internal: true
     icon: mdi:information-outline
     update_interval: never
     web_server:

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -65,6 +65,7 @@ button:
   - platform: template
     id: oq_commissioning_cm100_start
     name: "CM100 Start"
+    internal: true
     icon: mdi:play-circle-outline
     entity_category: config
     web_server:
@@ -94,6 +95,7 @@ button:
   - platform: template
     id: oq_commissioning_cm100_stop
     name: "CM100 Stop"
+    internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
     web_server:
@@ -108,6 +110,7 @@ binary_sensor:
   - platform: template
     id: oq_commissioning_cm100_active
     name: "CM100 active"
+    internal: true
     icon: mdi:state-machine
     entity_category: diagnostic
     web_server:
@@ -120,6 +123,7 @@ text_sensor:
   - platform: template
     id: oq_commissioning_status
     name: "Commissioning status"
+    internal: true
     icon: mdi:state-machine
     update_interval: never
     web_server:

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -393,6 +393,7 @@ button:
   - platform: template
     id: oq_trend_history_flush_button
     name: Trendhistorie nu opslaan
+    internal: true
     disabled_by_default: true
     icon: mdi:content-save
     entity_category: config
@@ -444,6 +445,7 @@ switch:
   - platform: template
     id: oq_trend_history_enabled_switch
     name: Trendopslag
+    internal: true
     disabled_by_default: true
     icon: mdi:chart-line
     entity_category: config
@@ -460,6 +462,7 @@ switch:
   - platform: template
     id: oq_trend_history_flash_switch
     name: Trendhistorie opslaan in flash
+    internal: true
     icon: mdi:database
     entity_category: config
     optimistic: true
@@ -569,6 +572,7 @@ sensor:
   - platform: template
     id: oq_trend_history_flash_size
     name: Trendhistorie grootte
+    internal: true
     disabled_by_default: true
     icon: mdi:database-outline
     unit_of_measurement: kB
@@ -583,6 +587,7 @@ sensor:
   - platform: template
     id: oq_trend_history_flash_writes
     name: Trendhistorie schrijfacties
+    internal: true
     disabled_by_default: true
     icon: mdi:pencil-box-multiple-outline
     accuracy_decimals: 0
@@ -624,6 +629,7 @@ text_sensor:
   - platform: template
     id: oq_trend_history_flash_available
     name: Trendhistorie beschikbaar
+    internal: true
     disabled_by_default: true
     icon: mdi:calendar-range
     entity_category: diagnostic
@@ -636,6 +642,7 @@ text_sensor:
   - platform: template
     id: oq_trend_history_flash_oldest
     name: Trendhistorie oudste punt
+    internal: true
     disabled_by_default: true
     icon: mdi:calendar-start
     entity_category: diagnostic
@@ -648,6 +655,7 @@ text_sensor:
   - platform: template
     id: oq_trend_history_flash_newest
     name: Trendhistorie nieuwste punt
+    internal: true
     disabled_by_default: true
     icon: mdi:clock-end
     entity_category: diagnostic
@@ -660,6 +668,7 @@ text_sensor:
   - platform: template
     id: oq_trend_history_flash_last_flush
     name: Trendhistorie laatste opslag
+    internal: true
     disabled_by_default: true
     icon: mdi:content-save-clock-outline
     entity_category: diagnostic

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -54,6 +54,7 @@ button:
   - platform: template
     id: oq_flow_autotune_start
     name: "Flow Autotune Start"
+    internal: true
     icon: mdi:play-circle-outline
     entity_category: config
     web_server:
@@ -71,6 +72,7 @@ button:
   - platform: template
     id: oq_flow_autotune_abort_btn
     name: "Flow Autotune Abort"
+    internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
     web_server:
@@ -82,6 +84,7 @@ button:
   - platform: template
     id: oq_flow_autotune_apply
     name: "Apply Flow Autotune Kp-Ki"
+    internal: true
     icon: mdi:check-circle-outline
     entity_category: config
     web_server:
@@ -108,6 +111,7 @@ number:
   - platform: template
     id: oq_flow_kp_suggested
     name: "Flow Autotune Kp suggested"
+    internal: true
     icon: mdi:alpha-k-circle-outline
     mode: slider
     min_value: ${oq_flow_kp_min}
@@ -123,6 +127,7 @@ number:
   - platform: template
     id: oq_flow_ki_suggested
     name: "Flow Autotune Ki suggested"
+    internal: true
     icon: mdi:alpha-i-circle-outline
     mode: slider
     min_value: ${oq_flow_ki_min}
@@ -139,6 +144,7 @@ text_sensor:
   - platform: template
     id: oq_flow_autotune_status
     name: "Flow Autotune status"
+    internal: true
     icon: mdi:information-outline
     web_server:
       sorting_group_id: oq_tuning_flow

--- a/openquatt/oq_hp_water_calibration.yaml
+++ b/openquatt/oq_hp_water_calibration.yaml
@@ -100,6 +100,7 @@ number:
   - platform: template
     id: hp1_water_in_temp_offset
     name: "HP1 water in temperature offset"
+    internal: true
     icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
@@ -117,6 +118,7 @@ number:
   - platform: template
     id: hp1_water_out_temp_offset
     name: "HP1 water out temperature offset"
+    internal: true
     icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
@@ -134,7 +136,7 @@ number:
   - platform: template
     id: hp2_water_in_temp_offset
     name: "HP2 water in temperature offset"
-    internal: ${monitoring_hp2_internal}
+    internal: true
     icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
@@ -152,7 +154,7 @@ number:
   - platform: template
     id: hp2_water_out_temp_offset
     name: "HP2 water out temperature offset"
-    internal: ${monitoring_hp2_internal}
+    internal: true
     icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
@@ -170,6 +172,7 @@ number:
   - platform: template
     id: oq_hp_calibration_hp1_water_in_offset_suggested
     name: "HP calibration HP1 water in offset suggested"
+    internal: true
     icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
@@ -187,6 +190,7 @@ number:
   - platform: template
     id: oq_hp_calibration_hp1_water_out_offset_suggested
     name: "HP calibration HP1 water out offset suggested"
+    internal: true
     icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
@@ -204,7 +208,7 @@ number:
   - platform: template
     id: oq_hp_calibration_hp2_water_in_offset_suggested
     name: "HP calibration HP2 water in offset suggested"
-    internal: ${monitoring_hp2_internal}
+    internal: true
     icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
@@ -222,7 +226,7 @@ number:
   - platform: template
     id: oq_hp_calibration_hp2_water_out_offset_suggested
     name: "HP calibration HP2 water out offset suggested"
-    internal: ${monitoring_hp2_internal}
+    internal: true
     icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
@@ -241,6 +245,7 @@ button:
   - platform: template
     id: oq_hp_water_calibration_start
     name: "HP Water Calibration Start"
+    internal: true
     icon: mdi:thermometer-sync
     entity_category: config
     disabled_by_default: true
@@ -255,6 +260,7 @@ button:
   - platform: template
     id: oq_hp_water_calibration_abort_btn
     name: "HP Water Calibration Abort"
+    internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
     disabled_by_default: true
@@ -267,6 +273,7 @@ button:
   - platform: template
     id: oq_hp_water_calibration_apply
     name: "Apply HP Water Calibration Offsets"
+    internal: true
     icon: mdi:check-circle-outline
     entity_category: config
     disabled_by_default: true
@@ -281,6 +288,7 @@ binary_sensor:
   - platform: template
     id: oq_hp_water_calibration_active_sensor
     name: "HP water calibration active"
+    internal: true
     icon: mdi:thermometer-sync
     entity_category: diagnostic
     disabled_by_default: true
@@ -293,6 +301,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_remaining_sensor
     name: "HP water calibration remaining"
+    internal: true
     icon: mdi:timer-outline
     unit_of_measurement: "s"
     state_class: measurement
@@ -307,6 +316,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_phase_sensor
     name: "HP water calibration phase"
+    internal: true
     icon: mdi:timeline-clock-outline
     state_class: measurement
     accuracy_decimals: 0
@@ -320,6 +330,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_spread_sensor
     name: "HP water calibration spread"
+    internal: true
     icon: mdi:thermometer-lines
     unit_of_measurement: "°C"
     device_class: temperature
@@ -335,6 +346,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_supply_delta_sensor
     name: "HP water calibration supply delta"
+    internal: true
     icon: mdi:thermometer-lines
     unit_of_measurement: "°C"
     device_class: temperature
@@ -350,6 +362,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_stable_progress_sensor
     name: "HP water calibration stable window progress"
+    internal: true
     icon: mdi:timer-check-outline
     unit_of_measurement: "s"
     state_class: measurement
@@ -364,6 +377,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_stable_required_sensor
     name: "HP water calibration stable window required"
+    internal: true
     icon: mdi:timer-check-outline
     unit_of_measurement: "s"
     state_class: measurement
@@ -378,6 +392,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_result_reference_sensor
     name: "HP water calibration result reference"
+    internal: true
     icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     device_class: temperature
@@ -393,6 +408,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_result_spread_before_sensor
     name: "HP water calibration result spread before"
+    internal: true
     icon: mdi:thermometer-lines
     unit_of_measurement: "°C"
     device_class: temperature
@@ -408,6 +424,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_result_expected_spread_sensor
     name: "HP water calibration result expected spread"
+    internal: true
     icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     device_class: temperature
@@ -423,6 +440,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_result_hp1_in_raw_avg_sensor
     name: "HP water calibration result HP1 water in raw average"
+    internal: true
     icon: mdi:thermometer-water
     unit_of_measurement: "°C"
     device_class: temperature
@@ -438,6 +456,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_result_hp1_out_raw_avg_sensor
     name: "HP water calibration result HP1 water out raw average"
+    internal: true
     icon: mdi:thermometer-water
     unit_of_measurement: "°C"
     device_class: temperature
@@ -453,7 +472,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_result_hp2_in_raw_avg_sensor
     name: "HP water calibration result HP2 water in raw average"
-    internal: ${monitoring_hp2_internal}
+    internal: true
     icon: mdi:thermometer-water
     unit_of_measurement: "°C"
     device_class: temperature
@@ -469,7 +488,7 @@ sensor:
   - platform: template
     id: oq_hp_water_calibration_result_hp2_out_raw_avg_sensor
     name: "HP water calibration result HP2 water out raw average"
-    internal: ${monitoring_hp2_internal}
+    internal: true
     icon: mdi:thermometer-water
     unit_of_measurement: "°C"
     device_class: temperature
@@ -486,6 +505,7 @@ text_sensor:
   - platform: template
     id: oq_hp_water_calibration_status
     name: "HP water calibration status"
+    internal: true
     icon: mdi:information-outline
     disabled_by_default: true
     update_interval: never

--- a/openquatt/oq_installation_monitoring.yaml
+++ b/openquatt/oq_installation_monitoring.yaml
@@ -59,6 +59,7 @@ button:
   - platform: template
     id: oq_acknowledge_compressor_cycling_alert
     name: "Acknowledge compressor cycling alert"
+    internal: true
     icon: mdi:check-circle-outline
     entity_category: config
     on_press:
@@ -239,6 +240,7 @@ sensor:
   - platform: template
     id: oq_compressor_cycling_alert_first_seen
     name: "Compressor cycling alert first seen"
+    internal: true
     icon: mdi:clock-start
     entity_category: diagnostic
     unit_of_measurement: s
@@ -254,6 +256,7 @@ sensor:
   - platform: template
     id: oq_compressor_cycling_alert_last_seen
     name: "Compressor cycling alert last seen"
+    internal: true
     icon: mdi:clock-end
     entity_category: diagnostic
     unit_of_measurement: s
@@ -269,6 +272,7 @@ sensor:
   - platform: template
     id: oq_compressor_cycling_alert_hp1_peak_2h
     name: "Compressor cycling alert HP1 peak 2h"
+    internal: true
     icon: mdi:chart-line
     entity_category: diagnostic
     accuracy_decimals: 0
@@ -281,6 +285,7 @@ sensor:
   - platform: template
     id: oq_compressor_cycling_alert_hp1_peak_72h
     name: "Compressor cycling alert HP1 peak 72h"
+    internal: true
     icon: mdi:chart-line
     entity_category: diagnostic
     accuracy_decimals: 0
@@ -294,7 +299,7 @@ sensor:
     id: oq_compressor_cycling_alert_hp2_peak_2h
     name: "Compressor cycling alert HP2 peak 2h"
     icon: mdi:chart-line
-    internal: ${monitoring_hp2_internal}
+    internal: true
     entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
@@ -307,7 +312,7 @@ sensor:
     id: oq_compressor_cycling_alert_hp2_peak_72h
     name: "Compressor cycling alert HP2 peak 72h"
     icon: mdi:chart-line
-    internal: ${monitoring_hp2_internal}
+    internal: true
     entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
@@ -320,6 +325,7 @@ binary_sensor:
   - platform: template
     id: oq_compressor_cycling_alert_latched_sensor
     name: "Compressor cycling alert latched"
+    internal: true
     icon: mdi:alert-circle-check-outline
     device_class: problem
     entity_category: diagnostic
@@ -332,7 +338,7 @@ binary_sensor:
     id: oq_compressor_cycling_alert_alternating_sensor
     name: "Compressor cycling alert alternating"
     icon: mdi:swap-horizontal-bold
-    internal: ${monitoring_hp2_internal}
+    internal: true
     entity_category: diagnostic
     lambda: |-
       return id(oq_compressor_cycling_alert_alternating);

--- a/openquatt/oq_manual_flow.yaml
+++ b/openquatt/oq_manual_flow.yaml
@@ -18,6 +18,7 @@ number:
   - platform: template
     id: oq_manual_flow_setpoint_lph
     name: "Manual flow service setpoint"
+    internal: true
     icon: mdi:waves-arrow-right
     unit_of_measurement: "L/h"
     mode: slider
@@ -35,6 +36,7 @@ button:
   - platform: template
     id: oq_manual_flow_start
     name: "Manual Flow Start"
+    internal: true
     icon: mdi:water-pump
     entity_category: config
     web_server:
@@ -46,6 +48,7 @@ button:
   - platform: template
     id: oq_manual_flow_abort
     name: "Manual Flow Abort"
+    internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
     web_server:
@@ -57,6 +60,7 @@ button:
   - platform: template
     id: oq_manual_flow_apply_heating
     name: "Apply Manual Flow To Heating"
+    internal: true
     icon: mdi:radiator
     entity_category: config
     web_server:
@@ -68,6 +72,7 @@ button:
   - platform: template
     id: oq_manual_flow_apply_cooling
     name: "Apply Manual Flow To Cooling"
+    internal: true
     icon: mdi:snowflake
     entity_category: config
     web_server:
@@ -80,6 +85,7 @@ binary_sensor:
   - platform: template
     id: oq_manual_flow_active_sensor
     name: "Manual flow active"
+    internal: true
     icon: mdi:water-pump
     entity_category: diagnostic
     web_server:
@@ -91,6 +97,7 @@ sensor:
   - platform: template
     id: oq_manual_flow_target_ipwm_sensor
     name: "Manual flow target iPWM"
+    internal: true
     icon: mdi:fan-speed-3
     unit_of_measurement: "iPWM"
     state_class: measurement
@@ -105,6 +112,7 @@ text_sensor:
   - platform: template
     id: oq_manual_flow_status
     name: "Manual flow status"
+    internal: true
     icon: mdi:information-outline
     update_interval: never
     web_server:

--- a/openquatt/oq_manual_hp.yaml
+++ b/openquatt/oq_manual_hp.yaml
@@ -38,6 +38,7 @@ select:
   - platform: template
     id: oq_manual_hp1_mode
     name: "Manual HP1 service mode"
+    internal: true
     icon: mdi:heat-pump
     optimistic: false
     restore_value: false
@@ -56,6 +57,7 @@ select:
   - platform: template
     id: oq_manual_hp2_mode
     name: "Manual HP2 service mode"
+    internal: true
     icon: mdi:heat-pump
     optimistic: false
     restore_value: false
@@ -75,6 +77,7 @@ number:
   - platform: template
     id: oq_manual_hp1_level
     name: "Manual HP1 compressor level"
+    internal: true
     icon: mdi:speedometer
     mode: slider
     min_value: 0
@@ -90,6 +93,7 @@ number:
   - platform: template
     id: oq_manual_hp2_level
     name: "Manual HP2 compressor level"
+    internal: true
     icon: mdi:speedometer
     mode: slider
     min_value: 0
@@ -106,6 +110,7 @@ button:
   - platform: template
     id: oq_manual_hp_start
     name: "Manual HP Start"
+    internal: true
     icon: mdi:heat-pump-outline
     entity_category: config
     web_server:
@@ -117,6 +122,7 @@ button:
   - platform: template
     id: oq_manual_hp_abort
     name: "Manual HP Abort"
+    internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
     web_server:
@@ -129,6 +135,7 @@ binary_sensor:
   - platform: template
     id: oq_manual_hp_active_sensor
     name: "Manual HP active"
+    internal: true
     icon: mdi:heat-pump
     entity_category: diagnostic
     web_server:
@@ -141,6 +148,7 @@ text_sensor:
   - platform: template
     id: oq_manual_hp_status
     name: "Manual HP status"
+    internal: true
     icon: mdi:information-outline
     update_interval: never
     web_server:
@@ -149,6 +157,7 @@ text_sensor:
   - platform: template
     id: oq_manual_hp_guard_status
     name: "Manual HP guard status"
+    internal: true
     icon: mdi:shield-check-outline
     update_interval: never
     web_server:

--- a/openquatt/oq_setup_status.yaml
+++ b/openquatt/oq_setup_status.yaml
@@ -22,6 +22,7 @@ button:
   - platform: template
     id: oq_setup_complete_button
     name: "Complete setup"
+    internal: true
     disabled_by_default: true
     icon: mdi:check-bold
     entity_category: config
@@ -34,6 +35,7 @@ button:
   - platform: template
     id: oq_setup_reset_button
     name: "Reset setup state"
+    internal: true
     disabled_by_default: true
     icon: mdi:restart
     entity_category: config
@@ -47,6 +49,7 @@ binary_sensor:
   - platform: template
     id: oq_setup_complete_sensor
     name: "Setup Complete"
+    internal: true
     icon: mdi:check-circle-outline
     device_class: running
     entity_category: diagnostic

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -445,6 +445,7 @@ binary_sensor:
   - platform: template
     id: oq_time_valid
     name: "Time valid"
+    internal: true
     disabled_by_default: true
     icon: mdi:clock-check
     device_class: connectivity
@@ -472,6 +473,7 @@ text_sensor:
   - platform: template
     id: oq_time_now_hhmm
     name: "Time now (HH:MM)"
+    internal: true
     icon: mdi:clock-outline
     update_interval: never
     entity_category: diagnostic

--- a/openquatt/oq_web_access.yaml
+++ b/openquatt/oq_web_access.yaml
@@ -29,6 +29,7 @@ switch:
   - platform: template
     id: oq_ram_log_history_switch
     name: RAM log history
+    internal: true
     disabled_by_default: true
     icon: mdi:memory
     entity_category: config


### PR DESCRIPTION
## Summary

- Mark service, commissioning, calibration, trend/log, setup, clock, and low-level actuator entities as `internal: true` so they stay out of Home Assistant by default.
- Remove CM100 commissioning, flow autotune, and boiler power test cards from the bundled HA dashboards.
- Clean up dashboard markdown literal blocks so soft-wrapped source lines do not render as visible line breaks in Lovelace.

## Why

This builds on #215, which added bulk entity polling including explicit internal entities. The local web app can now read those internal service entities directly, so service workflows no longer need to create a large visible Home Assistant entity surface. Home Assistant should remain focused on normal user controls and high-level warnings.

The dashboard markdown cleanup fixes a Lovelace rendering issue where YAML source wrapping inside `content: |-` was shown as real line breaks.

## Validation

- `./scripts/validate_local.sh` passed before the final dashboard-only markdown unwrap.
- `python3 scripts/check_docs_consistency.py` passed after the dashboard markdown cleanup.
- `python3 scripts/check_style_consistency.py` passed after the dashboard markdown cleanup.
- OTA upload to the Waveshare Duo succeeded during testing.