### PR TITLE
Add boiler control foundation

### DIFF
--- a/openquatt/includes/boiler/oq_boiler_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_logic.h
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+
+namespace oq_boiler {
+
+enum CommandSource : uint8_t {
+  COMMAND_SOURCE_NONE = 0,
+  COMMAND_SOURCE_CM3 = 1,
+  COMMAND_SOURCE_COMMISSIONING = 2,
+};
+
+enum BlockReason : uint8_t {
+  BLOCK_NONE = 0,
+  BLOCK_ASSIST_DISABLED = 1,
+  BLOCK_COMMAND_INVALID = 2,
+  BLOCK_COMMAND_STALE = 3,
+  BLOCK_SUPPLY_UNAVAILABLE = 4,
+  BLOCK_WATER_TEMP_INHIBIT = 5,
+  BLOCK_WATER_TEMP_HARD_TRIP = 6,
+  BLOCK_COMMISSIONING_WAITING = 7,
+  BLOCK_NO_HEAT_REQUEST = 8,
+  BLOCK_MIN_ON_TIME = 9,
+  BLOCK_MIN_OFF_TIME = 10,
+};
+
+struct BoilerCommand {
+  bool valid;
+  bool demand_present;
+  bool heat_request;
+  float requested_power_w;
+  float target_temperature_c;
+  uint8_t source;
+  uint32_t updated_at_ms;
+};
+
+struct ControllerInput {
+  bool assist_enabled;
+  bool supply_temperature_valid;
+  bool boiler_inhibit_active;
+  bool hard_trip_active;
+  bool output_active;
+  uint32_t now_ms;
+  uint32_t command_max_age_ms;
+  uint32_t output_last_change_ms;
+  uint32_t min_on_ms;
+  uint32_t min_off_ms;
+};
+
+struct ControllerDecision {
+  bool demand_present;
+  bool desired_active;
+  bool output_active;
+  bool force_off;
+  bool blocked;
+  uint8_t block_reason;
+};
+
+inline BoilerCommand make_legacy_command(int control_mode_code,
+                                         bool commissioning_active,
+                                         bool commissioning_boiler_task,
+                                         bool commissioning_boiler_request,
+                                         uint32_t now_ms) {
+  const bool in_cm3 = control_mode_code == 3;
+  const bool commissioning_task_active =
+      control_mode_code == 100 &&
+      commissioning_active &&
+      commissioning_boiler_task;
+  const bool commissioning_heat_request =
+      commissioning_task_active && commissioning_boiler_request;
+
+  BoilerCommand command{};
+  command.valid = true;
+  command.demand_present = in_cm3 || commissioning_task_active;
+  command.heat_request = in_cm3 || commissioning_heat_request;
+  command.requested_power_w = NAN;
+  command.target_temperature_c = NAN;
+  command.source = commissioning_task_active
+      ? COMMAND_SOURCE_COMMISSIONING
+      : in_cm3 ? COMMAND_SOURCE_CM3 : COMMAND_SOURCE_NONE;
+  command.updated_at_ms = now_ms;
+  return command;
+}
+
+inline bool command_is_fresh(const BoilerCommand &command,
+                             uint32_t now_ms,
+                             uint32_t max_age_ms) {
+  if (!command.valid || command.updated_at_ms == 0) return false;
+  if (max_age_ms == 0) return true;
+  return (uint32_t)(now_ms - command.updated_at_ms) <= max_age_ms;
+}
+
+inline bool minimum_time_active(uint32_t now_ms,
+                                uint32_t last_change_ms,
+                                uint32_t minimum_time_ms) {
+  if (minimum_time_ms == 0 || last_change_ms == 0) return false;
+  return (uint32_t)(now_ms - last_change_ms) < minimum_time_ms;
+}
+
+inline ControllerDecision evaluate(const BoilerCommand &command,
+                                   const ControllerInput &input) {
+  ControllerDecision decision{};
+  decision.demand_present = command.demand_present;
+  decision.desired_active = false;
+  decision.output_active = false;
+  decision.force_off = false;
+  decision.blocked = false;
+  decision.block_reason = BLOCK_NONE;
+
+  if (input.hard_trip_active) {
+    decision.force_off = true;
+    decision.block_reason = BLOCK_WATER_TEMP_HARD_TRIP;
+  } else if (input.boiler_inhibit_active) {
+    decision.force_off = true;
+    decision.block_reason = BLOCK_WATER_TEMP_INHIBIT;
+  } else if (!input.assist_enabled) {
+    decision.force_off = true;
+    decision.block_reason = BLOCK_ASSIST_DISABLED;
+  } else if (!command.valid) {
+    decision.force_off = true;
+    decision.block_reason = BLOCK_COMMAND_INVALID;
+  } else if (!command_is_fresh(command, input.now_ms, input.command_max_age_ms)) {
+    decision.force_off = true;
+    decision.block_reason = BLOCK_COMMAND_STALE;
+  } else if (!input.supply_temperature_valid) {
+    decision.force_off = true;
+    decision.block_reason = BLOCK_SUPPLY_UNAVAILABLE;
+  } else if (!command.demand_present) {
+    decision.block_reason = BLOCK_NO_HEAT_REQUEST;
+  } else if (!command.heat_request) {
+    decision.block_reason = command.source == COMMAND_SOURCE_COMMISSIONING
+        ? BLOCK_COMMISSIONING_WAITING
+        : BLOCK_NO_HEAT_REQUEST;
+  } else {
+    decision.desired_active = true;
+  }
+
+  if (decision.force_off) {
+    decision.output_active = false;
+  } else if (decision.desired_active) {
+    if (!input.output_active &&
+        minimum_time_active(input.now_ms, input.output_last_change_ms, input.min_off_ms)) {
+      decision.output_active = false;
+      decision.block_reason = BLOCK_MIN_OFF_TIME;
+    } else {
+      decision.output_active = true;
+      decision.block_reason = BLOCK_NONE;
+    }
+  } else if (input.output_active &&
+             minimum_time_active(input.now_ms, input.output_last_change_ms, input.min_on_ms)) {
+    decision.output_active = true;
+    decision.block_reason = BLOCK_MIN_ON_TIME;
+  }
+
+  decision.blocked = decision.demand_present && !decision.output_active;
+  return decision;
+}
+
+inline const char *block_reason_text(uint8_t reason) {
+  switch (reason) {
+    case BLOCK_ASSIST_DISABLED: return "boiler/CV assist disabled";
+    case BLOCK_COMMAND_INVALID: return "boiler command invalid";
+    case BLOCK_COMMAND_STALE: return "boiler command stale";
+    case BLOCK_SUPPLY_UNAVAILABLE: return "water supply temperature unavailable";
+    case BLOCK_WATER_TEMP_INHIBIT: return "water temperature boiler inhibit active";
+    case BLOCK_WATER_TEMP_HARD_TRIP: return "water temperature hard trip active";
+    case BLOCK_COMMISSIONING_WAITING: return "CM100 boiler commissioning waiting for flow settle";
+    case BLOCK_NO_HEAT_REQUEST: return "Control Mode is not CM3";
+    case BLOCK_MIN_ON_TIME: return "boiler minimum on-time active";
+    case BLOCK_MIN_OFF_TIME: return "boiler minimum off-time active";
+    default: return "";
+  }
+}
+
+}  // namespace oq_boiler

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -3,22 +3,25 @@
 # ==============================================================================
 #
 # Goal:
