### PR TITLE
Keep runtime polling paused throughout OTA

### DIFF
--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -383,7 +383,9 @@ script:
           condition:
             lambda: |-
               return id(oq_fw_check_completed_generation) == id(oq_fw_check_request_generation)
-                  && id(oq_fw_check_target_ready);
+                  && id(oq_fw_check_target_ready)
+                  && !id(oq_runtime_polling_paused).state
+                  && !id(oq_firmware_target_install_active);
           then:
             - lambda: |-
                 id(oq_firmware_target_install_active) = true;
@@ -404,7 +406,8 @@ script:
                   lambda: |-
                     return id(oq_http_ota_begin_observed)
                         || !id(oq_firmware_target_install_active);
-                timeout: 10s
+                # Cover both 10 s connection attempts and the 5 s retry delay.
+                timeout: 30s
             - if:
                 condition:
                   lambda: |-
@@ -419,11 +422,16 @@ script:
                       ESP_LOGE("oq_fw", "Firmware install did not reach the OTA start callback; polling resumed.");
           else:
             - lambda: |-
-                id(oq_firmware_target_install_active) = false;
-                id(oq_runtime_polling_paused).publish_state(false);
-                id(oq_ota_phase_code) = 5;
-                id(oq_firmware_update_status).publish_state("Error");
-                ESP_LOGE("oq_fw", "Firmware install blocked: target manifest check failed twice.");
+                // This script has not acquired the polling pause yet. Preserve
+                // any pause and status owned by an OTA that started while the
+                // manifest checks were running.
+                if (id(oq_runtime_polling_paused).state) {
+                  ESP_LOGW("oq_fw", "Firmware install request cancelled because another OTA became active.");
+                } else {
+                  id(oq_ota_phase_code) = 5;
+                  id(oq_firmware_update_status).publish_state("Error");
+                  ESP_LOGE("oq_fw", "Firmware install blocked: target manifest check failed twice.");
+                }
 
   - id: oq_capture_overview_trend_sample
     mode: single

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -189,10 +189,16 @@ ota:
                   id(oq_firmware_update_progress).publish_state(0.0f);
                   ESP_LOGW("oq_fw", "Firmware download connection failed; retrying attempt %u/2 in 5 seconds.",
                            id(oq_firmware_target_install_attempt));
+              - script.execute: oq_watch_http_ota_start
               - delay: 5s
-              - update.perform:
-                  id: oq_firmware_update
-                  force_update: true
+              - if:
+                  condition:
+                    lambda: |-
+                      return id(oq_firmware_target_install_active);
+                  then:
+                    - update.perform:
+                        id: oq_firmware_update
+                        force_update: true
             else:
               - lambda: |-
                   id(oq_firmware_target_install_active) = false;
@@ -330,6 +336,30 @@ script:
                    target.c_str(), channel.c_str(), source_url);
           id(oq_firmware_update).set_source_url(source_url);
 
+  - id: oq_watch_http_ota_start
+    mode: restart
+    then:
+      # The retry arms this before its 5 s delay. Seventeen seconds covers that
+      # delay, the shared 10 s HTTP timeout and scheduling margin.
+      - wait_until:
+          condition:
+            lambda: |-
+              return id(oq_http_ota_begin_observed)
+                  || !id(oq_firmware_target_install_active);
+          timeout: 17s
+      - if:
+          condition:
+            lambda: |-
+              return !id(oq_http_ota_begin_observed)
+                  && id(oq_firmware_target_install_active);
+          then:
+            - lambda: |-
+                id(oq_firmware_target_install_active) = false;
+                id(oq_runtime_polling_paused).publish_state(false);
+                id(oq_ota_phase_code) = 5;
+                id(oq_firmware_update_status).publish_state("Error");
+                ESP_LOGE("oq_fw", "Firmware install did not reach the OTA start callback; polling resumed.");
+
   - id: oq_install_firmware_update_target_deferred
     mode: single
     then:
@@ -396,30 +426,10 @@ script:
                 id(oq_firmware_update_status).publish_state("Starting");
                 id(oq_firmware_update_progress).publish_state(0.0f);
             - delay: 1500ms
+            - script.execute: oq_watch_http_ota_start
             - update.perform:
                 id: oq_firmware_update
                 force_update: true
-            # set_url()/flash() can reject before OTA callbacks run. Do not
-            # leave runtime polling latched off in that failure mode.
-            - wait_until:
-                condition:
-                  lambda: |-
-                    return id(oq_http_ota_begin_observed)
-                        || !id(oq_firmware_target_install_active);
-                # Cover both 10 s connection attempts and the 5 s retry delay.
-                timeout: 30s
-            - if:
-                condition:
-                  lambda: |-
-                    return !id(oq_http_ota_begin_observed)
-                        && id(oq_firmware_target_install_active);
-                then:
-                  - lambda: |-
-                      id(oq_firmware_target_install_active) = false;
-                      id(oq_runtime_polling_paused).publish_state(false);
-                      id(oq_ota_phase_code) = 5;
-                      id(oq_firmware_update_status).publish_state("Error");
-                      ESP_LOGE("oq_fw", "Firmware install did not reach the OTA start callback; polling resumed.");
           else:
             - lambda: |-
                 // This script has not acquired the polling pause yet. Preserve

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -19,6 +19,7 @@ esphome:
       - lambda: |-
           // Always start from a clean paused state after reboot or OTA.
           id(oq_runtime_polling_paused).publish_state(false);
