### PR TITLE
Simplify cooling capacity limiter

### DIFF
--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -1,0 +1,343 @@
+#pragma once
+
+#include <algorithm>
+#include <math.h>
+#include <stdint.h>
+
+namespace oq_cooling {
+
+enum ReasonCode {
+  REASON_INACTIVE = 0,
+  REASON_FULL = 1,
+  REASON_PROJECTED_FLOOR = 2,
+  REASON_SIMMER = 3,
+  REASON_FALLING_GAP = 4,
+  REASON_BUFFER_STOP = 5,
+  REASON_DEW_STOP = 6,
+  REASON_FALLBACK_FLOOR = 7,
+  REASON_RESTART_WAIT = 8,
+  REASON_ROOM_CAP = 9,
+  REASON_FALLBACK_CAP1 = 10,
+  REASON_LEVEL1_HOLD = 11,
+  REASON_OIL_RETURN_HOLD = 12,
+  REASON_OIL_RETURN_RECOVERY = 13,
+  REASON_CAPACITY_CAP = 14,
+};
+
+struct LimiterTuning {
+  float hard_dew_stop_base_gap_c = 0.15f;
+  float hard_dew_stop_margin_gain_c = 0.30f;
+  float hard_dew_restart_hyst_c = 0.20f;
+  float projection_horizon_min = 3.0f;
+  float projected_floor_brake_gap_c = 0.25f;
+  float projected_floor_release_gap_c = 0.45f;
+  float projected_floor_fast_fall_rate_c_per_min = 0.20f;
+  float projected_floor_fast_fall_brake_gain = 1.0f;
+  float projected_floor_fast_fall_brake_max_c = 0.15f;
+  float simmer_enable_gap_c = -0.20f;
+  float simmer_disable_gap_c = -0.30f;
+  float buffer_hard_stop_gap_c = -0.70f;
+  float limiter_soft_stop_gap_c = -0.10f;
+  float fallback_full_gap_c = 1.00f;
+  float fallback_cap1_gap_c = 0.30f;
+  float fallback_stop_gap_c = 0.00f;
+  uint32_t limiter_stop_confirm_ms = 30000UL;
+  uint32_t capacity_min_hold_ms = 180000UL;
+  uint32_t capacity_recovery_stable_ms = 120000UL;
+  float capacity_fast_fall_rate_c_per_min = -0.15f;
+  float capacity_slow_fall_rate_c_per_min = -0.05f;
+  float capacity_recovery_min_rate_c_per_min = -0.02f;
+  float hp_out_cap1_gap_c = 0.25f;
+  float hp_out_cap2_gap_c = 0.55f;
+  float hp_out_cap3_gap_c = 0.85f;
+  float hp_out_release_to2_gap_c = 0.65f;
+  float hp_out_release_to3_gap_c = 0.85f;
+  float hp_out_release_full_gap_c = 1.05f;
+};
+
+struct LimiterState {
+  bool simmer_allowed = false;
+  bool projection_brake_active = false;
+  uint32_t stop_candidate_since_ms = 0;
+  uint32_t dew_stop_candidate_since_ms = 0;
+  int capacity_cap = 10;
+  uint32_t capacity_last_change_ms = 0;
+  uint32_t capacity_recovery_since_ms = 0;
+};
+
+struct LimiterInput {
+  uint32_t now_ms = 0;
+  int demand_max = 1;
+  int capacity_demand_max = 1;
+  int previous_limited_demand = 0;
+  bool room_cap_active = false;
+  bool dew_mode = false;
+  bool fallback_mode = false;
+  bool oil_return_mask_active = false;
+  bool oil_return_recovery_cap_active = false;
+  float buffer_gap_c = NAN;
+  float filtered_gap_c = NAN;
+  float gap_rate_c_per_min = 0.0f;
+  float dew_gap_c = NAN;
+  float active_hp_out_gap_c = NAN;
+  float safety_margin_c = 0.0f;
+};
+
+struct LimiterOutput {
+  int allowed_max = 0;
+  int reason_code = REASON_INACTIVE;
+  float projected_gap_c = NAN;
+  bool reset_gap_rate_reference = false;
+  bool clamp_integral_to_zero = false;
+};
+
+inline const char *reason_name(int reason) {
+  static const char *const names[] = {
+      "inactive", "full", "projected_floor", "simmer", "falling_gap",
+      "buffer_stop", "dew_stop", "fallback_floor", "restart_wait", "room_cap",
+      "fallback_cap1", "level1_hold", "oil_return_hold", "oil_return_recovery",
+      "capacity_cap"};
+  return reason >= 0 && reason < (int)(sizeof(names) / sizeof(names[0])) ? names[reason] : names[0];
+}
+
+inline int clamp_level(int value, int min_value, int max_value) {
+  return std::max(min_value, std::min(max_value, value));
+}
+
+inline bool finite_float(float value) {
+  return !isnan(value);
+}
+
+inline bool elapsed(uint32_t now_ms, uint32_t since_ms, uint32_t duration_ms) {
+  return since_ms > 0 && now_ms > since_ms && (uint32_t)(now_ms - since_ms) >= duration_ms;
+}
+
+inline void apply_cap(int cap, int reason, int &allowed_cap, int &reason_code) {
+  cap = std::max(0, cap);
+  if (cap < allowed_cap ||
+      (cap == allowed_cap && reason != REASON_FULL &&
+       (reason_code == REASON_FULL || reason_code == REASON_ROOM_CAP))) {
+    allowed_cap = cap;
+    reason_code = reason;
+  }
+}
+
+inline int dew_capacity_risk_cap(const LimiterInput &in,
+                                 const LimiterTuning &tuning,
+                                 float hard_dew_restart_gap_c) {
+  int risk_cap = std::max(1, in.capacity_demand_max);
+  if (!in.dew_mode || !finite_float(in.dew_gap_c)) return risk_cap;
+
+  const float dew_cap1_gap_c = fmaxf(0.70f, hard_dew_restart_gap_c + 0.10f);
+  const float dew_cap2_gap_c = fmaxf(0.95f, hard_dew_restart_gap_c + 0.30f);
+  const float dew_cap3_gap_c = fmaxf(1.20f, hard_dew_restart_gap_c + 0.55f);
+
+  if (in.dew_gap_c <= dew_cap1_gap_c) risk_cap = std::min(risk_cap, 1);
+  else if (in.dew_gap_c <= dew_cap2_gap_c) risk_cap = std::min(risk_cap, 2);
+  else if (in.dew_gap_c <= dew_cap3_gap_c) risk_cap = std::min(risk_cap, 3);
+
+  if (in.gap_rate_c_per_min <= tuning.capacity_fast_fall_rate_c_per_min) {
+    if (in.dew_gap_c <= dew_cap2_gap_c) risk_cap = std::min(risk_cap, 1);
+    else if (in.dew_gap_c <= dew_cap3_gap_c) risk_cap = std::min(risk_cap, 2);
+  } else if (in.gap_rate_c_per_min <= tuning.capacity_slow_fall_rate_c_per_min &&
+             in.dew_gap_c <= dew_cap2_gap_c) {
+    risk_cap = std::min(risk_cap, 2);
+  }
+
+  if (finite_float(in.active_hp_out_gap_c)) {
+    if (in.active_hp_out_gap_c <= tuning.hp_out_cap1_gap_c) {
+      risk_cap = std::min(risk_cap, 1);
+    } else if (in.active_hp_out_gap_c <= tuning.hp_out_cap2_gap_c) {
+      risk_cap = std::min(risk_cap, 2);
+    } else if (in.active_hp_out_gap_c <= tuning.hp_out_cap3_gap_c) {
+      risk_cap = std::min(risk_cap, 3);
+    }
+  }
+  return risk_cap;
+}
+
+inline void update_hysteretic_capacity_cap(const LimiterInput &in,
+                                           const LimiterTuning &tuning,
+                                           float hard_dew_restart_gap_c,
+                                           LimiterState &state,
+                                           LimiterOutput &out) {
+  if (in.oil_return_mask_active) {
+    state.capacity_recovery_since_ms = 0;
+    return;
+  }
+
+  const int capacity_demand_max = std::max(1, in.capacity_demand_max);
+  if (!in.dew_mode || !finite_float(in.dew_gap_c)) {
+    state.capacity_cap = capacity_demand_max;
+    state.capacity_last_change_ms = 0;
+    state.capacity_recovery_since_ms = 0;
+    return;
+  }
+
+  const int risk_cap = dew_capacity_risk_cap(in, tuning, hard_dew_restart_gap_c);
+  int current_cap = state.capacity_cap;
+  if (current_cap < 1 || current_cap > capacity_demand_max) current_cap = capacity_demand_max;
+
+  if (risk_cap < current_cap) {
+    current_cap = risk_cap;
+    state.capacity_last_change_ms = in.now_ms;
+    state.capacity_recovery_since_ms = 0;
+    out.clamp_integral_to_zero = true;
+  } else if (risk_cap > current_cap && current_cap < capacity_demand_max) {
+    const float dew_release_to2_gap_c = fmaxf(1.05f, hard_dew_restart_gap_c + 0.45f);
+    const float dew_release_to3_gap_c = fmaxf(1.25f, hard_dew_restart_gap_c + 0.65f);
+    const float dew_release_full_gap_c = fmaxf(1.50f, hard_dew_restart_gap_c + 0.90f);
+    const float required_dew_gap_c =
+        current_cap <= 1 ? dew_release_to2_gap_c :
+        current_cap == 2 ? dew_release_to3_gap_c :
+        dew_release_full_gap_c;
+    const float required_hp_out_gap_c =
+        current_cap <= 1 ? tuning.hp_out_release_to2_gap_c :
+        current_cap == 2 ? tuning.hp_out_release_to3_gap_c :
+        tuning.hp_out_release_full_gap_c;
+    const bool hp_out_recovered =
+        !finite_float(in.active_hp_out_gap_c) || in.active_hp_out_gap_c >= required_hp_out_gap_c;
+    const bool recovery_ready =
+        in.dew_gap_c >= required_dew_gap_c &&
+        in.gap_rate_c_per_min >= tuning.capacity_recovery_min_rate_c_per_min &&
+        hp_out_recovered;
+
+    if (recovery_ready) {
+      if (state.capacity_recovery_since_ms == 0 || in.now_ms <= state.capacity_recovery_since_ms) {
+        state.capacity_recovery_since_ms = in.now_ms;
+      }
+      const bool hold_elapsed =
+          state.capacity_last_change_ms == 0 ||
+          in.now_ms <= state.capacity_last_change_ms ||
+          (uint32_t)(in.now_ms - state.capacity_last_change_ms) >= tuning.capacity_min_hold_ms;
+      if (hold_elapsed && elapsed(in.now_ms, state.capacity_recovery_since_ms,
+                                  tuning.capacity_recovery_stable_ms)) {
+        current_cap = std::min(capacity_demand_max, std::min(risk_cap, current_cap + 1));
+        state.capacity_last_change_ms = in.now_ms;
+        state.capacity_recovery_since_ms = 0;
+      }
+    } else {
+      state.capacity_recovery_since_ms = 0;
+    }
+  } else if (current_cap >= capacity_demand_max) {
+    state.capacity_recovery_since_ms = 0;
+  }
+
+  state.capacity_cap = current_cap;
+  if (current_cap < in.demand_max) {
+    apply_cap(current_cap, REASON_CAPACITY_CAP, out.allowed_max, out.reason_code);
+  }
+}
+
+inline LimiterOutput update_limiter(const LimiterInput &in,
+                                    const LimiterTuning &tuning,
+                                    LimiterState &state) {
+  LimiterOutput out;
+  out.allowed_max = std::max(0, in.demand_max);
+  out.reason_code = in.room_cap_active ? REASON_ROOM_CAP : REASON_FULL;
+  const float hard_dew_stop_gap_c =
+      tuning.hard_dew_stop_base_gap_c + (tuning.hard_dew_stop_margin_gain_c * in.safety_margin_c);
+  const float hard_dew_restart_gap_c = hard_dew_stop_gap_c + tuning.hard_dew_restart_hyst_c;
+  out.projected_gap_c = in.filtered_gap_c + (in.gap_rate_c_per_min * tuning.projection_horizon_min);
+
+  float projected_floor_dynamic_brake_gap_c = tuning.projected_floor_brake_gap_c;
+  if (in.gap_rate_c_per_min < -tuning.projected_floor_fast_fall_rate_c_per_min) {
+    const float fast_fall_extra_c =
+        ((-in.gap_rate_c_per_min) - tuning.projected_floor_fast_fall_rate_c_per_min) *
+        tuning.projected_floor_fast_fall_brake_gain;
+    projected_floor_dynamic_brake_gap_c +=
+        fminf(tuning.projected_floor_fast_fall_brake_max_c, fmaxf(0.0f, fast_fall_extra_c));
+  }
+  if (in.gap_rate_c_per_min >= 0.0f || out.projected_gap_c >= tuning.projected_floor_release_gap_c) {
+    state.projection_brake_active = false;
+  } else if (out.projected_gap_c <= projected_floor_dynamic_brake_gap_c) {
+    state.projection_brake_active = true;
+  }
+
+  if (in.filtered_gap_c > tuning.simmer_enable_gap_c) state.simmer_allowed = true;
+  else if (in.filtered_gap_c < tuning.simmer_disable_gap_c) state.simmer_allowed = false;
+
+  const bool dew_hard_stop_candidate =
+      !in.oil_return_mask_active &&
+      in.dew_mode && finite_float(in.dew_gap_c) && in.dew_gap_c <= hard_dew_stop_gap_c;
+  bool dew_hard_stop = false;
+  if (dew_hard_stop_candidate) {
+    if (state.dew_stop_candidate_since_ms == 0 || in.now_ms <= state.dew_stop_candidate_since_ms) {
+      state.dew_stop_candidate_since_ms = in.now_ms;
+    }
+    dew_hard_stop = elapsed(in.now_ms, state.dew_stop_candidate_since_ms, tuning.limiter_stop_confirm_ms);
+  } else {
+    state.dew_stop_candidate_since_ms = 0;
+  }
+
+  if (in.fallback_mode) {
+    if (in.filtered_gap_c <= tuning.fallback_stop_gap_c) {
+      apply_cap(0, REASON_FALLBACK_FLOOR, out.allowed_max, out.reason_code);
+    } else if (in.filtered_gap_c <= tuning.fallback_full_gap_c) {
+      apply_cap(1, REASON_FALLBACK_CAP1, out.allowed_max, out.reason_code);
+    }
+  } else {
+    const bool dew_gap_allows_simmer =
+        !in.dew_mode || !finite_float(in.dew_gap_c) || in.dew_gap_c > hard_dew_restart_gap_c;
+    if (dew_hard_stop) {
+      apply_cap(0, REASON_DEW_STOP, out.allowed_max, out.reason_code);
+    } else if (in.filtered_gap_c < tuning.buffer_hard_stop_gap_c ||
+               in.filtered_gap_c <= tuning.limiter_soft_stop_gap_c) {
+      apply_cap(0, REASON_BUFFER_STOP, out.allowed_max, out.reason_code);
+    } else if (in.filtered_gap_c <= 0.0f) {
+      apply_cap((dew_gap_allows_simmer && state.simmer_allowed) ? 1 : 0,
+                (dew_gap_allows_simmer && state.simmer_allowed) ? REASON_SIMMER : REASON_BUFFER_STOP,
+                out.allowed_max, out.reason_code);
+    }
+  }
+
+  const bool projection_caution_active =
+      !state.projection_brake_active &&
+      in.gap_rate_c_per_min < 0.0f &&
+      out.projected_gap_c <= tuning.projected_floor_release_gap_c;
+  if ((state.projection_brake_active || projection_caution_active) && out.allowed_max > 0) {
+    if (in.previous_limited_demand > 1) out.reset_gap_rate_reference = true;
+    apply_cap(1, REASON_PROJECTED_FLOOR, out.allowed_max, out.reason_code);
+  }
+
+  update_hysteretic_capacity_cap(in, tuning, hard_dew_restart_gap_c, state, out);
+
+  if (in.oil_return_mask_active) {
+    out.allowed_max = std::min(out.allowed_max, 1);
+    if (out.allowed_max <= 0) {
+      out.allowed_max = 1;
+      state.stop_candidate_since_ms = 0;
+    }
+    out.reason_code = REASON_OIL_RETURN_HOLD;
+  } else if (in.oil_return_recovery_cap_active && out.allowed_max > 0) {
+    out.allowed_max = std::min(out.allowed_max, 1);
+    out.reason_code = REASON_OIL_RETURN_RECOVERY;
+  }
+
+  const bool immediate_stop =
+      out.reason_code == REASON_DEW_STOP || out.reason_code == REASON_FALLBACK_FLOOR;
+  if (!immediate_stop && out.allowed_max <= 0) {
+    if (in.buffer_gap_c > 0.0f) {
+      out.allowed_max = 1;
+      out.reason_code = REASON_LEVEL1_HOLD;
+      state.stop_candidate_since_ms = 0;
+    } else if (in.filtered_gap_c > tuning.limiter_soft_stop_gap_c) {
+      if (state.stop_candidate_since_ms == 0 || in.now_ms <= state.stop_candidate_since_ms) {
+        state.stop_candidate_since_ms = in.now_ms;
+      }
+      if (!elapsed(in.now_ms, state.stop_candidate_since_ms, tuning.limiter_stop_confirm_ms)) {
+        out.allowed_max = 1;
+        out.reason_code = REASON_LEVEL1_HOLD;
+      }
+    } else {
+      state.stop_candidate_since_ms = 0;
+    }
+  } else {
+    state.stop_candidate_since_ms = 0;
+  }
+
+  out.allowed_max = std::max(0, out.allowed_max);
+  return out;
+}
+
+}  // namespace oq_cooling

