### PR TITLE
Fix sticky pump status initialization

### DIFF
--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -113,7 +113,7 @@ oq_cm2_min_run_s: "120"                               # Minimum dwell time in CM
 oq_cm0_sticky_wait_s: "86400"                         # Wait time in CM0 before sticky-pump run starts [s].
 oq_cm0_sticky_run_s: "60"                             # Duration of sticky-pump run in CM0 [s].
 oq_cm0_pump_stop_ipwm: "1000.0"                       # iPWM setpoint that forces pump off in CM0.
-oq_sticky_pwm: "850"                                  # Fixed iPWM fallback used during CM0 sticky circulation.
+oq_sticky_pwm: "800"                                  # Fixed iPWM fallback used during CM0 sticky circulation.
 
 # ----------------------------
 # HEATING STRATEGY

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -1462,10 +1462,7 @@ interval:
                 }
               }
 
-              const bool cur_st = id(oq_sticky_active).state;
-              if (cur_st != sticky_active_local) {
-                id(oq_sticky_active).publish_state(sticky_active_local);
-              }
+              publish_binary_if_changed(id(oq_sticky_active), sticky_active_local);
             }
 
             const bool sticky_active = in_cm0 && ms_window_active(id(oq_sticky_until_ms));
@@ -1492,7 +1489,7 @@ interval:
               set_number_value(id(${secondary_pump_speed_id}), target_pwm, 1.0f);
               #endif
             } else {
-              if (id(oq_sticky_active).state) id(oq_sticky_active).publish_state(false);
+              publish_binary_if_changed(id(oq_sticky_active), false);
             }
           };
 


### PR DESCRIPTION
## Summary
- Initialize the sticky pump binary sensor through the shared publish helper so it reports `not running` instead of staying `unknown`.
- Lower the fixed CM0 sticky pump iPWM fallback from `850` to `800` for a slightly stronger circulation pulse.

## Validation
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`