### PR TITLE
Fix MQTT diagnostic profile publishing

### DIFF
--- a/components/openquatt_mqtt_publisher/OpenQuattMqttPublisher.cpp
+++ b/components/openquatt_mqtt_publisher/OpenQuattMqttPublisher.cpp
@@ -53,6 +53,10 @@ void OpenQuattMqttPublisher::loop() {
   const bool just_connected = !this->last_connected_;
   this->last_connected_ = true;
   const bool force_publish = config_changed || just_connected;
+  const bool publish_state_profile = profile == PublishProfile::ESSENTIAL || profile == PublishProfile::STANDARD ||
+                                     profile == PublishProfile::DIAGNOSTIC;
+  const bool publish_heat_pumps_profile = profile == PublishProfile::STANDARD || profile == PublishProfile::DIAGNOSTIC;
+  const bool publish_diagnostics_profile = profile == PublishProfile::DIAGNOSTIC;
 
   if (force_publish) {
     if (profile == PublishProfile::OFF) {
@@ -69,17 +73,17 @@ void OpenQuattMqttPublisher::loop() {
 
   const uint32_t now_ms = millis();
 
-  if (profile == PublishProfile::ESSENTIAL || profile == PublishProfile::STANDARD) {
+  if (publish_state_profile) {
     const uint32_t state_interval_ms = this->config_->get_essential_interval_s() * 1000UL;
     this->publish_state_(force_publish, now_ms, state_interval_ms);
   }
 
-  if (profile == PublishProfile::STANDARD) {
+  if (publish_heat_pumps_profile) {
     const uint32_t heat_pumps_interval_ms = this->config_->get_standard_interval_s() * 1000UL;
     this->publish_heat_pumps_(force_publish, now_ms, heat_pumps_interval_ms);
   }
 
-  if (profile == PublishProfile::DIAGNOSTIC) {
+  if (publish_diagnostics_profile) {
     const uint32_t diagnostics_interval_ms = this->config_->get_diagnostic_interval_s() * 1000UL;
     this->publish_diagnostics_(force_publish, now_ms, diagnostics_interval_ms);
   }


### PR DESCRIPTION
# What changes in this PR?

- Makes the MQTT `diagnostic` publish profile also publish `state` and `heat_pumps`.
- Keeps `diagnostics` as an additional layer on top of the main telemetry topics.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Other

## Impact

- [ ] No runtime/control behavior change intended
- [x] Runtime/control behavior changed
- [ ] User-facing entities/configuration changed
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow touched

Notes:

Only the experimental MQTT publish behavior changes for the `diagnostic` profile. This does not affect control logic or actuator paths.

## Background

The `diagnostic` profile was treated as an alternative to `standard`, so only `openquatt/diagnostics` was published. The documentation describes `diagnostic` as extra diagnostics on top of the main telemetry layer; this PR makes the implementation match that contract.

## Validation

- `rtk python3 scripts/dev.py validate --config-only --jobs 4`
- `rtk git diff --check`