--- a/openquatt/includes/control/oq_cooling_safety_logic.h
+++ b/openquatt/includes/control/oq_cooling_safety_logic.h
@@ -1,0 +1,270 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+#include <string>
+
+namespace oq_cooling_safety {
+
+class CoolingSafetyRuntime {
+ public:
+  bool without_dew_point_enabled() {
+    return id(cooling_without_dew_point_mode).has_state() &&
+           option_allows_fallback(id(cooling_without_dew_point_mode).current_option());
+  }
+  bool without_dew_point_user_responsibility_enabled() {
+    return id(cooling_without_dew_point_mode).has_state() &&
+           id(cooling_without_dew_point_mode).current_option() ==
+               "Allow without dew point, user responsibility";
+  }
+  bool fallback_active() {
+    return !dew_selected_valid() && id(cooling_without_dew_point_enabled).state && fallback_min_valid();
+  }
+  bool permitted_core() {
+    const bool dew_ok = id(cooling_dew_point_available).state && dew_selected_valid() &&
+                        id(minimum_safe_supply_temp).has_state() &&
+                        finite(id(minimum_safe_supply_temp).state);
+    const bool fallback_ok = id(cooling_without_dew_point_enabled).state && fallback_min_valid();
+    const bool user_ok = id(cooling_without_dew_point_user_responsibility_enabled).state &&
+                         id(cooling_min_supply_temp).has_state() &&
+                         finite(id(cooling_min_supply_temp).state);
+    return id(cooling_without_dew_point_user_responsibility_enabled).state
+        ? user_ok
+        : (dew_ok || fallback_ok || user_ok);
+  }
+  bool request_active() {
+    if (!id(cooling_room_request_required).state) {
+      id(oq_cooling_request_latched) = false;
+      return id(cooling_enable_selected).has_state() && id(cooling_enable_selected).state;
+    }
+    if (!room_valid() || !setpoint_valid()) {
+      id(oq_cooling_request_latched) = false;
+      return false;
+    }
+    float on_delta_c = id(cooling_request_on_delta).state;
+    float off_delta_c = id(cooling_request_off_delta).state;
+    if (!finite(on_delta_c) || on_delta_c < 0.0f) on_delta_c = 0.4f;
+    if (!finite(off_delta_c) || off_delta_c < 0.0f) off_delta_c = 0.1f;
+    if (off_delta_c > on_delta_c) off_delta_c = on_delta_c;
+    const float room_c = id(room_temp_selected).state;
+    const float setpoint_c = id(room_setpoint_selected).state;
+    if (!id(oq_cooling_request_latched) && room_c > (setpoint_c + on_delta_c)) {
+      id(oq_cooling_request_latched) = true;
+    } else if (id(oq_cooling_request_latched) && room_c < (setpoint_c + off_delta_c)) {
+      id(oq_cooling_request_latched) = false;
+    }
+    return id(oq_cooling_request_latched);
+  }
+  bool permitted(float min_flow_lph) {
+    return id(cooling_permitted_core).has_state() && id(cooling_permitted_core).state &&
+           flow_valid() && id(flow_rate_selected).state >= min_flow_lph &&
+           !id(oq_lowflow_fault_active);
+  }
+  const char *guard_mode() {
+    if (id(cooling_without_dew_point_user_responsibility_enabled).state) return "User responsibility";
+    if (id(cooling_dew_point_available).state) {
+      if (id(cooling_dew_point_source).has_state()) {
+        if (id(cooling_dew_point_source).current_option() == "MQTT") return "Dew point (MQTT)";
+        if (id(cooling_dew_point_source).current_option() == "Home Assistant") return "Dew point (HA)";
+      }
+      return "Dew point";
+    }
+    if (!id(cooling_without_dew_point_enabled).state) return "Blocked";
+    return fallback_min_valid() ? "Fallback" : "Fallback blocked";
+  }
+  const char *block_reason(float min_flow_lph) {
+    if (!id(cooling_enable_selected).has_state() || !id(cooling_enable_selected).state) {
+      return "Cooling disabled";
+    }
+    if (!id(oq_enabled).state) return "OpenQuatt paused";
+    if (id(cooling_without_dew_point_user_responsibility_enabled).state &&
+        (!id(cooling_min_supply_temp).has_state() || !finite(id(cooling_min_supply_temp).state))) {
+      return "Cooling minimum unavailable";
+    }
+    if (!id(cooling_dew_point_available).state &&
+        !id(cooling_without_dew_point_user_responsibility_enabled).state) {
+      return fallback_block_reason();
+    }
+    if (!id(cooling_permitted_core).has_state() || !id(cooling_permitted_core).state) {
+      return "Safe supply floor unavailable";
+    }
+    if (!id(cooling_request_active).has_state() || !id(cooling_request_active).state) {
+      return "Cooling enabled, waiting for room temperature above cooling setpoint";
+    }
+    if (!flow_valid()) return "Flow unavailable";
+    if (id(oq_lowflow_fault_active) || id(flow_rate_selected).state < min_flow_lph) return "Flow too low";
+    return "Ready";
+  }
+  float safety_margin_selected() {
+    return clamp_float(id(cooling_safety_margin).state, 0.0f, 4.0f);
+  }
+  float selected_dew_point(uint32_t now_ms, uint32_t hold_ms) {
+    const int source_mode_code = dew_source_mode_code();
+    const bool ha_ok = ha_dew_valid();
+    const bool mqtt_ok = mqtt_dew_valid();
+    float selected_c = NAN;
+    int selected_route_code = 0;
+    if ((source_mode_code == 2 || source_mode_code == 3) && mqtt_ok) {
+      selected_c = id(mqtt_cooling_dew_point).state;
+      selected_route_code = 2;
+    }
+    if ((source_mode_code == 1 && ha_ok) ||
+        (source_mode_code == 3 && ha_ok && (!finite(selected_c) || id(cooling_dew_point_ha).state > selected_c))) {
+      selected_c = id(cooling_dew_point_ha).state;
+      selected_route_code = 1;
+    }
+    if (finite(selected_c)) {
+      id(oq_cooling_dew_point_selected_last_valid_c) = selected_c;
+      id(oq_cooling_dew_point_selected_last_valid_ms) = now_ms;
+      id(oq_cooling_dew_point_selected_last_mode_code) = source_mode_code;
+      id(oq_cooling_dew_point_selected_last_route_code) = selected_route_code;
+      id(oq_cooling_dew_point_selected_hold_active) = false;
+      return selected_c;
+    }
+    id(oq_cooling_dew_point_selected_hold_active) = false;
+    if (hold_ms > 0 &&
+        id(oq_cooling_dew_point_selected_last_route_code) != 2 &&
+        id(oq_cooling_dew_point_selected_last_valid_ms) > 0 &&
+        id(oq_cooling_dew_point_selected_last_mode_code) == source_mode_code &&
+        (uint32_t)(now_ms - id(oq_cooling_dew_point_selected_last_valid_ms)) < hold_ms &&
+        finite(id(oq_cooling_dew_point_selected_last_valid_c))) {
+      id(oq_cooling_dew_point_selected_hold_active) = true;
+      return id(oq_cooling_dew_point_selected_last_valid_c);
+    }
+    return NAN;
+  }
+  float minimum_safe_supply() {
+    return dew_selected_valid() && id(cooling_safety_margin_selected).has_state() &&
+                   finite(id(cooling_safety_margin_selected).state)
+               ? id(cooling_dew_point_selected).state + id(cooling_safety_margin_selected).state
+               : NAN;
+  }
+  float fallback_night_min_outdoor_temp() {
+    if (!id(oq_time).now().is_valid()) return NAN;
+    const auto now = id(oq_time).now();
+    if (now.hour < 6 &&
+        id(oq_cooling_fallback_night_window_day_key) >= 0 &&
+        finite(id(oq_cooling_fallback_night_min_current_c))) {
+      return id(oq_cooling_fallback_night_min_current_c);
+    }
+    return finite(id(oq_cooling_fallback_night_min_last_c))
+        ? id(oq_cooling_fallback_night_min_last_c)
+        : NAN;
+  }
+  float fallback_min_supply_temp() {
+    if (!outside_valid() || id(outside_temp_selected).state < 20.0f) return NAN;
+    const float outside_c = id(outside_temp_selected).state;
+    float fallback_floor_c = clamp_float(19.0f + ((outside_c - 20.0f) * 0.25f), 19.0f, 22.0f);
+    if (fallback_night_min_valid()) {
+      const float night_min_c = id(cooling_fallback_night_min_outdoor_temp).state;
+      if (night_min_c >= 20.0f) fallback_floor_c += 1.5f;
+      else if (night_min_c >= 19.0f) fallback_floor_c += 1.0f;
+      else if (night_min_c >= 18.0f) fallback_floor_c += 0.5f;
+    }
+    if (room_valid()) {
+      const float room_usability_floor_c = id(room_temp_selected).state - 1.0f;
+      if (room_usability_floor_c >= 20.0f) fallback_floor_c = fminf(fallback_floor_c, room_usability_floor_c);
+    }
+    return fallback_floor_c;
+  }
+  float effective_min_supply_temp() {
+    if (id(cooling_without_dew_point_user_responsibility_enabled).state &&
+        id(cooling_min_supply_temp).has_state() &&
+        finite(id(cooling_min_supply_temp).state)) {
+      return id(cooling_min_supply_temp).state;
+    }
+    if (id(minimum_safe_supply_temp).has_state() && finite(id(minimum_safe_supply_temp).state)) {
+      return id(minimum_safe_supply_temp).state;
+    }
+    return id(cooling_fallback_active).state && fallback_min_valid()
+        ? id(cooling_fallback_min_supply_temp).state
+        : NAN;
+  }
+  void update_fallback_night_min() {
+    if (!id(oq_time).now().is_valid() || !outside_valid()) return;
+    const auto now = id(oq_time).now();
+    const int day_key = (now.year * 10000) + (now.month * 100) + now.day_of_month;
+    if (now.hour < 6) {
+      if (id(oq_cooling_fallback_night_window_day_key) != day_key ||
+          !finite(id(oq_cooling_fallback_night_min_current_c))) {
+        id(oq_cooling_fallback_night_window_day_key) = day_key;
+        id(oq_cooling_fallback_night_min_current_c) = id(outside_temp_selected).state;
+      } else {
+        id(oq_cooling_fallback_night_min_current_c) =
+            fminf(id(oq_cooling_fallback_night_min_current_c), id(outside_temp_selected).state);
+      }
+      return;
+    }
+    if (id(oq_cooling_fallback_night_window_day_key) >= 0 &&
+        id(oq_cooling_fallback_night_window_day_key) != id(oq_cooling_fallback_night_min_last_day_key) &&
+        finite(id(oq_cooling_fallback_night_min_current_c))) {
+      id(oq_cooling_fallback_night_min_last_c) = id(oq_cooling_fallback_night_min_current_c);
+      id(oq_cooling_fallback_night_min_last_day_key) = id(oq_cooling_fallback_night_window_day_key);
+    }
+  }
+ private:
+  bool finite(float value) const { return !isnan(value); }
+  float clamp_float(float value, float min_value, float max_value) const {
+    if (value < min_value) return min_value;
+    return value > max_value ? max_value : value;
+  }
+  bool option_allows_fallback(const std::string &option) const {
+    return option == "Allow without dew point, use dew point approximation" ||
+           option == "Allow without dew point, use fallback" ||
+           option == "Allow without dew point";
+  }
+  int dew_source_mode_code() const {
+    if (!id(cooling_dew_point_source).has_state()) return 3;
+    const auto source = id(cooling_dew_point_source).current_option();
+    return source == "MQTT" ? 2 : (source == "Home Assistant" ? 1 : 3);
+  }
+  const char *fallback_block_reason() {
+    if (!id(cooling_without_dew_point_enabled).state) return "No dew point source";
+    if (!outside_valid()) return "Fallback outside temperature unavailable";
+    if (id(outside_temp_selected).state < 20.0f) return "Fallback blocked below 20\xC2\xB0" "C outdoor";
+    if (!fallback_min_valid()) return "Fallback minimum unavailable";
+    if (fallback_night_min_valid() && id(cooling_fallback_night_min_outdoor_temp).state >= 18.0f) {
+      if (id(cooling_fallback_night_min_outdoor_temp).state >= 20.0f) {
+        return "Fallback active (+1.5\xC2\xB0" "C tropical night)";
+      }
+      if (id(cooling_fallback_night_min_outdoor_temp).state >= 19.0f) {
+        return "Fallback active (+1.0\xC2\xB0" "C very warm night)";
+      }
+      return "Fallback active (+0.5\xC2\xB0" "C warm night)";
+    }
+    return "Fallback active";
+  }
+  bool dew_selected_valid() const {
+    return id(cooling_dew_point_selected).has_state() && finite(id(cooling_dew_point_selected).state);
+  }
+  bool fallback_min_valid() const {
+    return id(cooling_fallback_min_supply_temp).has_state() && finite(id(cooling_fallback_min_supply_temp).state);
+  }
+  bool fallback_night_min_valid() const {
+    return id(cooling_fallback_night_min_outdoor_temp).has_state() &&
+           finite(id(cooling_fallback_night_min_outdoor_temp).state);
+  }
+  bool outside_valid() const {
+    return id(outside_temp_selected).has_state() && finite(id(outside_temp_selected).state);
+  }
+  bool room_valid() const {
+    return id(room_temp_selected).has_state() && finite(id(room_temp_selected).state);
+  }
+  bool setpoint_valid() const {
+    return id(room_setpoint_selected).has_state() && finite(id(room_setpoint_selected).state);
+  }
+  bool flow_valid() const {
+    return id(flow_rate_selected).has_state() && finite(id(flow_rate_selected).state);
+  }
+  bool ha_dew_valid() const {
+    return id(cooling_dew_point_valid_ha).has_state() && id(cooling_dew_point_valid_ha).state &&
+           id(cooling_dew_point_ha).has_state() && finite(id(cooling_dew_point_ha).state);
+  }
+  bool mqtt_dew_valid() const {
+    return id(mqtt_cooling_dew_point_valid).has_state() && id(mqtt_cooling_dew_point_valid).state &&
+           id(mqtt_cooling_dew_point).has_state() && finite(id(mqtt_cooling_dew_point).state);
+  }
+};
+inline CoolingSafetyRuntime &runtime() { static CoolingSafetyRuntime instance; return instance; }
+
+}  // namespace oq_cooling_safety

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -156,18 +156,14 @@ binary_sensor:
     name: "Cooling Without Dew Point Enabled"
     internal: true
     lambda: |-
