### PR TITLE
Migrate ESP32 builds to native ESP-IDF

### DIFF
--- a/.github/workflows/esphome-build.yml
+++ b/.github/workflows/esphome-build.yml
@@ -61,13 +61,29 @@ jobs:
           cache: pip
           cache-dependency-path: .github/requirements-esphome.txt
 
-      - name: Cache PlatformIO
+      - name: Cache native ESP-IDF toolchain
         uses: actions/cache@v5
         with:
-          path: ~/.platformio
-          key: ${{ runner.os }}-platformio-${{ hashFiles('.github/requirements-esphome.txt') }}
+          path: ~/.cache/esphome/idf
+          key: ${{ runner.os }}-${{ runner.arch }}-esphome-idf-${{ hashFiles('.github/requirements-esphome.txt') }}
           restore-keys: |
-            ${{ runner.os }}-platformio-
+            ${{ runner.os }}-${{ runner.arch }}-esphome-idf-
+
+      - name: Make ccache available
+        run: |
+          if ! command -v ccache >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install --yes ccache
+          fi
+          ccache --version
+
+      - name: Cache compiler outputs
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/openquatt/ccache
+          key: ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ hashFiles('.github/requirements-esphome.txt') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ hashFiles('.github/requirements-esphome.txt') }}-
 
       - name: Install ESPHome
         run: |
@@ -77,6 +93,13 @@ jobs:
 
       - name: Compile firmware
         run: |
+          export ESPHOME_ESP_IDF_PREFIX="${HOME}/.cache/esphome/idf"
+          export IDF_CCACHE_ENABLE=1
+          export CCACHE_DIR="${HOME}/.cache/openquatt/ccache"
+          export CCACHE_MAXSIZE=2G
+          export CCACHE_NOHASHDIR=true
+          export CCACHE_DEPEND=1
+          export CCACHE_BASEDIR="${GITHUB_WORKSPACE}/${{ matrix.target.build_path }}"
           EXTRA_ARGS=()
           if [[ -n "${{ inputs.project_version }}" ]]; then
             EXTRA_ARGS+=(-s project_version "${{ inputs.project_version }}")
@@ -90,8 +113,15 @@ jobs:
           fi
           esphome "${EXTRA_ARGS[@]}" compile "${{ matrix.target.config }}"
 
-      - name: Repair and validate factory binary
-        run: python3 scripts/repair_factory_bin.py "${{ matrix.target.build_path }}/.pioenvs/openquatt"
+      - name: Show ccache statistics
+        if: ${{ always() }}
+        run: |
+          export CCACHE_DIR="${HOME}/.cache/openquatt/ccache"
+          export CCACHE_MAXSIZE=2G
+          ccache --show-stats
+
+      - name: Validate and normalize firmware artifacts
+        run: python3 scripts/repair_factory_bin.py "${{ matrix.target.build_path }}/build" --normalize-app
 
       - name: Upload firmware artifacts
         if: ${{ inputs.include_firmware_bin }}
@@ -100,9 +130,9 @@ jobs:
           name: ${{ matrix.target.artifact_name }}-${{ inputs.artifact_suffix }}
           if-no-files-found: error
           path: |
-            ${{ matrix.target.build_path }}/.pioenvs/openquatt/firmware.bin
-            ${{ matrix.target.build_path }}/.pioenvs/openquatt/firmware.ota.bin
-            ${{ matrix.target.build_path }}/.pioenvs/openquatt/firmware.factory.bin
+            ${{ matrix.target.build_path }}/build/firmware.bin
+            ${{ matrix.target.build_path }}/build/firmware.ota.bin
+            ${{ matrix.target.build_path }}/build/firmware.factory.bin
 
       - name: Upload OTA/factory artifacts
         if: ${{ !inputs.include_firmware_bin && inputs.include_factory_bin }}
@@ -111,8 +141,8 @@ jobs:
           name: ${{ matrix.target.artifact_name }}-${{ inputs.artifact_suffix }}
           if-no-files-found: error
           path: |
-            ${{ matrix.target.build_path }}/.pioenvs/openquatt/firmware.ota.bin
-            ${{ matrix.target.build_path }}/.pioenvs/openquatt/firmware.factory.bin
+            ${{ matrix.target.build_path }}/build/firmware.ota.bin
+            ${{ matrix.target.build_path }}/build/firmware.factory.bin
 
       - name: Upload OTA artifacts
         if: ${{ !inputs.include_firmware_bin && !inputs.include_factory_bin }}
@@ -120,4 +150,4 @@ jobs:
         with:
           name: ${{ matrix.target.artifact_name }}-${{ inputs.artifact_suffix }}
           if-no-files-found: error
-          path: ${{ matrix.target.build_path }}/.pioenvs/openquatt/firmware.ota.bin
+          path: ${{ matrix.target.build_path }}/build/firmware.ota.bin

--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -17,11 +17,10 @@ esphome:
     - ${oq_cpp_headers_dir}
     - ${oq_component_psram_buffer_header}
     - ${oq_component_flash_layout_header}
