### PR TITLE
Voeg Wi-Fi provisioning toe aan installer

### DIFF
--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -6,7 +6,7 @@
     <title>OpenQuatt installatiehulp</title>
     <meta
       name="description"
-      content="Installeer de nieuwste stabiele OpenQuatt-firmware op een ondersteund OpenQuatt-bord."
+      content="Stel Wi-Fi in op een voorgeïnstalleerde OpenQuatt-module of installeer de nieuwste stabiele firmware via USB."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -53,7 +53,7 @@
           <section class="sidebar-overview">
             <p class="sidebar-kicker">Installatiehulp</p>
             <p class="sidebar-copy">
-              Flash de stabiele OpenQuatt-firmware voor Single of Duo via USB en ga daarna verder met de web-app en het dashboard.
+              Stel Wi-Fi in op een voorgeïnstalleerde module of flash de stabiele OpenQuatt-firmware via USB.
             </p>
             <a class="sidebar-utility" href="../verwarmen-en-koelen.html">Naar uitleg</a>
           </section>
@@ -92,181 +92,231 @@
       <main class="docs-main">
         <section class="doc-header">
           <p class="doc-kicker">Installatiehulp</p>
-          <h1>Installeer de nieuwste stabiele OpenQuatt-firmware</h1>
+          <h1>Verbind of installeer je OpenQuatt-module</h1>
           <p class="doc-lead">
-            Kies eerst je opstelling, hardwareprofiel en verbinding. Deze pagina stelt daarna automatisch het juiste factory-image samen voor ESP Web Tools.
+            Stel Wi-Fi in op een voorgeïnstalleerde module of flash zelf de stabiele firmware.
           </p>
-          <div class="callout callout-warning">
-            <p class="callout-title">Let op</p>
-            <p>
-              Gebruik van OpenQuatt kan gevolgen hebben voor je Quatt-garantie. De standaard commerciële
-              Quatt-garantie vervalt in principe bij gebruik van externe aansturing zoals OpenQuatt. De
-              wettelijke garantie blijft bestaan, maar een garantieclaim kan daardoor in de praktijk wel
-              ingewikkelder worden.
-            </p>
-          </div>
-          <ul class="install-quicklist">
-            <li>Gebruik Chrome of Edge op desktop.</li>
-            <li>Sluit een USB-datakabel aan.</li>
-            <li>Kies Wi-Fi, of Ethernet bij de Heatpump Controller Q met netwerkkabel.</li>
-          </ul>
+          <p class="install-warning-inline">
+            <span>Let op</span>
+            OpenQuatt kan gevolgen hebben voor je Quatt-garantie.
+          </p>
         </section>
 
-        <div class="install-layout">
-          <section class="install-card install-flow">
-            <section class="install-step" id="topology-step">
-              <div class="install-step-head">
-                <p class="install-step-number">1</p>
-                <div>
-                  <h2>Kies je opstelling</h2>
-                  <p class="install-step-copy">Hiermee bepaal je of de firmware als Single of Duo wordt opgebouwd.</p>
-                </div>
-              </div>
-
-              <div class="choice-grid" id="topology-grid">
-                <label class="choice-card">
-                  <input type="radio" name="topology" value="single" />
-                  <span class="choice-title">Single</span>
-                  <span class="choice-body">Opstelling met een warmtepomp, zonder Duo-specifieke logica.</span>
-                </label>
-                <label class="choice-card">
-                  <input type="radio" name="topology" value="duo" />
-                  <span class="choice-title">Duo</span>
-                  <span class="choice-body">Opstelling met twee warmtepompen in de gecompileerde topologie.</span>
-                </label>
-              </div>
-            </section>
-
-            <section class="install-step" id="hardware-step">
-              <div class="install-step-head">
-                <p class="install-step-number">2</p>
-                <div>
-                  <h2>Kies je ESP-module</h2>
-                  <p class="install-step-copy">Hiermee bepaal je de exacte bordindeling en het juiste factory-image.</p>
-                </div>
-              </div>
-
-              <div class="choice-grid" id="hardware-grid">
-                <label class="choice-card">
-                  <input type="radio" name="hardware" value="waveshare" />
-                  <span class="choice-title">Waveshare</span>
-                  <span class="choice-body">Waveshare ESP32-S3-Relay-1CH voor OpenQuatt.</span>
-                </label>
-                <label class="choice-card">
-                  <input type="radio" name="hardware" value="heatpump_listener" />
-                  <span class="choice-title">Heatpump Listener</span>
-                  <span class="choice-body">Electropaultje Heatpump Listener voor OpenQuatt.</span>
-                </label>
-                <label class="choice-card">
-                  <input type="radio" name="hardware" value="heatpump_controller_q" />
-                  <span class="choice-title">Heatpump Controller Q</span>
-                  <span class="choice-body">Electropaultje Heatpump Controller Q-edition, de voorkeursmodule voor nieuwe installaties.</span>
-                </label>
-              </div>
-              <p class="install-step-copy">De Heatpump Controller Q-edition is verkrijgbaar via de <a href="https://electropaultje.nl/product/heatpump-controller-quatt-edition/">productpagina van Electropaultje</a>.</p>
-            </section>
-
-            <section class="install-step" id="connection-step">
-              <div class="install-step-head">
-                <p class="install-step-number">3</p>
-                <div>
-                  <h2>Kies je verbinding</h2>
-                  <p class="install-step-copy">De installer activeert alleen verbindingen waarvoor in de stabiele release een factory-image beschikbaar is.</p>
-                </div>
-              </div>
-
-              <div class="choice-grid" id="connection-grid">
-                <label class="choice-card" data-unavailable>
-                  <input type="radio" name="connection" value="wifi" disabled />
-                  <span class="choice-title">Wi-Fi</span>
-                  <span class="choice-body">De huidige standaardroute voor OpenQuatt-installaties.</span>
-                </label>
-                <label class="choice-card" data-unavailable>
-                  <input type="radio" name="connection" value="eth" disabled />
-                  <span class="choice-title">Ethernet</span>
-                  <span class="choice-body">Voor Heatpump Controller Q met netwerkkabel. Ethernet-builds hebben geen Wi-Fi fallback.</span>
-                </label>
-              </div>
-            </section>
-          </section>
-
-          <aside class="install-summary-wrap">
-            <section class="install-card install-summary-card" id="flash-step">
-              <p class="install-section-label">Gekozen firmware</p>
-              <h2 id="selection-title">Kies eerst je opstelling, module en verbinding</h2>
-              <p class="summary-copy" id="selection-copy">
-                Deze installatiehulp maakt automatisch een eenmalig ESP Web Tools-manifest voor het profiel dat je hier kiest.
-              </p>
-
-              <dl class="summary-list">
-                <div>
-                  <dt>Stabiele versie</dt>
-                  <dd id="selection-version">Laden...</dd>
-                </div>
-                <div>
-                  <dt>Opstelling</dt>
-                  <dd id="selection-topology">Niet gekozen</dd>
-                </div>
-                <div>
-                  <dt>Hardware</dt>
-                  <dd id="selection-hardware">Niet gekozen</dd>
-                </div>
-                <div>
-                  <dt>Verbinding</dt>
-                  <dd id="selection-connection">Niet gekozen</dd>
-                </div>
-                <div>
-                  <dt>Chipfamilie</dt>
-                  <dd id="selection-chip">Niet gekozen</dd>
-                </div>
-                <div>
-                  <dt>Factory-image</dt>
-                  <dd id="selection-file">Niet gekozen</dd>
-                </div>
-              </dl>
-
-              <div class="install-panel" id="install-panel" data-ready="false">
-                <p class="install-state" id="install-state">Kies eerst opstelling, module en verbinding om de installatieknop te activeren.</p>
-                <esp-web-install-button id="install-button">
-                  <button class="install-cta" slot="activate">Installeer OpenQuatt</button>
-                  <span class="install-fallback" slot="unsupported">
-                    Web Serial is in deze browser niet beschikbaar. Gebruik Chrome of Edge op desktop.
-                  </span>
-                  <span class="install-fallback" slot="not-allowed">
-                    Open deze installatiehulp via HTTPS om Web Serial te kunnen gebruiken.
-                  </span>
-                </esp-web-install-button>
-              </div>
-
-              <div class="manual-panel">
-                <p class="install-section-label">Handmatige route</p>
-                <a id="release-link" href="https://github.com/jeroen85/OpenQuatt/releases/latest" target="_blank" rel="noreferrer">
-                  Open de nieuwste stabiele release
-                </a>
-                <a href="https://web.esphome.io/" target="_blank" rel="noreferrer">
-                  Flash een gedownloade factory binary in ESP Web Tools
-                </a>
-              </div>
-            </section>
-          </aside>
-        </div>
-
-        <section class="install-card install-follow-up" id="after-flash">
-          <h2>Na het flashen</h2>
-          <div class="install-follow-up-grid">
-            <article class="install-follow-up-item">
-              <h3>Netwerk afronden</h3>
-              <p>Bij Wi-Fi laat je deze pagina open voor configuratie via USB. Bij Ethernet sluit je na het flashen de netwerkkabel aan.</p>
-            </article>
-            <article class="install-follow-up-item">
-              <h3>Web-app openen</h3>
-              <p>Open daarna <code>http://openquatt.local</code> en rond de Quick Start af voordat je verdergaat in Home Assistant.</p>
-            </article>
-            <article class="install-follow-up-item">
-              <h3>Fallback route</h3>
-              <p>Lukt Wi-Fi instellen niet, dan blijft het OpenQuatt access point beschikbaar om Wi-Fi alsnog handmatig in te stellen. Ethernet-builds zijn Ethernet-only.</p>
-            </article>
+        <section class="install-route-switcher" aria-label="Installatieroute">
+          <div class="install-route-tabs" role="tablist" aria-label="Installatieroute kiezen">
+            <button class="install-route-tab" id="route-preinstalled-tab" type="button" role="tab" aria-selected="true" aria-controls="route-preinstalled-panel" data-install-route-tab="preinstalled">
+              Voorgeïnstalleerde module
+            </button>
+            <button class="install-route-tab" id="route-install-tab" type="button" role="tab" aria-selected="false" aria-controls="route-install-panel" data-install-route-tab="install">
+              Zelf installeren
+            </button>
           </div>
