### PR TITLE
Move sensor source selection to web app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@
 ## GitHub And PRs
 
 - Do not prefix PR titles with `[codex]`; use a concise human-readable title instead.
+- Use `.github/pull_request_template.md` for PR bodies and fill every relevant section.
 
 ## Concise Mode
 

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1928,25 +1928,21 @@ views:
         cards:
           - type: heading
             icon: mdi:source-branch
-            heading: Sensor selection
+            heading: Sensor sources
             heading_style: title
           - type: markdown
             content: |-
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              Select which source OpenQuatt should use per signal. The `Selected` value should directly follow the chosen source. This makes it easy to verify that the effective control input matches your expectation.
+              This tab shows the value OpenQuatt uses per signal and the available raw sources. Configure sensor selection in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
 
               Use this block for:
-              - source selection during tuning
               - quick comparison between CIC, local, and HA Input
               - validation of the effective control input
-              - in Duo, `Flow source = Outdoor unit` reveals an extra choice for
-                `Flowmeter HP1`, `Flowmeter HP2`, or the existing local HP1/HP2 aggregate
+              - diagnosis of missing or unexpected source values
 
-              The local `HP1/HP2` aggregate is, in principle, the average of both flowmeters.
-
-              For `Outside temperature source`, `Auto` is the recommended mode. OpenQuatt then picks the lowest valid source between the local Duo aggregate and HA outside temperature, when HA is configured and valid. This keeps control robust when one source is temporarily biased warm by sun or local heat.
+              HA input source mapping remains further down on this tab.
 
               </details>
             text_only: true
@@ -1962,8 +1958,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_room_temperature_source
-                    name: Room temperature source
                   - entity: sensor.openquatt_room_temperature_effective_source
                     name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
@@ -1986,8 +1980,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_water_supply_source
-                    name: Water supply temperature source
                   - entity: sensor.openquatt_water_supply_temp_selected
                     name: Selected water supply temperature
                   - entity: sensor.openquatt_water_supply_temp
@@ -2008,16 +2000,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_flow_source
-                    name: Flow source
-                  - type: conditional
-                    row:
-                      entity: select.openquatt_outdoor_unit_flow_mode
-                      name: Outdoor unit flow mode
-                    conditions:
-                      - condition: state
-                        entity: select.openquatt_flow_source
-                        state: Outdoor unit
                   - entity: sensor.openquatt_flow_average_selected
                     name: Selected flow rate
                   - entity: sensor.openquatt_flow_average_local
@@ -2036,8 +2018,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_outside_temperature_source
-                    name: Outside temperature source
                   - entity: sensor.openquatt_outside_temperature_selected
                     name: Selected outside temperature
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
@@ -2056,8 +2036,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_room_setpoint_source
-                    name: Room setpoint source
                   - entity: sensor.openquatt_room_setpoint_effective_source
                     name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
@@ -2080,8 +2058,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_heating_enable_source
-                    name: Heating enable source
                   - entity: sensor.openquatt_heating_enable_effective_source
                     name: External source in use
                   - entity: binary_sensor.openquatt_heating_enable_selected
@@ -2108,8 +2084,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_cooling_enable_source
-                    name: Cooling enable source
                   - entity: switch.openquatt_manual_cooling_enable
                     name: Manual cooling enable (OpenQuatt)
                   - entity: sensor.openquatt_cooling_enable_effective_source
@@ -2131,14 +2105,14 @@ views:
             cards:
               - type: heading
                 icon: mdi:form-textbox
-                heading: Dynamic source selectors
+                heading: HA source entities
                 heading_style: subtitle
               - type: markdown
                 content: |-
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  Enter the entity IDs for the sources that must feed the OpenQuatt HA proxy sensors.
+                  Enter the HA entity IDs that must feed the OpenQuatt proxy values. This only maps Home Assistant entities into the proxy layer; choose whether OpenQuatt uses HA input in the OpenQuatt web app at `http://openquatt.local`.
 
                   Example values:
                   - `sensor.outdoor_temperature`
@@ -2259,18 +2233,20 @@ views:
             heading_style: title
           - type: markdown
             content: >
-              **Optional HA source selection not active**
+              **Optional HA source mapping not active**
 
 
               `openquatt_ha_dynamic_sources_package.yaml` is not loaded.  
 
