### PR TITLE
Add local ESPHome Device Builder entrypoint

### DIFF
--- a/openquatt-device-builder.yaml
+++ b/openquatt-device-builder.yaml
@@ -1,0 +1,20 @@
+# Place the OpenQuatt repository contents directly in the ESPHome config folder.
+# Enable exactly one profile below.
+substitutions:
+  device_name: openquatt
+  friendly_name: OpenQuatt
+  openquatt_root: openquatt
+  components_root: components
+
+packages:
+  openquatt: !include configs/heatpump_listener/single_wifi.yaml
+  # openquatt: !include configs/heatpump_listener/duo_wifi.yaml
+  # openquatt: !include configs/heatpump_controller_q/single_wifi.yaml
+  # openquatt: !include configs/heatpump_controller_q/duo_wifi.yaml
+  # openquatt: !include configs/heatpump_controller_q/single_eth.yaml
+  # openquatt: !include configs/heatpump_controller_q/duo_eth.yaml
+  # openquatt: !include configs/waveshare/single_wifi.yaml
+  # openquatt: !include configs/waveshare/duo_wifi.yaml
+
+esphome:
+  build_path: build/${device_name}

--- a/openquatt-device-builder.yaml
+++ b/openquatt-device-builder.yaml
@@ -5,7 +5,6 @@ substitutions:
   friendly_name: OpenQuatt
   openquatt_root: openquatt
   components_root: components
-  scripts_root: ../../../scripts
 
 packages:
   openquatt: !include configs/heatpump_listener/single_wifi.yaml

--- a/openquatt-device-builder.yaml
+++ b/openquatt-device-builder.yaml
@@ -5,6 +5,7 @@ substitutions:
   friendly_name: OpenQuatt
   openquatt_root: openquatt
   components_root: components
+  scripts_root: ../../../scripts
 
 packages:
   openquatt: !include configs/heatpump_listener/single_wifi.yaml

--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -18,8 +18,8 @@ esphome:
     - ${oq_component_psram_buffer_header}
   platformio_options:
     extra_scripts:
-      - pre:../../../scripts/normalize_factory_merge_inputs.py
-      - post:../../../scripts/repair_factory_bin.py
+      - pre:${scripts_root}/normalize_factory_merge_inputs.py
+      - post:${scripts_root}/repair_factory_bin.py
     build_flags:
       # Hard-pinned by the topology entrypoint to prevent accidental topology drift.
       - ${oq_topology_build_flag}

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -25,12 +25,15 @@ oq_connection: "unknown"                              # Compile-time connection 
 alternate_connection: ""                              # Optional connection target used for controlled Wi-Fi/Ethernet switching.
 alternate_main_release_manifest_url: ""               # Optional main-channel OTA manifest for the alternate connection target.
 alternate_dev_release_manifest_url: ""                # Optional dev-channel OTA manifest for the alternate connection target.
-oq_cpp_headers_dir: "../../openquatt/includes"              # Copy and include the grouped OpenQuatt C++ runtime headers.
-oq_component_psram_buffer_header: "../../components/openquatt_common/PsramBuffer.h" # Shared PSRAM-backed buffer helper for custom components.
-external_components_path: "../../components"              # Local custom component directory from nested config entrypoints.
+openquatt_root: "../../openquatt"                    # OpenQuatt package root relative to the active config file.
+components_root: "../../components"                  # Custom component root relative to the active config file.
+scripts_root: "../../../scripts"                     # Build script root relative to the active config file.
+oq_cpp_headers_dir: "${openquatt_root}/includes"     # Copy and include the grouped OpenQuatt C++ runtime headers.
+oq_component_psram_buffer_header: "${components_root}/openquatt_common/PsramBuffer.h" # Shared PSRAM-backed buffer helper for custom components.
+external_components_path: "${components_root}"      # Local custom component directory.
 oq_timezone: "Europe/Amsterdam"                         # SNTP timezone used by runtime timestamps.
