### PR TITLE
Delay initial usage telemetry publish after boot

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -391,9 +391,9 @@ void OpenQuattUsageTelemetry::apply_storage_(const Storage &storage) {
 }
 
 void OpenQuattUsageTelemetry::schedule_initial_publish_() {
-  // Keep zero as the unscheduled sentinel while allowing a newly recorded
-  // opt-in to publish on the next loop iteration.
-  this->next_publish_ms_ = millis() + 1U;
+  // Avoid overlapping the MQTT client and its worker stacks with the first
+  // full sensor/API publication wave after boot.
+  this->next_publish_ms_ = millis() + INITIAL_PUBLISH_DELAY_MS;
 }
 
 void OpenQuattUsageTelemetry::schedule_regular_publish_() {

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -77,6 +77,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
 
   static constexpr uint32_t STORAGE_MAGIC = 0x4F515553;
   static constexpr uint16_t STORAGE_VERSION = 2;
+  static constexpr uint32_t INITIAL_PUBLISH_DELAY_MS = 90UL * 1000UL;
   static constexpr uint32_t SESSION_TIMEOUT_MS = 30000;
   static constexpr uint32_t RETRY_MIN_MS = 5UL * 60UL * 1000UL;
   static constexpr uint32_t RETRY_MAX_MS = 60UL * 60UL * 1000UL;


### PR DESCRIPTION
# Wat verandert deze PR?

- Stelt alleen de eerste usage-telemetrypublicatie 90 seconden uit.
- Voorkomt dat de twee MQTT-taskstacks en buffers samenvallen met de eerste volledige sensor/API-publicatiegolf na een boot.
- Laat consent, payload, interval, retrygedrag en latere publicaties ongewijzigd.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De eerste anonieme usage-publicatie vindt 90 seconden later plaats. De uurlijkse cadence en alle regel-/Modbusfuncties blijven gelijk.

## Achtergrond

HIL op een Q Duo Wi-Fi met Home Assistant, beide Modbus-units en usage telemetry actief liet zien dat de eerste MQTT-publicatie kon overlappen met de eerste sensor/API-golf. In de ongewijzigde build zakte `Heap Min Free` daarbij incidenteel tot 3.055 B; met telemetry uit bleef 17.171 B over. Met deze vertraging bleven twee opeenvolgende boots op respectievelijk 27.027 B en 17.215 B, ook nadat de uitgestelde publicatie had plaatsgevonden. Beide Modbuslijnen bleven actuele waarden leveren.

Volledige diff is gecontroleerd op consent/persistence, retries, timer-wraparound, netwerkfouten en herstarts. Er veranderen geen telemetryvelden, identifiers of privacykeuzes.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is uitsluitend interne opstartfasering; de gebruiker ziet dezelfde instelling en hetzelfde publicatiecontract.

## Validatie

- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml`
- Q Duo Wi-Fi HIL: twee cold software boots met Home Assistant, usage telemetry en HP1/HP2 Modbus actief; HTTP, heap en beide AC-voltage-registers gecontroleerd vóór en na de 90-secondenmarkering.