+          id(oq_http_ota_begin_observed) = false;
           id(oq_ota_phase_code) = 0;
           id(oq_ota_progress_pct) = 0.0f;
           id(oq_firmware_update_status).publish_state("Idle");
@@ -117,8 +118,9 @@ ota:
       then:
         - lambda: |-
             id(oq_firmware_target_install_active) = false;
-            id(oq_runtime_polling_paused).publish_state(false);
-            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA.");
+            // ESPHome reboots immediately after this success callback. Keep all
+            // runtime polling paused until on_boot initializes the new image.
+            ESP_LOGI("oq_fw", "OTA complete; runtime polling remains paused until reboot.");
             id(oq_ota_phase_code) = 3;
             id(oq_ota_progress_pct) = 100.0f;
             id(oq_firmware_update_status).publish_state("Rebooting");
@@ -143,6 +145,7 @@ ota:
     on_begin:
       then:
         - lambda: |-
+            id(oq_http_ota_begin_observed) = true;
             id(oq_runtime_polling_paused).publish_state(true);
             ESP_LOGI("oq_fw", "Runtime polling paused for OTA.");
             id(oq_ota_phase_code) = 1;
@@ -160,17 +163,15 @@ ota:
       then:
         - lambda: |-
             id(oq_firmware_target_install_active) = false;
-            id(oq_runtime_polling_paused).publish_state(false);
-            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA.");
+            // http_request OTA also reboots immediately after this success
+            // callback. Only error and abort paths may resume the old image.
+            ESP_LOGI("oq_fw", "OTA complete; runtime polling remains paused until reboot.");
             id(oq_ota_phase_code) = 3;
             id(oq_ota_progress_pct) = 100.0f;
             id(oq_firmware_update_status).publish_state("Rebooting");
             id(oq_firmware_update_progress).publish_state(100.0f);
     on_error:
       then:
-        - lambda: |-
-            id(oq_runtime_polling_paused).publish_state(false);
-            ESP_LOGI("oq_fw", "Runtime polling resumed after OTA error.");
         - if:
             condition:
               lambda: |-
@@ -179,6 +180,8 @@ ota:
                     && id(oq_ota_progress_pct) <= 0.0f;
             then:
               - lambda: |-
+                  id(oq_http_ota_begin_observed) = false;
+                  id(oq_runtime_polling_paused).publish_state(true);
                   id(oq_firmware_target_install_attempt) += 1;
                   id(oq_ota_phase_code) = 7;
                   id(oq_ota_progress_pct) = 0.0f;
@@ -193,6 +196,8 @@ ota:
             else:
               - lambda: |-
                   id(oq_firmware_target_install_active) = false;
+                  id(oq_runtime_polling_paused).publish_state(false);
+                  ESP_LOGI("oq_fw", "Runtime polling resumed after OTA error.");
                   id(oq_ota_phase_code) = 5;
                   id(oq_firmware_update_status).publish_state("Error");
     on_abort:
@@ -281,6 +286,10 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
+  - id: oq_http_ota_begin_observed
+    type: bool
+    restore_value: false
+    initial_value: 'false'
   - id: oq_trend_capture_force_once
     type: bool
     restore_value: false
@@ -322,10 +331,11 @@ script:
           id(oq_firmware_update).set_source_url(source_url);
 
   - id: oq_install_firmware_update_target_deferred
-    mode: restart
+    mode: single
     then:
       - lambda: |-
-          // Clear a terminal phase from an earlier attempt before the web UI starts polling this install.
+          // Clear terminal state before starting a new install attempt.
+          id(oq_http_ota_begin_observed) = false;
           id(oq_ota_phase_code) = 1;
           id(oq_firmware_update_status).publish_state("Starting");
           id(oq_firmware_update_progress).publish_state(0.0f);
@@ -378,6 +388,7 @@ script:
             - lambda: |-
                 id(oq_firmware_target_install_active) = true;
                 id(oq_firmware_target_install_attempt) = 1;
+                id(oq_http_ota_begin_observed) = false;
                 id(oq_runtime_polling_paused).publish_state(true);
                 ESP_LOGI("oq_fw", "Runtime polling paused before deferred OTA.");
                 id(oq_firmware_update_status).publish_state("Starting");
@@ -386,9 +397,30 @@ script:
             - update.perform:
                 id: oq_firmware_update
                 force_update: true
