### PR TITLE
Reset debug logging after restart

### DIFF
--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -661,7 +661,8 @@ select:
       sorting_group_id: oq_system_diagnostics
     entity_category: diagnostic
     optimistic: true
-    restore_value: true
+    # Always recover to INFO after a reboot; DEBUG can overwhelm busy Duo installations.
+    restore_value: false
     options: [NONE, ERROR, WARN, INFO, CONFIG, DEBUG]
     initial_option: INFO
     on_value:

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -373,7 +373,7 @@
       ${a}
     </div>
   `}function Rv(){let e=Pl();if(!e)return"";let t=Xp(e),r=ov(e),n=o.loadingEntities||!!o.busyAction;return`
-    ${Ie({dataValue:"debugLevel",label:"Logger level",value:r||"Onbekend",note:"Past het runtime logniveau aan voor nieuwe firmwaremeldingen.",action:`<label class="oq-webserver-log-level-control" aria-label="Logger level">
+    ${Ie({dataValue:"debugLevel",label:"Logger level",value:r||"Onbekend",note:"Geldt tot de volgende herstart. DEBUG kan bij veel Modbusverkeer de controller en verbindingen zwaar belasten.",action:`<label class="oq-webserver-log-level-control" aria-label="Logger level">
         <select class="oq-helper-select" data-oq-field="debugLevel" ${n?"disabled":""}>
           ${t.map(a=>`<option value="${s(a)}" ${a===r?"selected":""}>${s(a)}</option>`).join("")}
         </select>

--- a/openquatt/web/js/openquatt-app.js
+++ b/openquatt/web/js/openquatt-app.js
@@ -373,7 +373,7 @@
       ${a}
     </div>
   `}function Rv(){let e=Pl();if(!e)return"";let t=Xp(e),r=ov(e),n=o.loadingEntities||!!o.busyAction;return`
-    ${Ie({dataValue:"debugLevel",label:"Logger level",value:r||"Onbekend",note:"Geldt tot de volgende herstart. DEBUG kan bij veel Modbusverkeer de controller en verbindingen zwaar belasten.",action:`<label class="oq-webserver-log-level-control" aria-label="Logger level">
+    ${Ie({dataValue:"debugLevel",label:"Logger level",value:r||"Onbekend",note:"DEBUG is tijdelijk en wordt na een herstart teruggezet naar INFO. Bij veel Modbusverkeer kan DEBUG zoveel logging produceren dat de web-app en Home Assistant traag of onbereikbaar worden.",action:`<label class="oq-webserver-log-level-control" aria-label="Logger level">
         <select class="oq-helper-select" data-oq-field="debugLevel" ${n?"disabled":""}>
           ${t.map(a=>`<option value="${s(a)}" ${a===r?"selected":""}>${s(a)}</option>`).join("")}
         </select>

--- a/openquatt/web/js/src/features/webserver-logs.js
+++ b/openquatt/web/js/src/features/webserver-logs.js
@@ -972,7 +972,7 @@ export function renderWebServerLoggerLevelControl() {
       dataValue: "debugLevel",
       label: "Logger level",
       value: value || "Onbekend",
-      note: "Geldt tot de volgende herstart. DEBUG kan bij veel Modbusverkeer de controller en verbindingen zwaar belasten.",
+      note: "DEBUG is tijdelijk en wordt na een herstart teruggezet naar INFO. Bij veel Modbusverkeer kan DEBUG zoveel logging produceren dat de web-app en Home Assistant traag of onbereikbaar worden.",
       action: `<label class="oq-webserver-log-level-control" aria-label="Logger level">
         <select class="oq-helper-select" data-oq-field="debugLevel" ${busy ? "disabled" : ""}>
           ${options.map((option) => `<option value="${escapeHtml(option)}" ${option === value ? "selected" : ""}>${escapeHtml(option)}</option>`).join("")}

--- a/openquatt/web/js/src/features/webserver-logs.js
+++ b/openquatt/web/js/src/features/webserver-logs.js
@@ -972,7 +972,7 @@ export function renderWebServerLoggerLevelControl() {
       dataValue: "debugLevel",
       label: "Logger level",
       value: value || "Onbekend",
-      note: "Past het runtime logniveau aan voor nieuwe firmwaremeldingen.",
+      note: "Geldt tot de volgende herstart. DEBUG kan bij veel Modbusverkeer de controller en verbindingen zwaar belasten.",
       action: `<label class="oq-webserver-log-level-control" aria-label="Logger level">
         <select class="oq-helper-select" data-oq-field="debugLevel" ${busy ? "disabled" : ""}>
           ${options.map((option) => `<option value="${escapeHtml(option)}" ${option === value ? "selected" : ""}>${escapeHtml(option)}</option>`).join("")}

--- a/openquatt/web/smoke-web.mjs
+++ b/openquatt/web/smoke-web.mjs
@@ -314,7 +314,7 @@ async function checkWriteActionContracts() {
   assertContains(entityWriteActions, "export async function commitOpenQuattRegulationResumeNow", "OpenQuatt resume write helper");
   assertContains(namedButtonActions, 'ODU_RUNTIME_FREQUENCY_BUTTON_KEYS.has(buttonKey)', "ODU runtime named buttons");
   assertContains(entityWriteActions, "ODU_RUNTIME_FREQUENCY_BUTTON_KEYS.has(key)", "ODU runtime named button write helper");
-  assertContains(webServerLogs, "DEBUG kan bij veel Modbusverkeer de controller en verbindingen zwaar belasten.", "Debug logger safety warning");
+  assertContains(webServerLogs, "kan DEBUG zoveel logging produceren dat de web-app en Home Assistant traag of onbereikbaar worden.", "Debug logger safety warning");
 }
 
 async function checkStateSliceContracts() {

--- a/openquatt/web/smoke-web.mjs
+++ b/openquatt/web/smoke-web.mjs
@@ -298,6 +298,7 @@ async function checkWriteActionContracts() {
   const firmwareActions = await source("js/src/features/firmware-actions.js");
   const debugRecording = await source("js/src/features/debug-recording.js");
   const systemActions = await source("js/src/features/system-actions.js");
+  const webServerLogs = await source("js/src/features/webserver-logs.js");
 
   assertContains(securityActions, 'fetch("/api-security/enable"', "API security enable");
   assertContains(securityActions, 'fetch("/api-security/rotate"', "API security rotate");
@@ -313,6 +314,7 @@ async function checkWriteActionContracts() {
   assertContains(entityWriteActions, "export async function commitOpenQuattRegulationResumeNow", "OpenQuatt resume write helper");
   assertContains(namedButtonActions, 'ODU_RUNTIME_FREQUENCY_BUTTON_KEYS.has(buttonKey)', "ODU runtime named buttons");
   assertContains(entityWriteActions, "ODU_RUNTIME_FREQUENCY_BUTTON_KEYS.has(key)", "ODU runtime named button write helper");
+  assertContains(webServerLogs, "DEBUG kan bij veel Modbusverkeer de controller en verbindingen zwaar belasten.", "Debug logger safety warning");
 }
 
 async function checkStateSliceContracts() {

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -2,6 +2,6 @@
 export const WEB_BUNDLE_GZIP_GROWTH_LIMIT = { bytes: 4_096, ratio: 0.02 };
 
 export const WEB_BUNDLE_BUDGETS = [
-  { file: "js/openquatt-app.js", raw: 805_000 },
+  { file: "js/openquatt-app.js", raw: 805_250 },
   { file: "css/openquatt-app.css", raw: 258_000 },
 ];


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat `Debug Level` na iedere herstart of OTA terugvallen op `INFO`, ook wanneer eerder runtime `DEBUG` was gekozen.
- Legt in de web-app uit dat de keuze tijdelijk is en dat veel DEBUG-logging de web-app en Home Assistant traag of onbereikbaar kan maken.
- Borgt de veiligheidswaarschuwing in de web-smoketest, werkt de gegenereerde webbundle bij en actualiseert het ruwe JS-budget van 805.000 naar 805.250 bytes.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Runtime logniveau `DEBUG` blijft beschikbaar voor diagnose, maar geldt bewust alleen tot de volgende herstart. De logger start daarna altijd op `INFO`; verwarmingsregeling en Modbusconfiguratie wijzigen niet.

## Achtergrond

`Debug Level` gebruikte `restore_value: true`. Daardoor bleef een tijdelijk gekozen `DEBUG`-niveau na OTA, rollback en powercycle actief. Op een Duo-installatie gaf het hoge Modbus-logvolume langdurige druk op web- en API-verbindingen. Deze wijziging maakt een herstart weer een betrouwbare herstelhandeling zonder de diagnostische mogelijkheid te verwijderen.

De volledige diff is gecontroleerd op fresh install, herstart, OTA/upgrade, bestaande opgeslagen state, runtimewijziging, settings-backup/restore en gegenereerde assets. Bestaande opgeslagen `DEBUG`-state wordt na een upgrade genegeerd; nieuwe installaties en upgrades starten beide op `INFO`. De interne debugselect maakt geen deel uit van settings-backups.

De beperkte budgetaanpassing houdt de expliciete uitleg leesbaar. Tegen `origin/dev` is de JS-bundle 805.120 bytes raw en 216.851 bytes gzip; gzip groeit 94 bytes (+0,04%) tegenover de toegestane 4.096 bytes.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De relevante uitleg staat direct bij de runtimebediening in de web-app. Er verandert geen ondersteunde gebruikersworkflow buiten deze interne diagnostische instelling.

## Validatie

- `npm run build:web`
- `npm run smoke:web`
- `OPENQUATT_WEB_BUNDLE_BASE_REF=origin/dev npm run check:web` (62/62 tests; webkwaliteit groen)
- `esphome config configs/heatpump_controller_q/single_wifi.yaml` (ESPHome 2026.7.0)
- `esphome config configs/heatpump_controller_q/duo_wifi.yaml` (ESPHome 2026.7.0)
- `git diff --check`

Daarnaast bleef de bestaande controller na het handmatig terugzetten van `DEBUG` naar `INFO` ruim tien minuten stabiel. Met Home Assistant daarna opnieuw ingeschakeld bleven circa drie minuten seriële logging en vier opeenvolgende HTTP 200-metingen vrij van API-, webserver-, wifi-, heap- en watchdogwaarschuwingen.
