### PR TITLE
Add cooling room dew point exclusion

### DIFF
--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -84,6 +84,7 @@ Dit pakket is vooral nuttig als:
 - je in meerdere kamers wilt koelen;
 - je per kamer een eigen dauwpunt, temperatuur of luchtvochtigheid hebt;
 - je OpenQuatt het hoogste geldige dauwpunt wilt laten gebruiken;
+- je een zichtbare kamer tijdelijk niet wilt laten meetellen;
 - je dauwpuntbronnen wilt aanpassen zonder opnieuw te flashen.
 
 Installatie in Home Assistant:
@@ -93,6 +94,7 @@ Installatie in Home Assistant:
 3. Herlaad de template-entiteiten of herstart Home Assistant.
 4. Zet `input_number.openquatt_cooling_room_count` op het aantal kamers dat je wilt gebruiken.
 5. Vul per kamer de bronhelpers in.
+6. Zet `input_boolean.openquatt_cooling_room_X_excluded` alleen aan voor kamers die niet moeten meetellen in de dauwpuntselectie.
 
 Per kamer heb je twee keuzes.
 
@@ -124,7 +126,9 @@ Het pakket publiceert daarna:
 - `binary_sensor.openquatt_ext_cooling_dew_point_valid`
 - `sensor.openquatt_ha_cooling_room_1_dew_point_effective` tot en met room 6
 
-OpenQuatt gebruikt standaard het hoogste geldige dauwpunt als veilige grens. Met `Dauwpuntsbenadering` blijft die echte meting leidend zodra hij beschikbaar is; ontbreekt hij, dan gebruikt OpenQuatt een conservatieve benadering. Met `Expliciet toestaan` wordt de dauwpuntgrens volledig overgeslagen, ook als er wel een dauwpuntmeting beschikbaar is.
+OpenQuatt gebruikt standaard het hoogste geldige dauwpunt van kamers die niet zijn uitgesloten als veilige grens. Zet je een kamer uit via de bijbehorende `input_boolean.openquatt_cooling_room_X_excluded`, dan blijft `sensor.openquatt_ha_cooling_room_X_dew_point_effective` wel berekend, maar telt die kamer niet mee voor `sensor.openquatt_ext_cooling_dew_point`.
+
+Met `Dauwpuntsbenadering` blijft die echte meting leidend zodra hij beschikbaar is; ontbreekt hij, dan gebruikt OpenQuatt een conservatieve benadering. Met `Expliciet toestaan` wordt de dauwpuntgrens volledig overgeslagen, ook als er wel een dauwpuntmeting beschikbaar is.
 
 ## Belangrijk om te onthouden
 

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -2302,7 +2302,9 @@ views:
 
               Prefer a direct dew point entity per room. If you do not have one, enter temperature and relative humidity instead.
 
-              OpenQuatt prefers the direct dew point per room and otherwise computes dew point from temperature + RH. For system safety it then uses the highest valid room value.
+              OpenQuatt prefers the direct dew point per room and otherwise computes dew point from temperature + RH. For system safety it then uses the highest valid room value from rooms not excluded from dew point selection.
+
+              Turn `Exclude from dew point selection` on to keep a room visible and keep calculating its room dew point, without including that room in the selected system value.
 
               Increase `Number of rooms` first; the input fields per room will appear below.
               </details>
@@ -2345,6 +2347,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_1_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_1_dew_point
                     name: Cooling room 1 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_1_temperature
@@ -2352,7 +2356,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_1_humidity
                     name: Cooling room 1 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_1_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2369,6 +2373,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_2_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_2_dew_point
                     name: Cooling room 2 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_2_temperature
@@ -2376,7 +2382,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_2_humidity
                     name: Cooling room 2 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_2_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2393,6 +2399,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_3_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_3_dew_point
                     name: Cooling room 3 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_3_temperature
@@ -2400,7 +2408,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_3_humidity
                     name: Cooling room 3 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_3_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2417,6 +2425,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_4_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_4_dew_point
                     name: Cooling room 4 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_4_temperature
@@ -2424,7 +2434,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_4_humidity
                     name: Cooling room 4 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_4_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2441,6 +2451,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_5_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_5_dew_point
                     name: Cooling room 5 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_5_temperature
@@ -2448,7 +2460,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_5_humidity
                     name: Cooling room 5 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_5_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2465,6 +2477,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_6_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_6_dew_point
                     name: Cooling room 6 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_6_temperature
@@ -2472,7 +2486,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_6_humidity
                     name: Cooling room 6 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_6_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2420,7 +2420,9 @@ views:
 
               Gebruik per kamer bij voorkeur een directe dauwpuntentity. Heb je die niet, vul dan temperatuur en relatieve luchtvochtigheid in.
 
