### PR TITLE
Close stalled EventSource sessions safely

### DIFF
--- a/components/web_server_idf/README.md
+++ b/components/web_server_idf/README.md
@@ -1,0 +1,28 @@
+# Temporary ESPHome web_server_idf override
+
+This directory is copied from ESPHome `2026.7.0`, tag commit
+`920a8b761b680d9864da2ef4b44b4af95c99dba8`.
+
+OpenQuatt temporarily overrides the built-in component because the upstream
+EventSource failure path marks its local file descriptor dead without closing
+the corresponding ESP-IDF HTTPD session. The main loop can then delete the
+response while HTTPD still retains its `sess_ctx`/`free_ctx`, leaking a client
+slot and leaving a dangling callback.
+
+The local delta is limited to:
+
+- request an identity-checked socket shutdown on the HTTPD task after 20
+  seconds without send progress during repeated `EAGAIN`/`EWOULDBLOCK`
+  results;
+- close sessions after other unrecoverable asynchronous send results;
+- keep the response alive until HTTPD invokes `destroy()`;
+- keep close intent terminal and retry a temporarily rejected close request at
+  a bounded cadence;
+- reject ESPHome versions other than `2026.7.0` so the override cannot silently
+  outlive its upstream base.
+
+Remove this override once the lifecycle fix is available in the ESPHome version
+pinned by `.github/requirements-esphome.txt`.
+
+The queued close callback relies on the existing ESPHome lifecycle in which
+`httpd_stop()` joins the HTTPD task before the EventSource handler is destroyed.

--- a/components/web_server_idf/__init__.py
+++ b/components/web_server_idf/__init__.py
@@ -1,0 +1,26 @@
+from esphome.components.esp32 import add_idf_sdkconfig_option
+import esphome.config_validation as cv
+from esphome.const import __version__ as ESPHOME_VERSION
+
+CODEOWNERS = ["@dentra"]
+SUPPORTED_ESPHOME_VERSION = "2026.7.0"
+
+
+def validate_esphome_version(config):
+    if ESPHOME_VERSION != SUPPORTED_ESPHOME_VERSION:
+        raise cv.Invalid(
+            "OpenQuatt's temporary web_server_idf override requires ESPHome "
+            f"{SUPPORTED_ESPHOME_VERSION}, found {ESPHOME_VERSION}"
+        )
+    return config
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema({}),
+    cv.only_on_esp32,
+    validate_esphome_version,
+)
+
+
+async def to_code(config):
+    # Increase the maximum supported size of headers section in HTTP request packet to be processed by the server
+    add_idf_sdkconfig_option("CONFIG_HTTPD_MAX_REQ_HDR_LEN", 1024)

--- a/components/web_server_idf/multipart.cpp
+++ b/components/web_server_idf/multipart.cpp
@@ -1,0 +1,263 @@
+#include "esphome/core/defines.h"
+#if defined(USE_ESP32) && defined(USE_WEBSERVER_OTA)
+#include "multipart.h"
+#include "utils.h"
+#include "esphome/core/log.h"
+#include <cstring>
+#include "multipart_parser.h"
+
+namespace esphome::web_server_idf {
+
+static const char *const TAG = "multipart";
+
+// ========== MultipartReader Implementation ==========
+
+MultipartReader::MultipartReader(const std::string &boundary) {
+  // Initialize settings with callbacks
+  memset(&settings_, 0, sizeof(settings_));
+  settings_.on_header_field = on_header_field;
+  settings_.on_header_value = on_header_value;
+  settings_.on_part_data = on_part_data;
+  settings_.on_part_data_end = on_part_data_end;
+
+  ESP_LOGV(TAG, "Initializing multipart parser with boundary: '%s' (len: %zu)", boundary.c_str(), boundary.length());
+
+  // Create parser with boundary
+  parser_ = multipart_parser_init(boundary.c_str(), &settings_);
+  if (parser_) {
+    multipart_parser_set_data(parser_, this);
+  } else {
+    ESP_LOGE(TAG, "Failed to initialize multipart parser");
+  }
+}
+
+MultipartReader::~MultipartReader() {
+  if (parser_) {
+    multipart_parser_free(parser_);
+  }
+}
+
+size_t MultipartReader::parse(const char *data, size_t len) {
+  if (!parser_) {
+    ESP_LOGE(TAG, "Parser not initialized");
+    return 0;
+  }
+
+  size_t parsed = multipart_parser_execute(parser_, data, len);
+
+  if (parsed != len) {
+    ESP_LOGW(TAG, "Parser consumed %zu of %zu bytes - possible error", parsed, len);
+  }
+
+  return parsed;
+}
+
+void MultipartReader::process_header_(const char *value, size_t length) {
+  // Process the completed header (field + value pair)
+  const char *field = current_header_field_.c_str();
+  size_t field_len = current_header_field_.length();
+
+  if (str_startswith_case_insensitive(field, field_len, "content-disposition")) {
+    // Parse name and filename from Content-Disposition
+    extract_header_param(value, length, "name", current_part_.name);
+    extract_header_param(value, length, "filename", current_part_.filename);
+  } else if (str_startswith_case_insensitive(field, field_len, "content-type")) {
+    str_trim(value, length, current_part_.content_type);
+  }
+
+  // Clear field for next header
+  current_header_field_.clear();
+}
+
+int MultipartReader::on_header_field(multipart_parser *parser, const char *at, size_t length) {
+  MultipartReader *reader = static_cast<MultipartReader *>(multipart_parser_get_data(parser));
+  reader->current_header_field_.assign(at, length);
+  return 0;
+}
+
+int MultipartReader::on_header_value(multipart_parser *parser, const char *at, size_t length) {
+  MultipartReader *reader = static_cast<MultipartReader *>(multipart_parser_get_data(parser));
+  reader->process_header_(at, length);
+  return 0;
+}
+
+int MultipartReader::on_part_data(multipart_parser *parser, const char *at, size_t length) {
+  MultipartReader *reader = static_cast<MultipartReader *>(multipart_parser_get_data(parser));
+  // Only process file uploads
+  if (reader->has_file() && reader->data_callback_) {
+    // IMPORTANT: The 'at' pointer points to data within the parser's input buffer.
+    // This data is only valid during this callback. The callback handler MUST
+    // process or copy the data immediately - it cannot store the pointer for
+    // later use as the buffer will be overwritten.
+    reader->data_callback_(reinterpret_cast<const uint8_t *>(at), length);
+  }
+  return 0;
+}
+
+int MultipartReader::on_part_data_end(multipart_parser *parser) {
+  MultipartReader *reader = static_cast<MultipartReader *>(multipart_parser_get_data(parser));
+  ESP_LOGV(TAG, "Part data end");
+  if (reader->part_complete_callback_) {
+    reader->part_complete_callback_();
+  }
+  // Clear part info for next part
+  reader->current_part_ = Part{};
+  return 0;
+}
+
+// ========== Utility Functions ==========
+
+// Case-insensitive string prefix check
+bool str_startswith_case_insensitive(const char *str, size_t str_len, const char *prefix) {
+  size_t prefix_len = strlen(prefix);
+  if (str_len < prefix_len) {
+    return false;
+  }
+  return str_ncmp_ci(str, prefix, prefix_len);
+}
+
+// Extract a parameter value from a header line
+// Handles both quoted and unquoted values
+// Assigns to out if found, clears out otherwise
+void extract_header_param(const char *header, size_t header_len, const char *param, std::string &out) {
+  size_t param_len = strlen(param);
+  size_t search_pos = 0;
+
+  while (search_pos < header_len) {
+    // Look for param name
+    const char *found = strcasestr_n(header + search_pos, header_len - search_pos, param);
+    if (!found) {
+      out.clear();
+      return;
+    }
+    size_t pos = found - header;
+
+    // Check if this is a word boundary (not part of another parameter)
+    if (pos > 0 && header[pos - 1] != ' ' && header[pos - 1] != ';' && header[pos - 1] != '\t') {
+      search_pos = pos + 1;
+      continue;
+    }
+
+    // Move past param name
+    pos += param_len;
+
+    // Skip whitespace and find '='
+    while (pos < header_len && (header[pos] == ' ' || header[pos] == '\t')) {
+      pos++;
+    }
+
+    if (pos >= header_len || header[pos] != '=') {
+      search_pos = pos;
+      continue;
+    }
+
+    pos++;  // Skip '='
+
+    // Skip whitespace after '='
+    while (pos < header_len && (header[pos] == ' ' || header[pos] == '\t')) {
+      pos++;
+    }
+
+    if (pos >= header_len) {
+      out.clear();
+      return;
+    }
+
+    // Check if value is quoted
+    if (header[pos] == '"') {
+      pos++;
+      const char *end = static_cast<const char *>(memchr(header + pos, '"', header_len - pos));
+      if (end) {
+        out.assign(header + pos, end - (header + pos));
+        return;
+      }
+      // Malformed - no closing quote
+      out.clear();
+      return;
+    }
+
+    // Unquoted value - find the end (semicolon, comma, or end of string)
+    size_t end = pos;
+    while (end < header_len && header[end] != ';' && header[end] != ',' && header[end] != ' ' && header[end] != '\t') {
+      end++;
+    }
+
+    out.assign(header + pos, end - pos);
+    return;
+  }
+
+  out.clear();
+}
+
+// Parse boundary from Content-Type header
+// Returns true if boundary found, false otherwise
+// boundary_start and boundary_len will point to the boundary value
+bool parse_multipart_boundary(const char *content_type, const char **boundary_start, size_t *boundary_len) {
+  if (!content_type) {
+    return false;
+  }
+
+  size_t content_type_len = strlen(content_type);
+
+  // Check for multipart/form-data (case-insensitive)
+  if (!strcasestr_n(content_type, content_type_len, "multipart/form-data")) {
+    return false;
+  }
+
+  // Look for boundary parameter
+  const char *b = strcasestr_n(content_type, content_type_len, "boundary=");
+  if (!b) {
+    return false;
+  }
+
+  const char *start = b + 9;  // Skip "boundary="
+
+  // Skip whitespace
+  while (*start == ' ' || *start == '\t') {
+    start++;
+  }
+
+  if (!*start) {
+    return false;
+  }
+
+  // Find end of boundary
+  const char *end = start;
+  if (*end == '"') {
+    // Quoted boundary
+    start++;
+    end++;
+    while (*end && *end != '"') {
+      end++;
+    }
+    *boundary_len = end - start;
+  } else {
+    // Unquoted boundary
+    while (*end && *end != ' ' && *end != ';' && *end != '\r' && *end != '\n' && *end != '\t') {
+      end++;
+    }
+    *boundary_len = end - start;
+  }
+
+  if (*boundary_len == 0) {
+    return false;
+  }
+
+  *boundary_start = start;
+
+  return true;
+}
+
+// Trim whitespace from both ends, assign result to out
+void str_trim(const char *str, size_t len, std::string &out) {
+  const char *start = str;
+  const char *end = str + len;
+  while (start < end && (*start == ' ' || *start == '\t' || *start == '\r' || *start == '\n'))
+    start++;
+  while (end > start && (end[-1] == ' ' || end[-1] == '\t' || end[-1] == '\r' || end[-1] == '\n'))
+    end--;
+  out.assign(start, end - start);
+}
+
+}  // namespace esphome::web_server_idf
+#endif  // defined(USE_ESP32) && defined(USE_WEBSERVER_OTA)

