### PR TITLE
Raise cooling restart delta max

### DIFF
--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -241,7 +241,7 @@ number:
     icon: mdi:thermometer-lines
     unit_of_measurement: "°C"
     min_value: 0.0
-    max_value: 2.0
+    max_value: 5.0
     step: 0.1
     mode: slider
     optimistic: true
@@ -673,7 +673,7 @@ interval:
           const float buffer_gap_c = supply_c - target_c;
           float restart_delta_c = id(cooling_restart_delta).state;
           if (isnan(restart_delta_c) || restart_delta_c < 0.0f) restart_delta_c = 1.0f;
-          if (restart_delta_c > 2.0f) restart_delta_c = 2.0f;
+          if (restart_delta_c > 5.0f) restart_delta_c = 5.0f;
 
           const bool user_responsibility_mode =
               id(cooling_without_dew_point_user_responsibility_enabled).has_state() &&

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -1422,7 +1422,7 @@
       ["Power House demand fall time", 3, 1, 10, 1, "min"],
       ["Cooling Minimum Supply Temp", 18, 5, 24, 0.5, "°C"],
       ["Cooling Demand Max", 4, 1, 10, 1, "step"],
-      ["Cooling Restart Delta", 1.0, 0, 2, 0.1, "°C"],
+      ["Cooling Restart Delta", 1.0, 0, 5, 0.1, "°C"],
       ["Cooling Request On Delta", 0.4, 0, 2, 0.1, "°C"],
       ["Cooling Request Off Delta", 0.1, 0, 2, 0.1, "°C"],
       ["Cooling Safety Margin", 2, 0, 4, 0.1, "°C"],


### PR DESCRIPTION
# Wat verandert deze PR?

- Verhoogt de max van `Cooling Restart Delta` van 2.0 naar 5.0 °C.
- Past de interne runtime-clamp mee aan naar 5.0 °C.
- Werkt de web mock-device metadata bij naar dezelfde maxwaarde.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De koel-watercyclus mag na een waterzijde-stop nu met een grotere herstart-hysterese worden ingesteld. Waarden boven 5.0 °C worden nog steeds intern begrensd.

## Achtergrond

Op verzoek is de bovengrens van `Cooling Restart Delta` verruimd van 2.0 naar 5.0 °C.

## Validatie

- `rtk python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- `rtk node --check openquatt/web/js/mock-device.js`
