### PR TITLE
Avoid conflicts in generated web bundles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Generated web bundles are kept from the current branch during merges.
+# Rebuild them from source with `rtk npm run build:web` after resolving source conflicts.
+openquatt/web/js/openquatt-app.js merge=openquatt-generated linguist-generated=true
+openquatt/web/css/openquatt-app.css merge=openquatt-generated linguist-generated=true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 # Wat verandert deze PR?
 
 <!-- Korte samenvatting in 1-3 bullets. -->
+<!-- Noteer commando's zonder rtk-prefix: `npm ci`, niet `rtk npm ci`. -->
 
 - 
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Run settings-backup consistency check
         run: node openquatt/web/check-settings-backup.mjs
 
+      - name: Install web build dependencies
+        run: npm ci
+
+      - name: Check generated web bundles
+        run: npm run check:web
+
   validate-and-compile:
     needs: validate-web-settings-backup
     uses: ./.github/workflows/esphome-build.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@
 
 - Do not prefix PR titles with `[codex]`; use a concise human-readable title instead.
 - Use `.github/pull_request_template.md` for PR bodies and fill every relevant section.
+- In PRs, issues, review comments, and other GitHub-facing communication, write commands without the `rtk` wrapper (for example, `npm ci`, not `rtk npm ci`). Keep using `rtk` when executing those commands locally.
 
 ## Concise Mode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,16 @@ For quick iterations, the standalone checks remain useful:
 - `python3 scripts/check_docs_consistency.py`
 
 The checker is intended as a local quality gate. Add new rules only once the current codebase can satisfy them consistently.
+
+## Generated Web Bundles
+
+The files `openquatt/web/js/openquatt-app.js` and `openquatt/web/css/openquatt-app.css` are generated and committed for firmware and release builds. Configure their merge driver once per clone:
+
+- `rtk npm run setup:git-merge-driver`
+
+The driver keeps the current bundle during a merge instead of creating generated-file conflicts. Resolve conflicts only in `openquatt/web/js/src/` and `openquatt/web/css/src/`, then regenerate and verify the committed bundles:
+
+- `rtk npm run build:web`
+- `rtk npm run check:web`
+
+CI runs the check and fails when the committed bundles do not match their sources.