-              With this optional package you can choose the Home Assistant source
+              With this optional package you can map the Home Assistant source
               entities for outside, water supply, room, setpoint, and cooling
-              enable at runtime, without reflashing OpenQuatt.
+              enable at runtime, without reflashing OpenQuatt. Configure sensor
+              selection itself in the OpenQuatt web app at
+              `http://openquatt.local`.
 
 
-              After installation, extra configuration blocks for dynamic source
-              selection will appear here.
+              After installation, extra configuration blocks for dynamic HA
+              source mapping will appear here.
 
 
               Installation guide:
@@ -2570,7 +2546,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensor configuration
 
-          Configure source selection and source mapping, then verify per signal the selected value and source status.
+          Review which value OpenQuatt uses per signal and whether the source status looks healthy. Configure sensor selection in the OpenQuatt web app: `http://openquatt.local`.
     top_margin: false
     dense_section_placement: false
   - title: Tuning

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2019,7 +2019,7 @@ views:
         cards:
           - type: heading
             icon: mdi:source-branch
-            heading: Sensorselectie
+            heading: Sensorbronnen
             heading_style: title
           - type: markdown
             content: |-
@@ -2028,28 +2028,22 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              Kies per signaal de bron die OpenQuatt gebruikt.
+              Deze tab toont per signaal de waarde die OpenQuatt gebruikt en de beschikbare ruwe bronnen.
 
-              De `Geselecteerde` waarde hoort de gekozen bron direct te volgen.
+              Sensorselectie wijzig je in de OpenQuatt web-app via `http://openquatt.local`, zodat hardwareprofiel, CIC-status en geldige opties daar samen worden bewaakt.
 
               Zo zie je snel of de effectieve regelinput overeenkomt met wat je verwacht.
 
 
               Gebruik dit blok voor:
 
-              - bronkeuze tijdens tuning
-
               - snelle vergelijking tussen CIC, lokaal en HA input
 
               - validatie van de effectieve regelinput
-              - bij `Flow bron = Outdoor unit` in een Duo-opstelling verschijnt een extra
-                keuze voor `Flowmeter HP1`, `Flowmeter HP2` of de bestaande lokale aggregatie van HP1/HP2
 
-              De lokale aggregatie van `HP1/HP2` is in principe het gemiddelde van beide
+              - diagnose van ontbrekende of afwijkende bronwaarden
 
-              flowmeters.
-
-              Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand. OpenQuatt kiest dan de laagste geldige bron tussen de lokale Duo-aggregatie en de HA-buitentemperatuur, als die bron is geconfigureerd en geldig is. Dat houdt de regeling robuust als een bron tijdelijk te warm uitvalt door zon of lokale opwarming.
+              Voor HA-invoer blijft de HA bronconfiguratie verderop op deze tab staan.
 
 
               </details>
@@ -2068,8 +2062,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_room_temperature_source
-                    name: Ruimtetemperatuur bron
                   - entity: sensor.openquatt_room_temperature_effective_source
                     name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
@@ -2092,8 +2084,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_water_supply_source
-                    name: Aanvoertemperatuur bron
                   - entity: sensor.openquatt_water_supply_temp_selected
                     name: Geselecteerde aanvoertemperatuur
                   - entity: sensor.openquatt_water_supply_temp
@@ -2114,16 +2104,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_flow_source
-                    name: Flow bron
-                  - type: conditional
-                    row:
-                      entity: select.openquatt_outdoor_unit_flow_mode
-                      name: Buitenunit flowmodus
-                    conditions:
-                      - condition: state
-                        entity: select.openquatt_flow_source
-                        state: Outdoor unit
                   - entity: sensor.openquatt_flow_average_selected
                     name: Geselecteerde flow
                   - entity: sensor.openquatt_flow_average_local
@@ -2142,8 +2122,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_outside_temperature_source
-                    name: Buitentemperatuur bron
                   - entity: sensor.openquatt_outside_temperature_selected
                     name: Geselecteerde buitentemperatuur
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
@@ -2162,8 +2140,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_room_setpoint_source
-                    name: Kamer setpoint bron
                   - entity: sensor.openquatt_room_setpoint_effective_source
                     name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