-              OpenQuatt gebruikt per kamer eerst het directe dauwpunt en berekent anders zelf het dauwpunt uit temperatuur + RH. Voor de systeembeveiliging telt daarna de hoogste geldige kamerwaarde.
+              OpenQuatt gebruikt per kamer eerst het directe dauwpunt en berekent anders zelf het dauwpunt uit temperatuur + RH. Voor de systeembeveiliging telt daarna de hoogste geldige kamerwaarde van kamers die niet zijn uitgesloten van de dauwpuntselectie.
+
+              Zet `Uitsluiten uit dauwpuntselectie` aan om een kamer zichtbaar te houden en het kamer-dauwpunt te blijven berekenen, maar die kamer niet mee te laten tellen voor de geselecteerde systeemwaarde.
 
               Verhoog eerst `Aantal kamers`; daarna verschijnen de invoervelden per kamer.
               </details>
@@ -2463,6 +2465,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_1_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_1_dew_point
                     name: Cooling room 1 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_1_temperature
@@ -2470,7 +2474,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_1_humidity
                     name: Cooling room 1 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_1_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2487,6 +2491,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_2_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_2_dew_point
                     name: Cooling room 2 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_2_temperature
@@ -2494,7 +2500,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_2_humidity
                     name: Cooling room 2 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_2_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2511,6 +2517,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_3_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_3_dew_point
                     name: Cooling room 3 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_3_temperature
@@ -2518,7 +2526,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_3_humidity
                     name: Cooling room 3 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_3_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2535,6 +2543,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_4_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_4_dew_point
                     name: Cooling room 4 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_4_temperature
@@ -2542,7 +2552,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_4_humidity
                     name: Cooling room 4 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_4_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2559,6 +2569,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_5_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_5_dew_point
                     name: Cooling room 5 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_5_temperature
@@ -2566,7 +2578,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_5_humidity
                     name: Cooling room 5 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_5_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2583,6 +2595,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_6_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_6_dew_point
                     name: Cooling room 6 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_6_temperature
@@ -2590,7 +2604,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_6_humidity
                     name: Cooling room 6 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_6_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1949,7 +1949,9 @@ views:
 
               Prefer a direct dew point entity per room. If you do not have one, enter temperature and relative humidity instead.
 
-              OpenQuatt prefers the direct dew point per room and otherwise computes dew point from temperature + RH. For system safety it then uses the highest valid room value.
+              OpenQuatt prefers the direct dew point per room and otherwise computes dew point from temperature + RH. For system safety it then uses the highest valid room value from rooms not excluded from dew point selection.
+
+              Turn `Exclude from dew point selection` on to keep a room visible and keep calculating its room dew point, without including that room in the selected system value.
 
               Increase `Number of rooms` first; the input fields per room will appear below.
               </details>
@@ -1992,6 +1994,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_1_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_1_dew_point
                     name: Cooling room 1 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_1_temperature
@@ -1999,7 +2003,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_1_humidity
                     name: Cooling room 1 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_1_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2016,6 +2020,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_2_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_2_dew_point
                     name: Cooling room 2 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_2_temperature
@@ -2023,7 +2029,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_2_humidity
                     name: Cooling room 2 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_2_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2040,6 +2046,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_3_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_3_dew_point
                     name: Cooling room 3 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_3_temperature
@@ -2047,7 +2055,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_3_humidity
                     name: Cooling room 3 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_3_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2064,6 +2072,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_4_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_4_dew_point
                     name: Cooling room 4 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_4_temperature
@@ -2071,7 +2081,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_4_humidity
                     name: Cooling room 4 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_4_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2088,6 +2098,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_5_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_5_dew_point
                     name: Cooling room 5 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_5_temperature
@@ -2095,7 +2107,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_5_humidity
                     name: Cooling room 5 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_5_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2112,6 +2124,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_6_excluded
+                    name: Exclude from dew point selection
                   - entity: input_text.openquatt_source_cooling_room_6_dew_point
                     name: Cooling room 6 dew point entity
                   - entity: input_text.openquatt_source_cooling_room_6_temperature
@@ -2119,7 +2133,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_6_humidity
                     name: Cooling room 6 humidity entity
                   - entity: sensor.openquatt_ha_cooling_room_6_dew_point_effective
-                    name: Effective dew point
+                    name: Room dew point
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -2009,7 +2009,9 @@ views:
 
               Gebruik per kamer bij voorkeur een directe dauwpuntentity. Heb je die niet, vul dan temperatuur en relatieve luchtvochtigheid in.
 
