### PR TITLE
Make web bundle size check deterministic

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Run settings-backup consistency check
         run: node openquatt/web/check-settings-backup.mjs
@@ -22,6 +24,8 @@ jobs:
         run: npm ci
 
       - name: Check generated web bundles
+        env:
+          OPENQUATT_WEB_BUNDLE_BASE_REF: ${{ github.event.pull_request.base.sha }}
         run: npm run check:web
 
       - name: Run web smoke checks

--- a/openquatt/web/check-web-quality.mjs
+++ b/openquatt/web/check-web-quality.mjs
@@ -1,12 +1,14 @@
+import { execFileSync } from "node:child_process";
 import { gzipSync } from "node:zlib";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { WEB_BUNDLE_BUDGETS } from "./web-budgets.mjs";
+import { WEB_BUNDLE_BUDGETS, WEB_BUNDLE_GZIP_GROWTH_LIMIT } from "./web-budgets.mjs";
 
 const webDir = path.dirname(fileURLToPath(import.meta.url));
 const sourceRoots = [path.join(webDir, "js", "src"), path.join(webDir, "css", "src")];
 const mojibakePattern = /â€|Ã.|Â(?:\s|\u00a0)/u;
+const bundleBaseRef = process.env.OPENQUATT_WEB_BUNDLE_BASE_REF?.trim();
 
 async function collectFiles(directory) {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -15,6 +17,23 @@ async function collectFiles(directory) {
     return entry.isDirectory() ? collectFiles(entryPath) : [entryPath];
   }));
   return files.flat();