-  platformio_options:
-    build_flags:
-      # Hard-pinned by the topology entrypoint to prevent accidental topology drift.
-      - ${oq_topology_build_flag}
-      - ${oq_hardware_build_flag}
+  build_flags:
+    # Hard-pinned by the topology entrypoint to prevent accidental topology drift.
+    - ${oq_topology_build_flag}
+    - ${oq_hardware_build_flag}
   on_boot:
     priority: -100
     then:
@@ -72,6 +71,7 @@ esp32:
   flash_size: ${esp_flash_size}
   variant: ${esp_variant}
   partitions: ${esp_partitions}
+  toolchain: esp-idf
   framework:
     type: esp-idf
     version: recommended

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
@@ -29,7 +29,6 @@ modbus:
   - uart_id: cic_compat_uart_bus
     id: cic_compat_modbus
     role: server
-    send_wait_time: 50ms
 
 packages:
   oq_cic_compatibility: !include ../oq_cic_compatibility.yaml

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -15,16 +15,6 @@ from typing import Iterable, Sequence
 
 from build_targets import filter_targets, load_targets
 
-EFUSE_SOC_UTILITY_SOURCE = '"esp_efuse_utility.c"'
-EFUSE_SOC_UTILITY_RENAMED = '"esp_efuse_utility_esp32s3.c"'
-SYSTEM_TIME_SOURCE = '"src/system_time.c"'
-SYSTEM_TIME_RENAMED = '"src/esp_timer_system_time.c"'
-PHY_LIB_PRINTF_SOURCE = '"src/lib_printf.c"'
-PHY_LIB_PRINTF_RENAMED = '"src/phy_lib_printf.c"'
-HAL_TARGET_EFUSE_SOURCE = '"${target}/efuse_hal.c"'
-HAL_TARGET_EFUSE_RENAMED = '"${target}/efuse_hal_${target}.c"'
-
-
 def repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
@@ -222,188 +212,6 @@ def format_duration(total_seconds: float) -> str:
     return f"{seconds}s"
 
 
