### PR TITLE
Harden OpenTherm boiler telemetry and diagnostics

### DIFF
--- a/openquatt/includes/boiler/oq_otb_telemetry.h
+++ b/openquatt/includes/boiler/oq_otb_telemetry.h
@@ -86,6 +86,17 @@ class TelemetryState {
     return state.valid && (uint32_t) (now_ms - state.last_valid_ms) <= max_age_ms;
   }
 
+  bool response_payload_is_usable(uint8_t message_id, uint8_t message_type) const {
+    // Every field tracked by this helper is requested as READ_DATA. A
+    // syntactically valid WRITE_ACK for such an ID must not reach ESPHome's
+    // payload processors as if it were a valid measurement.
+    if (field_index_for_message_id(message_id) >= 0) {
+      return message_type == MESSAGE_TYPE_READ_ACK;
+    }
+    return message_type == MESSAGE_TYPE_READ_ACK ||
+           message_type == MESSAGE_TYPE_WRITE_ACK;
+  }
+
   bool transport_is_available(
       uint32_t now_ms, uint32_t response_max_age_ms,
       uint32_t status_max_age_ms) const {

--- a/openquatt/includes/boiler/oq_otb_telemetry.h
+++ b/openquatt/includes/boiler/oq_otb_telemetry.h
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+namespace oq_otb {
+
+// OpenTherm message types used by the ESPHome master component.
+constexpr uint8_t MESSAGE_TYPE_INVALID_DATA = 2;
+constexpr uint8_t MESSAGE_TYPE_READ_ACK = 4;
+constexpr uint8_t MESSAGE_TYPE_WRITE_ACK = 5;
+constexpr uint8_t MESSAGE_TYPE_DATA_INVALID = 6;
+constexpr uint8_t MESSAGE_TYPE_UNKNOWN_DATA_ID = 7;
+
+enum Field : uint8_t {
+  FIELD_STATUS = 0,
+  FIELD_DEVICE_CONFIG,
+  FIELD_FAULT_FLAGS,
+  FIELD_MAX_BOILER_CAPACITY,
+  FIELD_RELATIVE_MODULATION,
+  FIELD_CH_WATER_PRESSURE,
+  FIELD_BOILER_WATER_TEMPERATURE,
+  FIELD_DHW_TEMPERATURE,
+  FIELD_RETURN_WATER_TEMPERATURE,
+  FIELD_OEM_DIAGNOSTIC,
+  FIELD_OT_VERSION_DEVICE,
+  FIELD_VERSION_DEVICE,
+  FIELD_COUNT,
+};
+
+enum TransportError : uint8_t {
+  TRANSPORT_ERROR_NONE = 0,
+  TRANSPORT_ERROR_NO_TRANSITION,
+  TRANSPORT_ERROR_INVALID_STOP_BIT,
+  TRANSPORT_ERROR_PARITY,
+  TRANSPORT_ERROR_NO_CHANGE_TOO_LONG,
+  TRANSPORT_ERROR_RESPONSE_TIMEOUT,
+  TRANSPORT_ERROR_HUB_SEND_TIMEOUT,
+  TRANSPORT_ERROR_HUB_RECEIVE_TIMEOUT,
+  TRANSPORT_ERROR_TIMER,
+};
+
+struct FieldState {
+  uint32_t last_valid_ms{0};
+  bool valid{false};
+};
+
+class TelemetryState {
+ public:
+  void record_response(uint32_t now_ms, uint8_t message_id, uint8_t message_type) {
+    this->last_response_ms_ = now_ms;
+    this->last_response_id_ = message_id;
+    this->last_response_type_ = message_type;
+    this->accepted_response_count_++;
+
+    const bool acknowledged =
+        message_type == MESSAGE_TYPE_READ_ACK || message_type == MESSAGE_TYPE_WRITE_ACK;
+    if (acknowledged) {
+      this->acknowledged_response_count_++;
+    } else if (message_type == MESSAGE_TYPE_DATA_INVALID) {
+      this->data_invalid_response_count_++;
+    } else if (message_type == MESSAGE_TYPE_UNKNOWN_DATA_ID) {
+      this->unknown_data_id_response_count_++;
+    } else {
+      this->unexpected_response_type_count_++;
+    }
+
+    const int field_index = field_index_for_message_id(message_id);
+    if (field_index < 0) return;
+
+    auto &field = this->fields_[field_index];
+    // All tracked telemetry messages are read requests. A WRITE_ACK for one of
+    // them is therefore not a valid sample, even though it is a valid frame.
+    if (message_type == MESSAGE_TYPE_READ_ACK) {
+      field.last_valid_ms = now_ms;
+      field.valid = true;
+    } else {
+      field.valid = false;
+    }
+  }
+
+  bool field_is_valid(Field field) const { return this->fields_[field].valid; }
+
+  bool field_is_fresh(Field field, uint32_t now_ms, uint32_t max_age_ms) const {
+    const auto &state = this->fields_[field];
+    return state.valid && (uint32_t) (now_ms - state.last_valid_ms) <= max_age_ms;
+  }
+
+  bool transport_is_available(
+      uint32_t now_ms, uint32_t response_max_age_ms,
+      uint32_t status_max_age_ms) const {
+    return this->accepted_response_count_ != 0 &&
+           (uint32_t) (now_ms - this->last_response_ms_) <= response_max_age_ms &&
+           this->field_is_fresh(FIELD_STATUS, now_ms, status_max_age_ms);
+  }
+
+  void record_log_message(uint32_t now_ms, const char *tag, const char *message) {
+    if (tag == nullptr || message == nullptr || strcmp(tag, "opentherm") != 0) return;
+
+    TransportError error = TRANSPORT_ERROR_NONE;
+    if (strstr(message, "NO_TRANSITION") != nullptr) {
+      error = TRANSPORT_ERROR_NO_TRANSITION;
+      this->no_transition_count_++;
+      this->protocol_error_count_++;
+    } else if (strstr(message, "INVALID_STOP_BIT") != nullptr) {
+      error = TRANSPORT_ERROR_INVALID_STOP_BIT;
+      this->invalid_stop_bit_count_++;
+      this->protocol_error_count_++;
+    } else if (strstr(message, "PARITY_ERROR") != nullptr) {
+      error = TRANSPORT_ERROR_PARITY;
+      this->parity_error_count_++;
+      this->protocol_error_count_++;
+    } else if (strstr(message, "NO_CHANGE_TOO_LONG") != nullptr) {
+      error = TRANSPORT_ERROR_NO_CHANGE_TOO_LONG;
+      this->no_change_too_long_count_++;
+      this->protocol_error_count_++;
+    } else if (strstr(message, "Timeout while waiting for response from device") != nullptr) {
+      error = TRANSPORT_ERROR_RESPONSE_TIMEOUT;
+      this->response_timeout_count_++;
+    } else if (strstr(message, "Hub timeout triggered during send") != nullptr) {
+      error = TRANSPORT_ERROR_HUB_SEND_TIMEOUT;
+      this->hub_send_timeout_count_++;
+    } else if (strstr(message, "Hub timeout triggered during receive") != nullptr) {
+      error = TRANSPORT_ERROR_HUB_RECEIVE_TIMEOUT;
+      this->hub_receive_timeout_count_++;
+    } else if (strstr(message, "Error occured while manipulating timer") != nullptr) {
+      error = TRANSPORT_ERROR_TIMER;
+      this->timer_error_count_++;
+    }
+
+    if (error == TRANSPORT_ERROR_NONE) return;
+    this->transport_error_count_++;
+    this->last_transport_error_ = error;
+    this->last_transport_error_ms_ = now_ms;
+  }
+
+  uint32_t last_response_ms() const { return this->last_response_ms_; }
+  int last_response_id() const { return this->last_response_id_; }
+  int last_response_type() const { return this->last_response_type_; }
+  uint32_t accepted_response_count() const { return this->accepted_response_count_; }
+  uint32_t acknowledged_response_count() const { return this->acknowledged_response_count_; }
+  uint32_t data_invalid_response_count() const { return this->data_invalid_response_count_; }
+  uint32_t unknown_data_id_response_count() const { return this->unknown_data_id_response_count_; }
+  uint32_t unexpected_response_type_count() const { return this->unexpected_response_type_count_; }
+
+  uint32_t transport_error_count() const { return this->transport_error_count_; }
+  uint32_t protocol_error_count() const { return this->protocol_error_count_; }
+  uint32_t response_timeout_count() const { return this->response_timeout_count_; }
+  uint32_t no_transition_count() const { return this->no_transition_count_; }
+  uint32_t invalid_stop_bit_count() const { return this->invalid_stop_bit_count_; }
+  uint32_t parity_error_count() const { return this->parity_error_count_; }
+  uint32_t no_change_too_long_count() const { return this->no_change_too_long_count_; }
+  uint32_t hub_send_timeout_count() const { return this->hub_send_timeout_count_; }
+  uint32_t hub_receive_timeout_count() const { return this->hub_receive_timeout_count_; }
+  uint32_t timer_error_count() const { return this->timer_error_count_; }
+  uint32_t last_transport_error_ms() const { return this->last_transport_error_ms_; }
+  TransportError last_transport_error() const { return this->last_transport_error_; }
+
+  const char *last_response_type_name() const {
+    switch (this->last_response_type_) {
+      case MESSAGE_TYPE_READ_ACK:
+        return "READ_ACK";
+      case MESSAGE_TYPE_WRITE_ACK:
+        return "WRITE_ACK";
+      case MESSAGE_TYPE_INVALID_DATA:
+        return "INVALID_DATA";
+      case MESSAGE_TYPE_DATA_INVALID:
+        return "DATA_INVALID";
+      case MESSAGE_TYPE_UNKNOWN_DATA_ID:
+        return "UNKNOWN_DATAID";
+      default:
+        return this->last_response_type_ < 0 ? "Never" : "Unexpected";
+    }
+  }
+
+  const char *last_transport_error_name() const {
+    switch (this->last_transport_error_) {
+      case TRANSPORT_ERROR_NO_TRANSITION:
+        return "NO_TRANSITION";
+      case TRANSPORT_ERROR_INVALID_STOP_BIT:
+        return "INVALID_STOP_BIT";
+      case TRANSPORT_ERROR_PARITY:
+        return "PARITY_ERROR";
+      case TRANSPORT_ERROR_NO_CHANGE_TOO_LONG:
+        return "NO_CHANGE_TOO_LONG";
+      case TRANSPORT_ERROR_RESPONSE_TIMEOUT:
+        return "RESPONSE_TIMEOUT";
+      case TRANSPORT_ERROR_HUB_SEND_TIMEOUT:
+        return "HUB_SEND_TIMEOUT";
+      case TRANSPORT_ERROR_HUB_RECEIVE_TIMEOUT:
+        return "HUB_RECEIVE_TIMEOUT";
+      case TRANSPORT_ERROR_TIMER:
+        return "TIMER_ERROR";
+      default:
+        return "None";
+    }
+  }
+
+ private:
+  static int field_index_for_message_id(uint8_t message_id) {
+    switch (message_id) {
+      case 0:
+        return FIELD_STATUS;
+      case 3:
+        return FIELD_DEVICE_CONFIG;
+      case 5:
+        return FIELD_FAULT_FLAGS;
+      case 15:
+        return FIELD_MAX_BOILER_CAPACITY;
+      case 17:
+        return FIELD_RELATIVE_MODULATION;
+      case 18:
+        return FIELD_CH_WATER_PRESSURE;
+      case 25:
+        return FIELD_BOILER_WATER_TEMPERATURE;
+      case 26:
+        return FIELD_DHW_TEMPERATURE;
+      case 28:
+        return FIELD_RETURN_WATER_TEMPERATURE;
+      case 115:
+        return FIELD_OEM_DIAGNOSTIC;
+      case 125:
+        return FIELD_OT_VERSION_DEVICE;
+      case 127:
+        return FIELD_VERSION_DEVICE;
+      default:
+        return -1;
+    }
+  }
+
+  FieldState fields_[FIELD_COUNT]{};
+
+  uint32_t last_response_ms_{0};
+  int last_response_id_{-1};
+  int last_response_type_{-1};
+  uint32_t accepted_response_count_{0};
+  uint32_t acknowledged_response_count_{0};
+  uint32_t data_invalid_response_count_{0};
+  uint32_t unknown_data_id_response_count_{0};
+  uint32_t unexpected_response_type_count_{0};
+
+  uint32_t transport_error_count_{0};
+  uint32_t protocol_error_count_{0};
+  uint32_t response_timeout_count_{0};
+  uint32_t no_transition_count_{0};
+  uint32_t invalid_stop_bit_count_{0};
+  uint32_t parity_error_count_{0};
+  uint32_t no_change_too_long_count_{0};
+  uint32_t hub_send_timeout_count_{0};
+  uint32_t hub_receive_timeout_count_{0};
+  uint32_t timer_error_count_{0};
+  uint32_t last_transport_error_ms_{0};
+  TransportError last_transport_error_{TRANSPORT_ERROR_NONE};
+};
+
+inline TelemetryState telemetry_state{};
+
+}  // namespace oq_otb

--- a/openquatt/includes/boiler/oq_otb_telemetry.h
+++ b/openquatt/includes/boiler/oq_otb_telemetry.h
@@ -47,7 +47,18 @@ struct FieldState {
 
 class TelemetryState {
  public:
+  void reset_link_session() {
+    this->session_has_response_ = false;
+    this->last_response_ms_ = 0;
+    this->last_response_id_ = -1;
+    this->last_response_type_ = -1;
+    for (auto &field : this->fields_) {
+      field = {};
+    }
+  }
+
   void record_response(uint32_t now_ms, uint8_t message_id, uint8_t message_type) {
+    this->session_has_response_ = true;
     this->last_response_ms_ = now_ms;
     this->last_response_id_ = message_id;
     this->last_response_type_ = message_type;
@@ -100,7 +111,7 @@ class TelemetryState {
   bool transport_is_available(
       uint32_t now_ms, uint32_t response_max_age_ms,
       uint32_t status_max_age_ms) const {
-    return this->accepted_response_count_ != 0 &&
+    return this->session_has_response_ &&
            (uint32_t) (now_ms - this->last_response_ms_) <= response_max_age_ms &&
            this->field_is_fresh(FIELD_STATUS, now_ms, status_max_age_ms);
   }
@@ -146,6 +157,7 @@ class TelemetryState {
   }
 
   uint32_t last_response_ms() const { return this->last_response_ms_; }
+  bool session_has_response() const { return this->session_has_response_; }
   int last_response_id() const { return this->last_response_id_; }
   int last_response_type() const { return this->last_response_type_; }
   uint32_t accepted_response_count() const { return this->accepted_response_count_; }
@@ -241,6 +253,7 @@ class TelemetryState {
 
   FieldState fields_[FIELD_COUNT]{};
 
+  bool session_has_response_{false};
   uint32_t last_response_ms_{0};
   int last_response_id_{-1};
   int last_response_type_{-1};

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -152,6 +152,7 @@ select:
             id(oq_boiler_transport_active) = false;
             id(boiler_relay).turn_off();
             ${oq_boiler_transport_shutdown_extra}
+            ${oq_boiler_transport_selection_extra}
 
 # ----------------------------
 # R1 OUTPUT

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -20,22 +20,15 @@ esphome:
           call.perform();
           id(oq_boiler_transport_active) = false;
 
+logger:
+  on_message:
+    level: WARN
+    then:
+      - lambda: |-
+          oq_otb::telemetry_state.record_log_message(
+              millis(), tag, message);
+
 globals:
-  - id: oq_otb_last_response_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_otb_response_count
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_otb_last_response_id
-    type: int
-    restore_value: false
-    initial_value: '-1'
-
   - id: oq_otb_link_initialized
     type: bool
     restore_value: false
@@ -45,6 +38,10 @@ opentherm:
   - id: oq_otb_hub
     in_pin: ${oq_ot_boiler_in_pin}
     out_pin: ${oq_ot_boiler_out_pin}
+    # Q-duo HIL: synchronous request handling eliminated simulator-side RX
+    # decode failures and master response timeouts. It does increase the
+    # observed main-loop duration; real-boiler timing remains a release gate.
+    sync_mode: true
     # The runtime switch is default-off and owns the actual STATUS bit. The hub
     # gate must be true or ESPHome would mask that switch permanently.
     ch_enable: true
@@ -57,10 +54,74 @@ opentherm:
     before_process_response:
       then:
         - lambda: |-
-            // Called only after the hub accepted a complete OpenTherm response.
-            id(oq_otb_last_response_ms) = millis();
-            id(oq_otb_response_count)++;
-            id(oq_otb_last_response_id) = x.id;
+            // Called only after the hub accepted a complete OpenTherm frame.
+            // A negative acknowledgement still proves that the link is alive,
+            // but its zero payload is not a measurement. Invalidate the affected
+            // entities and hide the frame from ESPHome's payload-only processor.
+            const uint8_t response_id = x.id;
+            const uint8_t response_type = x.type;
+            oq_otb::telemetry_state.record_response(
+                millis(), response_id, response_type);
+
+            const bool acknowledged =
+                response_type == esphome::opentherm::MessageType::READ_ACK ||
+                response_type == esphome::opentherm::MessageType::WRITE_ACK;
+            if (acknowledged) return;
+
+            switch (response_id) {
+              case esphome::opentherm::MessageId::STATUS:
+                id(otb_fault_indication).invalidate_state();
+                id(otb_ch_active).invalidate_state();
+                id(otb_dhw_active).invalidate_state();
+                id(otb_flame_on).invalidate_state();
+                id(otb_diagnostic_indication).invalidate_state();
+                id(oq_boiler_transport_active) = false;
+                break;
+              case esphome::opentherm::MessageId::DEVICE_CONFIG:
+                id(otb_dhw_present).invalidate_state();
+                break;
+              case esphome::opentherm::MessageId::FAULT_FLAGS:
+                id(otb_service_request).invalidate_state();
+                id(otb_lockout_reset).invalidate_state();
+                id(otb_low_water_pressure).invalidate_state();
+                id(otb_flame_fault).invalidate_state();
+                id(otb_air_pressure_fault).invalidate_state();
+                id(otb_water_over_temp).invalidate_state();
+                id(otb_oem_fault_code).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::MAX_BOILER_CAPACITY:
+                id(otb_max_capacity).publish_state(NAN);
+                id(otb_min_modulation).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::MODULATION_LEVEL:
+                id(otb_relative_modulation).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::CH_WATER_PRESSURE:
+                id(otb_ch_pressure).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::FEED_TEMP:
+                id(otb_boiler_water_temp).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::DHW_TEMP:
+                id(otb_dhw_temp).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::RETURN_WATER_TEMP:
+                id(otb_return_water_temp).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::OEM_DIAGNOSTIC:
+                id(otb_oem_diagnostic_code).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::OT_VERSION_DEVICE:
+                id(otb_opentherm_version).publish_state(NAN);
+                break;
+              case esphome::opentherm::MessageId::VERSION_DEVICE:
+                id(otb_device_type).publish_state(NAN);
+                id(otb_device_version).publish_state(NAN);
+                break;
+              default:
+                break;
+            }
+            x.id = 0xFF;
 
 number:
   - platform: opentherm
@@ -265,9 +326,9 @@ sensor:
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      const uint32_t last_response_ms = id(oq_otb_last_response_ms);
-      if (last_response_ms == 0) return NAN;
-      return (float) ((uint32_t)(millis() - last_response_ms)) / 1000.0f;
+      if (oq_otb::telemetry_state.accepted_response_count() == 0) return NAN;
+      return (float) ((uint32_t) (
+          millis() - oq_otb::telemetry_state.last_response_ms())) / 1000.0f;
 
   - platform: template
     id: otb_response_count
@@ -280,7 +341,150 @@ sensor:
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      return (float) id(oq_otb_response_count);
+      return (float) oq_otb::telemetry_state.acknowledged_response_count();
+
+  - platform: template
+    id: otb_complete_response_count
+    name: "OTB - Complete Response Count"
+    icon: mdi:counter
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.accepted_response_count();
+
+  - platform: template
+    id: otb_data_invalid_response_count
+    name: "OTB - DATA_INVALID Response Count"
+    icon: mdi:alert-circle-outline
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.data_invalid_response_count();
+
+  - platform: template
+    id: otb_unknown_data_id_response_count
+    name: "OTB - UNKNOWN_DATAID Response Count"
+    icon: mdi:help-circle-outline
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.unknown_data_id_response_count();
+
+  - platform: template
+    id: otb_unexpected_response_type_count
+    name: "OTB - Unexpected Response Type Count"
+    icon: mdi:message-alert-outline
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.unexpected_response_type_count();
+
+  - platform: template
+    id: otb_transport_error_count
+    name: "OTB - Transport Error Count"
+    icon: mdi:alert-octagon-outline
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.transport_error_count();
+
+  - platform: template
+    id: otb_protocol_error_count
+    name: "OTB - Protocol Error Count"
+    icon: mdi:pulse
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.protocol_error_count();
+
+  - platform: template
+    id: otb_response_timeout_count
+    name: "OTB - Response Timeout Count"
+    icon: mdi:timer-alert-outline
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.response_timeout_count();
+
+  - platform: template
+    id: otb_no_transition_count
+    name: "OTB - NO_TRANSITION Count"
+    icon: mdi:chart-timeline-variant-shimmer
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.no_transition_count();
+
+  - platform: template
+    id: otb_no_change_too_long_count
+    name: "OTB - NO_CHANGE_TOO_LONG Count"
+    icon: mdi:chart-timeline-variant-shimmer
+    accuracy_decimals: 0
+    state_class: total_increasing
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return (float) oq_otb::telemetry_state.no_change_too_long_count();
+
+  - platform: template
+    id: otb_last_transport_error_age
+    name: "OTB - Last Transport Error Age"
+    icon: mdi:timer-alert-outline
+    unit_of_measurement: "s"
+    accuracy_decimals: 1
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      if (oq_otb::telemetry_state.transport_error_count() == 0) return NAN;
+      return (float) ((uint32_t) (
+          millis() - oq_otb::telemetry_state.last_transport_error_ms())) /
+          1000.0f;
 
   - platform: template
     id: otb_last_response_id
@@ -292,8 +496,33 @@ sensor:
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      const int message_id = id(oq_otb_last_response_id);
+      const int message_id = oq_otb::telemetry_state.last_response_id();
       return message_id >= 0 ? (float) message_id : NAN;
+
+text_sensor:
+  - platform: template
+    id: otb_last_response_type
+    name: "OTB - Last Response Type"
+    icon: mdi:message-text-outline
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return {oq_otb::telemetry_state.last_response_type_name()};
+
+  - platform: template
+    id: otb_last_transport_error
+    name: "OTB - Last Transport Error"
+    icon: mdi:alert-decagram-outline
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    web_server:
+      sorting_group_id: oq_boiler
+    lambda: |-
+      return {oq_otb::telemetry_state.last_transport_error_name()};
 
 interval:
   - interval: ${oq_otb_command_apply_s}s
@@ -312,11 +541,16 @@ interval:
           const float flow_lph = id(flow_rate_selected).state;
           const bool flow_valid =
               !isnan(flow_lph) && flow_lph >= ${oq_cm_min_flow_lph};
+          const bool status_fresh =
+              oq_otb::telemetry_state.field_is_fresh(
+                  oq_otb::FIELD_STATUS, millis(),
+                  (uint32_t) (${oq_otb_field_timeout_s} * 1000UL));
           const bool command_active =
               opentherm_selected &&
               !id(oq_runtime_polling_paused).state &&
               !id(oq_boiler_runtime_pause_state) &&
               id(oq_otb_link_available_state) &&
+              status_fresh &&
               id(oq_boiler_output_request) &&
               target_valid &&
               flow_valid;
@@ -349,13 +583,73 @@ interval:
     startup_delay: 2s
     then:
       - lambda: |-
-          // Phase 1: derive availability solely from complete accepted responses.
+          // Overall link freshness cannot prove that every rotating data ID is
+          // still current. Expire repeating fields independently so one healthy
+          // response type cannot keep another field looking valid forever.
+          if (!id(oq_otb_link_available_state)) return;
           const uint32_t now_ms = millis();
-          const uint32_t last_response_ms = id(oq_otb_last_response_ms);
+          const uint32_t max_age_ms =
+              (uint32_t) (${oq_otb_field_timeout_s} * 1000UL);
+          auto field_is_stale = [&](oq_otb::Field field) -> bool {
+            return !oq_otb::telemetry_state.field_is_fresh(
+                field, now_ms, max_age_ms);
+          };
+          auto invalidate_sensor = [](auto *value) {
+            if (value->has_state() && !isnan(value->state)) {
+              value->publish_state(NAN);
+            }
+          };
+
+          if (field_is_stale(oq_otb::FIELD_STATUS)) {
+            id(otb_fault_indication).invalidate_state();
+            id(otb_ch_active).invalidate_state();
+            id(otb_dhw_active).invalidate_state();
+            id(otb_flame_on).invalidate_state();
+            id(otb_diagnostic_indication).invalidate_state();
+            id(oq_boiler_transport_active) = false;
+          }
+          if (field_is_stale(oq_otb::FIELD_FAULT_FLAGS)) {
+            id(otb_service_request).invalidate_state();
+            id(otb_lockout_reset).invalidate_state();
+            id(otb_low_water_pressure).invalidate_state();
+            id(otb_flame_fault).invalidate_state();
+            id(otb_air_pressure_fault).invalidate_state();
+            id(otb_water_over_temp).invalidate_state();
+            invalidate_sensor(id(otb_oem_fault_code));
+          }
+          if (field_is_stale(oq_otb::FIELD_RELATIVE_MODULATION)) {
+            invalidate_sensor(id(otb_relative_modulation));
+          }
+          if (field_is_stale(oq_otb::FIELD_CH_WATER_PRESSURE)) {
+            invalidate_sensor(id(otb_ch_pressure));
+          }
+          if (field_is_stale(oq_otb::FIELD_BOILER_WATER_TEMPERATURE)) {
+            invalidate_sensor(id(otb_boiler_water_temp));
+          }
+          if (field_is_stale(oq_otb::FIELD_RETURN_WATER_TEMPERATURE)) {
+            invalidate_sensor(id(otb_return_water_temp));
+          }
+          if (field_is_stale(oq_otb::FIELD_DHW_TEMPERATURE)) {
+            invalidate_sensor(id(otb_dhw_temp));
+          }
+          if (field_is_stale(oq_otb::FIELD_OEM_DIAGNOSTIC)) {
+            invalidate_sensor(id(otb_oem_diagnostic_code));
+          }
+
+  - interval: ${oq_otb_link_watch_s}s
+    startup_delay: 2s
+    then:
+      - lambda: |-
+          // Phase 1: require recent complete frames and a fresh mandatory STATUS.
+          const uint32_t now_ms = millis();
+          // STATUS (ID 0) is mandatory and control-critical. Optional fields
+          // may be unsupported without taking down the link, but an invalid or
+          // stale STATUS response means the transport is not safe to actuate.
           const bool available =
-              last_response_ms != 0 &&
-              (uint32_t)(now_ms - last_response_ms) <=
-                  (uint32_t) (${oq_otb_link_timeout_s} * 1000UL);
+              oq_otb::telemetry_state.transport_is_available(
+                  now_ms,
+                  (uint32_t) (${oq_otb_link_timeout_s} * 1000UL),
+                  (uint32_t) (${oq_otb_field_timeout_s} * 1000UL));
           const bool link_changed =
               !id(oq_otb_link_initialized) ||
               available != id(oq_otb_link_available_state);
@@ -396,17 +690,17 @@ interval:
 
           // Phase 2: prevent stale operational values from looking current after link loss.
           if (available) return;
-          id(otb_fault_indication).publish_state(false);
-          id(otb_ch_active).publish_state(false);
-          id(otb_dhw_active).publish_state(false);
-          id(otb_flame_on).publish_state(false);
-          id(otb_diagnostic_indication).publish_state(false);
-          id(otb_service_request).publish_state(false);
-          id(otb_lockout_reset).publish_state(false);
-          id(otb_low_water_pressure).publish_state(false);
-          id(otb_flame_fault).publish_state(false);
-          id(otb_air_pressure_fault).publish_state(false);
-          id(otb_water_over_temp).publish_state(false);
+          id(otb_fault_indication).invalidate_state();
+          id(otb_ch_active).invalidate_state();
+          id(otb_dhw_active).invalidate_state();
+          id(otb_flame_on).invalidate_state();
+          id(otb_diagnostic_indication).invalidate_state();
+          id(otb_service_request).invalidate_state();
+          id(otb_lockout_reset).invalidate_state();
+          id(otb_low_water_pressure).invalidate_state();
+          id(otb_flame_fault).invalidate_state();
+          id(otb_air_pressure_fault).invalidate_state();
+          id(otb_water_over_temp).invalidate_state();
           id(otb_relative_modulation).publish_state(NAN);
           id(otb_ch_pressure).publish_state(NAN);
           id(otb_boiler_water_temp).publish_state(NAN);

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -8,6 +8,23 @@
 # ==============================================================================
 
 esphome:
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          // The OpenTherm hub is runtime-owned by the installation choice. A
+          // normal R1 installation must not poll an unconnected boiler bus.
+          oq_otb::telemetry_state.reset_link_session();
+          id(oq_otb_link_initialized) = true;
+          id(oq_otb_link_available_state) = false;
+          id(otb_link_available).publish_state(false);
+          const bool opentherm_selected =
+              id(oq_boiler_connection).has_state() &&
+              id(oq_boiler_connection).current_option() == "OpenTherm";
+          if (!opentherm_selected) {
+            id(oq_otb_hub).on_shutdown();
+            id(oq_otb_hub).disable_loop();
+          }
   on_shutdown:
     priority: 700
     then:
@@ -38,10 +55,10 @@ opentherm:
   - id: oq_otb_hub
     in_pin: ${oq_ot_boiler_in_pin}
     out_pin: ${oq_ot_boiler_out_pin}
-    # Q-duo HIL: synchronous request handling eliminated simulator-side RX
-    # decode failures and master response timeouts. It does increase the
-    # observed main-loop duration; real-boiler timing remains a release gate.
-    sync_mode: true
+    # Keep the application loop asynchronous. A missing boiler response may
+    # take up to 800 ms; sync mode would block Modbus, API and web handling for
+    # that entire interval. RX reliability remains an explicit release gate.
+    sync_mode: false
     # The runtime switch is default-off and owns the actual STATUS bit. The hub
     # gate must be true or ESPHome would mask that switch permanently.
     ch_enable: true
@@ -324,7 +341,7 @@ sensor:
     web_server:
       sorting_group_id: oq_boiler
     lambda: |-
-      if (oq_otb::telemetry_state.accepted_response_count() == 0) return NAN;
+      if (!oq_otb::telemetry_state.session_has_response()) return NAN;
       return (float) ((uint32_t) (
           millis() - oq_otb::telemetry_state.last_response_ms())) / 1000.0f;
 

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -18,10 +18,13 @@ esphome:
           id(oq_otb_link_initialized) = true;
           id(oq_otb_link_available_state) = false;
           id(otb_link_available).publish_state(false);
+          id(oq_otb_hub_ready) = true;
           const bool opentherm_selected =
               id(oq_boiler_connection).has_state() &&
               id(oq_boiler_connection).current_option() == "OpenTherm";
-          if (!opentherm_selected) {
+          if (opentherm_selected) {
+            id(oq_otb_hub).enable_loop();
+          } else {
             id(oq_otb_hub).on_shutdown();
             id(oq_otb_hub).disable_loop();
           }
@@ -46,6 +49,13 @@ logger:
               millis(), tag, message);
 
 globals:
+  # The restored Boiler connection select is set up before the OpenTherm hub.
+  # Its boot callback must not dereference the hub until component setup ended.
+  - id: oq_otb_hub_ready
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
   - id: oq_otb_link_initialized
     type: bool
     restore_value: false

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -63,10 +63,8 @@ opentherm:
             oq_otb::telemetry_state.record_response(
                 millis(), response_id, response_type);
 
-            const bool acknowledged =
-                response_type == esphome::opentherm::MessageType::READ_ACK ||
-                response_type == esphome::opentherm::MessageType::WRITE_ACK;
-            if (acknowledged) return;
+            if (oq_otb::telemetry_state.response_payload_is_usable(
+                    response_id, response_type)) return;
 
             switch (response_id) {
               case esphome::opentherm::MessageId::STATUS:

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -229,6 +229,7 @@ oq_ot_response_enabled_default: "true"                # Allow the OT slave to an
 # ----------------------------
 oq_otb_link_watch_s: "1"                              # OTB link/freshness evaluation interval [s].
 oq_otb_link_timeout_s: "10"                           # Maximum age of the last valid boiler response [s].
+oq_otb_field_timeout_s: "10"                          # Maximum age of one repeating boiler telemetry field [s].
 
 # ----------------------------
 # CIC FEED

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -217,6 +217,7 @@ oq_boiler_otb_min_on_s: "30"                          # OpenTherm minimum reques
 oq_boiler_otb_min_off_s: "120"                        # OpenTherm minimum requested off-time [s].
 oq_otb_supported: "false"                             # Compile-time availability of the boiler OpenTherm master transport.
 oq_otb_command_apply_s: "1"                           # Apply validated CH/TSet state to the OpenTherm master [s].
+oq_boiler_transport_selection_extra: ""               # Hardware-specific start/stop hook after changing the boiler transport.
 
 # ----------------------------
 # OPEN THERM SLAVE

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -5,6 +5,17 @@ substitutions:
   oq_hardware_profile: "heatpump_controller_q"         # Compile-time hardware profile id.
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1" # Enable Q-only local sensor paths.
   oq_otb_supported: "true"                             # GPIO47/GPIO48 provide the boiler OpenTherm master transport.
+  oq_boiler_transport_selection_extra: |-
+    oq_otb::telemetry_state.reset_link_session();
+    id(oq_otb_link_initialized) = true;
+    id(oq_otb_link_available_state) = false;
+    id(otb_link_available).publish_state(false);
+    if (x == "OpenTherm") {
+      id(oq_otb_hub).enable_loop();
+    } else {
+      id(oq_otb_hub).on_shutdown();
+      id(oq_otb_hub).disable_loop();
+    }
   oq_boiler_transport_shutdown_extra: "id(oq_otb_ch_enable).turn_off(); { auto call = id(oq_otb_t_set_command).make_call(); call.set_value(0.0f); call.perform(); }" # Withdraw OTB synchronously on every transport edge.
   oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000" # Q-edition local PT1000 source.
   oq_local_supply_temp_selector_id: "oq_local_supply_temp_source" # Explicit local physical-sensor selection.

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -10,11 +10,13 @@ substitutions:
     id(oq_otb_link_initialized) = true;
     id(oq_otb_link_available_state) = false;
     id(otb_link_available).publish_state(false);
-    if (x == "OpenTherm") {
-      id(oq_otb_hub).enable_loop();
-    } else {
-      id(oq_otb_hub).on_shutdown();
-      id(oq_otb_hub).disable_loop();
+    if (id(oq_otb_hub_ready)) {
+      if (x == "OpenTherm") {
+        id(oq_otb_hub).enable_loop();
+      } else {
+        id(oq_otb_hub).on_shutdown();
+        id(oq_otb_hub).disable_loop();
+      }
     }
   oq_boiler_transport_shutdown_extra: "id(oq_otb_ch_enable).turn_off(); { auto call = id(oq_otb_t_set_command).make_call(); call.set_value(0.0f); call.perform(); }" # Withdraw OTB synchronously on every transport edge.
   oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000" # Q-edition local PT1000 source.

--- a/tests/host/ot_boiler_telemetry_test.cpp
+++ b/tests/host/ot_boiler_telemetry_test.cpp
@@ -1,0 +1,111 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "openquatt/includes/boiler/oq_otb_telemetry.h"
+
+int main() {
+  oq_otb::TelemetryState state;
+
+  assert(state.accepted_response_count() == 0);
+  assert(state.last_response_id() == -1);
+  assert(strcmp(state.last_response_type_name(), "Never") == 0);
+  assert(!state.field_is_valid(oq_otb::FIELD_CH_WATER_PRESSURE));
+
+  // Optional negative acknowledgements do not take down the transport, but
+  // the mandatory STATUS field must be valid and fresh for safe actuation.
+  oq_otb::TelemetryState link_state;
+  assert(!link_state.transport_is_available(0, 1000, 1000));
+  link_state.record_response(100, 18, oq_otb::MESSAGE_TYPE_READ_ACK);
+  assert(!link_state.transport_is_available(100, 1000, 1000));
+  link_state.record_response(150, 0, oq_otb::MESSAGE_TYPE_READ_ACK);
+  assert(link_state.transport_is_available(150, 1000, 1000));
+  link_state.record_response(200, 18, oq_otb::MESSAGE_TYPE_DATA_INVALID);
+  assert(link_state.transport_is_available(200, 1000, 1000));
+  link_state.record_response(250, 0, oq_otb::MESSAGE_TYPE_DATA_INVALID);
+  assert(!link_state.transport_is_available(250, 1000, 1000));
+  link_state.record_response(260, 0, oq_otb::MESSAGE_TYPE_READ_ACK);
+  assert(link_state.transport_is_available(260, 1000, 1000));
+  assert(!link_state.transport_is_available(1261, 1000, 1000));
+
+  // A READ_ACK makes only the matching field valid. Zero-valued payloads are
+  // still legitimate samples; validity comes from the response type, not data.
+  state.record_response(100, 18, oq_otb::MESSAGE_TYPE_READ_ACK);
+  assert(state.accepted_response_count() == 1);
+  assert(state.acknowledged_response_count() == 1);
+  assert(state.last_response_id() == 18);
+  assert(strcmp(state.last_response_type_name(), "READ_ACK") == 0);
+  assert(state.field_is_valid(oq_otb::FIELD_CH_WATER_PRESSURE));
+  assert(state.field_is_fresh(oq_otb::FIELD_CH_WATER_PRESSURE, 1100, 1000));
+  assert(!state.field_is_fresh(oq_otb::FIELD_CH_WATER_PRESSURE, 1101, 1000));
+  assert(!state.field_is_valid(oq_otb::FIELD_BOILER_WATER_TEMPERATURE));
+
+  // A semantic negative acknowledgement must invalidate the old sample
+  // immediately while remaining a complete response for link supervision.
+  state.record_response(200, 18, oq_otb::MESSAGE_TYPE_DATA_INVALID);
+  assert(state.accepted_response_count() == 2);
+  assert(state.data_invalid_response_count() == 1);
+  assert(!state.field_is_valid(oq_otb::FIELD_CH_WATER_PRESSURE));
+  assert(strcmp(state.last_response_type_name(), "DATA_INVALID") == 0);
+
+  state.record_response(300, 18, oq_otb::MESSAGE_TYPE_UNKNOWN_DATA_ID);
+  assert(state.unknown_data_id_response_count() == 1);
+  assert(!state.field_is_valid(oq_otb::FIELD_CH_WATER_PRESSURE));
+
+  // A WRITE_ACK is a valid frame for commands, but never a valid sample for
+  // the read-only telemetry fields tracked here.
+  state.record_response(400, 18, oq_otb::MESSAGE_TYPE_WRITE_ACK);
+  assert(state.acknowledged_response_count() == 2);
+  assert(!state.field_is_valid(oq_otb::FIELD_CH_WATER_PRESSURE));
+
+  state.record_response(500, 18, oq_otb::MESSAGE_TYPE_INVALID_DATA);
+  assert(state.unexpected_response_type_count() == 1);
+  assert(!state.field_is_valid(oq_otb::FIELD_CH_WATER_PRESSURE));
+
+  // Freshness calculations must remain correct across millis() wraparound.
+  state.record_response(UINT32_MAX - 5, 25, oq_otb::MESSAGE_TYPE_READ_ACK);
+  assert(state.field_is_fresh(oq_otb::FIELD_BOILER_WATER_TEMPERATURE, 4, 10));
+  assert(!state.field_is_fresh(oq_otb::FIELD_BOILER_WATER_TEMPERATURE, 5, 10));
+
+  // Only warnings emitted by the ESPHome OpenTherm component are counted.
+  state.record_log_message(1000, "wifi", "NO_TRANSITION");
+  state.record_log_message(1001, "opentherm", "Unrelated warning");
+  assert(state.transport_error_count() == 0);
+
+  state.record_log_message(
+      1010, "opentherm",
+      "Protocol error occured while receiving response: NO_TRANSITION");
+  state.record_log_message(
+      1020, "opentherm",
+      "Protocol error occured while receiving response: NO_CHANGE_TOO_LONG");
+  state.record_log_message(
+      1030, "opentherm",
+      "Protocol error occured while receiving response: INVALID_STOP_BIT");
+  state.record_log_message(
+      1040, "opentherm",
+      "Protocol error occured while receiving response: PARITY_ERROR");
+  state.record_log_message(
+      1050, "opentherm", "Timeout while waiting for response from device");
+  state.record_log_message(
+      1060, "opentherm", "Hub timeout triggered during send");
+  state.record_log_message(
+      1070, "opentherm", "Hub timeout triggered during receive");
+  state.record_log_message(
+      1080, "opentherm",
+      "Error occured while manipulating timer (TIMER_START_ERROR): ESP_FAIL");
+
+  assert(state.transport_error_count() == 8);
+  assert(state.protocol_error_count() == 4);
+  assert(state.no_transition_count() == 1);
+  assert(state.no_change_too_long_count() == 1);
+  assert(state.invalid_stop_bit_count() == 1);
+  assert(state.parity_error_count() == 1);
+  assert(state.response_timeout_count() == 1);
+  assert(state.hub_send_timeout_count() == 1);
+  assert(state.hub_receive_timeout_count() == 1);
+  assert(state.timer_error_count() == 1);
+  assert(state.last_transport_error_ms() == 1080);
+  assert(strcmp(state.last_transport_error_name(), "TIMER_ERROR") == 0);
+
+  return 0;
+}

--- a/tests/host/ot_boiler_telemetry_test.cpp
+++ b/tests/host/ot_boiler_telemetry_test.cpp
@@ -32,7 +32,17 @@ int main() {
   assert(!link_state.transport_is_available(250, 1000, 1000));
   link_state.record_response(260, 0, oq_otb::MESSAGE_TYPE_READ_ACK);
   assert(link_state.transport_is_available(260, 1000, 1000));
-  assert(!link_state.transport_is_available(1261, 1000, 1000));
+  const uint32_t accepted_before_reset = link_state.accepted_response_count();
+  link_state.reset_link_session();
+  assert(!link_state.session_has_response());
+  assert(link_state.accepted_response_count() == accepted_before_reset);
+  assert(link_state.last_response_id() == -1);
+  assert(strcmp(link_state.last_response_type_name(), "Never") == 0);
+  assert(!link_state.field_is_valid(oq_otb::FIELD_STATUS));
+  assert(!link_state.transport_is_available(260, 1000, 1000));
+  link_state.record_response(270, 0, oq_otb::MESSAGE_TYPE_READ_ACK);
+  assert(link_state.transport_is_available(270, 1000, 1000));
+  assert(!link_state.transport_is_available(1271, 1000, 1000));
 
   // A READ_ACK makes only the matching field valid. Zero-valued payloads are
   // still legitimate samples; validity comes from the response type, not data.

--- a/tests/host/ot_boiler_telemetry_test.cpp
+++ b/tests/host/ot_boiler_telemetry_test.cpp
@@ -11,6 +11,12 @@ int main() {
   assert(state.last_response_id() == -1);
   assert(strcmp(state.last_response_type_name(), "Never") == 0);
   assert(!state.field_is_valid(oq_otb::FIELD_CH_WATER_PRESSURE));
+  assert(state.response_payload_is_usable(
+      18, oq_otb::MESSAGE_TYPE_READ_ACK));
+  assert(!state.response_payload_is_usable(
+      18, oq_otb::MESSAGE_TYPE_WRITE_ACK));
+  assert(state.response_payload_is_usable(
+      1, oq_otb::MESSAGE_TYPE_WRITE_ACK));
 
   // Optional negative acknowledgements do not take down the transport, but
   // the mandatory STATUS field must be valid and fresh for safe actuation.


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt per OpenTherm-bericht-ID geldigheid en freshness toe, zodat `DATA_INVALID`, `UNKNOWN_DATAID`, onverwachte `WRITE_ACK` en stale ketelwaarden niet als geldige nullen of metingen worden gepubliceerd.
- Maakt complete/ACK/negatieve responses en master-side protocol-/timeoutfouten meetbaar; detaildiagnostiek is `disabled_by_default`.
- Houdt de OpenTherm-hub asynchroon zodat een ontbrekende ketel de applicatieloop niet tot circa 800 ms per gesprek blokkeert.
- Laat de hub uitsluitend pollen wanneer `Boiler connection = OpenTherm`, wist sessiefreshness op iedere transportwissel en voorkomt dat de herstelde select tijdens de setupvolgorde een nog niet geïnitialiseerde hub bedient.

Gestapelde PR: base is #351 (`codex/ot-boiler-safety-interlocks`). Mergevolgorde: #347 → #348 → #349 → #350 → #351 → deze PR. De afzonderlijke RMT-ontvangstkandidaat volgt als draft-PR #375.

## Type

- [x] Bugfix
- [x] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Een negatief antwoord voor een optioneel ketelveld houdt de OTB-link beschikbaar, maar maakt uitsluitend dat veld unavailable. Een ongeldig of stale mandatory STATUS-antwoord trekt de lokale ketelroute fail-safe in. Bij volledig linkverlies worden operationele ketelwaarden unavailable, `CH Enable` wordt ingetrokken en `TSet` wordt 0; herstel hergebruikt geen oud ketelcommando.

Een R1-installatie genereert geen OpenTherm-verkeer. Bij een transportwissel worden beide uitgangen eerst ingetrokken en kan de geselecteerde route alleen na een verse controllerbeslissing opnieuw activeren.

## Achtergrond

De ESPHome OpenTherm-entiteiten verwerken alleen de payload en publiceerden daardoor de nul-payload van `DATA_INVALID` als bijvoorbeeld `0.00 bar` of `0.00 °C`. Daarnaast waren incidentele decoderfouten en response-timeouts niet betrouwbaar kwantificeerbaar.

De pure C++-telemetrystate bewaart per ondersteund ID de laatste geldige response en classificeert ESPHome-waarschuwingen. Negatieve of semantisch onjuiste acknowledgements worden niet als meetpayload verwerkt.

Een eerdere `sync_mode: true`-variant verminderde in korte simulatormetingen ontvangstfouten, maar kon de ESPHome-hoofdloop bij een ontbrekende ketel langdurig blokkeren. Die variant is daarom verworpen. PR #375 onderzoekt afzonderlijk hardwarematige RMT-ontvangst zonder de hoofdloop te blokkeren.

Simulator-HIL op de gestapelde kandidaat:

- pressure `DATA_INVALID` → druk `NA`, ketellink blijft beschikbaar; geldig herstel → 1.70 bar;
- responses uit → ketellink uit, druk/keteltemperatuur `NA`, master `CH Enable=false`, `TSet=0.0 °C`; responses aan → zelfstandig linkherstel;
- actieve commissioningroute → centrale opdracht 60.0 °C, simulator ziet `CH Enable=ON` en `TSet=60.0 °C`, terwijl R1 uit blijft;
- twee antwoordloze intervallen → exact 113 bedoelde suppressions en 113 mastertimeouts; link en lokale output vallen af, herstel respecteert 120 s minimum-uit en vereist verse autorisatie;
- R1-runtimegate → simulatorrequest bleef exact 199511 en mastertimeout exact 7 gedurende twintig seconden;
- R1-bootrestore → simulatorrequest bleef vóór en na reboot exact 199590; OpenQuatt herstelde R1 met nul OTB-responses/timeouts;
- async OpenTherm laat nog gecorreleerde master-TX/simulator-RX-decodefouten en mastertimeouts zien. Dat is een expliciete releaseblokker en wordt niet door deze PR of #375 opgelost.

Open releasegates: master-TX/bus/simulator-RX met scope of gerichte TX-kandidaat, een begrensde OTB→R1-off-handshake, langdurige gelijktijdige OTT+OTB, echte CM3-strategyactivering en vergelijking met een echte ketel. Er is geen automatische fallback naar R1.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een gestapelde hardening-PR voor nog niet gemergede OTB-functionaliteit. Definitieve gebruikersdocumentatie volgt na echte-ketel- en actieve-strategy-HIL. Het lokale implementatie-/HIL-trackingdocument is bijgewerkt en staat bewust buiten Git.

## Audit

De complete laagdiff en daarna de volledige stack tegen actuele `dev` zijn apart koud/adversarieel beoordeeld op correctness, lifecycle, link-edge fail-safe, stale/negatieve/onverwachte responses, retries/herstel, HA-defaults, telemetrieprivacy en upgrade/fresh-install.

De reviews vonden en corrigeerden:

- onverwachte `WRITE_ACK` op een read-only veld kon anders nog als payload worden verwerkt;
- `sync_mode` kon Modbus, API en webafhandeling blokkeren;
- de hub pollde ook wanneer R1 geselecteerd was;
- de restore-callback van `Boiler connection` kon vóór `OpenthermHub::setup()` draaien.

Een resterende failure boundary is expliciet geparkeerd: bij OTB→R1 bewijzen lokale off-entities nog niet dat de ketel een laatste off-frame heeft ontvangen, en upstream `OpenTherm::stop()` stuurt het uitgangsniveau niet expliciet naar idle. Dit moet vóór productvrijgave worden gesloten en hardwarematig worden gevalideerd.

## Validatie

- `./scripts/run_host_regression_tests.sh` — 2/2 hosttests groen, inclusief validity/freshness, wraparound, response-semantiek en foutclassificatie.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — groen met ESPHome 2026.7.0.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — volledige PR6-firmwarecompile met de ingebouwde ESPHome OpenTherm-component groen; RAM 215499/341760 B (63.1%), flash 1955791/5242880 B (37.3%).
- `npm run check:web` — 71/71 tests, bundles en budgetten groen op de gerebasede stack.
- GitHub CI — host-, docs- en profielmatrix gestart op de gepubliceerde head; actuele status volgt in de checks.
