### PR TITLE
Voeg timestamp toe aan gebruiksstatistieken

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -549,7 +549,19 @@ void OpenQuattUsageTelemetry::build_payload_() {
   this->payload_ += this->payload_message_id_;
   this->payload_ += R"(","installation_id":")";
   this->payload_ += this->installation_id_;
-  this->payload_ += R"(","uptime_s":)";
+  this->payload_ += '"';
+  append_json_key_(this->payload_, "timestamp_s");
+  if (this->clock_ == nullptr) {
+    this->payload_ += "null";
+  } else {
+    const auto now = this->clock_->now();
+    if (now.is_valid()) {
+      this->payload_ += std::to_string(static_cast<uint64_t>(now.timestamp));
+    } else {
+      this->payload_ += "null";
+    }
+  }
+  this->payload_ += R"(,"uptime_s":)";
   this->payload_ += std::to_string(uptime_s);
   this->payload_ += R"(,"firmware_version":")";
   this->payload_ += json_escape_(this->firmware_version_);

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -12,6 +12,7 @@
 #include "esphome/components/select/select.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
+#include "esphome/components/time/real_time_clock.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "mqtt_client.h"
@@ -30,6 +31,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   void set_username(const std::string &username) { this->username_ = username; }
   void set_password(const std::string &password) { this->password_ = password; }
   void set_topic(const std::string &topic) { this->topic_ = topic; }
+  void set_clock(time::RealTimeClock *clock) { this->clock_ = clock; }
   void set_setup_complete_sensor(binary_sensor::BinarySensor *sensor) { this->setup_complete_sensor_ = sensor; }
   void set_choice_configured_sensor(binary_sensor::BinarySensor *sensor) { this->choice_configured_sensor_ = sensor; }
   void set_interval_ms(uint32_t interval_ms) { this->interval_ms_ = interval_ms; }
@@ -128,6 +130,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   std::string username_;
   std::string password_;
   std::string topic_;
+  time::RealTimeClock *clock_{nullptr};
   binary_sensor::BinarySensor *setup_complete_sensor_{nullptr};
   binary_sensor::BinarySensor *choice_configured_sensor_{nullptr};
   uint32_t interval_ms_{60UL * 60UL * 1000UL};

--- a/components/openquatt_usage_telemetry/__init__.py
+++ b/components/openquatt_usage_telemetry/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, openquatt_mqtt_config, select, sensor, switch
+from esphome.components import binary_sensor, openquatt_mqtt_config, select, sensor, switch, time
 from esphome.components.esp32 import (
     add_idf_sdkconfig_option,
     add_idf_component,
@@ -17,6 +17,7 @@ CONF_TLS = "tls"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_TOPIC = "topic"
+CONF_CLOCK = "clock"
 CONF_SETUP_COMPLETE_SENSOR = "setup_complete_sensor"
 CONF_CHOICE_CONFIGURED = "choice_configured"
 CONF_INTERVAL = "interval"
@@ -69,6 +70,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.All(cv.string_strict, cv.Length(max=192))
             ),
             cv.Required(CONF_TOPIC): cv.All(cv.publish_topic, cv.Length(max=128)),
+            cv.Required(CONF_CLOCK): cv.use_id(time.RealTimeClock),
             cv.Required(CONF_SETUP_COMPLETE_SENSOR): cv.use_id(binary_sensor.BinarySensor),
             cv.Required(CONF_CHOICE_CONFIGURED): binary_sensor.binary_sensor_schema(),
             cv.Optional(CONF_INTERVAL, default="1h"): cv.positive_time_period_milliseconds,
@@ -117,6 +119,8 @@ async def to_code(config):
     cg.add(var.set_username(config[CONF_USERNAME]))
     cg.add(var.set_password(config[CONF_PASSWORD]))
     cg.add(var.set_topic(config[CONF_TOPIC]))
+    clock = await cg.get_variable(config[CONF_CLOCK])
+    cg.add(var.set_clock(clock))
     setup_complete_sensor = await cg.get_variable(config[CONF_SETUP_COMPLETE_SENSOR])
     cg.add(var.set_setup_complete_sensor(setup_complete_sensor))
     choice_configured_sensor = await binary_sensor.new_binary_sensor(config[CONF_CHOICE_CONFIGURED])

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -209,6 +209,7 @@ Een ontbrekende telemetrykeuze geldt nooit als toestemming. Bestaande installati
 Het bericht bevat uitsluitend:
 
 - een willekeurig installatie-ID;
+- de Unix-timestamp van de momentopname in seconden, of `null` zolang de klok nog niet is gesynchroniseerd;
 - uptime;
 - firmwareversie en releasekanaal;
 - hardwareprofiel en, als beschikbaar, hardwarerevisie;

