### PR TITLE
Run usage telemetry MQTT cleanup outside loop task

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -220,6 +220,13 @@ void OpenQuattUsageTelemetry::setup() {
 }
 
 void OpenQuattUsageTelemetry::loop() {
+  if (this->cleanup_task_complete_.exchange(false)) {
+    this->complete_publish_session_();
+  }
+  if (this->finishing_session_.load()) {
+    return;
+  }
+
   if (this->session_active_.load()) {
     if (this->start_task_running_.load()) {
       return;
@@ -427,6 +434,15 @@ void OpenQuattUsageTelemetry::start_publish_session_() {
   }
 
   this->boot_publish_pending_ = false;
+
+  // Reserve the cleanup worker before MQTT/TLS can consume the remaining heap.
+  // If this allocation fails, no client resources exist yet and retrying is safe.
+  if (!this->prepare_cleanup_task_()) {
+    this->start_task_running_.store(false);
+    this->schedule_retry_();
+    return;
+  }
+
   if (this->payload_.empty()) {
     this->build_payload_();
   }
@@ -434,6 +450,8 @@ void OpenQuattUsageTelemetry::start_publish_session_() {
   this->publish_failed_.store(false);
   this->pending_message_id_.store(-1);
   this->finishing_session_.store(false);
+  this->cleanup_task_complete_.store(false);
+  this->cleanup_succeeded_.store(false);
   this->session_started_ms_ = millis();
   this->session_active_.store(true);
 
@@ -507,25 +525,41 @@ bool OpenQuattUsageTelemetry::start_client_() {
 }
 
 void OpenQuattUsageTelemetry::finish_publish_session_(bool succeeded) {
-  if (!this->session_active_.load() || this->start_task_running_.load()) {
+  if (!this->session_active_.load() || this->start_task_running_.load() ||
+      this->finishing_session_.exchange(true)) {
     return;
   }
-  this->finishing_session_.store(true);
+  this->cleanup_succeeded_.store(succeeded);
+  xTaskNotifyGive(this->cleanup_task_handle_.load());
+}
 
-  if (this->runtime_lock_ != nullptr && xSemaphoreTake(this->runtime_lock_, portMAX_DELAY) == pdTRUE) {
-    if (this->mqtt_client_ != nullptr) {
-      esp_mqtt_client_stop(this->mqtt_client_);
-      esp_mqtt_client_destroy(this->mqtt_client_);
-      this->mqtt_client_ = nullptr;
-    }
-    xSemaphoreGive(this->runtime_lock_);
+bool OpenQuattUsageTelemetry::prepare_cleanup_task_() {
+  if (this->cleanup_task_running_.exchange(true)) {
+    return false;
   }
+
+  TaskHandle_t task_handle = nullptr;
+  const BaseType_t created = xTaskCreatePinnedToCore(&OpenQuattUsageTelemetry::cleanup_client_task_,
+                                                     "oq_usage_cleanup", MQTT_CLEANUP_TASK_STACK_SIZE, this, 4,
+                                                     &task_handle, tskNO_AFFINITY);
+  if (created != pdPASS || task_handle == nullptr) {
+    this->cleanup_task_running_.store(false);
+    ESP_LOGE(TAG, "Failed to create usage telemetry MQTT cleanup task");
+    return false;
+  }
+  this->cleanup_task_handle_.store(task_handle);
+  return true;
+}
+
+void OpenQuattUsageTelemetry::complete_publish_session_() {
+  const bool succeeded = this->cleanup_succeeded_.load();
 
   this->session_active_.store(false);
   this->publish_succeeded_.store(false);
   this->publish_failed_.store(false);
   this->pending_message_id_.store(-1);
   this->finishing_session_.store(false);
+  this->cleanup_succeeded_.store(false);
 
   if (!this->enabled_.load()) {
     this->payload_.clear();
@@ -669,6 +703,29 @@ void OpenQuattUsageTelemetry::start_client_task_(void *arg) {
     }
     self->start_task_running_.store(false);
     App.wake_loop_threadsafe();
+  }
+  vTaskDelete(nullptr);
+}
+
+void OpenQuattUsageTelemetry::cleanup_client_task_(void *arg) {
+  auto *self = static_cast<OpenQuattUsageTelemetry *>(arg);
+  while (self != nullptr) {
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+    esp_mqtt_client_handle_t client = nullptr;
+    if (self->runtime_lock_ != nullptr && xSemaphoreTake(self->runtime_lock_, portMAX_DELAY) == pdTRUE) {
+      client = self->mqtt_client_;
+      self->mqtt_client_ = nullptr;
+      xSemaphoreGive(self->runtime_lock_);
+    }
+    if (client != nullptr) {
+      esp_mqtt_client_stop(client);
+      esp_mqtt_client_destroy(client);
+    }
+    self->cleanup_task_handle_.store(nullptr);
+    self->cleanup_task_running_.store(false);
+    self->cleanup_task_complete_.store(true);
+    App.wake_loop_threadsafe();
+    break;
   }
   vTaskDelete(nullptr);
 }

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -82,6 +82,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   static constexpr uint32_t RETRY_MIN_MS = 5UL * 60UL * 1000UL;
   static constexpr uint32_t RETRY_MAX_MS = 60UL * 60UL * 1000UL;
   static constexpr uint32_t MQTT_START_TASK_STACK_SIZE = 24576;
+  static constexpr uint32_t MQTT_CLEANUP_TASK_STACK_SIZE = 6144;
   static constexpr int MQTT_TASK_STACK_SIZE = 12288;
 
   struct StorageV1 {
@@ -118,12 +119,15 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   void start_publish_session_();
   bool start_client_();
   void finish_publish_session_(bool succeeded);
+  bool prepare_cleanup_task_();
+  void complete_publish_session_();
   void build_payload_();
   std::string read_hardware_revision_() const;
   static bool time_reached_(uint32_t now_ms, uint32_t target_ms);
   static std::string format_uuid_(const std::array<uint8_t, 16> &bytes);
   static std::string random_message_id_();
   static void start_client_task_(void *arg);
+  static void cleanup_client_task_(void *arg);
   static void mqtt_event_handler_(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
 
   std::string broker_;
@@ -169,6 +173,9 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   std::atomic<bool> session_active_{false};
   std::atomic<bool> finishing_session_{false};
   std::atomic<bool> start_task_running_{false};
+  std::atomic<bool> cleanup_task_running_{false};
+  std::atomic<bool> cleanup_task_complete_{false};
+  std::atomic<bool> cleanup_succeeded_{false};
   std::atomic<bool> publish_succeeded_{false};
   std::atomic<bool> publish_failed_{false};
   std::atomic<int> pending_message_id_{-1};
@@ -176,6 +183,7 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   uint32_t next_publish_ms_{0};
   uint8_t consecutive_failures_{0};
   bool boot_publish_pending_{false};
+  std::atomic<TaskHandle_t> cleanup_task_handle_{nullptr};
 };
 
 }  // namespace openquatt_usage_telemetry


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst `esp_mqtt_client_stop()` en `esp_mqtt_client_destroy()` uit de ESPHome-loop naar een vooraf gereserveerde FreeRTOS-worker.
- Rondt de sessiestatus en retryplanning pas in de hoofdloop af nadat de cleanup-worker gereed is.
- Laat een sessie vóór MQTT/TLS-resourceallocatie fail-closed en bounded retryen wanneer de cleanup-worker niet kan worden aangemaakt.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De usage-telemetry MQTT-client werd na publish, fout of timeout synchroon vanuit `loop()` gestopt en vernietigd. `esp_mqtt_client_stop()` kan daarbij circa één seconde blokkeren. Deze PR houdt de ESPHome-loop vrij; de telemetry-inhoud, opt-in, planning en retrygrenzen veranderen niet.

## Achtergrond

Dit is de nog relevante usage-telemetry-cleanup uit #366, opnieuw geïsoleerd en gerebased op de actuele `dev`. De Modbus- en OTA-delen van #366 zijn afzonderlijk geleverd in respectievelijk #369 en #371.

Lifecycle-audit:

- De cleanup-worker wordt gereserveerd vóór payload-, MQTT- en TLS-allocaties.
- Bij allocatiefalen bestaan nog geen MQTT-clientresources en volgt de bestaande begrensde back-off.
- Publish-success, fout, timeout en runtime-disable convergeren idempotent naar dezelfde cleanup-route.
- MQTT-callbacks worden vanaf `finishing_session_` genegeerd; de clientpointer wordt onder de bestaande mutex losgekoppeld.
- Als `stop/destroy` zelf blijft hangen, blijft alleen usage telemetry gepauzeerd; de ESPHome-loop en ketel-/warmtepompbesturing blijven doorlopen.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne lifecycle-correctie zonder wijziging aan UI, configuratie, payloadcontract of gebruikersgedrag.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml`
- GitHub CI op commit `12cac36`: groen.
- Volledige diff tegen `dev` opnieuw gecontroleerd op success/failure/timeout, enable/disable-interleavings, task-allocatiefalen, callback-races en restartgedrag.
- Success-HIL op Q Duo Wi-Fi `.92`, met HA en native API-statebelasting: de uitgestelde publish en cleanup voltooiden zonder loopwaarschuwing; heap free `88.775 B`, minimum `11.079 B`; beide HP's bleven actueel en HTTP antwoordde `200` in `0,059 s`.
- Timeout-HIL met een lokale TCP-blackhole die de MQTT-handshake 30 s liet hangen: heap herstelde van `63.059 B` tijdens de sessie naar `89.719 B` na cleanup, minimum `12.891 B`; de peerverbinding werd gesloten, beide HP-polls liepen door en HTTP antwoordde tijdens de timeout `200` in `0,612 s`.
- De normale PR-build is na foutinjectie teruggezet; native API, beide Modbuslijnen en HTTP `200` zijn opnieuw bevestigd. Tijdelijke HIL-config/server zijn verwijderd en er bleef geen testproces achter.