@@ -2186,8 +2162,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_heating_enable_source
-                    name: Warmtetoestemming bron
                   - entity: sensor.openquatt_heating_enable_effective_source
                     name: Gebruikte externe bron
                   - entity: binary_sensor.openquatt_heating_enable_selected
@@ -2214,8 +2188,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_cooling_enable_source
-                    name: Koeltoestemming bron
                   - entity: switch.openquatt_manual_cooling_enable
                     name: Handmatige koeltoestemming (OpenQuatt)
                   - entity: sensor.openquatt_cooling_enable_effective_source
@@ -2231,20 +2203,20 @@ views:
         cards:
           - type: heading
             icon: mdi:home-assistant
-            heading: Home Assistant input configuration
+            heading: Home Assistant bronkoppeling
             heading_style: title
           - type: vertical-stack
             cards:
               - type: heading
                 icon: mdi:form-textbox
-                heading: Dynamische bronselectors
+                heading: HA-bronentities
                 heading_style: subtitle
               - type: markdown
                 content: |-
                   <details>
                   <summary><strong>Uitleg</strong></summary>
 
-                  Vul hier de entity IDs in van de bronnen die de OpenQuatt HA proxy-sensoren moeten voeden.
+                  Vul hier de HA entity IDs in die de OpenQuatt proxywaarden moeten voeden. Dit is alleen de koppeling vanuit Home Assistant; of OpenQuatt een HA-invoer gebruikt kies je in de OpenQuatt web-app via `http://openquatt.local`.
 
                   Voorbeelden:
                   - `sensor.outdoor_temperature`
@@ -2311,11 +2283,11 @@ views:
                   - entity: sensor.openquatt_ext_outdoor_temperature
                     name: Proxy buitentemperatuur
                   - entity: binary_sensor.openquatt_ext_outdoor_temperature_valid
-                    name: Buitentemperatuur bron valid
+                    name: Buitentemperatuurbron geldig
                   - entity: sensor.openquatt_ext_water_supply_temperature
                     name: Proxy aanvoertemperatuur
                   - entity: binary_sensor.openquatt_ext_water_supply_temperature_valid
-                    name: Aanvoertemperatuur bron valid
+                    name: Aanvoertemperatuurbron geldig
                   - entity: sensor.openquatt_ext_room_setpoint
                     name: Proxy kamer setpoint
                   - entity: binary_sensor.openquatt_ext_room_setpoint_valid
@@ -2323,15 +2295,15 @@ views:
                   - entity: sensor.openquatt_ext_room_temperature
                     name: Proxy ruimtetemperatuur
                   - entity: binary_sensor.openquatt_ext_room_temperature_valid
-                    name: Ruimtetemperatuur bron valid
+                    name: Ruimtetemperatuurbron geldig
                   - entity: binary_sensor.openquatt_ext_heating_enable
                     name: Proxy warmtetoestemming
                   - entity: binary_sensor.openquatt_ext_heating_enable_valid
-                    name: Warmtetoestemming bron valid
+                    name: Warmtetoestemmingsbron geldig
                   - entity: binary_sensor.openquatt_ext_cooling_enable
                     name: Proxy koeltoestemming
                   - entity: binary_sensor.openquatt_ext_cooling_enable_valid
-                    name: Koeltoestemming bron valid
+                    name: Koeltoestemmingsbron geldig
           - type: vertical-stack
             cards:
               - type: heading
@@ -2345,7 +2317,7 @@ views:
 
                   Dit zijn de zes HA-invoerwaarden zoals OpenQuatt ze ontvangt. Deze horen de proxywaarden uit het middelste blok te volgen.
 
-                  Blijft een waarde op `Unknown`, controleer dan eerst of de bijbehorende `... bron valid` op `on` staat.
+                  Blijft een waarde op `Unknown`, controleer dan eerst of de bijbehorende `...bron geldig` op `on` staat.
 
                   </details>
                 text_only: true
@@ -2357,7 +2329,7 @@ views:
                   - entity: sensor.openquatt_ha_water_supply_temperature
                     name: HA - Aanvoertemperatuur
                   - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: HA - Thermostat Doeltemperatuur