--- a/RTK.md
+++ b/RTK.md
@@ -34,4 +34,8 @@ rtk npm run build:web
 rtk python3 scripts/check_docs_consistency.py
 ```
 
+## Communication
+
+- Use `rtk` when executing commands locally, but omit the wrapper in PRs, issues, review comments, and other GitHub-facing communication. Write `npm ci`, for example, rather than `rtk npm ci`.
+
 Use `rtk gain` occasionally to confirm savings tracking. If RTK hides needed details, rerun a narrower command rather than dumping broader output.

--- a/openquatt/web/build-assets.mjs
+++ b/openquatt/web/build-assets.mjs
@@ -7,6 +7,12 @@ import { resolveCssSources } from "./css-source-list.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const checkOnly = process.argv.includes("--check");
+
+const unsupportedArguments = process.argv.slice(2).filter((argument) => argument !== "--check");
+if (unsupportedArguments.length) {
+  throw new Error(`Unsupported arguments: ${unsupportedArguments.join(", ")}`);
+}
 
 const bundles = [
   {
@@ -57,12 +63,7 @@ function toBundlePath(value) {
   return value.split(path.sep).join("/");
 }
 
-async function buildBundle(bundle) {
-  if (bundle.label === "JS") {
-    await buildJavaScriptBundle(bundle);
-    return;
-  }
-
+async function renderCssBundle(bundle) {
   const parts = await Promise.all(
     bundle.sources.map(async (source) => ({
       source,
@@ -77,12 +78,10 @@ async function buildBundle(bundle) {
   const bodySegments = parts.map(({ content }) => content.trimEnd());
   const body = bodySegments.join("\n");
   const minified = (await transform(body, { loader: "css", minify: true })).code.trim();
-  await mkdir(path.dirname(bundle.output), { recursive: true });
-  await writeFile(bundle.output, `${header}\n${minified}\n`, "utf8");
-  console.log(`${bundle.label} bundle rebuilt: ${path.relative(__dirname, bundle.output)}`);
+  return `${header}\n${minified}\n`;
 }
 
-async function buildJavaScriptBundle(bundle) {
+async function renderJavaScriptBundle(bundle) {
   const result = await build({
     entryPoints: [bundle.entryPoint],
     bundle: true,
@@ -98,10 +97,42 @@ async function buildJavaScriptBundle(bundle) {
     "/* Source files are in ./js/src and ./css/src. Rebuild with: node openquatt/web/build-assets.mjs */",
   ].join("\n");
   const output = result.outputFiles[0]?.text || "";
+  return `${header}\n${output.trim()}\n`;
+}
+
+async function bundleIsCurrent(bundle, expected) {
+  try {
+    return await readFile(bundle.output, "utf8") === expected;
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function buildBundle(bundle) {
+  const output = bundle.label === "JS"
+    ? await renderJavaScriptBundle(bundle)
+    : await renderCssBundle(bundle);
+  if (checkOnly) {
+    return await bundleIsCurrent(bundle, output) ? null : path.relative(process.cwd(), bundle.output);
+  }
+
   await mkdir(path.dirname(bundle.output), { recursive: true });
-  await writeFile(bundle.output, `${header}\n${output.trim()}\n`, "utf8");
+  await writeFile(bundle.output, output, "utf8");
   console.log(`${bundle.label} bundle rebuilt: ${path.relative(__dirname, bundle.output)}`);
+  return null;
 }
 
 await checkSettingsBackupConfig();
-await Promise.all(bundles.map(buildBundle));
+const staleBundles = (await Promise.all(bundles.map(buildBundle))).filter(Boolean);
+
+if (checkOnly) {
+  if (staleBundles.length) {
+    console.error(`Generated web bundles are out of date:\n- ${staleBundles.join("\n- ")}\nRun: rtk npm run build:web`);
+    process.exitCode = 1;
+  } else {
+    console.log("Generated web bundles are up to date");
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "scripts": {
     "build:web": "node openquatt/web/build-assets.mjs",
-    "smoke:web": "node openquatt/web/smoke-web.mjs"
+    "check:web": "node openquatt/web/build-assets.mjs --check",
+    "smoke:web": "node openquatt/web/smoke-web.mjs",
+    "setup:git-merge-driver": "git config --local merge.openquatt-generated.name \"Keep current generated web bundle for rebuild\" && git config --local merge.openquatt-generated.driver true && git config --local merge.openquatt-generated.recursive binary"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Wat verandert deze PR?

- markeert de committed JS- en CSS-bundles als generated en koppelt ze aan een repo-specifieke merge-driver;
- voegt een niet-mutatieve freshness-check toe voor de gegenereerde webbundles;
- laat PR-CI falen wanneer de committed bundles niet overeenkomen met hun bronnen en documenteert de merge-workflow;
- verduidelijkt in de repo-instructies en het PR-template hoe commands in GitHub-communicatie worden weergegeven.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De normale webbuild blijft dezelfde bundle-inhoud produceren. De wijziging raakt alleen merge-afhandeling, lokale tooling, instructies en CI-validatie.

## Achtergrond

De gegenereerde bestanden `openquatt/web/js/openquatt-app.js` en `openquatt/web/css/openquatt-app.css` zijn nodig voor firmware en releases, maar veroorzaken regelmatig mergeconflicten.

Na eenmalig `npm run setup:git-merge-driver` houdt Git bij bundle-conflicten de huidige generated versie aan. De bedoelde workflow blijft: bronconflicten oplossen, `npm run build:web` uitvoeren en de nieuwe bundle-output committen. CI bewaakt dat deze stap niet wordt vergeten.

## Validatie

- `npm ci`
- `npm run build:web`
- `npm run check:web`
- `npm run smoke:web`
- `node --check openquatt/web/build-assets.mjs`
- workflow-YAML parse
- `git diff --check`
- gecontroleerd dat regeneratie geen wijziging in de committed bundles oplevert
