### PR TITLE
Capture ESP32 crash logs on boot

### DIFF
--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -5,6 +5,10 @@
 #include <cstdio>
 #include <cstring>
 
+#include "esphome/core/defines.h"
+#ifdef USE_ESP32_CRASH_HANDLER
+#include "esphome/components/esp32/crash_handler.h"
+#endif
 #include "esphome/components/logger/logger.h"
 #include "esphome/core/log.h"
 
@@ -419,6 +423,12 @@ void OpenQuattLogHistory::setup() {
                                                    size_t message_len) {
     static_cast<OpenQuattLogHistory *>(self)->on_log_(level, tag, message, message_len);
   });
+
+#ifdef USE_ESP32_CRASH_HANDLER
+  if (esp32::crash_handler_has_data()) {
+    esp32::crash_handler_log();
+  }
+#endif
 
   web_server_base::global_web_server_base->add_handler(new OpenQuattLogHistoryRequestHandler(this));
   this->sync_time_state_();


### PR DESCRIPTION
# Wat verandert deze PR?

- Replayed pending ESP32 previous-boot crashdata nadat de OpenQuatt RAM log history logger-callback is geregistreerd.
- Laat ESPHome's crash marker handling ongemoeid; deze PR roept geen `crash_handler_clear()` aan.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen boot/loggedrag wijzigt: ESP32 crashlogs van de vorige boot komen nu in de OpenQuatt RAM log history terecht zonder dat eerst een ESPHome dashboard logclient hoeft te verbinden. Geen control-, actuator-, thermal-, boiler- of flow-logica gewijzigd.

## Achtergrond

ESPHome logt previous-boot crashdata al tijdens logger setup, voordat `openquatt_log_history` de logger-callback registreert. Een latere ESPHome API log subscription triggert `crash_handler_log()` opnieuw, waardoor de regels dan pas zichtbaar werden. Deze PR replayt pending crashdata direct na callback-registratie, maar wist de ESPHome crashmarker niet.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config configs/heatpump_controller_q/single_wifi.yaml`