### PR TITLE
Extend cooling oil-return recovery until floor recovers

### DIFF
--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -617,18 +617,6 @@ interval:
           if (oil_return_active) {
             id(oq_cooling_oil_return_hold_until_ms) = now_ms + oil_return_hold_ms;
           }
-          const bool oil_return_mask_active =
-              oil_return_active ||
-              (id(oq_cooling_oil_return_hold_until_ms) > 0 &&
-               now_ms < id(oq_cooling_oil_return_hold_until_ms));
-          static bool last_oil_return_mask_active = false;
-          if (oil_return_mask_active != last_oil_return_mask_active) {
-            ESP_LOGI(
-                "quatt.cool",
-                "Cooling oil-return hold %s",
-                oil_return_mask_active ? "active" : "cleared");
-            last_oil_return_mask_active = oil_return_mask_active;
-          }
 
           const bool active =
               id(cooling_enable_selected).state &&
@@ -740,6 +728,36 @@ interval:
           const float hard_dew_stop_gap_c =
               hard_dew_stop_base_gap_c + (hard_dew_stop_margin_gain_c * safety_margin_c);
           const float hard_dew_restart_gap_c = hard_dew_stop_gap_c + hard_dew_restart_hyst_c;
+
+          const bool oil_return_hold_window_active =
+              id(oq_cooling_oil_return_hold_until_ms) > 0 &&
+              now_ms < id(oq_cooling_oil_return_hold_until_ms);
+          bool oil_return_mask_active = oil_return_active || oil_return_hold_window_active;
+          const bool oil_return_dew_recovered =
+              dew_mode && !isnan(dew_gap_c) && dew_gap_c > hard_dew_restart_gap_c;
+          const bool oil_return_fallback_recovered =
+              fallback_mode && filtered_gap_c > fallback_cap1_gap_c;
+          const bool oil_return_recovery_not_needed = !dew_mode && !fallback_mode;
+          if (!oil_return_active && oil_return_hold_window_active &&
+              (oil_return_recovery_not_needed ||
+               oil_return_dew_recovered ||
+               oil_return_fallback_recovered)) {
+            id(oq_cooling_oil_return_hold_until_ms) = 0;
+            oil_return_mask_active = false;
+          } else if (!oil_return_active &&
+              id(oq_cooling_oil_return_hold_until_ms) > 0 &&
+              !oil_return_hold_window_active) {
+            id(oq_cooling_oil_return_hold_until_ms) = 0;
+            oil_return_mask_active = false;
+          }
+          static bool last_oil_return_mask_active = false;
+          if (oil_return_mask_active != last_oil_return_mask_active) {
+            ESP_LOGI(
+                "quatt.cool",
+                "Cooling oil-return recovery %s",
+                oil_return_mask_active ? "active" : "cleared");
+            last_oil_return_mask_active = oil_return_mask_active;
+          }
 
           const float projected_gap_c =
               filtered_gap_c + (gap_rate_c_per_min * projection_horizon_min);

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -140,7 +140,7 @@ oq_heat_loop_tick_s: "5"                              # Scheduler tick for heat-
 oq_heat_loop_curve_s: "30"                            # Effective heat-control cadence in Heating Curve mode [s].
 oq_heat_loop_powerhouse_s: "60"                       # Effective heat-control cadence in Power House mode [s].
 oq_cooling_limiter_stop_confirm_s: "30"               # Confirm time before soft-stop and dew hard-stop take effect [s].
-oq_cooling_oil_return_hold_s: "600"                   # Keep cooling dew/floor limiter masked this long after oil-return clears [s].
+oq_cooling_oil_return_hold_s: "1200"                  # Maximum oil-return recovery window; floor-guard modes clear earlier after recovery [s].
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
 oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat de cooling oil-return recovery doorlopen tot de water/floor-marge echt hersteld is, in plaats van alleen op een vaste timer te vertrouwen.
- Houdt tijdens oil-return recovery maximaal level 1 toegestaan en blijft de dew/floor stop tijdelijk maskeren binnen een harde maximumduur.
- Verhoogt de maximale oil-return recovery window van 600s naar 1200s; dauwpunt- en fallbackmodi kunnen eerder vrijgeven zodra de marge hersteld is.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Cooling blijft na een compressor oil-return cycle rustiger op level 1 in recovery zolang de normale floor-marge nog niet terug is. In dauwpuntmodus wordt recovery vrijgegeven zodra `dew_gap > hard_dew_restart_gap_c`; in fallbackmodus zodra de gefilterde floor-gap boven de cap1-band komt. Zonder actieve floor-guard wordt de recovery niet onnodig vastgehouden nadat oil return voorbij is. De maximumduur blijft een harde vangrail.

## Achtergrond

Debugdata liet zien dat `oil_return_hold` de stop tijdens oil return voorkwam, maar dat vlak na het verlopen van de vaste hold alsnog een `dew_stop -> restart_wait` kon ontstaan terwijl de waterzijde nog nauwelijks boven de dauwpuntgrens zat. Deze PR maakt de hold herstelgestuurd: de timer is de maximale recovery window, niet meer het enige vrijgavecriterium.

## Validatie

- `rtk python3 scripts/dev.py bootstrap` om de lokale ESPHome-venv bij te werken naar de vereiste `2026.6.2`.
- `rtk python3 scripts/dev.py validate --config-only --config configs/waveshare/duo_wifi.yaml` succesvol.