### PR TITLE
Integrate boiler assist with heating strategies

### DIFF
--- a/openquatt/includes/boiler/oq_boiler_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_logic.h
@@ -94,6 +94,12 @@ inline AssistSignal heating_curve_assist(bool heat_request,
   };
 }
 
+inline bool cm3_should_hold(bool minimum_run_elapsed,
+                            bool okay_off,
+                            bool demote_confirmation_elapsed) {
+  return !minimum_run_elapsed || !okay_off || !demote_confirmation_elapsed;
+}
+
 inline PowerTarget target_from_power(float requested_power_w,
                                      float rated_power_w,
                                      float inlet_temperature_c,

--- a/openquatt/includes/boiler/oq_boiler_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_logic.h
@@ -7,8 +7,10 @@ namespace oq_boiler {
 
 enum CommandSource : uint8_t {
   COMMAND_SOURCE_NONE = 0,
-  COMMAND_SOURCE_CM3 = 1,
+  COMMAND_SOURCE_POWER_HOUSE = 1,
+  COMMAND_SOURCE_CM3 = COMMAND_SOURCE_POWER_HOUSE,
   COMMAND_SOURCE_COMMISSIONING = 2,
+  COMMAND_SOURCE_HEATING_CURVE = 3,
 };
 
 enum BlockReason : uint8_t {
@@ -23,6 +25,8 @@ enum BlockReason : uint8_t {
   BLOCK_NO_HEAT_REQUEST = 8,
   BLOCK_MIN_ON_TIME = 9,
   BLOCK_MIN_OFF_TIME = 10,
+  BLOCK_TRANSPORT_UNAVAILABLE = 11,
+  BLOCK_TARGET_INVALID = 12,
 };
 
 struct BoilerCommand {
@@ -40,6 +44,9 @@ struct ControllerInput {
   bool supply_temperature_valid;
   bool boiler_inhibit_active;
   bool hard_trip_active;
+  bool transport_available;
+  bool target_required;
+  bool target_valid;
   bool output_active;
   uint32_t now_ms;
   uint32_t command_max_age_ms;
@@ -47,6 +54,77 @@ struct ControllerInput {
   uint32_t min_on_ms;
   uint32_t min_off_ms;
 };
+
+struct PowerTarget {
+  bool valid;
+  float requested_power_w;
+  float target_temperature_c;
+};
+
+struct AssistSignal {
+  bool need_on;
+  bool okay_off;
+};
+
+inline AssistSignal power_house_assist(float deficit_w,
+                                       float on_threshold_w,
+                                       float off_threshold_w) {
+  return AssistSignal{
+      !isnan(deficit_w) && deficit_w >= on_threshold_w,
+      isnan(deficit_w) || deficit_w <= off_threshold_w,
+  };
+}
+
+inline AssistSignal heating_curve_assist(bool heat_request,
+                                         bool hp_saturated,
+                                         float target_temperature_c,
+                                         float supply_temperature_c,
+                                         float on_delta_c,
+                                         float off_delta_c) {
+  const bool temperatures_valid =
+      !isnan(target_temperature_c) && !isnan(supply_temperature_c);
+  const float target_error_c = temperatures_valid
+      ? target_temperature_c - supply_temperature_c
+      : NAN;
+  return AssistSignal{
+      heat_request && hp_saturated && temperatures_valid &&
+          target_error_c >= on_delta_c,
+      !heat_request || !hp_saturated || !temperatures_valid ||
+          target_error_c <= off_delta_c,
+  };
+}
+
+inline PowerTarget target_from_power(float requested_power_w,
+                                     float rated_power_w,
+                                     float inlet_temperature_c,
+                                     float flow_lph,
+                                     float cp_j_per_kgk,
+                                     float maximum_temperature_c) {
+  PowerTarget target{false, 0.0f, NAN};
+  if (isnan(requested_power_w) || isnan(rated_power_w) ||
+      isnan(inlet_temperature_c) || isnan(flow_lph) ||
+      isnan(cp_j_per_kgk) || isnan(maximum_temperature_c) ||
+      requested_power_w <= 0.0f || rated_power_w <= 0.0f ||
+      flow_lph <= 0.0f || cp_j_per_kgk <= 0.0f ||
+      inlet_temperature_c >= maximum_temperature_c) {
+    return target;
+  }
+
+  const float thermal_conductance_w_per_k =
+      (flow_lph / 3600.0f) * cp_j_per_kgk;
+  const float maximum_hydraulic_power_w =
+      thermal_conductance_w_per_k *
+      (maximum_temperature_c - inlet_temperature_c);
+  float usable_power_w = fminf(requested_power_w, rated_power_w);
+  usable_power_w = fminf(usable_power_w, maximum_hydraulic_power_w);
+  if (usable_power_w <= 0.0f) return target;
+
+  target.valid = true;
+  target.requested_power_w = usable_power_w;
+  target.target_temperature_c =
+      inlet_temperature_c + usable_power_w / thermal_conductance_w_per_k;
+  return target;
+}
 
 struct ControllerDecision {
   bool demand_present;
@@ -128,6 +206,12 @@ inline ControllerDecision evaluate(const BoilerCommand &command,
     decision.block_reason = BLOCK_SUPPLY_UNAVAILABLE;
   } else if (!command.demand_present) {
     decision.block_reason = BLOCK_NO_HEAT_REQUEST;
+  } else if (!input.transport_available) {
+    decision.force_off = true;
+    decision.block_reason = BLOCK_TRANSPORT_UNAVAILABLE;
+  } else if (command.heat_request && input.target_required && !input.target_valid) {
+    decision.force_off = true;
+    decision.block_reason = BLOCK_TARGET_INVALID;
   } else if (!command.heat_request) {
     decision.block_reason = command.source == COMMAND_SOURCE_COMMISSIONING
         ? BLOCK_COMMISSIONING_WAITING
@@ -166,9 +250,11 @@ inline const char *block_reason_text(uint8_t reason) {
     case BLOCK_WATER_TEMP_INHIBIT: return "water temperature boiler inhibit active";
     case BLOCK_WATER_TEMP_HARD_TRIP: return "water temperature hard trip active";
     case BLOCK_COMMISSIONING_WAITING: return "CM100 boiler commissioning waiting for flow settle";
-    case BLOCK_NO_HEAT_REQUEST: return "Control Mode is not CM3";
+    case BLOCK_NO_HEAT_REQUEST: return "no boiler heat request";
     case BLOCK_MIN_ON_TIME: return "boiler minimum on-time active";
     case BLOCK_MIN_OFF_TIME: return "boiler minimum off-time active";
+    case BLOCK_TRANSPORT_UNAVAILABLE: return "selected boiler transport unavailable";
+    case BLOCK_TARGET_INVALID: return "boiler target temperature invalid";
     default: return "";
   }
 }

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -3,8 +3,8 @@
 # ==============================================================================
 #
 # Goal:
-#   Validates the transport-neutral boiler command and applies it to the
-#   configured R1 relay during CM3 and the explicit CM100 boiler power test.
+#   Validates the transport-neutral boiler command and exposes one safe output
+#   request to the selected R1 or OpenTherm transport.
 #
 # Role in architecture:
 #   Owner of boiler safety gating and the R1 transport adapter. Control Mode and
@@ -13,7 +13,7 @@
 # What this package DOES do:
 #   - Switch boiler relay via configured output pin (`oq_boiler_relay_pin`)
 #   - Validate command availability/freshness before transport activation
-#   - Preserve the existing CM3/CM100 R1 behavior through the legacy dispatcher
+#   - Keep R1 and OpenTherm mutually exclusive through an explicit selection
 #   - Follow the shared water-temperature guardrail state from `oq_strategy_manager`
 #   - Enforce transport minimum on/off timing when configured
 #   - Publish optional diagnostics (for example boiler status / optionally derived power)
@@ -44,10 +44,11 @@ esphome:
     priority: 700
     then:
       - lambda: |-
-          // Fail-safe R1 shutdown; OTB adds its own controlled off handshake later.
+          // Fail-safe shared shutdown; OTB adds its own controlled off handshake.
           id(oq_boiler_command_valid) = false;
           id(oq_boiler_command_heat_request) = false;
           id(oq_boiler_output_request) = false;
+          id(oq_boiler_transport_active) = false;
           id(oq_boiler_block_reason_code) = oq_boiler::BLOCK_COMMAND_INVALID;
       - switch.turn_off: boiler_relay
 
@@ -69,6 +70,49 @@ globals:
     type: uint32_t
     restore_value: false
     initial_value: '0'
+
+  - id: oq_boiler_transport_active
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+  # Common declaration lets non-Q profiles compile the same controller. Only
+  # the Q OpenTherm package can set this state true.
+  - id: oq_otb_link_available_state
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
+# ----------------------------
+# TRANSPORT SELECTION
+# ----------------------------
+select:
+  - platform: template
+    id: oq_boiler_connection
+    name: "Boiler connection"
+    icon: mdi:connection
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    options:
+      - R1
+      - OpenTherm
+    initial_option: R1
+    web_server:
+      sorting_group_id: oq_control
+    on_value:
+      then:
+        - lambda: |-
+            // Break-before-make: a transport change immediately drops both the
+            // shared request and R1. The selected path may restart only after a
+            // fresh controller evaluation.
+            const uint32_t now_ms = millis();
+            if (id(oq_boiler_output_request)) {
+              id(oq_boiler_output_request) = false;
+              id(oq_boiler_output_last_change_ms) = now_ms;
+            }
+            id(oq_boiler_transport_active) = false;
+            id(boiler_relay).turn_off();
 
 # ----------------------------
 # R1 OUTPUT
@@ -104,7 +148,7 @@ binary_sensor:
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      return id(boiler_relay).state;
+      return id(oq_boiler_transport_active);
 
 sensor:
   - platform: template
@@ -119,15 +163,8 @@ sensor:
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      const int cm_code = id(oq_control_mode_code);
-      const bool commissioning_boiler =
-          (cm_code == 100) &&
-          id(oq_commissioning_active) &&
-          (id(oq_commissioning_task_code) == oq_commissioning::TASK_BOILER_POWER_TEST) &&
-          id(oq_commissioning_boiler_request);
-      const bool in_cm3 = (cm_code == 3);
       if (!id(oq_boiler_assist_enabled).state) return 0.0f;
-      if (!in_cm3 && !commissioning_boiler) return 0.0f;
+      if (!id(oq_boiler_transport_active)) return 0.0f;
 
       const float hp2_outlet_c = id(${heatpump_outlet_temp_id}).state;
       const float supply_c = id(water_supply_temp_selected).state;
@@ -157,6 +194,27 @@ interval:
           const uint32_t now_ms = millis();
           const float supply_c = id(water_supply_temp_selected).state;
           const bool has_valid_supply_temp = !isnan(supply_c);
+          const bool opentherm_selected =
+              id(oq_boiler_connection).has_state() &&
+              id(oq_boiler_connection).current_option() == "OpenTherm";
+          const bool transport_available =
+              !opentherm_selected ||
+              (${oq_otb_supported} && id(oq_otb_link_available_state));
+          const float target_c = id(oq_boiler_command_target_temperature_c);
+          const float boiler_flow_lph = id(flow_rate_selected).state;
+          const bool boiler_flow_valid =
+              !isnan(boiler_flow_lph) && boiler_flow_lph >= ${oq_cm_min_flow_lph};
+          const bool target_valid =
+              !isnan(target_c) && target_c > 0.0f && target_c <= 90.0f &&
+              boiler_flow_valid;
+          const uint32_t minimum_on_ms = (uint32_t) (
+              (opentherm_selected
+                   ? ${oq_boiler_otb_min_on_s}
+                   : ${oq_boiler_relay_min_on_s}) * 1000UL);
+          const uint32_t minimum_off_ms = (uint32_t) (
+              (opentherm_selected
+                   ? ${oq_boiler_otb_min_off_s}
+                   : ${oq_boiler_relay_min_off_s}) * 1000UL);
           const oq_boiler::BoilerCommand command{
               id(oq_boiler_command_valid),
               id(oq_boiler_command_demand_present),
@@ -171,12 +229,15 @@ interval:
               has_valid_supply_temp,
               id(oq_water_temp_boiler_inhibit_active),
               id(oq_water_temp_hard_trip_active),
-              id(boiler_relay).state,
+              transport_available,
+              opentherm_selected,
+              target_valid,
+              id(oq_boiler_output_request),
               now_ms,
               (uint32_t) (${oq_boiler_command_max_age_s} * 1000UL),
               id(oq_boiler_output_last_change_ms),
-              (uint32_t) (${oq_boiler_relay_min_on_s} * 1000UL),
-              (uint32_t) (${oq_boiler_relay_min_off_s} * 1000UL),
+              minimum_on_ms,
+              minimum_off_ms,
           };
           const auto decision = oq_boiler::evaluate(command, input);
           const bool commissioning_boiler =
@@ -186,7 +247,12 @@ interval:
               oq_boiler::block_reason_text(decision.block_reason);
           const bool boiler_allowed = decision.output_active;
           const bool boiler_requested = decision.demand_present;
+          const bool boiler_output_changed =
+              id(oq_boiler_output_request) != decision.output_active;
           id(oq_boiler_output_request) = decision.output_active;
+          if (boiler_output_changed) {
+            id(oq_boiler_output_last_change_ms) = now_ms;
+          }
           id(oq_boiler_block_reason_code) = decision.block_reason;
 
           // Phase 2: map the transport-neutral decision to existing decision-log semantics.
@@ -201,7 +267,9 @@ interval:
               return openquatt_decision_log::REASON_NO_CANDIDATE;
             }
             if (decision.block_reason == oq_boiler::BLOCK_COMMAND_INVALID ||
-                decision.block_reason == oq_boiler::BLOCK_COMMAND_STALE) {
+                decision.block_reason == oq_boiler::BLOCK_COMMAND_STALE ||
+                decision.block_reason == oq_boiler::BLOCK_TRANSPORT_UNAVAILABLE ||
+                decision.block_reason == oq_boiler::BLOCK_TARGET_INVALID) {
               return openquatt_decision_log::REASON_SENSOR_FALLBACK;
             }
             if (boiler_block_reason == "CM100 boiler commissioning waiting for flow settle") {
@@ -253,33 +321,36 @@ interval:
           }
           last_boiler_blocked = boiler_blocked;
 
-          // Phase 3: apply the evaluated output request to the R1 transport only.
-          if (boiler_allowed) {
-            if (!id(boiler_relay).state) {
-              id(oq_decision_log).emit(
-                  openquatt_decision_log::EVENT_BOILER_ASSIST_START,
-                  openquatt_decision_log::SUBJECT_CV,
-                  openquatt_decision_log::REASON_BOILER_ASSIST,
-                  openquatt_decision_log::SEVERITY_NORMAL,
-                  (uint8_t) cm_code,
-                  openquatt_decision_log::STATE_STANDBY,
-                  openquatt_decision_log::STATE_ACTIVE,
-                  has_valid_supply_temp ? (int16_t) lroundf(supply_c * 10.0f) : 0);
-              id(boiler_relay).turn_on();
-              id(oq_boiler_output_last_change_ms) = now_ms;
-            }
+          // Phase 3: log the shared request and apply it only to R1 when selected.
+          if (boiler_output_changed) {
+            id(oq_decision_log).emit(
+                boiler_allowed
+                    ? openquatt_decision_log::EVENT_BOILER_ASSIST_START
+                    : openquatt_decision_log::EVENT_BOILER_ASSIST_STOP,
+                openquatt_decision_log::SUBJECT_CV,
+                boiler_allowed
+                    ? openquatt_decision_log::REASON_BOILER_ASSIST
+                    : boiler_log_reason_code,
+                boiler_allowed
+                    ? openquatt_decision_log::SEVERITY_NORMAL
+                    : boiler_log_severity,
+                (uint8_t) cm_code,
+                boiler_allowed
+                    ? openquatt_decision_log::STATE_STANDBY
+                    : openquatt_decision_log::STATE_ACTIVE,
+                boiler_allowed
+                    ? openquatt_decision_log::STATE_ACTIVE
+                    : openquatt_decision_log::STATE_STANDBY,
+                has_valid_supply_temp ? (int16_t) lroundf(supply_c * 10.0f) : 0);
+          }
+
+          if (opentherm_selected) {
+            id(boiler_relay).turn_off();
+          } else if (boiler_allowed) {
+            id(boiler_relay).turn_on();
           } else {
-            if (id(boiler_relay).state) {
-              id(oq_decision_log).emit(
-                  openquatt_decision_log::EVENT_BOILER_ASSIST_STOP,
-                  openquatt_decision_log::SUBJECT_CV,
-                  boiler_log_reason_code,
-                  boiler_log_severity,
-                  (uint8_t) cm_code,
-                  openquatt_decision_log::STATE_ACTIVE,
-                  openquatt_decision_log::STATE_STANDBY,
-                  has_valid_supply_temp ? (int16_t) lroundf(supply_c * 10.0f) : 0);
-              id(boiler_relay).turn_off();
-              id(oq_boiler_output_last_change_ms) = now_ms;
-            }
+            id(boiler_relay).turn_off();
+          }
+          if (!opentherm_selected) {
+            id(oq_boiler_transport_active) = id(boiler_relay).state;
           }

--- a/openquatt/oq_boiler_dispatch.yaml
+++ b/openquatt/oq_boiler_dispatch.yaml
@@ -3,9 +3,10 @@
 # ==============================================================================
 #
 # Owns the transport-neutral command contract consumed by `oq_boiler_control`.
-# During the foundation phase this adapter intentionally reproduces the existing
-# CM3 and CM100 relay demand. Later work packages replace the legacy CM3 command
-# with strategy-derived requested power and target temperature.
+# CM3 commands are derived from the active heating strategy. Power House asks
+# for the remaining thermal power after the selected heat-pump levels; Heating
+# Curve forwards its supply target. CM100 remains an explicit commissioning
+# command. The selected transport is not considered here.
 #
 # This package never writes R1 or OpenTherm outputs.
 # ==============================================================================
@@ -51,16 +52,83 @@ interval:
     startup_delay: 4500ms
     then:
       - lambda: |-
-          // Phase 1: adapt the existing CM3/CM100 ownership into the shared contract.
+          // Phase 1: derive one transport-neutral command from CM3 or CM100.
           const int cm_code = id(oq_control_mode_code);
+          const uint32_t now_ms = millis();
           const bool commissioning_boiler_task =
               id(oq_commissioning_task_code) == oq_commissioning::TASK_BOILER_POWER_TEST;
-          const auto command = oq_boiler::make_legacy_command(
-              cm_code,
-              id(oq_commissioning_active),
-              commissioning_boiler_task,
-              id(oq_commissioning_boiler_request),
-              millis());
+          const bool commissioning_task_active =
+              cm_code == 100 &&
+              id(oq_commissioning_active) &&
+              commissioning_boiler_task;
+
+          oq_boiler::BoilerCommand command{
+              true,
+              false,
+              false,
+              NAN,
+              NAN,
+              oq_boiler::COMMAND_SOURCE_NONE,
+              now_ms,
+          };
+
+          if (cm_code == 3) {
+            command.demand_present = true;
+            const int strategy_code = id(oq_strategy_active_code);
+            if (strategy_code == 3) {
+              command.source = oq_boiler::COMMAND_SOURCE_POWER_HOUSE;
+              const float strategy_requested_w = id(oq_strategy_requested_power_w);
+              const float hp_expected_w = id(oq_strategy_hp_expected_power_w);
+              const float rated_boiler_w = id(oq_boiler_rated_heat_power).state;
+              command.valid =
+                  !isnan(strategy_requested_w) &&
+                  !isnan(hp_expected_w) &&
+                  !isnan(rated_boiler_w) &&
+                  rated_boiler_w > 0.0f;
+
+              if (command.valid) {
+                float remaining_power_w = strategy_requested_w - hp_expected_w;
+                remaining_power_w = fmaxf(0.0f, fminf(remaining_power_w, rated_boiler_w));
+                command.heat_request =
+                    id(oq_strategy_heat_request_active) && remaining_power_w > 0.5f;
+                command.requested_power_w = remaining_power_w;
+
+                if (command.heat_request) {
+                  const float flow_lph = id(flow_rate_selected).state;
+                  const float inlet_c = id(${secondary_water_out_temp_id}).state;
+                  float maximum_c = id(max_water_temp_limit_c).state;
+                  if (isnan(maximum_c)) maximum_c = 60.0f;
+                  maximum_c = fmaxf(25.0f, fminf(maximum_c, 75.0f));
+                  if (!isnan(flow_lph) && flow_lph >= ${oq_cm_min_flow_lph}) {
+                    const auto target = oq_boiler::target_from_power(
+                        remaining_power_w,
+                        rated_boiler_w,
+                        inlet_c,
+                        flow_lph,
+                        ${oq_water_cp_j_per_kgk},
+                        maximum_c);
+                    if (target.valid) {
+                      command.requested_power_w = target.requested_power_w;
+                      command.target_temperature_c = target.target_temperature_c;
+                    }
+                  }
+                }
+              }
+            } else if (strategy_code == 2) {
+              command.source = oq_boiler::COMMAND_SOURCE_HEATING_CURVE;
+              command.heat_request = id(oq_strategy_heat_request_active);
+              command.requested_power_w = NAN;
+              command.target_temperature_c = id(oq_strategy_supply_target_temp);
+            } else {
+              command.valid = false;
+            }
+          } else if (commissioning_task_active) {
+            command.demand_present = true;
+            command.heat_request = id(oq_commissioning_boiler_request);
+            command.requested_power_w = id(oq_boiler_rated_heat_power).state;
+            command.target_temperature_c = id(max_water_temp_limit_c).state;
+            command.source = oq_boiler::COMMAND_SOURCE_COMMISSIONING;
+          }
 
           // Phase 2: publish atomically before the controller interval evaluates it.
           id(oq_boiler_command_valid) = command.valid;

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -1,14 +1,24 @@
 # ==============================================================================
-# OpenQuatt – OpenTherm Boiler (OTB) passive master and telemetry
+# OpenQuatt – OpenTherm Boiler (OTB) master, transport and telemetry
 # ==============================================================================
 #
-# Q-hardware-only OpenTherm master. This phase deliberately keeps CH disabled
-# and TSet at 0 °C while proving the physical link and collecting boiler data.
-# DHW permission remains enabled so attaching a combi boiler for passive testing
-# does not disable normal tap-water operation.
-#
-# Active BoilerCommand transport is added in the CM3 strategy phase.
+# Q-hardware-only OpenTherm master. CH follows only the centrally validated
+# BoilerCommand output request while this transport is selected. DHW permission
+# remains enabled so OpenQuatt does not disable normal tap-water operation.
 # ==============================================================================
+
+esphome:
+  on_shutdown:
+    priority: 700
+    then:
+      - lambda: |-
+          // Best-effort normal shutdown handshake. Hard power loss remains
+          // inherently fail-silent because no OpenTherm requests are sent.
+          id(oq_otb_ch_enable).turn_off();
+          auto call = id(oq_otb_t_set_command).make_call();
+          call.set_value(0.0f);
+          call.perform();
+          id(oq_boiler_transport_active) = false;
 
 globals:
   - id: oq_otb_last_response_ms
@@ -26,11 +36,6 @@ globals:
     restore_value: false
     initial_value: '-1'
 
-  - id: oq_otb_link_available_state
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
   - id: oq_otb_link_initialized
     type: bool
     restore_value: false
@@ -40,7 +45,9 @@ opentherm:
   - id: oq_otb_hub
     in_pin: ${oq_ot_boiler_in_pin}
     out_pin: ${oq_ot_boiler_out_pin}
-    ch_enable: false
+    # The runtime switch is default-off and owns the actual STATUS bit. The hub
+    # gate must be true or ESPHome would mask that switch permanently.
+    ch_enable: true
     dhw_enable: true
     cooling_enable: false
     otc_active: false
@@ -69,6 +76,17 @@ number:
       step: 0.1
       initial_value: 0
       restore_value: false
+
+switch:
+  - platform: opentherm
+    opentherm_id: oq_otb_hub
+    ch_enable:
+      id: oq_otb_ch_enable
+      name: "OTB - Central Heating Command"
+      internal: true
+      entity_category: diagnostic
+      restore_mode: ALWAYS_OFF
+      icon: mdi:radiator
 
 binary_sensor:
   - platform: template
@@ -278,6 +296,53 @@ sensor:
       return message_id >= 0 ? (float) message_id : NAN;
 
 interval:
+  - interval: ${oq_otb_command_apply_s}s
+    startup_delay: 3s
+    then:
+      - lambda: |-
+          // Apply only the central controller output. Selection, link and target
+          // checks are repeated here so a lost link cannot leave CH requested
+          // while waiting for the slower safety loop.
+          const bool opentherm_selected =
+              id(oq_boiler_connection).has_state() &&
+              id(oq_boiler_connection).current_option() == "OpenTherm";
+          const float target_c = id(oq_boiler_command_target_temperature_c);
+          const bool target_valid =
+              !isnan(target_c) && target_c > 0.0f && target_c <= 90.0f;
+          const float flow_lph = id(flow_rate_selected).state;
+          const bool flow_valid =
+              !isnan(flow_lph) && flow_lph >= ${oq_cm_min_flow_lph};
+          const bool command_active =
+              opentherm_selected &&
+              id(oq_otb_link_available_state) &&
+              id(oq_boiler_output_request) &&
+              target_valid &&
+              flow_valid;
+
+          if (command_active) {
+            if (!id(oq_otb_t_set_command).has_state() ||
+                fabsf(id(oq_otb_t_set_command).state - target_c) >= 0.05f) {
+              auto call = id(oq_otb_t_set_command).make_call();
+              call.set_value(target_c);
+              call.perform();
+            }
+            id(oq_otb_ch_enable).turn_on();
+          } else {
+            id(oq_otb_ch_enable).turn_off();
+            if (!id(oq_otb_t_set_command).has_state() ||
+                fabsf(id(oq_otb_t_set_command).state) >= 0.05f) {
+              auto call = id(oq_otb_t_set_command).make_call();
+              call.set_value(0.0f);
+              call.perform();
+            }
+          }
+
+          id(oq_boiler_transport_active) =
+              opentherm_selected &&
+              id(oq_otb_link_available_state) &&
+              id(otb_ch_active).has_state() &&
+              id(otb_ch_active).state;
+
   - interval: ${oq_otb_link_watch_s}s
     startup_delay: 2s
     then:
@@ -301,6 +366,10 @@ interval:
 
           // Phase 2: prevent stale operational values from looking current after link loss.
           if (available) return;
+          if (id(oq_boiler_connection).has_state() &&
+              id(oq_boiler_connection).current_option() == "OpenTherm") {
+            id(oq_boiler_transport_active) = false;
+          }
           id(otb_fault_indication).publish_state(false);
           id(otb_ch_active).publish_state(false);
           id(otb_dhw_active).publish_state(false);

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -930,6 +930,10 @@ interval:
             id(oq_strategy_requested_power_w) = NAN;
             id(oq_strategy_supply_target_temp) = id(oq_supply_target_temp).state;
             id(oq_strategy_heat_request_active) = id(oq_curve_heat_request_active);
+            id(oq_strategy_hp_expected_power_w) = NAN;
+            id(oq_strategy_hp_max_power_w) = NAN;
+            id(oq_strategy_hp_saturated) =
+                id(oq_curve_heat_request_active) && d_out >= demand_max;
 
             const int regime_code = id(oq_curve_regime_code);
             const char *phase_text =
@@ -969,7 +973,8 @@ interval:
               // Reset curve integral whenever curve mode is not in an active, heat-delivering state.
               if (id(oq_heat_mode_code) != 1) return false;
               if (id(oq_water_temp_hard_trip_active)) return true;
-              if (id(oq_control_mode_code) != 2) return true;
+              const int cm_code = id(oq_control_mode_code);
+              if (cm_code != 2 && cm_code != 3) return true;
               if (!id(oq_curve_heat_request_active)) return true;
               const float spw = id(oq_supply_target_temp).state;
               const float pv  = id(oq_system_supply_temp).state;

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -671,13 +671,18 @@ interval:
           int request_owner_hp = 0;
           int request_reason_code = 0;
 
-          #if OQ_TOPOLOGY_DUO
-          const float Pr = id(house_rated_power_w).state;
+          const float strategy_rated_power_w = id(house_rated_power_w).state;
           float P_req_total = id(oq_phouse_req_w);
-          float P_cap = NAN;
-          if (!isnan(Pr) && Pr > 0.0f) P_cap = (Pr * ((float) f / (float) demand_max_f));
-          if (!isnan(P_cap)) P_req_total = std::min(P_req_total, P_cap);
+          float strategy_power_cap_w = NAN;
+          if (!isnan(strategy_rated_power_w) && strategy_rated_power_w > 0.0f) {
+            strategy_power_cap_w =
+                strategy_rated_power_w * ((float) f / (float) demand_max_f);
+          }
+          if (!isnan(strategy_power_cap_w)) {
+            P_req_total = std::min(P_req_total, strategy_power_cap_w);
+          }
 
+          #if OQ_TOPOLOGY_DUO
           const float cap_total = publish_capacity_and_deficit(P_req_total);
           const bool perf_inputs_valid = !isnan(Tamb) && !isnan(Tsup) && level_cap > 0;
           if (!perf_inputs_valid) {
@@ -1045,12 +1050,6 @@ interval:
           }
           #else
           publish_optimizer_reason("single_topology");
-          const float Pr = id(house_rated_power_w).state;
-          float P_req_total = id(oq_phouse_req_w);
-          float P_cap = NAN;
-          if (!isnan(Pr) && Pr > 0.0f) P_cap = (Pr * ((float) f / (float) demand_max_f));
-          if (!isnan(P_cap)) P_req_total = std::min(P_req_total, P_cap);
-
           const float cap_total = publish_capacity_and_deficit(P_req_total);
           const bool perf_inputs_valid = !isnan(Tamb) && !isnan(Tsup) && level_cap > 0;
           if (!perf_inputs_valid) {
@@ -1103,10 +1102,30 @@ interval:
           id(oq_ph_request_owner_hp) = request_owner_hp;
           id(oq_ph_request_reason_code) = request_reason_code;
 
+          float hp_expected_power_w = 0.0f;
+          bool hp_expected_power_valid = !isnan(Tamb) && !isnan(Tsup);
+          if (hp_expected_power_valid && hp1_req > 0) {
+            const float hp1_expected_w =
+                oq_perf::interp_power_th_w(hp1_req, Tamb, Tsup) * hp1_th_fac;
+            if (isnan(hp1_expected_w)) hp_expected_power_valid = false;
+            else hp_expected_power_w += hp1_expected_w;
+          }
+          if (hp_expected_power_valid && hp2_req > 0) {
+            const float hp2_expected_w =
+                oq_perf::interp_power_th_w(hp2_req, Tamb, Tsup) * hp2_th_fac;
+            if (isnan(hp2_expected_w)) hp_expected_power_valid = false;
+            else hp_expected_power_w += hp2_expected_w;
+          }
+
           id(oq_strategy_phase_code) = (f > 0) ? 1 : 0;
-          id(oq_strategy_requested_power_w) = id(oq_phouse_req_w);
+          id(oq_strategy_requested_power_w) = P_req_total;
           id(oq_strategy_supply_target_temp) = NAN;
           id(oq_strategy_heat_request_active) = (f > 0);
+          id(oq_strategy_hp_expected_power_w) =
+              hp_expected_power_valid ? hp_expected_power_w : NAN;
+          id(oq_strategy_hp_max_power_w) = id(oq_P_hp_cap_w);
+          id(oq_strategy_hp_saturated) =
+              (f > 0) && !isnan(id(oq_P_deficit_w)) && id(oq_P_deficit_w) > 0.0f;
           id(oq_strategy_phase_text).publish_state((f > 0) ? "heat" : "idle");
 
           char debug_buf[160];

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -58,6 +58,21 @@ globals:
     restore_value: false
     initial_value: 'false'
 
+  - id: oq_strategy_hp_expected_power_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
+  - id: oq_strategy_hp_max_power_w
+    type: float
+    restore_value: false
+    initial_value: 'NAN'
+
+  - id: oq_strategy_hp_saturated
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
   - id: oq_strategy_water_limit_factor
     type: float
     restore_value: false
@@ -97,6 +112,9 @@ select:
             id(oq_strategy_requested_power_w) = NAN;
             id(oq_strategy_supply_target_temp) = NAN;
             id(oq_strategy_heat_request_active) = false;
+            id(oq_strategy_hp_expected_power_w) = NAN;
+            id(oq_strategy_hp_max_power_w) = NAN;
+            id(oq_strategy_hp_saturated) = false;
             oq_curve::reset_control_state(
               id(oq_curve_demand_continuous),
               id(oq_demand_curve),

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -136,6 +136,8 @@ oq_cm3_promote_s: "300"                               # Required deficit duratio
 oq_cm3_demote_s: "120"                                # Required low-deficit duration for CM3 -> CM2 demotion [s].
 oq_cm3_min_run_s: "300"                               # Minimum dwell time in CM3 before demotion [s].
 oq_cm2_min_run_s: "120"                               # Minimum dwell time in CM2 before promotion [s].
+oq_cm3_curve_on_delta_c: "3.0"                        # Heating Curve target-minus-supply margin for CM2 -> CM3 [°C].
+oq_cm3_curve_off_delta_c: "1.0"                       # Heating Curve target-minus-supply margin for CM3 -> CM2 [°C].
 oq_cm0_sticky_wait_s: "86400"                         # Wait time in CM0 before sticky-pump run starts [s].
 oq_cm0_sticky_run_s: "60"                             # Duration of sticky-pump run in CM0 [s].
 oq_cm0_pump_stop_ipwm: "1000.0"                       # iPWM setpoint that forces pump off in CM0.
@@ -209,6 +211,10 @@ oq_boiler_loop_s: "5"                                 # Main interval for boiler
 oq_boiler_command_max_age_s: "15"                     # Fail-safe maximum age of the transport-neutral boiler command [s].
 oq_boiler_relay_min_on_s: "0"                         # R1 minimum on-time [s]; zero preserves existing relay behavior in foundation phase.
 oq_boiler_relay_min_off_s: "0"                        # R1 minimum off-time [s]; zero preserves existing relay behavior in foundation phase.
+oq_boiler_otb_min_on_s: "30"                          # OpenTherm minimum requested on-time [s]; safety trips override it.
+oq_boiler_otb_min_off_s: "120"                        # OpenTherm minimum requested off-time [s].
+oq_otb_supported: "false"                             # Compile-time availability of the boiler OpenTherm master transport.
+oq_otb_command_apply_s: "1"                           # Apply validated CH/TSet state to the OpenTherm master [s].
 
 # ----------------------------
 # OPEN THERM SLAVE

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -1363,6 +1363,8 @@ interval:
                       if (id(oq_cm3_need_since_ms) == 0) id(oq_cm3_need_since_ms) = now_ms;
                       if (now_ms - id(oq_cm3_need_since_ms) >= T_ON_MS) {
                         desired_local = 3;
+                        id(oq_cm3_need_since_ms) = 0;
+                        id(oq_cm3_demote_since_ms) = 0;
                         cm_transition_reason = promote_reason;
                       }
                     } else {
@@ -1370,16 +1372,30 @@ interval:
                     }
                   }
                 } else if (cm_now == 3) {
-                  if (now_ms - id(oq_cm_last_change_ms) >= MIN_CM3_MS) {
+                  const bool minimum_run_elapsed =
+                      now_ms - id(oq_cm_last_change_ms) >= MIN_CM3_MS;
+                  bool demote_confirmation_elapsed = false;
+                  if (minimum_run_elapsed) {
                     if (ok_off) {
                       if (id(oq_cm3_demote_since_ms) == 0) id(oq_cm3_demote_since_ms) = now_ms;
-                      if (now_ms - id(oq_cm3_demote_since_ms) >= T_OFF_MS) {
-                        desired_local = 2;
-                        cm_transition_reason = demote_reason;
-                      }
+                      demote_confirmation_elapsed =
+                          now_ms - id(oq_cm3_demote_since_ms) >= T_OFF_MS;
                     } else {
                       id(oq_cm3_demote_since_ms) = 0;
                     }
+                  } else {
+                    id(oq_cm3_demote_since_ms) = 0;
+                  }
+                  if (oq_boiler::cm3_should_hold(
+                          minimum_run_elapsed,
+                          ok_off,
+                          demote_confirmation_elapsed)) {
+                    desired_local = 3;
+                  } else {
+                    desired_local = 2;
+                    id(oq_cm3_need_since_ms) = 0;
+                    id(oq_cm3_demote_since_ms) = 0;
+                    cm_transition_reason = demote_reason;
                   }
                 } else {
                   id(oq_cm3_need_since_ms) = 0;

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -753,6 +753,7 @@ interval:
               id(cooling_permitted_core).has_state() && id(cooling_permitted_core).state;
           const bool cooling_req = cooling_req_raw && openquatt_enabled;
           const bool power_house_active = (strategy_active_code == 3);
+          const bool heating_curve_active = (strategy_active_code == 2);
 
           const int hp1_lvl = id(hp1_last_applied_level);
           const int hp1_cmd_lvl =
@@ -1305,8 +1306,8 @@ interval:
                     desired_local = 1;
                   }
 
-              // CM3 (boiler assist) is a Power House-only feature and only applies
-              // when the installation has explicit boiler/CV assist enabled.
+              // CM3 is the sole boiler-assist owner for both heating strategies.
+              // Transport selection affects availability, never strategy intent.
               const int cm_now =
                   (strcmp(cur_cm, "CM3") == 0) ? 3 :
                   (strcmp(cur_cm, "CM2") == 0) ? 2 :
@@ -1314,14 +1315,43 @@ interval:
                   (strcmp(cur_cm, "CM1") == 0) ? 1 :
                   (strcmp(cur_cm, "CM98") == 0) ? 98 : 0;
               const bool boiler_assist_enabled = id(oq_boiler_assist_enabled).state;
-              if (power_house_active && boiler_assist_enabled) {
-                // CM3 (boiler assist) auto-switching
-                // Promote/Demote: deficit-based (thermal deficit) + timers/hysteresis
-                const float deficit_w = id(oq_P_deficit_w);
-                const float on_th = id(oq_cm3_deficit_on_w).state;
-                const float off_th = id(oq_cm3_deficit_off_w).state;
-                const bool need_on = (!isnan(deficit_w) && deficit_w >= on_th);
-                const bool ok_off  = (isnan(deficit_w) || deficit_w <= off_th);
+              const bool opentherm_selected =
+                  id(oq_boiler_connection).has_state() &&
+                  id(oq_boiler_connection).current_option() == "OpenTherm";
+              const bool boiler_transport_available =
+                  !opentherm_selected ||
+                  (${oq_otb_supported} && id(oq_otb_link_available_state));
+              const bool boiler_assist_available =
+                  boiler_assist_enabled && boiler_transport_available;
+              if (heating_strategy_active && boiler_assist_available) {
+                bool need_on = false;
+                bool ok_off = true;
+                const char *promote_reason = "boiler assist promoted to CM3";
+                const char *demote_reason = "boiler assist cleared, demoting to CM2";
+
+                if (power_house_active) {
+                  const auto assist = oq_boiler::power_house_assist(
+                      id(oq_P_deficit_w),
+                      id(oq_cm3_deficit_on_w).state,
+                      id(oq_cm3_deficit_off_w).state);
+                  need_on = assist.need_on;
+                  ok_off = assist.okay_off;
+                  promote_reason = "power-house deficit promoted to CM3";
+                  demote_reason = "power-house deficit cleared, demoting to CM2";
+                } else if (heating_curve_active) {
+                  const auto assist = oq_boiler::heating_curve_assist(
+                      heating_req,
+                      id(oq_strategy_hp_saturated),
+                      id(oq_strategy_supply_target_temp),
+                      id(oq_system_supply_temp).state,
+                      ${oq_cm3_curve_on_delta_c},
+                      ${oq_cm3_curve_off_delta_c});
+                  need_on = assist.need_on;
+                  ok_off = assist.okay_off;
+                  promote_reason = "heating-curve saturation promoted to CM3";
+                  demote_reason = "heating-curve target recovered, demoting to CM2";
+                }
+
                 const uint32_t T_ON_MS = (uint32_t)(${oq_cm3_promote_s}UL * 1000UL);
                 const uint32_t T_OFF_MS = (uint32_t)(${oq_cm3_demote_s}UL * 1000UL);
                 const uint32_t MIN_CM3_MS = (uint32_t)(${oq_cm3_min_run_s}UL * 1000UL);
@@ -1333,7 +1363,7 @@ interval:
                       if (id(oq_cm3_need_since_ms) == 0) id(oq_cm3_need_since_ms) = now_ms;
                       if (now_ms - id(oq_cm3_need_since_ms) >= T_ON_MS) {
                         desired_local = 3;
-                        cm_transition_reason = "power-house deficit promoted to CM3";
+                        cm_transition_reason = promote_reason;
                       }
                     } else {
                       id(oq_cm3_need_since_ms) = 0;
@@ -1345,7 +1375,7 @@ interval:
                       if (id(oq_cm3_demote_since_ms) == 0) id(oq_cm3_demote_since_ms) = now_ms;
                       if (now_ms - id(oq_cm3_demote_since_ms) >= T_OFF_MS) {
                         desired_local = 2;
-                        cm_transition_reason = "power-house deficit cleared, demoting to CM2";
+                        cm_transition_reason = demote_reason;
                       }
                     } else {
                       id(oq_cm3_demote_since_ms) = 0;
@@ -1360,9 +1390,13 @@ interval:
                 id(oq_cm3_demote_since_ms) = 0;
                 if (cm_now == 3 && heating_req && base_target == 2) {
                   desired_local = 2;
-                  cm_transition_reason = boiler_assist_enabled
-                      ? "Power House assist disabled, returning to CM2"
-                      : "boiler/CV assist disabled, returning to CM2";
+                  if (!boiler_assist_enabled) {
+                    cm_transition_reason = "boiler/CV assist disabled, returning to CM2";
+                  } else if (!boiler_transport_available) {
+                    cm_transition_reason = "selected boiler transport unavailable, returning to CM2";
+                  } else {
+                    cm_transition_reason = "heating strategy unavailable for boiler assist, returning to CM2";
+                  }
                 }
               }
               }

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -4,6 +4,7 @@
 substitutions:
   oq_hardware_profile: "heatpump_controller_q"         # Compile-time hardware profile id.
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1" # Enable Q-only local sensor paths.
+  oq_otb_supported: "true"                             # GPIO47/GPIO48 provide the boiler OpenTherm master transport.
   oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000" # Q-edition local PT1000 source.
   oq_local_supply_temp_selector_id: "oq_local_supply_temp_source" # Explicit local physical-sensor selection.
   oq_controller_flow_sensor_id: "flow_rate_controller" # Use the controller pulse meter for V1 flow.

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -57,6 +57,7 @@ packages:
 openquatt_usage_telemetry:
   cic_compatibility_switch: cic_compatibility_enable
   ot_thermostat_switch: oq_ot_slave_enabled
+  boiler_connection_select: oq_boiler_connection
 
 psram:
   mode: octal


### PR DESCRIPTION
# Wat verandert deze PR?

- Koppelt Power House en Heating Curve binnen CM3 aan één transportneutraal ketelcommando.
- Berekent OTB-`TSet` uit strategyvermogen/-doel, geldige flow en watermetingen.
- Maakt R1 en OpenTherm wederzijds exclusief; R1 blijft de migratiestandaard.
- Koppelt `oq_boiler_connection` aan usage telemetry via `boiler_connection_select`.
- Houdt CM3 expliciet vast gedurende de minimumlooptijd en demotiebevestiging en wist overgangstimers bij promotie/demotie.

## Type

- [x] Bugfix
- [x] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Power House stuurt het resterende thermische vermogen; Heating Curve stuurt het geldige aanvoerdoel. CM3 blijft de enige boiler-assist-owner. CM4/boiler-only is bewust uitgesteld.

Een actieve Heating Curve-HIL liet zien dat CM2 correct naar CM3 promoveerde, maar CM3 in de volgende supervisory-cyclus onmiddellijk terugviel naar CM2. De CM3-branch kiest nu gedurende minimumlooptijd en demotiebevestiging expliciet opnieuw CM3; oude promotie- en demotietimers kunnen een volgende cyclus niet meer overslaan.

De herhaal-HIL en de aansluitende Power House-HIL bereikten beide via hun echte strategybron CM3 en hielden die ruim vijf minuten onafgebroken vast. Heating Curve leverde exact 38,0 °C. Power House moduleerde het hydraulisch afgeleide doel rond 42,3–42,5 °C; de simulator volgde binnen circa 0,02 °C.

## Achtergrond

Gestapeld op #348. Mergevolgorde: **#347 → #348 → #349 → #350 → #351 → #363 → #375 → #376 → #377**. Safety-rearm en lifecycle-hardening volgen direct in #351 en moeten vóór HIL/release mee.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Gebruikersdocumentatie volgt na safety-hardening en fysieke HIL-validatie.

## Audit

De complete diff tegen #348 is gecontroleerd op strategy-eigenaarschap, CM2/CM3-overgangen, overgangstimers, millis-wrap, ongeldige targets/flow, transportbeschikbaarheid, R1/OTB-exclusiviteit, shutdown, commissioning en telemetryprivacy. De lifecyclecorrectie is bovendien vergeleken met de eerder geteste top-stack: alleen de CM3-helper, supervisory-overgang en regressietest zijn toegevoegd.

Het telemetry-contract uit #354/#359 blijft gevolgd: R1 publiceert `on_off`, OpenTherm publiceert `opentherm`, en alleen installatie/configuratie wordt toegevoegd. Linkstatus, ketelvraag, vlam, modulatie, temperaturen en foutcodes gaan niet naar usage telemetry.

## Validatie

- `git diff --check codex/ot-boiler-opentherm..HEAD`
- `python3 scripts/dev.py validate --config-only --venv-dir /Users/jeroen/Downloads/Codex_projecten/OpenQuatt/.venv --config configs/heatpump_controller_q/duo_wifi.yaml`
- Op de opnieuw gestapelde top: `./scripts/run_host_regression_tests.sh` — 5/5 groen.
- Op de opnieuw gestapelde top: volledige Q Duo-configvalidatie en firmwarecompile groen.
- Heating Curve-HIL: na de normale timers CM3, ruim vijf minuten actief, exact `CH Enable=ON`/`TSet=38,0 °C`, R1 uit, `+4.260` simulatorrequests en geen master- of simulatorfouttellerstijging.
- Power House-HIL: met echte OT-kamerbron en tijdelijk begrensde normale `Day max level` ontstond een aantoonbaar HP-tekort. Na de normale bevestigingshold bleef CM3 ruim vijf minuten actief; target circa 42,3–42,5 °C, simulatorafwijking circa 0,02 °C, R1 uit, `+1.539` complete responses en geen steady-state master- of simulatorfouttellerstijging.
- Alle tijdelijke instellingen zijn hersteld: `Power House`, `Day max level=10`, kamer-setpoint 20,0 °C, `R1`, assist aan; eindstatus CM0, relay/command/CH uit en `TSet=0`.
