### PR TITLE
Limit OpenTherm support to Q profile

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1964,8 +1964,13 @@ views:
                     name: Selected room temperature
                   - entity: sensor.openquatt_cic_room_temperature
                     name: Room temperature (CIC)
-                  - entity: sensor.openquatt_ot_room_temperature
-                    name: Room temperature (OT thermostat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: sensor.openquatt_ot_room_temperature
+                      name: Room temperature (OT thermostat)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
                     name: Room temperature (HA Input)
           - type: vertical-stack
@@ -2042,8 +2047,13 @@ views:
                     name: Selected room setpoint
                   - entity: sensor.openquatt_cic_room_setpoint
                     name: Room setpoint (CIC)
-                  - entity: sensor.openquatt_ot_room_setpoint
-                    name: Room setpoint (OT thermostat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: sensor.openquatt_ot_room_setpoint
+                      name: Room setpoint (OT thermostat)
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: Room setpoint (HA Input)
           - type: vertical-stack
@@ -2066,8 +2076,13 @@ views:
                     name: Source selection valid
                   - entity: binary_sensor.openquatt_heating_blocked_by_thermostat
                     name: Heating blocked by thermostat
-                  - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
-                    name: Heating enable (OT thermostat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: binary_sensor.openquatt_ot_thermostat_ch_enable
+                      name: Heating enable (OT thermostat)
                   - entity: binary_sensor.openquatt_cic_ch_enabled
                     name: Heating enable (CIC)
                   - entity: binary_sensor.openquatt_ha_heating_enable
@@ -2468,46 +2483,51 @@ views:
                 entity: input_number.openquatt_cooling_room_count
                 above: 5
         column_span: 3
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:thermostat-box
-            heading: OpenTherm thermostat
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Explanation</strong></summary>
+      - type: conditional
+        conditions:
+          - entity: switch.openquatt_opentherm_enabled
+            state_not: unavailable
+        card:
+          type: grid
+          cards:
+            - type: heading
+              icon: mdi:thermostat-box
+              heading: OpenTherm thermostat
+              heading_style: title
+            - type: markdown
+              content: |-
+                <details>
+                <summary><strong>Explanation</strong></summary>
 
-              This block shows the direct OpenTherm thermostat link. Use it to verify that OpenQuatt sees thermostat heat/cooling intent and room values without going through CIC or Home Assistant.
+                This block shows the direct OpenTherm thermostat link. Use it to verify that OpenQuatt sees thermostat heat/cooling intent and room values without going through CIC or Home Assistant.
 
-              Check these first when OT behavior looks wrong:
-              - `OpenTherm Enabled`
-              - `OT link problem`
-              - `Thermostat CH enable`
-              - `Control setpoint`
-              - `Room setpoint`
-              - `Room temperature`
+                Check these first when OT behavior looks wrong:
+                - `OpenTherm Enabled`
+                - `OT link problem`
+                - `Thermostat CH enable`
+                - `Control setpoint`
+                - `Room setpoint`
+                - `Room temperature`
 
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: switch.openquatt_opentherm_enabled
-                name: OpenTherm Enabled
-              - entity: binary_sensor.openquatt_ot_link_problem
-                name: OT link problem
-              - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
-                name: Thermostat CH enable
-              - entity: binary_sensor.openquatt_ot_thermostat_cooling_enable
-                name: Thermostat cooling enable
-              - entity: sensor.openquatt_ot_control_setpoint
-                name: Control setpoint
-              - entity: sensor.openquatt_ot_room_setpoint
-                name: Room setpoint
-              - entity: sensor.openquatt_ot_room_temperature
-                name: Room temperature
+                </details>
+              text_only: true
+            - type: entities
+              show_header_toggle: false
+              entities:
+                - entity: switch.openquatt_opentherm_enabled
+                  name: OpenTherm Enabled
+                - entity: binary_sensor.openquatt_ot_link_problem
+                  name: OT link problem
+                - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
+                  name: Thermostat CH enable
+                - entity: binary_sensor.openquatt_ot_thermostat_cooling_enable
+                  name: Thermostat cooling enable
+                - entity: sensor.openquatt_ot_control_setpoint
+                  name: Control setpoint
+                - entity: sensor.openquatt_ot_room_setpoint
+                  name: Room setpoint
+                - entity: sensor.openquatt_ot_room_temperature
+                  name: Room temperature
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2068,8 +2068,13 @@ views:
                     name: Geselecteerde kamertemperatuur
                   - entity: sensor.openquatt_cic_room_temperature
                     name: Kamertemperatuur (CIC)
-                  - entity: sensor.openquatt_ot_room_temperature
-                    name: Kamertemperatuur (OT-thermostaat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: sensor.openquatt_ot_room_temperature
+                      name: Kamertemperatuur (OT-thermostaat)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
                     name: Kamertemperatuur (HA-invoer)
           - type: vertical-stack
@@ -2146,8 +2151,13 @@ views:
                     name: Geselecteerd kamer setpoint
                   - entity: sensor.openquatt_cic_room_setpoint
                     name: Kamer setpoint (CIC)
-                  - entity: sensor.openquatt_ot_room_setpoint
-                    name: Kamer setpoint (OT-thermostaat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: sensor.openquatt_ot_room_setpoint
+                      name: Kamer setpoint (OT-thermostaat)
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: Kamer setpoint (HA-invoer)
           - type: vertical-stack
@@ -2170,8 +2180,13 @@ views:
                     name: Bronselectie geldig
                   - entity: binary_sensor.openquatt_heating_blocked_by_thermostat
                     name: Verwarming geblokkeerd door thermostaat
-                  - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
-                    name: Warmtetoestemming (OT-thermostaat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: binary_sensor.openquatt_ot_thermostat_ch_enable
+                      name: Warmtetoestemming (OT-thermostaat)
                   - entity: binary_sensor.openquatt_cic_ch_enabled
                     name: Warmtetoestemming (CIC)
                   - entity: binary_sensor.openquatt_ha_heating_enable
@@ -2584,46 +2599,51 @@ views:
                 entity: input_number.openquatt_cooling_room_count
                 above: 5
         column_span: 3
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:thermostat-box
-            heading: OpenTherm-thermostaat
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Uitleg</strong></summary>
+      - type: conditional
+        conditions:
+          - entity: switch.openquatt_opentherm_enabled
+            state_not: unavailable
+        card:
+          type: grid
+          cards:
+            - type: heading
+              icon: mdi:thermostat-box
+              heading: OpenTherm-thermostaat
+              heading_style: title
+            - type: markdown
+              content: |-
+                <details>
+                <summary><strong>Uitleg</strong></summary>
 
-              Dit blok toont de directe OpenTherm-thermostaatkoppeling. Gebruik het om te controleren dat OpenQuatt warmtevraag, koelvraag en kamerwaarden rechtstreeks van de thermostaat ziet, dus buiten CIC of Home Assistant om.
+                Dit blok toont de directe OpenTherm-thermostaatkoppeling. Gebruik het om te controleren dat OpenQuatt warmtevraag, koelvraag en kamerwaarden rechtstreeks van de thermostaat ziet, dus buiten CIC of Home Assistant om.
 
-              Controleer bij afwijkingen eerst:
-              - `OpenTherm Enabled`
-              - `OT link problem`
-              - `Thermostaat CH enable`
-              - `Control setpoint`
-              - `Room setpoint`
-              - `Room temperature`
+                Controleer bij afwijkingen eerst:
+                - `OpenTherm Enabled`
+                - `OT link problem`
+                - `Thermostaat CH enable`
+                - `Control setpoint`
+                - `Room setpoint`
+                - `Room temperature`
 
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: switch.openquatt_opentherm_enabled
-                name: OpenTherm Enabled
-              - entity: binary_sensor.openquatt_ot_link_problem
-                name: OT link problem
-              - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
-                name: Thermostaat CH enable
-              - entity: binary_sensor.openquatt_ot_thermostat_cooling_enable
-                name: Thermostaat cooling enable
-              - entity: sensor.openquatt_ot_control_setpoint
-                name: Control setpoint
-              - entity: sensor.openquatt_ot_room_setpoint
-                name: Room setpoint
-              - entity: sensor.openquatt_ot_room_temperature
-                name: Room temperature
+                </details>
+              text_only: true
+            - type: entities
+              show_header_toggle: false
+              entities:
+                - entity: switch.openquatt_opentherm_enabled
+                  name: OpenTherm Enabled
+                - entity: binary_sensor.openquatt_ot_link_problem
+                  name: OT link problem
+                - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
+                  name: Thermostaat CH enable
+                - entity: binary_sensor.openquatt_ot_thermostat_cooling_enable
+                  name: Thermostaat cooling enable
+                - entity: sensor.openquatt_ot_control_setpoint
+                  name: Control setpoint
+                - entity: sensor.openquatt_ot_room_setpoint
+                  name: Room setpoint
+                - entity: sensor.openquatt_ot_room_temperature
+                  name: Room temperature
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1623,8 +1623,13 @@ views:
                     name: Selected room temperature
                   - entity: sensor.openquatt_cic_room_temperature
                     name: Room temperature (CIC)
-                  - entity: sensor.openquatt_ot_room_temperature
-                    name: Room temperature (OT thermostat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: sensor.openquatt_ot_room_temperature
+                      name: Room temperature (OT thermostat)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
                     name: Room temperature (HA Input)
           - type: vertical-stack
@@ -1701,8 +1706,13 @@ views:
                     name: Selected room setpoint
                   - entity: sensor.openquatt_cic_room_setpoint
                     name: Room setpoint (CIC)
-                  - entity: sensor.openquatt_ot_room_setpoint
-                    name: Room setpoint (OT thermostat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: sensor.openquatt_ot_room_setpoint
+                      name: Room setpoint (OT thermostat)
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: Room setpoint (HA Input)
           - type: vertical-stack
@@ -1725,8 +1735,13 @@ views:
                     name: Source selection valid
                   - entity: binary_sensor.openquatt_heating_blocked_by_thermostat
                     name: Heating blocked by thermostat
-                  - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
-                    name: Heating enable (OT thermostat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: binary_sensor.openquatt_ot_thermostat_ch_enable
+                      name: Heating enable (OT thermostat)
                   - entity: binary_sensor.openquatt_cic_ch_enabled
                     name: Heating enable (CIC)
                   - entity: binary_sensor.openquatt_ha_heating_enable
@@ -2127,46 +2142,51 @@ views:
                 entity: input_number.openquatt_cooling_room_count
                 above: 5
         column_span: 3
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:thermostat-box
-            heading: OpenTherm thermostat
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Explanation</strong></summary>
+      - type: conditional
+        conditions:
+          - entity: switch.openquatt_opentherm_enabled
+            state_not: unavailable
+        card:
+          type: grid
+          cards:
+            - type: heading
+              icon: mdi:thermostat-box
+              heading: OpenTherm thermostat
+              heading_style: title
+            - type: markdown
+              content: |-
+                <details>
+                <summary><strong>Explanation</strong></summary>
 
-              This block shows the direct OpenTherm thermostat link. Use it to verify that OpenQuatt sees thermostat heat/cooling intent and room values without going through CIC or Home Assistant.
+                This block shows the direct OpenTherm thermostat link. Use it to verify that OpenQuatt sees thermostat heat/cooling intent and room values without going through CIC or Home Assistant.
 
-              Check these first when OT behavior looks wrong:
-              - `OpenTherm Enabled`
-              - `OT link problem`
-              - `Thermostat CH enable`
-              - `Control setpoint`
-              - `Room setpoint`
-              - `Room temperature`
+                Check these first when OT behavior looks wrong:
+                - `OpenTherm Enabled`
+                - `OT link problem`
+                - `Thermostat CH enable`
+                - `Control setpoint`
+                - `Room setpoint`
+                - `Room temperature`
 
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: switch.openquatt_opentherm_enabled
-                name: OpenTherm Enabled
-              - entity: binary_sensor.openquatt_ot_link_problem
-                name: OT link problem
-              - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
-                name: Thermostat CH enable
-              - entity: binary_sensor.openquatt_ot_thermostat_cooling_enable
-                name: Thermostat cooling enable
-              - entity: sensor.openquatt_ot_control_setpoint
-                name: Control setpoint
-              - entity: sensor.openquatt_ot_room_setpoint
-                name: Room setpoint
-              - entity: sensor.openquatt_ot_room_temperature
-                name: Room temperature
+                </details>
+              text_only: true
+            - type: entities
+              show_header_toggle: false
+              entities:
+                - entity: switch.openquatt_opentherm_enabled
+                  name: OpenTherm Enabled
+                - entity: binary_sensor.openquatt_ot_link_problem
+                  name: OT link problem
+                - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
+                  name: Thermostat CH enable
+                - entity: binary_sensor.openquatt_ot_thermostat_cooling_enable
+                  name: Thermostat cooling enable
+                - entity: sensor.openquatt_ot_control_setpoint
+                  name: Control setpoint
+                - entity: sensor.openquatt_ot_room_setpoint
+                  name: Room setpoint
+                - entity: sensor.openquatt_ot_room_temperature
+                  name: Room temperature
       - type: grid
         cards:
           - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1670,8 +1670,13 @@ views:
                     name: Geselecteerde kamertemperatuur
                   - entity: sensor.openquatt_cic_room_temperature
                     name: Kamertemperatuur (CIC)
-                  - entity: sensor.openquatt_ot_room_temperature
-                    name: Kamertemperatuur (OT-thermostaat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: sensor.openquatt_ot_room_temperature
+                      name: Kamertemperatuur (OT-thermostaat)
                   - entity: sensor.openquatt_ha_thermostat_room_temperature
                     name: Kamertemperatuur (HA-invoer)
           - type: vertical-stack
@@ -1748,8 +1753,13 @@ views:
                     name: Geselecteerd kamer setpoint
                   - entity: sensor.openquatt_cic_room_setpoint
                     name: Kamer setpoint (CIC)
-                  - entity: sensor.openquatt_ot_room_setpoint
-                    name: Kamer setpoint (OT-thermostaat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: sensor.openquatt_ot_room_setpoint
+                      name: Kamer setpoint (OT-thermostaat)
                   - entity: sensor.openquatt_ha_thermostat_setpoint
                     name: Kamer setpoint (HA-invoer)
           - type: vertical-stack
@@ -1772,8 +1782,13 @@ views:
                     name: Bronselectie geldig
                   - entity: binary_sensor.openquatt_heating_blocked_by_thermostat
                     name: Verwarming geblokkeerd door thermostaat
-                  - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
-                    name: Warmtetoestemming (OT-thermostaat)
+                  - type: conditional
+                    conditions:
+                      - entity: switch.openquatt_opentherm_enabled
+                        state_not: unavailable
+                    row:
+                      entity: binary_sensor.openquatt_ot_thermostat_ch_enable
+                      name: Warmtetoestemming (OT-thermostaat)
                   - entity: binary_sensor.openquatt_cic_ch_enabled
                     name: Warmtetoestemming (CIC)
                   - entity: binary_sensor.openquatt_ha_heating_enable
@@ -2186,46 +2201,51 @@ views:
                 entity: input_number.openquatt_cooling_room_count
                 above: 5
         column_span: 3
-      - type: grid
-        cards:
-          - type: heading
-            icon: mdi:thermostat-box
-            heading: OpenTherm-thermostaat
-            heading_style: title
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Uitleg</strong></summary>
+      - type: conditional
+        conditions:
+          - entity: switch.openquatt_opentherm_enabled
+            state_not: unavailable
+        card:
+          type: grid
+          cards:
+            - type: heading
+              icon: mdi:thermostat-box
+              heading: OpenTherm-thermostaat
+              heading_style: title
+            - type: markdown
+              content: |-
+                <details>
+                <summary><strong>Uitleg</strong></summary>
 
-              Dit blok toont de directe OpenTherm-thermostaatkoppeling. Gebruik het om te controleren dat OpenQuatt warmtevraag, koelvraag en kamerwaarden rechtstreeks van de thermostaat ziet, dus buiten CIC of Home Assistant om.
+                Dit blok toont de directe OpenTherm-thermostaatkoppeling. Gebruik het om te controleren dat OpenQuatt warmtevraag, koelvraag en kamerwaarden rechtstreeks van de thermostaat ziet, dus buiten CIC of Home Assistant om.
 
-              Controleer bij afwijkingen eerst:
-              - `OpenTherm Enabled`
-              - `OT link problem`
-              - `Thermostaat CH enable`
-              - `Control setpoint`
-              - `Room setpoint`
-              - `Room temperature`
+                Controleer bij afwijkingen eerst:
+                - `OpenTherm Enabled`
+                - `OT link problem`
+                - `Thermostaat CH enable`
+                - `Control setpoint`
+                - `Room setpoint`
+                - `Room temperature`
 
-              </details>
-            text_only: true
-          - type: entities
-            show_header_toggle: false
-            entities:
-              - entity: switch.openquatt_opentherm_enabled
-                name: OpenTherm Enabled
-              - entity: binary_sensor.openquatt_ot_link_problem
-                name: OT link problem
-              - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
-                name: Thermostaat CH enable
-              - entity: binary_sensor.openquatt_ot_thermostat_cooling_enable
-                name: Thermostaat cooling enable
-              - entity: sensor.openquatt_ot_control_setpoint
-                name: Control setpoint
-              - entity: sensor.openquatt_ot_room_setpoint
-                name: Room setpoint
-              - entity: sensor.openquatt_ot_room_temperature
-                name: Room temperature
+                </details>
+              text_only: true
+            - type: entities
+              show_header_toggle: false
+              entities:
+                - entity: switch.openquatt_opentherm_enabled
+                  name: OpenTherm Enabled
+                - entity: binary_sensor.openquatt_ot_link_problem
+                  name: OT link problem
+                - entity: binary_sensor.openquatt_ot_thermostat_ch_enable
+                  name: Thermostaat CH enable
+                - entity: binary_sensor.openquatt_ot_thermostat_cooling_enable
+                  name: Thermostaat cooling enable
+                - entity: sensor.openquatt_ot_control_setpoint
+                  name: Control setpoint
+                - entity: sensor.openquatt_ot_room_setpoint
+                  name: Room setpoint
+                - entity: sensor.openquatt_ot_room_temperature
+                  name: Room temperature
       - type: grid
         cards:
           - type: heading

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -58,12 +58,11 @@ Package include order is intentional:
 16. `oq_ha_inputs`
 17. `oq_local_sensors`
 18. `oq_sensor_sources`
-19. `oq_ot_slave`
-20. `oq_webserver`
-21. `oq_HP_io` (HP1 always; HP2 only on Duo)
+19. `oq_webserver`
+20. `oq_HP_io` (HP1 always; HP2 only on Duo)
 
 This order mirrors data dependencies and ownership boundaries.
-`oq_ot_slave` uses the ESP-IDF RMT-based OpenTherm runtime and is only intended for RMT-capable ESP32 targets.
+Hardware profiles add the matching room/setpoint/heating-enable source selectors. The Heatpump Controller Q profile also includes `oq_ot_slave`; it uses the ESP-IDF RMT-based OpenTherm runtime and is only supported on the Q profile.
 
 ## 2. Ownership Model
 
@@ -282,6 +281,7 @@ Hardware profile substitutions are split into dedicated files:
 Shared non-hardware constants are in `openquatt/oq_substitutions_common.yaml`.
 
 Compile-time profile selection is done by choosing a matrix entrypoint from `build_targets.yaml`. Ethernet targets are enabled for the Heatpump Controller Q as separate Ethernet-only builds.
+OpenTherm thermostat support is part of the Heatpump Controller Q profile only. Waveshare and Heatpump Listener builds expose CIC, Home Assistant, and MQTT source paths instead.
 
 ### 9.1 Memory and flash expectations
 

--- a/openquatt/oq_sensor_source_selects_no_opentherm.yaml
+++ b/openquatt/oq_sensor_source_selects_no_opentherm.yaml
@@ -1,0 +1,80 @@
+# ==============================================================================
+# OpenQuatt - Sensor Source Selects: No OpenTherm
+# ==============================================================================
+#
+# Scope:
+#   Source selectors for hardware profiles without a supported OT thermostat bus.
+# ==============================================================================
+
+select:
+  - platform: template
+    name: "Room Temperature Source"
+    id: room_temp_source
+    icon: mdi:source-branch
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - CIC
+      - HA input
+      - MQTT
+    initial_option: CIC
+    web_server:
+      sorting_group_id: oq_sensor_selection
+
+  - platform: template
+    name: "Room Setpoint Source"
+    id: room_setpoint_source
+    icon: mdi:source-branch
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - CIC
+      - HA input
+      - MQTT
+    initial_option: CIC
+    web_server:
+      sorting_group_id: oq_sensor_selection
+
+  - platform: template
+    name: "Heating Enable Source"
+    id: heating_enable_source
+    icon: mdi:source-branch
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - Disabled
+      - CIC
+      - HA input
+      - MQTT
+    initial_option: Disabled
+    web_server:
+      sorting_group_id: oq_sensor_selection
+
+binary_sensor:
+  - platform: template
+    id: ot_thermostat_status_valid
+    internal: true
+    lambda: |-
+      return false;
+
+  - platform: template
+    id: ot_thermostat_ch_enable
+    internal: true
+    lambda: |-
+      return false;
+
+sensor:
+  - platform: template
+    id: ot_thermostat_room_temp
+    internal: true
+    lambda: |-
+      return NAN;
+
+  - platform: template
+    id: ot_thermostat_room_setpoint
+    internal: true
+    lambda: |-
+      return NAN;

--- a/openquatt/oq_sensor_source_selects_opentherm.yaml
+++ b/openquatt/oq_sensor_source_selects_opentherm.yaml
@@ -1,0 +1,58 @@
+# ==============================================================================
+# OpenQuatt - Sensor Source Selects: OpenTherm-capable
+# ==============================================================================
+#
+# Scope:
+#   Source selectors that expose the direct OpenTherm thermostat path.
+#   Include only on hardware profiles that actually provide the OT slave bridge.
+# ==============================================================================
+
+select:
+  - platform: template
+    name: "Room Temperature Source"
+    id: room_temp_source
+    icon: mdi:source-branch
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - CIC
+      - OT thermostat
+      - HA input
+      - MQTT
+    initial_option: OT thermostat
+    web_server:
+      sorting_group_id: oq_sensor_selection
+
+  - platform: template
+    name: "Room Setpoint Source"
+    id: room_setpoint_source
+    icon: mdi:source-branch
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - CIC
+      - OT thermostat
+      - HA input
+      - MQTT
+    initial_option: OT thermostat
+    web_server:
+      sorting_group_id: oq_sensor_selection
+
+  - platform: template
+    name: "Heating Enable Source"
+    id: heating_enable_source
+    icon: mdi:source-branch
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - Disabled
+      - OT thermostat
+      - CIC
+      - HA input
+      - MQTT
+    initial_option: Disabled
+    web_server:
+      sorting_group_id: oq_sensor_selection

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -130,38 +130,6 @@ select:
       sorting_group_id: oq_sensor_selection
 
   - platform: template
-    name: "Room Temperature Source"
-    id: room_temp_source
-    icon: mdi:source-branch
-    entity_category: config
-    optimistic: true
-    restore_value: true
-    options:
-      - CIC
-      - OT thermostat
-      - HA input
-      - MQTT
-    initial_option: OT thermostat
-    web_server:
-      sorting_group_id: oq_sensor_selection
-
-  - platform: template
-    name: "Room Setpoint Source"
-    id: room_setpoint_source
-    icon: mdi:source-branch
-    entity_category: config
-    optimistic: true
-    restore_value: true
-    options:
-      - CIC
-      - OT thermostat
-      - HA input
-      - MQTT
-    initial_option: OT thermostat
-    web_server:
-      sorting_group_id: oq_sensor_selection
-
-  - platform: template
     name: "Cooling Enable Source"
     id: cooling_enable_source
     icon: mdi:source-branch
@@ -174,23 +142,6 @@ select:
       - MQTT
       - CIC or HA input
     initial_option: CIC or HA input
-    web_server:
-      sorting_group_id: oq_sensor_selection
-
-  - platform: template
-    name: "Heating Enable Source"
-    id: heating_enable_source
-    icon: mdi:source-branch
-    entity_category: config
-    optimistic: true
-    restore_value: true
-    options:
-      - Disabled
-      - OT thermostat
-      - CIC
-      - HA input
-      - MQTT
-    initial_option: Disabled
     web_server:
       sorting_group_id: oq_sensor_selection
 
@@ -215,7 +166,9 @@ binary_sensor:
       if (!id(heating_enable_source).has_state()) return false;
       const auto source = id(heating_enable_source).current_option();
       if (source == "Disabled") return true;
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
       if (source == "OT thermostat") return id(ot_thermostat_status_valid).has_state() && id(ot_thermostat_status_valid).state;
+      #endif
       if (source == "CIC") {
         return id(feed_ok).has_state() && id(feed_ok).state &&
                id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
@@ -238,7 +191,9 @@ binary_sensor:
       const auto source = id(heating_enable_source).current_option();
       if (source == "Disabled") return true;
       if (!id(heating_enable_valid).state) return false;
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
       if (source == "OT thermostat") return id(ot_thermostat_ch_enable).state;
+      #endif
       if (source == "CIC") return id(cic_ch_enabled).state;
       if (source == "HA input") return id(heating_enable_ha).state;
       if (source == "MQTT") return id(mqtt_heating_enable).state;
@@ -568,9 +523,11 @@ sensor:
       if (source == "HA input") {
         if (id(room_temp_valid_ha).state && id(thermostat_room_temp_ha).has_state()) selected_c = id(thermostat_room_temp_ha).state;
       }
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
       if (source == "OT thermostat") {
         if (id(ot_thermostat_room_temp).has_state()) selected_c = id(ot_thermostat_room_temp).state;
       }
+      #endif
       if (source == "CIC") {
         if (id(cic_room_temp).has_state()) selected_c = id(cic_room_temp).state;
       }
@@ -624,9 +581,11 @@ sensor:
       if (source == "HA input") {
         if (id(room_setpoint_valid_ha).state && id(thermostat_setpoint_ha).has_state()) selected_c = id(thermostat_setpoint_ha).state;
       }
+      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
       if (source == "OT thermostat") {
         if (id(ot_thermostat_room_setpoint).has_state()) selected_c = id(ot_thermostat_room_setpoint).state;
       }
+      #endif
       if (source == "CIC") {
         if (id(cic_room_setpoint).has_state()) selected_c = id(cic_room_setpoint).state;
       }

--- a/openquatt/packages/50_integrations.yaml
+++ b/openquatt/packages/50_integrations.yaml
@@ -19,7 +19,3 @@ packages:
     file: ../oq_sensor_sources.yaml
     vars:
       sensor_sources_duo_flow_internal: "${sensor_sources_duo_flow_internal}"
-  oq_ot_slave: !include
-    file: ../oq_ot_slave.yaml
-    vars:
-      ot_secondary_present: "${ot_secondary_present}"

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -38,6 +38,11 @@ substitutions:
 
 packages:
   oq_cic_compatibility: !include heatpump_controller_q_cic_compatibility.yaml
+  oq_sensor_source_selects_opentherm: !include ../oq_sensor_source_selects_opentherm.yaml
+  oq_ot_slave: !include
+    file: ../oq_ot_slave.yaml
+    vars:
+      ot_secondary_present: "${ot_secondary_present}"
 
 psram:
   mode: octal

--- a/openquatt/profiles/heatpump_listener.yaml
+++ b/openquatt/profiles/heatpump_listener.yaml
@@ -10,14 +10,15 @@ substitutions:
   uart_tx_pin: "GPIO33"                                 # Active RS485 TX pin.
   uart_rx_pin: "GPIO32"                                 # Active RS485 RX pin.
   uart_rts_pin: "GPIO21"                                # Active RS485 DE/RE (flow control) pin.
-  oq_ot_thermostat_in_pin: "GPIO25"                     # Reserved OT thermostat RX pin placeholder for future wiring.
-  oq_ot_thermostat_out_pin: "GPIO26"                    # Reserved OT thermostat TX pin placeholder for future wiring.
   listener_temp_t1_pin: "GPIO4"                         # Optional external temperature sensor input T1.
   listener_temp_t2_pin: "GPIO5"                         # Optional external temperature sensor input T2.
   ds18b20_pin: "GPIO27"                                 # Active DS18B20 1-Wire pin.
   oq_boiler_relay_pin: "GPIO22"                         # Active boiler relay output pin.
   listener_aux_relay_pin: "GPIO23"                      # Optional auxiliary relay output.
   web_auth_recovery_pin: "GPIO0"                        # Temporary recovery input, wired to a spare button/jumper for setup.
+
+packages:
+  oq_sensor_source_selects_no_opentherm: !include ../oq_sensor_source_selects_no_opentherm.yaml
 
 psram:
   ignore_not_found: false

--- a/openquatt/profiles/waveshare.yaml
+++ b/openquatt/profiles/waveshare.yaml
@@ -10,11 +10,12 @@ substitutions:
   uart_tx_pin: "GPIO17"                                 # Active RS485 TX pin.
   uart_rx_pin: "GPIO18"                                 # Active RS485 RX pin.
   uart_rts_pin: "GPIO21"                                # Active RS485 DE/RE (flow control) pin.
-  oq_ot_thermostat_in_pin: "GPIO14"                     # OpenTherm thermostat input on header pin GPIO14.
-  oq_ot_thermostat_out_pin: "GPIO13"                    # OpenTherm thermostat output on header pin GPIO13.
   ds18b20_pin: "GPIO2"                                  # Active DS18B20 1-Wire pin.
   oq_boiler_relay_pin: "GPIO47"                         # Active boiler relay output pin.
   web_auth_recovery_pin: "GPIO0"                        # Temporary recovery input, wired to a spare button/jumper for setup.
+
+packages:
+  oq_sensor_source_selects_no_opentherm: !include ../oq_sensor_source_selects_no_opentherm.yaml
 
 psram:
   mode: octal

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -232,7 +232,6 @@ NESTED_KEY_ORDER_RULES = {
         "oq_mqtt_ingress",
         "oq_local_sensors",
         "oq_sensor_sources",
-        "oq_ot_slave",
     ),
     ("openquatt/packages/60_ui_runtime.yaml", "packages"): (
         "oq_setup_status",
@@ -245,6 +244,8 @@ NESTED_KEY_ORDER_RULES = {
     ),
     ("openquatt/profiles/heatpump_controller_q.yaml", "packages"): (
         "oq_cic_compatibility",
+        "oq_sensor_source_selects_opentherm",
+        "oq_ot_slave",
     ),
 }
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst OpenTherm support uit de algemene integratiebundle naar het Heatpump Controller Q-profiel.
- Geeft Waveshare en Heatpump Listener bronselecties zonder `OT thermostat`, met interne fallback-id's zodat gedeelde sensorlogica compileerbaar blijft.
- Maakt de OpenTherm-rijen en -kaart in de HA dashboards conditioneel op `switch.openquatt_opentherm_enabled`.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [x] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

OpenTherm-entiteiten worden niet meer exposed op Waveshare en Heatpump Listener builds. Q-edition behoudt de OpenTherm slave bridge en de `OT thermostat` bronopties. Non-Q dashboards verbergen OpenTherm-informatie wanneer de enable switch ontbreekt.

## Achtergrond

Waveshare en Heatpump Listener hadden wel OpenTherm-entiteiten in de firmware, maar geen ondersteund OT-pad. Daardoor konden gebruikers een niet-werkende OT-bron selecteren en toonde het HA dashboard OpenTherm-kaarten op profielen zonder support.

## Validatie

- `rtk npm run build:web`
- `rtk python3 scripts/check_style_consistency.py`
- `rtk python3 scripts/check_docs_consistency.py`
- `rtk python3 scripts/dev.py validate --config-only --config configs/waveshare/single_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/waveshare/duo_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_listener/single_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_listener/duo_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `rtk git diff --check`