-      return id(cooling_without_dew_point_mode).has_state() &&
-             (id(cooling_without_dew_point_mode).current_option() == "Allow without dew point, use dew point approximation" ||
-              id(cooling_without_dew_point_mode).current_option() == "Allow without dew point, use fallback" ||
-              id(cooling_without_dew_point_mode).current_option() == "Allow without dew point");
+      return oq_cooling_safety::runtime().without_dew_point_enabled();
 
   - platform: template
     id: cooling_without_dew_point_user_responsibility_enabled
     name: "Cooling Without Dew Point User Responsibility Enabled"
     internal: true
     lambda: |-
-      return id(cooling_without_dew_point_mode).has_state() &&
-             id(cooling_without_dew_point_mode).current_option() == "Allow without dew point, user responsibility";
+      return oq_cooling_safety::runtime().without_dew_point_user_responsibility_enabled();
 
   - platform: template
     id: cooling_fallback_active
@@ -176,13 +172,7 @@ binary_sensor:
     icon: mdi:water-alert
     device_class: running
     lambda: |-
-      const bool dew_point_configured =
-          id(cooling_dew_point_selected).has_state() && !isnan(id(cooling_dew_point_selected).state);
-      const bool fallback_floor_ok =
-          id(cooling_fallback_min_supply_temp).has_state() && !isnan(id(cooling_fallback_min_supply_temp).state);
-      return !dew_point_configured &&
-             id(cooling_without_dew_point_enabled).state &&
-             fallback_floor_ok;
+      return oq_cooling_safety::runtime().fallback_active();
     web_server:
       sorting_group_id: oq_cooling
 