+                    name: HA - Thermostaat doeltemperatuur
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
                     name: HA - Thermostaat kamertemperatuur
                   - entity: binary_sensor.openquatt_ha_heating_enable
@@ -2373,22 +2345,24 @@ views:
         cards:
           - type: heading
             icon: mdi:home-assistant
-            heading: Home Assistant input configuration
+            heading: Home Assistant bronkoppeling
             heading_style: title
           - type: markdown
             content: >
-              **Optionele HA-bronselectie niet actief**
+              **Optionele HA-bronkoppeling niet actief**
 
 
               `openquatt_ha_dynamic_sources_package.yaml` is niet geladen.  
 
               Met dit optionele package kun je in Home Assistant zelf de
               bron-entities voor buiten-, aanvoer-, kamer-, setpointtemperatuur
-              en koeltoestemming kiezen, zonder OpenQuatt opnieuw te flashen.
+              en koeltoestemming koppelen, zonder OpenQuatt opnieuw te flashen.
+              Sensorselectie zelf doe je daarna in de OpenQuatt web-app via
+              `http://openquatt.local`.
 
 
               Na installatie verschijnen hier extra configuratieblokken voor
-              dynamische bronselectie.
+              dynamische HA-bronkoppeling.
 
 
               Installatiehandleiding:
@@ -2689,9 +2663,7 @@ views:
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensorconfiguratie
 
 
-          Configureer bronkeuze en bronkoppeling, en verifieer daarna per signaal
-
-          de geselecteerde waarde en bronstatus.
+          Bekijk hier per signaal welke waarde OpenQuatt gebruikt en of de bronstatus klopt. Sensorselectie doe je in de OpenQuatt web-app: `http://openquatt.local`.
     top_margin: false
     dense_section_placement: false
   - title: Instellingen

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1587,21 +1587,21 @@ views:
         cards:
           - type: heading
             icon: mdi:source-branch
-            heading: Sensor selection
+            heading: Sensor sources
             heading_style: title
           - type: markdown
             content: |-
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              Select which source OpenQuatt should use per signal. The `Selected` value should directly follow the chosen source. This makes it easy to verify that the effective control input matches your expectation.
+              This tab shows the value OpenQuatt uses per signal and the available raw sources. Configure sensor selection in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
 
               Use this block for:
-              - source selection during tuning
               - quick comparison between CIC, local, and HA Input
               - validation of the effective control input
+              - diagnosis of missing or unexpected source values
 
-              For `Outside temperature source`, `Auto` is the recommended mode. OpenQuatt then picks the lowest valid source between the local outdoor-unit reading and HA outside temperature, when HA is configured and valid. This keeps control robust when one source is temporarily biased warm by sun or local heat.
+              HA input source mapping remains further down on this tab.
 
               </details>
             text_only: true
@@ -1617,8 +1617,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_room_temperature_source
-                    name: Room temperature source
                   - entity: sensor.openquatt_room_temperature_effective_source
                     name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
@@ -1641,8 +1639,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_water_supply_source
-                    name: Water supply temperature source
                   - entity: sensor.openquatt_water_supply_temp_selected
                     name: Selected water supply temperature
                   - entity: sensor.openquatt_water_supply_temp
@@ -1663,8 +1659,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_flow_source
-                    name: Flow source
                   - entity: sensor.openquatt_flow_average_selected
                     name: Selected flow rate
                   - entity: sensor.openquatt_flow_average_local
@@ -1683,8 +1677,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_outside_temperature_source
-                    name: Outside temperature source
                   - entity: sensor.openquatt_outside_temperature_selected
                     name: Selected outside temperature
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
@@ -1703,8 +1695,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_room_setpoint_source
-                    name: Room setpoint source
                   - entity: sensor.openquatt_room_setpoint_effective_source
                     name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
@@ -1727,8 +1717,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_heating_enable_source
-                    name: Heating enable source
                   - entity: sensor.openquatt_heating_enable_effective_source
                     name: External source in use
                   - entity: binary_sensor.openquatt_heating_enable_selected
@@ -1755,8 +1743,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_cooling_enable_source
-                    name: Cooling enable source
                   - entity: switch.openquatt_manual_cooling_enable
                     name: Manual cooling enable (OpenQuatt)
                   - entity: sensor.openquatt_cooling_enable_effective_source
