### PR TITLE
Fix duplicate ODU runtime header include

### DIFF
--- a/openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml
+++ b/openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml
@@ -21,10 +21,6 @@
 #
 # ==============================================================================
 
-esphome:
-  includes:
-    - ${openquatt_root}/includes/experimental/oq_odu_runtime_frequency_table.h
-
 switch:
   - platform: template
     id: ${hp_id}_odu_runtime_frequency_table_enable

--- a/openquatt/includes/experimental/oq_odu_runtime_frequency_table.h
+++ b/openquatt/includes/experimental/oq_odu_runtime_frequency_table.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifndef OPENQUATT_OQ_ODU_RUNTIME_FREQUENCY_TABLE_H
+#define OPENQUATT_OQ_ODU_RUNTIME_FREQUENCY_TABLE_H
+
 #include <array>
 #include <cmath>
 #include <cstdio>
@@ -233,3 +236,5 @@ inline void apply_runtime_table(RuntimeFrequencyTableRefs refs, bool enabled) {
 }
 
 }  // namespace oq_odu_runtime_frequency
+
+#endif  // OPENQUATT_OQ_ODU_RUNTIME_FREQUENCY_TABLE_H


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt een klassieke include guard toe rond de ODU runtime frequency helper header.
- Verwijdert de expliciete ESPHome include uit het ODU runtime HP-package; `common.yaml` neemt de include directory al mee.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Voorkomt een compile failure waarbij ESPHome dezelfde header via twee generated paden meeneemt (`src/oq_odu_runtime_frequency_table.h` en `src/includes/experimental/oq_odu_runtime_frequency_table.h`). Geen wijziging in ODU runtime registergedrag.

## Achtergrond

Run 28037751992 faalde in `waveshare_single_wifi` op redefinitions vanuit `oq_odu_runtime_frequency_table.h`. `#pragma once` was niet genoeg doordat ESPHome dezelfde fysieke header onder twee generated paden kopieerde. De expliciete package include is overbodig omdat `openquatt/base/common.yaml` `${oq_cpp_headers_dir}` al include't.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/waveshare/single_wifi.yaml`
- `rtk .venv/bin/esphome compile configs/waveshare/single_wifi.yaml`
- `rtk git diff --check`
