### PR TITLE
Add passive OpenTherm boiler telemetry

### DIFF
--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -1,0 +1,321 @@
+# ==============================================================================
+# OpenQuatt – OpenTherm Boiler (OTB) passive master and telemetry
+# ==============================================================================
+#
+# Q-hardware-only OpenTherm master. This phase deliberately keeps CH disabled
+# and TSet at 0 °C while proving the physical link and collecting boiler data.
+# DHW permission remains enabled so attaching a combi boiler for passive testing
+# does not disable normal tap-water operation.
+#
+# Active BoilerCommand transport is added in the CM3 strategy phase.
+# ==============================================================================
+
+globals:
+  - id: oq_otb_last_response_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_otb_response_count
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: oq_otb_last_response_id
+    type: int
+    restore_value: false
+    initial_value: '-1'
+
+  - id: oq_otb_link_available_state
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  - id: oq_otb_link_initialized
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+opentherm:
+  - id: oq_otb_hub
+    in_pin: ${oq_ot_boiler_in_pin}
+    out_pin: ${oq_ot_boiler_out_pin}
+    ch_enable: false
+    dhw_enable: true
+    cooling_enable: false
+    otc_active: false
+    ch2_active: false
+    summer_mode_active: false
+    dhw_block: false
+    before_process_response:
+      then:
+        - lambda: |-
+            // Called only after the hub accepted a complete OpenTherm response.
+            id(oq_otb_last_response_ms) = millis();
+            id(oq_otb_response_count)++;
+            id(oq_otb_last_response_id) = x.id;
+
+number:
+  - platform: opentherm
+    opentherm_id: oq_otb_hub
+    t_set:
+      id: oq_otb_t_set_command
+      name: "OTB - Control Setpoint Command"
+      internal: true
+      entity_category: diagnostic
+      icon: mdi:thermostat
+      min_value: 0
+      max_value: 90
+      step: 0.1
+      initial_value: 0
+      restore_value: false
+
+binary_sensor:
+  - platform: template
+    id: otb_link_available
+    name: "OTB - Boiler Link Available"
+    icon: mdi:link-variant
+    device_class: connectivity
+    entity_category: diagnostic
+    web_server:
+      sorting_group_id: oq_boiler
+
+  - platform: opentherm
+    opentherm_id: oq_otb_hub
+    fault_indication:
+      id: otb_fault_indication
+      name: "OTB - Fault Indication"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    ch_active:
+      id: otb_ch_active
+      name: "OTB - Central Heating Active"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    dhw_active:
+      id: otb_dhw_active
+      name: "OTB - Domestic Hot Water Active"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    flame_on:
+      id: otb_flame_on
+      name: "OTB - Flame On"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    diagnostic_indication:
+      id: otb_diagnostic_indication
+      name: "OTB - Diagnostic Indication"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    dhw_present:
+      id: otb_dhw_present
+      name: "OTB - DHW Present"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    service_request:
+      id: otb_service_request
+      name: "OTB - Service Required"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    lockout_reset:
+      id: otb_lockout_reset
+      name: "OTB - Lockout Reset"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    low_water_pressure:
+      id: otb_low_water_pressure
+      name: "OTB - Low Water Pressure"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    flame_fault:
+      id: otb_flame_fault
+      name: "OTB - Flame Fault"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    air_pressure_fault:
+      id: otb_air_pressure_fault
+      name: "OTB - Air Pressure Fault"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    water_over_temp:
+      id: otb_water_over_temp
+      name: "OTB - Water Overtemperature"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+
+sensor:
+  - platform: opentherm
+    opentherm_id: oq_otb_hub
+    rel_mod_level:
+      id: otb_relative_modulation
+      name: "OTB - Relative Modulation"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    ch_pressure:
+      id: otb_ch_pressure
+      name: "OTB - CH Water Pressure"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    t_boiler:
+      id: otb_boiler_water_temp
+      name: "OTB - Boiler Water Temperature"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    t_ret:
+      id: otb_return_water_temp
+      name: "OTB - Return Water Temperature"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    t_dhw:
+      id: otb_dhw_temp
+      name: "OTB - Domestic Hot Water Temperature"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    oem_fault_code:
+      id: otb_oem_fault_code
+      name: "OTB - OEM Fault Code"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    oem_diagnostic_code:
+      id: otb_oem_diagnostic_code
+      name: "OTB - OEM Diagnostic Code"
+      entity_category: diagnostic
+      web_server:
+        sorting_group_id: oq_boiler
+    max_capacity:
+      id: otb_max_capacity
+      name: "OTB - Maximum Boiler Capacity"
+      entity_category: diagnostic
+      disabled_by_default: true
+      web_server:
+        sorting_group_id: oq_boiler
+    min_mod_level:
+      id: otb_min_modulation
+      name: "OTB - Minimum Modulation"
+      entity_category: diagnostic
+      disabled_by_default: true
+      web_server:
+        sorting_group_id: oq_boiler
+    opentherm_version_device:
+      id: otb_opentherm_version
+      name: "OTB - OpenTherm Device Version"
+      entity_category: diagnostic
+      disabled_by_default: true
+      web_server:
+        sorting_group_id: oq_boiler
+    device_type:
+      id: otb_device_type
+      name: "OTB - Device Type"
+      entity_category: diagnostic
+      disabled_by_default: true
+      web_server:
+        sorting_group_id: oq_boiler
+    device_version:
+      id: otb_device_version
+      name: "OTB - Device Product Version"
+      entity_category: diagnostic
+      disabled_by_default: true
+      web_server:
+        sorting_group_id: oq_boiler
+
+  - platform: template
+    id: otb_last_response_age
+    name: "OTB - Last Response Age"
+    icon: mdi:timer-outline
+    unit_of_measurement: "s"
+    accuracy_decimals: 1
+    entity_category: diagnostic
+    update_interval: ${oq_otb_link_watch_s}s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      const uint32_t last_response_ms = id(oq_otb_last_response_ms);
+      if (last_response_ms == 0) return NAN;
+      return (float) ((uint32_t)(millis() - last_response_ms)) / 1000.0f;
+
+  - platform: template
+    id: otb_response_count
+    name: "OTB - Valid Response Count"
+    icon: mdi:counter
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) id(oq_otb_response_count);
+
+  - platform: template
+    id: otb_last_response_id
+    name: "OTB - Last Response Message ID"
+    icon: mdi:identifier
+    accuracy_decimals: 0
+    entity_category: diagnostic
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      const int message_id = id(oq_otb_last_response_id);
+      return message_id >= 0 ? (float) message_id : NAN;
+
+interval:
+  - interval: ${oq_otb_link_watch_s}s
+    startup_delay: 2s
+    then:
+      - lambda: |-
+          // Phase 1: derive availability solely from complete accepted responses.
+          const uint32_t now_ms = millis();
+          const uint32_t last_response_ms = id(oq_otb_last_response_ms);
+          const bool available =
+              last_response_ms != 0 &&
+              (uint32_t)(now_ms - last_response_ms) <=
+                  (uint32_t) (${oq_otb_link_timeout_s} * 1000UL);
+          const bool link_changed =
+              !id(oq_otb_link_initialized) ||
+              available != id(oq_otb_link_available_state);
+          if (!link_changed) return;
+
+          id(oq_otb_link_initialized) = true;
+          id(oq_otb_link_available_state) = available;
+          id(otb_link_available).publish_state(available);
+          ESP_LOGI("quatt.otb", "Boiler OpenTherm link %s", available ? "available" : "unavailable");
+
+          // Phase 2: prevent stale operational values from looking current after link loss.
+          if (available) return;
+          id(otb_fault_indication).publish_state(false);
+          id(otb_ch_active).publish_state(false);
+          id(otb_dhw_active).publish_state(false);
+          id(otb_flame_on).publish_state(false);
+          id(otb_diagnostic_indication).publish_state(false);
+          id(otb_service_request).publish_state(false);
+          id(otb_lockout_reset).publish_state(false);
+          id(otb_low_water_pressure).publish_state(false);
+          id(otb_flame_fault).publish_state(false);
+          id(otb_air_pressure_fault).publish_state(false);
+          id(otb_water_over_temp).publish_state(false);
+          id(otb_relative_modulation).publish_state(NAN);
+          id(otb_ch_pressure).publish_state(NAN);
+          id(otb_boiler_water_temp).publish_state(NAN);
+          id(otb_return_water_temp).publish_state(NAN);
+          id(otb_dhw_temp).publish_state(NAN);
+          id(otb_oem_fault_code).publish_state(NAN);
+          id(otb_oem_diagnostic_code).publish_state(NAN);

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -217,6 +217,12 @@ oq_ot_enabled_default: "false"                        # Default runtime state of
 oq_ot_response_enabled_default: "true"                # Allow the OT slave to answer thermostat requests by default.
 
 # ----------------------------
