### PR TITLE
Extend cooling oil return hold

### DIFF
--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -140,7 +140,7 @@ oq_heat_loop_tick_s: "5"                              # Scheduler tick for heat-
 oq_heat_loop_curve_s: "30"                            # Effective heat-control cadence in Heating Curve mode [s].
 oq_heat_loop_powerhouse_s: "60"                       # Effective heat-control cadence in Power House mode [s].
 oq_cooling_limiter_stop_confirm_s: "30"               # Confirm time before soft-stop and dew hard-stop take effect [s].
-oq_cooling_oil_return_hold_s: "360"                   # Keep cooling dew/floor limiter masked this long after oil-return clears [s].
+oq_cooling_oil_return_hold_s: "600"                   # Keep cooling dew/floor limiter masked this long after oil-return clears [s].
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
 oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].


### PR DESCRIPTION
# Wat verandert deze PR?

- Verhoogt `oq_cooling_oil_return_hold_s` van `360` naar `600` seconden.
- Houdt de cooling dew/floor limiter langer gemaskeerd na een compressor oil-return cycle.
- Voorkomt dat cooling kort na oil-return recovery onnodig uitvalt terwijl de waterzijde nog aan het herstellen is.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Tijdens oil return kan de HP zelf tijdelijk veel kouder water maken dan de normale cooling floor/dew limiter zou toestaan. De bestaande hold maskeerde die stops al, maar in debugdata liep de hold net te vroeg af: de HP oil-return foutcode was weg, de waterzijde was net aan het herstellen, en cooling viel daarna kort uit. Door de hold ruimer op `600s` te zetten blijft level-1 cooling langer toegestaan tijdens deze recovery.

## Achtergrond

In de debugrecording was `hp2Failures = Compressor oil return` zichtbaar tot ongeveer `1:20`, waarna OpenQuatt nog `360s` oil-return hold toepaste. Rond `7:20` eindigde de hold terwijl `coolingDewGap` pas net positief was en `coolingDemandRaw` naar `0` viel. Rond `8:30` kwam de normale coolingvraag weer terug. De extra marge voorkomt die korte uit/aan-cyclus.

## Validatie

- `rtk git diff --check`
- `rtk python3 scripts/dev.py bootstrap` om de lokale ESPHome `.venv` naar de gepinde `2026.6.2` te brengen
- `rtk python3 scripts/dev.py validate --config-only --config configs/waveshare/duo_wifi.yaml`