### PR TITLE
Make cooling capacity cap recover adaptively

### DIFF
--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -57,6 +57,7 @@ struct LimiterState {
   int capacity_cap = 10;
   uint32_t capacity_last_change_ms = 0;
   uint32_t capacity_recovery_since_ms = 0;
+  uint32_t capacity_full_recovery_since_ms = 0;
 };
 
 struct LimiterInput {
@@ -147,6 +148,7 @@ inline void update_hysteretic_capacity_cap(const LimiterInput &in,
                                            LimiterOutput &out) {
   if (in.oil_return_mask_active) {
     state.capacity_recovery_since_ms = 0;
+    state.capacity_full_recovery_since_ms = 0;
     return;
   }
 
@@ -155,6 +157,7 @@ inline void update_hysteretic_capacity_cap(const LimiterInput &in,
     state.capacity_cap = capacity_demand_max;
     state.capacity_last_change_ms = 0;
     state.capacity_recovery_since_ms = 0;
+    state.capacity_full_recovery_since_ms = 0;
     return;
   }
 
@@ -166,6 +169,7 @@ inline void update_hysteretic_capacity_cap(const LimiterInput &in,
     current_cap = risk_cap;
     state.capacity_last_change_ms = in.now_ms;
     state.capacity_recovery_since_ms = 0;
+    state.capacity_full_recovery_since_ms = 0;
     out.clamp_integral_to_zero = true;
   } else if (risk_cap > current_cap && current_cap < capacity_demand_max) {
     const float dew_release_to2_gap_c = fmaxf(1.05f, hard_dew_restart_gap_c + 0.45f);
@@ -175,13 +179,30 @@ inline void update_hysteretic_capacity_cap(const LimiterInput &in,
         current_cap <= 1 ? dew_release_to2_gap_c :
         current_cap == 2 ? dew_release_to3_gap_c :
         dew_release_full_gap_c;
-    const bool recovery_ready =
+    const bool staged_recovery_ready =
         in.dew_gap_c >= required_dew_gap_c &&
         in.gap_rate_c_per_min >= tuning.capacity_recovery_min_rate_c_per_min;
+    const bool capacity_bound =
+        current_cap < in.demand_max && in.previous_limited_demand >= current_cap;
+    const bool adaptive_recovery_ready =
+        current_cap >= 3 &&
+        capacity_bound &&
+        in.gap_rate_c_per_min >= tuning.capacity_recovery_min_rate_c_per_min;
+    const bool recovery_ready = staged_recovery_ready || adaptive_recovery_ready;
+    const bool full_recovery_ready =
+        staged_recovery_ready && risk_cap >= capacity_demand_max && current_cap >= 3;
 
     if (recovery_ready) {
       if (state.capacity_recovery_since_ms == 0 || in.now_ms <= state.capacity_recovery_since_ms) {
         state.capacity_recovery_since_ms = in.now_ms;
+      }
+      if (full_recovery_ready) {
+        if (state.capacity_full_recovery_since_ms == 0 ||
+            in.now_ms <= state.capacity_full_recovery_since_ms) {
+          state.capacity_full_recovery_since_ms = in.now_ms;
+        }
+      } else {
+        state.capacity_full_recovery_since_ms = 0;
       }
       const bool hold_elapsed =
           state.capacity_last_change_ms == 0 ||
@@ -190,18 +211,30 @@ inline void update_hysteretic_capacity_cap(const LimiterInput &in,
       if (hold_elapsed && elapsed(in.now_ms, state.capacity_recovery_since_ms,
                                   tuning.capacity_recovery_stable_ms)) {
         const bool full_capacity_recovered =
-            risk_cap >= capacity_demand_max && current_cap >= 3;
-        current_cap = full_capacity_recovered
+            full_recovery_ready && elapsed(in.now_ms, state.capacity_full_recovery_since_ms,
+                                           tuning.capacity_recovery_stable_ms);
+        const int non_full_capacity_max =
+            current_cap >= 3 ? capacity_demand_max - 1 : capacity_demand_max;
+        const int next_cap = full_capacity_recovered
             ? capacity_demand_max
-            : std::min(capacity_demand_max, std::min(risk_cap, current_cap + 1));
-        state.capacity_last_change_ms = in.now_ms;
-        state.capacity_recovery_since_ms = 0;
+            : std::min(non_full_capacity_max, std::min(risk_cap, current_cap + 1));
+        if (next_cap > current_cap) {
+          current_cap = next_cap;
+          state.capacity_last_change_ms = in.now_ms;
+          state.capacity_recovery_since_ms = 0;
+          state.capacity_full_recovery_since_ms = 0;
+        }
       }
     } else {
       state.capacity_recovery_since_ms = 0;
+      state.capacity_full_recovery_since_ms = 0;
     }
   } else if (current_cap >= capacity_demand_max) {
     state.capacity_recovery_since_ms = 0;
+    state.capacity_full_recovery_since_ms = 0;
+  } else {
+    state.capacity_recovery_since_ms = 0;
+    state.capacity_full_recovery_since_ms = 0;
   }
 
   state.capacity_cap = current_cap;

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -182,6 +182,11 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  - id: oq_cooling_capacity_full_recovery_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
   - id: oq_cooling_water_cycle_active
     type: bool
     restore_value: false
@@ -755,6 +760,7 @@ interval:
             id(oq_cooling_capacity_cap) = reset_capacity_cap;
             id(oq_cooling_capacity_last_change_ms) = 0;
             id(oq_cooling_capacity_recovery_since_ms) = 0;
+            id(oq_cooling_capacity_full_recovery_since_ms) = 0;
             return;
           }
 
@@ -797,6 +803,7 @@ interval:
             id(oq_cooling_capacity_cap) = 10;
             id(oq_cooling_capacity_last_change_ms) = 0;
             id(oq_cooling_capacity_recovery_since_ms) = 0;
+            id(oq_cooling_capacity_full_recovery_since_ms) = 0;
             id(oq_cooling_buffer_gap_rate_ref_ms) = 0;
             id(oq_cooling_pid_integral) = 0.0f;
             id(oq_cooling_pid_last_error_c) = buffer_gap_c;
@@ -988,6 +995,7 @@ interval:
           limiter_state.capacity_cap = id(oq_cooling_capacity_cap);
           limiter_state.capacity_last_change_ms = id(oq_cooling_capacity_last_change_ms);
           limiter_state.capacity_recovery_since_ms = id(oq_cooling_capacity_recovery_since_ms);
+          limiter_state.capacity_full_recovery_since_ms = id(oq_cooling_capacity_full_recovery_since_ms);
 
           oq_cooling::LimiterInput limiter_input;
           limiter_input.now_ms = now_ms;
@@ -1019,6 +1027,7 @@ interval:
           id(oq_cooling_capacity_cap) = limiter_state.capacity_cap;
           id(oq_cooling_capacity_last_change_ms) = limiter_state.capacity_last_change_ms;
           id(oq_cooling_capacity_recovery_since_ms) = limiter_state.capacity_recovery_since_ms;
+          id(oq_cooling_capacity_full_recovery_since_ms) = limiter_state.capacity_full_recovery_since_ms;
           id(oq_cooling_projected_gap_c) = limiter_output.projected_gap_c;
 
           const int allowed_max = limiter_output.allowed_max;


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat `capacity_cap` vanaf cap 3 adaptief en stapsgewijs herstellen wanneer de vorige koelvraag werkelijk tegen de cap aan zat en de aanvoer/dauwpunt-trend veilig blijft.
- Behoudt de bestaande staged recovery voor cap 1/2 en geeft volledige vrijgave pas vrij als de full-release marge zelf stabiel is.
- Voorkomt dat koeling op lvl3 blijft hangen puur omdat de vaste full-release marge nog niet gehaald is.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De dauwpuntbeveiliging blijft leidend voor omlaag begrenzen. Herstel omhoog wordt vanaf cap 3 minder sticky: als de limiter actief begrenst, de vorige `limited_demand` tegen de cap zat en de trend niet richting dauwpunt zakt, mag de cap na de bestaande hold/stable tijden een stap omhoog. Een sprong naar `capacity_demand_max` vereist daarnaast dat de full-release marge zelf lang genoeg stabiel is.

## Achtergrond

In de debugopname bleef koeling hangen op lvl3 terwijl `coolingBaseDemandRaw` 4-5 was, `coolingLimitedDemand` 3 bleef en `coolingLimiterReasonCode` `capacity_cap` was. De aanvoer lag rond 17,16-17,24 °C, het dauwpunt rond 15,88 °C en de marge rond 1,28-1,36 °C. Eerder waren er terechte `dew_stop` events, maar in deze stabiele herstelsituatie kwam de cap niet verder omdat de vaste full-release marge nog niet gehaald werd.

Deze wijziging maakt geen harde “marge X = level Y”-tabel. De cap krijgt alleen stap voor stap ruimte terug wanneer de regeling aantoonbaar tegen de cap aan zit en de bestaande trendbewaking herstel toestaat.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit wijzigt alleen interne herstel-logica van de dauwpunt/capacity limiter. Er komt geen nieuwe instelling, sensor, bediening of gebruikersworkflow bij; de bestaande gebruikersdocumentatie over koelen en dauwpuntbeveiliging blijft inhoudelijk gelijk.

## Validatie

- `git diff --check`
- `python3 scripts/dev.py bootstrap`
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml`
