### PR TITLE
Power down W5500 in Wi-Fi firmware

### DIFF
--- a/components/openquatt_w5500_power_down/OpenQuattW5500PowerDown.cpp
+++ b/components/openquatt_w5500_power_down/OpenQuattW5500PowerDown.cpp
@@ -1,0 +1,68 @@
+#include "OpenQuattW5500PowerDown.h"
+
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace openquatt_w5500_power_down {
+
+static const char *const TAG = "openquatt.w5500_power";
+
+void OpenQuattW5500PowerDown::setup() {
+  this->spi_setup();
+
+  const uint8_t version = this->read_register_(VERSIONR_REGISTER);
+  if (version != VERSIONR_EXPECTED) {
+    ESP_LOGE(TAG, "W5500 not detected: VERSIONR=0x%02X (expected 0x%02X)", version, VERSIONR_EXPECTED);
+    this->mark_failed();
+    return;
+  }
+
+  const uint8_t initial_phycfgr = this->read_register_(PHYCFGR_REGISTER);
+
+  // W5500 datasheet PHY reconfiguration sequence:
+  // select software-controlled Power Down, assert PHY reset, then release reset.
+  this->write_register_(PHYCFGR_REGISTER, PHYCFGR_POWER_DOWN);
+  this->write_register_(PHYCFGR_REGISTER, PHYCFGR_POWER_DOWN_RESET);
+  delay(PHY_RESET_HOLD_MS);
+  this->write_register_(PHYCFGR_REGISTER, PHYCFGR_POWER_DOWN);
+
+  const uint8_t final_phycfgr = this->read_register_(PHYCFGR_REGISTER);
+  this->power_down_active_ =
+      (final_phycfgr & PHYCFGR_CONFIGURATION_MASK) == PHYCFGR_POWER_DOWN;
+  if (!this->power_down_active_) {
+    ESP_LOGE(TAG, "W5500 Power Down verification failed: PHYCFGR=0x%02X", final_phycfgr);
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGI(TAG, "W5500 PHY powered down: PHYCFGR 0x%02X -> 0x%02X", initial_phycfgr, final_phycfgr);
+}
+
+void OpenQuattW5500PowerDown::dump_config() {
+  ESP_LOGCONFIG(TAG, "W5500 Wi-Fi Power Down:");
+  LOG_SPI_DEVICE(this);
+  ESP_LOGCONFIG(TAG, "  State: %s", this->power_down_active_ ? "POWER DOWN" : "NOT VERIFIED");
+}
+
+uint8_t OpenQuattW5500PowerDown::read_register_(uint16_t address) {
+  this->enable();
+  this->write_byte(static_cast<uint8_t>(address >> 8));
+  this->write_byte(static_cast<uint8_t>(address));
+  this->write_byte(0x00);  // Common register block, read, variable data length.
+  const uint8_t value = this->read_byte();
+  this->disable();
+  return value;
+}
+
+void OpenQuattW5500PowerDown::write_register_(uint16_t address, uint8_t value) {
+  this->enable();
+  this->write_byte(static_cast<uint8_t>(address >> 8));
+  this->write_byte(static_cast<uint8_t>(address));
+  this->write_byte(0x04);  // Common register block, write, variable data length.
+  this->write_byte(value);
+  this->disable();
+}
+
+}  // namespace openquatt_w5500_power_down
+}  // namespace esphome

--- a/components/openquatt_w5500_power_down/OpenQuattW5500PowerDown.h
+++ b/components/openquatt_w5500_power_down/OpenQuattW5500PowerDown.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+
+#include "esphome/components/spi/spi.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace openquatt_w5500_power_down {
+
+class OpenQuattW5500PowerDown
+    : public Component,
+      public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
+                            spi::DATA_RATE_8MHZ> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+ protected:
+  static constexpr uint16_t PHYCFGR_REGISTER = 0x002E;
+  static constexpr uint16_t VERSIONR_REGISTER = 0x0039;
+  static constexpr uint8_t VERSIONR_EXPECTED = 0x04;
+  static constexpr uint8_t PHYCFGR_POWER_DOWN = 0xF0;
+  static constexpr uint8_t PHYCFGR_POWER_DOWN_RESET = 0x70;
+  static constexpr uint8_t PHYCFGR_CONFIGURATION_MASK = 0xF8;
+  static constexpr uint32_t PHY_RESET_HOLD_MS = 10;
+
+  uint8_t read_register_(uint16_t address);
+  void write_register_(uint16_t address, uint8_t value);
+
+  bool power_down_active_{false};
+};
+
+}  // namespace openquatt_w5500_power_down
+}  // namespace esphome

