### PR TITLE
Consolidate Modbus polling and flow cadence

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -111,7 +111,7 @@ select:
       "Standby": 0
       "Cooling": 1
       "Heating": 2
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_target_readback_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -137,7 +137,7 @@ select:
       "8": 8
       "9": 9
       "10": 10
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_control_readback_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -154,7 +154,7 @@ select:
     optionsmap:
       "Off": 0
       "On": 1
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_control_readback_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -171,7 +171,7 @@ select:
     optionsmap:
       "Off": 0
       "On": 4096
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_control_readback_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -238,7 +238,7 @@ number:
     min_value: 0
     max_value: 1000
     mode: slider
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_control_readback_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -270,7 +270,7 @@ sensor:
     state_class: measurement
     register_type: holding
     address: 2099
-    #skip_updates: 0
+    skip_updates: ${oq_modbus_telemetry_skip}
     on_value:
       then:
         - lambda: |-
@@ -295,7 +295,7 @@ sensor:
           min_value: 0
           max_value: 300
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -316,7 +316,7 @@ sensor:
           min_value: 0
           max_value: 16
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -337,7 +337,7 @@ sensor:
           min_value: 0
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -358,7 +358,7 @@ sensor:
           min_value: 0
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     on_value:
       then:
         - lambda: |-
@@ -386,7 +386,7 @@ sensor:
           min_value: 0
           max_value: 1000
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -400,14 +400,14 @@ sensor:
     unit_of_measurement: "RPM"
     state_class: "measurement"
     accuracy_decimals: 0
-    # register_count: 2  # 2105 - 2106
+    register_count: 2  # 2105-2106; bridge reserved register 2106.
     filters:
       - multiply: 1
       - clamp:
           min_value: 0
           max_value: 1000
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -427,7 +427,7 @@ sensor:
           min_value: 0
           max_value: 1000
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -450,7 +450,7 @@ sensor:
           min_value: -30
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     on_value:
       then:
         - lambda: |-
@@ -478,7 +478,7 @@ sensor:
           min_value: -30
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -500,7 +500,7 @@ sensor:
           min_value: -30
           max_value: 150
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -515,7 +515,7 @@ sensor:
     device_class: "temperature"
     state_class: "measurement"
     accuracy_decimals: 2
-    register_count: 2  # 2113 - 2114
+    register_count: 3  # 2113-2115; bridge reserved register 2115.
     filters:
       - offset: -3000
       - multiply: 0.01
@@ -523,7 +523,7 @@ sensor:
           min_value: -30
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -544,7 +544,7 @@ sensor:
           min_value: 0
           max_value: 20
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -566,7 +566,7 @@ sensor:
           min_value: 0
           max_value: 60
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -575,7 +575,7 @@ sensor:
     id: ${hp_id}_pcb_firmware_raw
     register_type: holding
     address: 2122
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     value_type: U_WORD
     internal: true
 
@@ -588,7 +588,7 @@ sensor:
     register_type: holding
     register_count: 4  # 2123 - 2127
     address: 2123
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -601,7 +601,7 @@ sensor:
     register_type: holding
     register_count: 4  # 2127 - 2131
     address: 2127
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -623,7 +623,7 @@ sensor:
           min_value: -30
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -645,7 +645,7 @@ sensor:
           min_value: -30
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -671,7 +671,7 @@ sensor:
           min_value: -10
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -697,7 +697,7 @@ sensor:
           min_value: -10
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -746,7 +746,7 @@ sensor:
     device_class: "temperature"
     state_class: "measurement"
     accuracy_decimals: 2
-    # register_count: 2  # 2135 - 2137
+    register_count: 2  # 2135-2136; bridge reserved register 2136.
     filters:
       - offset: -3000
       - multiply: 0.01
@@ -754,7 +754,7 @@ sensor:
           min_value: -30
           max_value: 100
           ignore_out_of_range: true
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -772,7 +772,7 @@ sensor:
     accuracy_decimals: 2
     filters:
       - multiply: 0.1