@@ -192,20 +182,7 @@ binary_sensor:
     internal: true
     lambda: |-
       // Core cooling preconditions that are independent from the live flow interlock.
-      const bool dew_point_ok =
-          id(cooling_dew_point_available).state &&
-          id(cooling_dew_point_selected).has_state() && !isnan(id(cooling_dew_point_selected).state) &&
-          id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state);
-      const bool fallback_ok =
-          id(cooling_without_dew_point_enabled).state &&
-          id(cooling_fallback_min_supply_temp).has_state() && !isnan(id(cooling_fallback_min_supply_temp).state);
-      const bool user_responsibility_ok =
-          id(cooling_without_dew_point_user_responsibility_enabled).state &&
-          id(cooling_min_supply_temp).has_state() && !isnan(id(cooling_min_supply_temp).state);
-      if (id(cooling_without_dew_point_user_responsibility_enabled).state) {
-        return user_responsibility_ok;
-      }
-      return dew_point_ok || fallback_ok || user_responsibility_ok;
+      return oq_cooling_safety::runtime().permitted_core();
 
   - platform: template
     id: cooling_request_active
@@ -213,35 +190,7 @@ binary_sensor:
     icon: mdi:snowflake-thermometer
     device_class: running
     lambda: |-
-      if (!id(cooling_room_request_required).state) {
-        id(oq_cooling_request_latched) = false;
-        return id(cooling_enable_selected).has_state() && id(cooling_enable_selected).state;
-      }
-
-      // Apply simple room-temperature hysteresis so CM5 does not chatter around setpoint.
-      if (!id(room_temp_selected).has_state() || isnan(id(room_temp_selected).state)) {
-        id(oq_cooling_request_latched) = false;
-        return false;
-      }
-      if (!id(room_setpoint_selected).has_state() || isnan(id(room_setpoint_selected).state)) {
-        id(oq_cooling_request_latched) = false;
-        return false;
-      }
-
-      float on_delta_c = id(cooling_request_on_delta).state;
-      float off_delta_c = id(cooling_request_off_delta).state;
-      if (isnan(on_delta_c) || on_delta_c < 0.0f) on_delta_c = 0.4f;
-      if (isnan(off_delta_c) || off_delta_c < 0.0f) off_delta_c = 0.1f;
-      if (off_delta_c > on_delta_c) off_delta_c = on_delta_c;
-
-      const float room_c = id(room_temp_selected).state;
-      const float setpoint_c = id(room_setpoint_selected).state;
-      if (!id(oq_cooling_request_latched) && room_c > (setpoint_c + on_delta_c)) {
-        id(oq_cooling_request_latched) = true;
-      } else if (id(oq_cooling_request_latched) && room_c < (setpoint_c + off_delta_c)) {
-        id(oq_cooling_request_latched) = false;
-      }
-      return id(oq_cooling_request_latched);
+      return oq_cooling_safety::runtime().request_active();
     web_server:
       sorting_group_id: oq_cooling
 
@@ -252,11 +201,7 @@ binary_sensor:
     device_class: running
     lambda: |-
       // User-facing permission includes both the core cooling prerequisites and the live flow guard.
-      const bool core_ok =
-          id(cooling_permitted_core).has_state() && id(cooling_permitted_core).state;
-      const bool flow_valid = id(flow_rate_selected).has_state() && !isnan(id(flow_rate_selected).state);
-      const bool flow_ok = flow_valid && (id(flow_rate_selected).state >= (float) ${oq_cm_min_flow_lph});
-      return core_ok && flow_ok && !id(oq_lowflow_fault_active);
+      return oq_cooling_safety::runtime().permitted((float) ${oq_cm_min_flow_lph});
     web_server:
       sorting_group_id: oq_cooling
 
@@ -279,24 +224,7 @@ text_sensor:
     update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       // Summarize which cooling safety route is currently active.
-      if (id(cooling_without_dew_point_user_responsibility_enabled).state) {
-        return {"User responsibility"};
-      }
-      if (id(cooling_dew_point_available).state) {
-        if (id(cooling_dew_point_source).has_state()) {
-          if (id(cooling_dew_point_source).current_option() == "MQTT") return {"Dew point (MQTT)"};
-          if (id(cooling_dew_point_source).current_option() == "Home Assistant") return {"Dew point (HA)"};
-        }
-        return {"Dew point"};
-      }
-      if (!id(cooling_without_dew_point_enabled).state) {
-        return {"Blocked"};
-      }
-      if (id(cooling_fallback_min_supply_temp).has_state() &&
-          !isnan(id(cooling_fallback_min_supply_temp).state)) {
-        return {"Fallback"};
-      }
-      return {"Fallback blocked"};
+      return {oq_cooling_safety::runtime().guard_mode()};
     web_server:
       sorting_group_id: oq_cooling
 
@@ -308,56 +236,7 @@ text_sensor:
     update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       // Report the first blocking condition in operator-friendly terms.
-      if (!id(cooling_enable_selected).has_state() || !id(cooling_enable_selected).state) {
-        return {"Cooling disabled"};
-      }
-      if (!id(oq_enabled).state) {
-        return {"OpenQuatt paused"};
-      }
-      if (id(cooling_without_dew_point_user_responsibility_enabled).state &&
-          (!id(cooling_min_supply_temp).has_state() || isnan(id(cooling_min_supply_temp).state))) {
-        return {"Cooling minimum unavailable"};
-      }
-      if (!id(cooling_dew_point_available).state &&
-          !id(cooling_without_dew_point_user_responsibility_enabled).state) {
-        if (!id(cooling_without_dew_point_enabled).state) {
-          return {"No dew point source"};
-        }
-        if (!id(outside_temp_selected).has_state() || isnan(id(outside_temp_selected).state)) {
-          return {"Fallback outside temperature unavailable"};
-        }
-        if (id(outside_temp_selected).state < 20.0f) {
-          return {"Fallback blocked below 20°C outdoor"};
-        }
-        if (!id(cooling_fallback_min_supply_temp).has_state() || isnan(id(cooling_fallback_min_supply_temp).state)) {
-          return {"Fallback minimum unavailable"};
-        }
-        if (id(cooling_fallback_night_min_outdoor_temp).has_state() &&
-            !isnan(id(cooling_fallback_night_min_outdoor_temp).state) &&
-            id(cooling_fallback_night_min_outdoor_temp).state >= 18.0f) {
-          if (id(cooling_fallback_night_min_outdoor_temp).state >= 19.0f) {
-            if (id(cooling_fallback_night_min_outdoor_temp).state >= 20.0f) {
-              return {"Fallback active (+1.5°C tropical night)"};
-            }
-            return {"Fallback active (+1.0°C very warm night)"};
-          }
-          return {"Fallback active (+0.5°C warm night)"};
-        }
-        return {"Fallback active"};
-      }
-      if (!id(cooling_permitted_core).has_state() || !id(cooling_permitted_core).state) {
-        return {"Safe supply floor unavailable"};
-      }
-      if (!id(cooling_request_active).has_state() || !id(cooling_request_active).state) {
-        return {"Cooling enabled, waiting for room temperature above cooling setpoint"};
-      }
-      if (!id(flow_rate_selected).has_state() || isnan(id(flow_rate_selected).state)) {
-        return {"Flow unavailable"};
-      }
-      if (id(oq_lowflow_fault_active) || id(flow_rate_selected).state < (float) ${oq_cm_min_flow_lph}) {
-        return {"Flow too low"};
-      }
-      return {"Ready"};
+      return {oq_cooling_safety::runtime().block_reason((float) ${oq_cm_min_flow_lph})};
     web_server:
       sorting_group_id: oq_cooling
 
@@ -370,10 +249,7 @@ sensor:
     accuracy_decimals: 1
     update_interval: 10s
     lambda: |-
-      float margin_c = id(cooling_safety_margin).state;
-      if (margin_c < 0.0f) margin_c = 0.0f;
-      if (margin_c > 4.0f) margin_c = 4.0f;
-      return margin_c;
+      return oq_cooling_safety::runtime().safety_margin_selected();
     web_server:
       sorting_group_id: oq_cooling
 
