### PR TITLE
Optimize native ESP-IDF build caching

### DIFF
--- a/.github/workflows/esphome-build.yml
+++ b/.github/workflows/esphome-build.yml
@@ -61,13 +61,31 @@ jobs:
           cache: pip
           cache-dependency-path: .github/requirements-esphome.txt
 
+      - name: Install ESPHome
+        run: |
+          ESPHOME_VERSION="$(cat .github/requirements-esphome.txt | sed 's/^esphome==//')"
+          pip install --upgrade "esphome==${ESPHOME_VERSION}"
+          esphome version
+
+      - name: Resolve ESP-IDF version for cache key
+        id: idf_version
+        run: |
+          IDF_VERSION="$(python -c 'from esphome.components.esp32 import ESP_IDF_FRAMEWORK_VERSION_LOOKUP as versions; print(versions["recommended"])')"
+          echo "version=${IDF_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Cache native ESP-IDF toolchain
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache@v5
         with:
           path: ~/.cache/esphome/idf
-          key: ${{ runner.os }}-${{ runner.arch }}-esphome-idf-${{ hashFiles('.github/requirements-esphome.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-esphome-idf-
+          key: ${{ runner.os }}-${{ runner.arch }}-esphome-idf-${{ steps.idf_version.outputs.version }}
+
+      - name: Restore native ESP-IDF toolchain
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/esphome/idf
+          key: ${{ runner.os }}-${{ runner.arch }}-esphome-idf-${{ steps.idf_version.outputs.version }}
 
       - name: Make ccache available
         run: |
@@ -78,24 +96,28 @@ jobs:
           ccache --version
 
       - name: Cache compiler outputs
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache@v5
         with:
-          path: ~/.cache/openquatt/ccache
-          key: ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ hashFiles('.github/requirements-esphome.txt') }}-${{ github.sha }}
+          path: ~/.cache/openquatt/ccache/${{ matrix.target.id }}
+          key: ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ matrix.target.id }}-${{ steps.idf_version.outputs.version }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ hashFiles('.github/requirements-esphome.txt') }}-
+            ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ matrix.target.id }}-${{ steps.idf_version.outputs.version }}-
 
-      - name: Install ESPHome
-        run: |
-          ESPHOME_VERSION="$(cat .github/requirements-esphome.txt | sed 's/^esphome==//')"
-          pip install --upgrade "esphome==${ESPHOME_VERSION}"
-          esphome version
+      - name: Restore compiler outputs
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/openquatt/ccache/${{ matrix.target.id }}
+          key: ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ matrix.target.id }}-${{ steps.idf_version.outputs.version }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ matrix.target.id }}-${{ steps.idf_version.outputs.version }}-
 
       - name: Compile firmware
         run: |
           export ESPHOME_ESP_IDF_PREFIX="${HOME}/.cache/esphome/idf"
           export IDF_CCACHE_ENABLE=1
-          export CCACHE_DIR="${HOME}/.cache/openquatt/ccache"
+          export CCACHE_DIR="${HOME}/.cache/openquatt/ccache/${{ matrix.target.id }}"
           export CCACHE_MAXSIZE=2G
           export CCACHE_NOHASHDIR=true
           export CCACHE_DEPEND=1
@@ -116,7 +138,7 @@ jobs:
       - name: Show ccache statistics
         if: ${{ always() }}
         run: |
-          export CCACHE_DIR="${HOME}/.cache/openquatt/ccache"
+          export CCACHE_DIR="${HOME}/.cache/openquatt/ccache/${{ matrix.target.id }}"
           export CCACHE_MAXSIZE=2G
           ccache --show-stats
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Sleutelt de native ESP-IDF-cache op de werkelijk aanbevolen IDF-versie uit de gepinde ESPHome-installatie.
- Laat pull-requestjobs de grote IDF- en compileroutputcaches alleen herstellen; vertrouwde branch- en releasejobs mogen ze vullen.
- Geeft elk van de acht buildtargets een eigen `ccache`-directory en cachesleutel, zodat matrixjobs niet langer om één cache concurreren.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alle wijzigingen zijn beperkt tot GitHub Actions-caching. Firmwareconfiguratie en artifacts blijven ongewijzigd.

## Achtergrond

De acht parallelle jobs deelden één compileroutputsleutel, waardoor slechts één job de cache kon opslaan. Daarnaast maakte iedere PR een eigen ESP-IDF-cache van circa 1,59 GB en werd de toolchaincache ongeldig bij iedere ESPHome-pinwijziging, ook als de IDF-versie gelijk bleef.

De eerste run met de nieuwe sleutels vult de caches. Daarna kunnen PR's de relevante base-branchcache restore-only gebruiken.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit verandert alleen interne CI-cacheopslag en geen gebruikersgericht build- of artifactcontract.

## Validatie

- Workflow-YAML geparseerd met Ruby/Psych.
- ESPHome 2026.7.0-resolver gecontroleerd; deze levert ESP-IDF 5.5.4.
- `python3 scripts/build_targets.py github-matrix --status enabled` levert alle acht targets.
- `git diff --check origin/dev...HEAD` geslaagd.
- Geen lokale firmwarecompile uitgevoerd; de GitHub-matrix valideert het cachegedrag en de builds.