-    skip_updates: ${oq_skip_30s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -783,8 +783,8 @@ sensor:
     icon: mdi:water-pump
     register_type: holding
     address: 2138
-    force_new_range: true
-    #skip_updates: 0
+    force_new_range: false
+    skip_updates: ${oq_modbus_telemetry_skip}
     unit_of_measurement: "L/h"
     device_class: "volume_flow_rate"
     state_class: "measurement"
@@ -955,11 +955,32 @@ sensor:
   # individual Modbus bit entities per heat pump.
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
+    id: ${hp_id}_status_2108_raw
+    register_type: holding
+    address: 2108
+    value_type: U_WORD
+    register_count: 2  # 2108-2109; bridge reserved register 2109.
+    skip_updates: ${oq_modbus_telemetry_skip}
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            const uint16_t status = static_cast<uint16_t>(lroundf(x));
+            id(${hp_id}_fan_low_speed_mode).publish_state((status & 0x0001u) != 0u);
+            id(${hp_id}_bottom_plate_heater).publish_state((status & 0x0004u) != 0u);
+            id(${hp_id}_crankcase_heater).publish_state((status & 0x0008u) != 0u);
+            id(${hp_id}_fan_defrost_mode).publish_state((status & 0x0010u) != 0u);
+            id(${hp_id}_fan_high_speed_mode).publish_state((status & 0x0020u) != 0u);
+            id(${hp_id}_4_way_valve).publish_state((status & 0x0040u) != 0u);
+            id(${hp_id}_pump_relay).publish_state((status & 0x0800u) != 0u);
+
+  - platform: modbus_controller
+    modbus_controller_id: ${hp_id}
     id: ${hp_id}_status_2119_raw
     register_type: holding
     address: 2119
     value_type: U_WORD
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     internal: true
 
   - platform: modbus_controller
@@ -968,7 +989,7 @@ sensor:
     register_type: holding
     address: 2120
     value_type: U_WORD
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     internal: true
 
   - platform: modbus_controller
@@ -977,7 +998,7 @@ sensor:
     register_type: holding
     address: 2121
     value_type: U_WORD
-    skip_updates: ${oq_skip_10s}
+    skip_updates: ${oq_modbus_telemetry_skip}
     internal: true
 
   # ----------------------------
@@ -985,87 +1006,57 @@ sensor:
   # ----------------------------
 binary_sensor:
   # At least bits 0,2,4,5,6,11 are used for status in R2108.
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
+  - platform: template
     id: ${hp_id}_fan_low_speed_mode
     name: "${prefix}Fan Low Speed Mode"
     internal: true
     disabled_by_default: true
     icon: mdi:fan-speed-1
     device_class: running
-    register_type: holding
-    address: 2108
-    bitmask: 0x1
-    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
+  - platform: template
     id: ${hp_id}_bottom_plate_heater
     name: "${prefix}Bottom plate heater"
     icon: mdi:radiator
     device_class: heat
-    register_type: holding
-    address: 2108
-    bitmask: 0x4
-    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
+  - platform: template
     id: ${hp_id}_crankcase_heater
     name: "${prefix}Crankcase heater"
     icon: mdi:radiator
     device_class: heat
-    register_type: holding
-    address: 2108
-    bitmask: 0x8
-    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
+  - platform: template
     id: ${hp_id}_fan_defrost_mode
     name: "${prefix}Fan Defrost Mode"
     internal: true
     disabled_by_default: true
     icon: mdi:snowflake-melt
     device_class: running
-    register_type: holding
-    address: 2108
-    bitmask: 0x10
-    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
+  - platform: template
     id: ${hp_id}_fan_high_speed_mode
     name: "${prefix}Fan High Speed Mode"
     internal: true
     disabled_by_default: true
     icon: mdi:fan-speed-3
     device_class: running
-    register_type: holding
-    address: 2108
-    bitmask: 0x20
-    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
+  - platform: template
     id: ${hp_id}_4_way_valve
     name: "${prefix}4-Way valve"
     icon: mdi:valve
     device_class: running
-    register_type: holding
-    address: 2108
-    bitmask: 0x40
-    skip_updates: ${oq_skip_10s}
     on_state:
       then:
         - lambda: |-
@@ -1073,16 +1064,11 @@ binary_sensor:
     web_server:
       sorting_group_id: oq_${hp_id}
 
-  - platform: modbus_controller
-    modbus_controller_id: ${hp_id}
+  - platform: template
     id: ${hp_id}_pump_relay
     name: "${prefix}DC Pump Relay"
     icon: mdi:electric-switch
     device_class: running
-    register_type: holding
-    address: 2108
-    bitmask: 0x800
-    skip_updates: ${oq_skip_10s}
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -1094,7 +1080,7 @@ binary_sensor:
     device_class: running
     register_type: holding
     address: 2118
-    #skip_updates: 0
+    skip_updates: ${oq_modbus_telemetry_skip}
     on_state:
       then:
         - lambda: |-

--- a/openquatt/oq_air_purge.yaml
+++ b/openquatt/oq_air_purge.yaml
@@ -67,7 +67,7 @@ button:
     on_press:
       - lambda: |-
           oq_air_purge::runtime().start(
-              oq_air_purge::make_runtime_config(${oq_flow_loop_s}),
+              oq_air_purge::make_runtime_config(${oq_air_purge_loop_s}),
               (uint32_t) millis());
 
   - platform: template
@@ -98,10 +98,10 @@ switch:
 # MAIN LOOP
 # ----------------------------
 interval:
-  - interval: ${oq_flow_loop_s}s
+  - interval: ${oq_air_purge_loop_s}s
     startup_delay: 5200ms
     then:
       - lambda: |-
           oq_air_purge::runtime().tick(
-              oq_air_purge::make_runtime_config(${oq_flow_loop_s}),
+              oq_air_purge::make_runtime_config(${oq_air_purge_loop_s}),
               (uint32_t) millis());

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -127,6 +127,7 @@ button:
 # ----------------------------
 interval:
   - interval: ${oq_flow_ts}s
+    startup_delay: ${oq_flow_autotune_startup_delay_ms}ms
     then:
       - lambda: |-
           const auto cfg = oq_flow_autotune::make_runtime_config(

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -344,19 +344,27 @@ text_sensor:
 # CONTROL LOOPS
 # ----------------------------
 interval:
-  # Air Purge keeps its original 5s actuator cadence independently of the 10s PI.
-  # The purge task updates its target at 5.2s phase; this loop applies it 0.5s later.
-  - interval: ${oq_air_purge_loop_s}s
-    startup_delay: ${oq_air_purge_output_startup_delay_ms}ms
+  # Fixed-output service tasks keep their original 5s actuator cadence independently of the 10s PI.
+  # Air Purge updates at 5.2s phase; this loop applies it 0.5s later and also serves Quick Flow Test.
+  - interval: ${oq_flow_service_output_loop_s}s
+    startup_delay: ${oq_flow_service_output_startup_delay_ms}ms
     then:
       - lambda: |-
-          if (!id(oq_air_purge_active) ||
-              id(oq_control_mode_code) != 100 ||
-              id(oq_commissioning_task_code) != oq_commissioning::TASK_AIR_PURGE) {
+          if (id(oq_control_mode_code) != 100) {
             return;
           }
 
-          // Apply only changed purge targets so the 5s service tick does not add redundant Modbus writes.
+          // Select the active fixed-output service owner; task ownership keeps these modes mutually exclusive.
+          const int task_code = id(oq_commissioning_task_code);
+          const bool air_purge_output =
+              id(oq_air_purge_active) && task_code == oq_commissioning::TASK_AIR_PURGE;
+          const bool quick_flow_test_output =
+              id(oq_quick_flow_test_active) && task_code == oq_commissioning::TASK_MANUAL_FLOW;
+          if (!air_purge_output && !quick_flow_test_output) {
+            return;
+          }
+
+          // Apply only changed targets so the 5s service tick does not add redundant Modbus writes.
           auto clamp_iPWM = [](int value) -> int {
             constexpr int kMinIpwm = 50;
             constexpr int kMaxIpwm = 850;
@@ -374,11 +382,14 @@ interval:
             }
           };
 
-          const int purge_pwm = clamp_iPWM((int) id(oq_air_purge_target_ipwm));
-          id(oq_flow_last_pwm) = purge_pwm;
-          write_pump_pwm_if_changed(id(hp1_pump_speed), purge_pwm);
+          const int service_pwm = clamp_iPWM(
+              air_purge_output
+                  ? (int) id(oq_air_purge_target_ipwm)
+                  : (int) id(oq_quick_flow_test_target_ipwm));
+          id(oq_flow_last_pwm) = service_pwm;
+          write_pump_pwm_if_changed(id(hp1_pump_speed), service_pwm);
           if (${flow_secondary_enabled} != 0) {
-            write_pump_pwm_if_changed(id(${secondary_pump_speed_id}), purge_pwm);
+            write_pump_pwm_if_changed(id(${secondary_pump_speed_id}), service_pwm);
           }
 
   # Main PI and mode handling stays aligned to the 10s telemetry cadence.
@@ -718,7 +729,7 @@ interval:
             id(oq_flow_last_pwm) = purge_pwm;
             stable_cnt = 0;
             pi_failsafe = false;
-            // The dedicated 5s Air Purge output loop applies this target.
+            // The dedicated 5s service-output loop applies this target.
             if (last_mode != "AIR PURGE") {
               id(oq_flow_mode).publish_state("AIR PURGE");
               last_mode = "AIR PURGE";
@@ -735,10 +746,7 @@ interval:
             id(oq_flow_last_pwm) = test_pwm;
             stable_cnt = 0;
             pi_failsafe = false;
-            write_pump_pwm_if_changed(id(hp1_pump_speed), test_pwm);
-            if (${flow_secondary_enabled} != 0) {
-              write_pump_pwm_if_changed(id(${secondary_pump_speed_id}), test_pwm);
-            }
+            // The dedicated 5s service-output loop applies this target.
             if (last_mode != "QUICK FLOW TEST") {
               id(oq_flow_mode).publish_state("QUICK FLOW TEST");
               last_mode = "QUICK FLOW TEST";

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -341,11 +341,11 @@ text_sensor:
       sorting_group_id: oq_hydraulics
 
 # ----------------------------
-# MAIN LOOP (5s): PI + mode handling
+# MAIN LOOP (10s): PI + mode handling
 # ----------------------------
 interval:
   - interval: ${oq_flow_loop_s}s
-    startup_delay: 3200ms
+    startup_delay: ${oq_flow_loop_startup_delay_ms}ms
     then:
       - lambda: |-
           // ============================================================================

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -341,9 +341,47 @@ text_sensor:
       sorting_group_id: oq_hydraulics
 
 # ----------------------------
-# MAIN LOOP (10s): PI + mode handling
+# CONTROL LOOPS
 # ----------------------------
 interval:
+  # Air Purge keeps its original 5s actuator cadence independently of the 10s PI.
+  # The purge task updates its target at 5.2s phase; this loop applies it 0.5s later.
+  - interval: ${oq_air_purge_loop_s}s
+    startup_delay: ${oq_air_purge_output_startup_delay_ms}ms
+    then:
+      - lambda: |-
+          if (!id(oq_air_purge_active) ||
+              id(oq_control_mode_code) != 100 ||
+              id(oq_commissioning_task_code) != oq_commissioning::TASK_AIR_PURGE) {
+            return;
+          }
+
+          // Apply only changed purge targets so the 5s service tick does not add redundant Modbus writes.
+          auto clamp_iPWM = [](int value) -> int {
+            constexpr int kMinIpwm = 50;
+            constexpr int kMaxIpwm = 850;
+            if (value < kMinIpwm) return kMinIpwm;
+            if (value > kMaxIpwm) return kMaxIpwm;
+            return value;
+          };
+          auto write_pump_pwm_if_changed = [](auto *num, int value) {
+            if (num == nullptr) return;
+            const float cur = num->state;
+            if (isnan(cur) || fabsf(cur - value) > 1.0f) {
+              auto c = num->make_call();
+              c.set_value(value);
+              c.perform();
+            }
+          };
+
+          const int purge_pwm = clamp_iPWM((int) id(oq_air_purge_target_ipwm));
+          id(oq_flow_last_pwm) = purge_pwm;
+          write_pump_pwm_if_changed(id(hp1_pump_speed), purge_pwm);
+          if (${flow_secondary_enabled} != 0) {
+            write_pump_pwm_if_changed(id(${secondary_pump_speed_id}), purge_pwm);
+          }
+
+  # Main PI and mode handling stays aligned to the 10s telemetry cadence.
   - interval: ${oq_flow_loop_s}s
     startup_delay: ${oq_flow_loop_startup_delay_ms}ms
     then:
@@ -680,10 +718,7 @@ interval:
             id(oq_flow_last_pwm) = purge_pwm;
             stable_cnt = 0;
             pi_failsafe = false;
-            write_pump_pwm_if_changed(id(hp1_pump_speed), purge_pwm);
-            if (${flow_secondary_enabled} != 0) {
-              write_pump_pwm_if_changed(id(${secondary_pump_speed_id}), purge_pwm);
-            }
+            // The dedicated 5s Air Purge output loop applies this target.
             if (last_mode != "AIR PURGE") {
               id(oq_flow_mode).publish_state("AIR PURGE");
               last_mode = "AIR PURGE";

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -168,7 +168,8 @@ oq_defrost_comp_boost_steps: "1"                      # Extra level steps on non
 oq_flow_loop_s: "10"                                  # Control interval of the flow-control loop [s].
 oq_flow_loop_startup_delay_ms: "6000"                 # Phase PI after both staged HP telemetry reads [ms].
 oq_air_purge_loop_s: "5"                              # Independent Air Purge phase cadence; preserves 25s/15s pulse timing [s].
-oq_air_purge_output_startup_delay_ms: "5700"          # Apply each purge target shortly after its 5s phase tick [ms].
+oq_flow_service_output_loop_s: "5"                    # Fast actuator cadence for fixed-output service tasks [s].
+oq_flow_service_output_startup_delay_ms: "5700"       # Apply service targets shortly after their state-machine ticks [ms].
 oq_flow_mismatch_threshold_lph: "150.0"               # Allowed HP1-vs-HP2 flow difference before mismatch logic starts [L/h].
 oq_flow_mismatch_hyst_lph: "50.0"                     # Hysteresis on mismatch detection to prevent chatter [L/h].
 oq_flow_kp_min: "0.00"                                # Lower bound for Flow PI Kp.

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -165,7 +165,8 @@ oq_defrost_comp_boost_steps: "1"                      # Extra level steps on non
 # ----------------------------
 # FLOW CONTROL
 # ----------------------------
-oq_flow_loop_s: "5"                                   # Control interval of the flow-control loop [s].
+oq_flow_loop_s: "10"                                  # Control interval of the flow-control loop [s].
+oq_flow_loop_startup_delay_ms: "6000"                 # Phase PI after both staged HP telemetry reads [ms].
 oq_flow_mismatch_threshold_lph: "150.0"               # Allowed HP1-vs-HP2 flow difference before mismatch logic starts [L/h].
 oq_flow_mismatch_hyst_lph: "50.0"                     # Hysteresis on mismatch detection to prevent chatter [L/h].
 oq_flow_kp_min: "0.00"                                # Lower bound for Flow PI Kp.
@@ -176,7 +177,8 @@ oq_flow_ki_max: "0.0100"                              # Upper bound for Flow PI 
 # ----------------------------
 # FLOW AUTOTUNE
 # ----------------------------
-oq_flow_ts: "5"                                       # Autotune/main-loop sample time; must match flow-control [s].
+oq_flow_ts: "10"                                      # Autotune/main-loop sample time; must match flow-control [s].
+oq_flow_autotune_startup_delay_ms: "5500"             # Phase autotune after HP telemetry and shortly before PI [ms].
 oq_flow_pwm_min: "50"                                 # Lower pump iPWM bound during autotune.
 oq_flow_pwm_max: "850"                                # Upper pump iPWM bound during autotune.
 oq_flow_autotune_min_step: "5"                        # Minimum iPWM step size for the step test.
@@ -238,5 +240,6 @@ oq_modbus_update_interval_s: "5"                    # Base Modbus controller pol
 oq_modbus_command_throttle_ms: "500"                 # Minimum spacing between Modbus commands [ms].
 oq_modbus_max_cmd_retries: "1"                       # Retries per Modbus command; keep low to avoid long blocking on bad links.
 oq_modbus_startup_delay_ms: "0"                      # Default startup offset for staged Modbus polling [ms].
-oq_skip_10s: "1"                                      # 1 skip; effective polling every 10s.
-oq_skip_30s: "5"                                      # 5 skips; effective polling every 30s.
+oq_modbus_telemetry_skip: "1"                        # 2099-2138: 1 skipped base update, effective polling every 10s.
+oq_modbus_target_readback_skip: "1"                  # 3999 safety-relevant target readback every 10s.
+oq_modbus_control_readback_skip: "5"                 # 1999/2006/2010/2015 readback every 30s.

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -167,6 +167,8 @@ oq_defrost_comp_boost_steps: "1"                      # Extra level steps on non
 # ----------------------------
 oq_flow_loop_s: "10"                                  # Control interval of the flow-control loop [s].
 oq_flow_loop_startup_delay_ms: "6000"                 # Phase PI after both staged HP telemetry reads [ms].
+oq_air_purge_loop_s: "5"                              # Independent Air Purge phase cadence; preserves 25s/15s pulse timing [s].
+oq_air_purge_output_startup_delay_ms: "5700"          # Apply each purge target shortly after its 5s phase tick [ms].
 oq_flow_mismatch_threshold_lph: "150.0"               # Allowed HP1-vs-HP2 flow difference before mismatch logic starts [L/h].
 oq_flow_mismatch_hyst_lph: "50.0"                     # Hysteresis on mismatch detection to prevent chatter [L/h].
 oq_flow_kp_min: "0.00"                                # Lower bound for Flow PI Kp.


### PR DESCRIPTION
# Wat verandert deze PR?

- Leest Modbus-telemetrie `2099–2138` per warmtepomp als één FC03-blok van 40 registers, iedere 10 seconden.
- Houdt register `3999` op 10 seconden en de control-readbacks `1999`, `2006`, `2010` en `2015` op 30 seconden.
- Zet de flow-PI en autotune-sampletijd op 10 seconden en faseert hun intervalticks na de Modbus-telemetrie. De autotune-start blijft volledig gebruikersgestuurd.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De Modbusbelasting daalt doordat de volledige warmtepomptelemetrie als één aaneengesloten blok wordt gelezen. Alle bestaande entity-id's blijven behouden. De flowregeling rekent voortaan met dezelfde 10-seconden-cadans als de vernieuwde telemetrie; daarvoor zijn de PI- en autotune-sampletijden aangepast.

## Achtergrond

PR #325 en PR #326 zijn inmiddels in `dev` opgenomen. Deze branch is daarna opnieuw op de actuele `dev`-basis gezet en de PR is van de tijdelijke stack-base naar `dev` geretarget.

Validatie op een Q-edition duo Wi-Fi-installatie met tijdelijke Modbus-VERBOSE-logging bevestigde:

- Per HP één request vanaf `0x833` (`2099`) met `count 40`; de response bevat 80 databytes.
- Register `3999` wordt als losse read iedere 10 seconden gelezen.
- Registers `1999`, `2006`, `2010` en `2015` blijven op 30 seconden.
- HP1 en HP2 zijn circa drie seconden ten opzichte van elkaar gefaseerd.
- Eerste responsebytes kwamen na circa 25–90 ms binnen; responses werden correct geparsed.
- Geen Modbus-retries, time-outs of parsefouten waargenomen.

De tijdelijke VERBOSE-logging is na deze meting weer uit de uiteindelijke firmware verwijderd.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml --config configs/heatpump_controller_q/single_wifi.yaml --config configs/heatpump_controller_q/duo_eth.yaml --config configs/heatpump_controller_q/single_eth.yaml`
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`
- OTA en runtimecontrole op een Q-edition duo Wi-Fi via `openquatt.local`