--- a/components/openquatt_w5500_power_down/__init__.py
+++ b/components/openquatt_w5500_power_down/__init__.py
@@ -1,0 +1,36 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import spi
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["spi"]
+
+openquatt_w5500_power_down_ns = cg.esphome_ns.namespace(
+    "openquatt_w5500_power_down"
+)
+OpenQuattW5500PowerDown = openquatt_w5500_power_down_ns.class_(
+    "OpenQuattW5500PowerDown", cg.Component, spi.SPIDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(OpenQuattW5500PowerDown),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(
+        spi.spi_device_schema(
+            cs_pin_required=True,
+            default_data_rate="8MHz",
+            default_mode="mode0",
+        )
+    )
+)
+
+
+async def to_code(config):
+    cg.add_global(openquatt_w5500_power_down_ns.using)
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await spi.register_spi_device(var, config)

--- a/configs/heatpump_controller_q/duo_wifi.yaml
+++ b/configs/heatpump_controller_q/duo_wifi.yaml
@@ -32,5 +32,6 @@ packages:
   openquatt_profile_heatpump_controller_q_cic_compatibility_duo: !include ../../openquatt/profiles/heatpump_controller_q_cic_compatibility_duo.yaml
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_wifi: !include ../../openquatt/connection/wifi.yaml
+  openquatt_connection_wifi_w5500_power_down: !include ../../openquatt/connection/wifi_w5500_power_down.yaml
   <<: !include ../../openquatt/oq_packages_common.yaml
   <<: !include ../../openquatt/topology/duo_packages.yaml

--- a/configs/heatpump_controller_q/single_wifi.yaml
+++ b/configs/heatpump_controller_q/single_wifi.yaml
@@ -31,4 +31,5 @@ packages:
   openquatt_profile_heatpump_controller_q: !include ../../openquatt/profiles/heatpump_controller_q.yaml
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_wifi: !include ../../openquatt/connection/wifi.yaml
+  openquatt_connection_wifi_w5500_power_down: !include ../../openquatt/connection/wifi_w5500_power_down.yaml
   <<: !include ../../openquatt/oq_packages_common.yaml