--- a/components/web_server_idf/multipart.h
+++ b/components/web_server_idf/multipart.h
@@ -1,0 +1,85 @@
+#pragma once
+#include "esphome/core/defines.h"
+#if defined(USE_ESP32) && defined(USE_WEBSERVER_OTA)
+
+#include <cctype>
+#include <cstring>
+#include <esp_http_server.h>
+#include <functional>
+#include <multipart_parser.h>
+#include <string>
+#include <utility>
+
+namespace esphome::web_server_idf {
+
+// Wrapper around zorxx/multipart-parser for ESP-IDF OTA uploads
+class MultipartReader {
+ public:
+  struct Part {
+    std::string name;
+    std::string filename;
+    std::string content_type;
+  };
+
+  // IMPORTANT: The data pointer in DataCallback is only valid during the callback!
+  // The multipart parser passes pointers to its internal buffer which will be
+  // overwritten after the callback returns. Callbacks MUST process or copy the
+  // data immediately - storing the pointer for deferred processing will result
+  // in use-after-free bugs.
+  using DataCallback = std::function<void(const uint8_t *data, size_t len)>;
+  using PartCompleteCallback = std::function<void()>;
+
+  explicit MultipartReader(const std::string &boundary);
+  ~MultipartReader();
+
+  // Set callbacks for handling data
+  void set_data_callback(DataCallback &&callback) { data_callback_ = std::move(callback); }
+  void set_part_complete_callback(PartCompleteCallback &&callback) { part_complete_callback_ = std::move(callback); }
+
+  // Parse incoming data
+  size_t parse(const char *data, size_t len);
+
+  // Get current part info
+  const Part &get_current_part() const { return current_part_; }
+
+  // Check if we found a file upload
+  bool has_file() const { return !current_part_.filename.empty(); }
+
+ private:
+  static int on_header_field(multipart_parser *parser, const char *at, size_t length);
+  static int on_header_value(multipart_parser *parser, const char *at, size_t length);
+  static int on_part_data(multipart_parser *parser, const char *at, size_t length);
+  static int on_part_data_end(multipart_parser *parser);
+
+  multipart_parser *parser_{nullptr};
+  multipart_parser_settings settings_{};
+
+  Part current_part_;
+  std::string current_header_field_;
+
+  DataCallback data_callback_;
+  PartCompleteCallback part_complete_callback_;
+
+  void process_header_(const char *value, size_t length);
+};
+
+// ========== Utility Functions ==========
+
+// Case-insensitive string prefix check
+bool str_startswith_case_insensitive(const char *str, size_t str_len, const char *prefix);
+
+// Extract a parameter value from a header line
+// Handles both quoted and unquoted values
+// Assigns to out if found, clears out otherwise
+void extract_header_param(const char *header, size_t header_len, const char *param, std::string &out);
+
+// Parse boundary from Content-Type header
+// Returns true if boundary found, false otherwise
+// boundary_start and boundary_len will point to the boundary value
+bool parse_multipart_boundary(const char *content_type, const char **boundary_start, size_t *boundary_len);
+
+// Trim whitespace from both ends, assign result to out
+void str_trim(const char *str, size_t len, std::string &out);
+
+}  // namespace esphome::web_server_idf
+#endif  // defined(USE_ESP32) && defined(USE_WEBSERVER_OTA)

