### PR TITLE
Remove Hybrid version from HA dashboards

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2568,27 +2568,6 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:factory
-            heading: Quatt Hybrid version
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Explanation</strong></summary>
-
-              Choose which Quatt Hybrid you have. OpenQuatt uses this setting to apply the correct model rules and limits.
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: select.openquatt_quatt_hybrid_version
-                name: Quatt Hybrid version
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:volume-off
             heading: Silent mode settings
             heading_style: title

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2689,27 +2689,6 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:factory
-            heading: Quatt Hybrid-versie
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg</strong></summary>
-
-              Kies hier welke Quatt Hybrid je hebt. OpenQuatt gebruikt deze keuze om de juiste modelregels en limieten toe te passen.
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: select.openquatt_quatt_hybrid_version
-                name: Quatt Hybrid-versie
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:volume-off
             heading: Instellingen stille modus
             heading_style: title

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -2215,27 +2215,6 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:factory
-            heading: Quatt Hybrid version
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Explanation</strong></summary>
-
-              Choose which Quatt Hybrid you have. OpenQuatt uses this setting to apply the correct model rules and limits.
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: select.openquatt_quatt_hybrid_version
-                name: Quatt Hybrid version
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:volume-off
             heading: Silent mode settings
             heading_style: title

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2278,27 +2278,6 @@ views:
       - type: grid
         cards:
           - type: heading
-            icon: mdi:factory
-            heading: Quatt Hybrid-versie
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-
-              <summary><strong>Uitleg</strong></summary>
-
-              Kies hier welke Quatt Hybrid je hebt. OpenQuatt gebruikt deze keuze om de juiste modelregels en limieten toe te passen.
-
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: select.openquatt_quatt_hybrid_version
-                name: Quatt Hybrid-versie
-      - type: grid
-        cards:
-          - type: heading
             icon: mdi:volume-off
             heading: Instellingen stille modus
             heading_style: title


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert de `Quatt Hybrid-versie` / `Quatt Hybrid version` kaart uit de Home Assistant dashboardexports.
- Past dit toe op single/duo en NL/EN dashboards.
- Laat de web-app en Quick Start instellingen ongemoeid.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de voorgedefinieerde HA dashboards veranderen. De onderliggende `select.openquatt_quatt_hybrid_version` blijft bestaan en blijft via de OpenQuatt web-app/Quick Start beschikbaar.

## Achtergrond

De Quatt Hybrid-versie hoort niet meer als losse kaart in het HA dashboard. Deze PR is bewust gestackt op `codex/debug-recording-system-panel`, zodat één artifact de gestapelde wijzigingen kan testen terwijl deze dashboardwijziging apart reviewbaar blijft.

## Validatie

- `rtk rg -n "select\\.openquatt_quatt_hybrid_version|Quatt Hybrid-versie|Quatt Hybrid version" docs/dashboard` geeft geen matches.
- Dashboard YAML parse succesvol met de project-venv voor alle `docs/dashboard/openquatt_ha_dashboard_*.yaml` bestanden.
- `rtk python3 scripts/dev.py validate --config-only --config configs/waveshare/duo_wifi.yaml` succesvol.