+
+          <div class="install-route-panels">
+            <section class="install-card install-provision install-route-panel" id="route-preinstalled-panel" role="tabpanel" aria-labelledby="route-preinstalled-tab" data-install-route-panel="preinstalled">
+              <div class="install-provision-copy">
+                <p class="install-section-label">Voorgeïnstalleerde module</p>
+                <h2>Alleen Wi-Fi instellen</h2>
+                <p>
+                  Gebruik dit als je module al met OpenQuatt is geleverd. Deze stap zet alleen je Wi-Fi-gegevens op de module en flasht niets.
+                </p>
+                <ol class="install-provision-list">
+                  <li>Sluit de module met USB aan op deze computer.</li>
+                  <li>Klik op <strong>Configureer Wi-Fi</strong> en kies de juiste USB-poort.</li>
+                  <li>Vul je Wi-Fi-netwerk in en open daarna <code>http://openquatt.local</code>.</li>
+                </ol>
+              </div>
+
+              <div class="install-provision-tool" id="wifi-provision-panel">
+                <p class="install-state" id="wifi-provision-state">Sluit je voorgeïnstalleerde module via USB aan om Wi-Fi te configureren.</p>
+                <p class="install-provision-device" id="wifi-provision-device" hidden></p>
+
+                <div class="install-provision-actions">
+                  <button class="install-cta" id="wifi-provision-connect" type="button">Configureer Wi-Fi</button>
+                  <button class="install-secondary-button" id="wifi-provision-disconnect" type="button" hidden>Verbreek USB</button>
+                </div>
+
+                <form class="install-provision-form" id="wifi-provision-form" hidden>
+                  <label class="install-field">
+                    <span>Netwerknaam</span>
+                    <input id="wifi-provision-ssid" type="text" autocomplete="off" required />
+                  </label>
+                  <label class="install-field">
+                    <span>Wachtwoord</span>
+                    <input id="wifi-provision-password" type="password" autocomplete="current-password" />
+                  </label>
+                  <div class="install-provision-actions">
+                    <button class="install-cta" id="wifi-provision-submit" type="submit">Wi-Fi opslaan</button>
+                  </div>
+                </form>
+
+                <a class="install-link-button" id="wifi-provision-open-device" href="http://openquatt.local" target="_blank" rel="noreferrer" hidden>
+                  Open OpenQuatt
+                </a>
+              </div>
+            </section>
+
+            <div class="install-route-panel" id="route-install-panel" role="tabpanel" aria-labelledby="route-install-tab" data-install-route-panel="install" hidden>
+              <div class="install-layout">
+                <section class="install-card install-flow">
+                  <p class="install-section-label">Zelf installeren</p>
+                  <section class="install-step" id="topology-step">
+                    <div class="install-step-head">
+                      <p class="install-step-number">1</p>
+                      <div>
+                        <h2>Kies je opstelling</h2>
+                        <p class="install-step-copy">Hiermee bepaal je of de firmware als Single of Duo wordt opgebouwd.</p>
+                      </div>
+                    </div>
+
+                    <div class="choice-grid" id="topology-grid">
+                      <label class="choice-card">
+                        <input type="radio" name="topology" value="single" />
+                        <span class="choice-title">Single</span>
+                        <span class="choice-body">Opstelling met een warmtepomp, zonder Duo-specifieke logica.</span>
+                      </label>
+                      <label class="choice-card">
+                        <input type="radio" name="topology" value="duo" />
+                        <span class="choice-title">Duo</span>
+                        <span class="choice-body">Opstelling met twee warmtepompen in de gecompileerde topologie.</span>
+                      </label>
+                    </div>
+                  </section>
+
+                  <section class="install-step" id="hardware-step">
+                    <div class="install-step-head">
+                      <p class="install-step-number">2</p>
+                      <div>
+                        <h2>Kies je ESP-module</h2>
+                        <p class="install-step-copy">Hiermee bepaal je de exacte bordindeling en het juiste factory-image.</p>
+                      </div>
+                    </div>
+
+                    <div class="choice-grid" id="hardware-grid">
+                      <label class="choice-card">
+                        <input type="radio" name="hardware" value="waveshare" />
+                        <span class="choice-title">Waveshare</span>
+                        <span class="choice-body">Waveshare ESP32-S3-Relay-1CH voor OpenQuatt.</span>
+                      </label>
+                      <label class="choice-card">
+                        <input type="radio" name="hardware" value="heatpump_listener" />
+                        <span class="choice-title">Heatpump Listener</span>
+                        <span class="choice-body">Electropaultje Heatpump Listener voor OpenQuatt.</span>
+                      </label>
+                      <label class="choice-card">
+                        <input type="radio" name="hardware" value="heatpump_controller_q" />
+                        <span class="choice-title">Heatpump Controller Q</span>
+                        <span class="choice-body">Electropaultje Heatpump Controller Q-edition, de voorkeursmodule voor nieuwe installaties.</span>
+                      </label>
+                    </div>
+                    <p class="install-step-copy">De Heatpump Controller Q-edition is verkrijgbaar via de <a href="https://electropaultje.nl/product/heatpump-controller-quatt-edition/">productpagina van Electropaultje</a>.</p>
+                  </section>
+
+                  <section class="install-step" id="connection-step">
+                    <div class="install-step-head">
+                      <p class="install-step-number">3</p>
+                      <div>
+                        <h2>Kies je verbinding</h2>
+                        <p class="install-step-copy">De installer activeert alleen verbindingen waarvoor in de stabiele release een factory-image beschikbaar is.</p>
+                      </div>
+                    </div>
+
+                    <div class="choice-grid" id="connection-grid">
+                      <label class="choice-card" data-unavailable>
+                        <input type="radio" name="connection" value="wifi" disabled />
+                        <span class="choice-title">Wi-Fi</span>
+                        <span class="choice-body">De huidige standaardroute voor OpenQuatt-installaties.</span>
+                      </label>
+                      <label class="choice-card" data-unavailable>
+                        <input type="radio" name="connection" value="eth" disabled />
+                        <span class="choice-title">Ethernet</span>
+                        <span class="choice-body">Voor Heatpump Controller Q met netwerkkabel. Ethernet-builds hebben geen Wi-Fi fallback.</span>
+                      </label>
+                    </div>
+                  </section>
+                </section>
+
+                <aside class="install-summary-wrap">
+                  <section class="install-card install-summary-card" id="flash-step">
+                    <p class="install-section-label">Gekozen firmware</p>
+                    <h2 id="selection-title">Kies eerst je opstelling, module en verbinding</h2>
+                    <p class="summary-copy" id="selection-copy">
+                      Deze installatiehulp maakt automatisch een eenmalig ESP Web Tools-manifest voor het profiel dat je hier kiest.
+                    </p>
+
+                    <dl class="summary-list">
+                      <div>
+                        <dt>Stabiele versie</dt>
+                        <dd id="selection-version">Laden...</dd>
+                      </div>
+                      <div>
+                        <dt>Opstelling</dt>
+                        <dd id="selection-topology">Niet gekozen</dd>
+                      </div>
+                      <div>
+                        <dt>Hardware</dt>
+                        <dd id="selection-hardware">Niet gekozen</dd>
+                      </div>
+                      <div>
+                        <dt>Verbinding</dt>
+                        <dd id="selection-connection">Niet gekozen</dd>
+                      </div>
+                      <div>
+                        <dt>Chipfamilie</dt>
+                        <dd id="selection-chip">Niet gekozen</dd>
+                      </div>
+                      <div>
+                        <dt>Factory-image</dt>
+                        <dd id="selection-file">Niet gekozen</dd>
+                      </div>
+                    </dl>
+
+                    <div class="install-panel" id="install-panel" data-ready="false">
+                      <p class="install-state" id="install-state">Kies eerst opstelling, module en verbinding om de installatieknop te activeren.</p>
+                      <esp-web-install-button id="install-button">
+                        <button class="install-cta" slot="activate">Installeer OpenQuatt</button>
+                        <span class="install-fallback" slot="unsupported">
+                          Web Serial is in deze browser niet beschikbaar. Gebruik Chrome, Edge of Firefox op desktop.
+                        </span>
+                        <span class="install-fallback" slot="not-allowed">
+                          Open deze installatiehulp via HTTPS om Web Serial te kunnen gebruiken.
+                        </span>
+                      </esp-web-install-button>
+                    </div>
+
+                    <div class="manual-panel">
+                      <p class="install-section-label">Handmatige route</p>
+                      <a id="release-link" href="https://github.com/jeroen85/OpenQuatt/releases/latest" target="_blank" rel="noreferrer">
+                        Open de nieuwste stabiele release
+                      </a>
+                      <a href="https://web.esphome.io/" target="_blank" rel="noreferrer">
+                        Flash een gedownloade factory binary in ESP Web Tools
+                      </a>
+                    </div>
+                  </section>
+                </aside>
+              </div>
+
+            </div>
+          </div>
+
+          <section class="install-card install-follow-up" id="after-setup">
+            <h2>Daarna</h2>
+            <div class="install-follow-up-grid">
+              <article class="install-follow-up-item">
+                <h3>Netwerk afronden</h3>
+                <p>Bij Wi-Fi stel je het netwerk via USB in. Bij Ethernet sluit je na het flashen de netwerkkabel aan.</p>
+              </article>
+              <article class="install-follow-up-item">
+                <h3>Web-app openen</h3>
+                <p>Open daarna <code>http://openquatt.local</code> en rond de Quick Start af voordat je verdergaat in Home Assistant.</p>
+              </article>
+              <article class="install-follow-up-item">
+                <h3>Fallback route</h3>
+                <p>Lukt Wi-Fi instellen via USB niet, verbind dan met het OpenQuatt access point en stel Wi-Fi handmatig in. Ethernet-builds zijn Ethernet-only.</p>
+              </article>
+            </div>
+          </section>
         </section>
       </main>
 