+            # set_url()/flash() can reject before OTA callbacks run. Do not
+            # leave runtime polling latched off in that failure mode.
+            - wait_until:
+                condition:
+                  lambda: |-
+                    return id(oq_http_ota_begin_observed)
+                        || !id(oq_firmware_target_install_active);
+                timeout: 10s
+            - if:
+                condition:
+                  lambda: |-
+                    return !id(oq_http_ota_begin_observed)
+                        && id(oq_firmware_target_install_active);
+                then:
+                  - lambda: |-
+                      id(oq_firmware_target_install_active) = false;
+                      id(oq_runtime_polling_paused).publish_state(false);
+                      id(oq_ota_phase_code) = 5;
+                      id(oq_firmware_update_status).publish_state("Error");
+                      ESP_LOGE("oq_fw", "Firmware install did not reach the OTA start callback; polling resumed.");
           else:
             - lambda: |-
                 id(oq_firmware_target_install_active) = false;
+                id(oq_runtime_polling_paused).publish_state(false);
                 id(oq_ota_phase_code) = 5;
                 id(oq_firmware_update_status).publish_state("Error");
                 ESP_LOGE("oq_fw", "Firmware install blocked: target manifest check failed twice.");
@@ -874,7 +906,16 @@ button:
     web_server:
       sorting_group_id: oq_system_diagnostics
     on_press:
-      - script.execute: oq_install_firmware_update_target_deferred
+      - if:
+          condition:
+            lambda: |-
+              return !id(oq_runtime_polling_paused).state
+                  && !id(oq_firmware_target_install_active);
+          then:
+            - script.execute: oq_install_firmware_update_target_deferred
+          else:
+            - lambda: |-
+                ESP_LOGW("oq_fw", "Firmware install request ignored because an OTA operation is already active.");
 
 switch:
   - platform: template
@@ -953,8 +994,6 @@ binary_sensor:
     name: Runtime polling paused
     internal: true
     entity_category: diagnostic
-    lambda: |-
-      return false;
 
 sensor:
   - platform: debug


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat de interne polling-pauze tijdens zowel ESPHome-native als HTTP-OTA actief tot de succesvolle reboot.
- Houdt polling ook tijdens de éénmalige HTTP-downloadretry gepauzeerd en hervat uitsluitend bij terminale fout/abort op de oude firmware.
- Blokkeert dubbele installaties en herstelt polling wanneer een HTTP-OTA niet eens het startcallbackpad bereikt.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Modbus/trendpolling start tijdens een OTA niet opnieuw tussen retries of vlak vóór reboot. Na een fout/abort hervat de oude firmware expliciet; na succes initialiseert de nieuwe boot de normale toestand. Er veranderen geen Modbusregisters, intervallen of actuatiebesluiten.

## Achtergrond

De template-binary-sensor had een continue lambda die de gepubliceerde OTA-pauze opnieuw naar `false` kon drukken. Daarnaast hervatte het HTTP-foutpad polling al vóór de geplande retry. Deze PR maakt de toestand expliciet per lifecycle-edge en fail-safe onder re-entry, fout en reboot.

ESPHome 2026.7.0 roept na `OTA_COMPLETED` direct `App.safe_reboot()` aan (native na 100 ms, HTTP na 10 ms). Daarom blijft succes gepauzeerd tot `on_boot`; alleen fout/abort mag de oude runtime hervatten.

Volledige diff is afzonderlijk geaudit op native/HTTP lifecycle, retry-interleaving, dubbele requests, callbackloze vroege fout, reboot, millis/timing, persistente state en Modbusherstel. De callbackloze fallback is defensief: manifestpaden worden normaal door ESPHome tegen de manifestbasis genormaliseerd en bereiken dan het reguliere `on_error`-pad.

Reviewfollow-ups `9ac0ea0` en `0070032` controleren pause-ownership opnieuw na de manifestchecks en gebruiken één herstartbare startwatchdog. Die wordt vóór de eerste downloadpoging én direct bij het plannen van de retry bewapend; een OTA die intussen start behoudt zijn pauze, actieve vlag, fase en status.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Alleen interne OTA-fasering verandert; updateknoppen, statuscontract en configuratie blijven gelijk.

## Validatie

- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml`
- Native OTA op Q Duo Wi-Fi met Home Assistant en HP1/HP2 aangesloten: upload/reboot/herstel groen.
- Lokale HTTP-OTA HIL met tijdelijk LAN-manifest: tijdens upload `Runtime polling paused = ON`; na succesvolle reboot `OFF`, status `Idle`, Modbus hersteld.
- HTTP-foutinjectie met onbereikbare firmware-URL: status `Retrying`, exact één retry na 5 s, daarna `Error`, polling `OFF` en HP1/HP2 opnieuw actueel.
- Definitieve combinatie bovenop #369, #370 en reviewfollow-up #372: heap free 90.127 B, heap min free 19.743 B na de uitgestelde usage-publicatie; HP1 231 V, HP2 230 V en HTTP 200.
- Reviewfix opnieuw volledig voor Q Duo WiFi geconfigureerd en gecompileerd; lifecycle gecontroleerd voor eerste callbackloze start, `on_begin` gevolgd door fout, callbackloze retry, tweede timeout, concurrerende native/API-OTA en manifestfalen zonder eigen pause-ownership.
- Tijdelijke HIL-config, manifest, firmwarekopie en HTTP-server zijn na de test verwijderd.
