### PR TITLE
Mark bootstrap passwords sensitive

### DIFF
--- a/components/openquatt_mqtt_config/__init__.py
+++ b/components/openquatt_mqtt_config/__init__.py
@@ -36,7 +36,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_BOOTSTRAP_BROKER, default=""): cv.All(cv.string_strict, cv.Length(max=64)),
         cv.Optional(CONF_BOOTSTRAP_PORT, default=1883): cv.port,
         cv.Optional(CONF_BOOTSTRAP_USERNAME, default=""): cv.All(cv.string_strict, cv.Length(max=64)),
-        cv.Optional(CONF_BOOTSTRAP_PASSWORD, default=""): cv.All(cv.string_strict, cv.Length(max=128)),
+        cv.Optional(CONF_BOOTSTRAP_PASSWORD, default=""): cv.sensitive(
+            cv.All(cv.string_strict, cv.Length(max=128))
+        ),
         cv.Optional(CONF_BOOTSTRAP_BASE_TOPIC, default="openquatt"): cv.All(cv.publish_topic, cv.Length(max=64)),
         cv.Optional(CONF_DEFAULT_ENABLED, default=False): cv.boolean,
         cv.Optional(CONF_DEFAULT_PUBLISH_PROFILE, default="standard"): cv.enum(PUBLISH_PROFILE_ENUM, lower=True),

--- a/components/openquatt_web_auth/__init__.py
+++ b/components/openquatt_web_auth/__init__.py
@@ -14,7 +14,9 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(OpenQuattWebAuth),
         cv.Required(CONF_BOOTSTRAP_USERNAME): cv.All(cv.string_strict, cv.Length(min=1, max=32)),
-        cv.Required(CONF_BOOTSTRAP_PASSWORD): cv.All(cv.string_strict, cv.Length(min=1, max=64)),
+        cv.Required(CONF_BOOTSTRAP_PASSWORD): cv.sensitive(
+            cv.All(cv.string_strict, cv.Length(min=1, max=64))
+        ),
         cv.Optional(CONF_DEFAULT_AUTH_ENABLED, default=True): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)


### PR DESCRIPTION
## Wat verandert er

- Markeert `openquatt_web_auth.bootstrap_password` als `cv.sensitive(...)`.
- Markeert `openquatt_mqtt_config.bootstrap_password` als `cv.sensitive(...)`.

## Waarom

ESPHome 2026.6.x waarschuwt dat password-achtige velden nu nog via een legacy substring heuristic worden geredact. Die heuristic verdwijnt in ESPHome 2026.12. Door de schema validators expliciet sensitive te maken blijft redaction deterministisch.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_eth.yaml`