@@ -1778,14 +1764,14 @@ views:
             cards:
               - type: heading
                 icon: mdi:form-textbox
-                heading: Dynamic source selectors
+                heading: HA source entities
                 heading_style: subtitle
               - type: markdown
                 content: |-
                   <details>
                   <summary><strong>Explanation</strong></summary>
 
-                  Enter the entity IDs for the sources that must feed the OpenQuatt HA proxy sensors.
+                  Enter the HA entity IDs that must feed the OpenQuatt proxy values. This only maps Home Assistant entities into the proxy layer; choose whether OpenQuatt uses HA input in the OpenQuatt web app at `http://openquatt.local`.
 
                   Example values:
                   - `sensor.outdoor_temperature`
@@ -1906,18 +1892,20 @@ views:
             heading_style: title
           - type: markdown
             content: >
-              **Optional HA source selection not active**
+              **Optional HA source mapping not active**
 
 
               `openquatt_ha_dynamic_sources_package.yaml` is not loaded.  
 
-              With this optional package you can choose the Home Assistant source
+              With this optional package you can map the Home Assistant source
               entities for outside, water supply, room, setpoint, and cooling
-              enable at runtime, without reflashing OpenQuatt.
+              enable at runtime, without reflashing OpenQuatt. Configure sensor
+              selection itself in the OpenQuatt web app at
+              `http://openquatt.local`.
 
 
-              After installation, extra configuration blocks for dynamic source
-              selection will appear here.
+              After installation, extra configuration blocks for dynamic HA
+              source mapping will appear here.
 
 
               Installation guide:
@@ -2217,7 +2205,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensor configuration
 
-          Configure source selection and source mapping, then verify per signal the selected value and source status.
+          Review which value OpenQuatt uses per signal and whether the source status looks healthy. Configure sensor selection in the OpenQuatt web app: `http://openquatt.local`.
     top_margin: false
     dense_section_placement: false
   - title: Tuning

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1632,21 +1632,21 @@ views:
         cards:
           - type: heading
             icon: mdi:source-branch
-            heading: Sensorselectie
+            heading: Sensorbronnen
             heading_style: title
           - type: markdown
             content: |-
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Kies per signaal de bron die OpenQuatt gebruikt. De `Geselecteerde` waarde hoort de gekozen bron direct te volgen. Zo zie je snel of de effectieve regelinput overeenkomt met wat je verwacht.
+              Deze tab toont per signaal de waarde die OpenQuatt gebruikt en de beschikbare ruwe bronnen. Sensorselectie wijzig je in de OpenQuatt web-app via `http://openquatt.local`, zodat hardwareprofiel, CIC-status en geldige opties daar samen worden bewaakt.
 
               Gebruik dit blok voor:
-              - bronkeuze tijdens tuning
               - snelle vergelijking tussen CIC, lokaal en HA input
               - validatie van de effectieve regelinput
+              - diagnose van ontbrekende of afwijkende bronwaarden
 
-              Voor `Buitentemperatuur bron` is `Auto` de aanbevolen stand. OpenQuatt kiest dan de laagste geldige bron tussen de lokale buitenunitmeting en de HA-buitentemperatuur, als die bron is geconfigureerd en geldig is. Dat houdt de regeling robuust als een bron tijdelijk te warm uitvalt door zon of lokale opwarming.
+              Voor HA-invoer blijft de HA bronconfiguratie verderop op deze tab staan.
 
               </details>
             text_only: true
@@ -1664,8 +1664,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_room_temperature_source
-                    name: Ruimtetemperatuur bron
                   - entity: sensor.openquatt_room_temperature_effective_source
                     name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
@@ -1688,8 +1686,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_water_supply_source
-                    name: Aanvoertemperatuur bron
                   - entity: sensor.openquatt_water_supply_temp_selected
                     name: Geselecteerde aanvoertemperatuur
                   - entity: sensor.openquatt_water_supply_temp
@@ -1710,8 +1706,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_flow_source
-                    name: Flow bron
                   - entity: sensor.openquatt_flow_average_selected
                     name: Geselecteerde flow
                   - entity: sensor.openquatt_flow_average_local
