### PR TITLE
Use UART-level RS485 flow control for Modbus

### DIFF
--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -147,6 +147,7 @@ uart:
   - id: uart_bus
     tx_pin: ${uart_tx_pin}
     rx_pin: ${uart_rx_pin}
+    flow_control_pin: ${uart_rts_pin}
     baud_rate: 19200
     data_bits: 8
     stop_bits: 1
@@ -157,7 +158,6 @@ uart:
 modbus:
   - uart_id: uart_bus
     id: mod_bus
-    flow_control_pin: ${uart_rts_pin}
     send_wait_time: 100ms
 
 # ==============================================================================

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
@@ -17,6 +17,7 @@ uart:
   - id: cic_compat_uart_bus
     tx_pin: ${cic_compat_uart_tx_pin}
     rx_pin: ${cic_compat_uart_rx_pin}
+    flow_control_pin: ${cic_compat_uart_rts_pin}
     baud_rate: 19200
     data_bits: 8
     stop_bits: 1
@@ -28,7 +29,6 @@ modbus:
   - uart_id: cic_compat_uart_bus
     id: cic_compat_modbus
     role: server
-    flow_control_pin: ${cic_compat_uart_rts_pin}
     send_wait_time: 50ms
 
 packages:


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst RS485 DE/RE-aansturing voor de primaire Modbus-bus van `modbus.flow_control_pin` naar `uart.flow_control_pin`.
- Verplaatst dezelfde aansturing voor de Q-edition CiC-compatibility Modbus-serverbus naar `uart.flow_control_pin`.
- Laat de bestaande baudrate, parity, `rx_full_threshold`, `rx_timeout` en `send_wait_time` ongewijzigd.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Deze wijziging raakt de RS485-richtingsturing van de Modbus-bussen. De functionele registermapping en polling-cadans blijven gelijk, maar op ESP32/ESP-IDF wordt de RTS/DE-pin nu door de UART-driver als RS485 half-duplex flow-control gebruikt in plaats van door de ESPHome Modbus-laag handmatig rond `write_array()`/`flush()` te toggelen.

## Achtergrond

ESPHome documenteert dat, wanneer de UART `flow_control_pin` ondersteunt, deze in de `uart`-component geconfigureerd moet worden en niet in de `modbus`-component. In de ESP-IDF UART-backend activeert `uart.flow_control_pin` `UART_MODE_RS485_HALF_DUPLEX`, waardoor DE/RE-timing dichter bij de UART-driver ligt.

De bestaande OpenQuatt-config gebruikte `modbus.flow_control_pin`. Dat werkt, maar houdt de DE/RE-aansturing in de Modbus-componentlogica. Deze PR volgt de ESPHome-richtlijn en maakt de configuratie beter passend bij ESP32-S3/ESP-IDF RS485 half-duplex.

Aanleiding voor deze test is een veldobservatie waarbij Modbus rond compressorstart kan verstoren en het dashboard tijdelijk bevriest. Deze PR bewijst niet dat die storing hiermee opgelost is; hij maakt de RS485-aansturing wel driver-natiever en verwijdert dubbele/handmatige DE/RE-logica uit de Modbus-laag.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/waveshare/duo_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_listener/duo_wifi.yaml`
- `rtk .venv/bin/esphome compile configs/heatpump_controller_q/duo_wifi.yaml`
- Generated code gecontroleerd: `uart_bus->set_flow_control_pin(...)` en `cic_compat_uart_bus->set_flow_control_pin(...)` aanwezig; `mod_bus->set_flow_control_pin(...)` en `cic_compat_modbus->set_flow_control_pin(...)` afwezig.
- Fresh-compiled testfirmware OTA succesvol naar `openquatt.local` gestuurd; mDNS resolveerde naar `192.168.2.63`.

Nog te bevestigen op hardware: gedrag tijdens compressorstart, met name Modbus ONLINE/OFFLINE-meldingen, dashboardrespons, heapgedrag na reboot en of de ODU na de eerste minuten blijft doorlopen.