-              OpenQuatt gebruikt per kamer eerst het directe dauwpunt en berekent anders zelf het dauwpunt uit temperatuur + RH. Voor de systeembeveiliging telt daarna de hoogste geldige kamerwaarde.
+              OpenQuatt gebruikt per kamer eerst het directe dauwpunt en berekent anders zelf het dauwpunt uit temperatuur + RH. Voor de systeembeveiliging telt daarna de hoogste geldige kamerwaarde van kamers die niet zijn uitgesloten van de dauwpuntselectie.
+
+              Zet `Uitsluiten uit dauwpuntselectie` aan om een kamer zichtbaar te houden en het kamer-dauwpunt te blijven berekenen, maar die kamer niet mee te laten tellen voor de geselecteerde systeemwaarde.
 
               Verhoog eerst `Aantal kamers`; daarna verschijnen de invoervelden per kamer.
               </details>
@@ -2052,6 +2054,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_1_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_1_dew_point
                     name: Cooling room 1 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_1_temperature
@@ -2059,7 +2063,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_1_humidity
                     name: Cooling room 1 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_1_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2076,6 +2080,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_2_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_2_dew_point
                     name: Cooling room 2 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_2_temperature
@@ -2083,7 +2089,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_2_humidity
                     name: Cooling room 2 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_2_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2100,6 +2106,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_3_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_3_dew_point
                     name: Cooling room 3 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_3_temperature
@@ -2107,7 +2115,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_3_humidity
                     name: Cooling room 3 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_3_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2124,6 +2132,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_4_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_4_dew_point
                     name: Cooling room 4 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_4_temperature
@@ -2131,7 +2141,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_4_humidity
                     name: Cooling room 4 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_4_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2148,6 +2158,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_5_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_5_dew_point
                     name: Cooling room 5 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_5_temperature
@@ -2155,7 +2167,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_5_humidity
                     name: Cooling room 5 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_5_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count
@@ -2172,6 +2184,8 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
+                  - entity: input_boolean.openquatt_cooling_room_6_excluded
+                    name: Uitsluiten uit dauwpuntselectie
                   - entity: input_text.openquatt_source_cooling_room_6_dew_point
                     name: Cooling room 6 dauwpuntentity
                   - entity: input_text.openquatt_source_cooling_room_6_temperature
@@ -2179,7 +2193,7 @@ views:
                   - entity: input_text.openquatt_source_cooling_room_6_humidity
                     name: Cooling room 6 luchtvochtigheidentity
                   - entity: sensor.openquatt_ha_cooling_room_6_dew_point_effective
-                    name: Actief dauwpunt
+                    name: Kamer-dauwpunt
             visibility:
               - condition: numeric_state
                 entity: input_number.openquatt_cooling_room_count

--- a/docs/dashboard/openquatt_ha_dynamic_cooling_package.yaml
+++ b/docs/dashboard/openquatt_ha_dynamic_cooling_package.yaml
@@ -7,6 +7,8 @@
 #   - Per room, users may provide either:
 #       1) a direct dew point entity, or
 #       2) a temperature + humidity entity pair.
+#   - Per visible room, users can disable selection participation while keeping
+#     the room's effective dew point sensor calculated for inspection.
 #   - Home Assistant calculates the highest valid dew point and publishes one
 #     stable aggregate proxy consumed by OpenQuatt ESPHome:
 #       sensor.openquatt_ext_cooling_dew_point
@@ -40,6 +42,26 @@ input_number:
     max: 6
     step: 1
     mode: box
+
+input_boolean:
+  openquatt_cooling_room_1_excluded:
+    name: OpenQuatt cooling room 1 excluded
+    icon: mdi:toggle-switch
+  openquatt_cooling_room_2_excluded:
+    name: OpenQuatt cooling room 2 excluded
+    icon: mdi:toggle-switch
+  openquatt_cooling_room_3_excluded:
+    name: OpenQuatt cooling room 3 excluded
+    icon: mdi:toggle-switch
+  openquatt_cooling_room_4_excluded:
+    name: OpenQuatt cooling room 4 excluded
+    icon: mdi:toggle-switch
+  openquatt_cooling_room_5_excluded:
+    name: OpenQuatt cooling room 5 excluded
+    icon: mdi:toggle-switch
+  openquatt_cooling_room_6_excluded:
+    name: OpenQuatt cooling room 6 excluded
+    icon: mdi:toggle-switch
 
 input_text:
   openquatt_source_cooling_room_1_dew_point:
@@ -149,6 +171,12 @@ template:
       - platform: state
         entity_id:
           - input_number.openquatt_cooling_room_count
+          - input_boolean.openquatt_cooling_room_1_excluded
+          - input_boolean.openquatt_cooling_room_2_excluded
+          - input_boolean.openquatt_cooling_room_3_excluded
+          - input_boolean.openquatt_cooling_room_4_excluded
+          - input_boolean.openquatt_cooling_room_5_excluded
+          - input_boolean.openquatt_cooling_room_6_excluded
           - input_text.openquatt_source_cooling_room_1_dew_point
           - input_text.openquatt_source_cooling_room_1_temperature
           - input_text.openquatt_source_cooling_room_1_humidity
