### PR TITLE
feat(trends): implement advanced interval and variance filtering

### DIFF
--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -756,14 +756,79 @@ void OpenQuattTrends::capture_sample(float outside_c, float supply_c, float room
     return;
   }
 
+  // 1. INTERVAL TRACKING: Accumulate totals and track peaks/drops (absolute deviations)
+  // Always update absolute peak-hold trackers for zero-to-non-zero edge cases
+  if (flow_lph > this->max_flow_observed_) this->max_flow_observed_ = flow_lph;
+  if (input_w > this->max_input_w_observed_) this->max_input_w_observed_ = input_w;
+  if (output_w > this->max_output_w_observed_) this->max_output_w_observed_ = output_w;
+
+  // Accumulate running totals to calculate the 5-minute interval averages
+  this->interval_flow_sum_ += flow_lph;
+  this->interval_input_w_sum_ += input_w;
+  this->interval_output_w_sum_ += output_w;
+  this->interval_sample_count_++;
+
+  // Calculate current running averages to isolate the sample with the largest variance
+  float current_avg_flow = this->interval_flow_sum_ / this->interval_sample_count_;
+  float current_avg_input = this->interval_input_w_sum_ / this->interval_sample_count_;
+  float current_avg_output = this->interval_output_w_sum_ / this->interval_sample_count_;
+
+  // Track the raw sample value that caused the largest deviation (peaks or drops) from the running average
+  if (this->interval_sample_count_ == 1 || std::abs(flow_lph - current_avg_flow) > std::abs(this->max_dev_flow_val_ - current_avg_flow)) {
+    this->max_dev_flow_val_ = flow_lph;
+  }
+  if (this->interval_sample_count_ == 1 || std::abs(input_w - current_avg_input) > std::abs(this->max_dev_input_val_ - current_avg_input)) {
+    this->max_dev_input_val_ = input_w;
+  }
+  if (this->interval_sample_count_ == 1 || std::abs(output_w - current_avg_output) > std::abs(this->max_dev_output_val_ - current_avg_output)) {
+    this->max_dev_output_val_ = output_w;
+  }
+
+
+  // 2. GATEKEEPER: Check if 5 minutes (SAMPLE_INTERVAL_MS) have already passed
   const uint32_t now_monotonic_ms = static_cast<uint32_t>(millis());
   if (this->last_capture_ms_ != 0 &&
       static_cast<uint32_t>(now_monotonic_ms - static_cast<uint32_t>(this->last_capture_ms_)) < SAMPLE_INTERVAL_MS) {
     return;
   }
 
+
+  // 3. TIME IS UP (5 minutes passed): Filter and evaluate values to save
+  float flow_to_save = flow_lph;
+  float input_w_to_save = input_w;
+  float output_w_to_save = output_w;
+
+  // Protect against division by zero if no updates occurred
+  if (this->interval_sample_count_ > 0) {
+    float avg_flow = this->interval_flow_sum_ / this->interval_sample_count_;
+    float avg_input = this->interval_input_w_sum_ / this->interval_sample_count_;
+    float avg_output = this->interval_output_w_sum_ / this->interval_sample_count_;
+
+    // --- FLOW FILTERING ---
+    if (this->last_saved_flow_ == 0.0f) {
+      if (this->max_flow_observed_ > 0.0f) flow_to_save = this->max_flow_observed_;
+    } else {
+      // Dead-band filter: if the largest deviation (peak or drop) exceeds 5% of the average, save that extreme value
+      flow_to_save = (std::abs(this->max_dev_flow_val_ - avg_flow) > (0.05f * avg_flow)) ? this->max_dev_flow_val_ : avg_flow;
+    }
+
+    // --- INPUT POWER FILTERING ---
+    if (this->last_saved_input_w_ == 0.0f) {
+      if (this->max_input_w_observed_ > 0.0f) input_w_to_save = this->max_input_w_observed_;
+    } else {
+      input_w_to_save = (std::abs(this->max_dev_input_val_ - avg_input) > (0.05f * avg_input)) ? this->max_dev_input_val_ : avg_input;
+    }
+
+    // --- HEAT OUTPUT FILTERING ---
+    if (this->last_saved_output_w_ == 0.0f) {
+      if (this->max_output_w_observed_ > 0.0f) output_w_to_save = this->max_output_w_observed_;
+    } else {
+      output_w_to_save = (std::abs(this->max_dev_output_val_ - avg_output) > (0.05f * avg_output)) ? this->max_dev_output_val_ : avg_output;
+    }
+  }
+
   const uint64_t now_ms = this->current_time_ms_();
