### PR TITLE
Reduce repeated PT1000 fault logs

### DIFF
--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -105,7 +105,8 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
-    update_interval: 5s
+    # Poll explicitly below so an unused or disconnected probe cannot flood logs.
+    update_interval: never
     spi_id: oq_hpcq_pt1000_spi
     cs_pin: ${hpcq_pt1000_cs_pin}
     reference_resistance: ${hpcq_pt1000_reference_resistance_ohm}
@@ -149,3 +150,56 @@ sensor:
       - throttle_average: 10s
     web_server:
       sorting_group_id: oq_hydraulics
+
+interval:
+  - interval: 5s
+    startup_delay: 1s
+    then:
+      - lambda: |-
+          static bool read_attempted = false;
+          static bool repeated_fault_logs_suppressed = false;
+          static bool max31865_log_level_managed = false;
+          // Only touch the MAX31865 while its PT1000 is the active source.
+          const bool pt1000_selected =
+              id(water_supply_source).has_state() &&
+              id(oq_local_supply_temp_source).has_state() &&
+              id(water_supply_source).current_option() == "Local" &&
+              id(oq_local_supply_temp_source).current_option() == "PT1000";
+
+          if (!pt1000_selected) {
+            read_attempted = false;
+            if (id(water_supply_temp_pt1000).has_state() &&
+                !isnan(id(water_supply_temp_pt1000).state)) {
+              id(water_supply_temp_pt1000).publish_state(NAN);
+            }
+            id(water_supply_temp_pt1000).status_clear_warning();
+            id(water_supply_temp_pt1000).status_clear_error();
+            if (max31865_log_level_managed &&
+                esphome::logger::global_logger != nullptr) {
+              esphome::logger::global_logger->set_log_level(
+                  "max31865", esphome::logger::global_logger->get_log_level());
+              repeated_fault_logs_suppressed = false;
+            }
+            return;
+          }
+
+          const bool reading_valid =
+              id(water_supply_temp_pt1000).has_state() &&
+              !isnan(id(water_supply_temp_pt1000).state);
+          // Log the first failed read, then keep retrying silently until recovery.
+          if (read_attempted && !reading_valid &&
+              !repeated_fault_logs_suppressed &&
+              esphome::logger::global_logger != nullptr) {
+            esphome::logger::global_logger->set_log_level(
+                "max31865", ESPHOME_LOG_LEVEL_NONE);
+            repeated_fault_logs_suppressed = true;
+            max31865_log_level_managed = true;
+          } else if (reading_valid && max31865_log_level_managed &&
+                     esphome::logger::global_logger != nullptr) {
+            esphome::logger::global_logger->set_log_level(
+                "max31865", esphome::logger::global_logger->get_log_level());
+            repeated_fault_logs_suppressed = false;
+          }
+
+          read_attempted = true;
+          id(water_supply_temp_pt1000).update();

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -177,6 +177,7 @@ STRICT_TOP_LEVEL_ORDER_RULES = {
         "select",
         "spi",
         "sensor",
+        "interval",
     ),
 }
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Leest de MAX31865 alleen uit wanneer `Local` en `PT1000` daadwerkelijk als aanvoertemperatuurbron zijn geselecteerd.
- Logt de eerste mislukte PT1000-uitlezing, onderdrukt daarna herhaalde identieke MAX31865-meldingen en blijft elke 5 seconden op herstel controleren.
- Herstelt de MAX31865-tag naar het actuele globale logniveau zodra de sensor herstelt of niet meer geselecteerd is.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De actieve PT1000 blijft elke 5 seconden meten en een leesfout blijft via `PT1000 read problem` en de rode status-LED zichtbaar. Een niet-geselecteerde PT1000 wordt niet meer uitgelezen en de ruwe sensorstatus wordt veilig op `NAN` gezet. Na een fout blijft herdetectie op 5 seconden staan, zodat herstel niet wordt vertraagd.

## Achtergrond

De MAX31865 had een vaste `update_interval: 5s`. Daardoor bleef de driver bij een ontbrekende PT1000 iedere vijf seconden meerdere foutregels produceren, ook wanneer een andere temperatuurbron actief was.

De volledige diff tegen `dev` is gecontroleerd op bronwissels, opstart/herstart, fout- en herstelgedrag, status-LED-afhandeling en wijzigingen van het runtime-logniveau. Tijdens deze audit is de loggerrestore aangepast zodat een beheerde MAX31865-tag het actuele globale logniveau blijft volgen.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Er wijzigen geen instellingen, entiteiten of installatiehandelingen; dit is interne fout- en logafhandeling.

## Validatie

- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/single_wifi.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_eth.yaml`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_eth.yaml`
- `git diff --check`