-#   Controls the electric inline heater (boiler) as auxiliary heating in CM3
-#   and during the explicit CM100 boiler power test.
+#   Validates the transport-neutral boiler command and applies it to the
+#   configured R1 relay during CM3 and the explicit CM100 boiler power test.
 #
 # Role in architecture:
-#   Owner of the boiler relay; boiler control is passive and follows CM status from supervisory.
+#   Owner of boiler safety gating and the R1 transport adapter. Control Mode and
+#   strategy intent enter only through the shared command from `oq_boiler_dispatch`.
 #
 # What this package DOES do:
 #   - Switch boiler relay via configured output pin (`oq_boiler_relay_pin`)
-#   - Enables boiler at CM3; disables in all other CMs
+#   - Validate command availability/freshness before transport activation
+#   - Preserve the existing CM3/CM100 R1 behavior through the legacy dispatcher
 #   - Follow the shared water-temperature guardrail state from `oq_strategy_manager`
+#   - Enforce transport minimum on/off timing when configured
 #   - Publish optional diagnostics (for example boiler status / optionally derived power)
 #
 # What this package DOES NOT do:
 #   - Does not determine Control Mode (supervisory does)
 #   - Does not control heat pumps or flow
-#   - Does not regulate temperature setpoints
+#   - Does not derive strategy power or temperature setpoints
 #
 # Key assumptions:
 #   - Boiler is hydraulically in series after HP2; `water_supply_temp_selected` is available for max-temp protection
