### PR TITLE
Clarify installation and support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ OpenQuatt is open-source ESPHome-firmware voor Quatt Hybrid `Single`- en `Duo`-i
 >
 > Gebruik van OpenQuatt kan gevolgen hebben voor Quatts commerciële garantie. Raadpleeg de [actuele Quatt-voorwaarden](https://www.quatt.io/algemene-voorwaarden); wettelijke rechten staan daar los van.
 
+## Kies je route
+
+Kies alleen de route die bij jouw huidige hardware en situatie hoort. Home Assistant is geen onderdeel van de basisinstallatie.
+
+| Jouw situatie | Begin hier | Wat je gaat doen |
+|---|---|---|
+| Nieuwe Heatpump Controller Q-edition met OpenQuatt voorgeïnstalleerd | [Q-edition aansluiten en in gebruik nemen](docs/q-edition.md) | Controller aansluiten, online brengen en Quick Start afronden. Zelf firmware flashen is normaal niet nodig. |
+| Bestaande Waveshare- of Heatpump Listener-module | [Andere modules installeren](docs/installatie-en-ingebruikname.md) | Exact hardwareprofiel kiezen, firmware flashen en Quick Start afronden. Deze modules hebben limited/best-effort support. |
+| OpenQuatt draait al | [Web-app gebruiken](docs/web-app.md) | Instellingen beheren, updaten, backups maken en diagnose uitvoeren via `openquatt.local`. |
+| Eerst alleen rondkijken | [Web-app demo](https://jeroen85.github.io/OpenQuatt/demo/) | De interface bekijken zonder hardware of wijzigingen aan je installatie. |
+
 ## Wat is OpenQuatt?
 
 OpenQuatt is bedoeld voor gebruikers van een Quatt Hybrid `Single` of `Duo` die:
@@ -23,11 +34,11 @@ OpenQuatt is bedoeld voor gebruikers van een Quatt Hybrid `Single` of `Duo` die:
 - instellingen en verwarmingsstrategie zelf willen beheren;
 - koeling willen kunnen gebruiken waar hun installatie dat ondersteunt;
 - Home Assistant willen gebruiken voor dashboards en automatisering;
-- via de installer de juiste firmware voor hun opstelling, hardware en verbinding willen kiezen.
+- de juiste installatie- of beheerroute voor hun hardware willen volgen.
 
 OpenQuatt richt zich niet op Quatt All-Electric, Quatt Chill of koppeling met Quatt HomeBattery.
 
-Je hoeft voor de eerste installatie niet eerst alle technische achtergronddocumenten te lezen. De hoofdroute is: installer openen, je opstelling, hardware en verbinding kiezen, flashen, `openquatt.local` openen en Quick Start afronden. Home Assistant is optioneel voor OpenQuatt zelf en aanbevolen voor dashboards en automatisering.
+Je hoeft voor de eerste installatie niet eerst alle technische achtergronddocumenten te lezen. De routekiezer hierboven brengt je direct bij de juiste handleiding. Home Assistant is optioneel voor OpenQuatt zelf en aanbevolen voor dashboards en automatisering.
 
 ## Ondersteunde combinaties
 
@@ -39,27 +50,18 @@ Voor nieuwe installaties is de [`Electropaultje Heatpump Controller Q-edition`](
 
 Alle Wi-Fi-combinaties van bovenstaande opstelling en hardware zijn beschikbaar. Voor de Heatpump Controller Q zijn daarnaast Ethernet-builds beschikbaar voor `Single` en `Duo`. Ethernet en Wi-Fi zijn nu nog aparte firmware-builds; een Ethernet-build verwacht dus een werkende kabel/netwerkroute en heeft geen automatische Wi-Fi fallback of captive portal.
 
-## Snel starten
+## Wanneer is de installatie klaar?
 
-1. Open de [OpenQuatt installer](https://jeroen85.github.io/OpenQuatt/install/).
-2. Kies exact de combinatie die past bij jouw Quatt-opstelling, hardware en verbinding.
-3. Flash de firmware via USB in Chrome of Edge.
-4. Rond Wi-Fi-configuratie af, of sluit bij een Ethernet-build de netwerkkabel aan.
-5. Open `http://openquatt.local` en loop de Quick Start door.
-6. Gebruik OpenQuatt daarna via de geïntegreerde web-app.
-7. Optioneel: voeg OpenQuatt toe in Home Assistant. Selecteer tijdens het toevoegen nog geen area; wacht tot de entiteiten zijn aangemaakt, ken daarna de area toe en importeer eventueel het dashboard.
+De basisinstallatie is afgerond wanneer:
 
-Alleen de nieuwste stabiele eerste-installatiebestanden worden standaard via de installer aangeboden.
+- `http://openquatt.local` stabiel bereikbaar is;
+- Quick Start volledig is afgerond;
+- de warmtepompgegevens worden bijgewerkt;
+- aanvoertemperatuur, flow en buitentemperatuur aannemelijke waarden tonen.
 
-Voor de volledige installatiestappen en eerste controle:
+Home Assistant en het meegeleverde dashboard zijn optionele vervolgstappen. Ze zijn niet nodig om OpenQuatt zelf te installeren of via de web-app te gebruiken.
 
-- [Heatpump Controller Q-edition aansluiten en in gebruik nemen](docs/q-edition.md)
-- [Installatie en ingebruikname](docs/installatie-en-ingebruikname.md)
-- [Web-app gebruiken](docs/web-app.md)
-- [Web-app demo](https://jeroen85.github.io/OpenQuatt/demo/)
-- [Dashboard installeren](docs/dashboard/README.md)
-- [Dashboard gebruiken](docs/dashboardoverzicht.md)
-- [Problemen oplossen](docs/problemen-oplossen.md)
+Voor bestaande Waveshare- en Heatpump Listener-modules biedt de [installer](https://jeroen85.github.io/OpenQuatt/install/) de nieuwste stabiele eerste-installatiebestanden. Bij een HCQ gebruik je de installer alleen om Wi-Fi via USB in te stellen of als herstelroute. Ga bij problemen naar [Problemen oplossen](docs/problemen-oplossen.md).
 
 ## Mogelijkheden
 
@@ -71,18 +73,6 @@ OpenQuatt biedt:
 - koeling als bewuste OpenQuatt-functie waar de installatie dat ondersteunt;
 - optionele Home Assistant-integratie met dashboards;
 - OpenTherm-thermostaatuitlezing op Heatpump Controller Q-edition.
-
-## Ondersteunde hardware
-
-OpenQuatt richt zich nu bewust op drie hardwareprofielen:
-
-- [Electropaultje Heatpump Controller Q-edition](https://electropaultje.nl/product/heatpump-controller-q-edition/)
-- [Waveshare ESP32-S3-Relay-1CH](https://www.waveshare.com/esp32-s3-relay-1ch.htm)
-- [Electropaultje Heatpump Listener](https://electropaultje.nl/product/heatpump-listener/)
-
-Voor nieuwe installaties is de Heatpump Controller Q-edition de voorkeursmodule. Waveshare en Heatpump Listener zijn beschikbaar met limited/best-effort support.
-
-Alle ondersteunde OpenQuatt-profielen gebruiken PSRAM. De firmware zet `psram.ignore_not_found: false`, zodat ontbrekende PSRAM direct zichtbaar wordt als hardware- of profielprobleem in plaats van stil tot beperkte functionaliteit te leiden.
 
 ## Beperkingen
 
@@ -109,7 +99,8 @@ Compacte roadmap:
 
 Belangrijkste pagina's voor gebruikers:
 
-- [Installatie en ingebruikname](docs/installatie-en-ingebruikname.md) voor installeren en controle na de eerste start
+- [Heatpump Controller Q-edition aansluiten en in gebruik nemen](docs/q-edition.md) voor de normale route met nieuwe OpenQuatt-hardware
+- [Andere modules installeren](docs/installatie-en-ingebruikname.md) voor een bestaande Waveshare- of Heatpump Listener-module
 - [Web-app gebruiken](docs/web-app.md) voor Quick Start, instellingen, updates, backup en beveiliging
 - [Dashboard installeren](docs/dashboard/README.md) voor het importeren van dashboards
 - [Dashboard gebruiken](docs/dashboardoverzicht.md) voor dagelijkse controle in Home Assistant

--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -1,6 +1,6 @@
 # Dashboard installeren
 
-In deze map staan de dashboardbestanden voor OpenQuatt in Home Assistant. Volg voor een nieuwe installatie deze volgorde:
+Op deze pagina vind je de dashboardbestanden voor OpenQuatt in Home Assistant. Volg voor een nieuwe installatie deze volgorde:
 
 1. Rond Quick Start af via `http://openquatt.local`.
 2. Voeg OpenQuatt via de ESPHome-integratie toe aan Home Assistant.
@@ -11,12 +11,14 @@ In deze map staan de dashboardbestanden voor OpenQuatt in Home Assistant. Volg v
 
 Kies het bestand dat past bij je opstelling en voorkeurstaal:
 
-- `openquatt_ha_dashboard_duo_nl.yaml`
-- `openquatt_ha_dashboard_duo_en.yaml`
-- `openquatt_ha_dashboard_single_nl.yaml`
-- `openquatt_ha_dashboard_single_en.yaml`
+- [Single · Nederlands](openquatt_ha_dashboard_single_nl.yaml)
+- [Single · Engels](openquatt_ha_dashboard_single_en.yaml)
+- [Duo · Nederlands](openquatt_ha_dashboard_duo_nl.yaml)
+- [Duo · Engels](openquatt_ha_dashboard_duo_en.yaml)
 
 Gebruik `duo` voor Duo en `single` voor Single. Kies daarna `nl` of `en`.
+
+Open het gekozen bestand, kopieer de volledige inhoud en plak die later in de **Raw configuration editor** van Home Assistant.
 
 ## OpenQuatt via ESPHome toevoegen aan Home Assistant
 
@@ -92,7 +94,7 @@ Pas niet de dashboard-YAML aan naar een specifieke area. Zo'n dashboard werkt da
 
 ## Optioneel: dynamische bronselectie via Home Assistant
 
-Gebruik `openquatt_ha_dynamic_sources_package.yaml` alleen als je tijdens runtime zelf Home Assistant-bronnen wilt kunnen aanwijzen zonder opnieuw te flashen.
+Gebruik [openquatt_ha_dynamic_sources_package.yaml](openquatt_ha_dynamic_sources_package.yaml) alleen als je tijdens runtime zelf Home Assistant-bronnen wilt kunnen aanwijzen zonder opnieuw te flashen.
 
 Dat pakket maakt extra helper-entiteiten aan, zoals:
 
@@ -125,7 +127,7 @@ De algemene dynamische bronnen publiceren stabiele proxy-entiteiten, bijvoorbeel
 
 ## Optioneel: dynamische koelbronnen via Home Assistant
 
-Gebruik `openquatt_ha_dynamic_cooling_package.yaml` als je voor koeling een of meer dauwpuntbronnen vanuit Home Assistant wilt gebruiken.
+Gebruik [openquatt_ha_dynamic_cooling_package.yaml](openquatt_ha_dynamic_cooling_package.yaml) als je voor koeling een of meer dauwpuntbronnen vanuit Home Assistant wilt gebruiken.
 
 Dit pakket is vooral nuttig als:
 

--- a/docs/handmatige-installatie.md
+++ b/docs/handmatige-installatie.md
@@ -77,4 +77,4 @@ Loop vervolgens de Quick Start in de web-app door.
 - De browser sluiten voordat Wi-Fi is ingesteld.
 - Een Ethernet-bestand gebruiken op hardware zonder W5500 Ethernet-poort.
 
-Als je twijfelt, ga terug naar [Installatie en ingebruikname](installatie-en-ingebruikname.md) en gebruik de normale installer.
+Als je twijfelt, kies dan opnieuw je route in het [projectoverzicht](../README.md#kies-je-route) en gebruik de normale installer of Q-edition-handleiding.

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -59,7 +59,7 @@
           <section class="sidebar-overview">
             <p class="sidebar-kicker">Installatiehulp</p>
             <p class="sidebar-copy">
-              Stel Wi-Fi in op een voorgeïnstalleerde module of flash de stabiele OpenQuatt-firmware via USB.
+              Nieuwe HCQ: Wi-Fi instellen. Bestaande Waveshare of Listener: firmware installeren.
             </p>
             <a class="sidebar-utility" href="../q-edition.html">Open aansluithulp</a>
             <p class="docs-version" data-docs-version>Docs vanaf main</p>
@@ -85,9 +85,9 @@
             </button>
             <div class="sidebar-section-panel" id="install-nav-1" data-nav-panel hidden>
               <ul class="nav-list">
-                <li><a class="sidebar-link" href="../dashboard/index.html" data-sidebar-link>Dashboard installeren</a></li>
-                <li><a class="sidebar-link" href="../dashboardoverzicht.html" data-sidebar-link>Dashboard gebruiken</a></li>
                 <li><a class="sidebar-link" href="../web-app.html" data-sidebar-link>Web-app gebruiken</a></li>
+                <li><a class="sidebar-link" href="../dashboard/index.html" data-sidebar-link>Optioneel: dashboard installeren</a></li>
+                <li><a class="sidebar-link" href="../dashboardoverzicht.html" data-sidebar-link>Optioneel: dashboard gebruiken</a></li>
                 <li><a class="sidebar-link" href="../problemen-oplossen.html" data-sidebar-link>Problemen oplossen</a></li>
                 <li><a class="sidebar-link" href="../verwarmen-en-koelen.html" data-sidebar-link>Verwarmen en koelen uitgelegd</a></li>
               </ul>
@@ -99,9 +99,9 @@
       <main class="docs-main" id="main-content" tabindex="-1">
         <section class="doc-header">
           <p class="doc-kicker">Installatiehulp</p>
-          <h1>Verbind of installeer je OpenQuatt-module</h1>
+          <h1>HCQ verbinden of bestaande module installeren</h1>
           <p class="doc-lead">
-            Stel Wi-Fi in op een voorgeïnstalleerde module of flash zelf de stabiele firmware.
+            Stel Wi-Fi in op een voorgeïnstalleerde Heatpump Controller Q-edition, of flash een bestaande Waveshare- of Heatpump Listener-module. Kies de HCQ alleen bij zelf installeren als herstelroute.
           </p>
           <p class="install-warning-inline">
             <span>Let op</span>
@@ -112,30 +112,30 @@
         <section class="install-route-switcher" aria-label="Installatieroute">
           <div class="install-route-tabs" role="tablist" aria-label="Installatieroute kiezen">
             <button class="install-route-tab" id="route-preinstalled-tab" type="button" role="tab" aria-selected="true" aria-controls="route-preinstalled-panel" data-install-route-tab="preinstalled">
-              Voorgeïnstalleerde module
+              HCQ: Wi-Fi instellen
             </button>
             <button class="install-route-tab" id="route-install-tab" type="button" role="tab" aria-selected="false" aria-controls="route-install-panel" data-install-route-tab="install">
-              Zelf installeren
+              Andere module of herstel
             </button>
           </div>
 
           <div class="install-route-panels">
             <section class="install-card install-provision install-route-panel" id="route-preinstalled-panel" role="tabpanel" aria-labelledby="route-preinstalled-tab" data-install-route-panel="preinstalled">
               <div class="install-provision-copy">
-                <p class="install-section-label">Voorgeïnstalleerde module</p>
-                <h2>Alleen Wi-Fi instellen</h2>
+                <p class="install-section-label">Voorgeïnstalleerde Heatpump Controller Q-edition</p>
+                <h2>Alleen Wi-Fi instellen op je HCQ</h2>
                 <p>
-                  Gebruik dit als je module al met OpenQuatt is geleverd. Deze stap zet alleen je Wi-Fi-gegevens op de module en flasht niets.
+                  Gebruik dit bij een nieuwe HCQ waarop OpenQuatt al staat. Deze stap zet alleen je Wi-Fi-gegevens op de controller en flasht niets.
                 </p>
                 <ol class="install-provision-list">
-                  <li>Sluit de module met USB aan op deze computer.</li>
+                  <li>Sluit de HCQ met USB aan op deze computer.</li>
                   <li>Klik op <strong>Configureer Wi-Fi</strong> en kies de juiste USB-poort.</li>
                   <li>Vul je Wi-Fi-netwerk in en open daarna <code>http://openquatt.local</code>.</li>
                 </ol>
               </div>
 
               <div class="install-provision-tool" id="wifi-provision-panel">
-                <p class="install-state" id="wifi-provision-state">Sluit je voorgeïnstalleerde module via USB aan om Wi-Fi te configureren.</p>
+                <p class="install-state" id="wifi-provision-state">Sluit je voorgeïnstalleerde HCQ via USB aan om Wi-Fi te configureren.</p>
                 <p class="install-provision-device" id="wifi-provision-device" hidden></p>
 
                 <div class="install-provision-actions">
@@ -166,7 +166,8 @@
             <div class="install-route-panel" id="route-install-panel" role="tabpanel" aria-labelledby="route-install-tab" data-install-route-panel="install" hidden>
               <div class="install-layout">
                 <section class="install-card install-flow">
-                  <p class="install-section-label">Zelf installeren</p>
+                  <p class="install-section-label">Bestaande module installeren of HCQ herstellen</p>
+                  <p class="install-step-copy">Gebruik deze route voor een bestaande Waveshare of Heatpump Listener. Kies de HCQ hier alleen als OpenQuatt opnieuw moet worden geïnstalleerd of de normale herstelroute dat vraagt.</p>
                   <section class="install-step" id="topology-step">
                     <div class="install-step-head">
                       <p class="install-step-number">1</p>
@@ -212,8 +213,8 @@
                       </label>
                       <label class="choice-card">
                         <input type="radio" name="hardware" value="heatpump_controller_q" />
-                        <span class="choice-title">Heatpump Controller Q</span>
-                        <span class="choice-body">Electropaultje Heatpump Controller Q-edition, de voorkeursmodule voor nieuwe installaties.</span>
+                        <span class="choice-title">Heatpump Controller Q · herstel</span>
+                        <span class="choice-body">Alleen voor herinstallatie of herstel. Een nieuwe HCQ is al voorzien van OpenQuatt.</span>
                       </label>
                     </div>
                     <p class="install-step-copy">De Heatpump Controller Q-edition is verkrijgbaar via de <a href="https://electropaultje.nl/product/heatpump-controller-q-edition/">productpagina van Electropaultje</a>.</p>
@@ -312,11 +313,11 @@
             <div class="install-follow-up-grid">
               <article class="install-follow-up-item">
                 <h3>Netwerk afronden</h3>
-                <p>Bij Wi-Fi stel je het netwerk via USB in. Bij Ethernet sluit je na het flashen de netwerkkabel aan.</p>
+                <p>Bij een nieuwe HCQ stel je eerst Wi-Fi in; Quick Start wisselt zo nodig naar Ethernet. Bij Waveshare of Listener rond je Wi-Fi na het flashen af.</p>
               </article>
               <article class="install-follow-up-item">
                 <h3>Web-app openen</h3>
-                <p>Open daarna <code>http://openquatt.local</code> en rond de Quick Start af voordat je verdergaat in Home Assistant.</p>
+                <p>Open daarna <code>http://openquatt.local</code> en rond Quick Start af. Daarmee is de basisinstallatie klaar; Home Assistant is optioneel.</p>
               </article>
               <article class="install-follow-up-item">
                 <h3>Fallback route</h3>

--- a/docs/installatie-en-ingebruikname.md
+++ b/docs/installatie-en-ingebruikname.md
@@ -1,61 +1,43 @@
-# Installatie en ingebruikname
+# Andere modules installeren
 
-Deze handleiding beschrijft de eerste installatie van OpenQuatt. Heb je een module gekocht waar OpenQuatt al op staat, dan gebruik je de web installer alleen om Wi-Fi in te stellen. Flashen is dan niet nodig. Na het verbinden ga je eerst naar de lokale web-app via `http://openquatt.local`; Home Assistant komt daarna.
+Deze route is bedoeld voor een bestaande `Waveshare ESP32-S3-Relay-1CH` of `Electropaultje Heatpump Listener`. Voor deze modules kies en flash je zelf het exacte OpenQuatt-profiel. De pagina behandelt de software-installatie en geen hardware- of bedradingsinstructies.
 
-Heb je de Heatpump Controller Q-edition, gebruik dan bij voorkeur de doorlopende handleiding [Heatpump Controller Q-edition aansluiten en in gebruik nemen](q-edition.md).
+Heb je een nieuwe Heatpump Controller Q-edition met OpenQuatt voorgeïnstalleerd? Volg dan de primaire route [Heatpump Controller Q-edition aansluiten en in gebruik nemen](q-edition.md). Zelf firmware flashen is daarbij normaal niet nodig.
 
 > OpenQuatt is een open-sourceproject op best-effortbasis, zonder gegarandeerde responstijd of individuele ondersteuning. Voor gebruiksvragen en hulp bij diagnose kun je terecht in het [OpenQuatt Discord-kanaal](https://discord.com/channels/1176602554885492786/1464174190788874427). Een reproduceerbare bug meld je als [GitHub-issue](https://github.com/jeroen85/OpenQuatt/issues/new/choose).
 
 ## Installatieroute
 
-Voor een eerste installatie gebruik je de web installer uit de [README](../README.md). Daarmee stel je bij een voorgeïnstalleerde module alleen Wi-Fi in, of flash je zelf de juiste firmware. Bij Ethernet sluit je na het flashen de netwerkkabel aan.
+1. Open de [OpenQuatt installer](https://jeroen85.github.io/OpenQuatt/install/).
+2. Kies `Single` of `Duo` en daarna exact jouw hardwareprofiel.
+3. Sluit de module via USB aan en flash de firmware.
+4. Stel Wi-Fi in.
+5. Open `http://openquatt.local`.
+6. Rond Quick Start af en controleer de live warmtepompgegevens.
 
-Voor een voorgeïnstalleerde Wi-Fi-module is de route:
-
-1. installer openen;
-2. module via USB aansluiten;
-3. `Alleen Wi-Fi instellen` gebruiken;
-4. `openquatt.local` openen;
-5. Quick Start afronden;
-6. Home Assistant-dashboard importeren.
-
-Als je zelf firmware flasht, is de route:
-
-1. installer openen;
-2. opstelling en hardware kiezen;
-3. verbinding kiezen;
-4. firmware flashen;
-5. netwerk verbinden;
-6. `openquatt.local` openen;
-7. Quick Start afronden;
-8. Home Assistant-dashboard importeren.
+Daarmee is OpenQuatt geïnstalleerd. Home Assistant en het dashboard zijn optionele vervolgstappen.
 
 Gebruik [Handmatige installatie](handmatige-installatie.md) alleen als fallback.
 
 ## Wat zie je onderweg?
 
-| Moment | Wat zie je? | Volgende actie |
-|---|---|---|
-| Voorgeïnstalleerde module | Wi-Fi configureren via USB | Sluit de module aan, kies de USB-poort en sla je Wi-Fi-netwerk op. |
-| Installer | Keuzes voor `Single` of `Duo`, ESP-module en verbinding | Kies de exacte combinatie die bij je hardware past. |
-| ESP Web Tools | Browserdialoog voor verbinden, wissen en flashen | Laat het tabblad bij Wi-Fi open tot de Wi-Fi-configuratie is afgerond. Bij Ethernet sluit je na de flash de netwerkkabel aan. |
-| Web-app | `http://openquatt.local` met Quick Start | Kies Quatt Hybrid V1, V1.5 of V2 en rond de basisinstellingen af. |
-| Home Assistant | ESPHome-apparaat en dashboard | Voeg OpenQuatt toe en importeer daarna het juiste `Single`- of `Duo`-dashboard. |
+1. **Installer:** je kiest `Single` of `Duo` en jouw ESP-module. Kies exact de combinatie die bij je bestaande hardware past.
+2. **ESP Web Tools:** de browser vraagt met welke USB-poort hij moet verbinden en installeert daarna de firmware. Laat het tabblad open totdat ook Wi-Fi is ingesteld.
+3. **Web-app:** open `http://openquatt.local`, kies Quatt Hybrid V1, V1.5 of V2 en rond Quick Start af.
+4. **Optioneel: Home Assistant:** voeg OpenQuatt pas na de lokale eindcontrole toe en importeer eventueel het juiste dashboard.
 
 ## Benodigdheden
 
-- een ondersteund ESP32-bord:
-  - [Electropaultje Heatpump Controller Q-edition](https://electropaultje.nl/product/heatpump-controller-q-edition/), aanbevolen voor nieuwe installaties
-  - Waveshare ESP32-S3-Relay-1CH
-  - Electropaultje Heatpump Listener
-- een USB-kabel voor de eerste flash
-- een werkend Wi-Fi-netwerk of, bij Heatpump Controller Q Ethernet, een aangesloten netwerkkabel
-- Chrome of Edge op desktop voor de web installer
-- Home Assistant is optioneel voor OpenQuatt zelf en aanbevolen voor dashboards en automatisering
+- een bestaande Waveshare ESP32-S3-Relay-1CH of Electropaultje Heatpump Listener;
+- een USB-kabel voor de eerste flash;
+- een werkend Wi-Fi-netwerk;
+- Chrome of Edge op desktop voor de web installer.
+
+Home Assistant is optioneel voor OpenQuatt zelf en aanbevolen voor dashboards en automatisering.
 
 ## Kies het juiste profiel in de installer
 
-Kies in de installer altijd exact de combinatie van je opstelling, hardware en verbinding. Voor nieuwe installaties is de [Heatpump Controller Q-edition](https://electropaultje.nl/product/heatpump-controller-q-edition/) de voorkeursmodule.
+Kies in de installer altijd exact de combinatie van je opstelling en hardware. Waveshare en Heatpump Listener zijn beschikbaar met limited/best-effort support; de Heatpump Controller Q-edition is de focus voor nieuwe ontwikkeling en support.
 
 OpenQuatt ondersteunt Quatt Hybrid V1, V1.5 en V2. Die versie kies je na het flashen in de Quick Start van de web-app.
 
@@ -67,46 +49,26 @@ Je herkent de generatie aan het model en de sensoraansluiting:
 | `V1.5` | Model `AMM4-V1.5`: flowmeter in de buitenunit; onder de CV-ketel zit alleen een kleine clip-on temperatuursensor. |
 | `V2` | Model `AMH6` of `AMH6-2`: flowmeter in de buitenunit; onder de CV-ketel zit alleen een kleine clip-on temperatuursensor. |
 
-| Opstelling | Hardware | Verbinding | Installerkeuze |
-|---|---|---|---|
-| Single | Heatpump Controller Q | Wi-Fi | `Single` + `Heatpump Controller Q` + `Wi-Fi` |
-| Duo | Heatpump Controller Q | Wi-Fi | `Duo` + `Heatpump Controller Q` + `Wi-Fi` |
-| Single | Heatpump Controller Q | Ethernet | `Single` + `Heatpump Controller Q` + `Ethernet` |
-| Duo | Heatpump Controller Q | Ethernet | `Duo` + `Heatpump Controller Q` + `Ethernet` |
-| Single | Heatpump Listener | Wi-Fi | `Single` + `Heatpump Listener` + `Wi-Fi` |
-| Duo | Heatpump Listener | Wi-Fi | `Duo` + `Heatpump Listener` + `Wi-Fi` |
-| Single | Waveshare | Wi-Fi | `Single` + `Waveshare` + `Wi-Fi` |
-| Duo | Waveshare | Wi-Fi | `Duo` + `Waveshare` + `Wi-Fi` |
+Kies per hardware de volgende combinatie:
 
-Ethernet is alleen beschikbaar voor de Heatpump Controller Q. ESPHome ondersteunt Wi-Fi en Ethernet niet samen in dezelfde build, dus een Ethernet-installatie heeft geen Wi-Fi fallback of captive portal.
+- **Heatpump Listener:** `Single` of `Duo` + `Heatpump Listener` + `Wi-Fi`;
+- **Waveshare:** `Single` of `Duo` + `Waveshare` + `Wi-Fi`.
+
+Kies `Single` voor één warmtepomp en `Duo` voor twee warmtepompen.
 
 ## Installatie via de web installer
 
 > Let op: OpenQuatt kan gevolgen hebben voor Quatts commerciële garantie. Zie de [actuele Quatt-voorwaarden](https://www.quatt.io/algemene-voorwaarden); wettelijke rechten staan daar los van.
 
-### Voorgeïnstalleerde module: alleen Wi-Fi instellen
-
-Gebruik deze route als je module al met OpenQuatt is geleverd.
+### Firmware flashen
 
 1. Open de [OpenQuatt installer](https://jeroen85.github.io/OpenQuatt/install/).
-2. Sluit het ESP32-bord via USB aan.
-3. Gebruik `Alleen Wi-Fi instellen`.
-4. Kies de USB-poort van de module.
-5. Vul je Wi-Fi-netwerk en wachtwoord in.
-6. Open na het verbinden `http://openquatt.local`.
-7. Rond de Quick Start in de web-app af.
-8. Voeg het apparaat daarna toe in Home Assistant. Selecteer tijdens het toevoegen nog geen area; ken die pas toe nadat de OpenQuatt-entiteiten zijn aangemaakt.
-
-### Zelf firmware flashen
-
-1. Open de [OpenQuatt installer](https://jeroen85.github.io/OpenQuatt/install/).
-2. Kies de combinatie die past bij je opstelling, hardware en verbinding.
+2. Kies de combinatie die past bij je opstelling en hardware.
 3. Sluit het ESP32-bord via USB aan.
 4. Flash de firmware.
-5. Laat bij Wi-Fi het browsertabblad open, zodat de Wi-Fi-configuratie direct daarna kan worden aangeboden. Sluit bij Ethernet na de flash de netwerkkabel aan.
+5. Laat het browsertabblad open, zodat de Wi-Fi-configuratie direct daarna kan worden aangeboden.
 6. Open na de eerste start `http://openquatt.local`.
 7. Rond de Quick Start in de web-app af.
-8. Voeg het apparaat daarna toe in Home Assistant. Selecteer tijdens het toevoegen nog geen area; ken die pas toe nadat de OpenQuatt-entiteiten zijn aangemaakt.
 
 Praktisch voor een DS18B20: sluit die sensor bij voorkeur aan voordat OpenQuatt opstart. De 1-Wire sensor wordt tijdens het opstarten gedetecteerd; als je hem later aansluit, moet je het bord eerst herstarten voordat de sensor zichtbaar wordt.
 
@@ -125,27 +87,39 @@ http://openquatt.local
 
 Als die naam niet werkt, zoek dan het IP-adres van OpenQuatt in je router en open `http://<ip-adres>`.
 
-De web-app toont Quick Start zolang de basisinstellingen nog niet zijn afgerond. Loop die eerst rustig door. Quick Start zet de belangrijkste keuzes klaar:
+De web-app toont Quick Start zolang de basisinstellingen nog niet zijn afgerond. Loop die eerst rustig door. Quick Start zet de belangrijkste installatiekeuzes klaar:
 
-1. setup: `Single` of `Duo` en Wi-Fi of Ethernet;
-2. Quatt Hybrid-versie: V1, V1.5 of V2;
-3. flowmeting;
-4. bron voor kamertemperatuur en kamer-setpoint;
-5. ondersteuning door CV-ketel of boiler;
-6. verwarmingsstrategie;
-7. instellingen voor de gekozen strategie;
-8. flowregeling en afstelling;
-9. watertemperatuurbeveiliging;
-10. stille uren en compressorlimieten;
-11. controleren en afronden.
+Bij Waveshare en Heatpump Listener ligt `Single` of `Duo` al vast in de firmware die je in de installer hebt gekozen. Quick Start toont daarom geen stap **Kies je setup** en begint met:
 
-Gebruik daarna pas Home Assistant voor dashboard, dagelijkse controle en optionele dynamische bronselectie.
+1. Quatt Hybrid-versie: V1, V1.5 of V2;
+2. flowmeting;
+3. bron voor kamertemperatuur en kamer-setpoint;
+4. ondersteuning door CV-ketel of boiler;
+5. verwarmingsstrategie;
+6. instellingen voor de gekozen strategie;
+7. flowregeling en afstelling;
+8. watertemperatuurbeveiliging;
+9. stille uren en compressorlimieten;
+10. controleren en afronden.
+
+Blijkt dat je `Single` of `Duo` verkeerd hebt gekozen? Flash dan via de installer het juiste profiel voordat je verdergaat. Deze modules kunnen de setup niet vanuit Quick Start wisselen.
+
+## Wanneer is de installatie klaar?
+
+De basisinstallatie is afgerond wanneer:
+
+- `openquatt.local` stabiel bereikbaar is;
+- Quick Start volledig is afgerond;
+- de warmtepompgegevens worden bijgewerkt;
+- aanvoertemperatuur, flow en buitentemperatuur aannemelijke waarden tonen.
+
+Home Assistant is hiervoor niet nodig.
 
 Zie voor de lokale web-app:
 
 - [Web-app gebruiken](web-app.md)
 
-## Daarna: Home Assistant
+## Optioneel: Home Assistant
 
 Home Assistant ontdekt OpenQuatt meestal automatisch zodra beide op hetzelfde netwerk zitten. Open de melding bij **Instellingen -> Apparaten & diensten** en kies **Configureren**. Verschijnt er geen melding, kies dan **Integratie toevoegen -> ESPHome** en vul `openquatt.local` of het IP-adres van OpenQuatt in. Voer de ESPHome API-encryptiesleutel in als Home Assistant daarom vraagt.
 
@@ -154,17 +128,7 @@ Zie ook de officiële ESPHome-handleiding: [Connecting your device to Home Assis
 > [!IMPORTANT]
 > Selecteer bij het toevoegen van OpenQuatt nog geen Home Assistant-area. Sinds Home Assistant 2026.6 kan de gekozen area tijdens de eerste aanmaak in de `entity_id` terechtkomen, bijvoorbeeld `sensor.zolder_openquatt_flow`. De meegeleverde dashboards verwachten `sensor.openquatt_...`. Wacht daarom tot alle OpenQuatt-entiteiten bestaan en ken pas daarna een area toe. Een latere area-toewijzing verandert bestaande entity-ID's niet.
 
-Controleer na Quick Start bij voorkeur in deze volgorde:
-
-1. Het apparaat is online en zichtbaar in Home Assistant.
-2. De firmwareversie is zichtbaar.
-3. De warmtepompdata ververst.
-4. De gekozen meetwaarden lijken logisch:
-   - aanvoertemperatuur
-   - flow
-   - buitentemperatuur
-5. `CM override` staat op `Auto`.
-6. Het juiste dashboard is geïmporteerd.
+Controleer pas na de lokale eindcontrole of het apparaat online en zichtbaar is in Home Assistant. Importeer vervolgens eventueel het juiste dashboard.
 
 Zie voor het dashboard:
 
@@ -176,7 +140,6 @@ Zie voor het dashboard:
 ### Het apparaat verschijnt niet in Home Assistant
 
 - Controleer of Wi-Fi echt is ingesteld.
-- Gebruik je Ethernet, controleer dan of de netwerkkabel is aangesloten en DHCP een IP-adres heeft gegeven.
 - Kijk of het apparaat nog op het fallback access point zit.
 - Herstart het bord een keer.
 

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -13,7 +13,7 @@ Gebruik voor normale monitoring en bediening bij voorkeur de web-app en, als je 
 
 ## Waar stel je MQTT in?
 
-Open de OpenQuatt web-app en ga naar **Instellingen -> Integratie -> MQTT inputbronnen**.
+Open de OpenQuatt web-app en ga naar **Instellingen → Bronnen / integraties → MQTT inputbronnen**.
 
 Daar stel je de broker in:
 
@@ -50,7 +50,7 @@ openquatt/openquatt/input/thermostat/heating_enable
 openquatt/openquatt/input/thermostat/cooling_enable
 ```
 
-De web-app toont de uiteindelijke topics bij **Instellingen -> Integratie -> MQTT sensoren**. Gebruik bij voorkeur die getoonde topics, omdat daar de actuele device-naam al in verwerkt is.
+Open in dezelfde sectie **MQTT sensoren → Details** om de uiteindelijke topics te bekijken. Gebruik bij voorkeur die getoonde topics, omdat daar de actuele device-naam al in verwerkt is.
 In hetzelfde scherm kun je per topic **Topic gebruiken** uitzetten als je maar een deel van de MQTT-bronnen wilt inzetten.
 
 ## Payload
@@ -105,7 +105,7 @@ Publiceer daarom periodiek, bijvoorbeeld elke minuut of telkens wanneer de bronw
 
 ## Bronselectie
 
-Ga in de web-app naar **Instellingen -> Bronnen / Sensorselectie**.
+Ga in de web-app naar **Instellingen → Bronnen / integraties → Sensorselectie**.
 
 Bij `Koelingsdauwpunt` kies je:
 

--- a/docs/problemen-oplossen.md
+++ b/docs/problemen-oplossen.md
@@ -8,13 +8,17 @@ Controleer in deze volgorde:
 
 1. OpenQuatt is online.
 2. De web-app opent via `openquatt.local` of via het IP-adres.
-3. Home Assistant ziet het apparaat.
-4. De juiste dashboardvariant is gebruikt: `Single` of `Duo`.
-5. De gekozen bronwaarden lijken logisch.
-6. Flow en aanvoertemperatuur verversen.
-7. Er is geen handmatige override actief.
+3. De warmtepompgegevens worden bijgewerkt.
+4. De gekozen bronwaarden lijken logisch.
+5. Flow en aanvoertemperatuur verversen.
+6. Er is geen handmatige override actief.
 
 Als een stap niet klopt, los die eerst op voordat je naar tuning kijkt.
+
+Gebruik je Home Assistant? Controleer dan daarnaast:
+
+1. Home Assistant ziet het OpenQuatt-apparaat en de entiteiten ontvangen waarden.
+2. Je gebruikt de dashboardvariant die bij `Single` of `Duo` past.
 
 ## OpenQuatt is niet bereikbaar
 
@@ -57,6 +61,8 @@ Controleer:
 - `Single` of `Duo`;
 - voeding en massa;
 - of de gebruikte module past bij de installatie.
+
+Gebruik je een Heatpump Controller Q-edition? Maak voor een supportverzoek een scherpe foto van de verbinding tussen de HCQ en de warmtepomp. Zorg dat `M1`, de klemmarkeringen `GND/A/B`, de adervolgorde en de aangesloten Modbuskabel zichtbaar zijn. Maak niets los om de foto te nemen.
 
 Als de warmtepompdata ontbreekt, kunnen dashboard en regeling niet betrouwbaar verklaren wat er gebeurt.
 
@@ -182,9 +188,15 @@ Gebruik deze werkwijze:
 
 Begin bijna altijd met bronkeuze en flow. Strategie-instellingen komen daarna pas.
 
-## Vraag stellen of bug melden
+## Waar meld ik wat?
 
-Voor gebruiksvragen en hulp bij diagnose kun je terecht in het [OpenQuatt Discord-kanaal](https://discord.com/channels/1176602554885492786/1464174190788874427). Een reproduceerbare bug meld je als [GitHub-issue](https://github.com/jeroen85/OpenQuatt/issues/new/choose).
+| Situatie | Juiste route |
+|---|---|
+| Gebruiksvraag of hulp bij diagnose | Vraag het in het [OpenQuatt Discord-kanaal](https://discord.com/channels/1176602554885492786/1464174190788874427). |
+| Reproduceerbare fout in OpenQuatt | Meld die als [GitHub-issue](https://github.com/jeroen85/OpenQuatt/issues/new/choose). |
+| Fysiek probleem met de warmtepomp, lekkage of een mogelijk onveilige situatie | Stop en neem contact op met een vakbekwaam installateur of Quatt. |
+
+Twijfel je wat er gebeurt? Verander dan geen nieuwe instellingen, noteer de actuele toestand en verzamel eerst de informatie hieronder.
 
 Vermeld bij een hulpvraag of bugmelding:
 
@@ -192,7 +204,9 @@ Vermeld bij een hulpvraag of bugmelding:
 - Quatt-generatie, `Single` of `Duo`, en Wi-Fi of Ethernet;
 - wat je verwachtte en wat er daadwerkelijk gebeurde;
 - het tijdstip en de stappen om het probleem te herhalen;
-- relevante screenshots uit `Diagnose` of `Beslislog` en recente wijzigingen.
+- relevante screenshots uit `Diagnose` of `Beslislog` en recente wijzigingen;
+- bij een reproduceerbaar probleem: een [debugopname uit de web-app](web-app.md#debugopname-voor-support);
+- bij een ontbrekende warmtepompverbinding met de HCQ: een scherpe foto van `M1` en de Modbusverbinding met de warmtepomp.
 
 Deel nooit Wi-Fi-wachtwoorden, API-sleutels of andere geheimen.
 

--- a/docs/q-edition.md
+++ b/docs/q-edition.md
@@ -2,14 +2,14 @@
 
 Van nieuwe controller naar een werkende OpenQuatt-installatie. De Heatpump Controller Q-edition (HCQ) wordt standaard geleverd met `Single` + `Wi-Fi` voorgeïnstalleerd. Je brengt hem eerst online; de web-app begeleidt je daarna bij de juiste configuratie voor jouw opstelling en netwerkverbinding.
 
-## De route in zes stappen
+## De hoofdroute in vier stappen
 
 1. Maak de CiC en Quatt-buitenunit(s) spanningsloos, verplaats de kabels en voer de eindcontrole uit.
-2. Voed de HCQ via USB en schakel daarna de Quatt-buitenunit(s) weer in.
-3. Stel Wi-Fi in via USB of het OpenQuatt access point.
-4. Open `openquatt.local`.
-5. Kies in **Quick Start → Kies je setup** de juiste configuratie en rond Quick Start af.
-6. Voeg OpenQuatt eventueel toe aan Home Assistant.
+2. Voed de HCQ, schakel de Quatt-buitenunit(s) weer in en stel Wi-Fi in.
+3. Open `openquatt.local` en controleer de basisverbinding.
+4. Kies in **Quick Start → Kies je setup** de juiste configuratie en rond Quick Start af.
+
+Daarna werkt OpenQuatt zelfstandig via de web-app. Home Assistant is een optionele vervolgstap voor dashboards en automatisering.
 
 ## 1. Controller aansluiten
 
@@ -73,6 +73,8 @@ Laat de USB-poort bereikbaar. Je hebt deze later ook nodig voor Wi-Fi provisioni
 
 Een Wi-Fi-build biedt twee routes. Op een computer is provisioning via USB meestal het handigst. Op een telefoon of tablet staat de route via het OpenQuatt access point daarom als eerste.
 
+Wil je de HCQ uiteindelijk via Ethernet gebruiken? Breng de geleverde `Single` + `Wi-Fi`-build ook dan eerst via deze stap online en sluit de netwerkkabel aan. In Quick Start kies je daarna de juiste `Single`- of `Duo`-Ethernetsetup; de web-app installeert dan de bijbehorende firmware.
+
 ### Route A: via USB
 
 Deze route schrijft alleen de Wi-Fi-gegevens naar de controller en flasht geen nieuwe firmware.
@@ -121,8 +123,9 @@ Controleer voordat je verdergaat:
 
 - de controller blijft online;
 - de firmwareversie wordt getoond;
-- warmtepompgegevens worden bijgewerkt;
-- aanvoertemperatuur, flow en buitentemperatuur aannemelijke waarden tonen.
+- ten minste de basisgegevens van de eerste warmtepomp worden bijgewerkt.
+
+Gebruik je een Duo-opstelling, of wijkt de gewenste setup af van de voorgeïnstalleerde `Single` + `Wi-Fi`-build? Controleer de tweede warmtepomp en alle meetwaarden pas volledig nadat je in de volgende stap de juiste setup hebt gekozen.
 
 Zie [Web-app gebruiken](web-app.md) voor bediening, updates, backups en beveiliging.
 
@@ -159,7 +162,16 @@ Volg de route die de web-app voor jouw installatie toont. De basisstappen zijn:
 10. **Stille uren en niveaus:** stel het stille venster en de compressorlimieten voor dag en nacht in.
 11. **Bevestigen en afronden:** controleer je keuzes en markeer Quick Start als voltooid.
 
-## 5. Configuratie later wijzigen
+## Je installatie is klaar wanneer
+
+- `openquatt.local` stabiel bereikbaar is;
+- Quick Start volledig is afgerond;
+- de warmtepompgegevens worden bijgewerkt;
+- aanvoertemperatuur, flow en buitentemperatuur aannemelijke waarden tonen.
+
+Vanaf dit punt kun je OpenQuatt zelfstandig via de web-app gebruiken. Home Assistant en het dashboard zijn optionele vervolgstappen.
+
+## Configuratie later wijzigen
 
 Heb je Quick Start al afgerond en verandert de installatie later, dan kun je dezelfde firmwarewissel alsnog via de web-app starten. Maak voor de zekerheid eerst een backup; de bestaande OpenQuatt-instellingen blijven tijdens de update of wissel behouden.
 
@@ -173,13 +185,14 @@ Open in de web-app **Instellingen → Systeem** en kies bij **Updates** voor **O
 > [!IMPORTANT]
 > Wi-Fi en Ethernet blijven aparte firmware-builds. Een Ethernet-build heeft geen Wi-Fi fallback of captive portal. De web-app voert zo'n wissel daarom uit als firmware-update en toont vooraf de bijbehorende controle.
 
-## 6. Toevoegen aan Home Assistant
+## Optioneel: toevoegen aan Home Assistant
 
 Home Assistant is optioneel voor OpenQuatt zelf en aanbevolen voor dashboards en automatisering. Zodra OpenQuatt en Home Assistant op hetzelfde netwerk zitten, wordt het ESPHome-apparaat meestal automatisch gevonden.
 
+Open de melding bij **Instellingen → Apparaten & diensten** en kies **Configureren**. Verschijnt er geen melding, kies dan **Integratie toevoegen → ESPHome** en vul `openquatt.local` of het IP-adres van OpenQuatt in.
+
 Gebruik de bestaande handleidingen voor de vervolgstappen:
 
-- [OpenQuatt toevoegen en de eerste waarden controleren](installatie-en-ingebruikname.md#daarna-home-assistant)
 - [Het juiste Single- of Duo-dashboard installeren](dashboard/README.md)
 - [Het dashboard gebruiken](dashboardoverzicht.md)
 

--- a/docs/site.css
+++ b/docs/site.css
@@ -1709,6 +1709,145 @@ kbd {
     grid-template-columns: 1fr;
   }
 
+  .page-index .prose > table:first-of-type {
+    display: block;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .page-index .prose > table:first-of-type thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .page-index .prose > table:first-of-type tbody {
+    display: grid;
+    gap: 12px;
+  }
+
+  .page-index .prose > table:first-of-type tr {
+    display: grid;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--panel);
+  }
+
+  .page-index .prose > table:first-of-type td {
+    display: block;
+    width: auto;
+    padding: 11px 14px;
+    border: 0;
+    border-top: 1px solid var(--line);
+    line-height: 1.55;
+  }
+
+  .page-index .prose > table:first-of-type td:first-child {
+    border-top: 0;
+    font-weight: 700;
+  }
+
+  .page-index .prose > table:first-of-type td::before {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--ink-soft);
+    font-size: 0.68rem;
+    font-weight: 750;
+    letter-spacing: 0.07em;
+    line-height: 1.4;
+    text-transform: uppercase;
+  }
+
+  .page-index .prose > table:first-of-type td:nth-child(1)::before {
+    content: "Jouw situatie";
+  }
+
+  .page-index .prose > table:first-of-type td:nth-child(2)::before {
+    content: "Begin hier";
+  }
+
+  .page-index .prose > table:first-of-type td:nth-child(3)::before {
+    content: "Wat je gaat doen";
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) {
+    display: block;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) tbody {
+    display: grid;
+    gap: 12px;
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) tr {
+    display: grid;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    background: var(--panel);
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) td {
+    display: block;
+    width: auto;
+    padding: 11px 14px;
+    border: 0;
+    border-top: 1px solid var(--line);
+    line-height: 1.55;
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) td:first-child {
+    border-top: 0;
+    font-weight: 700;
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) td::before {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--ink-soft);
+    font-size: 0.68rem;
+    font-weight: 750;
+    letter-spacing: 0.07em;
+    line-height: 1.4;
+    text-transform: uppercase;
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) td:nth-child(1)::before {
+    content: "Stap";
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) td:nth-child(2)::before {
+    content: "Wat kies je?";
+  }
+
+  .page-web-app .prose > table:nth-of-type(2) td:nth-child(3)::before {
+    content: "Waarom?";
+  }
+
+  .prose :not(pre) > code {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
   .page-q-edition .doc-header {
     margin: -26px -8px 32px;
     padding: 36px 24px 40px;

--- a/docs/verwarmen-en-koelen.md
+++ b/docs/verwarmen-en-koelen.md
@@ -4,12 +4,13 @@ Deze pagina legt OpenQuatt uit in gewone taal. Het doel is niet dat je alle inte
 
 ## In een zin
 
-OpenQuatt zit tussen je thermostaat, je warmtepomp en Home Assistant:
+OpenQuatt zit tussen je thermostaat en je warmtepomp:
 
 - de thermostaat vraagt warmte of koeling;
 - de warmtepomp maakt die warmte of koeling;
 - OpenQuatt beslist hoe actief of terughoudend het systeem mag reageren;
-- Home Assistant laat zien wat er gebeurt en waar je iets kunt aanpassen.
+- de web-app laat zien wat er gebeurt en waar je iets kunt aanpassen;
+- Home Assistant kan daar optioneel een dashboard en automatisering aan toevoegen.
 
 ## Wat doet OpenQuatt precies?
 
@@ -20,7 +21,7 @@ Praktisch betekent dat:
 - OpenQuatt kijkt welke temperatuur- en flowwaarden het echt vertrouwt;
 - het voorkomt dat het systeem te agressief reageert op kleine schommelingen;
 - het houdt rekening met grenzen en beveiligingen;
-- het maakt gedrag zichtbaar in Home Assistant.
+- het maakt gedrag zichtbaar in de web-app en, als je die gebruikt, Home Assistant.
 
 ## Verwarmen: twee manieren van denken
 
@@ -105,33 +106,11 @@ Daarom werkt OpenQuatt bij koeling terughoudend:
 - de minimale veilige watertemperatuur moet bewaakt worden;
 - dauwpuntinformatie is normaal gesproken nodig.
 
-Standaard gebruikt OpenQuatt de kamerthermostaat om te bepalen of er echte koelvraag is. Koelvraag heeft dan een kleine hysterese rond het kamer-setpoint: de koelvraag start pas wanneer de kamertemperatuur meer dan `0,4°C` boven het setpoint zit. De koelvraag stopt weer zodra de kamer onder `setpoint + 0,1°C` komt. Dit voorkomt dat koeling steeds kort aan en uit schakelt rond het setpoint.
+Standaard gebruikt OpenQuatt de kamertemperatuur en het setpoint om vast te stellen of er echt koelvraag is. Een kleine marge voorkomt dat koeling steeds kort aan en uit schakelt rond het setpoint.
 
-Deze kamerlaag hoort bij deze runtime-instellingen:
+Bij koelvraag kijkt OpenQuatt vervolgens naar de watertemperatuur. De regeling start rustig, bouwt alleen op als dat nodig is en remt af of stopt wanneer de aanvoer dicht bij de veilige ondergrens komt.
 
-- `Cooling Room Request Required`
-- `Cooling Request On Delta`
-- `Cooling Request Off Delta`
-
-Als `Cooling Room Request Required` uit staat, telt koeltoestemming direct als koelvraag. De start- en stopmarge rond het kamer-setpoint worden dan niet gebruikt.
-
-Als er koelvraag is, stuurt OpenQuatt niet rechtstreeks op de kamertemperatuur. De kamerlaag bepaalt alleen of koeling nodig is. Daarna kijkt de waterregeling naar de aanvoertemperatuur.
-
-Daarbij gebruikt OpenQuatt twee afstanden:
-
-- `buffer gap`: hoeveel de aanvoer nog boven het koeldoel zit;
-- `dew gap`: hoeveel de aanvoer nog boven het echte dauwpunt zit.
-
-Het koeldoel is de hoogste waarde van:
-
-- `Cooling Minimum Supply Temp`;
-- de dauwpuntveilige of fallback-ondergrens.
-
-Zolang het water nog duidelijk warmer is dan dit doel, mag de regelaar meer koelvraag opbouwen tot `Cooling Demand Max`. Dicht bij het doel bouwt OpenQuatt terug. Als de ruimte nog koelvraag heeft en de veiligheidsruimte voldoende stabiel is, mag level 1 blijven draaien als rustige onderhoudsstand. Dat voorkomt dat de compressor telkens uitgaat zodra het water precies het target raakt.
-
-Een hogere `Cooling Demand Max` betekent niet dat OpenQuatt meteen hard gaat koelen. Een nieuwe koelrun start rustig op level 1. Pas als level 1 de aanvoer onvoldoende richting target trekt, mag de regelaar tijdelijk opschalen. Zodra de aanvoer duidelijk daalt, houdt OpenQuatt weer level 1 vast om doorschieten onder het target te voorkomen.
-
-Als level 1 nog steeds te veel koelt, of als de aanvoer te snel richting de veilige ondergrens zakt, stopt OpenQuatt alsnog. Na zo'n waterzijde-stop gebruikt `Cooling Restart Delta` hoeveel de aanvoer eerst weer boven het doel moet opwarmen voordat de watercyclus opnieuw mag starten.
+Wil je de exacte koelinstellingen, marges en begrenzingen begrijpen of wijzigen? Gebruik dan de technische naslag [Instellingen en meetwaarden](instellingen-en-meetwaarden.md#koeling).
 
 ### Waarom is dauwpunt zo belangrijk?
 
@@ -143,9 +122,7 @@ Daarom kijkt OpenQuatt bij koeling niet alleen naar comfort, maar ook naar veili
 - wat is dan de veilige ondergrens voor de watertemperatuur;
 - mag cooling op dit moment dus wel of niet vrijgegeven worden.
 
-Een dauwpunt kan uit Home Assistant komen of via MQTT worden aangeleverd. In de web-app kies je bij `Cooling Dew Point Source` tussen `Auto`, `Home Assistant` en `MQTT`. In `Auto` gebruikt OpenQuatt de hoogste geldige waarde, omdat dat voor koeling de veiligste keuze is.
-
-Een MQTT-dauwpunt blijft 15 minuten geldig. Zonder nieuwe MQTT-publicatie wordt die bron ongeldig en valt OpenQuatt terug op een andere geldige bron of blokkeert koeling volgens de gekozen beveiligingsmodus.
+Een dauwpunt kan uit Home Assistant of MQTT komen. In de web-app kies je de bron. Bij `Auto` gebruikt OpenQuatt de hoogste geldige dauwpuntwaarde, omdat die voor koeling de veiligste ondergrens geeft. Een externe waarde moet regelmatig worden bijgewerkt; bij een verouderde of ontbrekende waarde valt OpenQuatt terug op een andere geldige bron of blokkeert het koelen. Zie [MQTT inputbronnen](mqtt.md) voor de technische geldigheidsduur.
 
 ### Wat doet `Manual Cooling Enable`?
 
@@ -186,7 +163,8 @@ Voor de meeste gebruikers is deze volgorde beter:
 
 ## Verder lezen
 
-- Installeren en eerste controle: [Installatie en ingebruikname](installatie-en-ingebruikname.md)
-- Dashboard begrijpen: [Dashboard gebruiken](dashboardoverzicht.md)
+- Installatie- of beheerroute kiezen: [Kies je route](../README.md#kies-je-route)
+- OpenQuatt lokaal bedienen: [Web-app gebruiken](web-app.md)
+- Optioneel Home Assistant-dashboard: [Dashboard gebruiken](dashboardoverzicht.md)
 - Problemen oplossen: [Problemen oplossen](problemen-oplossen.md)
-- Technische verdieping: [Power House](power-house.md) en [Water Temperature Control](water-temperature-control.md)
+- Technische verdieping: [Instellingen en meetwaarden](instellingen-en-meetwaarden.md), [Power House](power-house.md) en [Water Temperature Control](water-temperature-control.md)

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -1,6 +1,6 @@
 # Web-app gebruiken
 
-De OpenQuatt web-app is de lokale bedienings- en instellingenpagina van je OpenQuatt-module. Na de installer is dit de eerste plek waar je naartoe gaat: open `http://openquatt.local`, rond Quick Start af en voeg daarna pas Home Assistant toe.
+De OpenQuatt web-app is de lokale bedienings- en instellingenpagina van je OpenQuatt-module. Zodra de controller online is, is dit de eerste plek waar je naartoe gaat: open `http://openquatt.local` en rond Quick Start af. Home Assistant komt eventueel daarna.
 
 ## Wanneer gebruik je de web-app?
 
@@ -14,17 +14,18 @@ Gebruik de web-app voor alles wat direct op OpenQuatt zelf hoort:
 - backup en restore van OpenQuatt-instellingen;
 - web-login, API-beveiliging, logboek en herstarten.
 
-Home Assistant blijft de prettigste plek voor dagelijks meekijken en dashboards. De web-app is de plek waar je de module zelf inricht, beheert en veilig terugvindt als er iets niet klopt.
+De web-app blijft altijd de plek waar je OpenQuatt inricht, beheert en controleert als er iets niet klopt. Gebruik je Home Assistant, dan is dat daarnaast een prettige plek voor dagelijks meekijken, dashboards en automatisering.
 
 ## Wat doe je waar?
 
 | Plek | Gebruik je vooral voor |
 |---|---|
-| Installer | Eerste flash, keuze voor `Single` of `Duo`, hardwareprofiel en verbinding. |
+| Q-edition-handleiding | Een voorgeïnstalleerde Heatpump Controller Q aansluiten, online brengen en juist configureren. |
+| Installer | Een bestaande Waveshare- of Heatpump Listener-module flashen, Wi-Fi op een nieuwe HCQ instellen of een HCQ herstellen. |
 | Web-app | Quick Start, installatiekeuzes, instellingen, updates, backup en beveiliging. |
-| Home Assistant | Dagelijks meekijken, dashboards, bronselectie en optionele dynamische bronnen. |
+| Optioneel: Home Assistant | Dagelijks meekijken, dashboards, bronselectie en dynamische bronnen. |
 
-De normale volgorde is dus: installer, web-app, daarna Home Assistant.
+Kies bij een eerste installatie eerst de passende route in het [projectoverzicht](../README.md#kies-je-route). Beide installatieroutes komen uit bij de web-app; Home Assistant is geen onderdeel van de basisinstallatie.
 
 ## Openen
 
@@ -48,23 +49,27 @@ Wil je de interface eerst rustig bekijken zonder echte hardware, open dan de [we
 
 Na de eerste installatie opent de web-app Quick Start zolang de basisinstallatie nog niet is afgerond.
 
-Quick Start begint voor de Heatpump Controller Q met een controle van de firmware-setup. Daarna volgen de bestaande configuratiestappen:
+Quick Start begint op de Heatpump Controller Q met een controle van de firmware-setup. Op Waveshare en Heatpump Listener wordt deze eerste stap overgeslagen, omdat `Single` of `Duo` daar al vastligt in de geïnstalleerde firmware. Daarna volgen de configuratiestappen:
 
 | Stap | Wat kies je? | Waarom? |
 |---|---|---|
-| `Kies je setup` | `Single` of `Duo`, via `Wi-Fi` of `Ethernet` | Installeert zo nodig direct de passende Q-edition-firmware voordat je verder configureert. |
-| `Kies je Quatt Hybrid` | V1, V1.5 of V2 | OpenQuatt gebruikt hiermee de juiste basislogica. |
-| `Flowmeting configureren` | De flowbron voor jouw Quatt-versie en controller | Zorgt dat de regeling de juiste flowmeting gebruikt. |
-| `Thermostaatgegevens configureren` | Eén bron voor kamertemperatuur en kamer-setpoint | Voorkomt dat de regeling waarden uit verschillende bronnen combineert. |
-| `CV-ketel of boiler` | Wel of geen ondersteuning door de ketel of boiler | Bepaalt of OpenQuatt aanvullende warmte mag inzetten. |
-| `Kies de verwarmingsstrategie` | `Power House` of `Water Temperature Control` | Dit bepaalt hoe OpenQuatt warmtevraag maakt. |
-| `Werk de regeling uit` | Strategie-instellingen | Je ziet alleen velden die bij de gekozen strategie horen. |
-| `Flowregeling en afstelling` | Automatische flow of vaste pompstand, plus Kp/Ki | Hiermee blijft de waterdoorstroming beheersbaar. |
-| `Watertemperatuur beveiligen` | Maximale watertemperatuur | OpenQuatt regelt terug voordat water te warm wordt. |
-| `Stille uren en niveaus` | Tijdvenster en maximale compressorstand | Handig voor nacht of geluidsgevoelige momenten. |
-| `Bevestigen en afronden` | Controle en afronden | Daarna ziet OpenQuatt de basisconfiguratie als klaar. |
+| `Kies je setup` | `Single` of `Duo`, via `Wi-Fi` of `Ethernet` | Alleen op de HCQ; installeert zo nodig direct de passende firmware. |
+| `Kies je Quatt Hybrid` | V1, V1.5 of V2 | Selecteert de juiste basislogica voor jouw warmtepompgeneratie. |
+| `Flowmeting configureren` | De juiste flowbron | Zorgt dat de regeling de juiste meting gebruikt. |
+| `Thermostaatgegevens configureren` | Eén bron voor kamertemperatuur en setpoint | Voorkomt dat OpenQuatt waarden uit verschillende bronnen combineert. |
+| `CV-ketel of boiler` | Ondersteuning wel of niet toestaan | Bepaalt of OpenQuatt aanvullende warmte mag inzetten. |
+| `Kies de verwarmingsstrategie` | `Power House` of `Water Temperature Control` | Bepaalt hoe OpenQuatt warmtevraag maakt. |
+| `Werk de regeling uit` | Strategie-instellingen | Toont alleen de instellingen die bij de gekozen strategie horen. |
+| `Flowregeling en afstelling` | Automatische flow of vaste pompstand | Bepaalt hoe OpenQuatt de waterdoorstroming regelt. |
+| `Watertemperatuur beveiligen` | Maximale watertemperatuur | Laat OpenQuatt terugregelen voordat het water te warm wordt. |
+| `Stille uren en niveaus` | Tijdvenster en compressorlimieten | Begrenst de compressor bijvoorbeeld 's nachts. |
+| `Bevestigen en afronden` | Je keuzes controleren | Markeert de basisconfiguratie als klaar. |
+
+Gebruik je Waveshare of Heatpump Listener? Begin dan inhoudelijk bij **Kies je Quatt Hybrid**; Quick Start toont alleen de stappen die voor jouw hardware van toepassing zijn.
 
 Je hoeft niet meteen perfecte waardes te kiezen. Het doel van Quick Start is een veilige, begrijpelijke basis. Fijnregelen kan later.
+
+De installatie is klaar zodra Quick Start is afgerond, `openquatt.local` stabiel bereikbaar blijft en de belangrijkste warmtepompwaarden logisch worden bijgewerkt. Home Assistant en het dashboard zijn optionele vervolgstappen.
 
 ## Hoofdschermen
 
@@ -93,7 +98,7 @@ Let vooral op:
 - er is geen onverwachte override actief;
 - de gekozen strategie past bij wat je in huis verwacht.
 
-Zie je hier al vreemde waarden, ga dan niet meteen tunen. Controleer eerst de bronkeuze in Home Assistant of in de instellingen.
+Zie je hier al vreemde waarden, ga dan niet meteen tunen. Controleer eerst de bronkeuze onder **Instellingen → Bronnen / integraties → Sensorselectie** en, als je Home Assistant gebruikt, de aangeleverde Home Assistant-bronnen.
 
 ## Resultaten
 
@@ -112,7 +117,7 @@ Trendopslag kan onder `Instellingen -> Systeem` worden beheerd. Als trendopslag 
 
 OpenQuatt bewaart de korte trendhistorie in PSRAM en kan aanvullend tot 30 dagen trendhistorie in flash bewaren. Als je flashopslag uitzet, blijft bestaande flashhistorie staan; OpenQuatt stopt dan alleen met nieuwe trenddata naar flash schrijven. Alle ondersteunde OpenQuatt-profielen gebruiken PSRAM; ontbrekende PSRAM wijst dus op een hardware- of profielprobleem.
 
-Via `Instellingen -> Gegevens bewaren` zijn Diagnose, Beslislog en Energie afzonderlijk te beheren. De Beslislog bewaart maximaal zeven dagen exacte gebeurtenissen en redenen na een herstart. Nieuwe gebeurtenissen worden per uur gebundeld naar flash geschreven. Met `Nu opslaan` kunnen nog niet opgeslagen gebeurtenissen vóór een update of herstart alvast worden vastgelegd.
+Via `Instellingen → Systeem → Gegevens bewaren` zijn Diagnose, Beslislog en Energie afzonderlijk te beheren. De Beslislog bewaart maximaal zeven dagen exacte gebeurtenissen en redenen na een herstart. Nieuwe gebeurtenissen worden per uur gebundeld naar flash geschreven. Met `Nu opslaan` kunnen nog niet opgeslagen gebeurtenissen vóór een update of herstart alvast worden vastgelegd.
 
 ## Beslislog
 
@@ -193,6 +198,17 @@ Hier vind je beheerfuncties:
 - logboek;
 - herstarten.
 
+#### Debugopname voor support
+
+Bij een reproduceerbaar probleem kun je tijdelijk supportgegevens opnemen:
+
+1. Open **Instellingen → Systeem → Systeemstatus → Debugopname**.
+2. Start de opname voordat je het probleem opnieuw veroorzaakt. Gebruik rolling debug als het probleem maar af en toe optreedt.
+3. Stop de opname nadat het probleem zichtbaar is en download het supportbestand.
+4. Voeg het gedownloade `.oqdebug.json`-bestand toe aan je Discord-vraag of GitHub-issue.
+
+De opname wordt lokaal in het apparaatgeheugen opgeslagen en niets wordt automatisch verzonden. Deel het bestand alleen binnen het supportverzoek waarvoor je het hebt gemaakt.
+
 ## Backup en restore
 
 Maak een backup voordat je grotere wijzigingen doet of voordat je een factory-update uitvoert.
@@ -236,4 +252,4 @@ Als de web-app niet opent:
 
 Als Quick Start niet verschijnt terwijl je nog niet klaar bent, open `Instellingen -> Systeem -> Quick Start` en reset de setupstatus.
 
-Ga daarna verder met [Dashboard installeren](dashboard/README.md) en [Dashboard gebruiken](dashboardoverzicht.md).
+Wil je OpenQuatt ook aan Home Assistant toevoegen? Ga dan optioneel verder met [Dashboard installeren](dashboard/README.md) en [Dashboard gebruiken](dashboardoverzicht.md).

--- a/scripts/build_pages_docs.py
+++ b/scripts/build_pages_docs.py
@@ -41,8 +41,8 @@ class RenderedPage:
 
 PAGES = [
     Page(PurePosixPath("README.md"), PurePosixPath("index.html"), "OpenQuatt", "Project", "Projectoverzicht, snelle start en hoofdroute."),
-    Page(PurePosixPath("docs/q-edition.md"), PurePosixPath("q-edition.html"), "Heatpump Controller Q-edition installeren", "Aan de slag", "Doorlopende route voor aansluiten, netwerk instellen, Quick Start en Home Assistant."),
-    Page(PurePosixPath("docs/installatie-en-ingebruikname.md"), PurePosixPath("installatie-en-ingebruikname.html"), "Installatie en ingebruikname", "Docs", "Installeren via de installer en daarna Quick Start in de web-app."),
+    Page(PurePosixPath("docs/q-edition.md"), PurePosixPath("q-edition.html"), "Heatpump Controller Q-edition aansluiten", "Aan de slag", "Doorlopende route voor aansluiten, netwerk instellen en Quick Start."),
+    Page(PurePosixPath("docs/installatie-en-ingebruikname.md"), PurePosixPath("installatie-en-ingebruikname.html"), "Andere modules installeren", "Andere hardware", "Een bestaande Waveshare- of Heatpump Listener-module installeren via de web installer."),
     Page(PurePosixPath("docs/web-app.md"), PurePosixPath("web-app.html"), "Web-app gebruiken", "Handleiding", "Quick Start, instellingen, updates, backup en beveiliging via openquatt.local."),
     Page(PurePosixPath("docs/dashboard/README.md"), PurePosixPath("dashboard/index.html"), "Dashboard installeren", "Docs", "Importeer het juiste dashboardbestand voor Single of Duo."),
     Page(PurePosixPath("docs/dashboardoverzicht.md"), PurePosixPath("dashboardoverzicht.html"), "Dashboard gebruiken", "Handleiding", "Dagelijkse controle en diagnosevolgorde in Home Assistant."),
@@ -67,15 +67,21 @@ SIDEBAR_GROUPS = [
             PurePosixPath("docs/q-edition.md"),
             PurePosixPath("docs/installatie-en-ingebruikname.md"),
             PurePosixPath("docs/web-app.md"),
-            PurePosixPath("docs/dashboard/README.md"),
         ],
     ),
     (
         "Dagelijks gebruik",
         "Begrijpen, volgen en rustig bijsturen.",
         [
-            PurePosixPath("docs/dashboardoverzicht.md"),
             PurePosixPath("docs/verwarmen-en-koelen.md"),
+        ],
+    ),
+    (
+        "Optioneel: Home Assistant",
+        "Dashboards toevoegen nadat OpenQuatt lokaal werkt.",
+        [
+            PurePosixPath("docs/dashboard/README.md"),
+            PurePosixPath("docs/dashboardoverzicht.md"),
         ],
     ),
     (
@@ -481,6 +487,7 @@ def render_template(rendered_page: RenderedPage, rendered_pages: list[RenderedPa
     asset_prefix = "./" if page.output.parent == PurePosixPath(".") else "../"
     install_href = rel_url(page.output, PurePosixPath("install/index.html"))
     q_edition_href = rel_url(page.output, PurePosixPath("q-edition.html"))
+    route_href = f"{rel_url(page.output, PurePosixPath('index.html'))}#kies-je-route"
     search_index_href = rel_url(page.output, PurePosixPath("search-index.json"))
     version_href = rel_url(page.output, PurePosixPath("firmware/main/version.json"))
     body_class = f"page-{slugify(page.output.stem, {})}"
@@ -490,8 +497,8 @@ def render_template(rendered_page: RenderedPage, rendered_pages: list[RenderedPa
     if page.source == PurePosixPath("README.md"):
         doc_actions = f"""
           <div class="doc-actions" aria-label="Snel starten">
-            <a class="doc-action doc-action-primary" href="{install_href}">Open installer</a>
-            <a class="doc-action" href="{q_edition_href}">Bekijk aansluithulp</a>
+            <a class="doc-action doc-action-primary" href="#kies-je-route">Kies je route</a>
+            <a class="doc-action" href="{q_edition_href}">Nieuwe HCQ aansluiten</a>
           </div>
         """
 
@@ -544,7 +551,7 @@ def render_template(rendered_page: RenderedPage, rendered_pages: list[RenderedPa
           <section class="sidebar-overview">
             <p class="sidebar-kicker">OpenQuatt Docs</p>
             <p class="sidebar-copy">Een korte route voor installeren, begrijpen en rustig bijsturen.</p>
-            <a class="sidebar-utility" href="{install_href}">Open webinstaller</a>
+            <a class="sidebar-utility" href="{route_href}">Kies je route</a>
             <p class="docs-version" data-docs-version>Docs vanaf main</p>
           </section>
           {build_sidebar(page)}


### PR DESCRIPTION
# Wat verandert deze PR?

- Maakt de documentatieroute ondubbelzinnig voor nieuwe HCQ-gebruikers, bestaande Waveshare/Listener-gebruikers en bestaande installaties.
- Scheidt basisinstallatie, optioneel Home Assistant-gebruik en diagnose/support consequenter.
- Verbetert mobiele weergave, installerlabels, dashboarddownloads, Quick Start-uitleg en menupaden.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alle wijzigingen zijn beperkt tot gebruikersdocumentatie, de statische documentatiesite en de installatiehulpcopy. Firmwaregedrag, entities en configuratiecontracten wijzigen niet.

## Achtergrond

De inhoud was grotendeels compleet, maar de ingang stuurde nieuwe HCQ-gebruikers te vroeg naar de installer en verschillende pagina's behandelden Home Assistant alsof dit onderdeel van de basisinstallatie was. Ook liepen de HCQ-stappen, alternatieve hardware-route en enkele web-appmenupaden niet overal gelijk.

Deze PR maakt HCQ de primaire route, houdt Waveshare/Listener als aparte limited/best-effort route en bewaart HCQ-flashen alleen als herstelmogelijkheid. Problemen oplossen verwijst gebruiksvragen naar Discord, reproduceerbare bugs naar GitHub en fysieke/onveilige situaties naar installateur of Quatt.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een documentatiegerichte PR; de relevante installatie-, web-app-, dashboard-, MQTT-, diagnose- en beginnerspagina's zijn gezamenlijk bijgewerkt.

## Validatie

- `npm run check:docs`
- `git diff --check`
- Lokale Pages-preview gebouwd met `python3 scripts/dev.py preview-pages --port 8010 --keep`
- Alle lokale links en anchors gecontroleerd over 17 gebouwde HTML-pagina's
- Acht kernpagina's gecontroleerd op mobiele overflow
- Startpagina en routekiezer gecontroleerd op 390×844 en 1280×900