--- a/components/web_server_idf/utils.cpp
+++ b/components/web_server_idf/utils.cpp
@@ -1,0 +1,118 @@
+#ifdef USE_ESP32
+#include <cstring>
+#include <cctype>
+#include "esphome/core/helpers.h"
+#include "http_parser.h"
+
+#include "utils.h"
+
+namespace esphome::web_server_idf {
+
+size_t url_decode(char *str) {
+  char *start = str;
+  char *ptr = str, buf;
+  for (; *str; str++, ptr++) {
+    if (*str == '%') {
+      str++;
+      if (parse_hex(str, 2, reinterpret_cast<uint8_t *>(&buf), 1) == 2) {
+        *ptr = buf;
+        str++;
+      } else {
+        str--;
+        *ptr = *str;
+      }
+    } else if (*str == '+') {
+      *ptr = ' ';
+    } else {
+      *ptr = *str;
+    }
+  }
+  *ptr = '\0';
+  return ptr - start;
+}
+
+bool request_has_header(httpd_req_t *req, const char *name) { return httpd_req_get_hdr_value_len(req, name); }
+
+optional<std::string> request_get_header(httpd_req_t *req, const char *name) {
+  size_t len = httpd_req_get_hdr_value_len(req, name);
+  if (len == 0) {
+    return {};
+  }
+
+  std::string str;
+  str.resize(len);
+
+  auto res = httpd_req_get_hdr_value_str(req, name, &str[0], len + 1);
+  if (res != ESP_OK) {
+    return {};
+  }
+
+  return {str};
+}
+
+optional<std::string> query_key_value(const char *query_url, size_t query_len, const char *key) {
+  if (query_url == nullptr || query_len == 0) {
+    return {};
+  }
+
+  // Value can't exceed query_len. Use small stack buffer for typical values,
+  // heap fallback for long ones (e.g. base64 IR data) to limit stack usage
+  // since callers may also have stack buffers for the query string.
+  SmallBufferWithHeapFallback<128, char> val(query_len);
+  if (httpd_query_key_value(query_url, key, val.get(), query_len) != ESP_OK) {
+    return {};
+  }
+
+  url_decode(val.get());
+  return {val.get()};
+}
+
+bool query_has_key(const char *query_url, size_t query_len, const char *key) {
+  if (query_url == nullptr || query_len == 0) {
+    return false;
+  }
+  // Minimal buffer — we only care if the key exists, not the value
+  char buf[1];
+  // httpd_query_key_value returns ESP_OK if found, ESP_ERR_HTTPD_RESULT_TRUNC if found
+  // but value truncated (expected with 1-byte buffer), or other errors for invalid input
+  auto err = httpd_query_key_value(query_url, key, buf, sizeof(buf));
+  return err == ESP_OK || err == ESP_ERR_HTTPD_RESULT_TRUNC;
+}
+
+// Helper function for case-insensitive string region comparison
+bool str_ncmp_ci(const char *s1, const char *s2, size_t n) {
+  for (size_t i = 0; i < n; i++) {
+    if (!char_equals_ci(s1[i], s2[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Bounded case-insensitive string search (like strcasestr but length-bounded)
+const char *strcasestr_n(const char *haystack, size_t haystack_len, const char *needle) {
+  if (!haystack) {
+    return nullptr;
+  }
+
+  size_t needle_len = strlen(needle);
+  if (needle_len == 0) {
+    return haystack;
+  }
+
+  if (haystack_len < needle_len) {
+    return nullptr;
+  }
+
+  const char *end = haystack + haystack_len - needle_len + 1;
+  for (const char *p = haystack; p < end; p++) {
+    if (str_ncmp_ci(p, needle, needle_len)) {
+      return p;
+    }
+  }
+
+  return nullptr;
+}
+
+}  // namespace esphome::web_server_idf
+#endif  // USE_ESP32

--- a/components/web_server_idf/utils.h
+++ b/components/web_server_idf/utils.h
@@ -1,0 +1,29 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include <esp_http_server.h>
+#include <string>
+#include "esphome/core/helpers.h"
+
+namespace esphome::web_server_idf {
+
+/// Decode URL-encoded string in-place (e.g., %20 -> space, + -> space)
+/// Returns the new length of the decoded string
+size_t url_decode(char *str);
+
+bool request_has_header(httpd_req_t *req, const char *name);
+optional<std::string> request_get_header(httpd_req_t *req, const char *name);
+optional<std::string> query_key_value(const char *query_url, size_t query_len, const char *key);
+bool query_has_key(const char *query_url, size_t query_len, const char *key);
+
+// Helper function for case-insensitive character comparison
+inline bool char_equals_ci(char a, char b) { return ::tolower(a) == ::tolower(b); }
+
+// Helper function for case-insensitive string region comparison
+bool str_ncmp_ci(const char *s1, const char *s2, size_t n);
+
+// Bounded case-insensitive string search (like strcasestr but length-bounded)
+const char *strcasestr_n(const char *haystack, size_t haystack_len, const char *needle);
+
+}  // namespace esphome::web_server_idf
+#endif  // USE_ESP32

--- a/components/web_server_idf/web_server_idf.cpp
+++ b/components/web_server_idf/web_server_idf.cpp
@@ -1,0 +1,1298 @@
+#ifdef USE_ESP32
+
+#include <cstdarg>
+#include <memory>
+#include <cstring>
+#include <cctype>
+#include <cinttypes>
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include "esp_tls_crypto.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "utils.h"
+#include "web_server_idf.h"
+
+#ifdef USE_WEBSERVER_AUTH_DIGEST
+#include <esp_random.h>
+#include <esp_rom_md5.h>
+#endif
+
+#ifdef USE_WEBSERVER_OTA
+#include <multipart_parser.h>
+#include "multipart.h"  // For parse_multipart_boundary and other utils
+#endif
+
+#ifdef USE_WEBSERVER
+#include "esphome/components/web_server/web_server.h"
+#include "esphome/components/web_server/list_entities.h"
+#endif  // USE_WEBSERVER
+
+// Include socket headers after Arduino headers to avoid IPADDR_NONE/INADDR_NONE macro conflicts
+#include <cerrno>
+#include <sys/socket.h>
+
+namespace esphome::web_server_idf {
+
+// Status strings not provided by esp_http_server.h
+#ifndef HTTPD_401
+#define HTTPD_401 "401 Unauthorized"
+#endif
+#ifndef HTTPD_409
+#define HTTPD_409 "409 Conflict"
+#endif
+#ifndef HTTPD_422
+#define HTTPD_422 "422 Unprocessable Entity"
+#endif
+
+#define CRLF_STR "\r\n"
+#define CRLF_LEN (sizeof(CRLF_STR) - 1)
+
+static const char *const TAG = "web_server_idf";
+
+// Chunk size for streaming request bodies; matches the Arduino AsyncWebServer buffer size.
+// Buffers of this size must live on the heap - the httpd task stack is too small.
+static constexpr size_t RECV_CHUNK_SIZE = 1460;
+static constexpr size_t YIELD_INTERVAL_BYTES = 16 * 1024;  // Yield every 16KB to prevent watchdog
+
+// Global instance to avoid guard variable (saves 8 bytes)
+// This is initialized at program startup before any threads
+namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+DefaultHeaders default_headers_instance;
+}  // namespace
+
+DefaultHeaders &DefaultHeaders::Instance() { return default_headers_instance; }
+
+namespace {
+// Non-blocking send function to prevent watchdog timeouts when TCP buffers are full
+/**
+ * Sends data on a socket in non-blocking mode.
+ *
+ * @param hd      HTTP server handle (unused).
+ * @param sockfd  Socket file descriptor.
+ * @param buf     Buffer to send.
+ * @param buf_len Length of buffer.
+ * @param flags   Flags for send().
+ * @return
+ *   - Number of bytes sent on success.
+ *   - HTTPD_SOCK_ERR_INVALID if buf is nullptr.
+ *   - HTTPD_SOCK_ERR_TIMEOUT if the send buffer is full (EAGAIN/EWOULDBLOCK).
+ *   - HTTPD_SOCK_ERR_FAIL for other errors.
+ */
+[[maybe_unused]] int nonblocking_send(httpd_handle_t hd, int sockfd, const char *buf, size_t buf_len, int flags) {
+  if (buf == nullptr) {
+    return HTTPD_SOCK_ERR_INVALID;
+  }
+
+  // Use MSG_DONTWAIT to prevent blocking when TCP send buffer is full
+  int ret = send(sockfd, buf, buf_len, flags | MSG_DONTWAIT);
+  if (ret < 0) {
+    const int err = errno;
+    if (err == EAGAIN || err == EWOULDBLOCK) {
+      // Buffer full - retry later
+      return HTTPD_SOCK_ERR_TIMEOUT;
+    }
+    // Real error
+    ESP_LOGD(TAG, "send error: errno %d", err);
+    return HTTPD_SOCK_ERR_FAIL;
+  }
+  return ret;
+}
+}  // namespace
+
+void AsyncWebServer::safe_close_with_shutdown(httpd_handle_t hd, int sockfd) {
+  // CRITICAL: Shut down receive BEFORE closing to prevent lwIP race conditions
+  //
+  // The race condition occurs because close() initiates lwIP teardown while
+  // the TCP/IP thread can still receive packets, causing assertions when
+  // recv_tcp() sees partially-torn-down state.
+  //
+  // By shutting down receive first, we tell lwIP to stop accepting new data BEFORE
+  // the teardown begins, eliminating the race window. We only shutdown RD (not RDWR)
+  // to allow the FIN packet to be sent cleanly during close().
+  //
+  // Note: This function may be called with an already-closed socket if the network
+  // stack closed it. In that case, shutdown() will fail but close() is safe to call.
+  //
+  // See: https://github.com/esphome/esphome-webserver/issues/163
+
+  // Attempt shutdown - ignore errors as socket may already be closed
+  shutdown(sockfd, SHUT_RD);
+
+  // Always close - safe even if socket is already closed by network stack
+  close(sockfd);
+}
+
+void AsyncWebServer::end() {
+  if (this->server_) {
+    httpd_stop(this->server_);
+    this->server_ = nullptr;
+  }
+}
+
+void AsyncWebServer::begin() {
+  if (this->server_) {
+    this->end();
+  }
+  // Default httpd stack is defined by ESP-IDF. Increase to accommodate SerializationBuffer's
+  // 640-byte stack buffer used by web_server JSON request handlers.
+  httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+  config.stack_size = config.stack_size + 256;
+  config.server_port = this->port_;
+  config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
+  // Always enable LRU purging to handle socket exhaustion gracefully.
+  // When max sockets is reached, the oldest connection is closed to make room for new ones.
+  // This prevents "httpd_accept_conn: error in accept (23)" errors.
+  // See: https://github.com/esphome/esphome/issues/12464
+  config.lru_purge_enable = true;
+  // Use custom close function that shuts down before closing to prevent lwIP race conditions
+  config.close_fn = AsyncWebServer::safe_close_with_shutdown;
+  if (httpd_start(&this->server_, &config) == ESP_OK) {
+    const httpd_uri_t handler_get = {
+        .uri = "",
+        .method = HTTP_GET,
+        .handler = AsyncWebServer::request_handler,
+        .user_ctx = this,
+    };
+    httpd_register_uri_handler(this->server_, &handler_get);
+
+    const httpd_uri_t handler_post = {
+        .uri = "",
+        .method = HTTP_POST,
+        .handler = AsyncWebServer::request_post_handler,
+        .user_ctx = this,
+    };
+    httpd_register_uri_handler(this->server_, &handler_post);
+
+    const httpd_uri_t handler_options = {
+        .uri = "",
+        .method = HTTP_OPTIONS,
+        .handler = AsyncWebServer::request_handler,
+        .user_ctx = this,
+    };
+    httpd_register_uri_handler(this->server_, &handler_options);
+  }
+}
+
+esp_err_t AsyncWebServer::request_post_handler(httpd_req_t *r) {
+  ESP_LOGVV(TAG, "Enter AsyncWebServer::request_post_handler. uri=%s", r->uri);
+  auto content_type = request_get_header(r, "Content-Type");
+
+  if (!request_has_header(r, "Content-Length")) {
+    ESP_LOGW(TAG, "Content length is required for post: %s", r->uri);
+    httpd_resp_send_err(r, HTTPD_411_LENGTH_REQUIRED, nullptr);
+    return ESP_OK;
+  }
+
+  if (content_type.has_value()) {
+    const char *content_type_char = content_type.value().c_str();
+
+    // Check most common case first
+    size_t content_type_len = strlen(content_type_char);
+    if (strcasestr_n(content_type_char, content_type_len, "application/x-www-form-urlencoded") != nullptr) {
+      // Normal form data - proceed with regular handling
+#ifdef USE_WEBSERVER_OTA
+    } else if (strcasestr_n(content_type_char, content_type_len, "multipart/form-data") != nullptr) {
+      auto *server = static_cast<AsyncWebServer *>(r->user_ctx);
+      return server->handle_multipart_upload_(r, content_type_char);
+#endif
+    } else {
+      // Other content types (e.g. application/json) are delivered raw to a matching
+      // custom handler via handleBody(), like the Arduino AsyncWebServer does
+      auto *server = static_cast<AsyncWebServer *>(r->user_ctx);
+      return server->handle_raw_body_(r, content_type_char);
+    }
+  }
+
+  // Handle regular form data
+  if (r->content_len > CONFIG_HTTPD_MAX_REQ_HDR_LEN) {
+    ESP_LOGW(TAG, "Request size is to big: %zu", r->content_len);
+    httpd_resp_send_err(r, HTTPD_400_BAD_REQUEST, nullptr);
+    return ESP_FAIL;
+  }
+
+  std::string post_query;
+  if (r->content_len > 0) {
+    post_query.resize(r->content_len);
+    const int ret = httpd_req_recv(r, &post_query[0], r->content_len + 1);
+    if (ret <= 0) {  // 0 return value indicates connection closed
+      if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
+        httpd_resp_send_err(r, HTTPD_408_REQ_TIMEOUT, nullptr);
+        return ESP_ERR_TIMEOUT;
+      }
+      httpd_resp_send_err(r, HTTPD_400_BAD_REQUEST, nullptr);
+      return ESP_FAIL;
+    }
+  }
+
+  AsyncWebServerRequest req(r, std::move(post_query));
+  return static_cast<AsyncWebServer *>(r->user_ctx)->request_handler_(&req);
+}
+
+esp_err_t AsyncWebServer::request_handler(httpd_req_t *r) {
+  ESP_LOGVV(TAG, "Enter AsyncWebServer::request_handler. method=%u, uri=%s", r->method, r->uri);
+  AsyncWebServerRequest req(r);
+  return static_cast<AsyncWebServer *>(r->user_ctx)->request_handler_(&req);
+}
+
+esp_err_t AsyncWebServer::request_handler_(AsyncWebServerRequest *request) const {
+  for (auto *handler : this->handlers_) {
+    if (handler->canHandle(request)) {
+      // At now process only basic requests.
+      // OTA requires multipart request support and handleUpload for it
+      handler->handleRequest(request);
+      return ESP_OK;
+    }
+  }
+  if (this->on_not_found_) {
+    this->on_not_found_(request);
+    return ESP_OK;
+  }
+  return ESP_ERR_NOT_FOUND;
+}
+
+esp_err_t AsyncWebServer::handle_raw_body_(httpd_req_t *r, const char *content_type) {
+  AsyncWebServerRequest req(r);
+  AsyncWebHandler *handler = nullptr;
+  for (auto *h : this->handlers_) {
+    if (h->canHandle(&req)) {
+      handler = h;
+      break;
+    }
+  }
+
+  if (handler == nullptr) {
+    ESP_LOGW(TAG, "Unsupported content type for POST: %s", content_type);
+    // fallback to get handler to support backward compatibility
+    return this->request_handler_(&req);
+  }
+
+  const size_t total = r->content_len;
+  if (total > 0) {
+    auto buffer = std::make_unique_for_overwrite<char[]>(RECV_CHUNK_SIZE);
+    size_t bytes_since_yield = 0;
+
+    for (size_t index = 0; index < total;) {
+      int recv_len = httpd_req_recv(r, buffer.get(), std::min(total - index, RECV_CHUNK_SIZE));
+
+      if (recv_len <= 0) {
+        httpd_resp_send_err(r, recv_len == HTTPD_SOCK_ERR_TIMEOUT ? HTTPD_408_REQ_TIMEOUT : HTTPD_400_BAD_REQUEST,
+                            nullptr);
+        return recv_len == HTTPD_SOCK_ERR_TIMEOUT ? ESP_ERR_TIMEOUT : ESP_FAIL;
+      }
+
+      handler->handleBody(&req, reinterpret_cast<uint8_t *>(buffer.get()), recv_len, index, total);
+      index += recv_len;
+      bytes_since_yield += recv_len;
+
+      if (bytes_since_yield > YIELD_INTERVAL_BYTES) {
+        vTaskDelay(1);
+        bytes_since_yield = 0;
+      }
+    }
+  }
+
+  handler->handleRequest(&req);
+  return ESP_OK;
+}
+
+AsyncWebServerRequest::~AsyncWebServerRequest() {
+  delete this->rsp_;
+  for (auto *param : this->params_) {
+    delete param;  // NOLINT(cppcoreguidelines-owning-memory)
+  }
+}
+
+bool AsyncWebServerRequest::hasHeader(const char *name) const { return request_has_header(*this, name); }
+
+optional<std::string> AsyncWebServerRequest::get_header(const char *name) const {
+  return request_get_header(*this, name);
+}
+
+StringRef AsyncWebServerRequest::url_to(std::span<char, URL_BUF_SIZE> buffer) const {
+  const char *uri = this->req_->uri;
+  const char *query_start = strchr(uri, '?');
+  size_t uri_len = query_start ? static_cast<size_t>(query_start - uri) : strlen(uri);
+  size_t copy_len = std::min(uri_len, URL_BUF_SIZE - 1);
+  memcpy(buffer.data(), uri, copy_len);
+  buffer[copy_len] = '\0';
+  // Decode URL-encoded characters in-place (e.g., %20 -> space)
+  size_t decoded_len = url_decode(buffer.data());
+  return StringRef(buffer.data(), decoded_len);
+}
+
+void AsyncWebServerRequest::redirect(const std::string &url) {
+  httpd_resp_set_status(*this, "302 Found");
+  httpd_resp_set_hdr(*this, "Location", url.c_str());
+  httpd_resp_set_hdr(*this, "Connection", "close");
+  httpd_resp_send(*this, nullptr, 0);
+}
+
+void AsyncWebServerRequest::init_response_(AsyncWebServerResponse *rsp, int code, const char *content_type) {
+  // Set status code - use constants for common codes, default to 500 for unknown codes
+  const char *status;
+  switch (code) {
+    case 200:
+      status = HTTPD_200;
+      break;
+    case 204:
+      status = HTTPD_204;
+      break;
+    case 400:
+      status = HTTPD_400;
+      break;
+    case 401:
+      status = HTTPD_401;
+      break;
+    case 404:
+      status = HTTPD_404;
+      break;
+    case 409:
+      status = HTTPD_409;
+      break;
+    case 422:
+      status = HTTPD_422;
+      break;
+    default:
+      status = HTTPD_500;
+      break;
+  }
+  httpd_resp_set_status(*this, status);
+
+  if (content_type && *content_type) {
+    httpd_resp_set_type(*this, content_type);
+  }
+  httpd_resp_set_hdr(*this, "Accept-Ranges", "none");
+
+  for (const auto &header : DefaultHeaders::Instance().headers_) {
+    httpd_resp_set_hdr(*this, header.name, header.value);
+  }
+
+  delete this->rsp_;
+  this->rsp_ = rsp;
+}
+
+#ifdef USE_WEBSERVER_AUTH
+
+#ifdef USE_WEBSERVER_AUTH_DIGEST
+namespace {
+
+// Hex-encode `len` bytes into `out`, which must hold at least 2 * len + 1 bytes. Null-terminated.
+void bytes_to_hex(const uint8_t *data, size_t len, char *out) {
+  static const char HEX[] = "0123456789abcdef";
+  for (size_t i = 0; i < len; i++) {
+    out[i * 2] = HEX[data[i] >> 4];
+    out[i * 2 + 1] = HEX[data[i] & 0x0f];
+  }
+  out[len * 2] = '\0';
+}
+
+// Extract the value of a Digest auth parameter (e.g. "nonce") from the comma-separated
+// parameter list. Values may be quoted or bare. Returns an empty ref when the key is absent.
+// Only whole parameter names match, so "nc" does not match inside "cnonce".
+StringRef digest_param(StringRef params, const char *key) {
+  size_t key_len = strlen(key);
+  const char *base = params.c_str();
+  size_t n = params.size();
+  size_t i = 0;
+  while (i < n) {
+    while (i < n && (base[i] == ' ' || base[i] == ','))
+      i++;
+    size_t name_start = i;
+    while (i < n && base[i] != '=' && base[i] != ',')
+      i++;
+    if (i >= n || base[i] == ',')
+      continue;  // token without a '=', skip it
+    size_t name_len = i - name_start;
+    while (name_len > 0 && base[name_start + name_len - 1] == ' ')
+      name_len--;
+    i++;  // consume '='
+    const char *val_start;
+    size_t val_len;
+    if (i < n && base[i] == '"') {
+      i++;
+      val_start = base + i;
+      while (i < n && base[i] != '"')
+        i++;
+      val_len = (base + i) - val_start;
+      if (i < n)
+        i++;  // consume closing quote
+    } else {
+      val_start = base + i;
+      while (i < n && base[i] != ',')
+        i++;
+      val_len = (base + i) - val_start;
+    }
+    if (name_len == key_len && memcmp(base + name_start, key, key_len) == 0)
+      return StringRef(val_start, val_len);
+    while (i < n && base[i] != ',')
+      i++;
+  }
+  return StringRef();
+}
+
+// Verify an RFC 2617 Digest response. Stateless (the nonce we issued is not tracked), which
+// matches the ESPAsyncWebServer backend used on the Arduino platforms.
+bool check_digest_auth(const char *username, const char *password, const std::string &header, const char *method) {
+  const size_t prefix_len = sizeof("Digest ") - 1;
+  StringRef params(header.c_str() + prefix_len, header.size() - prefix_len);
+
+  if (digest_param(params, "username") != username)
+    return false;
+
+  StringRef realm = digest_param(params, "realm");
+  StringRef nonce = digest_param(params, "nonce");
+  StringRef uri = digest_param(params, "uri");
+  StringRef qop = digest_param(params, "qop");
+  StringRef nc = digest_param(params, "nc");
+  StringRef cnonce = digest_param(params, "cnonce");
+  StringRef response = digest_param(params, "response");
+  if (response.size() != 32)
+    return false;
+
+  // Compute the three MD5 hashes by streaming the pieces straight into the ROM MD5 engine, so
+  // nothing is concatenated on the heap. Each hash is emitted as 32 lowercase hex characters.
+  md5_context_t ctx;
+  uint8_t digest[16];
+
+  // HA1 = MD5(username:realm:password) -- uses the realm the client echoed back.
+  char ha1[33];
+  esp_rom_md5_init(&ctx);
+  esp_rom_md5_update(&ctx, username, strlen(username));
+  esp_rom_md5_update(&ctx, ":", 1);
+  esp_rom_md5_update(&ctx, realm.c_str(), realm.size());
+  esp_rom_md5_update(&ctx, ":", 1);
+  esp_rom_md5_update(&ctx, password, strlen(password));
+  esp_rom_md5_final(digest, &ctx);
+  bytes_to_hex(digest, sizeof(digest), ha1);
+
+  // HA2 = MD5(method:uri) -- uses the uri the client echoed back.
+  char ha2[33];
+  esp_rom_md5_init(&ctx);
+  esp_rom_md5_update(&ctx, method, strlen(method));
+  esp_rom_md5_update(&ctx, ":", 1);
+  esp_rom_md5_update(&ctx, uri.c_str(), uri.size());
+  esp_rom_md5_final(digest, &ctx);
+  bytes_to_hex(digest, sizeof(digest), ha2);
+
+  // expected = MD5(HA1:nonce:nc:cnonce:qop:HA2)
+  char expected[33];
+  esp_rom_md5_init(&ctx);
+  esp_rom_md5_update(&ctx, ha1, 32);
+  esp_rom_md5_update(&ctx, ":", 1);
+  esp_rom_md5_update(&ctx, nonce.c_str(), nonce.size());
+  esp_rom_md5_update(&ctx, ":", 1);
+  esp_rom_md5_update(&ctx, nc.c_str(), nc.size());
+  esp_rom_md5_update(&ctx, ":", 1);
+  esp_rom_md5_update(&ctx, cnonce.c_str(), cnonce.size());
+  esp_rom_md5_update(&ctx, ":", 1);
+  esp_rom_md5_update(&ctx, qop.c_str(), qop.size());
+  esp_rom_md5_update(&ctx, ":", 1);
+  esp_rom_md5_update(&ctx, ha2, 32);
+  esp_rom_md5_final(digest, &ctx);
+  bytes_to_hex(digest, sizeof(digest), expected);
+
+  // Constant-time comparison of the two 32-char hex digests.
+  uint8_t result = 0;
+  for (size_t i = 0; i < 32; i++)
+    result |= static_cast<uint8_t>(expected[i] ^ response[i]);
+  return result == 0;
+}
+
+}  // namespace
+#endif  // USE_WEBSERVER_AUTH_DIGEST
+
+bool AsyncWebServerRequest::authenticate(const char *username, const char *password) const {
+  if (username == nullptr || password == nullptr || *username == 0) {
+    return true;
+  }
+  auto auth = this->get_header("Authorization");
+  if (!auth.has_value()) {
+    return false;
+  }
+
+  auto *auth_str = auth.value().c_str();
+
+#ifdef USE_WEBSERVER_AUTH_DIGEST
+  // The build fixed the scheme to Digest, so the Basic path is compiled out entirely.
+  const auto auth_prefix_len = sizeof("Digest ") - 1;
+  if (strncmp("Digest ", auth_str, auth_prefix_len) != 0) {
+    ESP_LOGW(TAG, "Only Digest authorization supported");
+    return false;
+  }
+  return check_digest_auth(username, password, auth.value(), http_method_str(this->method()));
+#else
+  const auto auth_prefix_len = sizeof("Basic ") - 1;
+  if (strncmp("Basic ", auth_str, auth_prefix_len) != 0) {
+    ESP_LOGW(TAG, "Only Basic authorization supported");
+    return false;
+  }
+
+  // Build user:pass in stack buffer to avoid heap allocation
+  constexpr size_t max_user_info_len = 256;
+  char user_info[max_user_info_len];
+  size_t user_len = strlen(username);
+  size_t pass_len = strlen(password);
+  size_t user_info_len = user_len + 1 + pass_len;
+
+  if (user_info_len >= max_user_info_len) {
+    ESP_LOGW(TAG, "Credentials too long for authentication");
+    return false;
+  }
+
+  memcpy(user_info, username, user_len);
+  user_info[user_len] = ':';
+  memcpy(user_info + user_len + 1, password, pass_len);
+  user_info[user_info_len] = '\0';
+
+  // Base64 output size is ceil(input_len * 4/3) + 1, with input bounded to 256 bytes
+  // max output is ceil(256 * 4/3) + 1 = 343 bytes, use 350 for safety
+  constexpr size_t max_digest_len = 350;
+  char digest[max_digest_len];
+  size_t out;
+  esp_crypto_base64_encode(reinterpret_cast<uint8_t *>(digest), max_digest_len, &out,
+                           reinterpret_cast<const uint8_t *>(user_info), user_info_len);
+
+  // Constant-time comparison to avoid timing side channels.
+  // No early return on length mismatch — the length difference is folded
+  // into the accumulator so any mismatch is rejected.
+  const char *provided = auth_str + auth_prefix_len;
+  size_t digest_len = out;  // length from esp_crypto_base64_encode
+  // Derive provided_len from the already-sized std::string rather than
+  // rescanning with strlen (avoids attacker-controlled scan length).
+  size_t provided_len = auth.value().size() - auth_prefix_len;
+  // Use full-width XOR so any bit difference in the lengths is preserved
+  // (uint8_t truncation would miss differences in higher bytes, e.g.
+  // digest_len vs digest_len + 256).
+  volatile size_t result = digest_len ^ provided_len;
+  // Iterate over the expected digest length only — the full-width length
+  // XOR above already rejects any length mismatch, and bounding the loop
+  // prevents a long Authorization header from forcing extra work.
+  for (size_t i = 0; i < digest_len; i++) {
+    char provided_ch = (i < provided_len) ? provided[i] : 0;
+    result |= static_cast<uint8_t>(digest[i] ^ provided_ch);
+  }
+  return result == 0;
+#endif  // USE_WEBSERVER_AUTH_DIGEST
+}
+
+void AsyncWebServerRequest::requestAuthentication() const {
+  httpd_resp_set_hdr(*this, "Connection", "keep-alive");
+#ifdef USE_WEBSERVER_AUTH_DIGEST
+  // Issue a fresh random nonce and opaque. The nonce is not stored, so this is stateless and
+  // does not defend against replay -- its purpose is to keep the password off the wire.
+  // The header value must stay alive until httpd_resp_send_err() below sends it, so the buffer
+  // lives on this stack frame (httpd_resp_set_hdr stores the pointer, it does not copy).
+  uint8_t random_bytes[16];
+  char nonce[33];
+  char opaque[33];
+  char header[160];
+  esp_fill_random(random_bytes, sizeof(random_bytes));
+  bytes_to_hex(random_bytes, sizeof(random_bytes), nonce);
+  esp_fill_random(random_bytes, sizeof(random_bytes));
+  bytes_to_hex(random_bytes, sizeof(random_bytes), opaque);
+  snprintf(header, sizeof(header), R"(Digest realm="Login Required", qop="auth", nonce="%s", opaque="%s")", nonce,
+           opaque);
+  httpd_resp_set_hdr(*this, "WWW-Authenticate", header);
+#else
+  httpd_resp_set_hdr(*this, "WWW-Authenticate", "Basic realm=\"Login Required\"");
+#endif  // USE_WEBSERVER_AUTH_DIGEST
+  httpd_resp_send_err(*this, HTTPD_401_UNAUTHORIZED, nullptr);
+}
+#endif  // USE_WEBSERVER_AUTH
+
+AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
+  // Check cache first - only successful lookups are cached
+  for (auto *param : this->params_) {
+    if (param->name() == name) {
+      return param;
+    }
+  }
+
+  // Look up value from query strings
+  auto val = this->find_query_value_(name);
+
+  // Don't cache misses to avoid wasting memory when handlers check for
+  // optional parameters that don't exist in the request
+  if (!val.has_value()) {
+    return nullptr;
+  }
+
+  auto *param = new AsyncWebParameter(name, val.value());  // NOLINT(cppcoreguidelines-owning-memory)
+  this->params_.push_back(param);
+  return param;
+}
+
+/// Search post_query then URL query with a callback.
+/// Returns first truthy result, or value-initialized default.
+/// URL query is accessed directly from req->uri (same pattern as url_to()).
+template<typename Func>
+static auto search_query_sources(httpd_req_t *req, const std::string &post_query, const char *name, Func func)
+    -> decltype(func(nullptr, size_t{0}, name)) {
+  if (!post_query.empty()) {
+    auto result = func(post_query.c_str(), post_query.size(), name);
+    if (result) {
+      return result;
+    }
+  }
+  // Use httpd API for query length, then access string directly from URI.
+  // http_parser identifies components by offset/length without modifying the URI string.
+  // This is the same pattern used by url_to().
+  auto len = httpd_req_get_url_query_len(req);
+  if (len == 0) {
+    return {};
+  }
+  const char *query = strchr(req->uri, '?');
+  if (query == nullptr) {
+    return {};
+  }
+  query++;  // skip '?'
+  return func(query, len, name);
+}
+
+optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {
+  return search_query_sources(this->req_, this->post_query_, name,
+                              [](const char *q, size_t len, const char *k) { return query_key_value(q, len, k); });
+}
+
+bool AsyncWebServerRequest::hasArg(const char *name) {
+  return search_query_sources(this->req_, this->post_query_, name, query_has_key);
+}
+
+std::string AsyncWebServerRequest::arg(const char *name) {
+  auto val = this->find_query_value_(name);
+  if (val.has_value()) {
+    return std::move(val.value());
+  }
+  return {};
+}
+
+void AsyncWebServerResponse::addHeader(const char *name, const char *value) {
+  httpd_resp_set_hdr(*this->req_, name, value);
+}
+
+void AsyncResponseStream::print(float value) {
+  // Use stack buffer to avoid temporary string allocation
+  // Size: sign (1) + digits (10) + decimal (1) + precision (6) + exponent (5) + null (1) = 24, use 32 for safety
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%f", value);
+  this->content_.append(buf, len);
+}
+
+void AsyncResponseStream::printf(const char *fmt, ...) {
+  va_list args;
+
+  va_start(args, fmt);
+  const int length = vsnprintf(nullptr, 0, fmt, args);
+  va_end(args);
+
+  std::string str;
+  str.resize(length);
+
+  va_start(args, fmt);
+  vsnprintf(&str[0], length + 1, fmt, args);
+  va_end(args);
+
+  this->print(str);
+}
+
+#ifdef USE_WEBSERVER
+AsyncEventSource::~AsyncEventSource() {
+  LockGuard guard{this->pending_mutex_};
+  for (auto *vec : {&this->sessions_, &this->pending_sessions_}) {
+    for (auto *ses : *vec) {
+      delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
+    }
+  }
+}
+
+void AsyncEventSource::handleRequest(AsyncWebServerRequest *request) {
+  // Httpd task: set up the live httpd_req_t and park the session; main loop does the rest.
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,clang-analyzer-cplusplus.NewDeleteLeaks)
+  auto *rsp = new AsyncEventSourceResponse(request, this, this->web_server_);
+  {
+    LockGuard guard{this->pending_mutex_};
+    this->pending_sessions_.push_back(rsp);
+    this->has_pending_sessions_.store(true, std::memory_order_release);
+  }
+  this->web_server_->enable_loop_soon_any_context();
+}
+
+// clang-analyzer traces a false-positive leak path from loop() through
+// adopt_pending_sessions_main_loop_() into start_session_main_loop_() and
+// finally ArduinoJson. Suppress along the entire in-our-code call chain.
+// NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks)
+bool AsyncEventSource::loop() {
+  // Fast path: one atomic load per tick. Slow path is out-of-line on connect.
+  if (this->has_pending_sessions_.load(std::memory_order_acquire)) {
+    this->adopt_pending_sessions_main_loop_();
+  }
+
+  // Clean up dead sessions safely
+  // This follows the ESP-IDF pattern where free_ctx marks resources as dead
+  // and the main loop handles the actual cleanup to avoid race conditions
+  for (size_t i = 0; i < this->sessions_.size();) {
+    auto *ses = this->sessions_[i];
+    // If the session has a dead socket (marked by destroy callback)
+    if (ses->fd_.load() == 0 && !ses->close_work_queued_.load(std::memory_order_acquire)) {
+      // destroy() already logged the close with the fd; don't double-log here.
+      delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
+      // Remove by swapping with last element (O(1) removal, order doesn't matter for sessions)
+      this->sessions_[i] = this->sessions_.back();
+      this->sessions_.pop_back();
+    } else {
+      ses->loop();
+      ++i;
+    }
+  }
+  return !this->sessions_.empty();
+}
+
+void AsyncEventSource::adopt_pending_sessions_main_loop_() {
+  std::vector<AsyncEventSourceResponse *> incoming;
+  {
+    LockGuard guard{this->pending_mutex_};
+    incoming.swap(this->pending_sessions_);
+    this->has_pending_sessions_.store(false, std::memory_order_relaxed);
+  }
+  for (auto *rsp : incoming) {
+    // Already disconnected? Drop it; skip on_connect_/session start on a dead session.
+    if (rsp->fd_.load() == 0) {
+      delete rsp;  // NOLINT(cppcoreguidelines-owning-memory)
+      continue;
+    }
+    this->sessions_.push_back(rsp);
+    // Prime first so on_connect_ observes a session that has already sent its
+    // initial ping/config/sorting_groups, matching the pre-refactor ordering.
+    rsp->start_session_main_loop_();
+    if (this->on_connect_) {
+      this->on_connect_(rsp);
+    }
+  }
+}
+// NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+void AsyncEventSource::try_send_nodefer(const char *message, size_t message_len, const char *event, uint32_t id,
+                                        uint32_t reconnect) {
+  for (auto *ses : this->sessions_) {
+    if (ses->fd_.load() != 0) {  // Skip dead sessions
+      ses->try_send_nodefer(message, message_len, event, id, reconnect);
+    }
+  }
+}
+
+void AsyncEventSource::deferrable_send_state(void *source, const char *event_type,
+                                             message_generator_t *message_generator) {
+  // Skip if no connected clients to avoid unnecessary processing
+  if (this->empty())
+    return;
+  for (auto *ses : this->sessions_) {
+    if (ses->fd_.load() != 0) {  // Skip dead sessions
+      ses->deferrable_send_state(source, event_type, message_generator);
+    }
+  }
+}
+
+AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *request,
+                                                   esphome::web_server_idf::AsyncEventSource *server,
+                                                   esphome::web_server::WebServer *ws)
+    : server_(server), web_server_(ws), entities_iterator_(ws, server) {
+  // Httpd task only. start_session_main_loop_() handles event_buffer_ / iterator setup.
+  httpd_req_t *req = *request;
+
+  httpd_resp_set_status(req, HTTPD_200);
+  httpd_resp_set_type(req, "text/event-stream");
+  httpd_resp_set_hdr(req, "Cache-Control", "no-cache");
+  httpd_resp_set_hdr(req, "Connection", "keep-alive");
+
+  for (const auto &header : DefaultHeaders::Instance().headers_) {
+    httpd_resp_set_hdr(req, header.name, header.value);
+  }
+
+  httpd_resp_send_chunk(req, CRLF_STR, CRLF_LEN);
+
+  req->sess_ctx = this;
+  req->free_ctx = AsyncEventSourceResponse::destroy;
+
+  this->hd_ = req->handle;
+  this->fd_.store(httpd_req_to_sockfd(req));
+
+  // Use non-blocking send to prevent watchdog timeouts when TCP buffers are full
+  httpd_sess_set_send_override(this->hd_, this->fd_.load(), nonblocking_send);
+}
+
+// NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
+void AsyncEventSourceResponse::start_session_main_loop_() {
+  auto *ws = this->web_server_;
+
+  // tcp send buffer is empty on connect, so these should always go through
+  auto message = ws->get_config_json();
+  this->try_send_nodefer(message.c_str(), message.size(), "ping", millis(), 30000);
+
+#ifdef USE_WEBSERVER_SORTING
+  for (auto &group : ws->sorting_groups_) {
+    json::JsonBuilder builder;
+    JsonObject root = builder.root();
+    root["name"] = group.second.name;
+    root["sorting_weight"] = group.second.weight;
+    message = builder.serialize();
+
+    // a (very) large number of these should be able to be queued initially without defer
+    // since the only thing in the send buffer at this point is the initial ping/config
+    this->try_send_nodefer(message.c_str(), message.size(), "sorting_group");
+  }
+#endif
+
+  this->entities_iterator_.begin(ws->include_internal_);
+}
+// NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+void AsyncEventSourceResponse::destroy(void *ptr) {
+  auto *rsp = static_cast<AsyncEventSourceResponse *>(ptr);
+  int fd = rsp->fd_.exchange(0);  // Atomically get and clear fd
+  ESP_LOGD(TAG, "Event source connection closed (fd: %d)", fd);
+  // Mark as dead - will be cleaned up in the main loop
+  // Note: We don't delete or remove from set here to avoid race conditions
+  // httpd will call our custom close_fn (safe_close_with_shutdown) which handles
+  // shutdown() before close() to prevent lwIP race conditions
+}
+
+// helper for allowing only unique entries in the queue
+void AsyncEventSourceResponse::deq_push_back_with_dedup_(void *source, message_generator_t *message_generator) {
+  DeferredEvent item(source, message_generator);
+
+  // Use range-based for loop instead of std::find_if to reduce template instantiation overhead and binary size
+  for (auto &event : this->deferred_queue_) {
+    if (event == item) {
+      return;  // Already in queue, no need to update since items are equal
+    }
+  }
+  this->deferred_queue_.push_back(item);
+}
+
+void AsyncEventSourceResponse::process_deferred_queue_() {
+  if (this->close_requested_.load()) {
+    return;
+  }
+  while (!deferred_queue_.empty()) {
+    DeferredEvent &de = deferred_queue_.front();
+    auto message = de.message_generator_(web_server_, de.source_);
+    if (this->try_send_nodefer(message.c_str(), message.size(), "state")) {
+      // O(n) but memory efficiency is more important than speed here which is why std::vector was chosen
+      deferred_queue_.erase(deferred_queue_.begin());
+    } else {
+      break;
+    }
+  }
+}
+
+void AsyncEventSourceResponse::request_close_() {
+  if (!this->close_requested_.exchange(true)) {
+    this->deferred_queue_.clear();
+    this->event_buffer_.clear();
+    this->event_bytes_sent_ = 0;
+    this->next_close_attempt_ms_ = 0;
+  }
+
+  this->process_close_();
+}
+
+void AsyncEventSourceResponse::process_close_() {
+  if (!this->close_requested_.load() || this->close_work_queued_.load(std::memory_order_acquire)) {
+    return;
+  }
+  const int fd = this->fd_.load();
+  if (fd == 0) {
+    return;
+  }
+
+  const uint32_t now = millis();
+  if (this->next_close_attempt_ms_ != 0 &&
+      static_cast<int32_t>(now - this->next_close_attempt_ms_) < 0) {
+    return;
+  }
+
+  // Queue an identity-checked shutdown on the HTTPD task. The public
+  // httpd_sess_trigger_close() queues only a reusable fd/session slot and can
+  // therefore close a new client if the original peer disconnects meanwhile.
+  this->close_work_queued_.store(true, std::memory_order_release);
+  this->next_close_attempt_ms_ = now + CLOSE_CONFIRM_INTERVAL_MS;
+  const esp_err_t err = httpd_queue_work(this->hd_, &AsyncEventSourceResponse::close_session_work_, this);
+  if (err == ESP_OK) {
+    return;
+  }
+
+  this->close_work_queued_.store(false, std::memory_order_release);
+  this->next_close_attempt_ms_ = now + CLOSE_RETRY_INTERVAL_MS;
+  if (!this->close_retry_warning_logged_) {
+    ESP_LOGW(TAG, "Failed to queue EventSource close (%s); retrying", esp_err_to_name(err));
+    this->close_retry_warning_logged_ = true;
+  }
+}
+
+void AsyncEventSourceResponse::close_session_work_(void *arg) {
+  auto *response = static_cast<AsyncEventSourceResponse *>(arg);
+  if (response == nullptr) {
+    return;
+  }
+
+  const int fd = response->fd_.load();
+  if (fd != 0 && httpd_sess_get_ctx(response->hd_, fd) == response) {
+    // The HTTPD task remains the session owner. Shutting the socket down makes
+    // its next select/recv path delete the session and invoke destroy().
+    shutdown(fd, SHUT_RDWR);
+  }
+
+  // Release self only after the HTTPD-task callback has finished every access.
+  response->close_work_queued_.store(false, std::memory_order_release);
+}
+
+void AsyncEventSourceResponse::process_buffer_() {
+  if (this->close_requested_.load() || event_buffer_.empty()) {
+    return;
+  }
+  if (event_bytes_sent_ == event_buffer_.size()) {
+    event_buffer_.resize(0);
+    event_bytes_sent_ = 0;
+    return;
+  }
+
+  size_t remaining = event_buffer_.size() - event_bytes_sent_;
+  int bytes_sent =
+      httpd_socket_send(this->hd_, this->fd_.load(), event_buffer_.c_str() + event_bytes_sent_, remaining, 0);
+  if (bytes_sent == HTTPD_SOCK_ERR_TIMEOUT) {
+    // EAGAIN/EWOULDBLOCK - socket buffer full, try again later
+    // NOTE: Similar logic exists in web_server/web_server.cpp in DeferredUpdateEventSource::process_deferred_queue_().
+    const uint32_t now = millis();
+    if (this->consecutive_send_failures_ == 0) {
+      this->send_failure_started_ms_ = now;
+    }
+    if (this->consecutive_send_failures_ != UINT16_MAX) {
+      this->consecutive_send_failures_++;
+    }
+    if (static_cast<int32_t>(now - (this->send_failure_started_ms_ + SEND_STALL_TIMEOUT_MS)) >= 0) {
+      ESP_LOGW(TAG, "Closing stuck EventSource connection after %" PRIu32 " ms without send progress",
+               now - this->send_failure_started_ms_);
+      this->request_close_();
+    }
+    return;
+  }
+  if (bytes_sent == HTTPD_SOCK_ERR_FAIL) {
+    // Low-level asynchronous sends do not make HTTPD close the session automatically.
+    this->request_close_();
+    return;
+  }
+  if (bytes_sent <= 0) {
+    // Unexpected error or zero bytes sent
+    ESP_LOGW(TAG, "Unexpected send result: %d", bytes_sent);
+    this->request_close_();
+    return;
+  }
+
+  // Successful send - reset failure counter
+  this->consecutive_send_failures_ = 0;
+  this->send_failure_started_ms_ = 0;
+  event_bytes_sent_ += bytes_sent;
+
+  // Log partial sends for debugging
+  if (event_bytes_sent_ < event_buffer_.size()) {
+    ESP_LOGV(TAG, "Partial send: %d/%zu bytes (total: %zu/%zu)", bytes_sent, remaining, event_bytes_sent_,
+             event_buffer_.size());
+  }
+
+  if (event_bytes_sent_ == event_buffer_.size()) {
+    event_buffer_.resize(0);
+    event_bytes_sent_ = 0;
+  }
+}
+
+void AsyncEventSourceResponse::loop() {
+  if (this->close_requested_.load()) {
+    this->process_close_();
+    return;
+  }
+  process_buffer_();
+  if (this->close_requested_.load())
+    return;
+  process_deferred_queue_();
+  if (this->close_requested_.load())
+    return;
+  if (!this->entities_iterator_.completed())
+    this->entities_iterator_.advance();
+}
+
+bool AsyncEventSourceResponse::try_send_nodefer(const char *message, size_t message_len, const char *event, uint32_t id,
+                                                uint32_t reconnect) {
+  if (this->fd_.load() == 0 || this->close_requested_.load()) {
+    return false;
+  }
+
+  process_buffer_();
+  if (this->close_requested_.load() || !event_buffer_.empty()) {
+    // there is still pending event data to send first
+    return false;
+  }
+
+  // 8 spaces are standing in for the hexidecimal chunk length to print later
+  const char chunk_len_header[] = "        " CRLF_STR;
+  const int chunk_len_header_len = sizeof(chunk_len_header) - 1;
+
+  event_buffer_.append(chunk_len_header);
+
+  // Use stack buffer for formatting numeric fields to avoid temporary string allocations
+  // Size: "retry: " (7) + max uint32 (10 digits) + CRLF (2) + null (1) = 20 bytes, use 32 for safety
+  constexpr size_t num_buf_size = 32;
+  char num_buf[num_buf_size];
+
+  if (reconnect) {
+    int len = snprintf(num_buf, num_buf_size, "retry: %" PRIu32 CRLF_STR, reconnect);
+    event_buffer_.append(num_buf, len);
+  }
+
+  if (id) {
+    int len = snprintf(num_buf, num_buf_size, "id: %" PRIu32 CRLF_STR, id);
+    event_buffer_.append(num_buf, len);
+  }
+
+  if (event && *event) {
+    event_buffer_.append("event: ", sizeof("event: ") - 1);
+    event_buffer_.append(event);
+    event_buffer_.append(CRLF_STR, CRLF_LEN);
+  }
+
+  // Match ESPAsyncWebServer: null message means no data lines and no terminating blank line
+  if (message) {
+    // SSE spec requires each line of a multi-line message to have its own "data:" prefix
+    // Handle \n, \r, and \r\n line endings (matching ESPAsyncWebServer behavior)
+
+    // Fast path: check if message contains any newlines at all
+    // Most SSE messages (JSON state updates) have no newlines
+    const char *first_n = static_cast<const char *>(memchr(message, '\n', message_len));
+    const char *first_r = static_cast<const char *>(memchr(message, '\r', message_len));
+
+    if (first_n == nullptr && first_r == nullptr) {
+      // No newlines - fast path (most common case)
+      event_buffer_.append("data: ", sizeof("data: ") - 1);
+      event_buffer_.append(message, message_len);
+      event_buffer_.append(CRLF_STR CRLF_STR, CRLF_LEN * 2);  // data line + blank line terminator
+    } else {
+      // Has newlines - handle multi-line message
+      const char *line_start = message;
+      const char *msg_end = message + message_len;
+
+      // Reuse the first search results
+      const char *next_n = first_n;
+      const char *next_r = first_r;
+
+      while (line_start <= msg_end) {
+        const char *line_end;
+        const char *next_line;
+
+        if (next_n == nullptr && next_r == nullptr) {
+          // No more line breaks - output remaining text as final line
+          event_buffer_.append("data: ", sizeof("data: ") - 1);
+          event_buffer_.append(line_start, msg_end - line_start);
+          event_buffer_.append(CRLF_STR, CRLF_LEN);
+          break;
+        }
+
+        // Determine line ending type and next line start
+        if (next_n != nullptr && next_r != nullptr) {
+          if (next_r + 1 == next_n) {
+            // \r\n sequence
+            line_end = next_r;
+            next_line = next_n + 1;
+          } else {
+            // Mixed \n and \r - use whichever comes first
+            line_end = (next_r < next_n) ? next_r : next_n;
+            next_line = line_end + 1;
+          }
+        } else if (next_n != nullptr) {
+          // Unix LF
+          line_end = next_n;
+          next_line = next_n + 1;
+        } else {
+          // Old Mac CR
+          line_end = next_r;
+          next_line = next_r + 1;
+        }
+
+        // Output this line
+        event_buffer_.append("data: ", sizeof("data: ") - 1);
+        event_buffer_.append(line_start, line_end - line_start);
+        event_buffer_.append(CRLF_STR, CRLF_LEN);
+
+        line_start = next_line;
+
+        // Check if we've consumed all content
+        if (line_start >= msg_end) {
+          break;
+        }
+
+        // Search for next newlines only in remaining string
+        next_n = static_cast<const char *>(memchr(line_start, '\n', msg_end - line_start));
+        next_r = static_cast<const char *>(memchr(line_start, '\r', msg_end - line_start));
+      }
+
+      // Terminate message with blank line
+      event_buffer_.append(CRLF_STR, CRLF_LEN);
+    }
+  }
+
+  if (event_buffer_.size() == static_cast<size_t>(chunk_len_header_len)) {
+    // Nothing was added, reset buffer
+    event_buffer_.resize(0);
+    return true;
+  }
+
+  event_buffer_.append(CRLF_STR, CRLF_LEN);
+
+  // chunk length header itself and the final chunk terminating CRLF are not counted as part of the chunk
+  int chunk_len = event_buffer_.size() - CRLF_LEN - chunk_len_header_len;
+  char chunk_len_str[9];
+  snprintf(chunk_len_str, 9, "%08x", chunk_len);
+  std::memcpy(&event_buffer_[0], chunk_len_str, 8);
+
+  event_bytes_sent_ = 0;
+  process_buffer_();
+
+  return true;
+}
+
+void AsyncEventSourceResponse::deferrable_send_state(void *source, const char *event_type,
+                                                     message_generator_t *message_generator) {
+  if (this->close_requested_.load())
+    return;
+
+  // allow all json "details_all" to go through before publishing bare state events, this avoids unnamed entries showing
+  // up in the web GUI and reduces event load during initial connect
+  if (!this->entities_iterator_.completed() && 0 != strcmp(event_type, "state_detail_all"))
+    return;
+
+  if (source == nullptr)
+    return;
+  if (event_type == nullptr)
+    return;
+  if (message_generator == nullptr)
+    return;
+
+  if (0 != strcmp(event_type, "state_detail_all") && 0 != strcmp(event_type, "state")) {
+    ESP_LOGE(TAG, "Can't defer non-state event");
+  }
+
+  process_buffer_();
+  if (this->close_requested_.load())
+    return;
+  process_deferred_queue_();
+  if (this->close_requested_.load())
+    return;
+
+  if (!event_buffer_.empty() || !deferred_queue_.empty()) {
+    // outgoing event buffer or deferred queue still not empty which means downstream tcp send buffer full, no point
+    // trying to send first
+    if (!this->close_requested_.load())
+      deq_push_back_with_dedup_(source, message_generator);
+  } else {
+    auto message = message_generator(web_server_, source);
+    if (!this->try_send_nodefer(message.c_str(), message.size(), "state") &&
+        !this->close_requested_.load()) {
+      deq_push_back_with_dedup_(source, message_generator);
+    }
+  }
+}
+#endif
+
+#ifdef USE_WEBSERVER_OTA
+esp_err_t AsyncWebServer::handle_multipart_upload_(httpd_req_t *r, const char *content_type) {
+  // Parse boundary and create reader
+  const char *boundary_start;
+  size_t boundary_len;
+  if (!parse_multipart_boundary(content_type, &boundary_start, &boundary_len)) {
+    ESP_LOGE(TAG, "Failed to parse multipart boundary");
+    httpd_resp_send_err(r, HTTPD_400_BAD_REQUEST, nullptr);
+    return ESP_FAIL;
+  }
+
+  AsyncWebServerRequest req(r);
+  AsyncWebHandler *handler = nullptr;
+  for (auto *h : this->handlers_) {
+    if (h->canHandle(&req)) {
+      handler = h;
+      break;
+    }
+  }
+
+  if (!handler) {
+    ESP_LOGW(TAG, "No handler found for OTA request");
+    httpd_resp_send_err(r, HTTPD_404_NOT_FOUND, nullptr);
+    return ESP_OK;
+  }
+
+  // Upload state
+  std::string filename;
+  size_t index = 0;
+  // Create reader on heap to reduce stack usage
+  auto reader = std::make_unique<MultipartReader>("--" + std::string(boundary_start, boundary_len));
+
+  // Configure callbacks
+  reader->set_data_callback([&](const uint8_t *data, size_t len) {
+    if (!reader->has_file() || !len)
+      return;
+
+    if (filename.empty()) {
+      filename = reader->get_current_part().filename;
+      ESP_LOGV(TAG, "Processing file: '%s'", filename.c_str());
+      handler->handleUpload(&req, filename, 0, nullptr, 0, false);  // Start
+    }
+
+    handler->handleUpload(&req, filename, index, const_cast<uint8_t *>(data), len, false);
+    index += len;
+  });
+
+  reader->set_part_complete_callback([&]() {
+    if (index > 0) {
+      handler->handleUpload(&req, filename, index, nullptr, 0, true);  // End
+      filename.clear();
+      index = 0;
+    }
+  });
+
+  auto buffer = std::make_unique_for_overwrite<char[]>(RECV_CHUNK_SIZE);
+  size_t bytes_since_yield = 0;
+
+  for (size_t remaining = r->content_len; remaining > 0;) {
+    int recv_len = httpd_req_recv(r, buffer.get(), std::min(remaining, RECV_CHUNK_SIZE));
+
+    if (recv_len <= 0) {
+      httpd_resp_send_err(r, recv_len == HTTPD_SOCK_ERR_TIMEOUT ? HTTPD_408_REQ_TIMEOUT : HTTPD_400_BAD_REQUEST,
+                          nullptr);
+      return recv_len == HTTPD_SOCK_ERR_TIMEOUT ? ESP_ERR_TIMEOUT : ESP_FAIL;
+    }
+
+    if (reader->parse(buffer.get(), recv_len) != static_cast<size_t>(recv_len)) {
+      ESP_LOGW(TAG, "Multipart parser error");
+      httpd_resp_send_err(r, HTTPD_400_BAD_REQUEST, nullptr);
+      return ESP_FAIL;
+    }
+
+    remaining -= recv_len;
+    bytes_since_yield += recv_len;
+
+    if (bytes_since_yield > YIELD_INTERVAL_BYTES) {
+      vTaskDelay(1);
+      bytes_since_yield = 0;
+    }
+  }
+
+  handler->handleRequest(&req);
+  return ESP_OK;
+}
+#endif  // USE_WEBSERVER_OTA
+
+}  // namespace esphome::web_server_idf
+
+#endif  // !defined(USE_ESP32)

