### PR TITLE
Report active PT1000 read failures

### DIFF
--- a/openquatt/profiles/heatpump_controller_q_status_leds.yaml
+++ b/openquatt/profiles/heatpump_controller_q_status_leds.yaml
@@ -7,8 +7,8 @@
 #
 # Behavior:
 #   - Yellow LED: on while the active network interface is connected.
-#   - Red LED: on while a firmware, OpenTherm, heat-pump or hard safety fault
-#     is active.
+#   - Red LED: on while a firmware, sensor, OpenTherm, heat-pump or hard safety
+#     fault is active.
 #   - Status LEDs enabled: disables both LED outputs when off.
 #
 # ==============================================================================
@@ -38,6 +38,30 @@ switch:
     web_server:
       sorting_group_id: oq_system_diagnostics
 
+binary_sensor:
+  - platform: template
+    id: oq_pt1000_read_problem
+    name: "PT1000 read problem"
+    internal: true
+    icon: mdi:thermometer-alert
+    device_class: problem
+    entity_category: diagnostic
+    lambda: |-
+      if (!id(water_supply_source).has_state() ||
+          !id(oq_local_supply_temp_source).has_state()) {
+        return false;
+      }
+
+      const bool pt1000_selected =
+          id(water_supply_source).current_option() == "Local" &&
+          id(oq_local_supply_temp_source).current_option() == "PT1000";
+      if (!pt1000_selected) return false;
+
+      return !id(water_supply_temp_pt1000).has_state() ||
+             isnan(id(water_supply_temp_pt1000).state);
+    filters:
+      - delayed_on: 15s
+
 interval:
   - interval: 1s
     then:
@@ -66,6 +90,8 @@ interval:
           const bool ota_fault = id(oq_ota_phase_code) == 5 || id(oq_ota_phase_code) == 6;
           const bool ot_problem =
               id(ot_link_problem).has_state() && id(ot_link_problem).state;
+          const bool pt1000_problem =
+              id(oq_pt1000_read_problem).has_state() && id(oq_pt1000_read_problem).state;
           const bool hp1_fault =
               id(hp1_ot_fault_active).has_state() && id(hp1_ot_fault_active).state;
           const bool secondary_fault =
@@ -77,6 +103,7 @@ interval:
           const bool fault_active =
               ota_fault ||
               ot_problem ||
+              pt1000_problem ||
               hp_fault ||
               id(oq_lowflow_fault_active) ||
               id(oq_strategy_water_hard_trip_active);


### PR DESCRIPTION
# Wat verandert deze PR?

- Detecteert intern wanneer de actief geselecteerde PT1000 niet uitleesbaar is.
- Activeert de melding pas na 15 seconden en wist haar bij de eerstvolgende geldige meting.
- Neemt de interne fout uitsluitend op in de rode status-LED; er wordt geen nieuwe Home Assistant- of webentiteit gepubliceerd.

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen het gedrag van de rode hardware-LED wijzigt. De verwarmingsregeling, sensorselectie, bestaande fallbacklogica en Home Assistant-entiteiten veranderen niet.

## Achtergrond

De MAX31865 publiceert al een ongeldige waarde bij een lees- of aansluitfout en het Q-profiel verwerpt daarnaast temperaturen buiten het geldige bereik. Er ontbrak alleen een interne foutstatus voor de rode LED.

De fout wordt uitsluitend bewaakt bij `Water Supply Source = Local` en `Local Water Supply Temp Source = PT1000`. Daardoor ontstaat geen alarm wanneer DS18B20, CIC of HA bewust als bron is gekozen.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_eth.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_eth.yaml`

De fysieke los-/vastkoppeltest van de PT1000 is niet lokaal uitgevoerd.