-  const TrendValues values = this->pack_values_(outside_c, supply_c, room_c, room_setpoint_c, flow_lph, input_w, output_w);
+  const TrendValues values = this->pack_values_(outside_c, supply_c, room_c, room_setpoint_c, flow_to_save, input_w_to_save, output_w_to_save);
   const bool any_valid = values.outside_c_x10 != INT16_MIN || values.supply_c_x10 != INT16_MIN ||
                          values.room_c_x10 != INT16_MIN || values.room_setpoint_c_x10 != INT16_MIN ||
                          values.flow_lph != UINT16_MAX || values.input_w != UINT16_MAX || values.output_w != UINT16_MAX;
@@ -771,6 +836,8 @@ void OpenQuattTrends::capture_sample(float outside_c, float supply_c, float room
     return;
   }
 
+
+  // 4. SAVE DATA & UPDATE TRACKERS
   const TrendSample sample = this->make_sample_(now_ms, values);
   this->push_ram_sample_(sample);
   this->last_capture_ms_ = now_monotonic_ms;
@@ -778,6 +845,25 @@ void OpenQuattTrends::capture_sample(float outside_c, float supply_c, float room
   if (this->flash_switch_enabled_()) {
     this->append_sample_to_flash_(sample);
   }
+
+  // Keep these filtered values for the next 5-minute cycle comparison
+  this->last_saved_flow_ = flow_to_save;
+  this->last_saved_input_w_ = input_w_to_save;
+  this->last_saved_output_w_ = output_w_to_save;
+
+  // RESET all temporary interval states for the next 5 minutes
+  this->max_flow_observed_ = 0.0f;
+  this->max_input_w_observed_ = 0.0f;
+  this->max_output_w_observed_ = 0.0f;
+  
+  this->interval_flow_sum_ = 0.0f;
+  this->interval_input_w_sum_ = 0.0f;
+  this->interval_output_w_sum_ = 0.0f;
+  this->interval_sample_count_ = 0;
+
+  this->max_dev_flow_val_ = 0.0f;
+  this->max_dev_input_val_ = 0.0f;
+  this->max_dev_output_val_ = 0.0f;
 }
 
 void OpenQuattTrends::set_flash_enabled(bool enabled) {
@@ -1092,4 +1178,3 @@ uint32_t OpenQuattTrends::get_flash_write_count() const {
 
 }  // namespace openquatt_trends
 }  // namespace esphome
-// OpenQuatt Workspace Target Lock

--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -302,6 +302,57 @@ uint32_t OpenQuattTrends::fnv1a_hash_(const uint8_t *data, size_t len) {
   return hash;
 }
 
