### PR TITLE
Hide debug tuning entities from Home Assistant

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -565,6 +565,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
     name: "${prefix}Firmware EEPROM"
+    internal: true
     disabled_by_default: true
     icon: mdi:memory
     register_type: holding
@@ -577,6 +578,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
     name: "${prefix}Control board item number"
+    internal: true
     disabled_by_default: true
     icon: mdi:identifier
     register_type: holding
@@ -970,6 +972,7 @@ binary_sensor:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_fan_low_speed_mode
     name: "${prefix}Fan Low Speed Mode"
+    internal: true
     disabled_by_default: true
     icon: mdi:fan-speed-1
     device_class: running
@@ -1010,6 +1013,7 @@ binary_sensor:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_fan_defrost_mode
     name: "${prefix}Fan Defrost Mode"
+    internal: true
     disabled_by_default: true
     icon: mdi:snowflake-melt
     device_class: running
@@ -1024,6 +1028,7 @@ binary_sensor:
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_fan_high_speed_mode
     name: "${prefix}Fan High Speed Mode"
+    internal: true
     disabled_by_default: true
     icon: mdi:fan-speed-3
     device_class: running
@@ -1291,6 +1296,7 @@ text_sensor:
   - platform: template
     id: ${hp_id}_pcb_firmware_version
     name: "${prefix}ODU PCB firmware version"
+    internal: true
     icon: mdi:chip
     entity_category: diagnostic
     disabled_by_default: true

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -352,6 +352,7 @@ select:
   - platform: template
     name: "Debug Level"
     id: debug_level_select
+    internal: true
     disabled_by_default: true
     icon: mdi:lan
     web_server:

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -130,6 +130,7 @@ number:
   - platform: template
     id: oq_flow_frost_pwm
     name: "Frost Circulation iPWM"
+    internal: true
     disabled_by_default: true
     icon: mdi:snowflake
     unit_of_measurement: "iPWM"
@@ -146,6 +147,7 @@ number:
   - platform: template
     id: oq_flow_auto_start_pwm
     name: "Flow AUTO start iPWM"
+    internal: true
     disabled_by_default: true
     icon: mdi:rocket-launch-outline
     unit_of_measurement: "iPWM"

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -331,6 +331,7 @@ button:
   - platform: template
     id: reset_heating_curve_pid_integral
     name: "Reset Heating Curve PID integral"
+    internal: true
     disabled_by_default: true
     icon: mdi:restart
     entity_category: config
@@ -344,6 +345,7 @@ climate:
   - platform: pid
     id: oq_heating_curve_pid
     name: "Heating Curve PID"
+    internal: true
     icon: mdi:thermostat
     sensor: oq_system_supply_temp
     default_target_temperature: 35 °C


### PR DESCRIPTION
## Summary

- Hide the selected debug/tuning controls from Home Assistant with `internal: true`.
- Covered entities include debug level, heating curve PID/reset, frost/auto-start iPWM tuning, HP firmware metadata, and HP fan mode diagnostics.
- `HPx - Set Pump Speed` was already internal on the current `dev` base, so no extra change was needed for that entity.

## Why

These entities are either low-level actuator/tuning controls or diagnostic implementation details. They should stay available to the local web app through internal entity access without adding more visible Home Assistant entity sprawl.

## Validation

- `./scripts/validate_local.sh` passed.