@@ -36,8 +39,39 @@
 #
 # ==============================================================================
 
+esphome:
+  on_shutdown:
+    priority: 700
+    then:
+      - lambda: |-
+          // Fail-safe R1 shutdown; OTB adds its own controlled off handshake later.
+          id(oq_boiler_command_valid) = false;
+          id(oq_boiler_command_heat_request) = false;
+          id(oq_boiler_output_request) = false;
+          id(oq_boiler_block_reason_code) = oq_boiler::BLOCK_COMMAND_INVALID;
+      - switch.turn_off: boiler_relay
+
 # ----------------------------
-# OUTPUTS
+# INTERNAL CONTROLLER STATE
+# ----------------------------
+globals:
+  - id: oq_boiler_output_request
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_boiler_block_reason_code
+    type: uint8_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_boiler_output_last_change_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+# ----------------------------
+# R1 OUTPUT
 # ----------------------------
 output:
   - platform: gpio
@@ -118,36 +152,44 @@ interval:
     startup_delay: 4600ms
     then:
       - lambda: |-
+          // Phase 1: snapshot the shared command and all fail-safe controller inputs.
           const int cm_code = id(oq_control_mode_code);
-          const bool commissioning_boiler_task =
-              (cm_code == 100) &&
-              id(oq_commissioning_active) &&
-              (id(oq_commissioning_task_code) == oq_commissioning::TASK_BOILER_POWER_TEST);
-          const bool commissioning_boiler =
-              commissioning_boiler_task &&
-              id(oq_commissioning_boiler_request);
-          // Boiler follows Control Mode CM3, but the shared water-temperature model
-          // may block it independently from CM ownership.
-          const bool in_cm3 = (cm_code == 3);
+          const uint32_t now_ms = millis();
           const float supply_c = id(water_supply_temp_selected).state;
           const bool has_valid_supply_temp = !isnan(supply_c);