--- a/docs/install/install.css
+++ b/docs/install/install.css
@@ -5,23 +5,82 @@
   margin-bottom: 28px;
 }
 
-.install-quicklist {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin: 22px 0 0;
-  padding: 0;
-  list-style: none;
+.install-page .doc-header h1 {
+  overflow-wrap: anywhere;
 }
 
-.install-quicklist li {
-  padding: 10px 14px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--panel);
+.install-warning-inline {
+  display: inline-flex;
+  gap: 10px;
+  align-items: baseline;
+  max-width: 860px;
+  margin: 16px 0 0;
+  padding: 10px 12px;
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
   color: var(--ink-soft);
-  font-size: 0.92rem;
-  line-height: 1.4;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.install-warning-inline span {
+  flex: 0 0 auto;
+  color: var(--accent-strong);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.install-route-switcher {
+  display: grid;
+  gap: 18px;
+}
+
+.install-route-tabs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  width: fit-content;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.install-route-tab {
+  min-height: 42px;
+  padding: 10px 16px;
+  border: 0;
+  border-radius: calc(var(--radius-md) - 4px);
+  background: transparent;
+  color: var(--ink-soft);
+  font: inherit;
+  font-size: 0.94rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+
+.install-route-tab:hover {
+  color: var(--accent-strong);
+}
+
+.install-route-tab[aria-selected="true"] {
+  background: var(--accent);
+  color: #ffffff;
+  box-shadow: 0 8px 20px rgba(234, 88, 12, 0.16);
+}
+
+.install-route-tab:focus-visible {
+  outline: 2px solid rgba(234, 88, 12, 0.65);
+  outline-offset: 2px;
+}
+
+.install-route-panel[hidden] {
+  display: none !important;
 }
 
 .install-layout {
@@ -40,6 +99,152 @@
 
 .install-flow {
   padding: 28px;
+}
+
+.install-flow > .install-section-label {
+  margin-bottom: 22px;
+}
+
+.install-provision {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 440px);
+  gap: 28px;
+  align-items: start;
+  margin-bottom: 0;
+  padding: 28px;
+}
+
+.install-provision-copy h2 {
+  margin: 10px 0 0;
+  color: var(--ink);
+  font-size: 1.6rem;
+  line-height: 1.12;
+}
+
+.install-provision-copy p:not(.install-section-label),
+.install-provision-list {
+  color: var(--ink-soft);
+  line-height: 1.6;
+}
+
+.install-provision-copy p:not(.install-section-label) {
+  margin: 12px 0 0;
+}
+
+.install-provision-list {
+  display: grid;
+  gap: 8px;
+  margin: 18px 0 0;
+  padding-left: 20px;
+}
+
+.install-provision-tool {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: #111827;
+}
+
+.install-provision [hidden] {
+  display: none !important;
+}
+
+.install-provision-device {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.9);
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.install-provision-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.install-provision-actions .install-cta,
+.install-provision-actions .install-secondary-button {
+  flex: 1 1 180px;
+}
+
+.install-provision-form {
+  display: grid;
+  gap: 12px;
+}
+
+.install-field {
+  display: grid;
+  gap: 7px;
+}
+
+.install-field span {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.install-field input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 13px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  font: inherit;
+}
+
+.install-field input:focus {
+  outline: 2px solid rgba(234, 88, 12, 0.65);
+  outline-offset: 2px;
+}
+
+.install-secondary-button,
+.install-link-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.install-secondary-button {
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.install-link-button {
+  border: 1px solid rgba(234, 88, 12, 0.3);
+  background: var(--accent);
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.install-secondary-button:hover,
+.install-link-button:hover {
+  border-color: rgba(255, 255, 255, 0.42);
+}
+
+.install-provision-tool[data-state="ok"] .install-state {
+  color: #bbf7d0;
+}
+
+.install-provision-tool[data-state="warning"] .install-state {
+  color: #fed7aa;
+}
+
+.install-provision-tool[data-state="error"] .install-state {
+  color: #fecaca;
 }
 
 .install-step + .install-step {
@@ -245,6 +450,7 @@ esp-web-install-button {
 
 .install-cta {
   width: 100%;
+  min-height: 46px;
   padding: 14px 16px;
   border: 0;
   border-radius: var(--radius-sm);
@@ -256,10 +462,16 @@ esp-web-install-button {
   transition: background 160ms ease, transform 160ms ease, box-shadow 160ms ease;
 }
 
-.install-cta:hover {
+.install-cta:hover:not(:disabled) {
   background: var(--accent-strong);
   transform: translateY(-1px);
   box-shadow: 0 14px 26px rgba(234, 88, 12, 0.24);
+}
+
+.install-cta:disabled,
+.install-secondary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .install-fallback {
@@ -335,6 +547,10 @@ esp-web-install-button {
     padding: 32px 24px 56px;
   }
 
+  .install-provision {
+    grid-template-columns: 1fr;
+  }
+
   .install-follow-up-grid {
     grid-template-columns: 1fr;
   }
@@ -345,11 +561,22 @@ esp-web-install-button {
     padding: 26px 8px 44px;
   }
 
-  .install-quicklist {
+  .install-page .doc-header h1 {
+    font-size: clamp(1.85rem, 10.5vw, 2.25rem);
+  }
+
+  .install-warning-inline {
     display: grid;
+    gap: 6px;
+  }
+
+  .install-route-tabs {
+    display: grid;
+    width: 100%;
   }
 
   .install-flow,
+  .install-provision,
   .install-summary-card,
   .install-follow-up {
     padding: 20px;

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -2,6 +2,7 @@ const FACTORY_ROOT = new URL("../firmware/main/", window.location.href).toString
 const VERSION_URL = new URL("../firmware/main/version.json", window.location.href).toString();
 const FACTORY_FILES_URL = new URL("../firmware/main/factory_files.json", window.location.href).toString();
 const FALLBACK_RELEASE_URL = "https://github.com/jeroen85/OpenQuatt/releases/latest";
+const FALLBACK_DEVICE_URL = "http://openquatt.local";
 
 const HARDWARE_LABELS = {
   waveshare: "Waveshare ESP32-S3-Relay-1CH",
@@ -113,13 +114,601 @@ const releaseLink = document.getElementById("release-link");
 const installPanel = document.getElementById("install-panel");
 const installState = document.getElementById("install-state");
 const installButton = document.getElementById("install-button");
+const provisionPanel = document.getElementById("wifi-provision-panel");
+const provisionState = document.getElementById("wifi-provision-state");
+const provisionDevice = document.getElementById("wifi-provision-device");
+const provisionConnectButton = document.getElementById("wifi-provision-connect");
+const provisionDisconnectButton = document.getElementById("wifi-provision-disconnect");
+const provisionForm = document.getElementById("wifi-provision-form");
+const provisionSsidInput = document.getElementById("wifi-provision-ssid");
+const provisionPasswordInput = document.getElementById("wifi-provision-password");
+const provisionSubmitButton = document.getElementById("wifi-provision-submit");
+const provisionOpenDeviceLink = document.getElementById("wifi-provision-open-device");
+const installRouteTabs = Array.from(document.querySelectorAll("[data-install-route-tab]"));
+const installRoutePanels = Array.from(document.querySelectorAll("[data-install-route-panel]"));
+
+const IMPROV_PACKET = {
+  CURRENT_STATE: 1,
+  ERROR_STATE: 2,
+  RPC: 3,
+  RPC_RESULT: 4,
+};
+
+const IMPROV_COMMAND = {
+  WIFI_SETTINGS: 1,
+  GET_CURRENT_STATE: 2,
+  GET_DEVICE_INFO: 3,
+};
+
+const IMPROV_STATE = {
+  READY: 2,
+  PROVISIONING: 3,
+  PROVISIONED: 4,
+};
+
+const IMPROV_ERROR_MESSAGES = {
+  1: "Ongeldig Improv-pakket ontvangen.",
+  2: "De module herkende het Improv-commando niet.",
+  3: "Verbinden met dit Wi-Fi-netwerk is niet gelukt.",
+  254: "Wi-Fi instellen duurde te lang.",
+  255: "Onbekende Improv-fout.",
+};
+
+const IMPROV_HEADER = [73, 77, 80, 82, 79, 86, 1];
+const IMPROV_INIT_TIMEOUT_MS = 12000;
+const IMPROV_PROVISION_TIMEOUT_MS = 30000;
+
+class ImprovSerialClient {
+  constructor(port, onDisconnect, onStateChange) {
+    this.port = port;
+    this.onDisconnect = onDisconnect;
+    this.onStateChange = onStateChange;
+    this.reader = null;
+    this.pendingRpc = null;
+    this.pendingState = null;
+    this.readLoopClosed = false;
+    this.state = null;
+    this.error = 0;
+    this.info = null;
+    this.nextUrl = "";
+  }
+
+  async connect() {
+    await this.port.open({ baudRate: 115200, bufferSize: 8192 });
+    this.startReadLoop();
+    await delay(1000);
+
+    const currentStateUrls = await this.requestCurrentState(IMPROV_INIT_TIMEOUT_MS);
+    this.nextUrl = getProvisionUrl(currentStateUrls[0]);
+    const info = await this.rpc(IMPROV_COMMAND.GET_DEVICE_INFO, [], { timeoutMs: IMPROV_INIT_TIMEOUT_MS });
+    this.info = {
+      firmware: info[0] || "OpenQuatt",
+      version: info[1] || "",
+      chipFamily: info[2] || "",
+      name: info[3] || "",
+    };
+  }
+
+  async close() {
+    this.rejectPending(new Error("USB-verbinding verbroken."));
+    this.rejectPendingState(new Error("USB-verbinding verbroken."));
+    if (this.reader) {
+      try {
+        await this.reader.cancel();
+      } catch (error) {
+        console.debug("Kon Improv-reader niet annuleren", error);
+      }
+    }
+    if (this.port?.readable || this.port?.writable) {
+      try {
+        await this.port.close();
+      } catch (error) {
+        console.debug("Kon seriele poort niet sluiten", error);
+      }
+    }
+  }
+
+  async provision(ssid, password, options = {}) {
+    const encoder = new TextEncoder();
+    const ssidBytes = Array.from(encoder.encode(ssid));
+    const passwordBytes = Array.from(encoder.encode(password));
+    const payload = [ssidBytes.length, ...ssidBytes, passwordBytes.length, ...passwordBytes];
+    const urls = await this.rpc(IMPROV_COMMAND.WIFI_SETTINGS, payload, {
+      timeoutMs: IMPROV_PROVISION_TIMEOUT_MS,
+      afterWrite: options.afterWrite,
+    });
+    this.nextUrl = getProvisionUrl(urls[0] || this.nextUrl);
+    return this.nextUrl;
+  }
+
+  startReadLoop() {
+    this.readLoopClosed = false;
+    this.readLoop().catch((error) => {
+      if (!this.readLoopClosed) {
+        console.debug("Improv read loop gestopt", error);
+        this.rejectPending(error);
+        this.onDisconnect?.();
+      }
+    });
+  }
+
+  async readLoop() {
+    this.reader = this.port.readable.getReader();
+    let packet = [];
+    let expectedLength = 0;
+    let skippingLogLine = false;
+
+    try {
+      while (true) {
+        const { value, done } = await this.reader.read();
+        if (done) {
+          break;
+        }
+        if (!value) {
+          continue;
+        }
+
+        for (const byte of value) {
+          if (skippingLogLine) {
+            if (byte === 10) {
+              skippingLogLine = false;
+            }
+            continue;
+          }
+          if (packet.length === 0 && byte === 10) {
+            continue;
+          }
+
+          packet.push(byte);
+
+          if (packet.length === 6 && String.fromCharCode(...packet) !== "IMPROV") {
+            packet = [];
+            expectedLength = 0;
+            skippingLogLine = true;
+            continue;
+          }
+
+          if (packet.length === 9) {
+            expectedLength = 10 + packet[8];
+          }
+
+          if (expectedLength && packet.length === expectedLength) {
+            this.handlePacket(packet);
+            packet = [];
+            expectedLength = 0;
+          }
+        }
+      }
+    } finally {
+      this.readLoopClosed = true;
+      this.reader?.releaseLock();
+      this.reader = null;
+    }
+  }
+
+  handlePacket(packet) {
+    const version = packet[6];
+    const type = packet[7];
+    const dataLength = packet[8];
+    const data = packet.slice(9, 9 + dataLength);
+    const checksum = packet[9 + dataLength];
+    const expectedChecksum = packet.slice(0, packet.length - 1).reduce((sum, byte) => (sum + byte) & 255, 0);
+
+    if (version !== 1 || checksum !== expectedChecksum) {
+      return;
+    }
+
+    if (type === IMPROV_PACKET.CURRENT_STATE) {
+      this.state = data[0];
+      this.onStateChange?.(data[0]);
+      this.resolvePendingState(data[0]);
+      return;
+    }
+
+    if (type === IMPROV_PACKET.ERROR_STATE) {
+      this.error = data[0];
+      if (this.error > 0) {
+        this.rejectPending(new Error(IMPROV_ERROR_MESSAGES[this.error] || `Improv-fout ${this.error}.`));
+      }
+      return;
+    }
+
+    if (type === IMPROV_PACKET.RPC_RESULT) {
+      this.handleRpcResult(data);
+    }
+  }
+
+  handleRpcResult(data) {
+    if (!this.pendingRpc) {
+      return;
+    }
+
+    const command = data[0];
+    if (command !== this.pendingRpc.command) {
+      return;
+    }
+
+    const strings = parseImprovStrings(data.slice(1));
+    if (this.pendingRpc.multiple) {
+      if (strings.length) {
+        this.pendingRpc.results.push(strings);
+        return;
+      }
+      this.resolvePending(this.pendingRpc.results);
+      return;
+    }
+
+    this.resolvePending(strings);
+  }
+
+  async rpc(command, payload, options = {}) {
+    if (this.pendingRpc) {
+      throw new Error("Er loopt al een Improv-actie.");
+    }
+
+    const timeoutMs = options.timeoutMs || IMPROV_INIT_TIMEOUT_MS;
+    const response = new Promise((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        this.rejectPending(new Error("Geen Improv-antwoord ontvangen."));
+      }, timeoutMs);
+      this.pendingRpc = {
+        command,
+        multiple: Boolean(options.multiple),
+        results: [],
+        resolve,
+        reject,
+        timer,
+      };
+    });
+
+    try {
+      await this.writePacket(IMPROV_PACKET.RPC, [command, payload.length, ...payload]);
+      options.afterWrite?.();
+    } catch (error) {
+      this.rejectPending(error);
+      throw error;
+    }
+    return response;
+  }
+
+  async requestCurrentState(timeoutMs) {
+    if (this.pendingRpc || this.pendingState) {
+      throw new Error("Er loopt al een Improv-actie.");
+    }
+
+    const stateResponse = new Promise((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        this.rejectPendingState(new Error("Geen Improv-status ontvangen."));
+      }, timeoutMs);
+      this.pendingState = { resolve, reject, timer };
+    });
+
+    const urlResponse = new Promise((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        this.rejectPending(new Error("Geen Improv-antwoord ontvangen."));
+      }, timeoutMs);
+      this.pendingRpc = {
+        command: IMPROV_COMMAND.GET_CURRENT_STATE,
+        multiple: false,
+        results: [],
+        resolve,
+        reject,
+        timer,
+      };
+    });
+    urlResponse.catch(() => {});
+
+    try {
+      await this.writePacket(IMPROV_PACKET.RPC, [IMPROV_COMMAND.GET_CURRENT_STATE, 0]);
+      const state = await stateResponse;
+      if (state !== IMPROV_STATE.PROVISIONED) {
+        this.resolvePending([]);
+        return [];
+      }
+      return await urlResponse;
+    } catch (error) {
+      this.rejectPending(error);
+      this.rejectPendingState(error);
+      throw error;
+    }
+  }
+
+  async writePacket(type, data) {
+    const packet = new Uint8Array([...IMPROV_HEADER, type, data.length, ...data, 0, 10]);
+    packet[packet.length - 2] = packet.slice(0, packet.length - 2).reduce((sum, byte) => (sum + byte) & 255, 0);
+    const writer = this.port.writable.getWriter();
+    try {
+      await writer.write(packet);
+    } finally {
+      writer.releaseLock();
+    }
+  }
+
+  resolvePending(value) {
+    if (!this.pendingRpc) {
+      return;
+    }
+    window.clearTimeout(this.pendingRpc.timer);
+    this.pendingRpc.resolve(value);
+    this.pendingRpc = null;
+  }
+
+  rejectPending(error) {
+    if (!this.pendingRpc) {
+      return;
+    }
+    window.clearTimeout(this.pendingRpc.timer);
+    this.pendingRpc.reject(error);
+    this.pendingRpc = null;
+  }
+
+  resolvePendingState(value) {
+    if (!this.pendingState) {
+      return;
+    }
+    window.clearTimeout(this.pendingState.timer);
+    this.pendingState.resolve(value);
+    this.pendingState = null;
+  }
+
+  rejectPendingState(error) {
+    if (!this.pendingState) {
+      return;
+    }
+    window.clearTimeout(this.pendingState.timer);
+    this.pendingState.reject(error);
+    this.pendingState = null;
+  }
+}
 
 let activeManifestUrl;
 let availableFactoryFiles;
+let provisionClient = null;
 let releaseInfo = {
   version: "latest",
   releaseUrl: FALLBACK_RELEASE_URL,
 };
+
+function delay(ms) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function parseImprovStrings(data) {
+  const decoder = new TextDecoder();
+  const stringCount = data[0] || 0;
+  const strings = [];
+  let offset = 1;
+
+  for (let index = 0; index < stringCount; index += 1) {
+    const length = data[offset] || 0;
+    const start = offset + 1;
+    const end = start + length;
+    strings.push(decoder.decode(new Uint8Array(data.slice(start, end))));
+    offset = end;
+  }
+
+  return strings;
+}
+
+function getProvisionUrl(url) {
+  if (!url) {
+    return FALLBACK_DEVICE_URL;
+  }
+
+  try {
+    const parsedUrl = new URL(url, window.location.href);
+    if (parsedUrl.hostname === "0.0.0.0" || parsedUrl.hostname === "::" || parsedUrl.hostname === "[::]") {
+      return FALLBACK_DEVICE_URL;
+    }
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      return FALLBACK_DEVICE_URL;
+    }
+    return parsedUrl.toString();
+  } catch (error) {
+    return FALLBACK_DEVICE_URL;
+  }
+}
+
+function setProvisionState(message, state = "") {
+  provisionState.textContent = message;
+  if (state) {
+    provisionPanel.dataset.state = state;
+  } else {
+    delete provisionPanel.dataset.state;
+  }
+}
+
+function setProvisionBusy(busy) {
+  provisionConnectButton.disabled = busy;
+  provisionDisconnectButton.disabled = busy;
+  provisionSubmitButton.disabled = busy;
+}
+
+function setProvisionFormVisible(visible) {
+  provisionForm.hidden = !visible;
+  provisionDisconnectButton.hidden = !visible;
+}
+
+function setProvisionOpenLink(url) {
+  provisionOpenDeviceLink.href = getProvisionUrl(url);
+  provisionOpenDeviceLink.hidden = false;
+}
+
+function updateProvisionDeviceInfo() {
+  if (!provisionClient?.info) {
+    provisionDevice.hidden = true;
+    provisionDevice.textContent = "";
+    return;
+  }
+
+  const parts = [
+    provisionClient.info.name || "OpenQuatt",
+    provisionClient.info.firmware,
+    provisionClient.info.version,
+    provisionClient.info.chipFamily,
+  ].filter(Boolean);
+  provisionDevice.textContent = parts.join(" / ");
+  provisionDevice.hidden = false;
+}
+
+function describeProvisionReadyState() {
+  if (provisionClient?.state === IMPROV_STATE.PROVISIONED) {
+    return "Module is al verbonden. Je kunt Wi-Fi wijzigen of direct OpenQuatt openen.";
+  }
+  if (provisionClient?.state === IMPROV_STATE.PROVISIONING) {
+    return "Module is bezig met Wi-Fi verbinden.";
+  }
+  return "Kies je Wi-Fi-netwerk en sla de gegevens op de module op.";
+}
+
+function handleProvisionStateChange(state) {
+  if (!provisionClient || provisionForm.hidden || !provisionSubmitButton.disabled) {
+    return;
+  }
+
+  if (state === IMPROV_STATE.PROVISIONING) {
+    setProvisionState("Wi-Fi-gegevens verzonden. De module probeert nu te verbinden; dit kan tot 30 seconden duren.");
+  }
+  if (state === IMPROV_STATE.PROVISIONED) {
+    setProvisionState("Wi-Fi is verbonden. Bevestiging ophalen...");
+  }
+}
+
+function getProvisionSubmitErrorMessage(error) {
+  if (error.message === "Geen Improv-antwoord ontvangen.") {
+    return "Geen bevestiging ontvangen. Controleer SSID en wachtwoord; als de module toch online kwam, open OpenQuatt.";
+  }
+  return error.message || "Verbinden met dit Wi-Fi-netwerk is niet gelukt.";
+}
+
+async function disconnectProvisionClient(message = "USB-verbinding verbroken.") {
+  const client = provisionClient;
+  provisionClient = null;
+  if (client) {
+    await client.close();
+  }
+
+  setProvisionFormVisible(false);
+  provisionDevice.hidden = true;
+  provisionOpenDeviceLink.hidden = true;
+  provisionConnectButton.textContent = "Configureer Wi-Fi";
+  setProvisionBusy(false);
+  setProvisionState(message, "warning");
+}
+
+async function startProvisionFlow() {
+  if (!("serial" in navigator)) {
+    setProvisionState("Web Serial is in deze browser niet beschikbaar. Gebruik Chrome, Edge of Firefox op desktop.", "error");
+    return;
+  }
+  if (!window.isSecureContext) {
+    setProvisionState("Open deze installatiehulp via HTTPS om Web Serial te kunnen gebruiken.", "error");
+    return;
+  }
+
+  setProvisionBusy(true);
+  provisionOpenDeviceLink.hidden = true;
+  setProvisionState("Kies de USB-poort van je OpenQuatt-module...");
+
+  try {
+    if (provisionClient) {
+      await disconnectProvisionClient("Nieuwe USB-poort kiezen.");
+      setProvisionBusy(true);
+    }
+
+    const port = await navigator.serial.requestPort();
+    const client = new ImprovSerialClient(
+      port,
+      () => {
+        disconnectProvisionClient("USB-verbinding verbroken.");
+      },
+      handleProvisionStateChange,
+    );
+    provisionClient = client;
+
+    setProvisionState("Verbinden met de module...");
+    await client.connect();
+    updateProvisionDeviceInfo();
+    setProvisionFormVisible(true);
+    provisionConnectButton.textContent = "Andere USB-poort";
+    setProvisionOpenLink(client.nextUrl);
+    setProvisionState(describeProvisionReadyState(), client.state === IMPROV_STATE.PROVISIONED ? "ok" : "");
+  } catch (error) {
+    if (error.name === "NotFoundError") {
+      setProvisionState("Geen USB-poort gekozen.", "warning");
+    } else {
+      console.debug("Wi-Fi provisioning kon niet starten", error);
+      setProvisionState(error.message || "Wi-Fi configureren kon niet starten.", "error");
+    }
+    if (provisionClient) {
+      const client = provisionClient;
+      provisionClient = null;
+      await client.close();
+      setProvisionFormVisible(false);
+      provisionDevice.hidden = true;
+      provisionOpenDeviceLink.hidden = true;
+      provisionConnectButton.textContent = "Configureer Wi-Fi";
+    }
+  } finally {
+    setProvisionBusy(false);
+  }
+}
+
+async function submitProvisionForm(event) {
+  event.preventDefault();
+  if (!provisionClient) {
+    setProvisionState("Verbind eerst de module via USB.", "warning");
+    return;
+  }
+
+  const ssid = provisionSsidInput.value.trim();
+  if (!ssid) {
+    setProvisionState("Vul een Wi-Fi-netwerknaam in.", "warning");
+    return;
+  }
+
+  setProvisionBusy(true);
+  setProvisionState("Wi-Fi-gegevens verzenden...");
+  try {
+    const nextUrl = await provisionClient.provision(ssid, provisionPasswordInput.value, {
+      afterWrite: () => {
+        setProvisionState(
+          "Wi-Fi-gegevens verzonden. De module probeert nu te verbinden; dit kan tot 30 seconden duren.",
+        );
+      },
+    });
+    setProvisionOpenLink(nextUrl);
+    setProvisionState("Wi-Fi is ingesteld. Open daarna OpenQuatt en rond de Quick Start af.", "ok");
+  } catch (error) {
+    console.debug("Wi-Fi provisioning mislukt", error);
+    setProvisionState(getProvisionSubmitErrorMessage(error), "error");
+  } finally {
+    setProvisionBusy(false);
+  }
+}
+
+function setInstallRoute(route) {
+  installRouteTabs.forEach((tab) => {
+    const active = tab.dataset.installRouteTab === route;
+    tab.setAttribute("aria-selected", active ? "true" : "false");
+    tab.tabIndex = active ? 0 : -1;
+  });
+  installRoutePanels.forEach((panel) => {
+    panel.hidden = panel.dataset.installRoutePanel !== route;
+  });
+}
+
+function focusAdjacentInstallRoute(currentTab, direction) {
+  const currentIndex = installRouteTabs.indexOf(currentTab);
+  if (currentIndex < 0) {
+    return;
+  }
+
+  const nextIndex = (currentIndex + direction + installRouteTabs.length) % installRouteTabs.length;
+  const nextTab = installRouteTabs[nextIndex];
+  setInstallRoute(nextTab.dataset.installRouteTab);
+  nextTab.focus();
+}
 
 function getStableVersionLabel() {
   return releaseInfo.version === "latest" ? "Nieuwste stabiele" : releaseInfo.version;
@@ -283,6 +872,38 @@ document.querySelectorAll('input[name="topology"], input[name="hardware"], input
   });
 });
 
+provisionConnectButton.addEventListener("click", startProvisionFlow);
+provisionDisconnectButton.addEventListener("click", () => {
+  disconnectProvisionClient("USB-verbinding verbroken.");
+});
+provisionForm.addEventListener("submit", submitProvisionForm);
+installRouteTabs.forEach((tab) => {
+  tab.addEventListener("click", () => {
+    setInstallRoute(tab.dataset.installRouteTab);
+  });
+  tab.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      focusAdjacentInstallRoute(tab, -1);
+    }
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      focusAdjacentInstallRoute(tab, 1);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      setInstallRoute(installRouteTabs[0].dataset.installRouteTab);
+      installRouteTabs[0].focus();
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      const lastTab = installRouteTabs[installRouteTabs.length - 1];
+      setInstallRoute(lastTab.dataset.installRouteTab);
+      lastTab.focus();
+    }
+  });
+});
+
 function getHardwareProfiles(topology, hardware) {
   if (topology) {
     return Object.values(PROFILES[topology]?.[hardware] || {});
@@ -362,8 +983,20 @@ window.addEventListener("beforeunload", () => {
   if (activeManifestUrl) {
     URL.revokeObjectURL(activeManifestUrl);
   }
+  if (provisionClient) {
+    provisionClient.close().catch((error) => console.debug("Kon Improv-client niet sluiten", error));
+  }
 });
 
 updateSummary();
 updateAvailability();
+setInstallRoute("preinstalled");
 loadReleaseInfo();
+
+if (!("serial" in navigator)) {
+  provisionConnectButton.disabled = true;
+  setProvisionState("Web Serial is in deze browser niet beschikbaar. Gebruik Chrome, Edge of Firefox op desktop.", "error");
+} else if (!window.isSecureContext) {
+  provisionConnectButton.disabled = true;
+  setProvisionState("Open deze installatiehulp via HTTPS om Web Serial te kunnen gebruiken.", "error");
+}

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -255,7 +255,9 @@ class ImprovSerialClient {
             }
             continue;
           }
-          if (packet.length === 0 && byte === 10) {
+
+          if (!expectedLength && packet.length < 6 && (byte === 10 || byte === 13)) {
+            packet = [];
             continue;
           }
 

--- a/docs/installatie-en-ingebruikname.md
+++ b/docs/installatie-en-ingebruikname.md
@@ -1,12 +1,21 @@
 # Installatie en ingebruikname
 
-Deze handleiding beschrijft de eerste installatie van OpenQuatt. Voor de meeste gebruikers is de web installer de juiste en enige normale route. Na het flashen ga je eerst naar de lokale web-app via `http://openquatt.local`; Home Assistant komt daarna.
+Deze handleiding beschrijft de eerste installatie van OpenQuatt. Heb je een module gekocht waar OpenQuatt al op staat, dan gebruik je de web installer alleen om Wi-Fi in te stellen. Flashen is dan niet nodig. Na het verbinden ga je eerst naar de lokale web-app via `http://openquatt.local`; Home Assistant komt daarna.
 
 ## Installatieroute
 
-Voor een eerste installatie gebruik je de web installer uit de [README](../README.md). Daarmee flash je de juiste firmware en kun je bij Wi-Fi direct daarna de Wi-Fi-configuratie afronden. Bij Ethernet sluit je na het flashen de netwerkkabel aan.
+Voor een eerste installatie gebruik je de web installer uit de [README](../README.md). Daarmee stel je bij een voorgeïnstalleerde module alleen Wi-Fi in, of flash je zelf de juiste firmware. Bij Ethernet sluit je na het flashen de netwerkkabel aan.
 
-De route is:
+Voor een voorgeïnstalleerde Wi-Fi-module is de route:
+
+1. installer openen;
+2. module via USB aansluiten;
+3. `Alleen Wi-Fi instellen` gebruiken;
+4. `openquatt.local` openen;
+5. Quick Start afronden;
+6. Home Assistant-dashboard importeren.
+
+Als je zelf firmware flasht, is de route:
 
 1. installer openen;
 2. opstelling en hardware kiezen;
@@ -23,6 +32,7 @@ Gebruik [Handmatige installatie](handmatige-installatie.md) alleen als fallback.
 
 | Moment | Wat zie je? | Volgende actie |
 |---|---|---|
+| Voorgeïnstalleerde module | Wi-Fi configureren via USB | Sluit de module aan, kies de USB-poort en sla je Wi-Fi-netwerk op. |
 | Installer | Keuzes voor `Single` of `Duo`, ESP-module en verbinding | Kies de exacte combinatie die bij je hardware past. |
 | ESP Web Tools | Browserdialoog voor verbinden, wissen en flashen | Laat het tabblad bij Wi-Fi open tot de Wi-Fi-configuratie is afgerond. Bij Ethernet sluit je na de flash de netwerkkabel aan. |
 | Web-app | `http://openquatt.local` met Quick Start | Kies Quatt Hybrid V1, V1.5 of V2 en rond de basisinstellingen af. |
@@ -36,7 +46,7 @@ Gebruik [Handmatige installatie](handmatige-installatie.md) alleen als fallback.
   - Electropaultje Heatpump Listener
 - een USB-kabel voor de eerste flash
 - een werkend Wi-Fi-netwerk of, bij Heatpump Controller Q Ethernet, een aangesloten netwerkkabel
-- Chrome of Edge voor de web installer
+- Chrome, Edge of Firefox op desktop voor de web installer
 - Home Assistant wordt sterk aanbevolen
 
 ## Kies het juiste profiel in de installer
@@ -61,6 +71,21 @@ Ethernet is alleen beschikbaar voor de Heatpump Controller Q. ESPHome ondersteun
 ## Installatie via de web installer
 
 > Let op: gebruik van OpenQuatt kan gevolgen hebben voor je Quatt-garantie. De standaard commerciële Quatt-garantie vervalt in principe bij gebruik van externe aansturing zoals OpenQuatt. De wettelijke garantie blijft bestaan, maar een garantieclaim kan daardoor in de praktijk wel ingewikkelder worden.
+
+### Voorgeïnstalleerde module: alleen Wi-Fi instellen
+
+Gebruik deze route als je module al met OpenQuatt is geleverd.
+
+1. Open de [OpenQuatt installer](https://jeroen85.github.io/OpenQuatt/install/).
+2. Sluit het ESP32-bord via USB aan.
+3. Gebruik `Alleen Wi-Fi instellen`.
+4. Kies de USB-poort van de module.
+5. Vul je Wi-Fi-netwerk en wachtwoord in.
+6. Open na het verbinden `http://openquatt.local`.
+7. Rond de Quick Start in de web-app af.
+8. Voeg het apparaat daarna toe in Home Assistant. Selecteer tijdens het toevoegen nog geen area; ken die pas toe nadat de OpenQuatt-entiteiten zijn aangemaakt.
+
+### Zelf firmware flashen
 
 1. Open de [OpenQuatt installer](https://jeroen85.github.io/OpenQuatt/install/).
 2. Kies de combinatie die past bij je opstelling, hardware en verbinding.


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt een aparte installerroute toe voor voorgeïnstalleerde OpenQuatt-modules waarbij alleen Wi-Fi via USB wordt ingesteld.
- Zet de installerroute om naar tabs voor `Voorgeïnstalleerde module` en `Zelf installeren`, met compactere garantie-waarschuwing en gedeelde fallback-informatie.
- Implementeert een eigen Improv Serial provisioning-flow met handmatige SSID/wachtwoord-invoer en fallback naar `http://openquatt.local` wanneer de module `0.0.0.0` teruggeeft.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alle wijzigingen zitten in de docs/install-pagina en installatiehandleiding. Er is geen firmware- of regelgedrag aangepast.

## Achtergrond

Voor gebruikers die een module kopen waarop OpenQuatt al voorgeïnstalleerd is, hoeft de installer geen flash-flow te tonen. Deze PR maakt die route expliciet: USB verbinden, Wi-Fi-gegevens invullen, en daarna OpenQuatt openen. De Wi-Fi-netwerklijst is bewust verwijderd omdat ESPHome Improv Serial alleen bestaande ESP-scanresultaten teruggeeft en die bij provisioned modules leeg kunnen zijn.

## Validatie

- `rtk node --check docs/install/install.js`
- `rtk python3 scripts/build_pages_docs.py /private/tmp/openquatt-docs-check`
- `rtk git diff --check HEAD~1..HEAD`
- Lokale preview gecontroleerd via `http://127.0.0.1:8767/install/`