-oq_webserver_css_include: "../../openquatt/web/css/openquatt-app.css" # Bundled OpenQuatt web UI stylesheet.
-oq_webserver_js_include: "../../openquatt/web/js/openquatt-app.js" # Bundled OpenQuatt web UI script.
+oq_webserver_css_include: "${openquatt_root}/web/css/openquatt-app.css" # Bundled OpenQuatt web UI stylesheet.
+oq_webserver_js_include: "${openquatt_root}/web/js/openquatt-app.js" # Bundled OpenQuatt web UI script.
 oq_webserver_css_url: ""                            # Optional external CSS for the ESPHome web UI.
 oq_webserver_js_url: ""                               # Custom OpenQuatt app is primary; load ESPHome fallback lazily on demand.
 web_auth_bootstrap_username: "admin"                  # Bootstrap username used to keep web auth support compiled in.

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -11,7 +11,7 @@ substitutions:
   esp_board: "esp32-s3-devkitc-1"                       # PlatformIO board shared with the Waveshare S3 build.
   esp_flash_size: "16MB"                                # Active ESP flash size.
   esp_variant: "esp32s3"                                # Active ESP variant.
-  esp_partitions: "../../openquatt/partitions/openquatt_16mb.csv" # Active partition table.
+  esp_partitions: "${openquatt_root}/partitions/openquatt_16mb.csv" # Active partition table.
   uart_tx_pin: "GPIO42"                                 # Modbus 1 TX; primary heat-pump bus.
   uart_rx_pin: "GPIO45"                                 # Modbus 1 RX; primary heat-pump bus.
   uart_rts_pin: "GPIO41"                                # Modbus 1 DE/RE; primary heat-pump bus.

--- a/openquatt/profiles/heatpump_listener.yaml
+++ b/openquatt/profiles/heatpump_listener.yaml
@@ -6,7 +6,7 @@ substitutions:
   esp_board: "esp32dev"                                 # Active ESP32 board type.
   esp_flash_size: "8MB"                                 # Active ESP flash size.
   esp_variant: "esp32"                                  # Active ESP variant.
-  esp_partitions: "../../openquatt/partitions/openquatt_8mb.csv" # Active partition table.
+  esp_partitions: "${openquatt_root}/partitions/openquatt_8mb.csv" # Active partition table.
   uart_tx_pin: "GPIO33"                                 # Active RS485 TX pin.
   uart_rx_pin: "GPIO32"                                 # Active RS485 RX pin.
   uart_rts_pin: "GPIO21"                                # Active RS485 DE/RE (flow control) pin.

--- a/openquatt/profiles/waveshare.yaml
+++ b/openquatt/profiles/waveshare.yaml
@@ -6,7 +6,7 @@ substitutions:
   esp_board: "esp32-s3-devkitc-1"                       # Active ESP32 board type.
   esp_flash_size: "16MB"                                # Active ESP flash size.
   esp_variant: "esp32s3"                                # Active ESP variant.
-  esp_partitions: "../../openquatt/partitions/openquatt_16mb.csv" # Active partition table.
+  esp_partitions: "${openquatt_root}/partitions/openquatt_16mb.csv" # Active partition table.
   uart_tx_pin: "GPIO17"                                 # Active RS485 TX pin.
   uart_rx_pin: "GPIO18"                                 # Active RS485 RX pin.
   uart_rts_pin: "GPIO21"                                # Active RS485 DE/RE (flow control) pin.


### PR DESCRIPTION
## Summary

This adds a simple local ESPHome Device Builder entrypoint for users who download or copy the OpenQuatt repository contents directly into their ESPHome configuration directory.

The new root-level `openquatt-device-builder.yaml`:

- defaults to the heat-pump listener, single heat pump, Wi-Fi profile
- lists the other supported hardware/topology/connection combinations as commented package lines
- lets users select a profile by leaving exactly one package line uncommented
- avoids GitHub package caching and does not require an extra compatibility component
- supports local custom components, partition tables, bundled web assets, shared C++ headers, and factory build scripts

