### PR TITLE
Preserve Modbus timing for ESPHome 2026.7

### DIFF
--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -235,6 +235,7 @@ modbus:
   - uart_id: uart_bus
     id: mod_bus
     send_wait_time: 100ms
+    turnaround_time: 100ms
 
 # ==============================================================================
 # SHARED RUNTIME STATE


### PR DESCRIPTION
# Wat verandert deze PR?

- Behoudt de bestaande Modbus-clientturnaround expliciet op 100 ms voor ESPHome 2026.7.
- Laat UART, flow-control, serveradressen, registermapping, courtesy responses en pollinginstellingen ongewijzigd.
- Bouwt voort op #341, waarin de niet-ondersteunde Q-edition serveroptie al is verwijderd.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

ESPHome 2026.7 verhoogt de standaardwaarde van client-`turnaround_time` van 100 naar 600 ms. OpenQuatt gebruikt al `command_throttle: 500ms`; deze PR houdt het bestaande clienttiminggedrag daarom expliciet op 100 ms.

## Achtergrond

#341 verzorgt de native ESP-IDF-toolchainmigratie en verwijdert de serveroptie die ESPHome 2026.7 niet meer accepteert. Na rebase op die wijziging resteert hier alleen de afzonderlijke clienttimingkeuze.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een interne ESPHome-configuratiemigratie die het bestaande timinggedrag behoudt en geen gebruikersconfiguratie, entiteiten of registermapping wijzigt.

## Validatie

- Alle acht targets valideerden en compileerden met ESPHome 2026.7.0 en de native toolchain.
- De gecombineerde 2026.7-build met deze instelling is succesvol via OTA op Waveshare single Wi-Fi-hardware geplaatst.
- Er was geen externe Modbus-slave aangesloten; responstiming blijft daarom een hardwareverificatiepunt.
