### PR TITLE
Prevent runtime starvation from offline I/O

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -221,6 +221,17 @@ void OpenQuattUsageTelemetry::setup() {
 }
 
 void OpenQuattUsageTelemetry::loop() {
+  if (this->cleanup_task_complete_.exchange(false)) {
+    this->complete_publish_session_();
+  }
+  if (this->finishing_session_.load()) {
+    if (!this->cleanup_task_running_.load() &&
+        time_reached_(millis(), this->next_cleanup_attempt_ms_)) {
+      this->start_cleanup_task_();
+    }
+    return;
+  }
+
   if (this->session_active_.load()) {
     if (this->start_task_running_.load()) {
       return;
@@ -421,6 +432,8 @@ void OpenQuattUsageTelemetry::start_publish_session_() {
   this->publish_failed_.store(false);
   this->pending_message_id_.store(-1);
   this->finishing_session_.store(false);
+  this->cleanup_task_complete_.store(false);
+  this->cleanup_succeeded_.store(false);
   this->session_started_ms_ = millis();
   this->session_active_.store(true);
 
@@ -494,25 +507,40 @@ bool OpenQuattUsageTelemetry::start_client_() {
 }
 
 void OpenQuattUsageTelemetry::finish_publish_session_(bool succeeded) {
-  if (!this->session_active_.load() || this->start_task_running_.load()) {
+  if (!this->session_active_.load() || this->start_task_running_.load() ||
+      this->finishing_session_.exchange(true)) {
     return;
   }
-  this->finishing_session_.store(true);
+  this->cleanup_succeeded_.store(succeeded);
+  this->next_cleanup_attempt_ms_ = millis();
+  this->start_cleanup_task_();
+}
 
-  if (this->runtime_lock_ != nullptr && xSemaphoreTake(this->runtime_lock_, portMAX_DELAY) == pdTRUE) {
-    if (this->mqtt_client_ != nullptr) {
-      esp_mqtt_client_stop(this->mqtt_client_);
-      esp_mqtt_client_destroy(this->mqtt_client_);
-      this->mqtt_client_ = nullptr;
-    }
-    xSemaphoreGive(this->runtime_lock_);
+void OpenQuattUsageTelemetry::start_cleanup_task_() {
+  if (!this->finishing_session_.load() || this->cleanup_task_running_.exchange(true)) {
+    return;
   }
+
+  const BaseType_t created = xTaskCreatePinnedToCore(&OpenQuattUsageTelemetry::cleanup_client_task_,
+                                                     "oq_usage_cleanup", MQTT_CLEANUP_TASK_STACK_SIZE, this, 4,
+                                                     nullptr, tskNO_AFFINITY);
+  if (created != pdPASS) {
+    this->cleanup_task_running_.store(false);
+    this->next_cleanup_attempt_ms_ = millis() + 1000U;
+    ESP_LOGE(TAG, "Failed to create usage telemetry MQTT cleanup task; retrying");
+  }
+}
+
+void OpenQuattUsageTelemetry::complete_publish_session_() {
+  const bool succeeded = this->cleanup_succeeded_.load();
 
   this->session_active_.store(false);
   this->publish_succeeded_.store(false);
   this->publish_failed_.store(false);
   this->pending_message_id_.store(-1);
   this->finishing_session_.store(false);
+  this->cleanup_succeeded_.store(false);
+  this->next_cleanup_attempt_ms_ = 0;
 
   if (!this->enabled_.load()) {
     this->payload_.clear();
@@ -655,6 +683,26 @@ void OpenQuattUsageTelemetry::start_client_task_(void *arg) {
       self->publish_failed_.store(true);
     }
     self->start_task_running_.store(false);
+    App.wake_loop_threadsafe();
+  }
+  vTaskDelete(nullptr);
+}
+
+void OpenQuattUsageTelemetry::cleanup_client_task_(void *arg) {
+  auto *self = static_cast<OpenQuattUsageTelemetry *>(arg);
+  if (self != nullptr) {
+    esp_mqtt_client_handle_t client = nullptr;
+    if (self->runtime_lock_ != nullptr && xSemaphoreTake(self->runtime_lock_, portMAX_DELAY) == pdTRUE) {
+      client = self->mqtt_client_;
+      self->mqtt_client_ = nullptr;
+      xSemaphoreGive(self->runtime_lock_);
+    }
+    if (client != nullptr) {
+      esp_mqtt_client_stop(client);
+      esp_mqtt_client_destroy(client);
+    }
+    self->cleanup_task_complete_.store(true);
+    self->cleanup_task_running_.store(false);
     App.wake_loop_threadsafe();
   }
   vTaskDelete(nullptr);

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -225,10 +225,6 @@ void OpenQuattUsageTelemetry::loop() {
     this->complete_publish_session_();
   }
   if (this->finishing_session_.load()) {
-    if (!this->cleanup_task_running_.load() &&
-        time_reached_(millis(), this->next_cleanup_attempt_ms_)) {
-      this->start_cleanup_task_();
-    }
     return;
   }
 
@@ -425,6 +421,14 @@ void OpenQuattUsageTelemetry::start_publish_session_() {
     return;
   }
 
+  // Reserve the cleanup worker before MQTT/TLS can consume the remaining heap.
+  // If this allocation fails, no client resources exist yet and retrying is safe.
+  if (!this->prepare_cleanup_task_()) {
+    this->start_task_running_.store(false);
+    this->schedule_retry_();
+    return;
+  }
+
   if (this->payload_.empty()) {
     this->build_payload_();
   }
@@ -512,23 +516,25 @@ void OpenQuattUsageTelemetry::finish_publish_session_(bool succeeded) {
     return;
   }
   this->cleanup_succeeded_.store(succeeded);
-  this->next_cleanup_attempt_ms_ = millis();
-  this->start_cleanup_task_();
+  xTaskNotifyGive(this->cleanup_task_handle_.load());
 }
 
-void OpenQuattUsageTelemetry::start_cleanup_task_() {
-  if (!this->finishing_session_.load() || this->cleanup_task_running_.exchange(true)) {
-    return;
+bool OpenQuattUsageTelemetry::prepare_cleanup_task_() {
+  if (this->cleanup_task_running_.exchange(true)) {
+    return false;
   }
 
+  TaskHandle_t task_handle = nullptr;
   const BaseType_t created = xTaskCreatePinnedToCore(&OpenQuattUsageTelemetry::cleanup_client_task_,
                                                      "oq_usage_cleanup", MQTT_CLEANUP_TASK_STACK_SIZE, this, 4,
-                                                     nullptr, tskNO_AFFINITY);
-  if (created != pdPASS) {
+                                                     &task_handle, tskNO_AFFINITY);
+  if (created != pdPASS || task_handle == nullptr) {
     this->cleanup_task_running_.store(false);
-    this->next_cleanup_attempt_ms_ = millis() + 1000U;
-    ESP_LOGE(TAG, "Failed to create usage telemetry MQTT cleanup task; retrying");
+    ESP_LOGE(TAG, "Failed to create usage telemetry MQTT cleanup task");
+    return false;
   }
+  this->cleanup_task_handle_.store(task_handle);
+  return true;
 }
 
 void OpenQuattUsageTelemetry::complete_publish_session_() {
@@ -540,7 +546,6 @@ void OpenQuattUsageTelemetry::complete_publish_session_() {
   this->pending_message_id_.store(-1);
   this->finishing_session_.store(false);
   this->cleanup_succeeded_.store(false);
-  this->next_cleanup_attempt_ms_ = 0;
 
   if (!this->enabled_.load()) {
     this->payload_.clear();
@@ -690,7 +695,8 @@ void OpenQuattUsageTelemetry::start_client_task_(void *arg) {
 
 void OpenQuattUsageTelemetry::cleanup_client_task_(void *arg) {
   auto *self = static_cast<OpenQuattUsageTelemetry *>(arg);
-  if (self != nullptr) {
+  while (self != nullptr) {
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
     esp_mqtt_client_handle_t client = nullptr;
     if (self->runtime_lock_ != nullptr && xSemaphoreTake(self->runtime_lock_, portMAX_DELAY) == pdTRUE) {
       client = self->mqtt_client_;
@@ -701,9 +707,11 @@ void OpenQuattUsageTelemetry::cleanup_client_task_(void *arg) {
       esp_mqtt_client_stop(client);
       esp_mqtt_client_destroy(client);
     }
-    self->cleanup_task_complete_.store(true);
+    self->cleanup_task_handle_.store(nullptr);
     self->cleanup_task_running_.store(false);
+    self->cleanup_task_complete_.store(true);
     App.wake_loop_threadsafe();
+    break;
   }
   vTaskDelete(nullptr);
 }

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -117,7 +117,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   void start_publish_session_();
   bool start_client_();
   void finish_publish_session_(bool succeeded);
-  void start_cleanup_task_();
+  bool prepare_cleanup_task_();
   void complete_publish_session_();
   void build_payload_();
   std::string read_hardware_revision_() const;
@@ -179,8 +179,8 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   std::atomic<int> pending_message_id_{-1};
   uint32_t session_started_ms_{0};
   uint32_t next_publish_ms_{0};
-  uint32_t next_cleanup_attempt_ms_{0};
   uint8_t consecutive_failures_{0};
+  std::atomic<TaskHandle_t> cleanup_task_handle_{nullptr};
 };
 
 }  // namespace openquatt_usage_telemetry

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -81,6 +81,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   static constexpr uint32_t RETRY_MIN_MS = 5UL * 60UL * 1000UL;
   static constexpr uint32_t RETRY_MAX_MS = 60UL * 60UL * 1000UL;
   static constexpr uint32_t MQTT_START_TASK_STACK_SIZE = 24576;
+  static constexpr uint32_t MQTT_CLEANUP_TASK_STACK_SIZE = 6144;
   static constexpr int MQTT_TASK_STACK_SIZE = 12288;
 
   struct StorageV1 {
@@ -116,12 +117,15 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   void start_publish_session_();
   bool start_client_();
   void finish_publish_session_(bool succeeded);
+  void start_cleanup_task_();
+  void complete_publish_session_();
   void build_payload_();
   std::string read_hardware_revision_() const;
   static bool time_reached_(uint32_t now_ms, uint32_t target_ms);
   static std::string format_uuid_(const std::array<uint8_t, 16> &bytes);
   static std::string random_message_id_();
   static void start_client_task_(void *arg);
+  static void cleanup_client_task_(void *arg);
   static void mqtt_event_handler_(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
 
   std::string broker_;
@@ -167,11 +171,15 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   std::atomic<bool> session_active_{false};
   std::atomic<bool> finishing_session_{false};
   std::atomic<bool> start_task_running_{false};
+  std::atomic<bool> cleanup_task_running_{false};
+  std::atomic<bool> cleanup_task_complete_{false};
+  std::atomic<bool> cleanup_succeeded_{false};
   std::atomic<bool> publish_succeeded_{false};
   std::atomic<bool> publish_failed_{false};
   std::atomic<int> pending_message_id_{-1};
   uint32_t session_started_ms_{0};
   uint32_t next_publish_ms_{0};
+  uint32_t next_cleanup_attempt_ms_{0};
   uint8_t consecutive_failures_{0};
 };
 

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -1357,9 +1357,7 @@ interval:
           id(${hp_id}_last_offline_probe_ms) = now == 0U ? 1U : now;
           auto probe = esphome::modbus_controller::ModbusCommandItem::create_read_command(
               id(${hp_id}), esphome::modbus::ModbusRegisterType::HOLDING, 2099, 1,
-              [=](esphome::modbus::ModbusRegisterType register_type, uint16_t start_address,
-                  const std::vector<uint8_t> &data) {
+              [=](esphome::modbus::ModbusRegisterType, uint16_t, const std::vector<uint8_t> &) {
                 id(${hp_id}_is_online) = true;
-                id(${hp_id}).on_register_data(register_type, start_address, data);
               });
           id(${hp_id}).queue_command(probe);

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -93,6 +93,11 @@ globals:
     restore_value: no
     initial_value: 'false'
 
+  - id: ${hp_id}_last_offline_probe_ms
+    type: uint32_t
+    restore_value: no
+    initial_value: '0'
+
 # ----------------------------
 # SELECT
 # ----------------------------
@@ -1327,9 +1332,34 @@ interval:
   - interval: ${oq_modbus_update_interval_s}s
     startup_delay: ${oq_modbus_startup_delay_ms}ms
     then:
-      - if:
-          condition:
-            lambda: |-
-              return !id(oq_runtime_polling_paused).state;
-          then:
-            - component.update: ${hp_id}
+      - lambda: |-
+          if (id(oq_runtime_polling_paused).state) {
+            return;
+          }
+
+          // A confirmed online HP keeps the normal full-register polling cadence.
+          if (id(${hp_id}_is_online)) {
+            id(${hp_id}).update();
+            return;
+          }
+
+          // An absent HP only receives one lightweight recovery probe per interval.
+          const uint32_t now = millis();
+          const uint32_t last_probe = id(${hp_id}_last_offline_probe_ms);
+          if (last_probe != 0U &&
+              now - last_probe < ${oq_modbus_offline_probe_interval_s}UL * 1000UL) {
+            return;
+          }
+          if (id(${hp_id}).get_command_queue_length() != 0U) {
+            return;
+          }
+
+          id(${hp_id}_last_offline_probe_ms) = now == 0U ? 1U : now;
+          auto probe = esphome::modbus_controller::ModbusCommandItem::create_read_command(
+              id(${hp_id}), esphome::modbus::ModbusRegisterType::HOLDING, 2099, 1,
+              [=](esphome::modbus::ModbusRegisterType register_type, uint16_t start_address,
+                  const std::vector<uint8_t> &data) {
+                id(${hp_id}_is_online) = true;
+                id(${hp_id}).on_register_data(register_type, start_address, data);
+              });
+          id(${hp_id}).queue_command(probe);

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -19,6 +19,7 @@ esphome:
       - lambda: |-
           // Always start from a clean paused state after reboot or OTA.
           id(oq_runtime_polling_paused).publish_state(false);
+          id(oq_http_ota_begin_observed) = false;
           id(oq_ota_phase_code) = 0;
           id(oq_ota_progress_pct) = 0.0f;
           id(oq_firmware_update_status).publish_state("Idle");
@@ -143,6 +144,7 @@ ota:
     on_begin:
       then:
         - lambda: |-
+            id(oq_http_ota_begin_observed) = true;
             id(oq_runtime_polling_paused).publish_state(true);
             ESP_LOGI("oq_fw", "Runtime polling paused for OTA.");
             id(oq_ota_phase_code) = 1;
@@ -281,6 +283,10 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+  - id: oq_http_ota_begin_observed
+    type: bool
+    restore_value: false
+    initial_value: 'false'
   - id: oq_trend_capture_force_once
     type: bool
     restore_value: false
@@ -325,7 +331,9 @@ script:
     mode: restart
     then:
       - lambda: |-
-          // Clear a terminal phase from an earlier attempt before the web UI starts polling this install.
+          // Clear terminal and pre-OTA state from an earlier/restarted attempt.
+          id(oq_runtime_polling_paused).publish_state(false);
+          id(oq_http_ota_begin_observed) = false;
           id(oq_ota_phase_code) = 1;
           id(oq_firmware_update_status).publish_state("Starting");
           id(oq_firmware_update_progress).publish_state(0.0f);
@@ -378,6 +386,7 @@ script:
             - lambda: |-
                 id(oq_firmware_target_install_active) = true;
                 id(oq_firmware_target_install_attempt) = 1;
+                id(oq_http_ota_begin_observed) = false;
                 id(oq_runtime_polling_paused).publish_state(true);
                 ESP_LOGI("oq_fw", "Runtime polling paused before deferred OTA.");
                 id(oq_firmware_update_status).publish_state("Starting");
@@ -386,9 +395,28 @@ script:
             - update.perform:
                 id: oq_firmware_update
                 force_update: true
+            # set_url()/flash() can reject before OTA callbacks run. Do not
+            # leave runtime polling latched off in that failure mode.
+            - wait_until:
+                condition:
+                  lambda: |-
+                    return id(oq_http_ota_begin_observed);
+                timeout: 5s
+            - if:
+                condition:
+                  lambda: |-
+                    return !id(oq_http_ota_begin_observed);
+                then:
+                  - lambda: |-
+                      id(oq_firmware_target_install_active) = false;
+                      id(oq_runtime_polling_paused).publish_state(false);
+                      id(oq_ota_phase_code) = 5;
+                      id(oq_firmware_update_status).publish_state("Error");
+                      ESP_LOGE("oq_fw", "Firmware install did not reach the OTA start callback; polling resumed.");
           else:
             - lambda: |-
                 id(oq_firmware_target_install_active) = false;
+                id(oq_runtime_polling_paused).publish_state(false);
                 id(oq_ota_phase_code) = 5;
                 id(oq_firmware_update_status).publish_state("Error");
                 ESP_LOGE("oq_fw", "Firmware install blocked: target manifest check failed twice.");
@@ -953,8 +981,6 @@ binary_sensor:
     name: Runtime polling paused
     internal: true
     entity_category: diagnostic
-    lambda: |-
-      return false;
 
 sensor:
   - platform: debug

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -246,6 +246,7 @@ ha_cooling_dew_point_valid_entity_id: "binary_sensor.openquatt_ext_cooling_dew_p
 # HP IO (MODBUS POLLING)
 # ----------------------------
 oq_modbus_update_interval_s: "5"                    # Base Modbus controller polling interval [s].
+oq_modbus_offline_probe_interval_s: "30"             # Sparse single-register probe while an HP is offline [s].
 oq_modbus_command_throttle_ms: "500"                 # Minimum spacing between Modbus commands [ms].
 oq_modbus_max_cmd_retries: "1"                       # Retries per Modbus command; keep low to avoid long blocking on bad links.
 oq_modbus_startup_delay_ms: "0"                      # Default startup offset for staged Modbus polling [ms].


### PR DESCRIPTION
# Wat verandert deze PR?

- Beperkt een niet-bereikbare warmtepomp tot één lichte register-2099-herstelprobe per 30 seconden; volledige polling hervat pas na een geldig antwoord.
- Verplaatst blokkerende usage-telemetry `stop/destroy` uit `loopTask` en reserveert de cleanup-worker voordat MQTT/TLS heap kan verbruiken.
- Maakt de runtime-pauze tijdens OTA duurzaam en herstelt polling ook na script-restart, manifestfout en een OTA-start die geen callback bereikt.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alle wijzigingen zijn fail-safe runtimeguards. Een offline HP wordt minder vaak bevraagd, maar een geldig probeantwoord schakelt direct terug naar de bestaande volledige polling. OTA blokkeert polling nu werkelijk tot een expliciete terminale callback. Er wijzigen geen entity-ID's, installatiekeuzes of regelsetpoints.

## Achtergrond

De recoverytest op de bestaande firmware liet twee onafhankelijke hoofdloopproblemen zien:

- twee afwezige Modbus-slaves bleven volledige registerrondes uitvoeren en reproduceerden een `loopTask`-watchdog rond 124 seconden;
- usage-telemetry ruimde MQTT synchroon in `loopTask` op en blokkeerde die taak circa één seconde.

De eerste asynchrone cleanupvariant kon bij lage heap juist geen cleanup-task meer alloceren nadat MQTT/TLS-resources al bestonden. Deze PR reserveert daarom eerst de 6144-byte cleanup-task. Mislukt dat, dan bestaan nog geen clientresources en volgt de bestaande begrensde retry-back-off.

De pre-PR-audit vond daarnaast dat `oq_runtime_polling_paused` iedere loop door een template-lambda naar `false` werd teruggezet. Na het verwijderen daarvan zijn ook restart- en early-failurepaden expliciet afgedekt, zodat de duurzame pauze niet kan blijven hangen.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit wijzigt uitsluitend interne polling-, cleanup- en OTA-lifecyclelogica. De webinterface, entities, configuratie en gebruikersworkflow blijven gelijk.

## Validatie

- `python3 scripts/dev.py validate --jobs 1`: groen voor alle acht ingeschakelde firmwaretargets (configuratie en volledige compile).
- M1 los: na de initiële burst exact één probe plus één retry per adres per 30 seconden; geen watchdog voorbij de eerdere 124-seconden-grens; HTTP en native API bleven gezond.
- Live M1-herstel: geldig antwoord zet de HP online en hervat normale polling zonder reboot.
- Gegenereerde Q Duo-code gecontroleerd: de pause-sensor heeft geen continue template-lambda en alle OTA rollbackpaden zijn aanwezig.
- Volledige diff afzonderlijk koud beoordeeld op dual-HP, `millis()`-wrap, task/heap-lifecycle, OTA restart/failure en recovery-interleavings; geen open blocker.

Nog uit te voeren voordat deze draft ready wordt: de complete actuele branch op het device testen voor telemetry-success/timeout, OTA-failure en HA-aan belasting. De cleanup-worker voegt tijdens een telemetrysessie tijdelijk 6144 bytes taakstack toe; allocatiefout faalt gesloten zonder MQTT-resources achter te laten.