@@ -1730,8 +1724,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_outside_temperature_source
-                    name: Buitentemperatuur bron
                   - entity: sensor.openquatt_outside_temperature_selected
                     name: Geselecteerde buitentemperatuur
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
@@ -1750,8 +1742,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_room_setpoint_source
-                    name: Kamer setpoint bron
                   - entity: sensor.openquatt_room_setpoint_effective_source
                     name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
@@ -1774,8 +1764,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_heating_enable_source
-                    name: Warmtetoestemming bron
                   - entity: sensor.openquatt_heating_enable_effective_source
                     name: Gebruikte externe bron
                   - entity: binary_sensor.openquatt_heating_enable_selected
@@ -1802,8 +1790,6 @@ views:
               - type: entities
                 show_header_toggle: false
                 entities:
-                  - entity: select.openquatt_cooling_enable_source
-                    name: Koeltoestemming bron
                   - entity: switch.openquatt_manual_cooling_enable
                     name: Handmatige koeltoestemming (OpenQuatt)
                   - entity: sensor.openquatt_cooling_enable_effective_source
@@ -1819,20 +1805,20 @@ views:
         cards:
           - type: heading
             icon: mdi:home-assistant
-            heading: Home Assistant input configuration
+            heading: Home Assistant bronkoppeling
             heading_style: title
           - type: vertical-stack
             cards:
               - type: heading
                 icon: mdi:form-textbox
-                heading: Dynamische bronselectors
+                heading: HA-bronentities
                 heading_style: subtitle
               - type: markdown
                 content: |-
                   <details>
                   <summary><strong>Uitleg</strong></summary>
 
-                  Vul hier de entity IDs in van de bronnen die de OpenQuatt HA proxy-sensoren moeten voeden.
+                  Vul hier de HA entity IDs in die de OpenQuatt proxywaarden moeten voeden. Dit is alleen de koppeling vanuit Home Assistant; of OpenQuatt een HA-invoer gebruikt kies je in de OpenQuatt web-app via `http://openquatt.local`.
 
                   Voorbeelden:
                   - `sensor.outdoor_temperature`
@@ -1885,7 +1871,7 @@ views:
 
                   De status `Valid` hoort voor alle zes signalen op `on` te staan.
 
-                  Als `Valid` op `off` staat, is de huidige bron niet ongeldig of niet beschikbaar.
+                  Als `Valid` op `off` staat, is de huidige bron ongeldig of niet beschikbaar.
 
                   Dan wordt de proxywaarde `Unavailable` totdat de bron weer geldig
 
@@ -1899,11 +1885,11 @@ views:
                   - entity: sensor.openquatt_ext_outdoor_temperature
                     name: Proxy buitentemperatuur
                   - entity: binary_sensor.openquatt_ext_outdoor_temperature_valid
-                    name: Buitentemperatuur bron valid
+                    name: Buitentemperatuurbron geldig
                   - entity: sensor.openquatt_ext_water_supply_temperature
                     name: Proxy aanvoertemperatuur
                   - entity: binary_sensor.openquatt_ext_water_supply_temperature_valid
-                    name: Aanvoertemperatuur bron valid
+                    name: Aanvoertemperatuurbron geldig
                   - entity: sensor.openquatt_ext_room_setpoint
                     name: Proxy kamer setpoint
                   - entity: binary_sensor.openquatt_ext_room_setpoint_valid
@@ -1911,15 +1897,15 @@ views:
                   - entity: sensor.openquatt_ext_room_temperature
                     name: Proxy ruimtetemperatuur
                   - entity: binary_sensor.openquatt_ext_room_temperature_valid
-                    name: Ruimtetemperatuur bron valid
+                    name: Ruimtetemperatuurbron geldig
                   - entity: binary_sensor.openquatt_ext_heating_enable
                     name: Proxy warmtetoestemming
                   - entity: binary_sensor.openquatt_ext_heating_enable_valid
-                    name: Warmtetoestemming bron valid
+                    name: Warmtetoestemmingsbron geldig
                   - entity: binary_sensor.openquatt_ext_cooling_enable
                     name: Proxy koeltoestemming
                   - entity: binary_sensor.openquatt_ext_cooling_enable_valid