@@ -390,77 +266,7 @@ sensor:
       // Hold the last valid selected aggregate briefly through source reload gaps.
       const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
       const uint32_t now_ms = (uint32_t) millis();
-      std::string source = "Auto";
-      if (id(cooling_dew_point_source).has_state()) {
-        source = id(cooling_dew_point_source).current_option();
-      }
-      const int source_mode_code = source == "MQTT" ? 2 : (source == "Home Assistant" ? 1 : 3);
-
-      const bool ha_valid =
-          id(cooling_dew_point_valid_ha).has_state() && id(cooling_dew_point_valid_ha).state &&
-          id(cooling_dew_point_ha).has_state() && !isnan(id(cooling_dew_point_ha).state);
-      const bool mqtt_valid =
-          id(mqtt_cooling_dew_point_valid).has_state() && id(mqtt_cooling_dew_point_valid).state &&
-          id(mqtt_cooling_dew_point).has_state() && !isnan(id(mqtt_cooling_dew_point).state);
-
-      bool selected_valid = false;
-      float selected_c = NAN;
-      int selected_route_code = 0;
-      if (source == "MQTT") {
-        if (mqtt_valid) {
-          selected_valid = true;
-          selected_c = id(mqtt_cooling_dew_point).state;
-          selected_route_code = 2;
-        }
-      } else if (source == "Home Assistant") {
-        if (ha_valid) {
-          selected_valid = true;
-          selected_c = id(cooling_dew_point_ha).state;
-          selected_route_code = 1;
-        }
-      } else {
-        if (ha_valid && mqtt_valid) {
-          selected_valid = true;
-          if (id(cooling_dew_point_ha).state > id(mqtt_cooling_dew_point).state) {
-            selected_c = id(cooling_dew_point_ha).state;
-            selected_route_code = 1;
-          } else {
-            selected_c = id(mqtt_cooling_dew_point).state;
-            selected_route_code = 2;
-          }
-        } else if (ha_valid) {
-          selected_valid = true;
-          selected_c = id(cooling_dew_point_ha).state;
-          selected_route_code = 1;
-        } else if (mqtt_valid) {
-          selected_valid = true;
-          selected_c = id(mqtt_cooling_dew_point).state;
-          selected_route_code = 2;
-        }
-      }
-
-      if (selected_valid && !isnan(selected_c)) {
-        id(oq_cooling_dew_point_selected_last_valid_c) = selected_c;
-        id(oq_cooling_dew_point_selected_last_valid_ms) = now_ms;
-        id(oq_cooling_dew_point_selected_last_mode_code) = source_mode_code;
-        id(oq_cooling_dew_point_selected_last_route_code) = selected_route_code;
-        id(oq_cooling_dew_point_selected_hold_active) = false;
-        return selected_c;
-      }
-
-      id(oq_cooling_dew_point_selected_hold_active) = false;
-      const bool selected_hold_allowed = id(oq_cooling_dew_point_selected_last_route_code) != 2;
-      if (hold_ms > 0 &&
-          selected_hold_allowed &&
-          id(oq_cooling_dew_point_selected_last_valid_ms) > 0 &&
-          id(oq_cooling_dew_point_selected_last_mode_code) == source_mode_code &&
-          (uint32_t)(now_ms - id(oq_cooling_dew_point_selected_last_valid_ms)) < hold_ms &&
-          !isnan(id(oq_cooling_dew_point_selected_last_valid_c))) {
-        id(oq_cooling_dew_point_selected_hold_active) = true;
-        return id(oq_cooling_dew_point_selected_last_valid_c);
-      }
-
-      return NAN;
+      return oq_cooling_safety::runtime().selected_dew_point(now_ms, hold_ms);
     filters:
       # Smooth short dew-point spikes and dips symmetrically before they move
       # the safe supply floor. Keep this responsive: the user safety margin
@@ -483,9 +289,7 @@ sensor:
     update_interval: 10s
     lambda: |-
       // This is the central cooling guardrail: never target water below dew point + margin.
-      if (!id(cooling_dew_point_selected).has_state() || isnan(id(cooling_dew_point_selected).state)) return NAN;
-      if (!id(cooling_safety_margin_selected).has_state() || isnan(id(cooling_safety_margin_selected).state)) return NAN;
-      return id(cooling_dew_point_selected).state + id(cooling_safety_margin_selected).state;
+      return oq_cooling_safety::runtime().minimum_safe_supply();
     web_server:
       sorting_group_id: oq_cooling
 
@@ -501,17 +305,7 @@ sensor:
     accuracy_decimals: 1
     update_interval: 60s
     lambda: |-
-      if (!id(oq_time).now().is_valid()) return NAN;
-      const auto now = id(oq_time).now();
-      if (now.hour < 6 &&
-          id(oq_cooling_fallback_night_window_day_key) >= 0 &&
-          !isnan(id(oq_cooling_fallback_night_min_current_c))) {
-        return id(oq_cooling_fallback_night_min_current_c);
-      }
-      if (!isnan(id(oq_cooling_fallback_night_min_last_c))) {
-        return id(oq_cooling_fallback_night_min_last_c);
-      }
-      return NAN;
+      return oq_cooling_safety::runtime().fallback_night_min_outdoor_temp();
     web_server:
       sorting_group_id: oq_cooling
 
@@ -528,39 +322,7 @@ sensor:
     update_interval: 10s
     lambda: |-
       // Conservative fallback floor for systems without a dew-point source.
-      if (!id(outside_temp_selected).has_state() || isnan(id(outside_temp_selected).state)) return NAN;
-      const float outside_c = id(outside_temp_selected).state;
-      if (outside_c < 20.0f) return NAN;
-
-      // Smooth equivalent of the old 20/24/28/32°C step table:
-      // 19°C at 20°C outdoor, rising linearly to 22°C at 32°C outdoor.
-      float base_floor_c = 19.0f + ((outside_c - 20.0f) * 0.25f);
-      if (base_floor_c < 19.0f) base_floor_c = 19.0f;
-      if (base_floor_c > 22.0f) base_floor_c = 22.0f;
-
-      float correction_c = 0.0f;
-      if (id(cooling_fallback_night_min_outdoor_temp).has_state() &&
-          !isnan(id(cooling_fallback_night_min_outdoor_temp).state)) {
-        const float night_min_c = id(cooling_fallback_night_min_outdoor_temp).state;
-        if (night_min_c >= 20.0f) correction_c = 1.5f;
-        else if (night_min_c >= 19.0f) correction_c = 1.0f;
-        else if (night_min_c >= 18.0f) correction_c = 0.5f;
-      }
-
-      float fallback_floor_c = base_floor_c + correction_c;
-      if (id(room_temp_selected).has_state() && !isnan(id(room_temp_selected).state)) {
-        // Usability limiter, not a condensation safety boundary: without a dew-point
-        // source, avoid raising the fallback floor so far above room temperature
-        // that fallback cooling becomes practically useless.
-        const float room_usability_relief_c = 1.0f;
-        const float room_usability_min_floor_c = 20.0f;
-        const float room_usability_floor_c = id(room_temp_selected).state - room_usability_relief_c;
-        if (room_usability_floor_c >= room_usability_min_floor_c) {
-          fallback_floor_c = fminf(fallback_floor_c, room_usability_floor_c);
-        }
-      }
-
-      return fallback_floor_c;
+      return oq_cooling_safety::runtime().fallback_min_supply_temp();
     web_server:
       sorting_group_id: oq_cooling
 
@@ -575,20 +337,7 @@ sensor:
     update_interval: 10s
     lambda: |-
       // Publish the active floor that raises the configured cooling target.
-      if (id(cooling_without_dew_point_user_responsibility_enabled).state &&
-          id(cooling_min_supply_temp).has_state() &&
-          !isnan(id(cooling_min_supply_temp).state)) {
-        return id(cooling_min_supply_temp).state;
-      }
-      if (id(minimum_safe_supply_temp).has_state() && !isnan(id(minimum_safe_supply_temp).state)) {
-        return id(minimum_safe_supply_temp).state;
-      }
-      if (id(cooling_fallback_active).state &&
-          id(cooling_fallback_min_supply_temp).has_state() &&
-          !isnan(id(cooling_fallback_min_supply_temp).state)) {
-        return id(cooling_fallback_min_supply_temp).state;
-      }
-      return NAN;
+      return oq_cooling_safety::runtime().effective_min_supply_temp();
     web_server:
       sorting_group_id: oq_cooling
 
@@ -597,30 +346,4 @@ interval:
     then:
       - lambda: |-
           // Track the minimum selected outside temperature during the local 00:00-06:00 window.
-          if (!id(oq_time).now().is_valid()) return;
-          if (!id(outside_temp_selected).has_state() || isnan(id(outside_temp_selected).state)) return;
-
-          const auto now = id(oq_time).now();
-          const int day_key = (now.year * 10000) + (now.month * 100) + now.day_of_month;
-          const bool in_night_window = now.hour < 6;
-          const float outside_c = id(outside_temp_selected).state;
-
-          if (in_night_window) {
-            if (id(oq_cooling_fallback_night_window_day_key) != day_key) {
-              id(oq_cooling_fallback_night_window_day_key) = day_key;
-              id(oq_cooling_fallback_night_min_current_c) = outside_c;
-            } else if (isnan(id(oq_cooling_fallback_night_min_current_c))) {
-              id(oq_cooling_fallback_night_min_current_c) = outside_c;
-            } else {
-              id(oq_cooling_fallback_night_min_current_c) =
-                  fminf(id(oq_cooling_fallback_night_min_current_c), outside_c);
-            }
-            return;
-          }
-
-          if (id(oq_cooling_fallback_night_window_day_key) >= 0 &&
-              id(oq_cooling_fallback_night_window_day_key) != id(oq_cooling_fallback_night_min_last_day_key) &&
-              !isnan(id(oq_cooling_fallback_night_min_current_c))) {
-            id(oq_cooling_fallback_night_min_last_c) = id(oq_cooling_fallback_night_min_current_c);
-            id(oq_cooling_fallback_night_min_last_day_key) = id(oq_cooling_fallback_night_window_day_key);
-          }
+          oq_cooling_safety::runtime().update_fallback_night_min();

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -114,7 +114,7 @@ globals:
 
   # 0=inactive, 1=full, 2=projected_floor, 3=simmer, 4=falling_gap, 5=buffer_stop,
   # 6=dew_stop, 7=fallback_floor, 8=restart_wait, 9=room_cap, 10=fallback_cap1,
