### PR TITLE
Back off Modbus polling while heat pumps are offline

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -93,6 +93,11 @@ globals:
     restore_value: no
     initial_value: 'false'
 
+  - id: ${hp_id}_last_offline_probe_ms
+    type: uint32_t
+    restore_value: no
+    initial_value: '0'
+
 # ----------------------------
 # SELECT
 # ----------------------------
@@ -1327,9 +1332,32 @@ interval:
   - interval: ${oq_modbus_update_interval_s}s
     startup_delay: ${oq_modbus_startup_delay_ms}ms
     then:
-      - if:
-          condition:
-            lambda: |-
-              return !id(oq_runtime_polling_paused).state;
-          then:
-            - component.update: ${hp_id}
+      - lambda: |-
+          if (id(oq_runtime_polling_paused).state) {
+            return;
+          }
+
+          // A confirmed online HP keeps the normal full-register polling cadence.
+          if (id(${hp_id}_is_online)) {
+            id(${hp_id}).update();
+            return;
+          }
+
+          // An absent HP only receives one lightweight recovery probe per interval.
+          const uint32_t now = millis();
+          const uint32_t last_probe = id(${hp_id}_last_offline_probe_ms);
+          if (last_probe != 0U &&
+              now - last_probe < ${oq_modbus_offline_probe_interval_s}UL * 1000UL) {
+            return;
+          }
+          if (id(${hp_id}).get_command_queue_length() != 0U) {
+            return;
+          }
+
+          id(${hp_id}_last_offline_probe_ms) = now == 0U ? 1U : now;
+          auto probe = esphome::modbus_controller::ModbusCommandItem::create_read_command(
+              id(${hp_id}), esphome::modbus::ModbusRegisterType::HOLDING, 2099, 1,
+              [=](esphome::modbus::ModbusRegisterType, uint16_t, const std::vector<uint8_t> &) {
+                id(${hp_id}_is_online) = true;
+              });
+          id(${hp_id}).queue_command(probe);

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -246,6 +246,7 @@ ha_cooling_dew_point_valid_entity_id: "binary_sensor.openquatt_ext_cooling_dew_p
 # HP IO (MODBUS POLLING)
 # ----------------------------
 oq_modbus_update_interval_s: "5"                    # Base Modbus controller polling interval [s].
+oq_modbus_offline_probe_interval_s: "30"             # Sparse single-register probe while an HP is offline [s].
 oq_modbus_command_throttle_ms: "500"                 # Minimum spacing between Modbus commands [ms].
 oq_modbus_max_cmd_retries: "1"                       # Retries per Modbus command; keep low to avoid long blocking on bad links.
 oq_modbus_startup_delay_ms: "0"                      # Default startup offset for staged Modbus polling [ms].


### PR DESCRIPTION
# Wat verandert deze PR?

- Vervang volledige vijfsecondenregisterscans voor een offline warmtepomp door één read-only herstelprobe op register 2099 per 30 seconden.
- Hervat automatisch de normale volledige Modbuspolling zodra de herstelprobe weer een geldig antwoord ontvangt.
- Behoud de bestaande OTA-pauze en normale pollingcadans voor online warmtepompen.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen het leespad van een niet-bereikbare Modbuswarmtepomp verandert. Een online warmtepomp behoudt de bestaande volledige pollingcadans. De herstelprobe leest uitsluitend working-mode-register 2099 en schrijft niets naar de warmtepomp.

## Achtergrond

Bij afwezige of losgekoppelde warmtepompen startte iedere vijf seconden opnieuw een volledige registerscan. De opeenvolgende Modbustime-outs konden de ESPHome-hoofdloop langdurig belasten en zijn samen met wifi-/API-belasting gereproduceerd tot een `loopTask`-watchdogreset.

De nieuwe offline-status begint fail-safe op `false`. Zolang een warmtepomp offline is, wordt alleen iedere 30 seconden één read-only register opgevraagd. Een geldig antwoord markeert de controller weer online; vanaf het volgende vijfsecondeninterval loopt de bestaande volledige registerpolling weer.

Deze PR wijzigt geen Modbuswrites, controlstrategie, entitycontract of gebruikersinstelling.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is intern herstel- en schedulergedrag zonder nieuwe gebruikersinstelling of gewijzigd entitycontract.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
  - style consistency: geslaagd
  - docs consistency: geslaagd
  - web/docs contract: geslaagd
  - ESPHome-configuratie: geslaagd met ESPHome 2026.7.0
- Volledige Q Duo WiFi-compile: geslaagd.
- Hardware-in-the-loop op een Q Duo WiFi-controller:
  - connected preflight met HP1 en HP2 online, HA actief en HTTP bereikbaar;
  - M1 los plus cold boot: HP1/HP2 bleven correct onbekend;
  - ruim veertien minuten stabiel voorbij de eerder gereproduceerde watchdoggrens van circa 124 seconden;
  - heap free circa 88–93 kB, minimum 18.119 B;
  - HTTP bleef 200 en HA bleef verbonden;
  - M1 live opnieuw aangesloten zonder reboot: HP1 en HP2 hervatten automatisch geldige volledige registerupdates en meldden `Standby`;
  - twee minuten herstelobservatie bleef stabiel.

## Pre-PR-audit

- Volledige diff tegen actuele `dev` beoordeeld op queuegedrag, millis-wrap, cold boot, offline/online-overgangen, OTA-pauze, dual-HP-busgebruik en fail-safe writes.
- Register 2099 is het bestaande read-only working-mode-register.
- De probe wordt niet ingepland wanneer de controllerqueue nog werk bevat.
- Geen user-facing configuratie, migratie, persistent state of terugvalgedrag toegevoegd.
- Resterend risico: op INFO-niveau zijn afzonderlijke probecommando's niet zichtbaar; de 30-secondenlimiet is daarom door code-inspectie en het uitblijven van de timeouttrein gevalideerd, niet met een runtimecommandoteller.