--- a/openquatt/oq_usage_telemetry.yaml
+++ b/openquatt/oq_usage_telemetry.yaml
@@ -21,6 +21,7 @@ openquatt_usage_telemetry:
   username: "${usage_telemetry_username}"
   password: "${usage_telemetry_password}"
   topic: "${usage_telemetry_topic}"
+  clock: oq_time
   setup_complete_sensor: oq_setup_complete_sensor
   choice_configured:
     id: oq_usage_telemetry_choice_configured

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -2157,7 +2157,7 @@ Kenmerken: Flowmeter in de buitenunit ge\xEFntegreerd. Onder CV-ketel enkel een 
             ${e}
           </div>
         </div>
-      `)}var rk=JSON.stringify({schema_version:1,message_id:"c8272f30-b64d-4af0-a13c-bf8e0cbde842",installation_id:"7df1c1f8-fc47-4ac8-b0d7-94d8c42d772f",uptime_s:86420,firmware_version:"v0.44.0",release_channel:"main",hardware_profile:"heatpump_controller_q",hardware_revision:"1.0 (batch 42)",topology:"duo",connection:"wifi",heap_free_b:178432,heap_min_free_b:151008,heap_largest_block_b:98304,psram_free_b:7023616,loop_time_ms:14,esp_internal_temp_c:47.8,wifi_rssi_dbm:-61,reset_reason:"power_on",cic_polling_enabled:!0,cic_compatibility_enabled:!1,ot_thermostat_enabled:!0,boiler_assist_enabled:!0,boiler_connection:"on_off",mqtt_inputs_enabled:!1,trend_ram_enabled:!0,trend_flash_enabled:!1,decision_log_flash_enabled:!1,energy_history_flash_enabled:!0,ram_log_history_enabled:!0},null,2);function Ii({enabled:e,busy:t,settings:r=!1}){let n=r?"Na inschakelen verstuurt OpenQuatt vrijwel direct en daarna ongeveer elk uur technische gegevens naar de OpenQuatt-loggingserver.":"Na het afronden verstuurt OpenQuatt vrijwel direct en daarna ongeveer elk uur technische gegevens naar de OpenQuatt-loggingserver.";return`
+      `)}var rk=JSON.stringify({schema_version:1,message_id:"c8272f30-b64d-4af0-a13c-bf8e0cbde842",installation_id:"7df1c1f8-fc47-4ac8-b0d7-94d8c42d772f",timestamp_s:1784527200,uptime_s:86420,firmware_version:"v0.44.0",release_channel:"main",hardware_profile:"heatpump_controller_q",hardware_revision:"1.0 (batch 42)",topology:"duo",connection:"wifi",heap_free_b:178432,heap_min_free_b:151008,heap_largest_block_b:98304,psram_free_b:7023616,loop_time_ms:14,esp_internal_temp_c:47.8,wifi_rssi_dbm:-61,reset_reason:"power_on",cic_polling_enabled:!0,cic_compatibility_enabled:!1,ot_thermostat_enabled:!0,boiler_assist_enabled:!0,boiler_connection:"on_off",mqtt_inputs_enabled:!1,trend_ram_enabled:!0,trend_flash_enabled:!1,decision_log_flash_enabled:!1,energy_history_flash_enabled:!0,ram_log_history_enabled:!0},null,2);function Ii({enabled:e,busy:t,settings:r=!1}){let n=r?"Na inschakelen verstuurt OpenQuatt vrijwel direct en daarna ongeveer elk uur technische gegevens naar de OpenQuatt-loggingserver.":"Na het afronden verstuurt OpenQuatt vrijwel direct en daarna ongeveer elk uur technische gegevens naar de OpenQuatt-loggingserver.";return`
     <div class="oq-usage-consent${e?" is-enabled":""}${r?" oq-usage-consent--settings":""}">
       <div class="oq-usage-consent-copy">
         <span class="oq-usage-consent-icon" aria-hidden="true">${pe("bar-chart","oq-usage-consent-icon-svg")}</span>
@@ -2179,7 +2179,7 @@ Kenmerken: Flowmeter in de buitenunit ge\xEFntegreerd. Onder CV-ketel enkel een 
           <h4 id="${a}">In het bericht</h4>
         </div>
         <ul>
-          <li><strong>Installatie</strong><span>Willekeurig ID en uptime</span></li>
+          <li><strong>Installatie</strong><span>Willekeurig ID, tijdstip en uptime</span></li>
           <li><strong>Software</strong><span>Versie en releasekanaal</span></li>
           <li><strong>Platform</strong><span>Hardware, opstelling, verbinding en wifi-signaal</span></li>
           <li><strong>Systeemstatus</strong><span>Geheugen, looptijd, chiptemperatuur en herstartreden</span></li>