-          std::string boiler_block_reason;
-          if (!id(oq_boiler_assist_enabled).state) {
-            boiler_block_reason = "boiler/CV assist disabled";
-          } else if (!has_valid_supply_temp) {
-            boiler_block_reason = "water supply temperature unavailable";
-          } else if (id(oq_water_temp_boiler_inhibit_active)) {
-            boiler_block_reason = "water temperature boiler inhibit active";
-          } else if (id(oq_water_temp_hard_trip_active)) {
-            boiler_block_reason = "water temperature hard trip active";
-          } else if (commissioning_boiler_task && !id(oq_commissioning_boiler_request)) {
-            boiler_block_reason = "CM100 boiler commissioning waiting for flow settle";
-          } else if (!in_cm3 && !commissioning_boiler) {
-            boiler_block_reason = "Control Mode is not CM3";
-          }
-          const bool boiler_allowed =
-              boiler_block_reason.empty();
-          const bool boiler_requested = in_cm3 || commissioning_boiler_task;
+          const oq_boiler::BoilerCommand command{
+              id(oq_boiler_command_valid),
+              id(oq_boiler_command_demand_present),
+              id(oq_boiler_command_heat_request),
+              id(oq_boiler_command_requested_power_w),
+              id(oq_boiler_command_target_temperature_c),
+              id(oq_boiler_command_source_code),
+              id(oq_boiler_command_updated_ms),
+          };
+          const oq_boiler::ControllerInput input{
+              id(oq_boiler_assist_enabled).state,
+              has_valid_supply_temp,
+              id(oq_water_temp_boiler_inhibit_active),
+              id(oq_water_temp_hard_trip_active),
+              id(boiler_relay).state,
+              now_ms,
+              (uint32_t) (${oq_boiler_command_max_age_s} * 1000UL),
+              id(oq_boiler_output_last_change_ms),
+              (uint32_t) (${oq_boiler_relay_min_on_s} * 1000UL),
+              (uint32_t) (${oq_boiler_relay_min_off_s} * 1000UL),
+          };
+          const auto decision = oq_boiler::evaluate(command, input);
+          const bool commissioning_boiler =
+              command.source == oq_boiler::COMMAND_SOURCE_COMMISSIONING &&
+              command.heat_request;
+          const std::string boiler_block_reason =
+              oq_boiler::block_reason_text(decision.block_reason);
+          const bool boiler_allowed = decision.output_active;
+          const bool boiler_requested = decision.demand_present;
+          id(oq_boiler_output_request) = decision.output_active;
+          id(oq_boiler_block_reason_code) = decision.block_reason;
+
+          // Phase 2: map the transport-neutral decision to existing decision-log semantics.
           auto boiler_log_reason = [&]()->uint8_t {
             if (id(oq_water_temp_boiler_inhibit_active) || id(oq_water_temp_hard_trip_active)) {
               return openquatt_decision_log::REASON_SOFT_GUARD;
@@ -158,8 +200,15 @@ interval:
             if (!id(oq_boiler_assist_enabled).state) {
               return openquatt_decision_log::REASON_NO_CANDIDATE;
             }
+            if (decision.block_reason == oq_boiler::BLOCK_COMMAND_INVALID ||
+                decision.block_reason == oq_boiler::BLOCK_COMMAND_STALE) {
+              return openquatt_decision_log::REASON_SENSOR_FALLBACK;
+            }
             if (boiler_block_reason == "CM100 boiler commissioning waiting for flow settle") {
               return openquatt_decision_log::REASON_FLOW_PREFLOW;
+            }
+            if (decision.block_reason == oq_boiler::BLOCK_MIN_OFF_TIME) {
+              return openquatt_decision_log::REASON_MIN_REST_ACTIVE;
             }
             return openquatt_decision_log::REASON_LESS_POWER;
           };
@@ -204,6 +253,7 @@ interval:
           }
           last_boiler_blocked = boiler_blocked;
 
+          // Phase 3: apply the evaluated output request to the R1 transport only.
           if (boiler_allowed) {
             if (!id(boiler_relay).state) {
               id(oq_decision_log).emit(
@@ -216,6 +266,7 @@ interval:
                   openquatt_decision_log::STATE_ACTIVE,
                   has_valid_supply_temp ? (int16_t) lroundf(supply_c * 10.0f) : 0);
               id(boiler_relay).turn_on();
+              id(oq_boiler_output_last_change_ms) = now_ms;
             }
           } else {
             if (id(boiler_relay).state) {
@@ -229,5 +280,6 @@ interval:
                   openquatt_decision_log::STATE_STANDBY,
                   has_valid_supply_temp ? (int16_t) lroundf(supply_c * 10.0f) : 0);
               id(boiler_relay).turn_off();
+              id(oq_boiler_output_last_change_ms) = now_ms;
             }
           }

