### PR TITLE
Release cooling capacity cap when supply margin recovers

### DIFF
--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -189,7 +189,11 @@ inline void update_hysteretic_capacity_cap(const LimiterInput &in,
           (uint32_t)(in.now_ms - state.capacity_last_change_ms) >= tuning.capacity_min_hold_ms;
       if (hold_elapsed && elapsed(in.now_ms, state.capacity_recovery_since_ms,
                                   tuning.capacity_recovery_stable_ms)) {
-        current_cap = std::min(capacity_demand_max, std::min(risk_cap, current_cap + 1));
+        const bool full_capacity_recovered =
+            risk_cap >= capacity_demand_max && current_cap >= 3;
+        current_cap = full_capacity_recovered
+            ? capacity_demand_max
+            : std::min(capacity_demand_max, std::min(risk_cap, current_cap + 1));
         state.capacity_last_change_ms = in.now_ms;
         state.capacity_recovery_since_ms = 0;
       }


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat `capacity_cap` volledig vrijgeven zodra de supply/dauwpuntmarge stabiel hersteld is.
- Voorkomt dat een oude cap kunstmatig blijft hangen op 3 of 4 terwijl de supply-marge ruim genoeg is voor normale regeling.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De limiter blijft snel terugregelen wanneer de supply-marge richting dauwpunt krap wordt. Als de supply-marge daarna stabiel ruim genoeg is, wordt de cap nu volledig losgelaten zodat de normale PI-regeling binnen `coolingDemandMax` zijn werk kan doen.

## Achtergrond

Na PR #330 stuurt `capacity_cap` alleen nog op centrale aanvoer/dauwpuntmarge. In een langere test bleef de cap alsnog hangen op niveau 3/4 terwijl de marge rond 1,5 °C lag en de trend stabiel was. In die situatie mag de regeling naar niveau 5 als de normale koelvraag dat vraagt.

## Validatie

- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`