-  # 11=level1_hold, 12=oil_return_hold, 13=oil_return_recovery
+  # 11=level1_hold, 12=oil_return_hold, 13=oil_return_recovery, 14=capacity_cap
   - id: oq_cooling_limiter_reason_code
     type: int
     restore_value: false
@@ -162,6 +162,21 @@ globals:
     initial_value: '0'
 
   - id: oq_cooling_oil_return_recovery_cap_until_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_cooling_capacity_cap
+    type: int
+    restore_value: false
+    initial_value: '10'
+
+  - id: oq_cooling_capacity_last_change_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_cooling_capacity_recovery_since_ms
     type: uint32_t
     restore_value: false
     initial_value: '0'
@@ -586,31 +601,16 @@ interval:
           // enough shape to behave across low-mass and high-mass water systems.
           const float filter_tau_s = 60.0f;
           const uint32_t rate_window_ms = 60000UL;
-          const float hard_dew_stop_base_gap_c = 0.15f;
-          const float hard_dew_stop_margin_gain_c = 0.30f;
-          const float hard_dew_restart_hyst_c = 0.20f;
-          const float projection_horizon_min = 3.0f;
-          const float projected_floor_brake_gap_c = 0.25f;
-          const float projected_floor_release_gap_c = 0.45f;
-          const float projected_floor_fast_fall_rate_c_per_min = 0.20f;
-          const float projected_floor_fast_fall_brake_gain = 1.0f;
-          const float projected_floor_fast_fall_brake_max_c = 0.15f;
           const uint32_t oil_return_recovery_stable_ms = 120000UL;
           const uint32_t oil_return_recovery_cap_ms = 120000UL;
           const float oil_return_recovery_dew_extra_c = 0.30f;
           const float oil_return_recovery_projected_extra_c = 0.15f;
           const float oil_return_recovery_fast_fall_rate_c_per_min = -0.05f;
-          const float simmer_enable_gap_c = -0.20f;
-          const float simmer_disable_gap_c = -0.30f;
-          const float buffer_hard_stop_gap_c = -0.70f;
-          const float limiter_soft_stop_gap_c = -0.10f;
-          const float fallback_full_gap_c = 1.00f;
-          const float fallback_cap1_gap_c = 0.30f;
-          const float fallback_stop_gap_c = 0.00f;
-          const uint32_t limiter_stop_confirm_ms =
-              (uint32_t) (${oq_cooling_limiter_stop_confirm_s} * 1000UL);
           const uint32_t oil_return_hold_ms =
               (uint32_t) (${oq_cooling_oil_return_hold_s} * 1000UL);
+          oq_cooling::LimiterTuning limiter_tuning;
+          limiter_tuning.limiter_stop_confirm_ms =
+              (uint32_t) (${oq_cooling_limiter_stop_confirm_s} * 1000UL);
           const uint32_t upscale_dwell_ms = 90000UL;
           const uint32_t downscale_dwell_ms = 30000UL;
           const float simmer_room_error_min_c = 0.20f;
@@ -648,8 +648,6 @@ interval:
             id(oq_cooling_pid_last_error_c) = 0.0f;
             id(oq_cooling_water_cycle_active) = false;
             id(oq_cooling_gap_filter_ready) = false;
-            id(oq_cooling_simmer_allowed) = false;
-            id(oq_cooling_projection_brake_active) = false;
             id(oq_cooling_projected_gap_c) = NAN;
             id(oq_cooling_limiter_allowed_max) = 0;
             id(oq_cooling_base_demand_raw) = 0;
@@ -658,10 +656,18 @@ interval:
             id(oq_cooling_stop_reason_code) = 0;
             id(oq_cooling_buffer_gap_rate_ref_ms) = 0;
             id(oq_cooling_last_demand_change_ms) = 0;
-            id(oq_cooling_stop_candidate_since_ms) = 0;
-            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
             id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
             id(oq_cooling_oil_return_recovery_cap_until_ms) = 0;
+            int reset_capacity_cap = (int) lroundf(id(cooling_demand_max_f).state);
+            if (reset_capacity_cap < 1) reset_capacity_cap = 1;
+            if (reset_capacity_cap > 10) reset_capacity_cap = 10;
+            id(oq_cooling_simmer_allowed) = false;
+            id(oq_cooling_projection_brake_active) = false;
+            id(oq_cooling_stop_candidate_since_ms) = 0;
+            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
+            id(oq_cooling_capacity_cap) = reset_capacity_cap;
+            id(oq_cooling_capacity_last_change_ms) = 0;
+            id(oq_cooling_capacity_recovery_since_ms) = 0;
             return;
           }
 
@@ -691,16 +697,19 @@ interval:
           if (last_guard_mode >= 0 && guard_mode != last_guard_mode) {
             id(oq_cooling_water_cycle_active) = false;
             id(oq_cooling_gap_filter_ready) = false;
-            id(oq_cooling_simmer_allowed) = false;
-            id(oq_cooling_projection_brake_active) = false;
             id(oq_cooling_projected_gap_c) = NAN;
             id(oq_cooling_stop_reason_code) = 0;
             id(oq_cooling_stop_buffer_gap_c) = 0.0f;
             id(oq_cooling_last_demand_change_ms) = 0;
-            id(oq_cooling_stop_candidate_since_ms) = 0;
-            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
             id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
             id(oq_cooling_oil_return_recovery_cap_until_ms) = 0;
+            id(oq_cooling_simmer_allowed) = false;
+            id(oq_cooling_projection_brake_active) = false;
+            id(oq_cooling_stop_candidate_since_ms) = 0;
+            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
+            id(oq_cooling_capacity_cap) = 10;
+            id(oq_cooling_capacity_last_change_ms) = 0;
+            id(oq_cooling_capacity_recovery_since_ms) = 0;
             id(oq_cooling_buffer_gap_rate_ref_ms) = 0;
             id(oq_cooling_pid_integral) = 0.0f;
             id(oq_cooling_pid_last_error_c) = buffer_gap_c;
@@ -747,11 +756,13 @@ interval:
           if (safety_margin_c < 0.0f) safety_margin_c = 0.0f;
           if (safety_margin_c > 2.0f) safety_margin_c = 2.0f;
           const float hard_dew_stop_gap_c =
-              hard_dew_stop_base_gap_c + (hard_dew_stop_margin_gain_c * safety_margin_c);
-          const float hard_dew_restart_gap_c = hard_dew_stop_gap_c + hard_dew_restart_hyst_c;
+              limiter_tuning.hard_dew_stop_base_gap_c +
+              (limiter_tuning.hard_dew_stop_margin_gain_c * safety_margin_c);
+          const float hard_dew_restart_gap_c =
+              hard_dew_stop_gap_c + limiter_tuning.hard_dew_restart_hyst_c;
 
           const float projected_gap_c =
-              filtered_gap_c + (gap_rate_c_per_min * projection_horizon_min);
+              filtered_gap_c + (gap_rate_c_per_min * limiter_tuning.projection_horizon_min);
           id(oq_cooling_projected_gap_c) = projected_gap_c;
 
           bool oil_return_hold_window_active =
@@ -773,12 +784,12 @@ interval:
                dew_gap_c >= hard_dew_restart_gap_c + oil_return_recovery_dew_extra_c);
           const bool oil_return_fallback_recovered =
               !fallback_mode ||
-              filtered_gap_c >= fallback_cap1_gap_c + oil_return_recovery_dew_extra_c;
+              filtered_gap_c >= limiter_tuning.fallback_cap1_gap_c + oil_return_recovery_dew_extra_c;
           const bool oil_return_filtered_recovered =
               filtered_gap_c >= 0.0f ||
-              (filtered_gap_c > limiter_soft_stop_gap_c && gap_rate_c_per_min > 0.10f);
+              (filtered_gap_c > limiter_tuning.limiter_soft_stop_gap_c && gap_rate_c_per_min > 0.10f);
           const bool oil_return_projected_recovered =
-              projected_gap_c >= projected_floor_release_gap_c + oil_return_recovery_projected_extra_c;
+              projected_gap_c >= limiter_tuning.projected_floor_release_gap_c + oil_return_recovery_projected_extra_c;
           const bool oil_return_trend_recovered =
               gap_rate_c_per_min >= oil_return_recovery_fast_fall_rate_c_per_min;
           const bool oil_return_recovery_safe =
@@ -843,27 +854,6 @@ interval:
             last_oil_return_mask_active = oil_return_mask_active;
           }
 
-          float projected_floor_dynamic_brake_gap_c = projected_floor_brake_gap_c;
-          if (gap_rate_c_per_min < -projected_floor_fast_fall_rate_c_per_min) {
-            const float fast_fall_extra_c =
-                ((-gap_rate_c_per_min) - projected_floor_fast_fall_rate_c_per_min) *
-                projected_floor_fast_fall_brake_gain;
-            projected_floor_dynamic_brake_gap_c +=
-                fminf(projected_floor_fast_fall_brake_max_c, fmaxf(0.0f, fast_fall_extra_c));
-          }
-          bool projection_brake_active = id(oq_cooling_projection_brake_active);
-          if (gap_rate_c_per_min >= 0.0f || projected_gap_c >= projected_floor_release_gap_c) {
-            projection_brake_active = false;
-          } else if (projected_gap_c <= projected_floor_dynamic_brake_gap_c) {
-            projection_brake_active = true;
-          }
-          id(oq_cooling_projection_brake_active) = projection_brake_active;
-
-          bool simmer_allowed = id(oq_cooling_simmer_allowed);
-          if (filtered_gap_c > simmer_enable_gap_c) simmer_allowed = true;
-          else if (filtered_gap_c < simmer_disable_gap_c) simmer_allowed = false;
-          id(oq_cooling_simmer_allowed) = simmer_allowed;
-
           float kp = id(cooling_pid_kp).state;
           float ki = id(cooling_pid_ki).state;
           float kd = id(cooling_pid_kd).state;
@@ -892,6 +882,55 @@ interval:
           int demand_max = (int) lroundf(id(cooling_demand_max_f).state);
           if (demand_max < 1) demand_max = 1;
           if (demand_max > 10) demand_max = 10;