@@ -180,7 +208,8 @@ template:
           {% set count = states('input_number.openquatt_cooling_room_count') | int(0) %}
           {% set ns = namespace(values=[]) %}
           {% for room in range(1, 7) %}
-            {% if room <= count %}
+            {% set excluded = is_state('input_boolean.openquatt_cooling_room_' ~ room ~ '_excluded', 'on') %}
+            {% if room <= count and not excluded %}
               {% set direct_selector = states('input_text.openquatt_source_cooling_room_' ~ room ~ '_dew_point') | trim %}
               {% set direct_entity, direct_attr = (direct_selector.split('|', 1) + [''])[:2] %}
               {% set direct_entity = direct_entity | trim %}
@@ -448,7 +477,8 @@ template:
           {% set count = states('input_number.openquatt_cooling_room_count') | int(0) %}
           {% set ns = namespace(valid=false) %}
           {% for room in range(1, 7) %}
-            {% if room <= count %}
+            {% set excluded = is_state('input_boolean.openquatt_cooling_room_' ~ room ~ '_excluded', 'on') %}
+            {% if room <= count and not excluded %}
               {% set direct_selector = states('input_text.openquatt_source_cooling_room_' ~ room ~ '_dew_point') | trim %}
               {% set direct_entity, direct_attr = (direct_selector.split('|', 1) + [''])[:2] %}
               {% set direct_entity = direct_entity | trim %}

--- a/docs/dashboardoverzicht.md
+++ b/docs/dashboardoverzicht.md
@@ -110,7 +110,9 @@ Voor een attribuut van een klimaatentiteit gebruik je:
 climate.woonkamer|current_temperature
 ```
 
-Het package berekent daarna het hoogste geldige dauwpunt en publiceert dat als `sensor.openquatt_ext_cooling_dew_point`. De geldigheid staat in `binary_sensor.openquatt_ext_cooling_dew_point_valid`.
+Het package berekent daarna het hoogste geldige dauwpunt van kamers die niet zijn uitgesloten en publiceert dat als `sensor.openquatt_ext_cooling_dew_point`. De geldigheid staat in `binary_sensor.openquatt_ext_cooling_dew_point_valid`.
+
+Wil je een zichtbare kamer tijdelijk uitsluiten, zet dan de bijbehorende `OpenQuatt cooling room X excluded` aan. Het kamer-dauwpunt blijft zichtbaar via `sensor.openquatt_ha_cooling_room_X_dew_point_effective`, maar telt niet mee voor de systeemselectie.
 
 Zie [Dashboard installeren](dashboard/README.md#optioneel-dynamische-koelbronnen-via-home-assistant) voor de installatie van het package.
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt per dynamische koelkamer `input_boolean.openquatt_cooling_room_X_excluded` toe.
- Laat uitgesloten kamers niet meetellen voor `sensor.openquatt_ext_cooling_dew_point` en `binary_sensor.openquatt_ext_cooling_dew_point_valid`, terwijl het kamer-dauwpunt wel berekend blijft.
- Werkt de Single/Duo NL/EN dashboards en dashboarddocs bij met de nieuwe uitsluit-toggle.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De wijziging raakt de Home Assistant-dauwpuntsselectie voor koeling: uitgesloten kamers tellen niet mee voor de geselecteerde systeemwaarde die OpenQuatt consumeert. Standaard staan de nieuwe exclusion helpers uit, zodat bestaande installaties hetzelfde blijven werken totdat een gebruiker bewust een kamer uitsluit. Er is geen ESPHome safety/control code of hardware-aansturing gewijzigd.

## Achtergrond

De gewenste workflow is dat een zichtbare kamer tijdelijk buiten de selectie/bepaling van het dauwpunt kan blijven, zonder de kamerconfiguratie te verwijderen en zonder het kamer-dauwpunt kwijt te raken. Daarom blijft `sensor.openquatt_ha_cooling_room_X_dew_point_effective` altijd rekenen voor zichtbare kamers, maar kijkt de aggregate selectie naar `input_boolean.openquatt_cooling_room_X_excluded`.

## Validatie

- `rtk python3 scripts/check_docs_consistency.py --changed-only`
- `rtk ruby -e "require 'yaml'; ARGV.each { |path| YAML.load_file(path) }; puts 'YAML OK'" docs/dashboard/openquatt_ha_dynamic_cooling_package.yaml docs/dashboard/openquatt_ha_dashboard_single_nl.yaml docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml docs/dashboard/openquatt_ha_dashboard_single_en.yaml docs/dashboard/openquatt_ha_dashboard_duo_en.yaml`