### PR TITLE
Update Q board GPIO map

### DIFF
--- a/openquatt/connection/eth.yaml
+++ b/openquatt/connection/eth.yaml
@@ -14,6 +14,7 @@ ethernet:
   mosi_pin: ${eth_mosi_pin}
   miso_pin: ${eth_miso_pin}
   cs_pin: ${eth_cs_pin}
+  interrupt_pin: ${eth_int_pin}
 
 text_sensor:
   - platform: ethernet_info

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -12,9 +12,9 @@ substitutions:
   esp_flash_size: "16MB"                                # Active ESP flash size.
   esp_variant: "esp32s3"                                # Active ESP variant.
   esp_partitions: "${openquatt_root}/partitions/openquatt_16mb.csv" # Active partition table.
-  uart_tx_pin: "GPIO45"                                 # Modbus 2 TX; primary heat-pump bus.
-  uart_rx_pin: "GPIO39"                                 # Modbus 2 RX; primary heat-pump bus.
-  uart_rts_pin: "GPIO38"                                # Modbus 2 mode / DE/RE; primary heat-pump bus.
+  uart_tx_pin: "GPIO40"                                 # Modbus 1 TX; primary heat-pump bus.
+  uart_rx_pin: "GPIO42"                                 # Modbus 1 RX; primary heat-pump bus.
+  uart_rts_pin: "GPIO41"                                # Modbus 1 mode / DE/RE; primary heat-pump bus.
   oq_ot_thermostat_in_pin: "GPIO21"                     # OpenTherm slave input.
   oq_ot_thermostat_out_pin: "GPIO14"                    # OpenTherm slave output.
   ds18b20_pin: "GPIO18"                                 # Dallas DS18B20 1-Wire input.

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -12,31 +12,32 @@ substitutions:
   esp_flash_size: "16MB"                                # Active ESP flash size.
   esp_variant: "esp32s3"                                # Active ESP variant.
   esp_partitions: "${openquatt_root}/partitions/openquatt_16mb.csv" # Active partition table.
-  uart_tx_pin: "GPIO40"                                 # Modbus 2 TX; primary heat-pump bus.
+  uart_tx_pin: "GPIO45"                                 # Modbus 2 TX; primary heat-pump bus.
   uart_rx_pin: "GPIO39"                                 # Modbus 2 RX; primary heat-pump bus.
-  uart_rts_pin: "GPIO38"                                # Modbus 2 DE/RE; primary heat-pump bus.
-  oq_ot_thermostat_in_pin: "GPIO16"                     # OpenTherm thermostat input.
-  oq_ot_thermostat_out_pin: "GPIO15"                    # OpenTherm thermostat output.
-  ds18b20_pin: "GPIO14"                                 # Dallas DS18B20 1-Wire input.
-  oq_boiler_relay_pin: "GPIO7"                          # Relay 1 output.
-  controller_aux_relay_pin: "GPIO8"                     # Relay 2 output reserved for controller logic.
+  uart_rts_pin: "GPIO38"                                # Modbus 2 mode / DE/RE; primary heat-pump bus.
+  oq_ot_thermostat_in_pin: "GPIO21"                     # OpenTherm slave input.
+  oq_ot_thermostat_out_pin: "GPIO14"                    # OpenTherm slave output.
+  ds18b20_pin: "GPIO18"                                 # Dallas DS18B20 1-Wire input.
+  oq_boiler_relay_pin: "GPIO16"                         # Relay 1 output.
+  controller_aux_relay_pin: "GPIO3"                     # Relay 2 output reserved for controller logic.
   web_auth_recovery_pin: "GPIO46"                       # Boot switch / recovery input.
   eth_mosi_pin: "GPIO10"                                # W5500 SPI MOSI.
   eth_miso_pin: "GPIO11"                                # W5500 SPI MISO.
   eth_clk_pin: "GPIO12"                                 # W5500 SPI CLK.
   eth_cs_pin: "GPIO13"                                  # W5500 SPI CS.
-  hpcq_pt1000_mosi_pin: "GPIO5"                         # MAX31865 MOSI / SDI.
-  hpcq_pt1000_miso_pin: "GPIO2"                         # MAX31865 MISO / SDO.
-  hpcq_pt1000_clk_pin: "GPIO4"                          # MAX31865 SPI clock.
-  hpcq_pt1000_cs_pin: "GPIO3"                           # MAX31865 chip select.
+  eth_int_pin: "GPIO9"                                  # W5500 interrupt.
+  hpcq_pt1000_mosi_pin: "GPIO7"                         # MAX31865 MOSI / SDI.
+  hpcq_pt1000_miso_pin: "GPIO4"                         # MAX31865 MISO / SDO.
+  hpcq_pt1000_clk_pin: "GPIO6"                          # MAX31865 SPI clock.
+  hpcq_pt1000_cs_pin: "GPIO5"                           # MAX31865 chip select.
   hpcq_pt1000_reference_resistance_ohm: "1500"          # PT1000 MAX31865 reference resistor.
   hpcq_pt1000_nominal_resistance_ohm: "1000"            # PT1000 nominal resistance at 0 degrees C.
   hpcq_pt1000_rtd_wires: "2"                            # Probe wiring mode; board jumpers must match.
