### PR TITLE
Fix pump iPWM dashboard history

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -917,9 +917,9 @@ views:
             hours_to_show: 4
             refresh_interval: 30
             entities:
-              - entity: number.openquatt_hp1_set_pump_speed
+              - entity: sensor.openquatt_hp1_pump_ipwm_command
                 name: HP1 iPWM
-              - entity: number.openquatt_hp2_set_pump_speed
+              - entity: sensor.openquatt_hp2_pump_ipwm_command
                 name: HP2 iPWM
             grid_options:
               columns: full

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -948,9 +948,9 @@ views:
             hours_to_show: 4
             refresh_interval: 30
             entities:
-              - entity: number.openquatt_hp1_set_pump_speed
+              - entity: sensor.openquatt_hp1_pump_ipwm_command
                 name: HP1 iPWM
-              - entity: number.openquatt_hp2_set_pump_speed
+              - entity: sensor.openquatt_hp2_pump_ipwm_command
                 name: HP2 iPWM
             grid_options:
               columns: full

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -911,7 +911,7 @@ views:
             hours_to_show: 4
             refresh_interval: 30
             entities:
-              - entity: number.openquatt_hp1_set_pump_speed
+              - entity: sensor.openquatt_hp1_pump_ipwm_command
                 name: HP1 iPWM
             grid_options:
               columns: full

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -931,7 +931,7 @@ views:
             hours_to_show: 4
             refresh_interval: 30
             entities:
-              - entity: number.openquatt_hp1_set_pump_speed
+              - entity: sensor.openquatt_hp1_pump_ipwm_command
                 name: HP1 iPWM
             grid_options:
               columns: full

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -246,6 +246,22 @@ number:
 # SENSOR
 # ----------------------------
 sensor:
+  - platform: template
+    id: ${hp_id}_pump_ipwm_command
+    name: "${prefix}Pump iPWM command"
+    icon: "mdi:speedometer"
+    unit_of_measurement: "iPWM"
+    state_class: "measurement"
+    accuracy_decimals: 0
+    update_interval: 30s
+    force_update: true
+    lambda: |-
+      const float pump_speed = id(${hp_id}_pump_speed).state;
+      if (isnan(pump_speed)) return {};
+      return pump_speed;
+    web_server:
+      sorting_group_id: oq_${hp_id}
+
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_working_mode


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt per warmtepomp een read-only `Pump iPWM command` sensor toe die de interne pump speed target volgt.
- Laat de single/duo HA-dashboardgrafieken deze sensors gebruiken in plaats van de interne `number.*_set_pump_speed` entities.
- Forceert periodieke sensorupdates zodat een constante iPWM-target zichtbaar blijft in history graphs.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Er komt een read-only sensor entity bij voor de HA-history/dashboardweergave. De bestaande interne Modbus number blijft de actuator/control target; de wijziging verandert geen pompaansturing.

## Achtergrond

De dashboardgrafiek gebruikte de interne `number.openquatt_hp*_set_pump_speed` entities. Omdat die verborgen/interne control-entities geen stabiele HA-history bron zijn, bleef de grafiek leeg. De nieuwe template sensor publiceert dezelfde iPWM-target als meetwaarde voor visualisatie.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`