### PR TITLE
Use supply temperature for cooling capacity cap

### DIFF
--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -47,12 +47,6 @@ struct LimiterTuning {
   float capacity_fast_fall_rate_c_per_min = -0.15f;
   float capacity_slow_fall_rate_c_per_min = -0.05f;
   float capacity_recovery_min_rate_c_per_min = -0.02f;
-  float hp_out_cap1_gap_c = 0.25f;
-  float hp_out_cap2_gap_c = 0.55f;
-  float hp_out_cap3_gap_c = 0.85f;
-  float hp_out_release_to2_gap_c = 0.65f;
-  float hp_out_release_to3_gap_c = 0.85f;
-  float hp_out_release_full_gap_c = 1.05f;
 };
 
 struct LimiterState {
@@ -79,7 +73,6 @@ struct LimiterInput {
   float filtered_gap_c = NAN;
   float gap_rate_c_per_min = 0.0f;
   float dew_gap_c = NAN;
-  float active_hp_out_gap_c = NAN;
   float safety_margin_c = 0.0f;
 };
 
@@ -144,15 +137,6 @@ inline int dew_capacity_risk_cap(const LimiterInput &in,
     risk_cap = std::min(risk_cap, 2);
   }
 
-  if (finite_float(in.active_hp_out_gap_c)) {
-    if (in.active_hp_out_gap_c <= tuning.hp_out_cap1_gap_c) {
-      risk_cap = std::min(risk_cap, 1);
-    } else if (in.active_hp_out_gap_c <= tuning.hp_out_cap2_gap_c) {
-      risk_cap = std::min(risk_cap, 2);
-    } else if (in.active_hp_out_gap_c <= tuning.hp_out_cap3_gap_c) {
-      risk_cap = std::min(risk_cap, 3);
-    }
-  }
   return risk_cap;
 }
 
@@ -191,16 +175,9 @@ inline void update_hysteretic_capacity_cap(const LimiterInput &in,
         current_cap <= 1 ? dew_release_to2_gap_c :
         current_cap == 2 ? dew_release_to3_gap_c :
         dew_release_full_gap_c;
-    const float required_hp_out_gap_c =
-        current_cap <= 1 ? tuning.hp_out_release_to2_gap_c :
-        current_cap == 2 ? tuning.hp_out_release_to3_gap_c :
-        tuning.hp_out_release_full_gap_c;
-    const bool hp_out_recovered =
-        !finite_float(in.active_hp_out_gap_c) || in.active_hp_out_gap_c >= required_hp_out_gap_c;
     const bool recovery_ready =
         in.dew_gap_c >= required_dew_gap_c &&
-        in.gap_rate_c_per_min >= tuning.capacity_recovery_min_rate_c_per_min &&
-        hp_out_recovered;
+        in.gap_rate_c_per_min >= tuning.capacity_recovery_min_rate_c_per_min;
 
     if (recovery_ready) {
       if (state.capacity_recovery_since_ms == 0 || in.now_ms <= state.capacity_recovery_since_ms) {

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -971,53 +971,6 @@ interval:
           if (demand_max > 10) demand_max = 10;
           const int capacity_demand_max = demand_max;
 
-          const float active_hp_out_gap_c = [&]()->float {
-            if (!dew_mode || isnan(id(cooling_dew_point_selected).state)) return NAN;
-            const float dew_c = id(cooling_dew_point_selected).state;
-            int owner = id(oq_cooling_request_owner_hp);
-            if (owner == 0) owner = id(oq_cooling_owner_hp);
-
-            auto gap_if_valid = [&](float temp_c)->float {
-              if (isnan(temp_c)) return NAN;
-              return temp_c - dew_c;
-            };
-
-            if (owner == 1 && id(hp1_water_out_temp).has_state()) {
-              const float gap_c = gap_if_valid(id(hp1_water_out_temp).state);
-              if (!isnan(gap_c)) return gap_c;
-            }
-            #if OQ_TOPOLOGY_DUO
-            if (owner == 2 && id(${secondary_water_out_temp_id}).has_state()) {
-              const float gap_c = gap_if_valid(id(${secondary_water_out_temp_id}).state);
-              if (!isnan(gap_c)) return gap_c;
-            }
-            #endif
-
-            if (id(hp1_last_applied_level) > 0 && id(hp1_water_out_temp).has_state()) {
-              const float gap_c = gap_if_valid(id(hp1_water_out_temp).state);
-              if (!isnan(gap_c)) return gap_c;
-            }
-            #if OQ_TOPOLOGY_DUO
-            if (id(${secondary_last_applied_level_id}) > 0 && id(${secondary_water_out_temp_id}).has_state()) {
-              const float gap_c = gap_if_valid(id(${secondary_water_out_temp_id}).state);
-              if (!isnan(gap_c)) return gap_c;
-            }
-            #endif
-
-            if (id(oq_cooling_request_hp1_level) > 0 && id(hp1_water_out_temp).has_state()) {
-              const float gap_c = gap_if_valid(id(hp1_water_out_temp).state);
-              if (!isnan(gap_c)) return gap_c;
-            }
-            #if OQ_TOPOLOGY_DUO
-            if (id(oq_cooling_request_hp2_level) > 0 && id(${secondary_water_out_temp_id}).has_state()) {
-              const float gap_c = gap_if_valid(id(${secondary_water_out_temp_id}).state);
-              if (!isnan(gap_c)) return gap_c;
-            }
-            #endif
-
-            return NAN;
-          }();
-
           bool room_cap_active = false;
           if (room_error_valid) {
             const int before_room_cap = demand_max;
@@ -1050,7 +1003,6 @@ interval:
           limiter_input.filtered_gap_c = filtered_gap_c;
           limiter_input.gap_rate_c_per_min = gap_rate_c_per_min;
           limiter_input.dew_gap_c = dew_gap_c;
-          limiter_input.active_hp_out_gap_c = active_hp_out_gap_c;
           limiter_input.safety_margin_c = safety_margin_c;
 
           const auto limiter_output =


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert de HP water-out temperatuur uit de `capacity_cap` koelbegrenzing.
- Laat de koelcapaciteit-cap alleen nog sturen op centrale aanvoer/dauwpuntmarge en de trend daarvan.
- Verwijdert de bijbehorende HP-out gap berekening uit `oq_cooling_strategy.yaml`.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De koelregeling blijft de bestaande dauwpuntbeveiliging gebruiken, maar `capacity_cap` kijkt niet langer naar de water-out temperatuur van de actieve HP. Centrale aanvoer blijft leidend voor de koelvraagbegrenzing.

## Achtergrond

In recente cooling debuglogs bleef `capacity_cap` de koelvraag beperken terwijl de centrale aanvoer nog voldoende boven het dauwpunt zat. De HP water-out check maakte de cap conservatiever dan bedoeld. Deze PR haalt die extra input uit de hysteretische capacity cap, zodat het gedrag aansluit bij het ontwerpuitgangspunt dat supply leidend is.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