+          const int capacity_demand_max = demand_max;
+
+          const float active_hp_out_gap_c = [&]()->float {
+            if (!dew_mode || isnan(id(cooling_dew_point_selected).state)) return NAN;
+            const float dew_c = id(cooling_dew_point_selected).state;
+            int owner = id(oq_cooling_request_owner_hp);
+            if (owner == 0) owner = id(oq_cooling_owner_hp);
+
+            auto gap_if_valid = [&](float temp_c)->float {
+              if (isnan(temp_c)) return NAN;
+              return temp_c - dew_c;
+            };
+
+            if (owner == 1 && id(hp1_water_out_temp).has_state()) {
+              const float gap_c = gap_if_valid(id(hp1_water_out_temp).state);
+              if (!isnan(gap_c)) return gap_c;
+            }
+            #if OQ_TOPOLOGY_DUO
+            if (owner == 2 && id(${secondary_water_out_temp_id}).has_state()) {
+              const float gap_c = gap_if_valid(id(${secondary_water_out_temp_id}).state);
+              if (!isnan(gap_c)) return gap_c;
+            }
+            #endif
+
+            if (id(hp1_last_applied_level) > 0 && id(hp1_water_out_temp).has_state()) {
+              const float gap_c = gap_if_valid(id(hp1_water_out_temp).state);
+              if (!isnan(gap_c)) return gap_c;
+            }
+            #if OQ_TOPOLOGY_DUO
+            if (id(${secondary_last_applied_level_id}) > 0 && id(${secondary_water_out_temp_id}).has_state()) {
+              const float gap_c = gap_if_valid(id(${secondary_water_out_temp_id}).state);
+              if (!isnan(gap_c)) return gap_c;
+            }
+            #endif
+
+            if (id(oq_cooling_request_hp1_level) > 0 && id(hp1_water_out_temp).has_state()) {
+              const float gap_c = gap_if_valid(id(hp1_water_out_temp).state);
+              if (!isnan(gap_c)) return gap_c;
+            }
+            #if OQ_TOPOLOGY_DUO
+            if (id(oq_cooling_request_hp2_level) > 0 && id(${secondary_water_out_temp_id}).has_state()) {
+              const float gap_c = gap_if_valid(id(${secondary_water_out_temp_id}).state);
+              if (!isnan(gap_c)) return gap_c;
+            }
+            #endif
+
+            return NAN;
+          }();
+
           bool room_cap_active = false;
           if (room_error_valid) {
             const int before_room_cap = demand_max;
@@ -901,148 +940,50 @@ interval:
             room_cap_active = demand_max < before_room_cap;
           }
 
-          auto reason_name = [](int reason)->const char* {
-            switch (reason) {
-              case 1: return "full";
-              case 2: return "projected_floor";
-              case 3: return "simmer";
-              case 4: return "falling_gap";
-              case 5: return "buffer_stop";
-              case 6: return "dew_stop";
-              case 7: return "fallback_floor";
-              case 8: return "restart_wait";
-              case 9: return "room_cap";
-              case 10: return "fallback_cap1";
-              case 11: return "level1_hold";
-              case 12: return "oil_return_hold";
-              case 13: return "oil_return_recovery";
-              default: return "inactive";
-            }
-          };
+          oq_cooling::LimiterState limiter_state;
+          limiter_state.simmer_allowed = id(oq_cooling_simmer_allowed);
+          limiter_state.projection_brake_active = id(oq_cooling_projection_brake_active);
+          limiter_state.stop_candidate_since_ms = id(oq_cooling_stop_candidate_since_ms);
+          limiter_state.dew_stop_candidate_since_ms = id(oq_cooling_dew_stop_candidate_since_ms);
+          limiter_state.capacity_cap = id(oq_cooling_capacity_cap);
+          limiter_state.capacity_last_change_ms = id(oq_cooling_capacity_last_change_ms);
+          limiter_state.capacity_recovery_since_ms = id(oq_cooling_capacity_recovery_since_ms);
 
-          int safe_floor_cap = demand_max;
-          int projection_cap = demand_max;
-          int fallback_cap = demand_max;
-          int mode_cap = demand_max;
-          int reason_code = room_cap_active ? 9 : 1;
-          const bool dew_hard_stop_candidate =
-              !oil_return_mask_active &&
-              dew_mode && !isnan(dew_gap_c) && dew_gap_c <= hard_dew_stop_gap_c;
-          bool dew_hard_stop = false;
-          if (dew_hard_stop_candidate) {
-            uint32_t dew_candidate_since_ms = id(oq_cooling_dew_stop_candidate_since_ms);
-            if (dew_candidate_since_ms == 0 || now_ms <= dew_candidate_since_ms) {
-              id(oq_cooling_dew_stop_candidate_since_ms) = now_ms;
-              dew_candidate_since_ms = now_ms;
-            }
-            dew_hard_stop = (uint32_t)(now_ms - dew_candidate_since_ms) >= limiter_stop_confirm_ms;
-          } else {
-            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
+          oq_cooling::LimiterInput limiter_input;
+          limiter_input.now_ms = now_ms;
+          limiter_input.demand_max = demand_max;
+          limiter_input.capacity_demand_max = capacity_demand_max;
+          limiter_input.previous_limited_demand = id(oq_cooling_limited_demand);
+          limiter_input.room_cap_active = room_cap_active;
+          limiter_input.dew_mode = dew_mode;
+          limiter_input.fallback_mode = fallback_mode;
+          limiter_input.oil_return_mask_active = oil_return_mask_active;
+          limiter_input.oil_return_recovery_cap_active = oil_return_recovery_cap_active;
+          limiter_input.buffer_gap_c = buffer_gap_c;
+          limiter_input.filtered_gap_c = filtered_gap_c;
+          limiter_input.gap_rate_c_per_min = gap_rate_c_per_min;
+          limiter_input.dew_gap_c = dew_gap_c;
+          limiter_input.active_hp_out_gap_c = active_hp_out_gap_c;
+          limiter_input.safety_margin_c = safety_margin_c;
+
+          const auto limiter_output =
+              oq_cooling::update_limiter(limiter_input, limiter_tuning, limiter_state);
+          if (limiter_output.reset_gap_rate_reference) {
+            id(oq_cooling_buffer_gap_rate_ref_c) = filtered_gap_c;
+            id(oq_cooling_buffer_gap_rate_ref_ms) = now_ms;
           }
+          if (limiter_output.clamp_integral_to_zero) integral = fminf(integral, 0.0f);
+          id(oq_cooling_simmer_allowed) = limiter_state.simmer_allowed;
+          id(oq_cooling_projection_brake_active) = limiter_state.projection_brake_active;
+          id(oq_cooling_stop_candidate_since_ms) = limiter_state.stop_candidate_since_ms;
+          id(oq_cooling_dew_stop_candidate_since_ms) = limiter_state.dew_stop_candidate_since_ms;
+          id(oq_cooling_capacity_cap) = limiter_state.capacity_cap;
+          id(oq_cooling_capacity_last_change_ms) = limiter_state.capacity_last_change_ms;
+          id(oq_cooling_capacity_recovery_since_ms) = limiter_state.capacity_recovery_since_ms;
+          id(oq_cooling_projected_gap_c) = limiter_output.projected_gap_c;
 
-          // Build the limiter as independent caps and take the strictest one.
-          // This keeps fallback, dew safety, projected floor approach and room overshoot from
-          // overwriting each other. The reason code tracks the cap that explains
-          // the current behavior in logs/debug state.
-          const bool dew_gap_allows_simmer =
-              !dew_mode || isnan(dew_gap_c) || dew_gap_c > hard_dew_restart_gap_c;
-          if (fallback_mode) {
-            if (filtered_gap_c <= fallback_stop_gap_c) {
-              fallback_cap = 0;
-              reason_code = 7;
-            } else if (filtered_gap_c <= fallback_cap1_gap_c) {
-              fallback_cap = std::min(fallback_cap, 1);
-              reason_code = 10;
-            } else if (filtered_gap_c <= fallback_full_gap_c) {
-              fallback_cap = std::min(fallback_cap, 1);
-              reason_code = 10;
-            }
-          } else {
-            if (dew_hard_stop) {
-              safe_floor_cap = 0;
-              reason_code = 6;
-            } else if (filtered_gap_c < buffer_hard_stop_gap_c) {
-              safe_floor_cap = 0;
-              reason_code = 5;
-            } else if (filtered_gap_c <= limiter_soft_stop_gap_c) {
-              safe_floor_cap = 0;
-              reason_code = 5;
-            } else if (filtered_gap_c <= 0.0f) {
-              if (dew_gap_allows_simmer && simmer_allowed) {
-                safe_floor_cap = std::min(safe_floor_cap, 1);
-                reason_code = 3;
-              } else {
-                safe_floor_cap = 0;
-                reason_code = 5;
-              }
-            } else {
-              safe_floor_cap = demand_max;
-              if (!room_cap_active) reason_code = 1;
-            }
-          }
-
-          const bool projection_caution_active =
-              !projection_brake_active &&
-              gap_rate_c_per_min < 0.0f &&
-              projected_gap_c <= projected_floor_release_gap_c;
-          if ((projection_brake_active || projection_caution_active) && safe_floor_cap > 0 && fallback_cap > 0) {
-            if (id(oq_cooling_limited_demand) > 1) {
-              id(oq_cooling_buffer_gap_rate_ref_c) = filtered_gap_c;
-              id(oq_cooling_buffer_gap_rate_ref_ms) = now_ms;
-            }
-            projection_cap = std::min(projection_cap, 1);
-            reason_code = 2;
-          }
-
-          int allowed_max = demand_max;
-          allowed_max = std::min(allowed_max, safe_floor_cap);
-          allowed_max = std::min(allowed_max, projection_cap);
-          allowed_max = std::min(allowed_max, fallback_cap);
-          allowed_max = std::min(allowed_max, mode_cap);
-          if (allowed_max < 0) allowed_max = 0;
-
-          // During oil-return and recovery hold we keep cooling alive at level 1.
-          // Oil-return forces a temporary compressor behavior that can dip water
-          // temperature below the normal floor. Mask the dew/floor stop here so
-          // we do not trigger an avoidable stop/restart cycle.
-          if (oil_return_mask_active) {
-            allowed_max = std::min(allowed_max, 1);
-            if (allowed_max <= 0) {
-              allowed_max = 1;
-              id(oq_cooling_stop_candidate_since_ms) = 0;
-            }
-            reason_code = 12;
-          } else if (oil_return_recovery_cap_active && allowed_max > 0) {
-            allowed_max = std::min(allowed_max, 1);
-            reason_code = 13;
-          }
-
-          // Soft-stop near target: avoid an immediate drop to 0 from limiter logic
-          // while raw gap is still positive or only slightly negative. Hard dew and
-          // fallback floor stops remain immediate safety exits.
-          const bool immediate_stop = (reason_code == 6 || reason_code == 7);
-          if (!immediate_stop && allowed_max <= 0) {
-            if (buffer_gap_c > 0.0f) {
-              allowed_max = 1;
-              reason_code = 11;
-              id(oq_cooling_stop_candidate_since_ms) = 0;
-            } else if (filtered_gap_c > limiter_soft_stop_gap_c) {
-              uint32_t candidate_since_ms = id(oq_cooling_stop_candidate_since_ms);
-              if (candidate_since_ms == 0 || now_ms <= candidate_since_ms) {
-                id(oq_cooling_stop_candidate_since_ms) = now_ms;
-                candidate_since_ms = now_ms;
-              }
-              if ((uint32_t) (now_ms - candidate_since_ms) < limiter_stop_confirm_ms) {
-                allowed_max = 1;
-                reason_code = 11;
-              }
-            } else {
-              id(oq_cooling_stop_candidate_since_ms) = 0;
-            }
-          } else {
-            id(oq_cooling_stop_candidate_since_ms) = 0;
-          }
-
+          const int allowed_max = limiter_output.allowed_max;
+          int reason_code = limiter_output.reason_code;
           id(oq_cooling_limiter_allowed_max) = allowed_max;
 
           // Restart hysteresis is only for water-side stops. If cooling stopped
@@ -1051,8 +992,10 @@ interval:
           bool water_cycle_active = id(oq_cooling_water_cycle_active);
           if (!water_cycle_active) {
             int stop_reason_code = id(oq_cooling_stop_reason_code);
-            if (stop_reason_code == 4 && (reason_code == 6 || reason_code == 7)) {
-              stop_reason_code = reason_code == 6 ? 2 : 3;
+            if (stop_reason_code == 4 &&
+                (reason_code == oq_cooling::REASON_DEW_STOP ||
+                 reason_code == oq_cooling::REASON_FALLBACK_FLOOR)) {
+              stop_reason_code = reason_code == oq_cooling::REASON_DEW_STOP ? 2 : 3;
               id(oq_cooling_stop_reason_code) = stop_reason_code;
               id(oq_cooling_stop_buffer_gap_c) = filtered_gap_c;
             }
@@ -1067,8 +1010,8 @@ interval:
                 filtered_gap_c > restart_threshold_c;
             const bool projected_floor_recovered =
                 !projected_floor_pause ||
-                !projection_brake_active ||
-                projected_gap_c >= projected_floor_release_gap_c ||
+                !limiter_state.projection_brake_active ||
+                projected_gap_c >= limiter_tuning.projected_floor_release_gap_c ||
                 gap_rate_c_per_min >= 0.0f;
             const bool restart_recovered =
                 oil_return_mask_active ||
@@ -1081,10 +1024,17 @@ interval:
               id(oq_cooling_base_demand_raw) = 0;
               id(oq_cooling_limited_demand) = 0;
               id(oq_cooling_limiter_reason_code) =
-                  (reason_code == 6 || reason_code == 7 || !restart_after_water_stop ||
-                   (projected_floor_pause && !projected_floor_recovered)) ? reason_code : 8;
+                  (reason_code == oq_cooling::REASON_DEW_STOP ||
+                   reason_code == oq_cooling::REASON_FALLBACK_FLOOR ||
+                   !restart_after_water_stop ||
+                   (projected_floor_pause && !projected_floor_recovered))
+                      ? reason_code
+                      : oq_cooling::REASON_RESTART_WAIT;
               id(oq_cooling_pid_last_error_c) = buffer_gap_c;
-              if (reason_code == 6 || reason_code == 7) id(oq_cooling_pid_integral) = 0.0f;
+              if (reason_code == oq_cooling::REASON_DEW_STOP ||
+                  reason_code == oq_cooling::REASON_FALLBACK_FLOOR) {
+                id(oq_cooling_pid_integral) = 0.0f;
+              }
               return;
             }
           }
@@ -1097,16 +1047,22 @@ interval:
             id(oq_cooling_water_cycle_active) = false;
             id(oq_cooling_stop_buffer_gap_c) = filtered_gap_c;
             id(oq_cooling_stop_reason_code) =
-                reason_code == 6 ? 2 : (reason_code == 7 ? 3 : 1);
+                reason_code == oq_cooling::REASON_DEW_STOP ? 2 :
+                (reason_code == oq_cooling::REASON_FALLBACK_FLOOR ? 3 : 1);
             id(oq_cooling_pid_last_error_c) = buffer_gap_c;
-            if (reason_code == 6 || reason_code == 7) id(oq_cooling_pid_integral) = 0.0f;
-            else if (reason_code != 2) integral = fminf(integral, 0.0f);
+            if (reason_code == oq_cooling::REASON_DEW_STOP ||
+                reason_code == oq_cooling::REASON_FALLBACK_FLOOR) {
+              id(oq_cooling_pid_integral) = 0.0f;
+            } else if (reason_code != oq_cooling::REASON_PROJECTED_FLOOR) {
+              integral = fminf(integral, 0.0f);
+            }
             id(oq_cooling_pid_integral) = integral;
 
             static int last_reason = -1;
             if (reason_code != last_reason) {
               ESP_LOGI("quatt.cool", "Cooling limiter: %s gap=%.2f ema=%.2f rate=%.2f dew=%.2f",
-                       reason_name(reason_code), buffer_gap_c, filtered_gap_c, gap_rate_c_per_min, dew_gap_c);
+                       oq_cooling::reason_name(reason_code), buffer_gap_c, filtered_gap_c,
+                       gap_rate_c_per_min, dew_gap_c);
               last_reason = reason_code;
             }
             return;
