### PR TITLE
Use RMT for OpenTherm response reception

### DIFF
--- a/components/opentherm/.gitignore
+++ b/components/opentherm/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+
+# The repository-wide output/ rule is for generated artifacts. This directory
+# is an ESPHome component platform and must remain part of the vendored source.
+!output/
+!output/**

--- a/components/opentherm/README.openquatt-research.md
+++ b/components/opentherm/README.openquatt-research.md
@@ -7,7 +7,8 @@ the source stays byte-for-byte equal to ESPHome 2026.7.0:
 - `__init__.py`: include the ESP-IDF RMT driver;
 - `hub.cpp`: service completed RMT frames from normal and synchronous loops;
 - `opentherm.cpp` and `opentherm.h`: ESP32 RMT capture, bounded hand-off,
-  timeout arbitration and diagnostics;
+  timeout arbitration, diagnostics and an explicit idle master-output level
+  when an in-flight conversation is stopped;
 - `opentherm_rmt_decoder.h`: the host-testable Manchester decoder.
 
 The full component, including the `output` platform, is deliberately present:
@@ -52,6 +53,13 @@ only master timeout correlated one-to-one with a simulator
 commissioning command and two controlled response-loss intervals also
 validated OT actuation, R1 exclusion, link-loss withdrawal, simulator watchdog
 shutdown, recovery at CH off/TSet 0 and the 120-second minimum off time.
+
+Runtime route changes can stop a conversation between Manchester half-bits.
+The built-in `OpenTherm::stop()` stops the timer but does not restore the output
+pin. This candidate explicitly drives the same idle-high level used during
+initialization, so disabling the hub cannot leave the digital master output at
+an asserted half-bit. This is physical fail-silent behavior; it does not claim
+that the boiler acknowledged a final CH-off frame.
 
 This remains a separate draft candidate, not a release-ready dependency fork.
 Preferred disposition is an upstream ESPHome fix followed by removal of this

--- a/components/opentherm/README.openquatt-research.md
+++ b/components/opentherm/README.openquatt-research.md
@@ -1,0 +1,60 @@
+# OpenTherm RX decoder candidate override
+
+This directory vendors the complete ESPHome 2026.7.0 `opentherm` component for
+an isolated OpenQuatt RMT receive candidate. Except for the files listed below,
+the source stays byte-for-byte equal to ESPHome 2026.7.0:
+
+- `__init__.py`: include the ESP-IDF RMT driver;
+- `hub.cpp`: service completed RMT frames from normal and synchronous loops;
+- `opentherm.cpp` and `opentherm.h`: ESP32 RMT capture, bounded hand-off,
+  timeout arbitration and diagnostics;
+- `opentherm_rmt_decoder.h`: the host-testable Manchester decoder.
+
+The full component, including the `output` platform, is deliberately present:
+ESPHome local external components replace rather than overlay the built-in
+component.
+
+Candidate history:
+
+- A (`f72d249`) pinned the existing GPTimer interrupt to priority 3. It still
+  produced `NO_CHANGE_TOO_LONG` and was rejected.
+- B1/B2 (`4ec00e3`, `06e2ce3`) introduced ESP32 RMT response capture and fixed
+  the input phase/polarity.
+- B3 (`cd7891e`) claimed the completed RMT frame in the ISR, but repeated boots
+  still produced whole-response timeouts.
+- B4 (`14951b2`) enabled the ESP-IDF cache-safe RMT RX ISR. It timed out quickly
+  and was rejected.
+- B5 (`bb3bcca`) serializes RMT completion and the 800 ms software deadline:
+  a completed frame is always consumed before declaring a timeout.
+- B6 (`bed4b48`) adds bounded diagnostics for rejected pulse duration,
+  half-bit overflow and incomplete captures. It does not change timing
+  tolerances or publish additional Home Assistant entities.
+- B7 (`01ba416`) arbitrates RMT completion and the software timeout under the
+  same ISR lock, arms the callback claim before starting capture and treats a
+  zero-symbol completion as a bounded decoder error instead of remaining
+  pending.
+
+The B5-B7 builds pass three host regressions. Two consecutive B6
+post-simulator-reboot gates of more than 1,000 complete responses and one B7
+gate of 1,093 responses completed with zero response timeouts, protocol errors
+and simulator RX/TX errors. The simulator response turnaround stayed below
+75 ms. Two earlier B6 gates, before the simulator reboot, each contained one
+response timeout but no rejected RMT frame. The simulator now counts immediate
+duplicate request IDs so a future timeout can distinguish a missed boiler
+response from a master request that never reached the simulator.
+
+The rebased B7 build subsequently passed a 62-minute transport soak with 15,834
+complete responses and no master or simulator error. A nine-hour soak with the
+OpenTherm product route selected produced about 135,900 valid responses. Its
+only master timeout correlated one-to-one with a simulator
+`TIMING_INVALID` while receiving the master request; no master-RX protocol,
+`NO_TRANSITION` or `NO_CHANGE_TOO_LONG` error occurred. An active 60 °C
+commissioning command and two controlled response-loss intervals also
+validated OT actuation, R1 exclusion, link-loss withdrawal, simulator watchdog
+shutdown, recovery at CH off/TSet 0 and the 120-second minimum off time.
+
+This remains a separate draft candidate, not a release-ready dependency fork.
+Preferred disposition is an upstream ESPHome fix followed by removal of this
+override. Merge is blocked on upstream review, real-boiler HIL, prolonged
+simultaneous OTT+OTB testing and resolution of the remaining rare
+master-TX/bus/simulator-RX timing event. OpenQuatt PR #363 remains unchanged.

--- a/components/opentherm/__init__.py
+++ b/components/opentherm/__init__.py
@@ -1,0 +1,145 @@
+from typing import Any
+
+from esphome import automation, pins
+import esphome.codegen as cg
+from esphome.components import sensor
+from esphome.components.esp32 import include_builtin_idf_component
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_TRIGGER_ID, PLATFORM_ESP32, PLATFORM_ESP8266
+from esphome.core import CORE
+
+from . import const, generate, schema, validate
+
+CODEOWNERS = ["@olegtarasov"]
+MULTI_CONF = True
+
+CONF_IN_PIN = "in_pin"
+CONF_OUT_PIN = "out_pin"
+CONF_CH_ENABLE = "ch_enable"
+CONF_DHW_ENABLE = "dhw_enable"
+CONF_COOLING_ENABLE = "cooling_enable"
+CONF_OTC_ACTIVE = "otc_active"
+CONF_CH2_ACTIVE = "ch2_active"
+CONF_SUMMER_MODE_ACTIVE = "summer_mode_active"
+CONF_DHW_BLOCK = "dhw_block"
+CONF_SYNC_MODE = "sync_mode"
+CONF_BEFORE_SEND = "before_send"
+CONF_BEFORE_PROCESS_RESPONSE = "before_process_response"
+
+# Triggers
+BeforeSendTrigger = generate.opentherm_ns.class_(
+    "BeforeSendTrigger",
+    automation.Trigger.template(generate.OpenthermData.operator("ref")),
+)
+BeforeProcessResponseTrigger = generate.opentherm_ns.class_(
+    "BeforeProcessResponseTrigger",
+    automation.Trigger.template(generate.OpenthermData.operator("ref")),
+)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(generate.OpenthermHub),
+            cv.Required(CONF_IN_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Required(CONF_OUT_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_CH_ENABLE, True): cv.boolean,
+            cv.Optional(CONF_DHW_ENABLE, True): cv.boolean,
+            cv.Optional(CONF_COOLING_ENABLE, False): cv.boolean,
+            cv.Optional(CONF_OTC_ACTIVE, False): cv.boolean,
+            cv.Optional(CONF_CH2_ACTIVE, False): cv.boolean,
+            cv.Optional(CONF_SUMMER_MODE_ACTIVE, False): cv.boolean,
+            cv.Optional(CONF_DHW_BLOCK, False): cv.boolean,
+            cv.Optional(CONF_SYNC_MODE, False): cv.boolean,
+            cv.Optional(CONF_BEFORE_SEND): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(BeforeSendTrigger),
+                }
+            ),
+            cv.Optional(CONF_BEFORE_PROCESS_RESPONSE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        BeforeProcessResponseTrigger
+                    ),
+                }
+            ),
+        }
+    )
+    .extend(
+        validate.create_entities_schema(
+            schema.INPUTS, (lambda _: cv.use_id(sensor.Sensor))
+        )
+    )
+    .extend(
+        validate.create_entities_schema(
+            schema.SETTINGS, (lambda s: s.validation_schema)
+        )
+    )
+    .extend(cv.COMPONENT_SCHEMA),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266]),
+)
+
+
+async def to_code(config: dict[str, Any]) -> None:
+    if CORE.is_esp32:
+        include_builtin_idf_component("esp_driver_gptimer")
+        include_builtin_idf_component("esp_driver_rmt")
+
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    # Set pins
+    in_pin = await cg.gpio_pin_expression(config[CONF_IN_PIN])
+    cg.add(var.set_in_pin(in_pin))
+
+    out_pin = await cg.gpio_pin_expression(config[CONF_OUT_PIN])
+    cg.add(var.set_out_pin(out_pin))
+
+    non_sensors = {
+        CONF_ID,
+        CONF_IN_PIN,
+        CONF_OUT_PIN,
+        CONF_BEFORE_SEND,
+        CONF_BEFORE_PROCESS_RESPONSE,
+    }
+    input_sensors = []
+    settings = []
+    for key, value in config.items():
+        if key in non_sensors:
+            continue
+        if key in schema.INPUTS:
+            input_sensor = await cg.get_variable(value)
+            cg.add(getattr(var, f"set_{key}_{const.INPUT_SENSOR}")(input_sensor))
+            input_sensors.append(key)
+        elif key in schema.SETTINGS:
+            if value == schema.SETTINGS[key].default_value:
+                continue
+            cg.add(getattr(var, f"set_{key}_{const.SETTING}")(value))
+            settings.append(key)
+        else:
+            cg.add(getattr(var, f"set_{key}")(value))
+
+    if len(input_sensors) > 0:
+        generate.define_has_component(const.INPUT_SENSOR, input_sensors)
+        generate.define_message_handler(
+            const.INPUT_SENSOR, input_sensors, schema.INPUTS
+        )
+        generate.define_readers(const.INPUT_SENSOR, input_sensors)
+        generate.add_messages(var, input_sensors, schema.INPUTS)
+
+    if len(settings) > 0:
+        generate.define_has_settings(settings, schema.SETTINGS)
+        generate.define_message_handler(const.SETTING, settings, schema.SETTINGS)
+        generate.define_setting_readers(const.SETTING, settings)
+        generate.add_messages(var, settings, schema.SETTINGS)
+
+    for conf in config.get(CONF_BEFORE_SEND, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(
+            trigger, [(generate.OpenthermData.operator("ref"), "x")], conf
+        )
+
+    for conf in config.get(CONF_BEFORE_PROCESS_RESPONSE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(
+            trigger, [(generate.OpenthermData.operator("ref"), "x")], conf
+        )

--- a/components/opentherm/automation.h
+++ b/components/opentherm/automation.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "hub.h"
+#include "opentherm.h"
+
+namespace esphome::opentherm {
+
+class BeforeSendTrigger final : public Trigger<OpenthermData &> {
+ public:
+  BeforeSendTrigger(OpenthermHub *hub) {
+    hub->add_on_before_send_callback([this](OpenthermData &x) { this->trigger(x); });
+  }
+};
+
+class BeforeProcessResponseTrigger final : public Trigger<OpenthermData &> {
+ public:
+  BeforeProcessResponseTrigger(OpenthermHub *hub) {
+    hub->add_on_before_process_response_callback([this](OpenthermData &x) { this->trigger(x); });
+  }
+};
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/binary_sensor/__init__.py
+++ b/components/opentherm/binary_sensor/__init__.py
@@ -1,0 +1,31 @@
+from typing import Any
+
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+
+from .. import const, generate, schema, validate
+
+DEPENDENCIES = [const.OPENTHERM]
+COMPONENT_TYPE = const.BINARY_SENSOR
+
+
+def get_entity_validation_schema(entity: schema.BinarySensorSchema) -> cv.Schema:
+    return binary_sensor.binary_sensor_schema(
+        device_class=(entity.device_class or cv.UNDEFINED),
+        icon=(entity.icon or cv.UNDEFINED),
+    )
+
+
+CONFIG_SCHEMA = validate.create_component_schema(
+    schema.BINARY_SENSORS, get_entity_validation_schema
+)
+
+
+async def to_code(config: dict[str, Any]) -> None:
+    await generate.component_to_code(
+        COMPONENT_TYPE,
+        schema.BINARY_SENSORS,
+        binary_sensor.BinarySensor,
+        generate.create_only_conf(binary_sensor.new_binary_sensor),
+        config,
+    )

--- a/components/opentherm/const.py
+++ b/components/opentherm/const.py
@@ -1,0 +1,12 @@
+OPENTHERM = "opentherm"
+
+CONF_OPENTHERM_ID = "opentherm_id"
+CONF_DATA_TYPE = "data_type"
+
+SENSOR = "sensor"
+BINARY_SENSOR = "binary_sensor"
+SWITCH = "switch"
+NUMBER = "number"
+OUTPUT = "output"
+INPUT_SENSOR = "input_sensor"
+SETTING = "setting"

--- a/components/opentherm/generate.py
+++ b/components/opentherm/generate.py
@@ -1,0 +1,173 @@
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import esphome.codegen as cg
+from esphome.const import CONF_ID
+
+from . import const
+from .schema import SettingSchema, TSchema
+
+opentherm_ns = cg.esphome_ns.namespace("opentherm")
+OpenthermHub = opentherm_ns.class_("OpenthermHub", cg.Component)
+OpenthermData = opentherm_ns.class_("OpenthermData")
+
+
+def define_has_component(component_type: str, keys: list[str]) -> None:
+    cg.add_define(
+        f"OPENTHERM_{component_type.upper()}_LIST(F, sep)",
+        cg.RawExpression(
+            " sep ".join(f"F({key}_{component_type.lower()})" for key in keys)
+        ),
+    )
+    for key in keys:
+        cg.add_define(f"OPENTHERM_HAS_{component_type.upper()}_{key}")
+
+
+# We need a separate set of macros for settings because there are different backing field types we need to take
+# into account
+def define_has_settings(keys: list[str], schemas: dict[str, SettingSchema]) -> None:
+    cg.add_define(
+        "OPENTHERM_SETTING_LIST(F, sep)",
+        cg.RawExpression(
+            " sep ".join(
+                f"F({schemas[key].backing_type}, {key}_setting, {schemas[key].default_value})"
+                for key in keys
+            )
+        ),
+    )
+    for key in keys:
+        cg.add_define(f"OPENTHERM_HAS_SETTING_{key}")
+
+
+def define_message_handler(
+    component_type: str, keys: list[str], schemas: dict[str, TSchema]
+) -> None:
+    # The macros defined here should be able to generate things like this:
+    # // Parsing a message and publishing to sensors
+    # case MessageId::Message:
+    #     // Can have multiple sensors here, for example for a Status message with multiple flags
+    #     this->thing_binary_sensor->publish_state(parse_flag8_lb_0(response));
+    #     this->other_binary_sensor->publish_state(parse_flag8_lb_1(response));
+    #     break;
+    # // Building a message for a write request
+    # case MessageId::Message: {
+    #     unsigned int data = 0;
+    #     data = write_flag8_lb_0(some_input_switch->state, data); // Where input_sensor can also be a number/output/switch
+    #     data = write_u8_hb(some_number->state, data);
+    #     return opentherm_->build_request_(MessageType::WriteData, MessageId::Message, data);
+    # }
+
+    messages: dict[str, list[tuple[str, str]]] = {}
+    for key in keys:
+        msg = schemas[key].message
+        if msg not in messages:
+            messages[msg] = []
+        messages[msg].append((key, schemas[key].message_data))
+
+    cg.add_define(
+        f"OPENTHERM_{component_type.upper()}_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep)",
+        cg.RawExpression(
+            " msg_sep ".join(
+                [
+                    f"MESSAGE({msg}) "
+                    + " entity_sep ".join(
+                        [
+                            f"ENTITY({key}_{component_type.lower()}, {msg_data})"
+                            for key, msg_data in keys
+                        ]
+                    )
+                    + " postscript"
+                    for msg, keys in messages.items()
+                ]
+            )
+        ),
+    )
+
+
+def define_readers(component_type: str, keys: list[str]) -> None:
+    for key in keys:
+        cg.add_define(
+            f"OPENTHERM_READ_{key}",
+            cg.RawExpression(f"this->{key}_{component_type.lower()}->state"),
+        )
+
+
+def define_setting_readers(component_type: str, keys: list[str]) -> None:
+    for key in keys:
+        cg.add_define(
+            f"OPENTHERM_READ_{key}",
+            cg.RawExpression(f"this->{key}_{component_type.lower()}"),
+        )
+
+
+def add_messages(hub: cg.MockObj, keys: list[str], schemas: dict[str, TSchema]):
+    messages: dict[str, tuple[bool, int | None]] = {}
+    for key in keys:
+        messages[schemas[key].message] = (
+            schemas[key].keep_updated,
+            schemas[key].order if hasattr(schemas[key], "order") else None,
+        )
+    for msg, (keep_updated, order) in messages.items():
+        msg_expr = cg.RawExpression(f"esphome::opentherm::MessageId::{msg}")
+        if keep_updated:
+            cg.add(hub.add_repeating_message(msg_expr))
+        elif order is not None:
+            cg.add(hub.add_initial_message(msg_expr, order))
+        else:
+            cg.add(hub.add_initial_message(msg_expr))
+
+
+def add_property_set(var: cg.MockObj, config_key: str, config: dict[str, Any]) -> None:
+    if config_key in config:
+        cg.add(getattr(var, f"set_{config_key}")(config[config_key]))
+
+
+Create = Callable[[dict[str, Any], str, cg.MockObj], Awaitable[cg.Pvariable]]
+
+
+def create_only_conf(
+    create: Callable[[dict[str, Any]], Awaitable[cg.Pvariable]],
+) -> Create:
+    return lambda conf, _key, _hub: create(conf)
+
+
+async def component_to_code(
+    component_type: str,
+    schemas: dict[str, TSchema],
+    type: cg.MockObjClass,
+    create: Create,
+    config: dict[str, Any],
+) -> list[str]:
+    """Generate the code for each configured component in the schema of a component type.
+
+    Parameters:
+    - component_type: The type of component, e.g. "sensor" or "binary_sensor"
+    - schema_: The schema for that component type, a list of available components
+    - type: The type of the component, e.g. sensor.Sensor or OpenthermOutput
+    - create: A constructor function for the component, which receives the config,
+      the key and the hub and should asynchronously return the new component
+    - config: The configuration for this component type
+
+    Returns: The list of keys for the created components
+    """
+    cg.add_define(f"OPENTHERM_USE_{component_type.upper()}")
+
+    hub = await cg.get_variable(config[const.CONF_OPENTHERM_ID])
+
+    keys: list[str] = []
+    for key, conf in config.items():
+        if not isinstance(conf, dict):
+            continue
+        id = conf[CONF_ID]
+        if id and id.type == type:
+            entity = await create(conf, key, hub)
+            if const.CONF_DATA_TYPE in conf:
+                schemas[key].message_data = conf[const.CONF_DATA_TYPE]
+            cg.add(getattr(hub, f"set_{key}_{component_type.lower()}")(entity))
+            keys.append(key)
+
+    define_has_component(component_type, keys)
+    define_message_handler(component_type, keys, schemas)
+    add_messages(hub, keys, schemas)
+
+    return keys

--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -1,0 +1,428 @@
+#include "hub.h"
+#include "esphome/core/helpers.h"
+
+#include <string>
+
+namespace esphome::opentherm {
+
+static const char *const TAG = "opentherm";
+namespace message_data {
+bool parse_flag8_lb_0(OpenthermData &data) { return read_bit(data.valueLB, 0); }
+bool parse_flag8_lb_1(OpenthermData &data) { return read_bit(data.valueLB, 1); }
+bool parse_flag8_lb_2(OpenthermData &data) { return read_bit(data.valueLB, 2); }
+bool parse_flag8_lb_3(OpenthermData &data) { return read_bit(data.valueLB, 3); }
+bool parse_flag8_lb_4(OpenthermData &data) { return read_bit(data.valueLB, 4); }
+bool parse_flag8_lb_5(OpenthermData &data) { return read_bit(data.valueLB, 5); }
+bool parse_flag8_lb_6(OpenthermData &data) { return read_bit(data.valueLB, 6); }
+bool parse_flag8_lb_7(OpenthermData &data) { return read_bit(data.valueLB, 7); }
+bool parse_flag8_hb_0(OpenthermData &data) { return read_bit(data.valueHB, 0); }
+bool parse_flag8_hb_1(OpenthermData &data) { return read_bit(data.valueHB, 1); }
+bool parse_flag8_hb_2(OpenthermData &data) { return read_bit(data.valueHB, 2); }
+bool parse_flag8_hb_3(OpenthermData &data) { return read_bit(data.valueHB, 3); }
+bool parse_flag8_hb_4(OpenthermData &data) { return read_bit(data.valueHB, 4); }
+bool parse_flag8_hb_5(OpenthermData &data) { return read_bit(data.valueHB, 5); }
+bool parse_flag8_hb_6(OpenthermData &data) { return read_bit(data.valueHB, 6); }
+bool parse_flag8_hb_7(OpenthermData &data) { return read_bit(data.valueHB, 7); }
+uint8_t parse_u8_lb(OpenthermData &data) { return data.valueLB; }
+uint8_t parse_u8_hb(OpenthermData &data) { return data.valueHB; }
+int8_t parse_s8_lb(OpenthermData &data) { return (int8_t) data.valueLB; }
+int8_t parse_s8_hb(OpenthermData &data) { return (int8_t) data.valueHB; }
+uint16_t parse_u16(OpenthermData &data) { return data.u16(); }
+uint16_t parse_u8_lb_60(OpenthermData &data) { return data.valueLB * 60; }
+uint16_t parse_u8_hb_60(OpenthermData &data) { return data.valueHB * 60; }
+int16_t parse_s16(OpenthermData &data) { return data.s16(); }
+float parse_f88(OpenthermData &data) { return data.f88(); }
+
+void write_flag8_lb_0(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 0, value); }
+void write_flag8_lb_1(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 1, value); }
+void write_flag8_lb_2(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 2, value); }
+void write_flag8_lb_3(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 3, value); }
+void write_flag8_lb_4(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 4, value); }
+void write_flag8_lb_5(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 5, value); }
+void write_flag8_lb_6(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 6, value); }
+void write_flag8_lb_7(const bool value, OpenthermData &data) { data.valueLB = write_bit(data.valueLB, 7, value); }
+void write_flag8_hb_0(const bool value, OpenthermData &data) { data.valueHB = write_bit(data.valueHB, 0, value); }
+void write_flag8_hb_1(const bool value, OpenthermData &data) { data.valueHB = write_bit(data.valueHB, 1, value); }
+void write_flag8_hb_2(const bool value, OpenthermData &data) { data.valueHB = write_bit(data.valueHB, 2, value); }
+void write_flag8_hb_3(const bool value, OpenthermData &data) { data.valueHB = write_bit(data.valueHB, 3, value); }
+void write_flag8_hb_4(const bool value, OpenthermData &data) { data.valueHB = write_bit(data.valueHB, 4, value); }
+void write_flag8_hb_5(const bool value, OpenthermData &data) { data.valueHB = write_bit(data.valueHB, 5, value); }
+void write_flag8_hb_6(const bool value, OpenthermData &data) { data.valueHB = write_bit(data.valueHB, 6, value); }
+void write_flag8_hb_7(const bool value, OpenthermData &data) { data.valueHB = write_bit(data.valueHB, 7, value); }
+void write_u8_lb(const uint8_t value, OpenthermData &data) { data.valueLB = value; }
+void write_u8_hb(const uint8_t value, OpenthermData &data) { data.valueHB = value; }
+void write_s8_lb(const int8_t value, OpenthermData &data) { data.valueLB = (uint8_t) value; }
+void write_s8_hb(const int8_t value, OpenthermData &data) { data.valueHB = (uint8_t) value; }
+void write_u16(const uint16_t value, OpenthermData &data) { data.u16(value); }
+void write_s16(const int16_t value, OpenthermData &data) { data.s16(value); }
+void write_f88(const float value, OpenthermData &data) { data.f88(value); }
+
+}  // namespace message_data
+
+OpenthermData OpenthermHub::build_request_(MessageId request_id) const {
+  OpenthermData data;
+  data.type = 0;
+  data.id = request_id;
+  data.valueHB = 0;
+  data.valueLB = 0;
+
+  // We need this special logic for STATUS message because we have two options for specifying boiler modes:
+  // with static config values in the hub, or with separate switches.
+  if (request_id == MessageId::STATUS) {
+    // NOLINTBEGIN
+    bool const ch_enabled = this->ch_enable && OPENTHERM_READ_ch_enable && OPENTHERM_READ_t_set > 0.0;
+    bool const dhw_enabled = this->dhw_enable && OPENTHERM_READ_dhw_enable;
+    bool const cooling_enabled =
+        this->cooling_enable && OPENTHERM_READ_cooling_enable && OPENTHERM_READ_cooling_control > 0.0;
+    bool const otc_enabled = this->otc_active && OPENTHERM_READ_otc_active;
+    bool const ch2_enabled = this->ch2_active && OPENTHERM_READ_ch2_active && OPENTHERM_READ_t_set_ch2 > 0.0;
+    bool const summer_mode_is_active = this->summer_mode_active && OPENTHERM_READ_summer_mode_active;
+    bool const dhw_blocked = this->dhw_block && OPENTHERM_READ_dhw_block;
+    // NOLINTEND
+
+    data.type = MessageType::READ_DATA;
+    data.valueHB = ch_enabled | (dhw_enabled << 1) | (cooling_enabled << 2) | (otc_enabled << 3) | (ch2_enabled << 4) |
+                   (summer_mode_is_active << 5) | (dhw_blocked << 6);
+
+    return data;
+  }
+
+  // Next, we start with write requests from switches and other inputs,
+  // because we would want to write that data if it is available, rather than
+  // request a read for that type (in the case that both read and write are
+  // supported).
+  switch (request_id) {
+    OPENTHERM_SWITCH_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_WRITE_MESSAGE, OPENTHERM_MESSAGE_WRITE_ENTITY, ,
+                                      OPENTHERM_MESSAGE_WRITE_POSTSCRIPT, )
+    OPENTHERM_NUMBER_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_WRITE_MESSAGE, OPENTHERM_MESSAGE_WRITE_ENTITY, ,
+                                      OPENTHERM_MESSAGE_WRITE_POSTSCRIPT, )
+    OPENTHERM_OUTPUT_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_WRITE_MESSAGE, OPENTHERM_MESSAGE_WRITE_ENTITY, ,
+                                      OPENTHERM_MESSAGE_WRITE_POSTSCRIPT, )
+    OPENTHERM_INPUT_SENSOR_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_WRITE_MESSAGE, OPENTHERM_MESSAGE_WRITE_ENTITY, ,
+                                            OPENTHERM_MESSAGE_WRITE_POSTSCRIPT, )
+    OPENTHERM_SETTING_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_WRITE_MESSAGE, OPENTHERM_MESSAGE_WRITE_SETTING, ,
+                                       OPENTHERM_MESSAGE_WRITE_POSTSCRIPT, )
+    default:
+      break;
+  }
+
+  // Finally, handle the simple read requests, which only change with the message id.
+  switch (request_id) {
+    OPENTHERM_SENSOR_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_READ_MESSAGE, OPENTHERM_IGNORE, , , )
+    default:
+      break;
+  }
+  switch (request_id) {
+    OPENTHERM_BINARY_SENSOR_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_READ_MESSAGE, OPENTHERM_IGNORE, , , )
+    default:
+      break;
+  }
+
+  // And if we get here, a message was requested which somehow wasn't handled.
+  // This shouldn't happen due to the way the defines are configured, so we
+  // log an error and just return a 0 message.
+  ESP_LOGE(TAG, "Tried to create a request with unknown id %d. This should never happen, so please open an issue.",
+           request_id);
+  return {};
+}
+
+OpenthermHub::OpenthermHub() : Component(), in_pin_{}, out_pin_{} {}
+
+void OpenthermHub::process_response(OpenthermData &data) {
+  ESP_LOGD(TAG, "Received OpenTherm response with id %d (%s)", data.id,
+           this->opentherm_->message_id_to_str((MessageId) data.id));
+  this->opentherm_->debug_data(data);
+
+  switch (data.id) {
+    OPENTHERM_SENSOR_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_RESPONSE_MESSAGE, OPENTHERM_MESSAGE_RESPONSE_ENTITY, ,
+                                      OPENTHERM_MESSAGE_RESPONSE_POSTSCRIPT, )
+  }
+  switch (data.id) {
+    OPENTHERM_BINARY_SENSOR_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_RESPONSE_MESSAGE, OPENTHERM_MESSAGE_RESPONSE_ENTITY, ,
+                                             OPENTHERM_MESSAGE_RESPONSE_POSTSCRIPT, )
+  }
+}
+
+void OpenthermHub::setup() {
+  this->opentherm_ = make_unique<OpenTherm>(this->in_pin_, this->out_pin_);
+  if (!this->opentherm_->initialize()) {
+    ESP_LOGE(TAG, "Failed to initialize OpenTherm protocol. See previous log messages for details.");
+    this->mark_failed();
+    return;
+  }
+
+  // Ensure that there is at least one request, as we are required to
+  // communicate at least once every second. Sending the status request is
+  // good practice anyway.
+  this->add_repeating_message(MessageId::STATUS);
+  this->write_initial_messages_(this->messages_);
+  this->message_iterator_ = this->messages_.begin();
+}
+
+void OpenthermHub::on_shutdown() { this->opentherm_->stop(); }
+
+// Disabling clang-tidy for this particular line since it keeps removing the trailing underscore (bug?)
+void OpenthermHub::write_initial_messages_(std::vector<MessageId> &target) {  // NOLINT
+  std::vector<std::pair<MessageId, uint8_t>> sorted;
+  std::copy_if(this->configured_messages_.begin(), this->configured_messages_.end(), std::back_inserter(sorted),
+               [](const std::pair<MessageId, uint8_t> &pair) { return pair.second < REPEATING_MESSAGE_ORDER; });
+  std::sort(sorted.begin(), sorted.end(),
+            [](const std::pair<MessageId, uint8_t> &a, const std::pair<MessageId, uint8_t> &b) {
+              return a.second < b.second;
+            });
+
+  target.clear();
+  std::transform(sorted.begin(), sorted.end(), std::back_inserter(target),
+                 [](const std::pair<MessageId, uint8_t> &pair) { return pair.first; });
+}
+
+// Disabling clang-tidy for this particular line since it keeps removing the trailing underscore (bug?)
+void OpenthermHub::write_repeating_messages_(std::vector<MessageId> &target) {  // NOLINT
+  target.clear();
+  for (auto const &pair : this->configured_messages_) {
+    if (pair.second == REPEATING_MESSAGE_ORDER) {
+      target.push_back(pair.first);
+    }
+  }
+}
+
+void OpenthermHub::loop() {
+  this->opentherm_->process();
+  if (this->sync_mode_) {
+    this->sync_loop_();
+    return;
+  }
+
+  auto cur_time = millis();
+  auto const cur_mode = this->opentherm_->get_mode();
+
+  if (this->handle_error_(cur_mode)) {
+    return;
+  }
+
+  switch (cur_mode) {
+    case OperationMode::WRITE:
+    case OperationMode::READ:
+    case OperationMode::LISTEN:
+      break;
+    case OperationMode::IDLE:
+      this->check_timings_(cur_time);
+      if (this->should_skip_loop_(cur_time)) {
+        break;
+      }
+      this->start_conversation_();
+      break;
+    case OperationMode::SENT:
+      // Message sent, now listen for the response.
+      this->opentherm_->listen();
+      break;
+    case OperationMode::RECEIVED:
+      this->read_response_();
+      break;
+    default:
+      break;
+  }
+  this->last_mode_ = cur_mode;
+}
+
+bool OpenthermHub::handle_error_(OperationMode mode) {
+  switch (mode) {
+    case OperationMode::ERROR_PROTOCOL:
+      // Protocol error can happen only while reading boiler response.
+      this->handle_protocol_error_();
+      return true;
+    case OperationMode::ERROR_TIMEOUT:
+      // Timeout error might happen while we wait for device to respond.
+      this->handle_timeout_error_();
+      return true;
+    case OperationMode::ERROR_TIMER:
+      // Timer error can happen only on ESP32.
+      this->handle_timer_error_();
+      return true;
+    default:
+      return false;
+  }
+}
+
+void OpenthermHub::sync_loop_() {
+  if (!this->opentherm_->is_idle()) {
+    ESP_LOGE(TAG, "OpenTherm is not idle at the start of the loop");
+    return;
+  }
+
+  auto cur_time = millis();
+
+  this->check_timings_(cur_time);
+
+  if (this->should_skip_loop_(cur_time)) {
+    return;
+  }
+
+  this->start_conversation_();
+  // There may be a timer error at this point
+  if (this->handle_error_(this->opentherm_->get_mode())) {
+    return;
+  }
+
+  // Spin while message is being sent to device
+  if (!this->spin_wait_(1150, [&] {
+        this->opentherm_->process();
+        return this->opentherm_->is_active();
+      })) {
+    ESP_LOGE(TAG, "Hub timeout triggered during send");
+    this->stop_opentherm_();
+    return;
+  }
+
+  // Check for errors and ensure we are in the right state (message sent successfully)
+  if (this->handle_error_(this->opentherm_->get_mode())) {
+    return;
+  } else if (!this->opentherm_->is_sent()) {
+    ESP_LOGW(TAG, "Unexpected state after sending request: %s",
+             this->opentherm_->operation_mode_to_str(this->opentherm_->get_mode()));
+    this->stop_opentherm_();
+    return;
+  }
+
+  // Listen for the response
+  this->opentherm_->listen();
+  // There may be a timer error at this point
+  if (this->handle_error_(this->opentherm_->get_mode())) {
+    return;
+  }
+
+  // Spin while response is being received
+  if (!this->spin_wait_(1150, [&] {
+        this->opentherm_->process();
+        return this->opentherm_->is_active();
+      })) {
+    ESP_LOGE(TAG, "Hub timeout triggered during receive");
+    this->stop_opentherm_();
+    return;
+  }
+
+  // Check for errors and ensure we are in the right state (message received successfully)
+  if (this->handle_error_(this->opentherm_->get_mode())) {
+    return;
+  } else if (!this->opentherm_->has_message()) {
+    ESP_LOGW(TAG, "Unexpected state after receiving response: %s",
+             this->opentherm_->operation_mode_to_str(this->opentherm_->get_mode()));
+    this->stop_opentherm_();
+    return;
+  }
+
+  this->read_response_();
+}
+
+void OpenthermHub::check_timings_(uint32_t cur_time) {
+  if (this->last_conversation_start_ > 0 && (cur_time - this->last_conversation_start_) > 1150) {
+    ESP_LOGW(TAG,
+             "%d ms elapsed since the start of the last convo, but 1150 ms are allowed at maximum. Look at other "
+             "components that might slow the loop down.",
+             (int) (cur_time - this->last_conversation_start_));
+  }
+}
+
+bool OpenthermHub::should_skip_loop_(uint32_t cur_time) const {
+  if (this->last_conversation_end_ > 0 && (cur_time - this->last_conversation_end_) < 100) {
+    ESP_LOGV(TAG, "Less than 100 ms elapsed since last convo, skipping this iteration");
+    return true;
+  }
+
+  return false;
+}
+
+void OpenthermHub::start_conversation_() {
+  if (this->message_iterator_ == this->messages_.end()) {
+    if (this->sending_initial_) {
+      this->sending_initial_ = false;
+      this->write_repeating_messages_(this->messages_);
+    }
+    this->message_iterator_ = this->messages_.begin();
+  }
+
+  auto request = this->build_request_(*this->message_iterator_);
+
+  this->before_send_callback_.call(request);
+
+  ESP_LOGD(TAG, "Sending request with id %d (%s)", request.id,
+           this->opentherm_->message_id_to_str((MessageId) request.id));
+  this->opentherm_->debug_data(request);
+  // Send the request
+  this->last_conversation_start_ = millis();
+  this->opentherm_->send(request);
+}
+
+void OpenthermHub::read_response_() {
+  OpenthermData response;
+  if (!this->opentherm_->get_message(response)) {
+    ESP_LOGW(TAG, "Couldn't get the response, but flags indicated success. This is a bug.");
+    this->stop_opentherm_();
+    return;
+  }
+
+  this->stop_opentherm_();
+
+  this->before_process_response_callback_.call(response);
+  this->process_response(response);
+
+  this->message_iterator_++;
+}
+
+void OpenthermHub::stop_opentherm_() {
+  this->opentherm_->stop();
+  this->last_conversation_end_ = millis();
+}
+
+void OpenthermHub::handle_protocol_error_() {
+  OpenThermError error;
+  this->opentherm_->get_protocol_error(error);
+  ESP_LOGW(TAG, "Protocol error occured while receiving response: %s",
+           this->opentherm_->protocol_error_to_str(error.error_type));
+  this->opentherm_->debug_error(error);
+  this->stop_opentherm_();
+}
+
+void OpenthermHub::handle_timeout_error_() {
+  ESP_LOGW(TAG, "Timeout while waiting for response from device");
+  this->stop_opentherm_();
+}
+
+void OpenthermHub::handle_timer_error_() {
+  this->opentherm_->report_and_reset_timer_error();
+  this->stop_opentherm_();
+  // Timer error is critical, there is no point in retrying.
+  this->mark_failed();
+}
+
+void OpenthermHub::dump_config() {
+  std::vector<MessageId> initial_messages;
+  std::vector<MessageId> repeating_messages;
+  this->write_initial_messages_(initial_messages);
+  this->write_repeating_messages_(repeating_messages);
+
+  ESP_LOGCONFIG(TAG,
+                "OpenTherm:\n"
+                "  Sync mode: %s\n"
+                "  Sensors: %s\n"
+                "  Binary sensors: %s\n"
+                "  Switches: %s\n"
+                "  Input sensors: %s\n"
+                "  Outputs: %s\n"
+                "  Numbers: %s",
+                YESNO(this->sync_mode_), SHOW(OPENTHERM_SENSOR_LIST(ID, )), SHOW(OPENTHERM_BINARY_SENSOR_LIST(ID, )),
+                SHOW(OPENTHERM_SWITCH_LIST(ID, )), SHOW(OPENTHERM_INPUT_SENSOR_LIST(ID, )),
+                SHOW(OPENTHERM_OUTPUT_LIST(ID, )), SHOW(OPENTHERM_NUMBER_LIST(ID, )));
+  LOG_PIN("  In: ", this->in_pin_);
+  LOG_PIN("  Out: ", this->out_pin_);
+  ESP_LOGCONFIG(TAG, "  Initial requests:");
+  for (auto type : initial_messages) {
+    ESP_LOGCONFIG(TAG, "  - %d (%s)", type, this->opentherm_->message_id_to_str(type));
+  }
+  ESP_LOGCONFIG(TAG, "  Repeating requests:");
+  for (auto type : repeating_messages) {
+    ESP_LOGCONFIG(TAG, "  - %d (%s)", type, this->opentherm_->message_id_to_str(type));
+  }
+}
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/hub.h
+++ b/components/opentherm/hub.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include <vector>
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+#include "opentherm.h"
+
+#ifdef OPENTHERM_USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+
+#ifdef OPENTHERM_USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
+#ifdef OPENTHERM_USE_SWITCH
+#include "esphome/components/opentherm/switch/opentherm_switch.h"
+#endif
+
+#ifdef OPENTHERM_USE_OUTPUT
+#include "esphome/components/opentherm/output/opentherm_output.h"
+#endif
+
+#ifdef OPENTHERM_USE_NUMBER
+#include "esphome/components/opentherm/number/opentherm_number.h"
+#endif
+
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "opentherm_macros.h"
+
+namespace esphome::opentherm {
+
+static const uint8_t REPEATING_MESSAGE_ORDER = 255;
+static const uint8_t INITIAL_UNORDERED_MESSAGE_ORDER = 254;
+
+// OpenTherm component for ESPHome
+class OpenthermHub final : public Component {
+ protected:
+  // Communication pins for the OpenTherm interface
+  InternalGPIOPin *in_pin_, *out_pin_;
+  // The OpenTherm interface
+  std::unique_ptr<OpenTherm> opentherm_;
+
+  OPENTHERM_SENSOR_LIST(OPENTHERM_DECLARE_SENSOR, )
+
+  OPENTHERM_BINARY_SENSOR_LIST(OPENTHERM_DECLARE_BINARY_SENSOR, )
+
+  OPENTHERM_SWITCH_LIST(OPENTHERM_DECLARE_SWITCH, )
+
+  OPENTHERM_NUMBER_LIST(OPENTHERM_DECLARE_NUMBER, )
+
+  OPENTHERM_OUTPUT_LIST(OPENTHERM_DECLARE_OUTPUT, )
+
+  OPENTHERM_INPUT_SENSOR_LIST(OPENTHERM_DECLARE_INPUT_SENSOR, )
+
+  OPENTHERM_SETTING_LIST(OPENTHERM_DECLARE_SETTING, )
+
+  bool sending_initial_ = true;
+  std::unordered_map<MessageId, uint8_t> configured_messages_;
+  std::vector<MessageId> messages_;
+  std::vector<MessageId>::const_iterator message_iterator_;
+
+  uint32_t last_conversation_start_ = 0;
+  uint32_t last_conversation_end_ = 0;
+  OperationMode last_mode_ = IDLE;
+  OpenthermData last_request_;
+
+  // Synchronous communication mode prevents other components from disabling interrupts while
+  // we are talking to the boiler. Enable if you experience random intermittent invalid response errors.
+  // Very likely to happen while using Dallas temperature sensors.
+  bool sync_mode_ = false;
+
+  CallbackManager<void(OpenthermData &)> before_send_callback_;
+  CallbackManager<void(OpenthermData &)> before_process_response_callback_;
+
+  // Create OpenTherm messages based on the message id
+  OpenthermData build_request_(MessageId request_id) const;
+  bool handle_error_(OperationMode mode);
+  void handle_protocol_error_();
+  void handle_timeout_error_();
+  void handle_timer_error_();
+  void stop_opentherm_();
+  void start_conversation_();
+  void read_response_();
+  void check_timings_(uint32_t cur_time);
+  bool should_skip_loop_(uint32_t cur_time) const;
+  void sync_loop_();
+
+  void write_initial_messages_(std::vector<MessageId> &target);
+  void write_repeating_messages_(std::vector<MessageId> &target);
+
+  template<typename F> bool spin_wait_(uint32_t timeout, F func) {
+    auto start_time = millis();
+    while (func()) {
+      yield();
+      auto cur_time = millis();
+      if (cur_time - start_time >= timeout) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+ public:
+  // Constructor with references to the global interrupt handlers
+  OpenthermHub();
+
+  // Handle responses from the OpenTherm interface
+  void process_response(OpenthermData &data);
+
+  // Setters for the input and output OpenTherm interface pins
+  void set_in_pin(InternalGPIOPin *in_pin) { this->in_pin_ = in_pin; }
+  void set_out_pin(InternalGPIOPin *out_pin) { this->out_pin_ = out_pin; }
+
+  OPENTHERM_SENSOR_LIST(OPENTHERM_SET_SENSOR, )
+
+  OPENTHERM_BINARY_SENSOR_LIST(OPENTHERM_SET_BINARY_SENSOR, )
+
+  OPENTHERM_SWITCH_LIST(OPENTHERM_SET_SWITCH, )
+
+  OPENTHERM_NUMBER_LIST(OPENTHERM_SET_NUMBER, )
+
+  OPENTHERM_OUTPUT_LIST(OPENTHERM_SET_OUTPUT, )
+
+  OPENTHERM_INPUT_SENSOR_LIST(OPENTHERM_SET_INPUT_SENSOR, )
+
+  OPENTHERM_SETTING_LIST(OPENTHERM_SET_SETTING, )
+
+  // Add a request to the vector of initial requests
+  void add_initial_message(MessageId message_id) {
+    this->configured_messages_[message_id] = INITIAL_UNORDERED_MESSAGE_ORDER;
+  }
+  void add_initial_message(MessageId message_id, uint8_t order) { this->configured_messages_[message_id] = order; }
+  // Add a request to the set of repeating requests. Note that a large number of repeating
+  // requests will slow down communication with the boiler. Each request may take up to 1 second,
+  // so with all sensors enabled, it may take about half a minute before a change in setpoint
+  // will be processed.
+  void add_repeating_message(MessageId message_id) { this->configured_messages_[message_id] = REPEATING_MESSAGE_ORDER; }
+
+  // There are seven status variables, which can either be set as a simple variable,
+  // or using a switch. ch_enable and dhw_enable default to true, the others to false.
+  bool ch_enable = true, dhw_enable = true, cooling_enable = false, otc_active = false, ch2_active = false,
+       summer_mode_active = false, dhw_block = false;
+
+  // Setters for the status variables
+  void set_ch_enable(bool value) { this->ch_enable = value; }
+  void set_dhw_enable(bool value) { this->dhw_enable = value; }
+  void set_cooling_enable(bool value) { this->cooling_enable = value; }
+  void set_otc_active(bool value) { this->otc_active = value; }
+  void set_ch2_active(bool value) { this->ch2_active = value; }
+  void set_summer_mode_active(bool value) { this->summer_mode_active = value; }
+  void set_dhw_block(bool value) { this->dhw_block = value; }
+  void set_sync_mode(bool sync_mode) { this->sync_mode_ = sync_mode; }
+
+  template<typename F> void add_on_before_send_callback(F &&callback) {
+    this->before_send_callback_.add(std::forward<F>(callback));
+  }
+  template<typename F> void add_on_before_process_response_callback(F &&callback) {
+    this->before_process_response_callback_.add(std::forward<F>(callback));
+  }
+
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+
+  void setup() override;
+  void on_shutdown() override;
+  void loop() override;
+  void dump_config() override;
+};
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/input.h
+++ b/components/opentherm/input.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace esphome::opentherm {
+
+class OpenthermInput {
+ public:
+  bool auto_min_value, auto_max_value;
+
+  virtual void set_min_value(float min_value) = 0;
+  virtual void set_max_value(float max_value) = 0;
+
+  virtual void set_auto_min_value(bool auto_min_value) { this->auto_min_value = auto_min_value; }
+  virtual void set_auto_max_value(bool auto_max_value) { this->auto_max_value = auto_max_value; }
+};
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/input.py
+++ b/components/opentherm/input.py
@@ -1,0 +1,49 @@
+from typing import Any
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_MAX_VALUE, CONF_MIN_VALUE
+
+from . import generate, schema
+
+CONF_AUTO_MIN_VALUE = "auto_min_value"
+CONF_AUTO_MAX_VALUE = "auto_max_value"
+
+OpenthermInput = generate.opentherm_ns.class_("OpenthermInput")
+
+
+def validate_min_value_less_than_max_value(conf):
+    if (
+        CONF_MIN_VALUE in conf
+        and CONF_MAX_VALUE in conf
+        and conf[CONF_MIN_VALUE] > conf[CONF_MAX_VALUE]
+    ):
+        raise cv.Invalid(f"{CONF_MIN_VALUE} must be less than {CONF_MAX_VALUE}")
+    return conf
+
+
+def input_schema(entity: schema.InputSchema) -> cv.Schema:
+    result = cv.Schema(
+        {
+            cv.Optional(CONF_MIN_VALUE, entity.range[0]): cv.float_range(
+                entity.range[0], entity.range[1]
+            ),
+            cv.Optional(CONF_MAX_VALUE, entity.range[1]): cv.float_range(
+                entity.range[0], entity.range[1]
+            ),
+        }
+    )
+    result = result.add_extra(validate_min_value_less_than_max_value)
+    if entity.auto_min_value is not None:
+        result = result.extend({cv.Optional(CONF_AUTO_MIN_VALUE, False): cv.boolean})
+    if entity.auto_max_value is not None:
+        result = result.extend({cv.Optional(CONF_AUTO_MAX_VALUE, False): cv.boolean})
+
+    return result
+
+
+def generate_setters(entity: cg.MockObj, conf: dict[str, Any]) -> None:
+    generate.add_property_set(entity, CONF_MIN_VALUE, conf)
+    generate.add_property_set(entity, CONF_MAX_VALUE, conf)
+    generate.add_property_set(entity, CONF_AUTO_MIN_VALUE, conf)
+    generate.add_property_set(entity, CONF_AUTO_MAX_VALUE, conf)

--- a/components/opentherm/number/__init__.py
+++ b/components/opentherm/number/__init__.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_INITIAL_VALUE,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_RESTORE_VALUE,
+    CONF_STEP,
+)
+
+from .. import const, generate, input, schema, validate
+
+DEPENDENCIES = [const.OPENTHERM]
+COMPONENT_TYPE = const.NUMBER
+
+OpenthermNumber = generate.opentherm_ns.class_(
+    "OpenthermNumber", number.Number, cg.Component, input.OpenthermInput
+)
+
+
+async def new_openthermnumber(config: dict[str, Any]) -> cg.Pvariable:
+    var = await number.new_number(
+        config,
+        min_value=config[CONF_MIN_VALUE],
+        max_value=config[CONF_MAX_VALUE],
+        step=config[CONF_STEP],
+    )
+    await cg.register_component(var, config)
+    input.generate_setters(var, config)
+
+    if (initial_value := config.get(CONF_INITIAL_VALUE)) is not None:
+        cg.add(var.set_initial_value(initial_value))
+    if (restore_value := config.get(CONF_RESTORE_VALUE)) is not None:
+        cg.add(var.set_restore_value(restore_value))
+
+    return var
+
+
+def get_entity_validation_schema(entity: schema.InputSchema) -> cv.Schema:
+    return (
+        number.number_schema(
+            OpenthermNumber, unit_of_measurement=entity.unit_of_measurement
+        )
+        .extend(
+            {
+                cv.Optional(CONF_STEP, entity.step): cv.float_,
+                cv.Optional(CONF_INITIAL_VALUE): cv.float_,
+                cv.Optional(CONF_RESTORE_VALUE): cv.boolean,
+            }
+        )
+        .extend(input.input_schema(entity))
+        .extend(cv.COMPONENT_SCHEMA)
+    )
+
+
+CONFIG_SCHEMA = validate.create_component_schema(
+    schema.INPUTS, get_entity_validation_schema
+)
+
+
+async def to_code(config: dict[str, Any]) -> None:
+    keys = await generate.component_to_code(
+        COMPONENT_TYPE,
+        schema.INPUTS,
+        OpenthermNumber,
+        generate.create_only_conf(new_openthermnumber),
+        config,
+    )
+    generate.define_readers(COMPONENT_TYPE, keys)

--- a/components/opentherm/number/opentherm_number.cpp
+++ b/components/opentherm/number/opentherm_number.cpp
@@ -1,0 +1,40 @@
+#include "opentherm_number.h"
+
+namespace esphome::opentherm {
+
+static const char *const TAG = "opentherm.number";
+
+void OpenthermNumber::control(float value) {
+  this->publish_state(value);
+
+  if (this->restore_value_)
+    this->pref_.save(&value);
+}
+
+void OpenthermNumber::setup() {
+  float value;
+  if (!this->restore_value_) {
+    value = this->initial_value_;
+  } else {
+    this->pref_ = this->make_entity_preference<float>();
+    if (!this->pref_.load(&value)) {
+      if (!std::isnan(this->initial_value_)) {
+        value = this->initial_value_;
+      } else {
+        value = this->traits.get_min_value();
+      }
+    }
+  }
+  this->publish_state(value);
+}
+
+void OpenthermNumber::dump_config() {
+  LOG_NUMBER("", "OpenTherm Number", this);
+  ESP_LOGCONFIG(TAG,
+                "  Restore value: %d\n"
+                "  Initial value: %.2f\n"
+                "  Current value: %.2f",
+                this->restore_value_, this->initial_value_, this->state);
+}
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/number/opentherm_number.h
+++ b/components/opentherm/number/opentherm_number.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "esphome/core/preferences.h"
+#include "esphome/core/log.h"
+#include "esphome/components/opentherm/input.h"
+
+namespace esphome::opentherm {
+
+// Just a simple number, which stores the number
+class OpenthermNumber final : public number::Number, public Component, public OpenthermInput {
+ protected:
+  void control(float value) override;
+  void setup() override;
+  void dump_config() override;
+
+  float initial_value_{NAN};
+  bool restore_value_{false};
+
+  ESPPreferenceObject pref_;
+
+ public:
+  void set_min_value(float min_value) override { this->traits.set_min_value(min_value); }
+  void set_max_value(float max_value) override { this->traits.set_max_value(max_value); }
+  void set_initial_value(float initial_value) { initial_value_ = initial_value; }
+  void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
+};
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -1,0 +1,831 @@
+/*
+ * OpenTherm protocol implementation. Originally taken from https://github.com/jpraus/arduino-opentherm, but
+ * heavily modified to comply with ESPHome coding standards and provide better logging.
+ * Original code is licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+ * Public License, which is compatible with GPLv3 license, which covers C++ part of ESPHome project.
+ */
+
+#include "opentherm.h"
+#include "opentherm_rmt_decoder.h"
+#include "esphome/core/helpers.h"
+#include <cinttypes>
+#ifdef USE_ESP32
+#include "esp_err.h"
+#endif
+#ifdef ESP8266
+#include "Arduino.h"
+#endif
+#include <string>
+
+namespace esphome::opentherm {
+
+using std::string;
+
+static const char *const TAG = "opentherm";
+
+#ifdef ESP8266
+OpenTherm *OpenTherm::instance = nullptr;
+#endif
+
+OpenTherm::OpenTherm(InternalGPIOPin *in_pin, InternalGPIOPin *out_pin, int32_t device_timeout)
+    : in_pin_(in_pin),
+      out_pin_(out_pin),
+      mode_(OperationMode::IDLE),
+      error_type_(ProtocolErrorType::NO_ERROR),
+      capture_(0),
+      clock_(0),
+      data_(0),
+      bit_pos_(0),
+      timeout_counter_(-1),
+      device_timeout_(device_timeout) {
+  this->isr_in_pin_ = in_pin->to_isr();
+  this->isr_out_pin_ = out_pin->to_isr();
+}
+
+bool OpenTherm::initialize() {
+#ifdef ESP8266
+  OpenTherm::instance = this;
+#endif
+  this->in_pin_->pin_mode(gpio::FLAG_INPUT);
+  this->in_pin_->setup();
+  this->out_pin_->pin_mode(gpio::FLAG_OUTPUT);
+  this->out_pin_->setup();
+  this->out_pin_->digital_write(true);
+
+#ifdef USE_ESP32
+  return this->init_esp32_timer_() && this->init_esp32_rmt_();
+#else
+  return true;
+#endif
+}
+
+void OpenTherm::listen() {
+  this->stop_timer_();
+#ifdef USE_ESP32
+  this->cancel_esp32_rmt_();
+#else
+  this->timeout_counter_ = this->device_timeout_ * 5;  // timer_ ticks at 5 ticks/ms
+#endif
+
+  this->mode_ = OperationMode::LISTEN;
+  this->data_ = 0;
+  this->bit_pos_ = 0;
+
+#ifdef USE_ESP32
+  this->receive_deadline_us_ =
+      micros() + static_cast<uint32_t>(this->device_timeout_) * 1000U;
+  if (!this->arm_esp32_rmt_()) {
+    this->timer_error_ = ESP_FAIL;
+    this->timer_error_type_ = TimerErrorType::TIMER_START_ERROR;
+    this->mode_ = OperationMode::ERROR_TIMER;
+    return;
+  }
+#else
+  this->start_read_timer_();
+#endif
+}
+
+void OpenTherm::send(OpenthermData &data) {
+  this->stop_timer_();
+  this->data_ = data.type;
+  this->data_ = (this->data_ << 12) | data.id;
+  this->data_ = (this->data_ << 8) | data.valueHB;
+  this->data_ = (this->data_ << 8) | data.valueLB;
+  if (!check_parity_(this->data_)) {
+    this->data_ = this->data_ | 0x80000000;
+  }
+
+  this->clock_ = 1;     // clock starts at HIGH
+  this->bit_pos_ = 33;  // count down (33 == start bit, 32-1 data, 0 == stop bit)
+  this->mode_ = OperationMode::WRITE;
+
+  this->start_write_timer_();
+}
+
+bool OpenTherm::get_message(OpenthermData &data) {
+  if (this->mode_ == OperationMode::RECEIVED) {
+    data.type = (this->data_ >> 28) & 0x7;
+    data.id = (this->data_ >> 16) & 0xFF;
+    data.valueHB = (this->data_ >> 8) & 0xFF;
+    data.valueLB = this->data_ & 0xFF;
+    return true;
+  }
+  return false;
+}
+
+bool OpenTherm::get_protocol_error(OpenThermError &error) {
+  if (this->mode_ != OperationMode::ERROR_PROTOCOL) {
+    return false;
+  }
+
+  error.error_type = this->error_type_;
+  error.bit_pos = this->bit_pos_;
+  error.capture = this->capture_;
+  error.clock = this->clock_;
+  error.data = this->data_;
+
+  return true;
+}
+
+void OpenTherm::stop() {
+  this->stop_timer_();
+#ifdef USE_ESP32
+  this->cancel_esp32_rmt_();
+#endif
+  this->mode_ = OperationMode::IDLE;
+}
+
+void OpenTherm::process() {
+#ifdef USE_ESP32
+  this->process_esp32_rmt_();
+#endif
+}
+
+void IRAM_ATTR OpenTherm::read_() {
+  this->data_ = 0;
+  this->bit_pos_ = 0;
+  this->mode_ = OperationMode::READ;
+  this->capture_ = 1;         // reset counter and add as if read start bit
+  this->clock_ = 1;           // clock is high at the start of comm
+  this->start_read_timer_();  // get us into 1/4 of manchester code. 5 timer ticks constitute 1 ms, which is 1 bit
+                              // period in OpenTherm.
+}
+
+#ifdef USE_ESP32
+bool IRAM_ATTR OpenTherm::timer_isr(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_ctx) {
+  auto *arg = static_cast<OpenTherm *>(user_ctx);
+#else
+bool IRAM_ATTR OpenTherm::timer_isr(OpenTherm *arg) {
+#endif
+  if (arg->mode_ == OperationMode::LISTEN) {
+#ifdef USE_ESP32
+    arg->mode_ = OperationMode::ERROR_TIMEOUT;
+    arg->stop_timer_();
+    return false;
+#else
+    if (arg->timeout_counter_ == 0) {
+      arg->mode_ = OperationMode::ERROR_TIMEOUT;
+      arg->stop_timer_();
+      return false;
+    }
+    bool const value = arg->isr_in_pin_.digital_read();
+    if (value) {  // incoming data (rising signal)
+      arg->read_();
+    }
+    if (arg->timeout_counter_ > 0) {
+      arg->timeout_counter_--;
+    }
+#endif
+  } else if (arg->mode_ == OperationMode::READ) {
+    bool const value = arg->isr_in_pin_.digital_read();
+    uint8_t const last = (arg->capture_ & 1);
+    if (value != last) {
+      // transition of signal from last sampling
+      if (arg->clock_ == 1 && arg->capture_ > 0xF) {
+        // no transition in the middle of the bit
+        arg->mode_ = OperationMode::ERROR_PROTOCOL;
+        arg->error_type_ = ProtocolErrorType::NO_TRANSITION;
+        arg->stop_timer_();
+        return false;
+      } else if (arg->clock_ == 1 || arg->capture_ > 0xF) {
+        // transition in the middle of the bit OR no transition between two bit, both are valid data points
+        if (arg->bit_pos_ == BitPositions::STOP_BIT) {
+          // expecting stop bit
+          auto stop_bit_error = arg->verify_stop_bit_(last);
+          if (stop_bit_error == ProtocolErrorType::NO_ERROR) {
+            arg->mode_ = OperationMode::RECEIVED;
+            arg->stop_timer_();
+            return false;
+          } else {
+            // end of data not verified, invalid data
+            arg->mode_ = OperationMode::ERROR_PROTOCOL;
+            arg->error_type_ = stop_bit_error;
+            arg->stop_timer_();
+            return false;
+          }
+        } else {
+          // normal data point at clock high
+          arg->bit_read_(last);
+          arg->clock_ = 0;
+        }
+      } else {
+        // clock low, not a data point, switch clock
+        arg->clock_ = 1;
+      }
+      arg->capture_ = 1;  // reset counter
+    } else if (arg->capture_ > 0xFF) {
+      // no change for too long, invalid manchester encoding
+      arg->mode_ = OperationMode::ERROR_PROTOCOL;
+      arg->error_type_ = ProtocolErrorType::NO_CHANGE_TOO_LONG;
+      arg->stop_timer_();
+      return false;
+    }
+    arg->capture_ = (arg->capture_ << 1) | value;
+  } else if (arg->mode_ == OperationMode::WRITE) {
+    // write data to pin
+    if (arg->bit_pos_ == 33 || arg->bit_pos_ == 0) {  // start bit
+      arg->write_bit_(1, arg->clock_);
+    } else {  // data bits
+      arg->write_bit_(read_bit(arg->data_, arg->bit_pos_ - 1), arg->clock_);
+    }
+    if (arg->clock_ == 0) {
+      if (arg->bit_pos_ <= 0) {            // check termination
+        arg->mode_ = OperationMode::SENT;  // all data written
+        arg->stop_timer_();
+      }
+      arg->bit_pos_--;
+      arg->clock_ = 1;
+    } else {
+      arg->clock_ = 0;
+    }
+  }
+
+  return false;
+}
+
+#ifdef ESP8266
+void IRAM_ATTR OpenTherm::esp8266_timer_isr() { OpenTherm::timer_isr(OpenTherm::instance); }
+#endif
+
+void IRAM_ATTR OpenTherm::bit_read_(uint8_t value) {
+  this->data_ = (this->data_ << 1) | value;
+  this->bit_pos_++;
+}
+
+ProtocolErrorType IRAM_ATTR OpenTherm::verify_stop_bit_(uint8_t value) {
+  if (value) {  // stop bit detected
+    return check_parity_(this->data_) ? ProtocolErrorType::NO_ERROR : ProtocolErrorType::PARITY_ERROR;
+  } else {  // no stop bit detected, error
+    return ProtocolErrorType::INVALID_STOP_BIT;
+  }
+}
+
+void IRAM_ATTR OpenTherm::write_bit_(uint8_t high, uint8_t clock) {
+  if (clock == 1) {                           // left part of manchester encoding
+    this->isr_out_pin_.digital_write(!high);  // low means logical 1 to protocol
+  } else {                                    // right part of manchester encoding
+    this->isr_out_pin_.digital_write(high);   // high means logical 0 to protocol
+  }
+}
+
+#ifdef USE_ESP32
+
+bool OpenTherm::init_esp32_timer_() {
+  // 80MHz / 80 = 1MHz resolution (1µs per tick)
+  gptimer_config_t config = {
+      .clk_src = GPTIMER_CLK_SRC_DEFAULT,
+      .direction = GPTIMER_COUNT_UP,
+      .resolution_hz = 1000000,
+      .intr_priority = 0,
+  };
+
+  esp_err_t result = gptimer_new_timer(&config, &this->timer_handle_);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to create timer: %s", esp_err_to_name(result));
+    return false;
+  }
+
+  gptimer_event_callbacks_t cbs = {
+      .on_alarm = OpenTherm::timer_isr,
+  };
+  result = gptimer_register_event_callbacks(this->timer_handle_, &cbs, this);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register timer callback: %s", esp_err_to_name(result));
+    gptimer_del_timer(this->timer_handle_);
+    this->timer_handle_ = nullptr;
+    return false;
+  }
+
+  result = gptimer_enable(this->timer_handle_);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to enable timer: %s", esp_err_to_name(result));
+    gptimer_del_timer(this->timer_handle_);
+    this->timer_handle_ = nullptr;
+    return false;
+  }
+
+  return true;
+}
+
+bool OpenTherm::init_esp32_rmt_() {
+  rmt_rx_channel_config_t config{};
+  config.gpio_num = static_cast<gpio_num_t>(this->in_pin_->get_pin());
+  config.clk_src = RMT_CLK_SRC_DEFAULT;
+  config.resolution_hz = 1000000;
+  config.mem_block_symbols = RMT_CAPTURE_SYMBOLS;
+  config.intr_priority = 0;
+  config.flags.invert_in = false;
+  config.flags.with_dma = false;
+  config.flags.io_loop_back = false;
+  config.flags.allow_pd = false;
+
+  esp_err_t result = rmt_new_rx_channel(&config, &this->rmt_rx_channel_);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to create RMT RX channel: %s", esp_err_to_name(result));
+    this->rmt_rx_channel_ = nullptr;
+    return false;
+  }
+
+  rmt_rx_event_callbacks_t callbacks{};
+  callbacks.on_recv_done = OpenTherm::rmt_rx_done_callback_;
+  result = rmt_rx_register_event_callbacks(this->rmt_rx_channel_, &callbacks, this);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register RMT RX callback: %s", esp_err_to_name(result));
+    rmt_del_channel(this->rmt_rx_channel_);
+    this->rmt_rx_channel_ = nullptr;
+    return false;
+  }
+
+  result = rmt_enable(this->rmt_rx_channel_);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to enable RMT RX channel: %s", esp_err_to_name(result));
+    rmt_del_channel(this->rmt_rx_channel_);
+    this->rmt_rx_channel_ = nullptr;
+    return false;
+  }
+
+  ESP_LOGCONFIG(TAG, "OpenTherm RMT receive capture active on GPIO%u",
+                static_cast<unsigned>(this->in_pin_->get_pin()));
+  return true;
+}
+
+bool OpenTherm::arm_esp32_rmt_() {
+  if (this->rmt_rx_channel_ == nullptr) {
+    return false;
+  }
+
+  rmt_receive_config_t config{};
+  config.signal_range_min_ns = 3187;
+  config.signal_range_max_ns = 2500000;
+  config.flags.en_partial_rx = false;
+
+  portENTER_CRITICAL(&this->rmt_mux_);
+  this->rmt_symbol_count_ = 0;
+  this->rmt_frame_ready_ = false;
+  this->rmt_armed_ = true;
+  portEXIT_CRITICAL(&this->rmt_mux_);
+
+  const esp_err_t result =
+      rmt_receive(this->rmt_rx_channel_, this->rmt_rx_symbols_, sizeof(this->rmt_rx_symbols_), &config);
+  if (result != ESP_OK) {
+    portENTER_CRITICAL(&this->rmt_mux_);
+    this->rmt_armed_ = false;
+    portEXIT_CRITICAL(&this->rmt_mux_);
+    ESP_LOGE(TAG, "Failed to arm RMT RX: %s", esp_err_to_name(result));
+    return false;
+  }
+  return true;
+}
+
+void OpenTherm::cancel_esp32_rmt_() {
+  bool armed = false;
+  portENTER_CRITICAL(&this->rmt_mux_);
+  armed = this->rmt_armed_;
+  this->rmt_armed_ = false;
+  this->rmt_frame_ready_ = false;
+  this->rmt_symbol_count_ = 0;
+  portEXIT_CRITICAL(&this->rmt_mux_);
+
+  if (!armed || this->rmt_rx_channel_ == nullptr) {
+    return;
+  }
+  const esp_err_t disable_result = rmt_disable(this->rmt_rx_channel_);
+  if (disable_result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to cancel RMT RX: %s", esp_err_to_name(disable_result));
+    return;
+  }
+  const esp_err_t enable_result = rmt_enable(this->rmt_rx_channel_);
+  if (enable_result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to re-enable RMT RX: %s", esp_err_to_name(enable_result));
+  }
+}
+
+bool IRAM_ATTR OpenTherm::rmt_rx_done_callback_(rmt_channel_handle_t,
+                                                const rmt_rx_done_event_data_t *event, void *user_ctx) {
+  auto *instance = static_cast<OpenTherm *>(user_ctx);
+  if (instance == nullptr || event == nullptr) {
+    return false;
+  }
+
+  portENTER_CRITICAL_ISR(&instance->rmt_mux_);
+  if (instance->rmt_armed_ && instance->mode_ == OperationMode::LISTEN) {
+    instance->rmt_symbol_count_ =
+        event->num_symbols < RMT_CAPTURE_SYMBOLS ? event->num_symbols : RMT_CAPTURE_SYMBOLS;
+    instance->rmt_armed_ = false;
+    instance->rmt_frame_ready_ = true;
+    // Claim the completed frame immediately while keeping the bounded
+    // Manchester decode in the main loop.
+    instance->mode_ = OperationMode::RMT_PENDING;
+  }
+  portEXIT_CRITICAL_ISR(&instance->rmt_mux_);
+  return false;
+}
+
+void OpenTherm::process_esp32_rmt_() {
+  if (this->mode_ != OperationMode::LISTEN && this->mode_ != OperationMode::RMT_PENDING) {
+    return;
+  }
+
+  const bool deadline_expired =
+      static_cast<int32_t>(micros() - this->receive_deadline_us_) >= 0;
+  bool frame_ready = false;
+  size_t symbol_count = 0;
+  portENTER_CRITICAL(&this->rmt_mux_);
+  if (this->rmt_frame_ready_) {
+    frame_ready = true;
+    symbol_count = this->rmt_symbol_count_;
+    this->rmt_frame_ready_ = false;
+  } else if (this->mode_ == OperationMode::LISTEN && deadline_expired) {
+    // Arbitrate completion and timeout under the same lock used by the ISR:
+    // exactly one of them is allowed to claim this receive operation.
+    this->mode_ = OperationMode::ERROR_TIMEOUT;
+  }
+  portEXIT_CRITICAL(&this->rmt_mux_);
+  if (!frame_ready) {
+    return;
+  }
+
+  rmt_decoder::Pulse pulses[RMT_CAPTURE_SYMBOLS * 2]{};
+  size_t pulse_count = 0;
+  for (size_t symbol_index = 0; symbol_index < symbol_count; symbol_index++) {
+    const rmt_symbol_word_t &symbol = this->rmt_rx_symbols_[symbol_index];
+    if (symbol.duration0 != 0) {
+      pulses[pulse_count++] = {symbol.duration0, symbol.level0 != 0};
+    }
+    if (symbol.duration1 != 0) {
+      pulses[pulse_count++] = {symbol.duration1, symbol.level1 != 0};
+    }
+  }
+
+  this->stop_timer_();
+  const rmt_decoder::DecodeResult result = rmt_decoder::decode(pulses, pulse_count);
+  if (result.error != rmt_decoder::DecodeError::NONE) {
+    const char *decode_error = "unknown";
+    switch (result.error) {
+      case rmt_decoder::DecodeError::GLITCH:
+        decode_error = "glitch";
+        break;
+      case rmt_decoder::DecodeError::TIMING:
+        decode_error = "timing";
+        break;
+      case rmt_decoder::DecodeError::START_BIT:
+        decode_error = "start_bit";
+        break;
+      case rmt_decoder::DecodeError::MANCHESTER:
+        decode_error = "manchester";
+        break;
+      case rmt_decoder::DecodeError::STOP_BIT:
+        decode_error = "stop_bit";
+        break;
+      case rmt_decoder::DecodeError::PARITY:
+        decode_error = "parity";
+        break;
+      default:
+        break;
+    }
+
+    const char *capture_failure = "none";
+    switch (result.capture_failure) {
+      case rmt_decoder::CaptureFailure::PULSE_DURATION:
+        capture_failure = "pulse_duration";
+        break;
+      case rmt_decoder::CaptureFailure::HALF_BIT_OVERFLOW:
+        capture_failure = "half_bit_overflow";
+        break;
+      case rmt_decoder::CaptureFailure::HALF_BIT_COUNT:
+        capture_failure = "half_bit_count";
+        break;
+      default:
+        break;
+    }
+
+    ESP_LOGW(TAG,
+             "RMT RX decode rejected: error=%s capture=%s symbols=%u pulses=%u half_bits=%u "
+             "pulse=%u duration=%uus bit=%u",
+             decode_error, capture_failure, static_cast<unsigned>(symbol_count),
+             static_cast<unsigned>(result.pulse_count), static_cast<unsigned>(result.half_bit_count),
+             static_cast<unsigned>(result.failure_pulse_index),
+             static_cast<unsigned>(result.failure_pulse_duration_us),
+             static_cast<unsigned>(result.bit_position));
+  }
+  this->data_ = result.data;
+  this->bit_pos_ = result.bit_position;
+  this->capture_ = static_cast<uint32_t>(symbol_count);
+  this->clock_ = 0;
+  switch (result.error) {
+    case rmt_decoder::DecodeError::NONE:
+      this->error_type_ = ProtocolErrorType::NO_ERROR;
+      this->mode_ = OperationMode::RECEIVED;
+      break;
+    case rmt_decoder::DecodeError::STOP_BIT:
+      this->error_type_ = ProtocolErrorType::INVALID_STOP_BIT;
+      this->mode_ = OperationMode::ERROR_PROTOCOL;
+      break;
+    case rmt_decoder::DecodeError::PARITY:
+      this->error_type_ = ProtocolErrorType::PARITY_ERROR;
+      this->mode_ = OperationMode::ERROR_PROTOCOL;
+      break;
+    case rmt_decoder::DecodeError::TIMING:
+      this->error_type_ = ProtocolErrorType::NO_CHANGE_TOO_LONG;
+      this->mode_ = OperationMode::ERROR_PROTOCOL;
+      break;
+    default:
+      this->error_type_ = ProtocolErrorType::NO_TRANSITION;
+      this->mode_ = OperationMode::ERROR_PROTOCOL;
+      break;
+  }
+}
+
+void IRAM_ATTR OpenTherm::start_esp32_timer_(uint64_t alarm_value, bool auto_reload) {
+  // We will report timer errors outside of interrupt handler
+  this->timer_error_ = ESP_OK;
+  this->timer_error_type_ = TimerErrorType::NO_TIMER_ERROR;
+
+  this->alarm_config_.alarm_count = alarm_value;
+  this->alarm_config_.flags.auto_reload_on_alarm = auto_reload;
+  this->timer_error_ = gptimer_set_alarm_action(this->timer_handle_, &this->alarm_config_);
+  if (this->timer_error_ != ESP_OK) {
+    this->timer_error_type_ = TimerErrorType::SET_ALARM_VALUE_ERROR;
+    return;
+  }
+  this->timer_error_ = gptimer_start(this->timer_handle_);
+  if (this->timer_error_ != ESP_OK) {
+    this->timer_error_type_ = TimerErrorType::TIMER_START_ERROR;
+  }
+}
+
+void OpenTherm::report_and_reset_timer_error() {
+  if (this->timer_error_ == ESP_OK) {
+    return;
+  }
+
+  ESP_LOGE(TAG, "Error occured while manipulating timer (%s): %s", this->timer_error_to_str(this->timer_error_type_),
+           esp_err_to_name(this->timer_error_));
+
+  this->timer_error_ = ESP_OK;
+  this->timer_error_type_ = NO_TIMER_ERROR;
+}
+
+// One-shot response timeout. Manchester edge capture is handled by RMT.
+void IRAM_ATTR OpenTherm::start_read_timer_() {
+  InterruptLock const lock;
+  this->start_esp32_timer_(static_cast<uint64_t>(this->device_timeout_) * 1000ULL, false);
+}
+
+// 2 kHz timer_
+void IRAM_ATTR OpenTherm::start_write_timer_() {
+  InterruptLock const lock;
+  this->start_esp32_timer_(500, true);
+}
+
+void IRAM_ATTR OpenTherm::stop_timer_() {
+  InterruptLock const lock;
+  // We will report timer errors outside of interrupt handler
+  this->timer_error_ = ESP_OK;
+  this->timer_error_type_ = TimerErrorType::NO_TIMER_ERROR;
+
+  this->timer_error_ = gptimer_stop(this->timer_handle_);
+  if (this->timer_error_ != ESP_OK) {
+    this->timer_error_type_ = TimerErrorType::TIMER_PAUSE_ERROR;
+    return;
+  }
+  this->timer_error_ = gptimer_set_raw_count(this->timer_handle_, 0);
+  if (this->timer_error_ != ESP_OK) {
+    this->timer_error_type_ = TimerErrorType::SET_COUNTER_VALUE_ERROR;
+  }
+}
+
+#endif  // USE_ESP32
+
+#ifdef ESP8266
+// 5 kHz timer_
+void IRAM_ATTR OpenTherm::start_read_timer_() {
+  InterruptLock const lock;
+  timer1_attachInterrupt(OpenTherm::esp8266_timer_isr);
+  timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);  // 5MHz (5 ticks/us - 1677721.4 us max)
+  timer1_write(1000);                            // 5kHz
+}
+
+// 2 kHz timer_
+void IRAM_ATTR OpenTherm::start_write_timer_() {
+  InterruptLock const lock;
+  timer1_attachInterrupt(OpenTherm::esp8266_timer_isr);
+  timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);  // 5MHz (5 ticks/us - 1677721.4 us max)
+  timer1_write(2500);                            // 2kHz
+}
+
+void IRAM_ATTR OpenTherm::stop_timer_() {
+  InterruptLock const lock;
+  timer1_disable();
+  timer1_detachInterrupt();
+}
+
+// There is nothing to report on ESP8266
+void OpenTherm::report_and_reset_timer_error() {}
+
+#endif  // END ESP8266
+
+// https://stackoverflow.com/questions/21617970/how-to-check-if-value-has-even-parity-of-bits-or-odd
+bool IRAM_ATTR OpenTherm::check_parity_(uint32_t val) {
+  val ^= val >> 16;
+  val ^= val >> 8;
+  val ^= val >> 4;
+  val ^= val >> 2;
+  val ^= val >> 1;
+  return (~val) & 1;
+}
+
+#define TO_STRING_MEMBER(name) \
+  case name: \
+    return #name;
+
+const char *OpenTherm::operation_mode_to_str(OperationMode mode) {
+  switch (mode) {
+    TO_STRING_MEMBER(IDLE)
+    TO_STRING_MEMBER(LISTEN)
+    TO_STRING_MEMBER(READ)
+    TO_STRING_MEMBER(RECEIVED)
+    TO_STRING_MEMBER(WRITE)
+    TO_STRING_MEMBER(SENT)
+    TO_STRING_MEMBER(RMT_PENDING)
+    TO_STRING_MEMBER(ERROR_PROTOCOL)
+    TO_STRING_MEMBER(ERROR_TIMEOUT)
+    TO_STRING_MEMBER(ERROR_TIMER)
+    default:
+      return "<INVALID>";
+  }
+}
+const char *OpenTherm::protocol_error_to_str(ProtocolErrorType error_type) {
+  switch (error_type) {
+    TO_STRING_MEMBER(NO_ERROR)
+    TO_STRING_MEMBER(NO_TRANSITION)
+    TO_STRING_MEMBER(INVALID_STOP_BIT)
+    TO_STRING_MEMBER(PARITY_ERROR)
+    TO_STRING_MEMBER(NO_CHANGE_TOO_LONG)
+    default:
+      return "<INVALID>";
+  }
+}
+const char *OpenTherm::timer_error_to_str(TimerErrorType error_type) {
+  switch (error_type) {
+    TO_STRING_MEMBER(NO_TIMER_ERROR)
+    TO_STRING_MEMBER(SET_ALARM_VALUE_ERROR)
+    TO_STRING_MEMBER(TIMER_START_ERROR)
+    TO_STRING_MEMBER(TIMER_PAUSE_ERROR)
+    TO_STRING_MEMBER(SET_COUNTER_VALUE_ERROR)
+    default:
+      return "<INVALID>";
+  }
+}
+const char *OpenTherm::message_type_to_str(MessageType message_type) {
+  switch (message_type) {
+    TO_STRING_MEMBER(READ_DATA)
+    TO_STRING_MEMBER(READ_ACK)
+    TO_STRING_MEMBER(WRITE_DATA)
+    TO_STRING_MEMBER(WRITE_ACK)
+    TO_STRING_MEMBER(INVALID_DATA)
+    TO_STRING_MEMBER(DATA_INVALID)
+    TO_STRING_MEMBER(UNKNOWN_DATAID)
+    default:
+      return "<INVALID>";
+  }
+}
+
+const char *OpenTherm::message_id_to_str(MessageId id) {
+  switch (id) {
+    TO_STRING_MEMBER(STATUS)
+    TO_STRING_MEMBER(CH_SETPOINT)
+    TO_STRING_MEMBER(CONTROLLER_CONFIG)
+    TO_STRING_MEMBER(DEVICE_CONFIG)
+    TO_STRING_MEMBER(COMMAND_CODE)
+    TO_STRING_MEMBER(FAULT_FLAGS)
+    TO_STRING_MEMBER(REMOTE)
+    TO_STRING_MEMBER(COOLING_CONTROL)
+    TO_STRING_MEMBER(CH2_SETPOINT)
+    TO_STRING_MEMBER(CH_SETPOINT_OVERRIDE)
+    TO_STRING_MEMBER(TSP_COUNT)
+    TO_STRING_MEMBER(TSP_COMMAND)
+    TO_STRING_MEMBER(FHB_SIZE)
+    TO_STRING_MEMBER(FHB_COMMAND)
+    TO_STRING_MEMBER(MAX_MODULATION_LEVEL)
+    TO_STRING_MEMBER(MAX_BOILER_CAPACITY)
+    TO_STRING_MEMBER(ROOM_SETPOINT)
+    TO_STRING_MEMBER(MODULATION_LEVEL)
+    TO_STRING_MEMBER(CH_WATER_PRESSURE)
+    TO_STRING_MEMBER(DHW_FLOW_RATE)
+    TO_STRING_MEMBER(DAY_TIME)
+    TO_STRING_MEMBER(DATE)
+    TO_STRING_MEMBER(YEAR)
+    TO_STRING_MEMBER(ROOM_SETPOINT_CH2)
+    TO_STRING_MEMBER(ROOM_TEMP)
+    TO_STRING_MEMBER(FEED_TEMP)
+    TO_STRING_MEMBER(DHW_TEMP)
+    TO_STRING_MEMBER(OUTSIDE_TEMP)
+    TO_STRING_MEMBER(RETURN_WATER_TEMP)
+    TO_STRING_MEMBER(SOLAR_STORE_TEMP)
+    TO_STRING_MEMBER(SOLAR_COLLECT_TEMP)
+    TO_STRING_MEMBER(FEED_TEMP_CH2)
+    TO_STRING_MEMBER(DHW2_TEMP)
+    TO_STRING_MEMBER(EXHAUST_TEMP)
+    TO_STRING_MEMBER(FAN_SPEED)
+    TO_STRING_MEMBER(FLAME_CURRENT)
+    TO_STRING_MEMBER(ROOM_TEMP_CH2)
+    TO_STRING_MEMBER(REL_HUMIDITY)
+    TO_STRING_MEMBER(DHW_BOUNDS)
+    TO_STRING_MEMBER(CH_BOUNDS)
+    TO_STRING_MEMBER(OTC_CURVE_BOUNDS)
+    TO_STRING_MEMBER(DHW_SETPOINT)
+    TO_STRING_MEMBER(MAX_CH_SETPOINT)
+    TO_STRING_MEMBER(OTC_CURVE_RATIO)
+    TO_STRING_MEMBER(HVAC_STATUS)
+    TO_STRING_MEMBER(REL_VENT_SETPOINT)
+    TO_STRING_MEMBER(DEVICE_VENT)
+    TO_STRING_MEMBER(HVAC_VER_ID)
+    TO_STRING_MEMBER(REL_VENTILATION)
+    TO_STRING_MEMBER(REL_HUMID_EXHAUST)
+    TO_STRING_MEMBER(EXHAUST_CO2)
+    TO_STRING_MEMBER(SUPPLY_INLET_TEMP)
+    TO_STRING_MEMBER(SUPPLY_OUTLET_TEMP)
+    TO_STRING_MEMBER(EXHAUST_INLET_TEMP)
+    TO_STRING_MEMBER(EXHAUST_OUTLET_TEMP)
+    TO_STRING_MEMBER(EXHAUST_FAN_SPEED)
+    TO_STRING_MEMBER(SUPPLY_FAN_SPEED)
+    TO_STRING_MEMBER(REMOTE_VENTILATION_PARAM)
+    TO_STRING_MEMBER(NOM_REL_VENTILATION)
+    TO_STRING_MEMBER(HVAC_NUM_TSP)
+    TO_STRING_MEMBER(HVAC_IDX_TSP)
+    TO_STRING_MEMBER(HVAC_FHB_SIZE)
+    TO_STRING_MEMBER(HVAC_FHB_IDX)
+    TO_STRING_MEMBER(RF_SIGNAL)
+    TO_STRING_MEMBER(DHW_MODE)
+    TO_STRING_MEMBER(OVERRIDE_FUNC)
+    TO_STRING_MEMBER(SOLAR_MODE_FLAGS)
+    TO_STRING_MEMBER(SOLAR_ASF)
+    TO_STRING_MEMBER(SOLAR_VERSION_ID)
+    TO_STRING_MEMBER(SOLAR_PRODUCT_ID)
+    TO_STRING_MEMBER(SOLAR_NUM_TSP)
+    TO_STRING_MEMBER(SOLAR_IDX_TSP)
+    TO_STRING_MEMBER(SOLAR_FHB_SIZE)
+    TO_STRING_MEMBER(SOLAR_FHB_IDX)
+    TO_STRING_MEMBER(SOLAR_STARTS)
+    TO_STRING_MEMBER(SOLAR_HOURS)
+    TO_STRING_MEMBER(SOLAR_ENERGY)
+    TO_STRING_MEMBER(SOLAR_TOTAL_ENERGY)
+    TO_STRING_MEMBER(FAILED_BURNER_STARTS)
+    TO_STRING_MEMBER(BURNER_FLAME_LOW)
+    TO_STRING_MEMBER(OEM_DIAGNOSTIC)
+    TO_STRING_MEMBER(BURNER_STARTS)
+    TO_STRING_MEMBER(CH_PUMP_STARTS)
+    TO_STRING_MEMBER(DHW_PUMP_STARTS)
+    TO_STRING_MEMBER(DHW_BURNER_STARTS)
+    TO_STRING_MEMBER(BURNER_HOURS)
+    TO_STRING_MEMBER(CH_PUMP_HOURS)
+    TO_STRING_MEMBER(DHW_PUMP_HOURS)
+    TO_STRING_MEMBER(DHW_BURNER_HOURS)
+    TO_STRING_MEMBER(OT_VERSION_CONTROLLER)
+    TO_STRING_MEMBER(OT_VERSION_DEVICE)
+    TO_STRING_MEMBER(VERSION_CONTROLLER)
+    TO_STRING_MEMBER(VERSION_DEVICE)
+    default:
+      return "<INVALID>";
+  }
+}
+
+void OpenTherm::debug_data(OpenthermData &data) {
+  char type_buf[9], id_buf[9], hb_buf[9], lb_buf[9];
+  ESP_LOGD(TAG, "%s %s %s %s", format_bin_to(type_buf, data.type), format_bin_to(id_buf, data.id),
+           format_bin_to(hb_buf, data.valueHB), format_bin_to(lb_buf, data.valueLB));
+  ESP_LOGD(TAG, "type: %s; id: %u; HB: %u; LB: %u; uint_16: %u; float: %f",
+           this->message_type_to_str((MessageType) data.type), data.id, data.valueHB, data.valueLB, data.u16(),
+           data.f88());
+}
+void OpenTherm::debug_error(OpenThermError &error) const {
+  ESP_LOGD(TAG, "data: 0x%08" PRIx32 "; clock: %u; capture: 0x%08" PRIx32 "; bit_pos: %u", error.data, this->clock_,
+           error.capture, error.bit_pos);
+}
+
+float OpenthermData::f88() { return ((float) this->s16()) / 256.0f; }
+
+void OpenthermData::f88(float value) { this->s16((int16_t) (value * 256)); }
+
+uint16_t OpenthermData::u16() {
+  uint16_t const value = this->valueHB;
+  return (value << 8) | this->valueLB;
+}
+
+void OpenthermData::u16(uint16_t value) {
+  this->valueLB = value & 0xFF;
+  this->valueHB = (value >> 8) & 0xFF;
+}
+
+int16_t OpenthermData::s16() {
+  int16_t const value = this->valueHB;
+  return (value << 8) | this->valueLB;
+}
+
+void OpenthermData::s16(int16_t value) {
+  this->valueLB = value & 0xFF;
+  this->valueHB = (value >> 8) & 0xFF;
+}
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -132,6 +132,10 @@ void OpenTherm::stop() {
 #ifdef USE_ESP32
   this->cancel_esp32_rmt_();
 #endif
+  // A runtime transport change can stop an in-flight request. Always restore
+  // the master output to its initialized idle level instead of leaving the
+  // final Manchester half-bit asserted on the physical interface.
+  this->out_pin_->digital_write(true);
   this->mode_ = OperationMode::IDLE;
 }
 

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -1,0 +1,428 @@
+/*
+ * OpenTherm protocol implementation. Originally taken from https://github.com/jpraus/arduino-opentherm, but
+ * heavily modified to comply with ESPHome coding standards and provide better logging.
+ * Original code is licensed under Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+ * Public License, which is compatible with GPLv3 license, which covers C++ part of ESPHome project.
+ */
+
+#pragma once
+
+#include <string>
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_ESP32
+#include "driver/gptimer.h"
+#include "driver/rmt_rx.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/portmacro.h"
+#endif
+
+namespace esphome::opentherm {
+
+template<class T> constexpr T read_bit(T value, uint8_t bit) { return (value >> bit) & 0x01; }
+
+template<class T> constexpr T set_bit(T value, uint8_t bit) { return value |= (1UL << bit); }
+
+template<class T> constexpr T clear_bit(T value, uint8_t bit) { return value &= ~(1UL << bit); }
+
+template<class T> constexpr T write_bit(T value, uint8_t bit, uint8_t bit_value) {
+  return bit_value ? set_bit(value, bit) : clear_bit(value, bit);
+}
+
+enum OperationMode {
+  IDLE = 0,  // no operation
+
+  LISTEN = 1,    // waiting for transmission to start
+  READ = 2,      // reading 32-bit data frame
+  RECEIVED = 3,  // data frame received with valid start and stop bit
+
+  WRITE = 4,  // writing data to output
+  SENT = 5,   // all data written to output
+  RMT_PENDING = 6,  // ESP32 hardware captured a frame; main-loop decode pending
+
+  ERROR_PROTOCOL = 8,  // protocol error, can happed only during READ
+  ERROR_TIMEOUT = 9,   // timeout while waiting for response from device, only during LISTEN
+  ERROR_TIMER = 10     // error operating the ESP32 timer
+};
+
+enum ProtocolErrorType {
+  NO_ERROR = 0,            // No error
+  NO_TRANSITION = 1,       // No transition in the middle of the bit
+  INVALID_STOP_BIT = 2,    // Stop bit wasn't present when expected
+  PARITY_ERROR = 3,        // Parity check didn't pass
+  NO_CHANGE_TOO_LONG = 4,  // No level change for too much timer ticks
+};
+
+enum TimerErrorType {
+  NO_TIMER_ERROR = 0,           // No error
+  SET_ALARM_VALUE_ERROR = 1,    // No transition in the middle of the bit
+  TIMER_START_ERROR = 2,        // Stop bit wasn't present when expected
+  TIMER_PAUSE_ERROR = 3,        // Parity check didn't pass
+  SET_COUNTER_VALUE_ERROR = 4,  // No level change for too much timer ticks
+};
+
+enum MessageType {
+  READ_DATA = 0,
+  READ_ACK = 4,
+  WRITE_DATA = 1,
+  WRITE_ACK = 5,
+  INVALID_DATA = 2,
+  DATA_INVALID = 6,
+  UNKNOWN_DATAID = 7
+};
+
+enum MessageId {
+  STATUS = 0,
+  CH_SETPOINT = 1,
+  CONTROLLER_CONFIG = 2,
+  DEVICE_CONFIG = 3,
+  COMMAND_CODE = 4,
+  FAULT_FLAGS = 5,
+  REMOTE = 6,
+  COOLING_CONTROL = 7,
+  CH2_SETPOINT = 8,
+  CH_SETPOINT_OVERRIDE = 9,
+  TSP_COUNT = 10,
+  TSP_COMMAND = 11,
+  FHB_SIZE = 12,
+  FHB_COMMAND = 13,
+  MAX_MODULATION_LEVEL = 14,
+  MAX_BOILER_CAPACITY = 15,  // u8_hb - u8_lb gives min modulation level
+  ROOM_SETPOINT = 16,
+  MODULATION_LEVEL = 17,
+  CH_WATER_PRESSURE = 18,
+  DHW_FLOW_RATE = 19,
+  DAY_TIME = 20,
+  DATE = 21,
+  YEAR = 22,
+  ROOM_SETPOINT_CH2 = 23,
+  ROOM_TEMP = 24,
+  FEED_TEMP = 25,
+  DHW_TEMP = 26,
+  OUTSIDE_TEMP = 27,
+  RETURN_WATER_TEMP = 28,
+  SOLAR_STORE_TEMP = 29,
+  SOLAR_COLLECT_TEMP = 30,
+  FEED_TEMP_CH2 = 31,
+  DHW2_TEMP = 32,
+  EXHAUST_TEMP = 33,
+  FAN_SPEED = 35,
+  FLAME_CURRENT = 36,
+  ROOM_TEMP_CH2 = 37,
+  REL_HUMIDITY = 38,
+  DHW_BOUNDS = 48,
+  CH_BOUNDS = 49,
+  OTC_CURVE_BOUNDS = 50,
+  DHW_SETPOINT = 56,
+  MAX_CH_SETPOINT = 57,
+  OTC_CURVE_RATIO = 58,
+
+  // HVAC Specific Message IDs
+  HVAC_STATUS = 70,
+  REL_VENT_SETPOINT = 71,
+  DEVICE_VENT = 74,
+  HVAC_VER_ID = 75,
+  REL_VENTILATION = 77,
+  REL_HUMID_EXHAUST = 78,
+  EXHAUST_CO2 = 79,
+  SUPPLY_INLET_TEMP = 80,
+  SUPPLY_OUTLET_TEMP = 81,
+  EXHAUST_INLET_TEMP = 82,
+  EXHAUST_OUTLET_TEMP = 83,
+  EXHAUST_FAN_SPEED = 84,
+  SUPPLY_FAN_SPEED = 85,
+  REMOTE_VENTILATION_PARAM = 86,
+  NOM_REL_VENTILATION = 87,
+  HVAC_NUM_TSP = 88,
+  HVAC_IDX_TSP = 89,
+  HVAC_FHB_SIZE = 90,
+  HVAC_FHB_IDX = 91,
+
+  RF_SIGNAL = 98,
+  DHW_MODE = 99,
+  OVERRIDE_FUNC = 100,
+
+  // Solar Specific Message IDs
+  SOLAR_MODE_FLAGS = 101,  // hb0-2 Controller storage mode
+                           // lb0   Device fault
+                           // lb1-3 Device mode status
+                           // lb4-5 Device status
+  SOLAR_ASF = 102,
+  SOLAR_VERSION_ID = 103,
+  SOLAR_PRODUCT_ID = 104,
+  SOLAR_NUM_TSP = 105,
+  SOLAR_IDX_TSP = 106,
+  SOLAR_FHB_SIZE = 107,
+  SOLAR_FHB_IDX = 108,
+  SOLAR_STARTS = 109,
+  SOLAR_HOURS = 110,
+  SOLAR_ENERGY = 111,
+  SOLAR_TOTAL_ENERGY = 112,
+
+  FAILED_BURNER_STARTS = 113,
+  BURNER_FLAME_LOW = 114,
+  OEM_DIAGNOSTIC = 115,
+  BURNER_STARTS = 116,
+  CH_PUMP_STARTS = 117,
+  DHW_PUMP_STARTS = 118,
+  DHW_BURNER_STARTS = 119,
+  BURNER_HOURS = 120,
+  CH_PUMP_HOURS = 121,
+  DHW_PUMP_HOURS = 122,
+  DHW_BURNER_HOURS = 123,
+  OT_VERSION_CONTROLLER = 124,
+  OT_VERSION_DEVICE = 125,
+  VERSION_CONTROLLER = 126,
+  VERSION_DEVICE = 127
+};
+
+enum BitPositions { STOP_BIT = 33 };
+
+/**
+ * Structure to hold Opentherm data packet content.
+ * Use f88(), u16() or s16() functions to get appropriate value of data packet accoridng to id of message.
+ */
+struct OpenthermData {
+  uint8_t type;
+  uint8_t id;
+  uint8_t valueHB;
+  uint8_t valueLB;
+
+  OpenthermData() : type(0), id(0), valueHB(0), valueLB(0) {}
+
+  /**
+   * @return float representation of data packet value
+   */
+  float f88();
+
+  /**
+   * @param float number to set as value of this data packet
+   */
+  void f88(float value);
+
+  /**
+   * @return unsigned 16b integer representation of data packet value
+   */
+  uint16_t u16();
+
+  /**
+   * @param unsigned 16b integer number to set as value of this data packet
+   */
+  void u16(uint16_t value);
+
+  /**
+   * @return signed 16b integer representation of data packet value
+   */
+  int16_t s16();
+
+  /**
+   * @param signed 16b integer number to set as value of this data packet
+   */
+  void s16(int16_t value);
+};
+
+struct OpenThermError {
+  ProtocolErrorType error_type;
+  uint32_t capture;
+  uint8_t clock;
+  uint32_t data;
+  uint8_t bit_pos;
+};
+
+/**
+ * Opentherm static class that supports either listening or sending Opentherm data packets in the same time
+ */
+class OpenTherm {
+ public:
+  OpenTherm(InternalGPIOPin *in_pin, InternalGPIOPin *out_pin, int32_t device_timeout = 800);
+
+  /**
+   * Setup pins.
+   */
+  bool initialize();
+
+  /**
+   * Start listening for Opentherm data packet comming from line connected to given pin.
+   * If data packet is received then has_message() function returns true and data packet can be retrieved by calling
+   * get_message() function. If timeout > 0 then this function waits for incomming data package for timeout millis and
+   * if no data packet is recevived, error state is indicated by is_error() function. If either data packet is received
+   * or timeout is reached listening is stopped.
+   */
+  void listen();
+
+  /**
+   * Use this function to check whether listen() function already captured a valid data packet.
+   *
+   * @return true if data packet has been captured from line by listen() function.
+   */
+  bool has_message() { return mode_ == OperationMode::RECEIVED; }
+
+  /**
+   * Use this to retrive data packed captured by listen() function. Data packet is ready when has_message() function
+   * returns true. This function can be called multiple times until stop() is called.
+   *
+   * @param data reference to data structure to which fill the data packet data.
+   * @return true if packet was ready and was filled into data structure passed, false otherwise.
+   */
+  bool get_message(OpenthermData &data);
+
+  /**
+   * Immediately send out Opentherm data packet to line connected on given pin.
+   * Completed data transfer is indicated by is_sent() function.
+   * Error state is indicated by is_error() function.
+   *
+   * @param data Opentherm data packet.
+   */
+  void send(OpenthermData &data);
+
+  /**
+   * Process a completed hardware receive capture. This is a no-op on ESP8266.
+   */
+  void process();
+
+  /**
+   * Stops listening for data packet or sending out data packet and resets internal state of this class.
+   * Stops all timers and unattaches all interrupts.
+   */
+  void stop();
+
+  /**
+   * Get protocol error details in case a protocol error occured.
+   * @param error reference to data structure to which fill the error details
+   * @return true if protocol error occured during last conversation, false otherwise.
+   */
+  bool get_protocol_error(OpenThermError &error);
+
+  /**
+   * Use this function to check whether send() function already finished sending data packed to line.
+   *
+   * @return true if data packet has been sent, false otherwise.
+   */
+  bool is_sent() { return mode_ == OperationMode::SENT; }
+
+  /**
+   * Indicates whether listinig or sending is not in progress.
+   * That also means that no timers are running and no interrupts are attached.
+   *
+   * @return true if listening nor sending is in progress.
+   */
+  bool is_idle() { return mode_ == OperationMode::IDLE; }
+
+  /**
+   * Indicates whether last listen() or send() operation ends up with an error. Includes both timeout and
+   * protocol errors.
+   *
+   * @return true if last listen() or send() operation ends up with an error.
+   */
+  bool is_error() {
+    return mode_ == OperationMode::ERROR_TIMEOUT || mode_ == OperationMode::ERROR_PROTOCOL || mode_ == ERROR_TIMER;
+  }
+
+  /**
+   * Indicates whether last listen() or send() operation ends up with a *timeout* error
+   * @return true if last listen() or send() operation ends up with a *timeout* error.
+   */
+  bool is_timeout() { return mode_ == OperationMode::ERROR_TIMEOUT; }
+
+  /**
+   * Indicates whether last listen() or send() operation ends up with a *protocol* error
+   * @return true if last listen() or send() operation ends up with a *protocol* error.
+   */
+  bool is_protocol_error() { return mode_ == OperationMode::ERROR_PROTOCOL; }
+
+  /**
+   * Indicates whether start_esp32_timer_() or stop_timer_() had an error. Only relevant when used on ESP32.
+   * @return true if there was an error.
+   */
+  bool is_timer_error() { return mode_ == OperationMode::ERROR_TIMER; }
+
+  bool is_active() { return mode_ == LISTEN || mode_ == READ || mode_ == WRITE || mode_ == RMT_PENDING; }
+
+  OperationMode get_mode() { return mode_; }
+
+  void debug_data(OpenthermData &data);
+  void debug_error(OpenThermError &error) const;
+  void report_and_reset_timer_error();
+
+  const char *protocol_error_to_str(ProtocolErrorType error_type);
+  const char *timer_error_to_str(TimerErrorType error_type);
+  const char *message_type_to_str(MessageType message_type);
+  const char *operation_mode_to_str(OperationMode mode);
+  const char *message_id_to_str(MessageId id);
+
+#ifdef USE_ESP32
+  static bool timer_isr(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_ctx);
+  static bool IRAM_ATTR rmt_rx_done_callback_(rmt_channel_handle_t channel,
+                                             const rmt_rx_done_event_data_t *event, void *user_ctx);
+#else
+  static bool timer_isr(OpenTherm *arg);
+#endif
+
+#ifdef ESP8266
+  static void esp8266_timer_isr();
+#endif
+
+ private:
+  InternalGPIOPin *in_pin_;
+  InternalGPIOPin *out_pin_;
+  ISRInternalGPIOPin isr_in_pin_;
+  ISRInternalGPIOPin isr_out_pin_;
+
+#ifdef USE_ESP32
+  static constexpr size_t RMT_CAPTURE_SYMBOLS = 96;
+  gptimer_handle_t timer_handle_{nullptr};
+  gptimer_alarm_config_t alarm_config_{
+      .alarm_count = 0,
+      .reload_count = 0,
+      .flags = {.auto_reload_on_alarm = true},
+  };
+  rmt_channel_handle_t rmt_rx_channel_{nullptr};
+  rmt_symbol_word_t rmt_rx_symbols_[RMT_CAPTURE_SYMBOLS]{};
+  portMUX_TYPE rmt_mux_ = portMUX_INITIALIZER_UNLOCKED;
+  volatile size_t rmt_symbol_count_{0};
+  volatile bool rmt_armed_{false};
+  volatile bool rmt_frame_ready_{false};
+  uint32_t receive_deadline_us_{0};
+#endif
+
+  OperationMode mode_;
+  ProtocolErrorType error_type_;
+  uint32_t capture_;
+  uint8_t clock_;
+  uint32_t data_;
+  uint8_t bit_pos_;
+  int32_t timeout_counter_;  // <0 no timeout
+  int32_t device_timeout_;
+
+#ifdef USE_ESP32
+  esp_err_t timer_error_ = ESP_OK;
+  TimerErrorType timer_error_type_ = TimerErrorType::NO_TIMER_ERROR;
+
+  bool init_esp32_timer_();
+  bool init_esp32_rmt_();
+  bool arm_esp32_rmt_();
+  void cancel_esp32_rmt_();
+  void process_esp32_rmt_();
+  void start_esp32_timer_(uint64_t alarm_value, bool auto_reload);
+#endif
+
+  void stop_timer_();
+
+  void read_();               // data detected start reading
+  void start_read_timer_();   // ESP32 response timeout; ESP8266 reads at 1/5 bit length (5kHz)
+  void start_write_timer_();  // writing timer_ to send manchester code (at 2kHz)
+  bool check_parity_(uint32_t val);
+
+  void bit_read_(uint8_t value);
+  ProtocolErrorType verify_stop_bit_(uint8_t value);
+  void write_bit_(uint8_t high, uint8_t clock);
+
+#ifdef ESP8266
+  // ESP8266 timer can accept callback with no parameters, so we have this hack to save a static instance of OpenTherm
+  static OpenTherm *instance;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+#endif
+};
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/opentherm_macros.h
+++ b/components/opentherm/opentherm_macros.h
@@ -1,0 +1,161 @@
+#pragma once
+
+namespace esphome::opentherm {
+
+// ===== hub.h macros =====
+
+// *_LIST macros will be generated in defines.h if at least one sensor from each platform is used.
+// These lists will look like this:
+// #define OPENTHERM_BINARY_SENSOR_LIST(F, sep) F(sensor_1) sep F(sensor_2)
+// These lists will be used in hub.h to define sensor fields (passing macros like OPENTHERM_DECLARE_SENSOR as F)
+// and setters (passing macros like OPENTHERM_SET_SENSOR as F) (see below)
+// In order for things not to break, we define empty lists here in case some platforms are not used in config.
+#ifndef OPENTHERM_SENSOR_LIST
+#define OPENTHERM_SENSOR_LIST(F, sep)
+#endif
+#ifndef OPENTHERM_BINARY_SENSOR_LIST
+#define OPENTHERM_BINARY_SENSOR_LIST(F, sep)
+#endif
+#ifndef OPENTHERM_SWITCH_LIST
+#define OPENTHERM_SWITCH_LIST(F, sep)
+#endif
+#ifndef OPENTHERM_NUMBER_LIST
+#define OPENTHERM_NUMBER_LIST(F, sep)
+#endif
+#ifndef OPENTHERM_OUTPUT_LIST
+#define OPENTHERM_OUTPUT_LIST(F, sep)
+#endif
+#ifndef OPENTHERM_INPUT_SENSOR_LIST
+#define OPENTHERM_INPUT_SENSOR_LIST(F, sep)
+#endif
+#ifndef OPENTHERM_SETTING_LIST
+#define OPENTHERM_SETTING_LIST(F, sep)
+#endif
+
+// Use macros to create fields for every entity specified in the ESPHome configuration
+#define OPENTHERM_DECLARE_SENSOR(entity) sensor::Sensor *entity;
+#define OPENTHERM_DECLARE_BINARY_SENSOR(entity) binary_sensor::BinarySensor *entity;
+#define OPENTHERM_DECLARE_SWITCH(entity) OpenthermSwitch *entity;
+#define OPENTHERM_DECLARE_NUMBER(entity) OpenthermNumber *entity;
+#define OPENTHERM_DECLARE_OUTPUT(entity) OpenthermOutput *entity;
+#define OPENTHERM_DECLARE_INPUT_SENSOR(entity) sensor::Sensor *entity;
+#define OPENTHERM_DECLARE_SETTING(type, entity, def) type entity = def;
+
+// Setter macros
+#define OPENTHERM_SET_SENSOR(entity) \
+  void set_##entity(sensor::Sensor *sensor) { this->entity = sensor; }
+
+#define OPENTHERM_SET_BINARY_SENSOR(entity) \
+  void set_##entity(binary_sensor::BinarySensor *binary_sensor) { this->entity = binary_sensor; }
+
+#define OPENTHERM_SET_SWITCH(entity) \
+  void set_##entity(OpenthermSwitch *sw) { this->entity = sw; }
+
+#define OPENTHERM_SET_NUMBER(entity) \
+  void set_##entity(OpenthermNumber *number) { this->entity = number; }
+
+#define OPENTHERM_SET_OUTPUT(entity) \
+  void set_##entity(OpenthermOutput *output) { this->entity = output; }
+
+#define OPENTHERM_SET_INPUT_SENSOR(entity) \
+  void set_##entity(sensor::Sensor *sensor) { this->entity = sensor; }
+
+#define OPENTHERM_SET_SETTING(type, entity, def) \
+  void set_##entity(type value) { this->entity = value; }
+
+// ===== hub.cpp macros =====
+
+// *_MESSAGE_HANDLERS are generated in defines.h and look like this:
+// OPENTHERM_NUMBER_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep) MESSAGE(COOLING_CONTROL)
+// ENTITY(cooling_control_number, f88) postscript msg_sep They contain placeholders for message part and entities parts,
+// since one message can contain multiple entities. MESSAGE part is substituted with OPENTHERM_MESSAGE_WRITE_MESSAGE,
+// OPENTHERM_MESSAGE_READ_MESSAGE or OPENTHERM_MESSAGE_RESPONSE_MESSAGE. ENTITY part is substituted with
+// OPENTHERM_MESSAGE_WRITE_ENTITY or OPENTHERM_MESSAGE_RESPONSE_ENTITY. OPENTHERM_IGNORE is used for sensor read
+// requests since no data needs to be sent or processed, just the data id.
+
+// In order for things not to break, we define empty lists here in case some platforms are not used in config.
+#ifndef OPENTHERM_SENSOR_MESSAGE_HANDLERS
+#define OPENTHERM_SENSOR_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep)
+#endif
+#ifndef OPENTHERM_BINARY_SENSOR_MESSAGE_HANDLERS
+#define OPENTHERM_BINARY_SENSOR_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep)
+#endif
+#ifndef OPENTHERM_SWITCH_MESSAGE_HANDLERS
+#define OPENTHERM_SWITCH_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep)
+#endif
+#ifndef OPENTHERM_NUMBER_MESSAGE_HANDLERS
+#define OPENTHERM_NUMBER_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep)
+#endif
+#ifndef OPENTHERM_OUTPUT_MESSAGE_HANDLERS
+#define OPENTHERM_OUTPUT_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep)
+#endif
+#ifndef OPENTHERM_INPUT_SENSOR_MESSAGE_HANDLERS
+#define OPENTHERM_INPUT_SENSOR_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep)
+#endif
+#ifndef OPENTHERM_SETTING_MESSAGE_HANDLERS
+#define OPENTHERM_SETTING_MESSAGE_HANDLERS(MESSAGE, ENTITY, entity_sep, postscript, msg_sep)
+#endif
+
+// Write data request builders
+#define OPENTHERM_MESSAGE_WRITE_MESSAGE(msg) \
+  case MessageId::msg: { \
+    data.type = MessageType::WRITE_DATA; \
+    data.id = request_id;
+#define OPENTHERM_MESSAGE_WRITE_ENTITY(key, msg_data) message_data::write_##msg_data(this->key->state, data);
+#define OPENTHERM_MESSAGE_WRITE_SETTING(key, msg_data) message_data::write_##msg_data(this->key, data);
+#define OPENTHERM_MESSAGE_WRITE_POSTSCRIPT \
+  return data; \
+  }
+
+// Read data request builder
+#define OPENTHERM_MESSAGE_READ_MESSAGE(msg) \
+  case MessageId::msg: \
+    data.type = MessageType::READ_DATA; \
+    data.id = request_id; \
+    return data;
+
+// Data processing builders
+#define OPENTHERM_MESSAGE_RESPONSE_MESSAGE(msg) case MessageId::msg:
+#define OPENTHERM_MESSAGE_RESPONSE_ENTITY(key, msg_data) this->key->publish_state(message_data::parse_##msg_data(data));
+#define OPENTHERM_MESSAGE_RESPONSE_POSTSCRIPT break;
+
+#define OPENTHERM_IGNORE(x, y)
+
+// Default macros for STATUS entities
+#ifndef OPENTHERM_READ_ch_enable
+#define OPENTHERM_READ_ch_enable true
+#endif
+#ifndef OPENTHERM_READ_dhw_enable
+#define OPENTHERM_READ_dhw_enable true
+#endif
+#ifndef OPENTHERM_READ_t_set
+#define OPENTHERM_READ_t_set 0.0
+#endif
+#ifndef OPENTHERM_READ_cooling_enable
+#define OPENTHERM_READ_cooling_enable false
+#endif
+#ifndef OPENTHERM_READ_cooling_control
+#define OPENTHERM_READ_cooling_control 0.0
+#endif
+#ifndef OPENTHERM_READ_otc_active
+#define OPENTHERM_READ_otc_active false
+#endif
+#ifndef OPENTHERM_READ_ch2_active
+#define OPENTHERM_READ_ch2_active false
+#endif
+#ifndef OPENTHERM_READ_t_set_ch2
+#define OPENTHERM_READ_t_set_ch2 0.0
+#endif
+#ifndef OPENTHERM_READ_summer_mode_active
+#define OPENTHERM_READ_summer_mode_active false
+#endif
+#ifndef OPENTHERM_READ_dhw_block
+#define OPENTHERM_READ_dhw_block false
+#endif
+
+// These macros utilize the structure of *_LIST macros in order
+#define ID(x) x
+#define SHOW_INNER(x) #x
+#define SHOW(x) SHOW_INNER(x)
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/opentherm_rmt_decoder.h
+++ b/components/opentherm/opentherm_rmt_decoder.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace esphome::opentherm::rmt_decoder {
+
+static constexpr size_t FRAME_BITS = 34;
+static constexpr size_t HALF_BITS = FRAME_BITS * 2;
+static constexpr uint16_t HALF_BIT_MIN_US = 380;
+static constexpr uint16_t HALF_BIT_MAX_US = 620;
+static constexpr uint16_t FULL_BIT_MIN_US = 880;
+static constexpr uint16_t FULL_BIT_MAX_US = 1120;
+
+struct Pulse {
+  uint16_t duration_us;
+  bool level;
+};
+
+enum class DecodeError : uint8_t {
+  NONE = 0,
+  GLITCH,
+  TIMING,
+  START_BIT,
+  MANCHESTER,
+  STOP_BIT,
+  PARITY,
+};
+
+enum class CaptureFailure : uint8_t {
+  NONE = 0,
+  PULSE_DURATION,
+  HALF_BIT_OVERFLOW,
+  HALF_BIT_COUNT,
+};
+
+struct DecodeResult {
+  uint32_t data{0};
+  DecodeError error{DecodeError::NONE};
+  uint8_t bit_position{0};
+  size_t pulse_count{0};
+  size_t failure_pulse_index{0};
+  uint16_t failure_pulse_duration_us{0};
+  size_t half_bit_count{0};
+  CaptureFailure capture_failure{CaptureFailure::NONE};
+};
+
+inline bool has_even_parity(uint32_t value) {
+  value ^= value >> 16;
+  value ^= value >> 8;
+  value ^= value >> 4;
+  value ^= value >> 2;
+  value ^= value >> 1;
+  return (~value) & 1U;
+}
+
+inline DecodeResult decode(const Pulse *pulses, size_t pulse_count) {
+  DecodeResult result{};
+  result.pulse_count = pulse_count;
+  uint8_t half_bits[HALF_BITS]{};
+  uint8_t decoded_half_bits[HALF_BITS]{};
+  size_t half_bit_count = 0;
+
+  for (size_t pulse_index = 0; pulse_index < pulse_count; pulse_index++) {
+    const Pulse &pulse = pulses[pulse_index];
+    if (pulse.duration_us == 0) {
+      continue;
+    }
+
+    uint8_t repeats = 0;
+    if (pulse.duration_us >= HALF_BIT_MIN_US && pulse.duration_us <= HALF_BIT_MAX_US) {
+      repeats = 1;
+    } else if (pulse.duration_us >= FULL_BIT_MIN_US && pulse.duration_us <= FULL_BIT_MAX_US) {
+      repeats = 2;
+    } else {
+      result.error = pulse.duration_us < HALF_BIT_MIN_US ? DecodeError::GLITCH : DecodeError::TIMING;
+      result.failure_pulse_index = pulse_index;
+      result.failure_pulse_duration_us = pulse.duration_us;
+      result.half_bit_count = half_bit_count;
+      result.capture_failure = CaptureFailure::PULSE_DURATION;
+      return result;
+    }
+
+    if (half_bit_count + repeats > HALF_BITS) {
+      result.error = DecodeError::TIMING;
+      result.failure_pulse_index = pulse_index;
+      result.failure_pulse_duration_us = pulse.duration_us;
+      result.half_bit_count = half_bit_count;
+      result.capture_failure = CaptureFailure::HALF_BIT_OVERFLOW;
+      return result;
+    }
+    for (uint8_t repeat = 0; repeat < repeats; repeat++) {
+      half_bits[half_bit_count++] = pulse.level ? 1U : 0U;
+    }
+  }
+
+  // RMT starts at the first transition and may therefore omit the leading low
+  // half of the start bit. It may likewise omit the final high half when the
+  // frame is terminated by the idle-range threshold. Only salvage those two
+  // exact 67-half-bit boundary cases.
+  if (half_bit_count == HALF_BITS - 1U && half_bit_count > 0) {
+    if (half_bits[0] == 1U) {
+      for (size_t index = half_bit_count; index > 0; index--) {
+        half_bits[index] = half_bits[index - 1U];
+      }
+      half_bits[0] = 0U;
+      half_bit_count++;
+    } else if (half_bits[half_bit_count - 1U] == 0U) {
+      half_bits[half_bit_count++] = 1U;
+    }
+  }
+
+  if (half_bit_count != HALF_BITS) {
+    result.error = DecodeError::TIMING;
+    result.failure_pulse_index = pulse_count;
+    result.half_bit_count = half_bit_count;
+    result.capture_failure = CaptureFailure::HALF_BIT_COUNT;
+    return result;
+  }
+  result.half_bit_count = half_bit_count;
+
+  // The OpenQuatt OT input front-end presents an inverted signal, and RMT
+  // starts capturing at the first edge rather than at the logical frame
+  // boundary. The existing OpenQuatt OT-slave receiver has established this
+  // single one-half-bit-forward, inverted interpretation in long-running HIL.
+  for (size_t index = 0; index < HALF_BITS - 1U; index++) {
+    decoded_half_bits[index] = half_bits[index + 1U] ^ 0x1U;
+  }
+  decoded_half_bits[HALF_BITS - 1U] = decoded_half_bits[HALF_BITS - 2U] ^ 0x1U;
+
+  for (size_t bit_index = 0; bit_index < FRAME_BITS; bit_index++) {
+    result.bit_position = static_cast<uint8_t>(bit_index);
+    const uint8_t first = decoded_half_bits[bit_index * 2U];
+    const uint8_t second = decoded_half_bits[(bit_index * 2U) + 1U];
+    bool bit_value = false;
+    if (first == 0U && second == 1U) {
+      bit_value = true;
+    } else if (first == 1U && second == 0U) {
+      bit_value = false;
+    } else {
+      result.error = bit_index == 0 ? DecodeError::START_BIT : DecodeError::MANCHESTER;
+      return result;
+    }
+
+    if (bit_index == 0) {
+      if (!bit_value) {
+        result.error = DecodeError::START_BIT;
+        return result;
+      }
+      continue;
+    }
+    if (bit_index == FRAME_BITS - 1U) {
+      if (!bit_value) {
+        result.error = DecodeError::STOP_BIT;
+        return result;
+      }
+      break;
+    }
+    result.data = (result.data << 1U) | static_cast<uint32_t>(bit_value);
+  }
+
+  if (!has_even_parity(result.data)) {
+    result.error = DecodeError::PARITY;
+    return result;
+  }
+
+  result.error = DecodeError::NONE;
+  return result;
+}
+
+}  // namespace esphome::opentherm::rmt_decoder

--- a/components/opentherm/output/__init__.py
+++ b/components/opentherm/output/__init__.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+import esphome.codegen as cg
+from esphome.components import output
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+from .. import const, generate, input, schema, validate
+
+DEPENDENCIES = [const.OPENTHERM]
+COMPONENT_TYPE = const.OUTPUT
+
+OpenthermOutput = generate.opentherm_ns.class_(
+    "OpenthermOutput", output.FloatOutput, cg.Component, input.OpenthermInput
+)
+
+
+async def new_openthermoutput(
+    config: dict[str, Any], key: str, _hub: cg.MockObj
+) -> cg.Pvariable:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await output.register_output(var, config)
+    cg.add(var.set_id(cg.RawExpression(f'"{key}_{config[CONF_ID]}"')))
+    input.generate_setters(var, config)
+    return var
+
+
+def get_entity_validation_schema(entity: schema.InputSchema) -> cv.Schema:
+    return (
+        output.FLOAT_OUTPUT_SCHEMA.extend(
+            {cv.GenerateID(): cv.declare_id(OpenthermOutput)}
+        )
+        .extend(input.input_schema(entity))
+        .extend(cv.COMPONENT_SCHEMA)
+    )
+
+
+CONFIG_SCHEMA = validate.create_component_schema(
+    schema.INPUTS, get_entity_validation_schema
+)
+
+
+async def to_code(config: dict[str, Any]) -> None:
+    keys = await generate.component_to_code(
+        COMPONENT_TYPE, schema.INPUTS, OpenthermOutput, new_openthermoutput, config
+    )
+    generate.define_readers(COMPONENT_TYPE, keys)

--- a/components/opentherm/output/opentherm_output.cpp
+++ b/components/opentherm/output/opentherm_output.cpp
@@ -1,0 +1,21 @@
+#include "esphome/core/helpers.h"  // for clamp() and lerp()
+#include "opentherm_output.h"
+
+namespace esphome::opentherm {
+
+static const char *const TAG = "opentherm.output";
+
+void opentherm::OpenthermOutput::write_state(float state) {
+  ESP_LOGD(TAG, "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);
+#ifdef USE_OUTPUT_FLOAT_POWER_SCALING
+  bool zero_means_zero = this->zero_means_zero_;
+#else
+  bool zero_means_zero = false;
+#endif
+  this->state = state < 0.003f && zero_means_zero
+                    ? 0.0f
+                    : clamp(std::lerp(min_value_, max_value_, state), min_value_, max_value_);
+  this->has_state_ = true;
+  ESP_LOGD(TAG, "Output %s set to %.2f", this->id_, this->state);
+}
+}  // namespace esphome::opentherm

--- a/components/opentherm/output/opentherm_output.h
+++ b/components/opentherm/output/opentherm_output.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/components/output/float_output.h"
+#include "esphome/components/opentherm/input.h"
+#include "esphome/core/log.h"
+
+namespace esphome::opentherm {
+
+class OpenthermOutput final : public output::FloatOutput, public Component, public OpenthermInput {
+ protected:
+  bool has_state_ = false;
+  const char *id_ = nullptr;
+
+  float min_value_, max_value_;
+
+ public:
+  float state;
+
+  void set_id(const char *id) { this->id_ = id; }
+
+  void write_state(float state) override;
+
+  bool has_state() { return this->has_state_; };
+
+  void set_min_value(float min_value) override { this->min_value_ = min_value; }
+  void set_max_value(float max_value) override { this->max_value_ = max_value; }
+  float get_min_value() { return this->min_value_; }
+  float get_max_value() { return this->max_value_; }
+};
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/schema.py
+++ b/components/opentherm/schema.py
@@ -1,0 +1,891 @@
+# This file contains a schema for all supported sensors, binary sensors and
+# inputs of the OpenTherm component.
+
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+import esphome.config_validation as cv
+from esphome.const import (
+    DEVICE_CLASS_COLD,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_HEAT,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_PROBLEM,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_NONE,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_CELSIUS,
+    UNIT_EMPTY,
+    UNIT_KILOWATT,
+    UNIT_MICROAMP,
+    UNIT_PERCENT,
+    UNIT_REVOLUTIONS_PER_MINUTE,
+)
+
+
+@dataclass
+class EntitySchema:
+    description: str
+    """Description of the item, based on the OpenTherm spec"""
+
+    message: str
+    """OpenTherm message id used to read or write the value"""
+
+    keep_updated: bool
+    """Whether the value should be read or write repeatedly (True) or only during
+    the initialization phase (False)
+    """
+
+    message_data: str
+    """Instructions on how to interpret the data in the message
+      - flag8_[hb|lb]_[0-7]: data is a byte of single bit flags,
+                             this flag is set in the high (hb) or low byte (lb),
+                             at position 0 to 7
+      - u8_[hb|lb]: data is an unsigned 8-bit integer,
+                    in the high (hb) or low byte (lb)
+      - s8_[hb|lb]: data is an signed 8-bit integer,
+                    in the high (hb) or low byte (lb)
+      - f88: data is a signed fixed point value with
+              1 sign bit, 7 integer bits, 8 fractional bits
+      - u16: data is an unsigned 16-bit integer
+      - s16: data is a signed 16-bit integer
+    """
+
+
+TSchema = TypeVar("TSchema", bound=EntitySchema)
+
+
+@dataclass
+class SensorSchema(EntitySchema):
+    accuracy_decimals: int
+    state_class: str
+    unit_of_measurement: str | None = None
+    icon: str | None = None
+    device_class: str | None = None
+    disabled_by_default: bool = False
+    order: int | None = None
+
+
+SENSORS: dict[str, SensorSchema] = {
+    "rel_mod_level": SensorSchema(
+        description="Relative modulation level",
+        unit_of_measurement=UNIT_PERCENT,
+        accuracy_decimals=2,
+        icon="mdi:percent",
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="MODULATION_LEVEL",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "ch_pressure": SensorSchema(
+        description="Water pressure in CH circuit",
+        unit_of_measurement="bar",
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_PRESSURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="CH_WATER_PRESSURE",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "dhw_flow_rate": SensorSchema(
+        description="Water flow rate in DHW circuit",
+        unit_of_measurement="l/min",
+        accuracy_decimals=2,
+        icon="mdi:waves-arrow-right",
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="DHW_FLOW_RATE",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "t_boiler": SensorSchema(
+        description="Boiler water temperature",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="FEED_TEMP",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "t_dhw": SensorSchema(
+        description="DHW temperature",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="DHW_TEMP",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "t_outside": SensorSchema(
+        description="Outside temperature",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="OUTSIDE_TEMP",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "t_ret": SensorSchema(
+        description="Return water temperature",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="RETURN_WATER_TEMP",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "t_storage": SensorSchema(
+        description="Solar storage temperature",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="SOLAR_STORE_TEMP",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "t_collector": SensorSchema(
+        description="Solar collector temperature",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="SOLAR_COLLECT_TEMP",
+        keep_updated=True,
+        message_data="s16",
+    ),
+    "t_flow_ch2": SensorSchema(
+        description="Flow water temperature CH2 circuit",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="FEED_TEMP_CH2",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "t_dhw2": SensorSchema(
+        description="Domestic hot water temperature 2",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="DHW2_TEMP",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "t_exhaust": SensorSchema(
+        description="Boiler exhaust temperature",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="EXHAUST_TEMP",
+        keep_updated=True,
+        message_data="s16",
+    ),
+    "fan_speed": SensorSchema(
+        description="Boiler fan speed",
+        unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
+        accuracy_decimals=0,
+        icon="mdi:fan",
+        device_class=DEVICE_CLASS_EMPTY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="FAN_SPEED",
+        keep_updated=True,
+        message_data="u8_lb_60",
+    ),
+    "fan_speed_setpoint": SensorSchema(
+        description="Boiler fan speed setpoint",
+        unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
+        accuracy_decimals=0,
+        icon="mdi:fan",
+        device_class=DEVICE_CLASS_EMPTY,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="FAN_SPEED",
+        keep_updated=True,
+        message_data="u8_hb_60",
+    ),
+    "flame_current": SensorSchema(
+        description="Boiler flame current",
+        unit_of_measurement=UNIT_MICROAMP,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="FLAME_CURRENT",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "burner_starts": SensorSchema(
+        description="Number of starts burner",
+        accuracy_decimals=0,
+        icon="mdi:gas-burner",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        message="BURNER_STARTS",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "ch_pump_starts": SensorSchema(
+        description="Number of starts CH pump",
+        accuracy_decimals=0,
+        icon="mdi:pump",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        message="CH_PUMP_STARTS",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "dhw_pump_valve_starts": SensorSchema(
+        description="Number of starts DHW pump/valve",
+        accuracy_decimals=0,
+        icon="mdi:water-pump",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        message="DHW_PUMP_STARTS",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "dhw_burner_starts": SensorSchema(
+        description="Number of starts burner during DHW mode",
+        accuracy_decimals=0,
+        icon="mdi:gas-burner",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        message="DHW_BURNER_STARTS",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "burner_operation_hours": SensorSchema(
+        description="Number of hours that burner is in operation",
+        accuracy_decimals=0,
+        icon="mdi:clock-outline",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        message="BURNER_HOURS",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "ch_pump_operation_hours": SensorSchema(
+        description="Number of hours that CH pump has been running",
+        accuracy_decimals=0,
+        icon="mdi:clock-outline",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        message="CH_PUMP_HOURS",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "dhw_pump_valve_operation_hours": SensorSchema(
+        description="Number of hours that DHW pump has been running or DHW valve has been opened",
+        accuracy_decimals=0,
+        icon="mdi:clock-outline",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        message="DHW_PUMP_HOURS",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "dhw_burner_operation_hours": SensorSchema(
+        description="Number of hours that burner is in operation during DHW mode",
+        accuracy_decimals=0,
+        icon="mdi:clock-outline",
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+        message="DHW_BURNER_HOURS",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "t_dhw_set_ub": SensorSchema(
+        description="Upper bound for adjustment of DHW setpoint",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="DHW_BOUNDS",
+        keep_updated=False,
+        message_data="s8_hb",
+    ),
+    "t_dhw_set_lb": SensorSchema(
+        description="Lower bound for adjustment of DHW setpoint",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="DHW_BOUNDS",
+        keep_updated=False,
+        message_data="s8_lb",
+    ),
+    "max_t_set_ub": SensorSchema(
+        description="Upper bound for adjustment of max CH setpoint",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="CH_BOUNDS",
+        keep_updated=False,
+        message_data="s8_hb",
+    ),
+    "max_t_set_lb": SensorSchema(
+        description="Lower bound for adjustment of max CH setpoint",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="CH_BOUNDS",
+        keep_updated=False,
+        message_data="s8_lb",
+    ),
+    "t_dhw_set": SensorSchema(
+        description="Domestic hot water temperature setpoint",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="DHW_SETPOINT",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "max_t_set": SensorSchema(
+        description="Maximum allowable CH water setpoint",
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="MAX_CH_SETPOINT",
+        keep_updated=True,
+        message_data="f88",
+    ),
+    "oem_fault_code": SensorSchema(
+        description="OEM fault code",
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_NONE,
+        message="FAULT_FLAGS",
+        keep_updated=True,
+        message_data="u8_lb",
+    ),
+    "oem_diagnostic_code": SensorSchema(
+        description="OEM diagnostic code",
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_NONE,
+        message="OEM_DIAGNOSTIC",
+        keep_updated=True,
+        message_data="u16",
+    ),
+    "max_capacity": SensorSchema(
+        description="Maximum boiler capacity (KW)",
+        unit_of_measurement=UNIT_KILOWATT,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+        disabled_by_default=True,
+        message="MAX_BOILER_CAPACITY",
+        keep_updated=False,
+        message_data="u8_hb",
+    ),
+    "min_mod_level": SensorSchema(
+        description="Minimum modulation level",
+        unit_of_measurement=UNIT_PERCENT,
+        accuracy_decimals=0,
+        icon="mdi:percent",
+        disabled_by_default=True,
+        state_class=STATE_CLASS_MEASUREMENT,
+        message="MAX_BOILER_CAPACITY",
+        keep_updated=False,
+        message_data="u8_lb",
+    ),
+    "opentherm_version_device": SensorSchema(
+        description="Version of OpenTherm implemented by device",
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_NONE,
+        disabled_by_default=True,
+        message="OT_VERSION_DEVICE",
+        keep_updated=False,
+        message_data="f88",
+        order=2,
+    ),
+    "device_type": SensorSchema(
+        description="Device product type",
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_NONE,
+        disabled_by_default=True,
+        message="VERSION_DEVICE",
+        keep_updated=False,
+        message_data="u8_hb",
+        order=0,
+    ),
+    "device_version": SensorSchema(
+        description="Device product version",
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_NONE,
+        disabled_by_default=True,
+        message="VERSION_DEVICE",
+        keep_updated=False,
+        message_data="u8_lb",
+        order=0,
+    ),
+    "device_id": SensorSchema(
+        description="Device ID code",
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_NONE,
+        disabled_by_default=True,
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="u8_lb",
+        order=4,
+    ),
+    "otc_hc_ratio_ub": SensorSchema(
+        description="OTC heat curve ratio upper bound",
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_NONE,
+        disabled_by_default=True,
+        message="OTC_CURVE_BOUNDS",
+        keep_updated=False,
+        message_data="u8_hb",
+    ),
+    "otc_hc_ratio_lb": SensorSchema(
+        description="OTC heat curve ratio lower bound",
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_NONE,
+        disabled_by_default=True,
+        message="OTC_CURVE_BOUNDS",
+        keep_updated=False,
+        message_data="u8_lb",
+    ),
+}
+
+
+@dataclass
+class BinarySensorSchema(EntitySchema):
+    icon: str | None = None
+    device_class: str | None = None
+    order: int | None = None
+
+
+BINARY_SENSORS: dict[str, BinarySensorSchema] = {
+    "fault_indication": BinarySensorSchema(
+        description="Status: Fault indication",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_lb_0",
+    ),
+    "ch_active": BinarySensorSchema(
+        description="Status: Central Heating active",
+        device_class=DEVICE_CLASS_HEAT,
+        icon="mdi:radiator",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_lb_1",
+    ),
+    "dhw_active": BinarySensorSchema(
+        description="Status: Domestic Hot Water active",
+        device_class=DEVICE_CLASS_HEAT,
+        icon="mdi:faucet",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_lb_2",
+    ),
+    "flame_on": BinarySensorSchema(
+        description="Status: Flame on",
+        device_class=DEVICE_CLASS_HEAT,
+        icon="mdi:fire",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_lb_3",
+    ),
+    "cooling_active": BinarySensorSchema(
+        description="Status: Cooling active",
+        device_class=DEVICE_CLASS_COLD,
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_lb_4",
+    ),
+    "ch2_active": BinarySensorSchema(
+        description="Status: Central Heating 2 active",
+        device_class=DEVICE_CLASS_HEAT,
+        icon="mdi:radiator",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_lb_5",
+    ),
+    "diagnostic_indication": BinarySensorSchema(
+        description="Status: Diagnostic event",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_lb_6",
+    ),
+    "electricity_production": BinarySensorSchema(
+        description="Status: Electricity production",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_lb_7",
+    ),
+    "dhw_present": BinarySensorSchema(
+        description="Configuration: DHW present",
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="flag8_hb_0",
+        order=4,
+    ),
+    "control_type_on_off": BinarySensorSchema(
+        description="Configuration: Control type is on/off",
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="flag8_hb_1",
+        order=4,
+    ),
+    "cooling_supported": BinarySensorSchema(
+        description="Configuration: Cooling supported",
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="flag8_hb_2",
+        order=4,
+    ),
+    "dhw_storage_tank": BinarySensorSchema(
+        description="Configuration: DHW storage tank",
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="flag8_hb_3",
+        order=4,
+    ),
+    "controller_pump_control_allowed": BinarySensorSchema(
+        description="Configuration: Controller pump control allowed",
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="flag8_hb_4",
+        order=4,
+    ),
+    "ch2_present": BinarySensorSchema(
+        description="Configuration: CH2 present",
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="flag8_hb_5",
+        order=4,
+    ),
+    "water_filling": BinarySensorSchema(
+        description="Configuration: Remote water filling",
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="flag8_hb_6",
+        order=4,
+    ),
+    "heat_mode": BinarySensorSchema(
+        description="Configuration: Heating or cooling",
+        message="DEVICE_CONFIG",
+        keep_updated=False,
+        message_data="flag8_hb_7",
+        order=4,
+    ),
+    "dhw_setpoint_transfer_enabled": BinarySensorSchema(
+        description="Remote boiler parameters: DHW setpoint transfer enabled",
+        message="REMOTE",
+        keep_updated=False,
+        message_data="flag8_hb_0",
+    ),
+    "max_ch_setpoint_transfer_enabled": BinarySensorSchema(
+        description="Remote boiler parameters: CH maximum setpoint transfer enabled",
+        message="REMOTE",
+        keep_updated=False,
+        message_data="flag8_hb_1",
+    ),
+    "dhw_setpoint_rw": BinarySensorSchema(
+        description="Remote boiler parameters: DHW setpoint read/write",
+        message="REMOTE",
+        keep_updated=False,
+        message_data="flag8_lb_0",
+    ),
+    "max_ch_setpoint_rw": BinarySensorSchema(
+        description="Remote boiler parameters: CH maximum setpoint read/write",
+        message="REMOTE",
+        keep_updated=False,
+        message_data="flag8_lb_1",
+    ),
+    "service_request": BinarySensorSchema(
+        description="Service required",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="FAULT_FLAGS",
+        keep_updated=True,
+        message_data="flag8_hb_0",
+    ),
+    "lockout_reset": BinarySensorSchema(
+        description="Lockout Reset",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="FAULT_FLAGS",
+        keep_updated=True,
+        message_data="flag8_hb_1",
+    ),
+    "low_water_pressure": BinarySensorSchema(
+        description="Low water pressure fault",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="FAULT_FLAGS",
+        keep_updated=True,
+        message_data="flag8_hb_2",
+    ),
+    "flame_fault": BinarySensorSchema(
+        description="Flame fault",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="FAULT_FLAGS",
+        keep_updated=True,
+        message_data="flag8_hb_3",
+    ),
+    "air_pressure_fault": BinarySensorSchema(
+        description="Air pressure fault",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="FAULT_FLAGS",
+        keep_updated=True,
+        message_data="flag8_hb_4",
+    ),
+    "water_over_temp": BinarySensorSchema(
+        description="Water overtemperature",
+        device_class=DEVICE_CLASS_PROBLEM,
+        message="FAULT_FLAGS",
+        keep_updated=True,
+        message_data="flag8_hb_5",
+    ),
+}
+
+
+@dataclass
+class SwitchSchema(EntitySchema):
+    default_mode: str | None = None
+
+
+SWITCHES: dict[str, SwitchSchema] = {
+    "ch_enable": SwitchSchema(
+        description="Central Heating enabled",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_hb_0",
+        default_mode="restore_default_off",
+    ),
+    "dhw_enable": SwitchSchema(
+        description="Domestic Hot Water enabled",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_hb_1",
+        default_mode="restore_default_off",
+    ),
+    "cooling_enable": SwitchSchema(
+        description="Cooling enabled",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_hb_2",
+        default_mode="restore_default_off",
+    ),
+    "otc_active": SwitchSchema(
+        description="Outside temperature compensation active",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_hb_3",
+        default_mode="restore_default_off",
+    ),
+    "ch2_active": SwitchSchema(
+        description="Central Heating 2 active",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_hb_4",
+        default_mode="restore_default_off",
+    ),
+    "summer_mode_active": SwitchSchema(
+        description="Summer mode active",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_hb_5",
+        default_mode="restore_default_off",
+    ),
+    "dhw_block": SwitchSchema(
+        description="DHW blocked",
+        message="STATUS",
+        keep_updated=True,
+        message_data="flag8_hb_6",
+        default_mode="restore_default_off",
+    ),
+}
+
+
+@dataclass
+class AutoConfigure:
+    message: str
+    message_data: str
+
+
+@dataclass
+class InputSchema(EntitySchema):
+    unit_of_measurement: str
+    step: float
+    range: tuple[int, int]
+    icon: str | None = None
+    auto_max_value: AutoConfigure | None = None
+    auto_min_value: AutoConfigure | None = None
+
+
+INPUTS: dict[str, InputSchema] = {
+    "t_set": InputSchema(
+        description="Control setpoint: temperature setpoint for the boiler's supply water",
+        unit_of_measurement=UNIT_CELSIUS,
+        step=0.1,
+        message="CH_SETPOINT",
+        keep_updated=True,
+        message_data="f88",
+        range=(0, 100),
+        auto_max_value=AutoConfigure(message="MAX_CH_SETPOINT", message_data="f88"),
+    ),
+    "t_set_ch2": InputSchema(
+        description="Control setpoint 2: temperature setpoint for the boiler's supply water on the second heating circuit",
+        unit_of_measurement=UNIT_CELSIUS,
+        step=0.1,
+        message="CH2_SETPOINT",
+        keep_updated=True,
+        message_data="f88",
+        range=(0, 100),
+        auto_max_value=AutoConfigure(message="MAX_CH_SETPOINT", message_data="f88"),
+    ),
+    "cooling_control": InputSchema(
+        description="Cooling control signal",
+        unit_of_measurement=UNIT_PERCENT,
+        step=1.0,
+        message="COOLING_CONTROL",
+        keep_updated=True,
+        message_data="f88",
+        range=(0, 100),
+    ),
+    "t_dhw_set": InputSchema(
+        description="Domestic hot water temperature setpoint",
+        unit_of_measurement=UNIT_CELSIUS,
+        step=0.1,
+        message="DHW_SETPOINT",
+        keep_updated=True,
+        message_data="f88",
+        range=(0, 127),
+        auto_min_value=AutoConfigure(message="DHW_BOUNDS", message_data="s8_lb"),
+        auto_max_value=AutoConfigure(message="DHW_BOUNDS", message_data="s8_hb"),
+    ),
+    "max_t_set": InputSchema(
+        description="Maximum allowable CH water setpoint",
+        unit_of_measurement=UNIT_CELSIUS,
+        step=0.1,
+        message="MAX_CH_SETPOINT",
+        keep_updated=True,
+        message_data="f88",
+        range=(0, 127),
+        auto_min_value=AutoConfigure(message="CH_BOUNDS", message_data="s8_lb"),
+        auto_max_value=AutoConfigure(message="CH_BOUNDS", message_data="s8_hb"),
+    ),
+    "t_room_set": InputSchema(
+        description="Current room temperature setpoint (informational)",
+        unit_of_measurement=UNIT_CELSIUS,
+        step=0.1,
+        message="ROOM_SETPOINT",
+        keep_updated=True,
+        message_data="f88",
+        range=(-40, 127),
+    ),
+    "t_room_set_ch2": InputSchema(
+        description="Current room temperature setpoint on CH2 (informational)",
+        unit_of_measurement=UNIT_CELSIUS,
+        step=0.1,
+        message="ROOM_SETPOINT_CH2",
+        keep_updated=True,
+        message_data="f88",
+        range=(-40, 127),
+    ),
+    "t_room": InputSchema(
+        description="Current sensed room temperature (informational)",
+        unit_of_measurement=UNIT_CELSIUS,
+        step=0.1,
+        message="ROOM_TEMP",
+        keep_updated=True,
+        message_data="f88",
+        range=(-40, 127),
+    ),
+    "max_rel_mod_level": InputSchema(
+        description="Maximum relative modulation level",
+        unit_of_measurement=UNIT_PERCENT,
+        step=1,
+        icon="mdi:percent",
+        message="MAX_MODULATION_LEVEL",
+        keep_updated=True,
+        message_data="f88",
+        range=(0, 100),
+    ),
+    "otc_hc_ratio": InputSchema(
+        description="OTC heat curve ratio",
+        unit_of_measurement=UNIT_CELSIUS,
+        step=0.1,
+        message="OTC_CURVE_RATIO",
+        keep_updated=True,
+        message_data="f88",
+        range=(0, 127),
+        auto_min_value=AutoConfigure(message="OTC_CURVE_BOUNDS", message_data="u8_lb"),
+        auto_max_value=AutoConfigure(message="OTC_CURVE_BOUNDS", message_data="u8_hb"),
+    ),
+}
+
+
+@dataclass
+class SettingSchema(EntitySchema):
+    backing_type: str
+    validation_schema: cv.Schema
+    default_value: Any
+    order: int | None = None
+
+
+SETTINGS: dict[str, SettingSchema] = {
+    "controller_product_type": SettingSchema(
+        description="Controller product type",
+        message="VERSION_CONTROLLER",
+        keep_updated=False,
+        message_data="u8_hb",
+        backing_type="uint8_t",
+        validation_schema=cv.int_range(min=0, max=255),
+        default_value=0,
+        order=1,
+    ),
+    "controller_product_version": SettingSchema(
+        description="Controller product version",
+        message="VERSION_CONTROLLER",
+        keep_updated=False,
+        message_data="u8_lb",
+        backing_type="uint8_t",
+        validation_schema=cv.int_range(min=0, max=255),
+        default_value=0,
+        order=1,
+    ),
+    "opentherm_version_controller": SettingSchema(
+        description="Version of OpenTherm implemented by controller",
+        message="OT_VERSION_CONTROLLER",
+        keep_updated=False,
+        message_data="f88",
+        backing_type="float",
+        validation_schema=cv.positive_float,
+        default_value=0,
+        order=3,
+    ),
+    "controller_configuration": SettingSchema(
+        description="Controller configuration",
+        message="CONTROLLER_CONFIG",
+        keep_updated=False,
+        message_data="u8_hb",
+        backing_type="uint8_t",
+        validation_schema=cv.int_range(min=0, max=255),
+        default_value=0,
+        order=5,
+    ),
+    "controller_id": SettingSchema(
+        description="Controller ID code",
+        message="CONTROLLER_CONFIG",
+        keep_updated=False,
+        message_data="u8_lb",
+        backing_type="uint8_t",
+        validation_schema=cv.int_range(min=0, max=255),
+        default_value=0,
+        order=5,
+    ),
+}

--- a/components/opentherm/sensor/__init__.py
+++ b/components/opentherm/sensor/__init__.py
@@ -1,0 +1,50 @@
+from typing import Any
+
+from esphome.components import sensor
+import esphome.config_validation as cv
+
+from .. import const, generate, schema, validate
+
+DEPENDENCIES = [const.OPENTHERM]
+COMPONENT_TYPE = const.SENSOR
+
+MSG_DATA_TYPES = {
+    "u8_lb",
+    "u8_hb",
+    "s8_lb",
+    "s8_hb",
+    "u8_lb_60",
+    "u8_hb_60",
+    "u16",
+    "s16",
+    "f88",
+}
+
+
+def get_entity_validation_schema(entity: schema.SensorSchema) -> cv.Schema:
+    return sensor.sensor_schema(
+        unit_of_measurement=entity.unit_of_measurement or cv.UNDEFINED,  # pylint: disable=protected-access
+        accuracy_decimals=entity.accuracy_decimals,
+        device_class=entity.device_class or cv.UNDEFINED,  # pylint: disable=protected-access
+        icon=entity.icon or cv.UNDEFINED,  # pylint: disable=protected-access
+        state_class=entity.state_class,
+    ).extend(
+        {
+            cv.Optional(const.CONF_DATA_TYPE): cv.one_of(*MSG_DATA_TYPES),
+        }
+    )
+
+
+CONFIG_SCHEMA = validate.create_component_schema(
+    schema.SENSORS, get_entity_validation_schema
+)
+
+
+async def to_code(config: dict[str, Any]) -> None:
+    await generate.component_to_code(
+        COMPONENT_TYPE,
+        schema.SENSORS,
+        sensor.Sensor,
+        generate.create_only_conf(sensor.new_sensor),
+        config,
+    )

--- a/components/opentherm/switch/__init__.py
+++ b/components/opentherm/switch/__init__.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+
+from .. import const, generate, schema, validate
+
+DEPENDENCIES = [const.OPENTHERM]
+COMPONENT_TYPE = const.SWITCH
+
+OpenthermSwitch = generate.opentherm_ns.class_(
+    "OpenthermSwitch", switch.Switch, cg.Component
+)
+
+
+async def new_openthermswitch(config: dict[str, Any]) -> cg.Pvariable:
+    var = await switch.new_switch(config)
+    await cg.register_component(var, config)
+    return var
+
+
+def get_entity_validation_schema(entity: schema.SwitchSchema) -> cv.Schema:
+    return switch.switch_schema(
+        OpenthermSwitch, default_restore_mode=entity.default_mode
+    ).extend(cv.COMPONENT_SCHEMA)
+
+
+CONFIG_SCHEMA = validate.create_component_schema(
+    schema.SWITCHES, get_entity_validation_schema
+)
+
+
+async def to_code(config: dict[str, Any]) -> None:
+    keys = await generate.component_to_code(
+        COMPONENT_TYPE,
+        schema.SWITCHES,
+        OpenthermSwitch,
+        generate.create_only_conf(new_openthermswitch),
+        config,
+    )
+    generate.define_readers(COMPONENT_TYPE, keys)

--- a/components/opentherm/switch/opentherm_switch.cpp
+++ b/components/opentherm/switch/opentherm_switch.cpp
@@ -1,0 +1,26 @@
+#include "opentherm_switch.h"
+
+namespace esphome::opentherm {
+
+static const char *const TAG = "opentherm.switch";
+
+void OpenthermSwitch::write_state(bool state) { this->publish_state(state); }
+
+void OpenthermSwitch::setup() {
+  auto restored = this->get_initial_state_with_restore_mode();
+  bool state = false;
+  if (!restored.has_value()) {
+    ESP_LOGD(TAG, "Couldn't restore state for OpenTherm switch '%s'", this->get_name().c_str());
+  } else {
+    ESP_LOGD(TAG, "Restored state for OpenTherm switch '%s': %d", this->get_name().c_str(), restored.value());
+    state = restored.value();
+  }
+  this->write_state(state);
+}
+
+void OpenthermSwitch::dump_config() {
+  LOG_SWITCH("", "OpenTherm Switch", this);
+  ESP_LOGCONFIG(TAG, "  Current state: %d", this->state);
+}
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/switch/opentherm_switch.h
+++ b/components/opentherm/switch/opentherm_switch.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/log.h"
+
+namespace esphome::opentherm {
+
+class OpenthermSwitch final : public switch_::Switch, public Component {
+ protected:
+  void write_state(bool state) override;
+
+ public:
+  void setup() override;
+  void dump_config() override;
+};
+
+}  // namespace esphome::opentherm

--- a/components/opentherm/validate.py
+++ b/components/opentherm/validate.py
@@ -1,0 +1,36 @@
+from collections.abc import Callable
+
+from voluptuous import Schema
+
+import esphome.config_validation as cv
+
+from . import const, generate, schema
+from .schema import TSchema
+
+
+def create_entities_schema(
+    entities: dict[str, TSchema],
+    get_entity_validation_schema: Callable[[TSchema], cv.Schema],
+) -> Schema:
+    entity_schema = {}
+    for key, entity in entities.items():
+        schema_key = (
+            cv.Optional(key, entity.default_value)
+            if hasattr(entity, "default_value")
+            else cv.Optional(key)
+        )
+        entity_schema[schema_key] = get_entity_validation_schema(entity)
+    return cv.Schema(entity_schema)
+
+
+def create_component_schema(
+    entities: dict[str, schema.EntitySchema],
+    get_entity_validation_schema: Callable[[TSchema], cv.Schema],
+) -> Schema:
+    return (
+        cv.Schema(
+            {cv.GenerateID(const.CONF_OPENTHERM_ID): cv.use_id(generate.OpenthermHub)}
+        )
+        .extend(create_entities_schema(entities, get_entity_validation_schema))
+        .extend(cv.COMPONENT_SCHEMA)
+    )

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -7,6 +7,12 @@
 # remains enabled so OpenQuatt does not disable normal tap-water operation.
 # ==============================================================================
 
+external_components:
+  - source:
+      type: local
+      path: ${external_components_path}
+    components: [opentherm]
+
 esphome:
   on_boot:
     priority: -100

--- a/tests/host/opentherm_rmt_decoder_test.cpp
+++ b/tests/host/opentherm_rmt_decoder_test.cpp
@@ -1,0 +1,159 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../../components/opentherm/opentherm_rmt_decoder.h"
+
+namespace {
+
+using esphome::opentherm::rmt_decoder::DecodeError;
+using esphome::opentherm::rmt_decoder::CaptureFailure;
+using esphome::opentherm::rmt_decoder::Pulse;
+
+uint32_t with_even_parity(uint32_t value_without_parity) {
+  value_without_parity &= 0x7FFFFFFFU;
+  if (!esphome::opentherm::rmt_decoder::has_even_parity(value_without_parity)) {
+    value_without_parity |= 0x80000000U;
+  }
+  return value_without_parity;
+}
+
+struct EncodedFrame {
+  Pulse pulses[68]{};
+  size_t size{0};
+
+  void erase_first() {
+    for (size_t index = 1; index < size; index++) {
+      pulses[index - 1U] = pulses[index];
+    }
+    size--;
+  }
+
+  void erase_last() { size--; }
+};
+
+EncodedFrame encode(uint32_t data, int jitter_us = 0) {
+  uint8_t logical_half_bits[68]{};
+  uint8_t captured_half_bits[68]{};
+  size_t half_bit_count = 0;
+  const auto append_bit = [&](bool value) {
+    logical_half_bits[half_bit_count++] = value ? 0U : 1U;
+    logical_half_bits[half_bit_count++] = value ? 1U : 0U;
+  };
+
+  append_bit(true);
+  for (int bit = 31; bit >= 0; bit--) {
+    append_bit(((data >> bit) & 1U) != 0);
+  }
+  append_bit(true);
+
+  // Inverse of the single RMT interpretation used by the decoder: the first
+  // captured half-bit is ignored, and every following half-bit is inverted.
+  captured_half_bits[0] = 0U;
+  for (size_t index = 0; index < 67U; index++) {
+    captured_half_bits[index + 1U] = logical_half_bits[index] ^ 0x1U;
+  }
+
+  EncodedFrame encoded;
+  size_t run_start = 0;
+  while (run_start < 68U) {
+    size_t run_end = run_start + 1U;
+    while (run_end < 68U && captured_half_bits[run_end] == captured_half_bits[run_start]) {
+      run_end++;
+    }
+    const int base_duration = static_cast<int>((run_end - run_start) * 500U);
+    const int signed_jitter = encoded.size % 2U == 0U ? jitter_us : -jitter_us;
+    encoded.pulses[encoded.size++] =
+        Pulse{static_cast<uint16_t>(base_duration + signed_jitter), captured_half_bits[run_start] != 0U};
+    run_start = run_end;
+  }
+  return encoded;
+}
+
+}  // namespace
+
+int main() {
+  const uint32_t data = with_even_parity(0x40001234U);
+
+  const auto nominal = encode(data);
+  auto decoded = esphome::opentherm::rmt_decoder::decode(nominal.pulses, nominal.size);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == data);
+
+  const auto jittered = encode(data, 19);
+  decoded = esphome::opentherm::rmt_decoder::decode(jittered.pulses, jittered.size);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == data);
+
+  decoded = esphome::opentherm::rmt_decoder::decode(nullptr, 0);
+  assert(decoded.error == DecodeError::TIMING);
+  assert(decoded.capture_failure == CaptureFailure::HALF_BIT_COUNT);
+  assert(decoded.pulse_count == 0U);
+  assert(decoded.half_bit_count == 0U);
+
+  auto missing_leading_half = nominal;
+  assert(missing_leading_half.pulses[0].duration_us == 500);
+  missing_leading_half.erase_first();
+  decoded =
+      esphome::opentherm::rmt_decoder::decode(missing_leading_half.pulses, missing_leading_half.size);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == data);
+
+  const uint32_t trailing_data = with_even_parity(0x40001235U);
+  auto missing_trailing_half = encode(trailing_data);
+  assert(missing_trailing_half.pulses[missing_trailing_half.size - 1U].duration_us == 500);
+  missing_trailing_half.erase_last();
+  decoded =
+      esphome::opentherm::rmt_decoder::decode(missing_trailing_half.pulses, missing_trailing_half.size);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == trailing_data);
+
+  auto glitch = nominal;
+  glitch.pulses[1].duration_us = 200;
+  decoded = esphome::opentherm::rmt_decoder::decode(glitch.pulses, glitch.size);
+  assert(decoded.error == DecodeError::GLITCH);
+  assert(decoded.capture_failure == CaptureFailure::PULSE_DURATION);
+  assert(decoded.failure_pulse_index == 1U);
+  assert(decoded.failure_pulse_duration_us == 200U);
+
+  auto invalid_timing = nominal;
+  invalid_timing.pulses[1].duration_us = 750;
+  decoded = esphome::opentherm::rmt_decoder::decode(invalid_timing.pulses, invalid_timing.size);
+  assert(decoded.error == DecodeError::TIMING);
+  assert(decoded.capture_failure == CaptureFailure::PULSE_DURATION);
+  assert(decoded.failure_pulse_index == 1U);
+  assert(decoded.failure_pulse_duration_us == 750U);
+
+  auto too_many_half_bits = nominal;
+  too_many_half_bits.pulses[too_many_half_bits.size++] = Pulse{1000U, false};
+  decoded =
+      esphome::opentherm::rmt_decoder::decode(too_many_half_bits.pulses, too_many_half_bits.size);
+  assert(decoded.error == DecodeError::TIMING);
+  assert(decoded.capture_failure == CaptureFailure::HALF_BIT_OVERFLOW);
+  assert(decoded.failure_pulse_index == too_many_half_bits.size - 1U);
+  assert(decoded.failure_pulse_duration_us == 1000U);
+  assert(decoded.half_bit_count == 68U);
+
+  auto too_few_half_bits = nominal;
+  too_few_half_bits.erase_last();
+  too_few_half_bits.erase_last();
+  decoded =
+      esphome::opentherm::rmt_decoder::decode(too_few_half_bits.pulses, too_few_half_bits.size);
+  assert(decoded.error == DecodeError::TIMING);
+  assert(decoded.capture_failure == CaptureFailure::HALF_BIT_COUNT);
+  assert(decoded.failure_pulse_index == too_few_half_bits.size);
+  assert(decoded.failure_pulse_duration_us == 0U);
+  assert(decoded.half_bit_count < 67U);
+
+  auto invalid_manchester = nominal;
+  invalid_manchester.pulses[1].level = invalid_manchester.pulses[0].level;
+  decoded =
+      esphome::opentherm::rmt_decoder::decode(invalid_manchester.pulses, invalid_manchester.size);
+  assert(decoded.error != DecodeError::NONE);
+
+  const auto invalid_parity = encode(data ^ 0x1U);
+  decoded = esphome::opentherm::rmt_decoder::decode(invalid_parity.pulses, invalid_parity.size);
+  assert(decoded.error == DecodeError::PARITY);
+
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Vendort uitsluitend de ESPHome 2026.7.0 `opentherm`-component en vervangt op ESP32 de timer-sampled boilerresponse door hardware-RMT-capture.
- Decodeert Manchester-frames begrensd in de hoofdloop en sluit completion/timeout-races atomair.
- Zet de masteruitgang bij `OpenTherm::stop()` expliciet terug naar hetzelfde idle-high niveau als tijdens initialisatie, zodat een transportwissel geen afgebroken half-bit op GPIO48 laat staan.
- Voegt een hosttest toe voor nominale frames, jitter, grens-halfbits, glitches, timing, Manchester, stopbit en parity.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De OpenTherm master blijft protocolmatig gelijk, maar ESP32-responseontvangst gebruikt RMT in plaats van 5 kHz timer-sampling. De volledige vendored component is bytegelijk aan ESPHome 2026.7.0 behalve de expliciet gedocumenteerde RMT- en idle-outputdelta. Dit is een draft/researchkandidaat en geen releaseklare dependency fork.

De expliciete idle-write maakt stoppen fysiek fail-silent. Hij claimt niet dat de ketel een laatste `CH Enable=false`-frame heeft ontvangen of bevestigd; die begrensde afbouwbeslissing blijft een afzonderlijke productgate.

## Achtergrond

De standaard ESPHome-ontvanger gaf op de Q-hardware incidenteel `NO_TRANSITION` en `NO_CHANGE_TOO_LONG`, terwijl de simulator geldige responses verzond. De RMT-variant doorstond een transportsoak van 62 minuten en een geselecteerde-route-soak van negen uur zonder master-RX-protocolfout. Actieve commissioning, linkverlies, herstel, minimum-uit-tijd en R1-interlock zijn eveneens doorlopen.

Een runtimewissel kan de hub midden in een Manchester-frame stoppen. De ingebouwde `OpenTherm::stop()` stopt de timer, maar schrijft het uitgangsniveau niet terug. Daardoor kon het laatste fysieke half-bit blijven staan. De kandidaat herstelt na het stoppen altijd het idle-high niveau dat `initialize()` ook gebruikt.

De resterende communicatiefout ligt aantoonbaar elders: in async mode ziet de simulator nog master-TX-decodefouten die met OpenQuatt-response-time-outs correleren. Een GPTimer-priority-3 A/B-test hielp niet en is niet opgenomen. Deze PR blijft daarom draft tot master-TX/bus/simulator-RX is opgelost, echte-ketel-HIL en langdurige OTT+OTB-HIL groen zijn en een upstreamroute is gekozen.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een interne transportkandidaat zonder nieuwe gebruikersinstelling of entity. Onderzoeksachtergrond en exacte ESPHome-delta staan naast de override in `components/opentherm/README.openquatt-research.md`.

## Audit

De complete PR-diff tegen #363 en de delta tegen ESPHome 2026.7.0 zijn opnieuw koud beoordeeld. De idle-write gebeurt pas nadat timer en RMT zijn gestopt, vanuit de normale componentcontext; selectiecallbacks bedienen de hub pas na `setup()`. De wijziging introduceert geen allocatie, wachtroutine of nieuwe callback.

Open failure boundaries:

- de ketel bevestigt niet noodzakelijk een laatste CH-off-frame vóór de bus stil wordt;
- async master-TX/bus/simulator-RX produceert nog incidentele request-decodefouten;
- echte-ketel- en langdurige OTT+OTB-validatie ontbreken;
- de componentoverride moet bij voorkeur worden vervangen door een upstream ESPHome-fix.

## Validatie

- `./scripts/run_host_regression_tests.sh` — 3/3 groen.
- `python3 scripts/dev.py validate --venv-dir .venv --config-only --config configs/heatpump_controller_q/single_wifi.yaml` — style, docs, webcontract en config groen.
- `.venv/bin/esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — ESPHome 2026.7.0 groen; RAM 215543/341760 B (63.1%), flash 1957919/5242880 B (37.3%).
- `npm run check:web` — 71/71 groen; gegenereerde bundles actueel.
- R1 runtimegating: simulatorrequests en OTB-time-outs blijven exact vlak.
- R1 bootrestore: simulatorrequestteller bleef exact gelijk over reboot; nul OTB-responses/time-outs, link uit.
- RMT RX: geen `NO_TRANSITION`/`NO_CHANGE_TOO_LONG` in de geselecteerde negen-uurssoak of actieve commandotest.
- Open releaseblokker: async master-TX veroorzaakt nog simulator-RX-decodefouten en corresponderende response-time-outs.


## Prior art en upstreamstrategie

[Oleg Tarasovs experimentele `opentherm-dev`-branch](https://github.com/olegtarasov/esphome/tree/opentherm-dev) gebruikt op ESP32 RMT voor zowel RX als TX. Dit is relevante prior art, maar de branch splitst de component in een andere base-/platformarchitectuur en gebruikt een andere decoder en state-machine. Die grotere refactor wordt daarom niet in deze PR overgenomen.

Deze PR blijft bewust beperkt tot:

- RMT voor ontvangst van ketelresponses;
- de expliciete idle-high-correctie in `stop()`;
- regressietests en HIL voor precies die delta.

Vervolg en upstreamwerk worden gesplitst:

1. een kleine idle-high-`stop()`-PR tegen actuele ESPHome `dev`;
2. afzonderlijk RMT-RX tegen actuele ESPHome `dev`;
3. RMT-TX pas later, uitsluitend wanneer een gecontroleerde A/B-test de resterende master-TX/requestfouten aantoonbaar oplost.

Beslisregel: helpt RMT-RX voldoende, dan blijft upstream RX-only. Verdwijnen ook de gecorreleerde requestfouten met RMT-TX, dan volgt daarvoor een aparte PR. Helpt RMT-TX niet, dan voegen we die complexiteit niet toe en gaat het onderzoek verder op simulator-, bus- en hardwarepad.