-                    name: Koeltoestemming bron valid
+                    name: Koeltoestemmingsbron geldig
           - type: vertical-stack
             cards:
               - type: heading
@@ -1933,7 +1919,7 @@ views:
 
                   Dit zijn de zes HA-invoerwaarden zoals OpenQuatt ze ontvangt. Deze horen de proxywaarden uit het middelste blok te volgen.
 
-                  Blijft een waarde op `Unknown`, controleer dan eerst of de bijbehorende `... bron valid` op `on` staat.
+                  Blijft een waarde op `Unknown`, controleer dan eerst of de bijbehorende `...bron geldig` op `on` staat.
 
                   </details>
                 text_only: true
@@ -1945,7 +1931,7 @@ views:
                   - entity: sensor.openquatt_ha_water_supply_temperature
                     name: HA - Aanvoertemperatuur
                   - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: HA - Thermostat Doeltemperatuur
+                    name: HA - Thermostaat doeltemperatuur
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
                     name: HA - Thermostaat kamertemperatuur
                   - entity: binary_sensor.openquatt_ha_heating_enable
@@ -1961,23 +1947,24 @@ views:
         cards:
           - type: heading
             icon: mdi:home-assistant
-            heading: Home Assistant input configuration
+            heading: Home Assistant bronkoppeling
             heading_style: title
           - type: markdown
             content: >
-              **Optionele HA-bronselectie niet actief**
+              **Optionele HA-bronkoppeling niet actief**
 
 
               `openquatt_ha_dynamic_sources_package.yaml` is niet geladen.  
 
               Met dit optionele package kun je in Home Assistant zelf de
               bron-entities voor buiten-, aanvoer-, kamer-,
-              setpointtemperatuur en koeltoestemming kiezen, zonder OpenQuatt
-              opnieuw te flashen.
+              setpointtemperatuur en koeltoestemming koppelen, zonder OpenQuatt
+              opnieuw te flashen. Sensorselectie zelf doe je daarna in de
+              OpenQuatt web-app via `http://openquatt.local`.
 
 
               Na installatie verschijnen hier extra configuratieblokken voor
-              dynamische bronselectie.
+              dynamische HA-bronkoppeling.
 
 
               Installatiehandleiding:
@@ -2278,9 +2265,7 @@ views:
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensorconfiguratie
 
 
-          Configureer bronkeuze en bronkoppeling, en verifieer daarna per signaal
-
-          de geselecteerde waarde en bronstatus.
+          Bekijk hier per signaal welke waarde OpenQuatt gebruikt en of de bronstatus klopt. Sensorselectie doe je in de OpenQuatt web-app: `http://openquatt.local`.
     top_margin: false
     dense_section_placement: false
   - title: Instellingen


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert OpenQuatt source-select controls uit de Home Assistant dashboards; de dashboards tonen voortaan read-only waarden, ruwe bronmetingen en diagnose.
- Verduidelijkt in NL/EN dat sensorselectie in de OpenQuatt web-app via `http://openquatt.local` gebeurt, terwijl HA alleen HA-bronkoppeling/proxywaarden beheert.
- Legt in `AGENTS.md` vast dat toekomstige PR-bodies `.github/pull_request_template.md` moeten volgen.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de gegenereerde HA-dashboardweergave en Codex-instructies wijzigen. De onderliggende ESPHome entities/selects blijven bestaan voor compatibiliteit; OpenQuatt control/runtime-logica is niet aangepast.

## Achtergrond

HA toont ESPHome-selectopties statisch en kan niet dezelfde hardwareprofiel-, CIC- en Q-edition-context toepassen als de OpenQuatt web-app. Daarom verhuist de normale bronkeuze visueel naar de web-app, terwijl HA geschikt blijft voor monitoring, diagnose en optionele HA-bronkoppeling.

## Validatie

- `rtk ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' docs/dashboard/openquatt_ha_dashboard_single_nl.yaml docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml docs/dashboard/openquatt_ha_dashboard_single_en.yaml docs/dashboard/openquatt_ha_dashboard_duo_en.yaml`
- Gerichte `rtk rg`-check dat `select.openquatt_*_source` en `select.openquatt_outdoor_unit_flow_mode` niet meer in de vier dashboardbestanden staan.

Niet visueel in Home Assistant gerenderd.