@@ -1135,16 +1091,22 @@ interval:
           // limiter says level 1 is safe and the room still has meaningful demand.
           int demand_candidate = std::min(base_demand, allowed_max);
           const bool oil_return_level1_hold =
-              (reason_code == 12 || reason_code == 13) && allowed_max >= 1;
+              (reason_code == oq_cooling::REASON_OIL_RETURN_HOLD ||
+               reason_code == oq_cooling::REASON_OIL_RETURN_RECOVERY) && allowed_max >= 1;
           const bool can_simmer =
               oil_return_level1_hold ||
               ((!room_error_valid || room_error_c > simmer_room_error_min_c) &&
                allowed_max >= 1 &&
-               (reason_code == 3 || reason_code == 4 || fallback_mode));
+               (reason_code == oq_cooling::REASON_SIMMER ||
+                reason_code == oq_cooling::REASON_FALLING_GAP ||
+                fallback_mode));
           if (can_simmer && demand_candidate < 1) {
             demand_candidate = 1;
-            if (reason_code != 4 && reason_code != 10 && reason_code != 12 && reason_code != 13) {
-              reason_code = 3;
+            if (reason_code != oq_cooling::REASON_FALLING_GAP &&
+                reason_code != oq_cooling::REASON_FALLBACK_CAP1 &&
+                reason_code != oq_cooling::REASON_OIL_RETURN_HOLD &&
+                reason_code != oq_cooling::REASON_OIL_RETURN_RECOVERY) {
+              reason_code = oq_cooling::REASON_SIMMER;
             }
           }
 
@@ -1163,7 +1125,7 @@ interval:
               // the water gap down, the normal up-dwell can still promote it.
               demand = std::min(demand_candidate, 1);
             } else if (last_change_ms == 0 || elapsed_change_ms >= upscale_dwell_ms) {
-              demand = demand_candidate;
+              demand = std::min(demand_candidate, prev_limited + 1);
             } else {
               demand = prev_limited;
             }
@@ -1183,7 +1145,7 @@ interval:
           static int last_reason = -1;
           if (reason_code != last_reason) {
             ESP_LOGI("quatt.cool", "Cooling limiter: %s f=%d raw=%d lim=%d gap=%.2f ema=%.2f rate=%.2f dew=%.2f",
-                     reason_name(reason_code), demand, base_demand, allowed_max,
+                     oq_cooling::reason_name(reason_code), demand, base_demand, allowed_max,
                      buffer_gap_c, filtered_gap_c, gap_rate_c_per_min, dew_gap_c);
             last_reason = reason_code;
           }
@@ -1435,25 +1397,6 @@ interval:
           id(oq_strategy_heat_request_active) = (f > 0);
           id(oq_strategy_phase_text).publish_state((f > 0) ? "cool" : "idle");
 
-          auto cooling_reason_name = [](int reason)->const char* {
-            switch (reason) {
-              case 1: return "full";
-              case 2: return "projected_floor";
-              case 3: return "simmer";
-              case 4: return "falling_gap";
-              case 5: return "buffer_stop";
-              case 6: return "dew_stop";
-              case 7: return "fallback_floor";
-              case 8: return "restart_wait";
-              case 9: return "room_cap";
-              case 10: return "fallback_cap1";
-              case 11: return "level1_hold";
-              case 12: return "oil_return_hold";
-              case 13: return "oil_return_recovery";
-              default: return "inactive";
-            }
-          };
-
           char debug_buf[240];
           snprintf(
             debug_buf, sizeof(debug_buf),
@@ -1466,6 +1409,6 @@ interval:
             id(oq_cooling_buffer_gap_filtered_c),
             id(oq_cooling_buffer_gap_rate_c_per_min),
             id(oq_cooling_dew_gap_c),
-            cooling_reason_name(id(oq_cooling_limiter_reason_code)),
+            oq_cooling::reason_name(id(oq_cooling_limiter_reason_code)),
             id(cooling_supply_target).state);
           ESP_LOGD("quatt.strategy", "%s", debug_buf);


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst de normale koelcapaciteit-limiter naar `oq_cooling_limiter_logic.h` als één state-machine helper.
- Vervangt losse YAML-caps voor fallback, projectie, safe-floor/simmer en dauwpuntcapaciteit door één `allowed_max`-beslissing.
- Houdt `coolingDemandMax` als gebruikers-bovengrens; automatische terug-/opschaling blijft intern en stapsgewijs.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Koelvraag wordt eerder en langer automatisch begrensd bij kleine/dalende dauwpuntruimte of actieve HP water-out rond/onder dauwpunt. Opschalen gebeurt maximaal een niveau per dwell en pas na stabiele herstelmarge. Oil-return recovery blijft een aparte machine-uitzondering.

## Achtergrond

De bestaande YAML had meerdere parallelle caps (`safe_floor`, `projection`, `fallback`, `simmer`, `level1_hold`) plus een nieuwe dauwpuntcap. Dat maakte het gedrag lastig te volgen en liet in de oude log toe dat koeling rond 16:34-16:38 weer naar level 4 ging, terwijl de dauwpuntmarge beperkt was en HP water-out al rond/onder dauwpunt zat. Deze PR houdt hetzelfde regelpad maar centraliseert de normale capacity-beslissing in een pure C++ helper.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config configs/heatpump_controller_q/single_wifi.yaml`
- `rtk git diff --cached --check`