-  hpcq_flow_pin: "GPIO6"                                # V1 central flowmeter pulse input.
+  hpcq_flow_pin: "GPIO15"                               # V1 central flowmeter pulse input.
   hpcq_flow_kf_lpm_per_hz: "0.05"                       # DN15 datasheet Kff: Qv[l/min] = Kf * f[Hz] + Q0.
   hpcq_flow_q0_lpm: "0"                                 # DN15 datasheet intercept [l/min].
-  hpcq_status_led_yellow_pin: "GPIO47"                  # Yellow status LED output.
-  hpcq_status_led_red_pin: "GPIO48"                     # Red status LED output.
+  hpcq_status_led_yellow_pin: "GPIO1"                   # Yellow status LED output.
+  hpcq_status_led_red_pin: "GPIO2"                      # Red status LED output.
   hpcq_status_led_inverted: "false"                     # Set true when the board LED is active-low.
 
 packages:

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
@@ -6,9 +6,9 @@
 # controller. Listener and Waveshare builds must not initialize dummy pins.
 # ==============================================================================
 substitutions:
-  cic_compat_uart_tx_pin: "GPIO42"                      # Modbus 1 TX; CiC compatibility port.
-  cic_compat_uart_rx_pin: "GPIO45"                      # Modbus 1 RX; CiC compatibility port.
-  cic_compat_uart_rts_pin: "GPIO41"                     # Modbus 1 DE/RE; CiC compatibility port.
+  cic_compat_uart_tx_pin: "GPIO40"                      # Modbus 1 TX; CiC compatibility port.
+  cic_compat_uart_rx_pin: "GPIO42"                      # Modbus 1 RX; CiC compatibility port.
+  cic_compat_uart_rts_pin: "GPIO41"                     # Modbus 1 mode / DE/RE; CiC compatibility port.
   cic_compat_modbus_address_hp1: "0x01"                 # CiC-facing Modbus address for HP1 data.
   cic_compat_modbus_address_hp2: "0x02"                 # CiC-facing Modbus address for HP2 data.
   oq_cic_compat_restore_mode_default: "RESTORE_DEFAULT_OFF" # Default compatibility mode state.

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
@@ -6,9 +6,9 @@
 # controller. Listener and Waveshare builds must not initialize dummy pins.
 # ==============================================================================
 substitutions:
-  cic_compat_uart_tx_pin: "GPIO40"                      # Modbus 1 TX; CiC compatibility port.
-  cic_compat_uart_rx_pin: "GPIO42"                      # Modbus 1 RX; CiC compatibility port.
-  cic_compat_uart_rts_pin: "GPIO41"                     # Modbus 1 mode / DE/RE; CiC compatibility port.
+  cic_compat_uart_tx_pin: "GPIO45"                      # Modbus 2 TX; CiC compatibility port.
+  cic_compat_uart_rx_pin: "GPIO39"                      # Modbus 2 RX; CiC compatibility port.
+  cic_compat_uart_rts_pin: "GPIO38"                     # Modbus 2 mode / DE/RE; CiC compatibility port.
   cic_compat_modbus_address_hp1: "0x01"                 # CiC-facing Modbus address for HP1 data.
   cic_compat_modbus_address_hp2: "0x02"                 # CiC-facing Modbus address for HP2 data.
   oq_cic_compat_restore_mode_default: "RESTORE_DEFAULT_OFF" # Default compatibility mode state.


### PR DESCRIPTION
# Wat verandert deze PR?

- Werkt de Heatpump Controller Q GPIO-substitutions bij naar de nieuwe boardrevisie.
- Zet de primaire warmtepompbus terug op Modbus 1 en de CiC compatibility port op Modbus 2, waarmee de M1/M2-wissel uit #267 wordt omgedraaid voor deze revisie.
- Zet OpenTherm slave, relais, flow, PT1000, DS18B20, status-LEDs en W5500 `ETH INT` om naar de nieuwe GPIO-map.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De Q-hardware pinmap wijzigt definitief naar de nieuwe boardrevisie. Er is geen overgangslaag toegevoegd omdat de bestaande gebruikersset klein is.

## Achtergrond

De nieuwe Q-boardrevisie heeft andere GPIO-toewijzingen voor onder meer Modbus, OpenTherm slave, relais, flowmeter, PT1000 SPI, status-LEDs, DS18B20 en W5500 interrupt. Niet-gebruikte signalen zoals External GPIO en OpenTherm Master krijgen in deze PR nog geen YAML-consumer.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_eth.yaml`
