### PR TITLE
Hide technical diagnostics from HA

### DIFF
--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -78,6 +78,7 @@ sensor:
   - platform: debug
     psram:
       name: "PSRAM Free"
+      internal: true
       icon: mdi:memory
       entity_category: diagnostic
       disabled_by_default: true

--- a/openquatt/oq_cic.yaml
+++ b/openquatt/oq_cic.yaml
@@ -117,6 +117,7 @@ sensor:
   - platform: template
     id: cic_backoff_s
     name: "CIC - Polling interval"
+    internal: true
     unit_of_measurement: "s"
     device_class: duration
     state_class: measurement
@@ -130,6 +131,7 @@ sensor:
   - platform: template
     id: cic_last_success_age_s
     name: "CIC - Last success age"
+    internal: true
     unit_of_measurement: "s"
     device_class: duration
     state_class: measurement

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -492,6 +492,7 @@ select:
     name: "Firmware Update Target"
     id: oq_firmware_update_target
     icon: mdi:swap-horizontal
+    internal: true
     disabled_by_default: true
     web_server:
       sorting_group_id: oq_system_diagnostics
@@ -745,6 +746,7 @@ button:
   - platform: template
     id: oq_install_firmware_update_target
     name: Install Firmware Update Target
+    internal: true
     disabled_by_default: true
     icon: mdi:swap-horizontal-bold
     entity_category: diagnostic
@@ -820,12 +822,14 @@ sensor:
   - platform: debug
     free:
       name: "Heap Free"
+      internal: true
       icon: mdi:memory
       entity_category: diagnostic
       disabled_by_default: true
       accuracy_decimals: 0
     block:
       name: "Heap Max Block"
+      internal: true
       icon: mdi:memory
       entity_category: diagnostic
       disabled_by_default: true
@@ -838,6 +842,7 @@ sensor:
       accuracy_decimals: 0
     fragmentation:
       name: "Heap Fragmentation"
+      internal: true
       icon: mdi:memory
       entity_category: diagnostic
       disabled_by_default: true
@@ -846,6 +851,7 @@ sensor:
   - platform: template
     name: Firmware Update Progress
     id: oq_firmware_update_progress
+    internal: true
     icon: mdi:progress-upload
     unit_of_measurement: "%"
     accuracy_decimals: 0
@@ -898,6 +904,7 @@ text_sensor:
   - platform: template
     id: oq_firmware_update_status
     name: Firmware Update Status
+    internal: true
     icon: mdi:upload-network-outline
     entity_category: diagnostic
     update_interval: never
@@ -935,6 +942,7 @@ text_sensor:
   - platform: template
     id: oq_installation_topology_text
     name: OpenQuatt Installation Topology
+    internal: true
     icon: mdi:home-analytics
     entity_category: diagnostic
     update_interval: never
@@ -949,6 +957,7 @@ text_sensor:
   - platform: template
     id: oq_hardware_profile_text
     name: OpenQuatt Hardware Profile
+    internal: true
     icon: mdi:developer-board
     entity_category: diagnostic
     update_interval: never
@@ -959,6 +968,7 @@ text_sensor:
   - platform: template
     id: oq_connection_text
     name: OpenQuatt Connection
+    internal: true
     icon: mdi:lan-connect
     entity_category: diagnostic
     update_interval: never

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -396,6 +396,7 @@ sensor:
   - platform: template
     id: cooling_fallback_night_min_outdoor_temp
     name: "Cooling Fallback Night Minimum Outdoor Temp"
+    internal: true
     disabled_by_default: true
     icon: mdi:weather-night
     unit_of_measurement: "°C"
@@ -421,6 +422,7 @@ sensor:
   - platform: template
     id: cooling_fallback_min_supply_temp
     name: "Cooling Fallback Minimum Supply Temp"
+    internal: true
     disabled_by_default: true
     icon: mdi:thermometer-chevron-down
     unit_of_measurement: "°C"

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -323,6 +323,7 @@ sensor:
   - platform: template
     id: oq_phouse_comfort_memory_c_sensor
     name: "Power House – comfort memory"
+    internal: true
     icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     device_class: temperature
@@ -339,6 +340,7 @@ sensor:
   - platform: template
     id: oq_phouse_effective_room_target_c_sensor
     name: "Power House – effective room target"
+    internal: true
     icon: mdi:target
     unit_of_measurement: "°C"
     device_class: temperature

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -142,6 +142,7 @@ text_sensor:
   - platform: template
     id: oq_strategy_phase_text
     name: "Strategy phase"
+    internal: true
     icon: mdi:state-machine
     update_interval: never
     entity_category: diagnostic


### PR DESCRIPTION
# Wat verandert deze PR?

- Maakt een kleine eerste batch technische system diagnostics `internal: true`, zodat ze niet meer als HA-entity of standaard webserver-entity zichtbaar zijn.
- Behoudt toegang voor de OpenQuatt web-app via de custom bulk entity endpoint.
- Raakt geen regelgedrag, opslaglayout, MQTT, dashboardsensoren of meet-/stuurwaarden.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Deze PR verbergt alleen technische diagnostics/config-helper entities voor HA en de standaard webserverlijst. De entities blijven intern bestaan en blijven expliciet opvraagbaar door de OpenQuatt web-app.

Intern gemaakt:

- `Firmware Update Target`
- `Install Firmware Update Target`
- `Firmware Update Progress`
- `Firmware Update Status`
- `OpenQuatt Installation Topology`
- `OpenQuatt Hardware Profile`
- `OpenQuatt Connection`
- `PSRAM Free`
- `Heap Free`
- `Heap Max Block`
- `Heap Fragmentation`
- `Power House – comfort memory`
- `Power House – effective room target`
- `Strategy phase`
- `CIC - Polling interval`
- `CIC - Last success age`
- `Cooling Fallback Night Minimum Outdoor Temp`
- `Cooling Fallback Minimum Supply Temp`

## Achtergrond

Dit is PR D na de metadata/entity-reductie: een behoudende eerste stap om zichtbare HA/web entities verder op te schonen zonder bediening of dashboards met meetwaarden te breken. Bewust niet meegenomen: `Heap Min Free`, IP/WiFi, ESP-temperatuur, `Firmware Update`, `Check Firmware Updates`, restart/safe-mode en reguliere gebruikersinstellingen.

Dashboardreferenties zijn gecontroleerd; voor deze intern gemaakte entities zijn geen HA-dashboardwijzigingen nodig.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
