### PR TITLE
Fix usage telemetry startup scheduling

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -215,9 +215,8 @@ void OpenQuattUsageTelemetry::setup() {
   }
 
   this->apply_storage_(storage);
-  if (this->enabled_.load() && this->is_setup_complete_()) {
-    this->schedule_initial_publish_();
-  }
+  this->boot_publish_pending_ = this->enabled_.load();
+  this->next_publish_ms_ = 0;
 }
 
 void OpenQuattUsageTelemetry::loop() {
@@ -242,13 +241,17 @@ void OpenQuattUsageTelemetry::loop() {
 
   if (!this->enabled_.load() || !this->is_setup_complete_() || !this->is_configured() ||
       !network::is_connected()) {
-    if (!this->is_setup_complete_()) {
+    if (this->boot_publish_pending_) {
       this->next_publish_ms_ = 0;
     }
     return;
   }
   if (this->next_publish_ms_ == 0U) {
-    this->schedule_initial_publish_();
+    if (this->boot_publish_pending_) {
+      this->schedule_initial_publish_();
+    } else {
+      this->schedule_immediate_publish_();
+    }
   }
   if (time_reached_(millis(), this->next_publish_ms_)) {
     this->start_publish_session_();
@@ -304,14 +307,17 @@ void OpenQuattUsageTelemetry::write_state(bool state) {
   if (state) {
     this->consecutive_failures_ = 0;
     if (this->is_setup_complete_()) {
-      this->schedule_initial_publish_();
+      this->boot_publish_pending_ = false;
+      this->schedule_immediate_publish_();
     } else {
+      this->boot_publish_pending_ = true;
       this->next_publish_ms_ = 0;
     }
     if (!this->is_configured()) {
       ESP_LOGW(TAG, "Usage statistics were enabled, but no telemetry broker is configured in this build");
     }
   } else {
+    this->boot_publish_pending_ = false;
     this->next_publish_ms_ = 0;
     if (!this->session_active_.load()) {
       this->payload_.clear();
@@ -392,8 +398,14 @@ void OpenQuattUsageTelemetry::apply_storage_(const Storage &storage) {
 
 void OpenQuattUsageTelemetry::schedule_initial_publish_() {
   // Avoid overlapping the MQTT client and its worker stacks with the first
-  // full sensor/API publication wave after boot.
+  // full sensor/API publication wave after connectivity becomes available.
   this->next_publish_ms_ = millis() + INITIAL_PUBLISH_DELAY_MS;
+}
+
+void OpenQuattUsageTelemetry::schedule_immediate_publish_() {
+  // Defer to the next loop iteration so a runtime opt-in does not start MQTT
+  // work inside the switch write callback.
+  this->next_publish_ms_ = millis() + 1U;
 }
 
 void OpenQuattUsageTelemetry::schedule_regular_publish_() {
@@ -414,6 +426,7 @@ void OpenQuattUsageTelemetry::start_publish_session_() {
     return;
   }
 
+  this->boot_publish_pending_ = false;
   if (this->payload_.empty()) {
     this->build_payload_();
   }

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -112,6 +112,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   bool is_setup_complete_() const;
   void apply_storage_(const Storage &storage);
   void schedule_initial_publish_();
+  void schedule_immediate_publish_();
   void schedule_regular_publish_();
   void schedule_retry_();
   void start_publish_session_();
@@ -174,6 +175,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   uint32_t session_started_ms_{0};
   uint32_t next_publish_ms_{0};
   uint8_t consecutive_failures_{0};
+  bool boot_publish_pending_{false};
 };
 
 }  // namespace openquatt_usage_telemetry


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat de 90 seconden uitstel uitsluitend gelden voor de eerste telemetrypublicatie na opstart.
- Start die vertraging pas zodra Quick Start, brokerconfiguratie en netwerkverbinding gereed zijn.
- Behoud direct publiceren na een bewuste runtime-inschakeling en behoud bestaande retry- en uurplanning.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Dit is de follow-up voor de twee nog openstaande reviewpunten op #370. Er verandert niets aan consent, payload, persistent storage of het publicatie-interval.

## Achtergrond

#370 bewapende de opstartvertraging al tijdens component-setup en gebruikte dezelfde vertraging bij runtime opt-in. Daardoor kon een trage netwerkstart de vertraging feitelijk opheffen en wachtte een bewuste runtime-inschakeling onnodig 90 seconden.

De lifecycle is gecontroleerd voor: herstelde opt-in met vertraagde netwerkverbinding, opt-in tijdens onboarding, runtime opt-in na onboarding, netwerkverlies tijdens de opstartvertraging, mislukte eerste publicatie, uitzetten tijdens een pending of actieve sessie, en de bestaande retry-/uurplanning.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Alleen interne timing wordt gecorrigeerd; er wijzigen geen instellingen, entiteiten of gebruikerscontracten.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml`
- Volledige diff tegen `dev` gecontroleerd op lifecycle, retries, netwerkverlies, consent en persistente state.