--- a/openquatt/connection/wifi_w5500_power_down.yaml
+++ b/openquatt/connection/wifi_w5500_power_down.yaml
@@ -1,0 +1,28 @@
+# ==============================================================================
+# OpenQuatt - Heatpump Controller Q Wi-Fi W5500 Power Down
+# ==============================================================================
+# The Wi-Fi firmware does not load ESPHome's Ethernet driver. Configure the
+# otherwise unused W5500 PHY for Power Down through its dedicated SPI bus.
+# Ethernet firmware omits this package and performs the normal W5500 reset and
+# PHY initialization through ESP-IDF.
+# ==============================================================================
+
+external_components:
+  - source:
+      type: local
+      path: ${external_components_path}
+    components: [openquatt_w5500_power_down]
+
+spi:
+  - id: oq_w5500_power_down_spi
+    mosi_pin: ${eth_mosi_pin}
+    miso_pin: ${eth_miso_pin}
+    clk_pin: ${eth_clk_pin}
+    interface: spi2
+
+openquatt_w5500_power_down:
+  id: oq_w5500_power_down
+  spi_id: oq_w5500_power_down_spi
+  cs_pin: ${eth_cs_pin}
+  data_rate: 8MHz
+  spi_mode: mode0

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -180,6 +180,7 @@ NESTED_KEY_ORDER_RULES = {
         "openquatt_profile_heatpump_controller_q",
         "openquatt_base_common",
         "openquatt_connection_wifi",
+        "openquatt_connection_wifi_w5500_power_down",
     ),
     ("configs/heatpump_controller_q/single_eth.yaml", "packages"): (
         "openquatt_profile_heatpump_controller_q",
@@ -191,6 +192,7 @@ NESTED_KEY_ORDER_RULES = {
         "openquatt_profile_heatpump_controller_q_cic_compatibility_duo",
         "openquatt_base_common",
         "openquatt_connection_wifi",
+        "openquatt_connection_wifi_w5500_power_down",
     ),
     ("configs/heatpump_controller_q/duo_eth.yaml", "packages"): (
         "openquatt_profile_heatpump_controller_q",


### PR DESCRIPTION
# Wat verandert deze PR?

- Zet de W5500-PHY in de Heatpump Controller Q Wi-Fi-firmware in Power Down via `PHYCFGR`: `F0 → 70 → 10 ms → F0`.
- Controleert eerst `VERSIONR` en verifieert daarna de `PHYCFGR`-readback; een fout blijft beperkt tot het component en blokkeert Wi-Fi of de regeling niet.
- Ethernet-builds laden dit package niet en blijven de normale ESP-IDF W5500-reset en PHY-initialisatie gebruiken.

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de W5500-voedingstoestand verandert in de Q Wi-Fi-builds. Er veranderen geen regelparameters, entiteiten of Ethernet-builds. Bij een ontbrekende of niet-responderende W5500 logt het component een fout en blijft de overige firmware doorwerken.

## Achtergrond

Implementeert #322. De W5500 gebruikt een eigen SPI2-bus; de bestaande MAX31865 blijft op SPI3. Bij een OTA-wissel naar Ethernet initialiseert de bestaande ESP-IDF-driver de W5500 opnieuw.

### Van het issuevoorstel naar de volledige registersequentie

Issue #322 identificeert terecht `OPMDC=110` als Power Down-selectie en onderbouwt het nut met metingen van stroomverbruik en temperatuur. Die bevinding vormt de basis van deze PR.

Het issue beschrijft `0b00110000` (`0x30`), precies het bitpatroon voor `OPMDC=110`. Bij een volledige write naar `PHYCFGR` worden ook de twee omliggende besturingsbits ingevuld:

- `OPMD=1` laat de W5500 de softwarematige `OPMDC`-selectie gebruiken;
- `RST=1` laat de interne PHY normaal uit reset.

De [W5500-datasheet](https://docs.wiznet.io/img/products/w5500/W5500_ds_v110e.pdf#page=42) beschrijft hiervoor de vereisten: stel `OPMD=1` en `OPMDC` in, activeer daarna de interne PHY-reset met `RST=0` en zet `RST` na de reset weer op `1`. Deze PR vertaalt die vereisten naar de volgende registertoestanden:

1. `F0`: zet `OPMD=1`, selecteert `OPMDC=110` en houdt de PHY uit reset;
2. `70`: behoudt dezelfde mode en activeert de interne PHY-reset;
3. na 10 ms zet `F0` de reset weer vrij terwijl Power Down geselecteerd blijft.

De drie registertoestanden volgen daarmee de procedure uit de datasheet en de [WIZnet ioLibrary](https://github.com/Wiznet/ioLibrary_Driver/blob/master/Ethernet/wizchip_conf.c). De datasheet schrijft voor deze interne reset geen wachttijd van 10 ms voor; die conservatieve resetduur sluit aan bij de [Espressif W5500 PHY-driver](https://github.com/espressif/esp-idf/blob/v5.5.2/components/esp_eth/src/spi/w5500/esp_eth_phy_w5500.c). Een readback controleert vervolgens dat `RST=1`, `OPMD=1` en `OPMDC=110` werkelijk zijn vastgelegd.

Zo blijft de kern van het issuevoorstel behouden, terwijl de overige `PHYCFGR`-besturingsbits en de reset expliciet worden afgehandeld.

Getest: en functioneel bevonden.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_eth.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_eth.yaml`
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/single_wifi.yaml`
