### PR TITLE
Remove factory hooks from common

### DIFF
--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -17,9 +17,6 @@ esphome:
     - ${oq_cpp_headers_dir}
     - ${oq_component_psram_buffer_header}
   platformio_options:
-    extra_scripts:
-      - pre:${scripts_root}/normalize_factory_merge_inputs.py
-      - post:${scripts_root}/repair_factory_bin.py
     build_flags:
       # Hard-pinned by the topology entrypoint to prevent accidental topology drift.
       - ${oq_topology_build_flag}


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert de factory merge/repair extra scripts uit `openquatt/base/common.yaml`.
- Laat de factory repair flow wel staan in CI en build tooling voor release-artifacts.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Deze wijziging verwijdert alleen de common hook rond factory-binary generation. De repair stap blijft in de CI/build-keten bestaan als guardrail voor release-artifacts.

## Achtergrond

ESPHome maakt voor deze target zelf al een valide factory-bin. De extra hooks bleken daarom niet nodig in `common`, maar we houden de repair stap bewust in de build- en releaseflow.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/waveshare/duo_wifi.yaml`
- Eerder een A/B-compile op `configs/waveshare/duo_wifi.yaml`, waarbij de factory-bin zonder de common hooks valide bleef.