### PR TITLE
Temp. Fix: Swap Heatpump Controller Q Modbus ports

### DIFF
--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -12,9 +12,9 @@ substitutions:
   esp_flash_size: "16MB"                                # Active ESP flash size.
   esp_variant: "esp32s3"                                # Active ESP variant.
   esp_partitions: "${openquatt_root}/partitions/openquatt_16mb.csv" # Active partition table.
-  uart_tx_pin: "GPIO42"                                 # Modbus 1 TX; primary heat-pump bus.
-  uart_rx_pin: "GPIO45"                                 # Modbus 1 RX; primary heat-pump bus.
-  uart_rts_pin: "GPIO41"                                # Modbus 1 DE/RE; primary heat-pump bus.
+  uart_tx_pin: "GPIO40"                                 # Modbus 2 TX; primary heat-pump bus.
+  uart_rx_pin: "GPIO39"                                 # Modbus 2 RX; primary heat-pump bus.
+  uart_rts_pin: "GPIO38"                                # Modbus 2 DE/RE; primary heat-pump bus.
   oq_ot_thermostat_in_pin: "GPIO16"                     # OpenTherm thermostat input.
   oq_ot_thermostat_out_pin: "GPIO15"                    # OpenTherm thermostat output.
   ds18b20_pin: "GPIO14"                                 # Dallas DS18B20 1-Wire input.

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
@@ -6,9 +6,9 @@
 # controller. Listener and Waveshare builds must not initialize dummy pins.
 # ==============================================================================
 substitutions:
-  cic_compat_uart_tx_pin: "GPIO40"                      # Modbus 2 TX; CiC compatibility port.
-  cic_compat_uart_rx_pin: "GPIO39"                      # Modbus 2 RX; CiC compatibility port.
-  cic_compat_uart_rts_pin: "GPIO38"                     # Modbus 2 DE/RE; CiC compatibility port.
+  cic_compat_uart_tx_pin: "GPIO42"                      # Modbus 1 TX; CiC compatibility port.
+  cic_compat_uart_rx_pin: "GPIO45"                      # Modbus 1 RX; CiC compatibility port.
+  cic_compat_uart_rts_pin: "GPIO41"                     # Modbus 1 DE/RE; CiC compatibility port.
   cic_compat_modbus_address_hp1: "0x01"                 # CiC-facing Modbus address for HP1 data.
   cic_compat_modbus_address_hp2: "0x02"                 # CiC-facing Modbus address for HP2 data.
   oq_cic_compat_restore_mode_default: "RESTORE_DEFAULT_OFF" # Default compatibility mode state.


### PR DESCRIPTION
## Summary
- Move the primary Heatpump Controller Q heat-pump Modbus bus to the second RS485 port GPIOs.
- Move the CiC compatibility Modbus server to the first RS485 port GPIOs.
- Update the inline comments so the configured port labels match the hardware routing.

## Resulting mapping
| Port | Purpose | TX | RX | DE/RE |
|---|---|---:|---:|---:|
| Modbus 1 | CiC compatibility / secondary RS485 | `GPIO42` | `GPIO45` | `GPIO41` |
| Modbus 2 | Primary heat-pump bus | `GPIO40` | `GPIO39` | `GPIO38` |

## Validation
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml --config configs/heatpump_controller_q/single_eth.yaml --config configs/heatpump_controller_q/duo_wifi.yaml --config configs/heatpump_controller_q/duo_eth.yaml`