+# OPEN THERM BOILER MASTER
+# ----------------------------
+oq_otb_link_watch_s: "1"                              # OTB link/freshness evaluation interval [s].
+oq_otb_link_timeout_s: "10"                           # Maximum age of the last valid boiler response [s].
+
+# ----------------------------
 # CIC FEED
 # ----------------------------
 cic_backoff_start_ms: "5000"                          # Initial polling backoff after success/startup [ms].

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -17,6 +17,8 @@ substitutions:
   uart_rts_pin: "GPIO41"                                # Modbus 1 mode / DE/RE; primary heat-pump bus.
   oq_ot_thermostat_in_pin: "GPIO21"                     # OpenTherm slave input.
   oq_ot_thermostat_out_pin: "GPIO14"                    # OpenTherm slave output.
+  oq_ot_boiler_in_pin: "GPIO47"                         # OpenTherm boiler master input.
+  oq_ot_boiler_out_pin: "GPIO48"                        # OpenTherm boiler master output.
   ds18b20_pin: "GPIO18"                                 # Dallas DS18B20 1-Wire input.
   oq_boiler_relay_pin: "GPIO16"                         # Relay 1 output.
   controller_aux_relay_pin: "GPIO3"                     # Relay 2 output reserved for controller logic.
@@ -49,6 +51,7 @@ packages:
     file: ../oq_ot_slave.yaml
     vars:
       ot_secondary_present: "${ot_secondary_present}"