+bool OpenQuattTrends::valid_unsigned_metric_(float value) {
+  return std::isfinite(value) && value >= 0.0f;
+}
+
+void OpenQuattTrends::reset_interval_metric_samples_(IntervalMetricState &state) {
+  state.sum = 0.0f;
+  state.count = 0;
+  state.min = 0.0f;
+  state.max = 0.0f;
+}
+
+void OpenQuattTrends::update_interval_metric_(IntervalMetricState &state, float value) {
+  if (!valid_unsigned_metric_(value)) {
+    return;
+  }
+  if (state.count == 0) {
+    state.min = value;
+    state.max = value;
+  } else {
+    state.min = std::min(state.min, value);
+    state.max = std::max(state.max, value);
+  }
+  state.sum += value;
+  state.count++;
+}
+
+float OpenQuattTrends::select_interval_metric_value_(const IntervalMetricState &state, float fallback) {
+  if (state.count == 0) {
+    return fallback;
+  }
+
+  const float average = state.sum / static_cast<float>(state.count);
+  if (state.last_saved == 0.0f && state.max > 0.0f) {
+    return state.max;
+  }
+
+  const float min_deviation = std::abs(state.min - average);
+  const float max_deviation = std::abs(state.max - average);
+  const bool max_is_furthest = max_deviation > min_deviation;
+  const float furthest_value = max_is_furthest ? state.max : state.min;
+  const float furthest_deviation = max_is_furthest ? max_deviation : min_deviation;
+
+  return furthest_deviation > (INTERVAL_DEVIATION_RATIO * average) ? furthest_value : average;
+}
+
+void OpenQuattTrends::update_last_saved_metric_(IntervalMetricState &state, float value) {
+  if (valid_unsigned_metric_(value)) {
+    state.last_saved = value;
+  }
+}
+
 OpenQuattTrends::TrendValues OpenQuattTrends::pack_values_(float outside_c, float supply_c, float room_c,
                                                             float room_setpoint_c, float flow_lph, float input_w,
                                                             float output_w) const {
@@ -750,94 +801,51 @@ bool OpenQuattTrends::read_flash_block_(uint32_t slot_index, uint32_t expected_s
   return true;
 }
 
+void OpenQuattTrends::reset_interval_samples_() {
+  reset_interval_metric_samples_(this->flow_interval_);
+  reset_interval_metric_samples_(this->input_w_interval_);
+  reset_interval_metric_samples_(this->output_w_interval_);
+}
+
+void OpenQuattTrends::reset_interval_filters_() {
+  this->reset_interval_samples_();
+  this->flow_interval_.last_saved = 0.0f;
+  this->input_w_interval_.last_saved = 0.0f;
+  this->output_w_interval_.last_saved = 0.0f;
+}
+
 void OpenQuattTrends::capture_sample(float outside_c, float supply_c, float room_c, float room_setpoint_c, float flow_lph,
                                      float input_w, float output_w) {
   if (!this->capture_enabled_()) {
     return;
   }
 
-  // 1. INTERVAL TRACKING: Accumulate totals and track peaks/drops (absolute deviations)
-  // Always update absolute peak-hold trackers for zero-to-non-zero edge cases
-  if (flow_lph > this->max_flow_observed_) this->max_flow_observed_ = flow_lph;
-  if (input_w > this->max_input_w_observed_) this->max_input_w_observed_ = input_w;
-  if (output_w > this->max_output_w_observed_) this->max_output_w_observed_ = output_w;
+  this->update_interval_metric_(this->flow_interval_, flow_lph);
+  this->update_interval_metric_(this->input_w_interval_, input_w);
+  this->update_interval_metric_(this->output_w_interval_, output_w);
 
-  // Accumulate running totals to calculate the 5-minute interval averages
-  this->interval_flow_sum_ += flow_lph;
-  this->interval_input_w_sum_ += input_w;
-  this->interval_output_w_sum_ += output_w;
-  this->interval_sample_count_++;
-
-  // Calculate current running averages to isolate the sample with the largest variance
-  float current_avg_flow = this->interval_flow_sum_ / this->interval_sample_count_;
-  float current_avg_input = this->interval_input_w_sum_ / this->interval_sample_count_;
-  float current_avg_output = this->interval_output_w_sum_ / this->interval_sample_count_;
-
-  // Track the raw sample value that caused the largest deviation (peaks or drops) from the running average
-  if (this->interval_sample_count_ == 1 || std::abs(flow_lph - current_avg_flow) > std::abs(this->max_dev_flow_val_ - current_avg_flow)) {
-    this->max_dev_flow_val_ = flow_lph;
-  }
-  if (this->interval_sample_count_ == 1 || std::abs(input_w - current_avg_input) > std::abs(this->max_dev_input_val_ - current_avg_input)) {
-    this->max_dev_input_val_ = input_w;
-  }
-  if (this->interval_sample_count_ == 1 || std::abs(output_w - current_avg_output) > std::abs(this->max_dev_output_val_ - current_avg_output)) {
-    this->max_dev_output_val_ = output_w;
-  }
-
-
-  // 2. GATEKEEPER: Check if 5 minutes (SAMPLE_INTERVAL_MS) have already passed
   const uint32_t now_monotonic_ms = static_cast<uint32_t>(millis());
   if (this->last_capture_ms_ != 0 &&
       static_cast<uint32_t>(now_monotonic_ms - static_cast<uint32_t>(this->last_capture_ms_)) < SAMPLE_INTERVAL_MS) {
     return;
   }
 
-
-  // 3. TIME IS UP (5 minutes passed): Filter and evaluate values to save
-  float flow_to_save = flow_lph;
-  float input_w_to_save = input_w;
-  float output_w_to_save = output_w;
-
-  // Protect against division by zero if no updates occurred
-  if (this->interval_sample_count_ > 0) {
-    float avg_flow = this->interval_flow_sum_ / this->interval_sample_count_;
-    float avg_input = this->interval_input_w_sum_ / this->interval_sample_count_;
-    float avg_output = this->interval_output_w_sum_ / this->interval_sample_count_;
-
-    // --- FLOW FILTERING ---
-    if (this->last_saved_flow_ == 0.0f) {
-      if (this->max_flow_observed_ > 0.0f) flow_to_save = this->max_flow_observed_;
-    } else {
-      // Dead-band filter: if the largest deviation (peak or drop) exceeds 5% of the average, save that extreme value
-      flow_to_save = (std::abs(this->max_dev_flow_val_ - avg_flow) > (0.05f * avg_flow)) ? this->max_dev_flow_val_ : avg_flow;
-    }
-
-    // --- INPUT POWER FILTERING ---
-    if (this->last_saved_input_w_ == 0.0f) {
-      if (this->max_input_w_observed_ > 0.0f) input_w_to_save = this->max_input_w_observed_;
-    } else {
-      input_w_to_save = (std::abs(this->max_dev_input_val_ - avg_input) > (0.05f * avg_input)) ? this->max_dev_input_val_ : avg_input;
-    }
-
-    // --- HEAT OUTPUT FILTERING ---
-    if (this->last_saved_output_w_ == 0.0f) {
-      if (this->max_output_w_observed_ > 0.0f) output_w_to_save = this->max_output_w_observed_;
-    } else {
-      output_w_to_save = (std::abs(this->max_dev_output_val_ - avg_output) > (0.05f * avg_output)) ? this->max_dev_output_val_ : avg_output;
-    }
-  }
+  const float flow_to_save = select_interval_metric_value_(this->flow_interval_, flow_lph);
+  const float input_w_to_save = select_interval_metric_value_(this->input_w_interval_, input_w);
+  const float output_w_to_save = select_interval_metric_value_(this->output_w_interval_, output_w);
 
   const uint64_t now_ms = this->current_time_ms_();
-  const TrendValues values = this->pack_values_(outside_c, supply_c, room_c, room_setpoint_c, flow_to_save, input_w_to_save, output_w_to_save);
+  const TrendValues values = this->pack_values_(outside_c, supply_c, room_c, room_setpoint_c, flow_to_save,
+                                                input_w_to_save, output_w_to_save);
   const bool any_valid = values.outside_c_x10 != INT16_MIN || values.supply_c_x10 != INT16_MIN ||
                          values.room_c_x10 != INT16_MIN || values.room_setpoint_c_x10 != INT16_MIN ||
                          values.flow_lph != UINT16_MAX || values.input_w != UINT16_MAX || values.output_w != UINT16_MAX;
   if (!any_valid) {
+    this->last_capture_ms_ = now_monotonic_ms;
+    this->reset_interval_samples_();
     return;
   }
 
-
-  // 4. SAVE DATA & UPDATE TRACKERS
   const TrendSample sample = this->make_sample_(now_ms, values);
   this->push_ram_sample_(sample);
   this->last_capture_ms_ = now_monotonic_ms;
@@ -846,24 +854,10 @@ void OpenQuattTrends::capture_sample(float outside_c, float supply_c, float room
     this->append_sample_to_flash_(sample);
   }
 
-  // Keep these filtered values for the next 5-minute cycle comparison
-  this->last_saved_flow_ = flow_to_save;
-  this->last_saved_input_w_ = input_w_to_save;
-  this->last_saved_output_w_ = output_w_to_save;
-
-  // RESET all temporary interval states for the next 5 minutes
-  this->max_flow_observed_ = 0.0f;
-  this->max_input_w_observed_ = 0.0f;
-  this->max_output_w_observed_ = 0.0f;
-  
-  this->interval_flow_sum_ = 0.0f;
-  this->interval_input_w_sum_ = 0.0f;
-  this->interval_output_w_sum_ = 0.0f;
-  this->interval_sample_count_ = 0;
-
-  this->max_dev_flow_val_ = 0.0f;
-  this->max_dev_input_val_ = 0.0f;
-  this->max_dev_output_val_ = 0.0f;
+  update_last_saved_metric_(this->flow_interval_, flow_to_save);
+  update_last_saved_metric_(this->input_w_interval_, input_w_to_save);
+  update_last_saved_metric_(this->output_w_interval_, output_w_to_save);
+  this->reset_interval_samples_();
 }
 
 void OpenQuattTrends::set_flash_enabled(bool enabled) {
@@ -890,6 +884,7 @@ void OpenQuattTrends::clear_history() {
   this->last_capture_ms_ = 0;
   this->flash_dirty_ = false;
   this->flash_archive_seeded_ = false;
+  this->reset_interval_filters_();
   this->reset_flash_builder_();
   this->clear_flash_archive_();
 }

--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -1092,3 +1092,4 @@ uint32_t OpenQuattTrends::get_flash_write_count() const {
 
 }  // namespace openquatt_trends
 }  // namespace esphome
+// OpenQuatt Workspace Target Lock

--- a/components/openquatt_trends/OpenQuattTrends.h
+++ b/components/openquatt_trends/OpenQuattTrends.h
@@ -44,6 +44,27 @@ class OpenQuattTrends : public Component {
   float get_flash_storage_kib() const;
   uint32_t get_flash_write_count() const;
 
+  // --- Peak Hold Trackers (Used for zero-to-non-zero edge cases) ---
+  float max_flow_observed_ = 0.0f;
+  float max_input_w_observed_ = 0.0f;
+  float max_output_w_observed_ = 0.0f;
+
+  // --- Historical States for Cycle Checks ---
+  float last_saved_flow_ = 0.0f;
+  float last_saved_input_w_ = 0.0f;
+  float last_saved_output_w_ = 0.0f;
+
+  // --- Running Totals for 5-Minute Interval Averages ---
+  float interval_flow_sum_ = 0.0f;
+  float interval_input_w_sum_ = 0.0f;
+  float interval_output_w_sum_ = 0.0f;
+  uint32_t interval_sample_count_ = 0;
+
+  // --- Maximum Deviation Sample Trackers (Catches both Peaks and Drops) ---
+  float max_dev_flow_val_ = 0.0f;
+  float max_dev_input_val_ = 0.0f;
+  float max_dev_output_val_ = 0.0f;
+
  protected:
   static constexpr uint32_t TAG_MAGIC = 0x4F545247;  // "OTRG"
   static constexpr uint16_t TAG_VERSION = 1;
@@ -193,4 +214,3 @@ class OpenQuattTrends : public Component {
 
 }  // namespace openquatt_trends
 }  // namespace esphome
-// OpenQuatt Workspace Target Lock

--- a/components/openquatt_trends/OpenQuattTrends.h
+++ b/components/openquatt_trends/OpenQuattTrends.h
@@ -44,31 +44,11 @@ class OpenQuattTrends : public Component {
   float get_flash_storage_kib() const;
   uint32_t get_flash_write_count() const;
 
-  // --- Peak Hold Trackers (Used for zero-to-non-zero edge cases) ---
-  float max_flow_observed_ = 0.0f;
-  float max_input_w_observed_ = 0.0f;
-  float max_output_w_observed_ = 0.0f;
-
-  // --- Historical States for Cycle Checks ---
-  float last_saved_flow_ = 0.0f;
-  float last_saved_input_w_ = 0.0f;
-  float last_saved_output_w_ = 0.0f;
-
-  // --- Running Totals for 5-Minute Interval Averages ---
-  float interval_flow_sum_ = 0.0f;
-  float interval_input_w_sum_ = 0.0f;
-  float interval_output_w_sum_ = 0.0f;
-  uint32_t interval_sample_count_ = 0;
-
-  // --- Maximum Deviation Sample Trackers (Catches both Peaks and Drops) ---
-  float max_dev_flow_val_ = 0.0f;
-  float max_dev_input_val_ = 0.0f;
-  float max_dev_output_val_ = 0.0f;
-
  protected:
   static constexpr uint32_t TAG_MAGIC = 0x4F545247;  // "OTRG"
   static constexpr uint16_t TAG_VERSION = 1;
   static constexpr uint32_t SAMPLE_INTERVAL_MS = 5UL * 60UL * 1000UL;
+  static constexpr float INTERVAL_DEVIATION_RATIO = 0.05f;
   static constexpr uint32_t RAM_WINDOW_MS = 7UL * 24UL * 60UL * 60UL * 1000UL;
   static constexpr uint32_t ARCHIVE_WINDOW_MS = 30UL * 24UL * 60UL * 60UL * 1000UL;
   static constexpr size_t RAM_CAPACITY = 7UL * 24UL * 12UL;
@@ -118,6 +98,14 @@ class OpenQuattTrends : public Component {
     uint32_t slot_index{0};
   };
 
+  struct IntervalMetricState {
+    float sum{0.0f};
+    uint32_t count{0};
+    float min{0.0f};
+    float max{0.0f};
+    float last_saved{0.0f};
+  };
+
   struct FlashBlockBuilder {
     bool active{false};
     uint64_t start_timestamp_ms{0};
@@ -143,6 +131,11 @@ class OpenQuattTrends : public Component {
   static float decode_temp_(int16_t value);
   static float decode_unsigned_(uint16_t value);
   static uint32_t fnv1a_hash_(const uint8_t *data, size_t len);
+  static bool valid_unsigned_metric_(float value);
+  static void reset_interval_metric_samples_(IntervalMetricState &state);
+  static void update_interval_metric_(IntervalMetricState &state, float value);
+  static float select_interval_metric_value_(const IntervalMetricState &state, float fallback);
+  static void update_last_saved_metric_(IntervalMetricState &state, float value);
 
   TrendValues pack_values_(float outside_c, float supply_c, float room_c, float room_setpoint_c, float flow_lph,
                            float input_w, float output_w) const;
@@ -176,6 +169,8 @@ class OpenQuattTrends : public Component {
   uint64_t get_latest_archive_timestamp_ms_() const;
   void update_flash_metadata_(uint64_t latest_timestamp_ms);
   void reset_flash_metadata_();
+  void reset_interval_samples_();
+  void reset_interval_filters_();
   uint64_t get_flash_oldest_timestamp_ms_() const;
   uint64_t get_flash_newest_timestamp_ms_() const;
   uint64_t get_flash_last_flush_timestamp_ms_() const;
@@ -210,6 +205,9 @@ class OpenQuattTrends : public Component {
   size_t flash_index_count_{0};
 
   FlashBlockBuilder flash_builder_{};
+  IntervalMetricState flow_interval_{};
+  IntervalMetricState input_w_interval_{};
+  IntervalMetricState output_w_interval_{};
 };
 
 }  // namespace openquatt_trends

--- a/components/openquatt_trends/OpenQuattTrends.h
+++ b/components/openquatt_trends/OpenQuattTrends.h
@@ -193,3 +193,4 @@ class OpenQuattTrends : public Component {
 
 }  // namespace openquatt_trends
 }  // namespace esphome
+// OpenQuatt Workspace Target Lock

--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -17,6 +17,9 @@ esphome:
     - ${oq_cpp_headers_dir}
     - ${oq_component_psram_buffer_header}
   platformio_options:
+    extra_scripts:
+      - pre:${scripts_root}/normalize_factory_merge_inputs.py
+      - post:${scripts_root}/repair_factory_bin.py
     build_flags:
       # Hard-pinned by the topology entrypoint to prevent accidental topology drift.
       - ${oq_topology_build_flag}

--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -17,9 +17,6 @@ esphome:
     - ${oq_cpp_headers_dir}
     - ${oq_component_psram_buffer_header}
   platformio_options:
-    extra_scripts:
-      - pre:${scripts_root}/normalize_factory_merge_inputs.py
-      - post:${scripts_root}/repair_factory_bin.py
     build_flags:
       # Hard-pinned by the topology entrypoint to prevent accidental topology drift.
       - ${oq_topology_build_flag}


### PR DESCRIPTION
# What does this PR change?

<!-- Short summary in 1-3 bullets. -->

- Implements a hybrid data filtering mechanism for water flow, power input, and heat output inside trend captures.
- Introduces an absolute peak-hold fallback filter that retains peak spikes specifically when the previously saved interval value was zero.
- Adds an absolute 5% dead-band filter over the 5-minute interval average that actively logs extreme peaks or sudden drops if they exceed the variance threshold; otherwise, it logs a clean average.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Explanation:

Changes how sensor values (`flow_lph`, `input_w`, and `output_w`) are processed and filtered before being packed and written into flash/RAM log histories.

## Background

This filter architecture addresses measurement noise and short-lived spikes/drops across cycles. By utilizing `std::abs`, the logic handles both positive spikes (peaks) and sudden drops (e.g., a pump cutting out or a sudden load drop) symmetrically. 

The strategy ensures:
1. **Edge Case Retention:** If the last interval logged a zero value, a peak-hold filter runs to capture intermittent or initial activity spikes.
2. **Noise Reduction:** Under continuous operating conditions, values are averaged across the 5-minute cycle to keep trends smooth.
3. **Anomaly Awareness:** If an individual reading deviates from the running average by more than 5%, the dead-band triggers, saving that specific extreme sample to prevent missing critical transient events.

The 5-minute tracking trackers automatically baseline themselves using the first sample of a cycle to avoid initial zero-value calculation biases.

## Validation

- Compiled locally using PlatformIO to verify template structures and component targets.
- Verified tracking behaviors and edge scenarios mathematically against expected average variations.
