### PR TITLE
Clamp cooling power during startup

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -906,7 +906,11 @@ sensor:
       const float water_cp_j_per_kgk = ${oq_water_cp_j_per_kgk};  // J/(kg·K)
       const float mass_flow_kgps = flow_lph / 3600.0f;            // kg/s (≈ L/h)
       const float delta_t_k = t_in_c - t_out_c;                   // K, positive while cooling
-      return mass_flow_kgps * water_cp_j_per_kgk * delta_t_k;
+      const float cooling_power_w = mass_flow_kgps * water_cp_j_per_kgk * delta_t_k;
+
+      // During startup the water outlet can briefly still be warmer than the inlet.
+      // That is not cooling output, so do not expose or integrate it as negative power.
+      return (cooling_power_w < 0.0f) ? 0.0f : cooling_power_w;
 
   - platform: template
     id: ${hp_id}_cop


### PR DESCRIPTION
# Wat verandert deze PR?

- Begrens het berekende koelvermogen per warmtepomp op minimaal 0 W.
- Voorkom daardoor een negatief koelvermogen en negatieve EER tijdens de start van koelen.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de afgeleide thermische koelmeting verandert. Aansturing en beveiligingen blijven ongewijzigd. Negatieve opstartwaarden worden als 0 W gepubliceerd en niet meer in de koelenergie geïntegreerd.

## Achtergrond

Bij het inschakelen van koelen kan de wateruitlaat kort nog warmer zijn dan de waterinlaat. De ΔT-formule gaf dan een negatieve koelafgifte; de afgeleide EER nam hetzelfde teken over.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