--- a/openquatt/oq_boiler_dispatch.yaml
+++ b/openquatt/oq_boiler_dispatch.yaml
@@ -1,0 +1,72 @@
+# ==============================================================================
+# OpenQuatt – Boiler Command Dispatch
+# ==============================================================================
+#
+# Owns the transport-neutral command contract consumed by `oq_boiler_control`.
+# During the foundation phase this adapter intentionally reproduces the existing
+# CM3 and CM100 relay demand. Later work packages replace the legacy CM3 command
+# with strategy-derived requested power and target temperature.
+#
+# This package never writes R1 or OpenTherm outputs.
+# ==============================================================================
+
+globals:
+  - id: oq_boiler_command_valid
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_boiler_command_demand_present
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_boiler_command_heat_request
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_boiler_command_requested_power_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
+  - id: oq_boiler_command_target_temperature_c
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
+  - id: oq_boiler_command_source_code
+    type: uint8_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_boiler_command_updated_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+interval:
+  - interval: ${oq_boiler_loop_s}s
+    startup_delay: 4500ms
+    then:
+      - lambda: |-
+          // Phase 1: adapt the existing CM3/CM100 ownership into the shared contract.
+          const int cm_code = id(oq_control_mode_code);
+          const bool commissioning_boiler_task =
+              id(oq_commissioning_task_code) == oq_commissioning::TASK_BOILER_POWER_TEST;
+          const auto command = oq_boiler::make_legacy_command(
+              cm_code,
+              id(oq_commissioning_active),
+              commissioning_boiler_task,
+              id(oq_commissioning_boiler_request),
+              millis());
+
+          // Phase 2: publish atomically before the controller interval evaluates it.
+          id(oq_boiler_command_valid) = command.valid;
+          id(oq_boiler_command_demand_present) = command.demand_present;
+          id(oq_boiler_command_heat_request) = command.heat_request;
+          id(oq_boiler_command_requested_power_w) = command.requested_power_w;
+          id(oq_boiler_command_target_temperature_c) = command.target_temperature_c;
+          id(oq_boiler_command_source_code) = command.source;
+          id(oq_boiler_command_updated_ms) = command.updated_at_ms;

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -206,6 +206,9 @@ oq_water_cp_j_per_kgk: "4186.0"                       # Specific heat capacity o
 # BOILER CONTROL
 # ----------------------------
 oq_boiler_loop_s: "5"                                 # Main interval for boiler gating/safety loop [s].
+oq_boiler_command_max_age_s: "15"                     # Fail-safe maximum age of the transport-neutral boiler command [s].
+oq_boiler_relay_min_on_s: "0"                         # R1 minimum on-time [s]; zero preserves existing relay behavior in foundation phase.
+oq_boiler_relay_min_off_s: "0"                        # R1 minimum off-time [s]; zero preserves existing relay behavior in foundation phase.
 
 # ----------------------------
 # OPEN THERM SLAVE

--- a/openquatt/packages/50_integrations.yaml
+++ b/openquatt/packages/50_integrations.yaml
@@ -2,6 +2,7 @@
 # OpenQuatt - Integration Packages
 # ==============================================================================
 packages:
+  oq_boiler_dispatch: !include ../oq_boiler_dispatch.yaml
   oq_boiler_control: !include
     file: ../oq_boiler_control.yaml
     vars:

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -296,6 +296,7 @@ NESTED_KEY_ORDER_RULES = {
         "oq_boiler_test",
     ),
     ("openquatt/packages/50_integrations.yaml", "packages"): (
+        "oq_boiler_dispatch",
         "oq_boiler_control",
         "oq_energy",
         "oq_cic",


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt het transportneutrale `BoilerCommand`-/controllercontract toe.
- Houdt R1 als standaardtransport en centraliseert freshness, thermische blokkades en actuatorbeslissingen.
- Verplaatst CM3/CM100-intent naar een dispatcher die zelf geen transport aanstuurt.

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Dit is laag 1 van de gestapelde OT-ketelreeks. Bestaande installaties blijven standaard R1 gebruiken; deze PR bevat nog geen OpenTherm-master.

## Achtergrond

Mergevolgorde: **#347 → #348 → #349 → #350 → #351**. CM4/boiler-only blijft buiten deze reeks en wordt na OT-ketel apart ontworpen. Implementatieplanning en voortgangstracking blijven lokaal buiten de repository.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

OTB is nog niet vrijgegeven. Gebruikersdocumentatie volgt na fysieke HIL-validatie van de volledige stack.

## Audit

De complete laagdiff is gecontroleerd op bestaande R1-compatibiliteit, stale/ongeldige commando's, hard-trip/inhibit-prioriteit, shutdown en fresh-install defaults. R1 blijft default-on-selectie; niet-herstelde runtimeglobals starten fail-safe uit.

## Validatie

- `git diff --check origin/dev..HEAD`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- De volledige gestapelde kandidaat is aanvullend gecompileerd en cross-hardware gevalideerd in #351.