## Motivation

The existing entrypoints under `configs/` use relative paths because they are normally built from the OpenQuatt repository checkout. When such an entrypoint is referenced through an ESPHome GitHub package, ESPHome stores it in `.esphome/packages/`. Relative paths can then resolve against the package cache instead of the ESPHome configuration directory. For example, `../../components` may resolve to `/components`, causing configuration errors because that directory does not exist.

For users who already download OpenQuatt locally, a remote package adds unnecessary indirection. This PR makes the local layout explicit and allows the regular entrypoints and custom components to be used directly by ESPHome Device Builder.

## Required directory layout

Copy the repository contents into the ESPHome configuration directory so the relevant folders are siblings:

```text
/config/
├── openquatt-device-builder.yaml
├── configs/
│   ├── heatpump_listener/
│   ├── heatpump_controller_q/
│   └── waveshare/
├── openquatt/
├── components/
└── scripts/
```

The repository may be downloaded as a ZIP or obtained with Git. No GitHub package declaration is required in the ESPHome YAML.

## Example YAML

The included `openquatt-device-builder.yaml` can be used directly:

```yaml
# Place the OpenQuatt repository contents directly in the ESPHome config folder.
# Enable exactly one profile below.
substitutions:
  device_name: openquatt
  friendly_name: OpenQuatt
  openquatt_root: openquatt
  components_root: components

packages:
  openquatt: !include configs/heatpump_listener/single_wifi.yaml
  # openquatt: !include configs/heatpump_listener/duo_wifi.yaml
  # openquatt: !include configs/heatpump_controller_q/single_wifi.yaml
  # openquatt: !include configs/heatpump_controller_q/duo_wifi.yaml
  # openquatt: !include configs/heatpump_controller_q/single_eth.yaml
  # openquatt: !include configs/heatpump_controller_q/duo_eth.yaml
  # openquatt: !include configs/waveshare/single_wifi.yaml
  # openquatt: !include configs/waveshare/duo_wifi.yaml

esphome:
  build_path: build/${device_name}
```

To select another profile, comment the active package line and uncomment exactly one alternative. For example, a Controller Q with two heat pumps and Ethernet uses:

```yaml
packages:
  # openquatt: !include configs/heatpump_listener/single_wifi.yaml
  openquatt: !include configs/heatpump_controller_q/duo_eth.yaml
```

`device_name` and `friendly_name` may be changed without modifying the OpenQuatt package files.

## Implementation

Shared root substitutions are introduced for paths that must work both from the normal nested `configs/` entrypoints and from the new root-level wrapper:

- `openquatt_root`
- `components_root`
- `scripts_root`

These substitutions are used for:

- custom ESPHome components
- shared OpenQuatt C++ includes
- `PsramBuffer.h`
- 8 MB and 16 MB partition tables
- bundled web UI CSS and JavaScript
- factory binary normalization and repair scripts

The existing defaults remain relative to the nested configuration entrypoints, so current repository builds keep their existing behavior. The root-level wrapper overrides only the roots required for the local ESPHome Device Builder layout.

## User impact

Users can now:

1. Download OpenQuatt into the ESPHome configuration directory.
2. Open `openquatt-device-builder.yaml` in ESPHome Device Builder.
3. Select the required profile by uncommenting one line.
4. Validate, compile, and install it like a normal local ESPHome configuration.

Existing `configs/` targets and development workflows remain supported.

## Validation

- `esphome config openquatt-device-builder.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_listener/single_wifi.yaml`
- full ESPHome compile of `openquatt-device-builder.yaml` with ESPHome 2026.5.3
- `git diff --check`

The full listener single Wi-Fi build completed successfully, including custom component loading, C++ includes, web assets, partition selection, firmware linking, factory binary generation, and factory binary repair.