+  oq_boiler_opentherm: !include ../oq_boiler_opentherm.yaml
 
 openquatt_usage_telemetry:
   cic_compatibility_switch: cic_compatibility_enable

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -321,6 +321,7 @@ NESTED_KEY_ORDER_RULES = {
         "oq_cic_compatibility",
         "oq_sensor_source_selects_opentherm",
         "oq_ot_slave",
+        "oq_boiler_opentherm",
     ),
 }
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt de ingebouwde ESPHome OpenTherm-master toe voor Q op GPIO47 (Master In) en GPIO48 (Master Out).
- Publiceert ketellink, status, fouten, temperaturen, druk en modulatie.
- Houdt CH passief uit en `TSet=0`; `DHW Enable` blijft altijd aan zodat OpenQuatt tapwaterbedrijf niet blokkeert.

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Dit is de passieve OTB-laag. R1 blijft ongewijzigd de standaard; actieve heating-strategy-aansturing volgt in #349.

## Achtergrond

Gestapeld op #347. Mergevolgorde: **#347 → #348 → #349 → #350 → #351**. Alleen Q-hardware krijgt OTB; CM4 blijft buiten scope.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Gebruikersdocumentatie volgt na fysieke HIL-validatie van de volledige stack.

## Audit

De link wordt uitsluitend geldig na een compleet geaccepteerd OpenTherm-antwoord en verloopt na 10 s zonder antwoord. Operationele ketelwaarden worden bij linkverlies ongeldig gemaakt; CH start niet uit restore-state.

## Validatie

- `git diff --check codex/ot-boiler-foundation..HEAD`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- De volledige gestapelde kandidaat is aanvullend gecompileerd in #351.