-def framework_espidf_package_dirs(pio_core_dir: Path) -> list[Path]:
-    candidates = [
-        pio_core_dir / "packages" / "framework-espidf",
-        Path.home() / ".platformio" / "packages" / "framework-espidf",
-    ]
-    seen: set[Path] = set()
-    dirs: list[Path] = []
-    for candidate in candidates:
-        resolved = candidate.expanduser()
-        if resolved in seen:
-            continue
-        seen.add(resolved)
-        dirs.append(resolved)
-    return dirs
-
-
-def patch_framework_espidf_efuse_main_cmake(package_dir: Path) -> bool:
-    cmake_path = package_dir / "components" / "efuse" / "CMakeLists.txt"
-    if not cmake_path.is_file():
-        return False
-
-    text = cmake_path.read_text(encoding="utf-8")
-    updated = text
-    if 'src/esp_efuse_utility.c' not in updated and 'list(APPEND srcs "src/esp_efuse_api.c"\n                 "src/efuse_controller/keys/${type}/esp_efuse_api_key.c")' in updated:
-        updated = updated.replace(
-            'list(APPEND srcs "src/esp_efuse_api.c"\n                 "src/efuse_controller/keys/${type}/esp_efuse_api_key.c")',
-            'list(APPEND srcs "src/esp_efuse_api.c"\n                 "src/esp_efuse_utility.c"\n                 "src/efuse_controller/keys/${type}/esp_efuse_api_key.c")',
-            1,
-        )
-
-    if updated == text:
-        return False
-
-    cmake_path.write_text(updated, encoding="utf-8")
-    return True
-
-
-def patch_framework_espidf_efuse_sources(package_dir: Path) -> bool:
-    patched = False
-    for sources_path in package_dir.glob("components/efuse/*/sources.cmake"):
-        if not sources_path.is_file():
-            continue
-
-        text = sources_path.read_text(encoding="utf-8")
-        target_dir = sources_path.parent.name
-        if target_dir != "esp32s3" or EFUSE_SOC_UTILITY_SOURCE not in text:
-            continue
-
-        updated = text.replace(EFUSE_SOC_UTILITY_SOURCE, EFUSE_SOC_UTILITY_RENAMED, 1)
-        if updated != text:
-            sources_path.write_text(updated, encoding="utf-8")
-            renamed_path = sources_path.parent / "esp_efuse_utility_esp32s3.c"
-            original_path = sources_path.parent / "esp_efuse_utility.c"
-            if original_path.is_file() and not renamed_path.exists():
-                renamed_path.write_text(original_path.read_text(encoding="utf-8"), encoding="utf-8")
-            patched = True
-    return patched
-
-
-def patch_framework_espidf_system_time_source(package_dir: Path) -> bool:
-    cmake_path = package_dir / "components" / "esp_timer" / "CMakeLists.txt"
-    source_path = package_dir / "components" / "esp_timer" / "src" / "system_time.c"
-    renamed_path = source_path.with_name("esp_timer_system_time.c")
-    if not cmake_path.is_file() or not source_path.is_file():
-        return False
-
-    text = cmake_path.read_text(encoding="utf-8")
-    if SYSTEM_TIME_SOURCE not in text:
-        return False
-
-    if not renamed_path.exists():
-        renamed_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
-    cmake_path.write_text(text.replace(SYSTEM_TIME_SOURCE, SYSTEM_TIME_RENAMED, 1), encoding="utf-8")
-    return True
-
-
-def patch_framework_espidf_phy_lib_printf_source(package_dir: Path) -> bool:
-    cmake_path = package_dir / "components" / "esp_phy" / "CMakeLists.txt"
-    source_path = package_dir / "components" / "esp_phy" / "src" / "lib_printf.c"
-    renamed_path = source_path.with_name("phy_lib_printf.c")
-    if not cmake_path.is_file() or not source_path.is_file():
-        return False
-
-    text = cmake_path.read_text(encoding="utf-8")
-    if PHY_LIB_PRINTF_SOURCE not in text:
-        return False
-
-    if not renamed_path.exists():
-        renamed_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
-    cmake_path.write_text(text.replace(PHY_LIB_PRINTF_SOURCE, PHY_LIB_PRINTF_RENAMED, 1), encoding="utf-8")
-    return True
-
-
-def patch_framework_espidf_hal_target_efuse_source(package_dir: Path) -> bool:
-    cmake_path = package_dir / "components" / "hal" / "CMakeLists.txt"
-    hal_dir = package_dir / "components" / "hal"
-    if not cmake_path.is_file() or not hal_dir.is_dir():
-        return False
-
-    text = cmake_path.read_text(encoding="utf-8")
-    if HAL_TARGET_EFUSE_SOURCE not in text:
-        return False
-
-    patched = False
-    for source_path in hal_dir.glob("*/efuse_hal.c"):
-        renamed_path = source_path.with_name(f"efuse_hal_{source_path.parent.name}.c")
-        if not renamed_path.exists():
-            renamed_path.write_text(source_path.read_text(encoding="utf-8"), encoding="utf-8")
-            patched = True
-
-    cmake_path.write_text(text.replace(HAL_TARGET_EFUSE_SOURCE, HAL_TARGET_EFUSE_RENAMED, 1), encoding="utf-8")
-    return True
-
-
-def apply_framework_espidf_source_workarounds(pio_core_dir: Path) -> list[Path]:
-    patched: list[Path] = []
-    for package_dir in framework_espidf_package_dirs(pio_core_dir):
-        main_patched = patch_framework_espidf_efuse_main_cmake(package_dir)
-        sources_patched = patch_framework_espidf_efuse_sources(package_dir)
-        system_time_patched = patch_framework_espidf_system_time_source(package_dir)
-        phy_lib_printf_patched = patch_framework_espidf_phy_lib_printf_source(package_dir)
-        hal_patched = patch_framework_espidf_hal_target_efuse_source(package_dir)
-        if main_patched or sources_patched or system_time_patched or phy_lib_printf_patched or hal_patched:
-            patched.append(package_dir)
-    return patched
-
-
-def has_framework_espidf_efuse_workaround(package_dir: Path) -> bool:
-    cmake_path = package_dir / "components" / "efuse" / "CMakeLists.txt"
-    esp32s3_sources = package_dir / "components" / "efuse" / "esp32s3" / "sources.cmake"
-    renamed_source = package_dir / "components" / "efuse" / "esp32s3" / "esp_efuse_utility_esp32s3.c"
-    return (
-        cmake_path.is_file()
-        and 'src/esp_efuse_utility.c' in cmake_path.read_text(encoding="utf-8")
-        and esp32s3_sources.is_file()
-        and renamed_source.is_file()
-    )
-
-
-def has_framework_espidf_system_time_workaround(package_dir: Path) -> bool:
-    cmake_path = package_dir / "components" / "esp_timer" / "CMakeLists.txt"
-    renamed_source = package_dir / "components" / "esp_timer" / "src" / "esp_timer_system_time.c"
-    return (
-        cmake_path.is_file()
-        and SYSTEM_TIME_RENAMED in cmake_path.read_text(encoding="utf-8")
-        and renamed_source.is_file()
-    )
-
-
-def has_framework_espidf_phy_lib_printf_workaround(package_dir: Path) -> bool:
-    cmake_path = package_dir / "components" / "esp_phy" / "CMakeLists.txt"
-    renamed_source = package_dir / "components" / "esp_phy" / "src" / "phy_lib_printf.c"
-    return (
-        cmake_path.is_file()
-        and PHY_LIB_PRINTF_RENAMED in cmake_path.read_text(encoding="utf-8")
-        and renamed_source.is_file()
-    )
-
-
-def has_framework_espidf_hal_target_efuse_workaround(package_dir: Path) -> bool:
-    cmake_path = package_dir / "components" / "hal" / "CMakeLists.txt"
-    renamed_source = package_dir / "components" / "hal" / "esp32s3" / "efuse_hal_esp32s3.c"
-    return (
-        cmake_path.is_file()
-        and HAL_TARGET_EFUSE_RENAMED in cmake_path.read_text(encoding="utf-8")
-        and renamed_source.is_file()
-    )
-
-
-def has_framework_espidf_source_workaround(pio_core_dir: Path, duplicate_object: str) -> bool:
-    for package_dir in framework_espidf_package_dirs(pio_core_dir):
-        if duplicate_object == "esp_efuse_fields.c.o" and has_framework_espidf_efuse_workaround(package_dir):
-            return True
-        if duplicate_object == "efuse_hal.c.o" and has_framework_espidf_hal_target_efuse_workaround(package_dir):
-            return True
-        if duplicate_object == "system_time.c.o" and has_framework_espidf_system_time_workaround(package_dir):
-            return True
-        if duplicate_object == "lib_printf.c.o" and has_framework_espidf_phy_lib_printf_workaround(package_dir):
-            return True
-    return False
-
-
 def run_command(
     command: Sequence[str],
     *,
@@ -476,10 +284,36 @@ def run_logged(
     print(f"[ok] {label}")
 
 
-def resolve_command_root(root_dir: Path) -> tuple[Path, Path]:
-    pio_core_dir = root_dir / ".cache" / "platformio"
-    pio_core_dir.mkdir(parents=True, exist_ok=True)
-    return root_dir, pio_core_dir
+def default_native_idf_tools_dir() -> Path:
+    if sys.platform == "darwin":
+        cache_root = Path.home() / "Library" / "Caches"
+    elif os.name == "nt":
+        cache_root = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        cache_root = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_root / "esphome" / "idf"
+
+
+def configure_native_ccache(
+    env: dict[str, str],
+    native_idf_tools_dir: Path,
+) -> tuple[bool, str]:
+    explicit_setting = env.get("IDF_CCACHE_ENABLE")
+    if explicit_setting is not None and explicit_setting.strip().lower() in {"", "0", "false", "no", "off"}:
+        return False, "disabled by IDF_CCACHE_ENABLE"
+
+    ccache_executable = shutil.which("ccache", path=env.get("PATH"))
+    if ccache_executable is None:
+        if explicit_setting is not None:
+            raise SystemExit("IDF_CCACHE_ENABLE is set, but the ccache executable is not available in PATH.")
+        return False, "not installed"
+
+    env.setdefault("IDF_CCACHE_ENABLE", "1")
+    env.setdefault("CCACHE_DIR", str(native_idf_tools_dir / "ccache"))
+    env.setdefault("CCACHE_MAXSIZE", "2G")
+    env.setdefault("CCACHE_NOHASHDIR", "true")
+    env.setdefault("CCACHE_DEPEND", "1")
+    return True, f"{ccache_executable} (cache: {env['CCACHE_DIR']})"
 
 
 def build_pages_site(site_dir: Path, factory_dir: Path, helper_python: Sequence[str]) -> None:
@@ -591,7 +425,7 @@ def bootstrap_command(args: argparse.Namespace) -> int:
 def validate_command(args: argparse.Namespace) -> int:
     root_dir = repo_root()
     venv_dir = resolve_path(args.venv_dir)
-    command_root, pio_core_dir = resolve_command_root(root_dir)
+    command_root = root_dir
     log_dir = root_dir / ".tmp" / "validate_local_logs"
     helper_python = resolve_helper_python(venv_dir)
     esphome_command = resolve_esphome_command(venv_dir)
@@ -600,11 +434,13 @@ def validate_command(args: argparse.Namespace) -> int:
     log_dir.mkdir(parents=True, exist_ok=True)
 
     env = os.environ.copy()
-    env["PLATFORMIO_CORE_DIR"] = str(pio_core_dir)
-    env["PLATFORMIO_HOME_DIR"] = str(pio_core_dir)
+    env.setdefault("ESPHOME_ESP_IDF_PREFIX", str(default_native_idf_tools_dir()))
+    native_idf_tools_dir = Path(env["ESPHOME_ESP_IDF_PREFIX"]).expanduser()
+    ccache_enabled, ccache_status = configure_native_ccache(env, native_idf_tools_dir)
 
     print(f"Workspace root: {root_dir}")
-    print(f"PlatformIO core dir: {pio_core_dir}")
+    print(f"ESP-IDF tools dir: {native_idf_tools_dir}")
+    print(f"ccache: {ccache_status}")
     print(f"Log dir: {log_dir}")
     print(f"Parallel compile jobs: {args.jobs}")
 
@@ -646,113 +482,114 @@ def validate_command(args: argparse.Namespace) -> int:
         print("Validation complete.")
         return 0
 
-    patched_packages = apply_framework_espidf_source_workarounds(pio_core_dir)
-    for package_dir in patched_packages:
-        print(f"[fix] patched framework-espidf duplicate sources in {package_dir}")
-    if patched_packages:
-        shutil.rmtree(command_root / ".esphome" / "build", ignore_errors=True)
-
     compile_queue = list(args.configs)
-    packages_dir = pio_core_dir / "packages"
-    espressif_cache_dir = command_root / ".esphome" / ".espressif"
-    cold_platformio_cache = not packages_dir.exists() or not any(packages_dir.iterdir())
-    # ESPHome 2026.5 keeps managed components per build path. Only treat the
-    # legacy shared cache as cold when it is actually present.
-    cold_espressif_cache = espressif_cache_dir.exists() and not any(espressif_cache_dir.iterdir())
-    force_serial_compile = args.jobs > 1 and (cold_platformio_cache or cold_espressif_cache)
-    if force_serial_compile:
+    frameworks_dir = native_idf_tools_dir / "frameworks"
+    cold_native_idf_cache = not frameworks_dir.exists() or not any(frameworks_dir.iterdir())
+    if args.jobs > 1 and cold_native_idf_cache:
         print(
-            "Cold compile cache detected; running this validation sequentially once "
-            "to avoid ESP-IDF component-cache races."
+            "Cold native ESP-IDF cache detected; compiling the first target separately "
+            "before starting parallel target builds."
         )
-        shutil.rmtree(espressif_cache_dir, ignore_errors=True)
 
     def compile_one(config: str) -> tuple[str, int, Path]:
         log_path = log_dir / f"{config_log_stem(config)}.compile.log"
         label = f"compile {config}"
+        build_root = command_root / target_build_paths.get(config, f".esphome/build/{Path(config).stem}")
+        compile_env = env.copy()
+        if ccache_enabled:
+            compile_env.setdefault("CCACHE_BASEDIR", str(build_root.resolve()))
         print(f"[run] {label}", flush=True)
         exit_code = run_command(
             [*esphome_command, "compile", config],
             cwd=command_root,
-            env=env,
+            env=compile_env,
             log_path=log_path,
             check=False,
             heartbeat_label=label,
         )
         if exit_code != 0:
             tail = tail_lines(log_path, limit=160)
-            duplicate_object = next(
-                (
-                    object_name
-                    for object_name in ("esp_efuse_fields.c.o", "efuse_hal.c.o", "system_time.c.o", "lib_printf.c.o")
-                    if object_name in tail
-                ),
-                "",
+            tail_lower = tail.lower()
+            cmake_cache_mismatch = (
+                "does not match the source" in tail_lower
+                and "used to generate cache" in tail_lower
             )
-            source_duplicate = (
-                "Multiple ways to build the same target were specified for:" in tail
-                and bool(duplicate_object)
-            )
-            cache_race = (
-                ".esphome/.espressif/service_" in tail
-                and ("ArduinoJson" in tail or "idf_component_manager" in tail)
-            )
-            if source_duplicate:
-                patched = apply_framework_espidf_source_workarounds(pio_core_dir)
-                if patched or has_framework_espidf_source_workaround(pio_core_dir, duplicate_object):
-                    print(
-                        f"[retry] compile {config}: resetting build cache after framework-espidf "
-                        "duplicate-target failure."
-                    )
-                    build_root = command_root / target_build_paths.get(config, f".esphome/build/{Path(config).stem}")
-                    shutil.rmtree(build_root, ignore_errors=True)
-                    exit_code = run_command(
-                        [*esphome_command, "compile", config],
-                        cwd=command_root,
-                        env=env,
-                        log_path=log_path,
-                        check=False,
-                        heartbeat_label=label,
-                    )
-                    tail = tail_lines(log_path, limit=160)
-
-            if cache_race:
-                print(
-                    f"[retry] compile {config}: resetting ESP-IDF component cache after a generated-cache race."
+            retryable_failure = any(
+                marker in tail_lower
+                for marker in (
+                    "connection reset by peer",
+                    "failed to download",
+                    "temporary failure in name resolution",
+                    "timed out while downloading",
+                    "another process",
                 )
-                shutil.rmtree(espressif_cache_dir, ignore_errors=True)
+            ) or ("idf_component_manager" in tail_lower and "lock" in tail_lower)
+            retryable_failure = retryable_failure or (
+                "downloaded component" in tail_lower and "corrupted" in tail_lower
+            )
+            retryable_failure = retryable_failure or "does not contain a component" in tail_lower
+            if cmake_cache_mismatch:
+                print(
+                    f"[retry] compile {config}: resetting the native CMake build directory "
+                    "after the ESP-IDF cache location changed."
+                )
+                shutil.rmtree(build_root / "build", ignore_errors=True)
+            elif retryable_failure:
+                print(
+                    f"[retry] compile {config}: retrying after a transient native ESP-IDF failure."
+                )
+            if cmake_cache_mismatch or retryable_failure:
                 exit_code = run_command(
                     [*esphome_command, "compile", config],
                     cwd=command_root,
-                    env=env,
+                    env=compile_env,
                     log_path=log_path,
                     check=False,
                     heartbeat_label=label,
                 )
         if exit_code == 0:
-            build_dir = command_root / target_build_paths.get(config, f".esphome/build/{Path(config).stem}") / ".pioenvs" / "openquatt"
+            build_dir = build_root / "build"
+            artifact_log_path = log_dir / f"{config_log_stem(config)}.artifacts.log"
             exit_code = run_command(
-                [*helper_python, str(command_scripts_dir / "repair_factory_bin.py"), str(build_dir)],
+                [
+                    *helper_python,
+                    str(command_scripts_dir / "repair_factory_bin.py"),
+                    str(build_dir),
+                    "--normalize-app",
+                ],
                 cwd=command_root,
-                env=env,
-                log_path=log_path,
+                env=compile_env,
+                log_path=artifact_log_path,
                 check=False,
-                heartbeat_label=f"repair factory {config}",
+                heartbeat_label=f"validate artifacts {config}",
             )
+            if exit_code != 0:
+                log_path = artifact_log_path
         return config, exit_code, log_path
 
     results: list[tuple[str, int, Path]] = []
+    if compile_queue and args.jobs > 1 and cold_native_idf_cache:
+        results.append(compile_one(compile_queue.pop(0)))
+
     if compile_queue:
-        if args.jobs == 1 or force_serial_compile:
+        if args.jobs == 1:
             results = [compile_one(config) for config in compile_queue]
         else:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:
-                futures = [executor.submit(compile_one, config) for config in compile_queue]
-                for future in concurrent.futures.as_completed(futures):
-                    results.append(future.result())
+            compile_groups: dict[Path, list[str]] = {}
+            for config in compile_queue:
+                compile_groups.setdefault(Path(config).parent, []).append(config)
 
-            order = {config: index for index, config in enumerate(compile_queue)}
-            results.sort(key=lambda item: order[item[0]])
+            def compile_group(configs: list[str]) -> list[tuple[str, int, Path]]:
+                return [compile_one(config) for config in configs]
+
+            worker_count = min(args.jobs, len(compile_groups))
+            with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:
+                futures = [executor.submit(compile_group, configs) for configs in compile_groups.values()]
+                for future in concurrent.futures.as_completed(futures):
+                    results.extend(future.result())
+
+    order = {config: index for index, config in enumerate(args.configs)}
+    results.sort(key=lambda item: order[item[0]])
 
     failures = 0
     for config, exit_code, log_path in results:

--- a/scripts/repair_factory_bin.py
+++ b/scripts/repair_factory_bin.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import shutil
+import struct
 from typing import Iterable
 
 ESP_IMAGE_MAGIC = 0xE9
@@ -69,7 +71,13 @@ def fallback_candidates(raw_path: str, build_dir: Path, role: str, offset: int) 
     if role == "otadata":
         candidates.append(build_dir / "ota_data_initial.bin")
     if role == "app" or (not role and is_app_image_name(raw_name)):
-        candidates.append(build_dir / "firmware.bin")
+        candidates.extend(
+            (
+                build_dir / "openquatt.bin",
+                build_dir / "firmware.bin",
+                build_dir / "firmware.ota.bin",
+            )
+        )
 
     return candidates
 
@@ -97,7 +105,9 @@ def has_esp_image_magic(path: Path) -> bool:
 
 def is_app_image_name(name: str) -> bool:
     normalized = name.lower()
-    return normalized == "firmware.bin" or normalized.startswith("openquatt_")
+    return normalized in {"openquatt.bin", "firmware.bin", "firmware.ota.bin"} or normalized.startswith(
+        "openquatt_"
+    )
 
 
 def resolve_flash_file(raw_path: str, build_dir: Path, role: str, offset: int) -> Path:
@@ -145,10 +155,9 @@ def collect_sections(build_dir: Path, flasher_args: dict) -> tuple[list[tuple[in
 
     if not sections:
         raise FactoryBinError(f"No flash sections found in {build_dir / 'flasher_args.json'}")
-    if "bootloader" not in role_offsets:
-        raise FactoryBinError("flasher_args.json does not describe a bootloader section")
-    if "app" not in role_offsets:
-        raise FactoryBinError("flasher_args.json does not describe an app section")
+    for required_role in ("bootloader", "partition-table", "app"):
+        if required_role not in role_offsets:
+            raise FactoryBinError(f"flasher_args.json does not describe a {required_role} section")
 
     return sorted(sections.items()), role_offsets
 
@@ -175,7 +184,37 @@ def read_bytes(path: Path, offset: int, size: int) -> bytes:
     return data
 
 
-def validate_factory_bin(output_path: Path, role_offsets: dict[str, int]) -> None:
+def parse_partition_table(path: Path) -> list[dict[str, int | str]]:
+    entries: list[dict[str, int | str]] = []
+    data = path.read_bytes()
+    entry_size = 32
+    for position in range(0, len(data), entry_size):
+        raw = data[position : position + entry_size]
+        if len(raw) < entry_size or raw[:2] in (b"\xff\xff", b"\xeb\xeb"):
+            break
+        magic, partition_type, subtype, offset, size, raw_label, flags = struct.unpack("<HBBII16sI", raw)
+        if magic != 0x50AA:
+            raise FactoryBinError(f"Invalid partition entry magic at {hex(position)} in {path}")
+        entries.append(
+            {
+                "type": partition_type,
+                "subtype": subtype,
+                "offset": offset,
+                "size": size,
+                "label": raw_label.split(b"\0", 1)[0].decode("utf-8", errors="replace"),
+                "flags": flags,
+            }
+        )
+    if not entries:
+        raise FactoryBinError(f"Partition table contains no entries: {path}")
+    return entries
+
+
+def validate_factory_bin(
+    output_path: Path,
+    role_offsets: dict[str, int],
+    sections: list[tuple[int, Path]],
+) -> tuple[str, int]:
     bootloader_offset = role_offsets["bootloader"]
     app_offset = role_offsets["app"]
 
@@ -193,14 +232,66 @@ def validate_factory_bin(output_path: Path, role_offsets: dict[str, int]) -> Non
             f"(got 0x{app_magic:02x})"
         )
 
-    partition_offset = role_offsets.get("partition-table")
-    if partition_offset is not None:
-        partition_magic = read_bytes(output_path, partition_offset, 2)
-        if partition_magic != PARTITION_TABLE_MAGIC:
+    partition_offset = role_offsets["partition-table"]
+    partition_magic = read_bytes(output_path, partition_offset, 2)
+    if partition_magic != PARTITION_TABLE_MAGIC:
+        raise FactoryBinError(
+            f"{output_path.name} has no partition table magic at {hex(partition_offset)} "
+            f"(got {partition_magic.hex()})"
+        )
+
+    section_by_offset = dict(sections)
+    for offset, source_path in sections:
+        expected = source_path.read_bytes()
+        actual = read_bytes(output_path, offset, len(expected))
+        if actual != expected:
             raise FactoryBinError(
-                f"{output_path.name} has no partition table magic at {hex(partition_offset)} "
-                f"(got {partition_magic.hex()})"
+                f"{output_path.name} does not contain {source_path.name} unchanged at {hex(offset)}"
             )
+
+    partition_path = section_by_offset[partition_offset]
+    app_path = section_by_offset[app_offset]
+    partition_entries = parse_partition_table(partition_path)
+    app_partition = next(
+        (
+            entry
+            for entry in partition_entries
+            if entry["type"] == 0x00 and entry["offset"] == app_offset
+        ),
+        None,
+    )
+    if app_partition is None:
+        raise FactoryBinError(
+            f"Partition table has no app partition at the flasher app offset {hex(app_offset)}"
+        )
+    app_partition_size = int(app_partition["size"])
+    if app_path.stat().st_size > app_partition_size:
+        raise FactoryBinError(
+            f"{app_path.name} ({app_path.stat().st_size} bytes) exceeds partition "
+            f"{app_partition['label']} ({app_partition_size} bytes)"
+        )
+    return str(app_partition["label"]), app_partition_size
+
+
+def normalize_app_artifact(
+    build_dir: Path,
+    sections: list[tuple[int, Path]],
+    role_offsets: dict[str, int],
+) -> Path:
+    app_path = dict(sections)[role_offsets["app"]]
+    ota_path = build_dir / "firmware.ota.bin"
+    factory_path = build_dir / "firmware.factory.bin"
+    elf_path = build_dir / "firmware.elf"
+    for required_path in (app_path, ota_path, factory_path, elf_path):
+        if not required_path.is_file():
+            raise FactoryBinError(f"Required native ESP-IDF artifact not found: {required_path}")
+    if app_path.read_bytes() != ota_path.read_bytes():
+        raise FactoryBinError(f"{ota_path.name} differs from native app image {app_path.name}")
+
+    normalized_path = build_dir / "firmware.bin"
+    if app_path.resolve() != normalized_path.resolve():
+        shutil.copy2(app_path, normalized_path)
+    return normalized_path
 
 
 def repair_factory_bin(build_dir: Path, output_name: str = "firmware.factory.bin") -> Path:
@@ -209,45 +300,53 @@ def repair_factory_bin(build_dir: Path, output_name: str = "firmware.factory.bin
     sections, role_offsets = collect_sections(build_dir, flasher_args)
     output_path = build_dir / output_name
     merge_sections(sections, output_path)
-    validate_factory_bin(output_path, role_offsets)
+    validate_factory_bin(output_path, role_offsets, sections)
     return output_path
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Repair and validate an ESPHome ESP-IDF factory binary.")
-    parser.add_argument("build_dir", help="Path to the .pioenvs/openquatt build directory.")
+    parser = argparse.ArgumentParser(
+        description="Validate native ESPHome ESP-IDF artifacts and optionally repair a legacy factory image."
+    )
+    parser.add_argument("build_dir", help="Path to the native <build_path>/build artifact directory.")
     parser.add_argument("--output-name", default="firmware.factory.bin", help="Factory binary filename to write.")
+    parser.add_argument(
+        "--repair-legacy",
+        action="store_true",
+        help="Rebuild the factory image from flasher_args.json before validating it.",
+    )
+    parser.add_argument(
+        "--normalize-app",
+        action="store_true",
+        help="Copy the native app image to firmware.bin after validating the artifact set.",
+    )
     args = parser.parse_args()
 
     try:
-        output_path = repair_factory_bin(Path(args.build_dir), args.output_name)
+        build_dir = Path(args.build_dir).resolve()
+        flasher_args = load_flasher_args(build_dir)
+        sections, role_offsets = collect_sections(build_dir, flasher_args)
+        output_path = build_dir / args.output_name
+        if args.repair_legacy:
+            merge_sections(sections, output_path)
+        if not output_path.is_file():
+            raise FactoryBinError(f"Factory binary not found: {output_path}")
+        app_partition, app_partition_size = validate_factory_bin(output_path, role_offsets, sections)
+        normalized_path = normalize_app_artifact(build_dir, sections, role_offsets) if args.normalize_app else None
     except FactoryBinError as exc:
         raise SystemExit(str(exc)) from exc
 
-    print(f"[ok] repaired factory binary: {output_path}")
+    action = "repaired and validated" if args.repair_legacy else "validated"
+    offsets = ", ".join(
+        f"{role}={hex(role_offsets[role])}" for role in ("bootloader", "partition-table", "app")
+    )
+    print(
+        f"[ok] {action} factory binary: {output_path} "
+        f"({offsets}, partition={app_partition}, size={app_partition_size})"
+    )
+    if normalized_path is not None:
+        print(f"[ok] normalized native app artifact: {normalized_path}")
     return 0
-
-
-def _register_platformio_action() -> None:
-    try:
-        Import("env")  # type: ignore[name-defined]  # noqa: F821
-    except NameError:
-        return
-
-    def repair_factory_bin_action(source, target, env):  # noqa: ANN001
-        build_dir = Path(env.subst("$BUILD_DIR"))
-        try:
-            output_path = repair_factory_bin(build_dir)
-        except FactoryBinError as exc:
-            print(f"Error repairing factory binary: {exc}")
-            env.Exit(1)
-            return
-        print(f"Repaired and validated factory binary: {output_path}")
-
-    env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", repair_factory_bin_action)  # noqa: F821
-
-
-_register_platformio_action()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Wat verandert deze PR?

- Configureert alle acht ESP32-targets expliciet voor de native ESP-IDF-toolchain van ESPHome.
- Migreert buildflags, lokale buildtooling en CI van PlatformIO-paden naar native `<build_path>/build`-artifacts.
- Valideert native factory-images en behoudt het bestaande publieke `firmware.bin`-, OTA- en factory-artifactcontract.
- Centraliseert de ESP-IDF-toolchaincache en schakelt persistente ccache-ondersteuning in voor lokale builds en GitHub Actions.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De firmwaretoolchain en artifactproductie wijzigen, maar het firmwaregedrag en de publieke release-artifactnamen blijven gelijk. De niet-ondersteunde `send_wait_time`-optie op de Modbus-server is verwijderd omdat ESPHome 2026.7.0 deze configuratie afwijst en ESPHome 2026.6.2 haar niet toepast in de serverroute.

## Achtergrond

ESPHome 2026.7.0 gebruikt native ESP-IDF standaard. De repository gebruikte al `framework: esp-idf`, maar miste de expliciete native toolchainkeuze en verwachtte nog PlatformIO-buildpaden, caches en frameworkworkarounds.

De definitieve ESPHome-pin en `min_version` blijven bewust op 2026.6.2; de 2026.7.0-validatie is uitgevoerd met een aparte lokale omgeving.

Native artifacts staan nu onder `<build_path>/build/`. `openquatt.bin` wordt na validatie genormaliseerd naar `firmware.bin`, zodat downstream release- en PR-workflows hetzelfde contract behouden.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een interne buildketenmigratie zonder gebruikersgerichte configuratie- of bedieningswijziging.

## Validatie

- `python scripts/dev.py validate --venv-dir <esphome-2026.6.2-venv> --jobs 4`
  - configvalidatie en volledige native compilatie geslaagd voor alle acht targets.
- `python scripts/dev.py validate --venv-dir <esphome-2026.7.0-venv> --jobs 1`
  - configvalidatie en volledige native compilatie geslaagd voor alle acht targets.
- Gegenereerde CMake-compilecommando's bevatten beide OpenQuatt topology- en hardwaredefines.
- OTA-, app-, ELF- en factory-artifacts zijn voor alle targets gecontroleerd.
- Factory-images zijn byte-voor-byte gecontroleerd op bootloader, partitietabel en applicatiesegment.
- Waveshare ESP32-S3 hardware-smoke:
  - USB factory flash geslaagd;
  - OTA uitsluitend naar `192.168.2.106` geslaagd;
  - API, webinterface en herstart geslaagd;
  - Modbusverzoeken waargenomen; geen externe Modbus-slave aangesloten voor een responsmeting.