--- a/openquatt/web/js/src/features/usage-telemetry.js
+++ b/openquatt/web/js/src/features/usage-telemetry.js
@@ -6,6 +6,7 @@ const USAGE_TELEMETRY_EXAMPLE_JSON = JSON.stringify({
   schema_version: 1,
   message_id: "c8272f30-b64d-4af0-a13c-bf8e0cbde842",
   installation_id: "7df1c1f8-fc47-4ac8-b0d7-94d8c42d772f",
+  timestamp_s: 1784527200,
   uptime_s: 86420,
   firmware_version: "v0.44.0",
   release_channel: "main",
@@ -74,7 +75,7 @@ export function renderUsageTelemetryDisclosure({ collapsible = false, idPrefix =
           <h4 id="${includedTitleId}">In het bericht</h4>
         </div>
         <ul>
-          <li><strong>Installatie</strong><span>Willekeurig ID en uptime</span></li>
+          <li><strong>Installatie</strong><span>Willekeurig ID, tijdstip en uptime</span></li>
           <li><strong>Software</strong><span>Versie en releasekanaal</span></li>
           <li><strong>Platform</strong><span>Hardware, opstelling, verbinding en wifi-signaal</span></li>
           <li><strong>Systeemstatus</strong><span>Geheugen, looptijd, chiptemperatuur en herstartreden</span></li>

--- a/openquatt/web/tests/usage-telemetry-hydration.test.mjs
+++ b/openquatt/web/tests/usage-telemetry-hydration.test.mjs
@@ -102,6 +102,7 @@ test("usage telemetry disclosure matches the hourly payload scope", async () => 
   assert.match(disclosureSource, /Nooit een wifi-netwerknaam, wifi-wachtwoord, gebruikersnaam, ander wachtwoord of inloggegevens/);
   assert.match(disclosureSource, /Voorbeeld van het verzonden bericht \(JSON\)/);
   assert.match(disclosureSource, /schema_version/);
+  assert.match(disclosureSource, /timestamp_s/);
   assert.match(disclosureSource, /oq-usage-disclosure--collapsible/);
   assert.match(disclosureSource, /data-oq-action="toggle-usage-telemetry-details"/);
   assert.match(disclosureSource, /technisch wel het bron-IP-adres zien/);


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt `timestamp_s` toe aan elk MQTT-bericht met gebruiksstatistieken: een Unix-timestamp in seconden van de momentopname.
- Stuurt `null` zolang de bestaande SNTP-klok nog niet is gesynchroniseerd; `schema_version` blijft `1`.
- Werkt de privacyuitleg, voorbeeldpayload, regressietest en gegenereerde webbundle bij.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [x] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de uitgaande telemetrypayload verandert; regeling, consent, MQTT-planning en entities blijven gelijk. Bij een retry wordt de timestamp samen met de verse momentopname opnieuw bepaald, terwijl het bestaande `message_id` voor deduplicatie behouden blijft.

## Achtergrond

De timestamp komt uit de bestaande `oq_time` SNTP-klok en bevat geen tijdzone-afhankelijke formattering. Een nog ongeldige klok levert bewust `null` op in plaats van een misleidende epochwaarde.

Pre-PR audit van de volledige diff omvatte payloadvaliditeit, ongesynchroniseerde tijd, retries, OTA/upgrades, bestaande en nieuwe installaties, privacy, alle configuratievarianten en synchronisatie tussen firmware, webvoorbeeld, documentatie en gegenereerde bundle. Er zijn geen opslagmigraties, nieuwe credentials of wijzigingen aan consent/fail-closed gedrag.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De veldlijst en de volledige JSON-voorbeeldpayload tonen nu `timestamp_s`, inclusief het gedrag vóór tijdsynchronisatie.

## Validatie

- `npm run build:web`
- `npm run check:web` — 62 tests geslaagd; bundle en kwaliteitscontrole akkoord
- `npm run check:docs`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml --config configs/heatpump_controller_q/duo_wifi.yaml --config configs/heatpump_controller_q/single_eth.yaml --config configs/heatpump_controller_q/duo_eth.yaml --config configs/waveshare/single_wifi.yaml --config configs/waveshare/duo_wifi.yaml --config configs/heatpump_listener/single_wifi.yaml --config configs/heatpump_listener/duo_wifi.yaml`
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml` — volledige firmwarecompile geslaagd
- `git diff --check`