--- a/components/web_server_idf/web_server_idf.h
+++ b/components/web_server_idf/web_server_idf.h
@@ -1,0 +1,411 @@
+#pragma once
+#ifdef USE_ESP32
+
+#include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/string_ref.h"
+#include <esp_http_server.h>
+
+#include <atomic>
+#include <functional>
+#include <list>
+#include <map>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifdef USE_WEBSERVER
+#include "esphome/components/json/json_util.h"
+#include "esphome/components/web_server/list_entities.h"
+#endif
+
+namespace esphome {
+#ifdef USE_WEBSERVER
+namespace web_server {
+class WebServer;
+};  // namespace web_server
+#endif
+namespace web_server_idf {
+
+class AsyncWebParameter {
+ public:
+  AsyncWebParameter(std::string name, std::string value) : name_(std::move(name)), value_(std::move(value)) {}
+  const std::string &name() const { return this->name_; }
+  const std::string &value() const { return this->value_; }
+
+ protected:
+  std::string name_;
+  std::string value_;
+};
+
+class AsyncWebServerRequest;
+
+class AsyncWebServerResponse {
+ public:
+  AsyncWebServerResponse(const AsyncWebServerRequest *req) : req_(req) {}
+  virtual ~AsyncWebServerResponse() {}
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void addHeader(const char *name, const char *value);
+
+  virtual const char *get_content_data() const = 0;
+  virtual size_t get_content_size() const = 0;
+
+ protected:
+  const AsyncWebServerRequest *req_;
+};
+
+class AsyncWebServerResponseEmpty : public AsyncWebServerResponse {
+ public:
+  AsyncWebServerResponseEmpty(const AsyncWebServerRequest *req) : AsyncWebServerResponse(req) {}
+
+  const char *get_content_data() const override { return nullptr; };
+  size_t get_content_size() const override { return 0; };
+};
+
+class AsyncWebServerResponseContent : public AsyncWebServerResponse {
+ public:
+  AsyncWebServerResponseContent(const AsyncWebServerRequest *req, std::string content)
+      : AsyncWebServerResponse(req), content_(std::move(content)) {}
+
+  const char *get_content_data() const override { return this->content_.c_str(); };
+  size_t get_content_size() const override { return this->content_.size(); };
+
+ protected:
+  std::string content_;
+};
+
+class AsyncResponseStream : public AsyncWebServerResponse {
+ public:
+  AsyncResponseStream(const AsyncWebServerRequest *req) : AsyncWebServerResponse(req) {}
+
+  const char *get_content_data() const override { return this->content_.c_str(); };
+  size_t get_content_size() const override { return this->content_.size(); };
+
+  void print(const char *str) { this->content_.append(str); }
+  void print(const std::string &str) { this->content_.append(str); }
+  void print(float value);
+  void printf(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void write(uint8_t c) { this->content_.push_back(static_cast<char>(c)); }
+
+ protected:
+  std::string content_;
+};
+
+class AsyncWebServerResponseProgmem : public AsyncWebServerResponse {
+ public:
+  AsyncWebServerResponseProgmem(const AsyncWebServerRequest *req, const uint8_t *data, const size_t size)
+      : AsyncWebServerResponse(req), data_(data), size_(size) {}
+
+  const char *get_content_data() const override { return reinterpret_cast<const char *>(this->data_); };
+  size_t get_content_size() const override { return this->size_; };
+
+ protected:
+  const uint8_t *data_;
+  size_t size_;
+};
+
+class AsyncWebServerRequest {
+  friend class AsyncWebServer;
+
+ public:
+  ~AsyncWebServerRequest();
+
+  http_method method() const { return static_cast<http_method>(this->req_->method); }
+  static constexpr size_t URL_BUF_SIZE = CONFIG_HTTPD_MAX_URI_LEN + 1;  ///< Buffer size for url_to()
+  /// Write URL (without query string) to buffer, returns StringRef pointing to buffer.
+  /// URL is decoded (e.g., %20 -> space).
+  StringRef url_to(std::span<char, URL_BUF_SIZE> buffer) const;
+  // Remove before 2026.9.0
+  ESPDEPRECATED("Use url_to() instead. Removed in 2026.9.0", "2026.3.0")
+  std::string url() const {
+    char buffer[URL_BUF_SIZE];
+    return std::string(this->url_to(buffer));
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  size_t contentLength() const { return this->req_->content_len; }
+
+#ifdef USE_WEBSERVER_AUTH
+  bool authenticate(const char *username, const char *password) const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void requestAuthentication() const;
+#endif
+
+  void redirect(const std::string &url);
+
+  inline void ESPHOME_ALWAYS_INLINE send(AsyncWebServerResponse *response) {
+    httpd_resp_send(*this, response->get_content_data(), response->get_content_size());
+  }
+  inline void ESPHOME_ALWAYS_INLINE send(int code, const char *content_type = nullptr, const char *content = nullptr) {
+    this->init_response_(nullptr, code, content_type);
+    if (content) {
+      httpd_resp_send(*this, content, HTTPD_RESP_USE_STRLEN);
+    } else {
+      httpd_resp_send(*this, nullptr, 0);
+    }
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncWebServerResponse *beginResponse(int code, const char *content_type) {
+    auto *res = new AsyncWebServerResponseEmpty(this);  // NOLINT(cppcoreguidelines-owning-memory)
+    this->init_response_(res, code, content_type);
+    return res;
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncWebServerResponse *beginResponse(int code, const char *content_type, const std::string &content) {
+    auto *res = new AsyncWebServerResponseContent(this, content);  // NOLINT(cppcoreguidelines-owning-memory)
+    this->init_response_(res, code, content_type);
+    return res;
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncWebServerResponse *beginResponse(int code, const char *content_type, const uint8_t *data,
+                                        const size_t data_size) {
+    auto *res = new AsyncWebServerResponseProgmem(this, data, data_size);  // NOLINT(cppcoreguidelines-owning-memory)
+    this->init_response_(res, code, content_type);
+    return res;
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncResponseStream *beginResponseStream(const char *content_type) {
+    auto *res = new AsyncResponseStream(this);  // NOLINT(cppcoreguidelines-owning-memory)
+    this->init_response_(res, 200, content_type);
+    return res;
+  }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  bool hasParam(const char *name) { return this->getParam(name) != nullptr; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  bool hasParam(const std::string &name) { return this->getParam(name.c_str()) != nullptr; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncWebParameter *getParam(const char *name);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncWebParameter *getParam(const std::string &name) { return this->getParam(name.c_str()); }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  bool hasArg(const char *name);
+  std::string arg(const char *name);
+  std::string arg(const std::string &name) { return this->arg(name.c_str()); }
+
+  operator httpd_req_t *() const { return this->req_; }
+  optional<std::string> get_header(const char *name) const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  bool hasHeader(const char *name) const;
+
+ protected:
+  httpd_req_t *req_;
+  AsyncWebServerResponse *rsp_{};
+  // Use vector instead of map/unordered_map: most requests have 0-3 params, so linear search
+  // is faster than tree/hash overhead. AsyncWebParameter stores both name and value to avoid
+  // duplicate storage. Only successful lookups are cached to prevent cache pollution when
+  // handlers check for optional parameters that don't exist.
+  optional<std::string> find_query_value_(const char *name) const;
+  std::vector<AsyncWebParameter *> params_;
+  std::string post_query_;
+  AsyncWebServerRequest(httpd_req_t *req) : req_(req) {}
+  AsyncWebServerRequest(httpd_req_t *req, std::string post_query) : req_(req), post_query_(std::move(post_query)) {}
+  void init_response_(AsyncWebServerResponse *rsp, int code, const char *content_type);
+};
+
+class AsyncWebHandler;
+
+class AsyncWebServer {
+ public:
+  AsyncWebServer(uint16_t port) : port_(port){};
+  ~AsyncWebServer() { this->end(); }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void onNotFound(std::function<void(AsyncWebServerRequest *request)> &&fn) { on_not_found_ = std::move(fn); }
+
+  void begin();
+  void end();
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncWebHandler &addHandler(AsyncWebHandler *handler) {
+    this->handlers_.push_back(handler);
+    return *handler;
+  }
+
+  httpd_handle_t get_server() { return this->server_; }
+
+ protected:
+  uint16_t port_{};
+  httpd_handle_t server_{};
+  static esp_err_t request_handler(httpd_req_t *r);
+  static esp_err_t request_post_handler(httpd_req_t *r);
+  esp_err_t request_handler_(AsyncWebServerRequest *request) const;
+  static void safe_close_with_shutdown(httpd_handle_t hd, int sockfd);
+  esp_err_t handle_raw_body_(httpd_req_t *r, const char *content_type);
+#ifdef USE_WEBSERVER_OTA
+  esp_err_t handle_multipart_upload_(httpd_req_t *r, const char *content_type);
+#endif
+  std::vector<AsyncWebHandler *> handlers_;
+  std::function<void(AsyncWebServerRequest *request)> on_not_found_{};
+};
+
+class AsyncWebHandler {
+ public:
+  virtual ~AsyncWebHandler() {}
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  virtual bool canHandle(AsyncWebServerRequest *request) const { return false; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  virtual void handleRequest(AsyncWebServerRequest *request) {}
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  virtual void handleUpload(AsyncWebServerRequest *request, const std::string &filename, size_t index, uint8_t *data,
+                            size_t len, bool final) {}
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  virtual void handleBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {}
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  virtual bool isRequestHandlerTrivial() const { return true; }
+};
+
+#ifdef USE_WEBSERVER
+class AsyncEventSource;
+class AsyncEventSourceResponse;
+
+using message_generator_t = json::SerializationBuffer<>(esphome::web_server::WebServer *, void *);
+
+/*
+  This class holds a pointer to the source component that wants to publish a state event, and a pointer to a function
+  that will lazily generate that event.  The two pointers allow dedup in the deferred queue if multiple publishes for
+  the same component are backed up, and take up only two pointers of memory.  The entry in the deferred queue (a
+  std::vector) is the DeferredEvent instance itself (not a pointer to one elsewhere in heap) so still only two pointers
+  per entry (and no heap fragmentation).  Even 100 backed up events (you'd have to have at least 100 sensors publishing
+  because of dedup) would take up only 0.8 kB.
+*/
+struct DeferredEvent {
+  friend class AsyncEventSourceResponse;
+
+ protected:
+  void *source_;
+  message_generator_t *message_generator_;
+
+ public:
+  DeferredEvent(void *source, message_generator_t *message_generator)
+      : source_(source), message_generator_(message_generator) {}
+  bool operator==(const DeferredEvent &test) const {
+    return (source_ == test.source_ && message_generator_ == test.message_generator_);
+  }
+};
+static_assert(sizeof(DeferredEvent) == sizeof(void *) + sizeof(message_generator_t *),
+              "DeferredEvent should have no padding");
+
+class AsyncEventSourceResponse {
+  friend class AsyncEventSource;
+
+ public:
+  bool try_send_nodefer(const char *message, size_t message_len, const char *event = nullptr, uint32_t id = 0,
+                        uint32_t reconnect = 0);
+  void deferrable_send_state(void *source, const char *event_type, message_generator_t *message_generator);
+  void loop();
+
+ protected:
+  AsyncEventSourceResponse(const AsyncWebServerRequest *request, esphome::web_server_idf::AsyncEventSource *server,
+                           esphome::web_server::WebServer *ws);
+
+  // Main-loop only: sends initial ping/config/sorting_groups, starts entity iterator.
+  void start_session_main_loop_();
+
+  void deq_push_back_with_dedup_(void *source, message_generator_t *message_generator);
+  void process_deferred_queue_();
+  void process_buffer_();
+  void request_close_();
+  void process_close_();
+  static void close_session_work_(void *arg);
+
+  static void destroy(void *p);
+  AsyncEventSource *server_;
+  httpd_handle_t hd_{};
+  std::atomic<int> fd_{};
+  std::vector<DeferredEvent> deferred_queue_;
+  esphome::web_server::WebServer *web_server_;
+  esphome::web_server::ListEntitiesIterator entities_iterator_;
+  std::string event_buffer_;
+  size_t event_bytes_sent_;
+  uint16_t consecutive_send_failures_{0};
+  uint32_t send_failure_started_ms_{0};
+  uint32_t next_close_attempt_ms_{0};
+  bool close_retry_warning_logged_{false};
+  std::atomic<bool> close_work_queued_{false};
+  std::atomic<bool> close_requested_{false};
+  static constexpr uint32_t SEND_STALL_TIMEOUT_MS = 20000;
+  static constexpr uint32_t CLOSE_RETRY_INTERVAL_MS = 250;
+  static constexpr uint32_t CLOSE_CONFIRM_INTERVAL_MS = 1000;
+};
+
+using AsyncEventSourceClient = AsyncEventSourceResponse;
+
+class AsyncEventSource : public AsyncWebHandler {
+  friend class AsyncEventSourceResponse;
+  using connect_handler_t = std::function<void(AsyncEventSourceClient *)>;
+
+ public:
+  AsyncEventSource(std::string url, esphome::web_server::WebServer *ws) : url_(std::move(url)), web_server_(ws) {}
+  ~AsyncEventSource() override;
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  bool canHandle(AsyncWebServerRequest *request) const override {
+    if (request->method() != HTTP_GET)
+      return false;
+    char url_buf[AsyncWebServerRequest::URL_BUF_SIZE];
+    return request->url_to(url_buf) == this->url_;
+  }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void handleRequest(AsyncWebServerRequest *request) override;
+  // Callback runs on the main loop (not the httpd task) after the session's
+  // initial ping/config/sorting_groups have been sent.
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void onConnect(connect_handler_t &&cb) { this->on_connect_ = std::move(cb); }
+
+  void try_send_nodefer(const char *message, size_t message_len, const char *event = nullptr, uint32_t id = 0,
+                        uint32_t reconnect = 0);
+  void deferrable_send_state(void *source, const char *event_type, message_generator_t *message_generator);
+  /// Returns true if there are sessions remaining (including pending cleanup).
+  bool loop();
+  bool empty() { return this->count() == 0; }
+
+  size_t count() const { return this->sessions_.size(); }
+
+ protected:
+  // Cold path: move sessions from pending_sessions_ into sessions_ and greet each one.
+  void __attribute__((noinline, cold)) adopt_pending_sessions_main_loop_();
+
+  std::string url_;
+  // Main-loop only. Vector: SSE sessions are 1-5 connections, linear search beats set.
+  std::vector<AsyncEventSourceResponse *> sessions_;
+  // Httpd-task intake; guarded by pending_mutex_, gated by has_pending_sessions_.
+  std::vector<AsyncEventSourceResponse *> pending_sessions_;
+  Mutex pending_mutex_;
+  connect_handler_t on_connect_{};
+  esphome::web_server::WebServer *web_server_;
+  std::atomic<bool> has_pending_sessions_{false};
+};
+#endif  // USE_WEBSERVER
+
+struct HttpHeader {
+  const char *name;
+  const char *value;
+};
+
+class DefaultHeaders {
+  friend class AsyncWebServerRequest;
+#ifdef USE_WEBSERVER
+  friend class AsyncEventSourceResponse;
+#endif
+
+ public:
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  void addHeader(const char *name, const char *value) { this->headers_.push_back({name, value}); }
+
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  static DefaultHeaders &Instance();
+
+ protected:
+  // Stack-allocated, no reallocation machinery. Count defined in web_server_base where headers are added.
+  StaticVector<HttpHeader, WEB_SERVER_DEFAULT_HEADERS_COUNT> headers_;
+};
+
+}  // namespace web_server_idf
+}  // namespace esphome
+
+using namespace esphome::web_server_idf;  // NOLINT(google-global-names-in-headers)
+
+#endif  // !defined(USE_ESP32)

--- a/openquatt/oq_webserver.yaml
+++ b/openquatt/oq_webserver.yaml
@@ -5,6 +5,12 @@
 #   Central layout of web_server groups so all packages use the same UI structure
 #   (consistent in HA/diagnostics workflow).
 # ==============================================================================
+external_components:
+  - source:
+      type: local
+      path: ${external_components_path}
+    components: [web_server_idf]
+
 web_server:
   port: 80
   version: 3


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt tijdelijk een exacte, versiegebonden kopie van ESPHome `web_server_idf` 2026.7.0 toe.
- Sluit een SSE/EventSource na 20 seconden zonder sendprogress via een context-gevalideerde callback op de HTTPD-task.
- Houdt close-intent terminaal, begrenst retries en bewaart de response totdat HTTPD zijn `free_ctx`/`destroy()` heeft uitgevoerd.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alle firmwaretargets gebruiken tijdelijk de lokale `web_server_idf`-override. Alleen vastgelopen of onherstelbaar gefaalde SSE-verbindingen worden anders afgehandeld; web-entities, authenticatie en normale responses blijven gelijk. Een exacte ESPHome-versieguard voorkomt stil doorgebruik na een dependency-upgrade.

## Achtergrond

De melding `Closing stuck EventSource connection after 2500 failed sends` telde non-blocking `EAGAIN`-pogingen, geen inkomende requests. Upstream zette daarna alleen de lokale fd op nul en liet de ESP-IDF HTTPD-session open. De main loop kon de response vervolgens verwijderen terwijl HTTPD dezelfde pointer nog als `sess_ctx/free_ctx` bezat. Dat lekt een clientslot en creëert een use-after-freepad, passend bij TCP-connecties die wel accepteren maar geen HTTP-byte meer sturen.

De correctie gebruikt verstreken tijd sinds de laatste sendprogress in plaats van een loop-afhankelijke teller. De HTTPD-workcallback controleert `httpd_sess_get_ctx(hd, fd) == response` voordat hij `shutdown()` uitvoert; hierdoor kan een snel hergebruikte fd nooit een nieuwe client sluiten. Queue-failure retryt na 250 ms en een nog niet bevestigde close na 1 seconde.

De vendorbron komt uit ESPHome-tagcommit `920a8b761b680d9864da2ef4b44b4af95c99dba8`. Buiten de versieguard, README en beschreven SSE-delta zijn de gekopieerde bronnen byte-identiek aan ESPHome 2026.7.0. Achtergrond: https://github.com/esphome/esphome/issues/10542 en https://github.com/esphome/esphome/pull/11002.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Er wijzigen geen gebruikersinstellingen of UI-contracten. De tijdelijke override bevat wel een eigen README met herkomst, delta, lifecycle-aanname en verwijdervoorwaarde.

## Validatie

- `python3 scripts/dev.py validate --jobs 1`: groen voor alle acht ingeschakelde firmwaretargets (configuratie en volledige compile).
- Gegenereerde Q Duo-build gecontroleerd op exact één lokale `web_server_idf.cpp` en de nieuwe close-route.
- Vendorvergelijking: alleen `__init__.py`, `web_server_idf.cpp` en `web_server_idf.h` verschillen functioneel van ESPHome 2026.7.0; de overige gekopieerde bronbestanden zijn byte-identiek.
- Volledige diff tweemaal koud beoordeeld op peer-close, fd/session-reuse, queue failure, `destroy()`-volgorde, server-stop en `millis()`-wrap; geen open blocker.

Nog uit te voeren voordat deze draft ready wordt: device-HIL met een bewust vastgelopen `/events`-client en herhaald connect/disconnect/reload. Resterend upstream-baselinerisico is de bestaande stale-fd-TOCTOU in normale `httpd_socket_send`; deze PR introduceert of vergroot dat pad niet.