+}
+
+function readBundleAtRef(ref, file) {
+  const gitPath = path.posix.join("openquatt/web", file);
+  try {
+    return execFileSync("git", ["-C", webDir, "show", `${ref}:${gitPath}`], {
+      maxBuffer: 10 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const detail = error.stderr?.toString().trim();
+    throw new Error(`Could not read ${gitPath} at ${ref}${detail ? `: ${detail}` : ""}`);
+  }
+}
+
+function formatDelta(value) {
+  return `${value >= 0 ? "+" : ""}${value}`;
 }
 
 const sourceFiles = (await Promise.all(sourceRoots.map(collectFiles))).flat();
@@ -27,15 +46,41 @@ for (const sourceFile of sourceFiles) {
 }
 
 const budgetFailures = [];
+const bundleReports = [];
 for (const budget of WEB_BUNDLE_BUDGETS) {
   const contents = await readFile(path.join(webDir, budget.file));
-  const sizes = { raw: contents.byteLength, gzip: gzipSync(contents).byteLength };
-  for (const kind of ["raw", "gzip"]) {
-    if (sizes[kind] > budget[kind]) {
-      budgetFailures.push(`${budget.file} ${kind}: ${sizes[kind]} > ${budget[kind]} bytes`);
-    }
+  const rawBytes = contents.byteLength;
+  const gzipBytes = gzipSync(contents).byteLength;
+  if (rawBytes > budget.raw) {
+    budgetFailures.push(`${budget.file} raw: ${rawBytes} > ${budget.raw} bytes`);
+  }
+
+  if (!bundleBaseRef) {
+    bundleReports.push(`${budget.file}: raw ${rawBytes} B, gzip ${gzipBytes} B (no base comparison)`);
+    continue;
+  }
+
+  const baseGzipBytes = gzipSync(readBundleAtRef(bundleBaseRef, budget.file)).byteLength;
+  const gzipDelta = gzipBytes - baseGzipBytes;
+  const ratioLimit = Math.floor(baseGzipBytes * WEB_BUNDLE_GZIP_GROWTH_LIMIT.ratio);
+  const allowedIncrease = Math.min(WEB_BUNDLE_GZIP_GROWTH_LIMIT.bytes, ratioLimit);
+  const deltaPercent = baseGzipBytes ? (gzipDelta / baseGzipBytes) * 100 : 0;
+  const formattedDeltaPercent = `${deltaPercent >= 0 ? "+" : ""}${deltaPercent.toFixed(2)}`;
+  bundleReports.push(
+    `${budget.file}: raw ${rawBytes} B, gzip ${gzipBytes} B, `
+    + `base ${baseGzipBytes} B, delta ${formatDelta(gzipDelta)} B (${formattedDeltaPercent}%), `
+    + `limit +${allowedIncrease} B`,
+  );
+  if (gzipDelta > allowedIncrease) {
+    budgetFailures.push(
+      `${budget.file} gzip growth: ${formatDelta(gzipDelta)} > +${allowedIncrease} bytes `
+      + `(base ${baseGzipBytes}, current ${gzipBytes})`,
+    );
   }
 }
+
+console.log(`Web bundle sizes${bundleBaseRef ? ` compared with ${bundleBaseRef}` : ""}:`);
+bundleReports.forEach((report) => console.log(`- ${report}`));
 
 if (encodingFailures.length || budgetFailures.length) {
   const failures = [

--- a/openquatt/web/smoke-web.mjs
+++ b/openquatt/web/smoke-web.mjs
@@ -2,10 +2,8 @@ import { access, readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import vm from "node:vm";
-import { gzipSync } from "node:zlib";
 import { build, transform } from "esbuild";
 import { resolveCssSources } from "./css-source-list.mjs";
-import { WEB_BUNDLE_BUDGETS } from "./web-budgets.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const webDir = path.dirname(__filename);
@@ -274,20 +272,6 @@ async function checkCssBundleFresh() {
   const actual = await readFile(outputPath, "utf8");
   if (actual !== expected) {
     throw new Error("CSS bundle is stale. Run: rtk npm run build:web");
-  }
-}
-
-async function checkBundleGzipBudgets() {
-  const errors = [];
-  for (const budget of WEB_BUNDLE_BUDGETS) {
-    const bytes = await readFile(path.join(webDir, budget.file));
-    const gzipBytes = gzipSync(bytes).length;
-    if (gzipBytes > budget.gzip) {
-      errors.push(`${budget.file} gzip ${gzipBytes} B exceeds budget ${budget.gzip} B`);
-    }
-  }
-  if (errors.length) {
-    throw new Error(`Bundle budget check failed:\n- ${errors.join("\n- ")}`);
   }
 }
 
@@ -729,7 +713,6 @@ async function main() {
   await checkRuntimeBoundaryContracts();
   await checkJavaScriptBundleFresh();
   await checkCssBundleFresh();
-  await checkBundleGzipBudgets();
   console.log("Web smoke ok");
 }
 

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -1,4 +1,7 @@
+// Fail when gzip growth exceeds the smaller of these two limits.
+export const WEB_BUNDLE_GZIP_GROWTH_LIMIT = { bytes: 4_096, ratio: 0.02 };
+
 export const WEB_BUNDLE_BUDGETS = [
-  { file: "js/openquatt-app.js", raw: 792_000, gzip: 208_500 },
-  { file: "css/openquatt-app.css", raw: 255_000, gzip: 42_000 },
+  { file: "js/openquatt-app.js", raw: 792_000 },
+  { file: "css/openquatt-app.css", raw: 255_000 },
 ];


### PR DESCRIPTION
# Wat verandert deze PR?

- Vergelijkt de gzip-grootte van webbundles met de PR-base binnen dezelfde CI-runtime.
- Blokkeert groei boven de kleinste grens van 4 KiB of 2%, terwijl de bestaande deterministische raw-limieten behouden blijven.
- Verwijdert de dubbele gzipcontrole uit de web-smokecheck.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de CI-controle voor webbundlegrootte verandert. Firmware, webfunctionaliteit en gegenereerde bundles blijven ongewijzigd.

## Achtergrond

De absolute gziplimiet werd gemeten met de lokale Node/zlib-versie. Dezelfde bundle was lokaal 208.239 bytes en in CI 208.509 bytes, waardoor een niet-webgerelateerde PR op 9 bytes boven de limiet faalde.

CI haalt nu twee commits op en comprimeert zowel de PR-bundle als de bundle op `github.event.pull_request.base.sha` met dezelfde runtime. Iedere delta wordt gelogd; alleen betekenisvolle groei blokkeert de build. Zonder PR-base, zoals bij een push naar `main`, blijven de raw-limieten actief en wordt alleen de relatieve gzipcontrole overgeslagen.

## Validatie

- `npm ci`
- `OPENQUATT_WEB_BUNDLE_BASE_REF=origin/dev npm run check:web`
- `npm run smoke:web`
- `git diff --check`
