### PR TITLE
Confirm OpenTherm off frames before transport stop

### DIFF
--- a/openquatt/includes/boiler/oq_otb_off_flush.h
+++ b/openquatt/includes/boiler/oq_otb_off_flush.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace oq_otb {
+
+constexpr uint8_t OFF_FLUSH_TYPE_READ_DATA = 0;
+constexpr uint8_t OFF_FLUSH_TYPE_WRITE_DATA = 1;
+constexpr uint8_t OFF_FLUSH_TYPE_READ_ACK = 4;
+constexpr uint8_t OFF_FLUSH_TYPE_WRITE_ACK = 5;
+constexpr uint8_t OFF_FLUSH_ID_STATUS = 0;
+constexpr uint8_t OFF_FLUSH_ID_CH_SETPOINT = 1;
+
+class OffFlushState {
+ public:
+  void begin() {
+    this->active_ = true;
+    this->status_off_sent_ = false;
+    this->setpoint_zero_sent_ = false;
+    this->status_off_acknowledged_ = false;
+    this->setpoint_zero_acknowledged_ = false;
+  }
+
+  void end() { this->active_ = false; }
+
+  void record_request(
+      uint8_t message_id, uint8_t message_type,
+      uint8_t value_hb, uint8_t value_lb) {
+    if (!this->active_) return;
+
+    if (message_id == OFF_FLUSH_ID_STATUS &&
+        message_type == OFF_FLUSH_TYPE_READ_DATA &&
+        (value_hb & 0x01U) == 0U) {
+      this->status_off_sent_ = true;
+    } else if (
+        message_id == OFF_FLUSH_ID_CH_SETPOINT &&
+        message_type == OFF_FLUSH_TYPE_WRITE_DATA &&
+        value_hb == 0U && value_lb == 0U) {
+      this->setpoint_zero_sent_ = true;
+    }
+  }
+
+  void record_response(
+      uint8_t message_id, uint8_t message_type,
+      uint8_t value_hb, uint8_t value_lb) {
+    if (!this->active_) return;
+
+    if (message_id == OFF_FLUSH_ID_STATUS &&
+        message_type == OFF_FLUSH_TYPE_READ_ACK &&
+        this->status_off_sent_) {
+      this->status_off_acknowledged_ = true;
+    } else if (
+        message_id == OFF_FLUSH_ID_CH_SETPOINT &&
+        message_type == OFF_FLUSH_TYPE_WRITE_ACK &&
+        value_hb == 0U && value_lb == 0U &&
+        this->setpoint_zero_sent_) {
+      this->setpoint_zero_acknowledged_ = true;
+    }
+  }
+
+  bool active() const { return this->active_; }
+  bool complete() const {
+    return this->status_off_acknowledged_ &&
+           this->setpoint_zero_acknowledged_;
+  }
+  bool status_off_acknowledged() const {
+    return this->status_off_acknowledged_;
+  }
+  bool setpoint_zero_acknowledged() const {
+    return this->setpoint_zero_acknowledged_;
+  }
+
+ private:
+  bool active_{false};
+  bool status_off_sent_{false};
+  bool setpoint_zero_sent_{false};
+  bool status_off_acknowledged_{false};
+  bool setpoint_zero_acknowledged_{false};
+};
+
+inline OffFlushState off_flush_state;
+
+}  // namespace oq_otb

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -38,12 +38,10 @@ esphome:
     priority: 700
     then:
       - lambda: |-
-          // Best-effort normal shutdown handshake. Hard power loss remains
-          // inherently fail-silent because no OpenTherm requests are sent.
-          id(oq_otb_ch_enable).turn_off();
-          auto call = id(oq_otb_t_set_command).make_call();
-          call.set_value(0.0f);
-          call.perform();
+          // A normal shutdown gets one bounded opportunity to deliver and
+          // acknowledge STATUS(CH=off) plus TSet=0 before the hub is stopped.
+          // Hard power loss remains inherently fail-silent.
+          id(oq_otb_withdraw_and_flush).execute();
           id(oq_boiler_transport_active) = false;
 
 logger:
@@ -84,6 +82,11 @@ opentherm:
     ch2_active: false
     summer_mode_active: false
     dhw_block: false
+    before_send:
+      then:
+        - lambda: |-
+            oq_otb::off_flush_state.record_request(
+                x.id, x.type, x.valueHB, x.valueLB);
     before_process_response:
       then:
         - lambda: |-
@@ -93,6 +96,8 @@ opentherm:
             // entities and hide the frame from ESPHome's payload-only processor.
             const uint8_t response_id = x.id;
             const uint8_t response_type = x.type;
+            oq_otb::off_flush_state.record_response(
+                response_id, response_type, x.valueHB, x.valueLB);
             oq_otb::telemetry_state.record_response(
                 millis(), response_id, response_type);
 
@@ -153,6 +158,60 @@ opentherm:
                 break;
             }
             x.id = 0xFF;
+
+script:
+  - id: oq_otb_withdraw_and_flush
+    mode: single
+    then:
+      - lambda: |-
+          // Phase 1: withdraw the local command before sending any new frame.
+          // A fresh link is the runtime proof that the hub can converse.
+          // Component::is_in_loop_state() is deliberately not used here:
+          // runtime transport gating can report LOOP_DONE during this edge
+          // even though the active session still needs its final off frames.
+          const bool can_confirm =
+              id(oq_otb_hub_ready) &&
+              id(oq_otb_link_available_state);
+          if (can_confirm) {
+            oq_otb::off_flush_state.begin();
+          }
+
+          id(oq_otb_ch_enable).turn_off();
+          auto call = id(oq_otb_t_set_command).make_call();
+          call.set_value(0.0f);
+          call.perform();
+
+          if (!can_confirm) return;
+
+          // Phase 2: advance only the OT hub until both off requests are
+          // acknowledged or the bounded shutdown budget is exhausted.
+          constexpr uint32_t flush_timeout_ms = 3500;
+          const uint32_t started_ms = millis();
+          while (!oq_otb::off_flush_state.complete() &&
+                 (uint32_t) (millis() - started_ms) < flush_timeout_ms) {
+            id(oq_otb_hub).loop();
+            App.feed_wdt();
+            delay(1);
+          }
+
+          // Phase 3: retain a clear diagnostic without blocking shutdown.
+          const uint32_t elapsed_ms =
+              (uint32_t) (millis() - started_ms);
+          if (oq_otb::off_flush_state.complete()) {
+            ESP_LOGI(
+                "quatt.boiler",
+                "OpenTherm off handshake acknowledged in %u ms",
+                (unsigned) elapsed_ms);
+          } else {
+            ESP_LOGW(
+                "quatt.boiler",
+                "OpenTherm off handshake timed out after %u ms "
+                "(STATUS=%s, TSet=%s)",
+                (unsigned) elapsed_ms,
+                YESNO(oq_otb::off_flush_state.status_off_acknowledged()),
+                YESNO(oq_otb::off_flush_state.setpoint_zero_acknowledged()));
+          }
+          oq_otb::off_flush_state.end();
 
 number:
   - platform: opentherm

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -6,18 +6,21 @@ substitutions:
   oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=1" # Enable Q-only local sensor paths.
   oq_otb_supported: "true"                             # GPIO47/GPIO48 provide the boiler OpenTherm master transport.
   oq_boiler_transport_selection_extra: |-
-    oq_otb::telemetry_state.reset_link_session();
-    id(oq_otb_link_initialized) = true;
-    id(oq_otb_link_available_state) = false;
-    id(otb_link_available).publish_state(false);
+    // Preserve the old session until a leaving-OpenTherm off flush has had
+    // its bounded acknowledgement opportunity.
     if (id(oq_otb_hub_ready)) {
       if (x == "OpenTherm") {
         id(oq_otb_hub).enable_loop();
       } else {
+        id(oq_otb_withdraw_and_flush).execute();
         id(oq_otb_hub).on_shutdown();
         id(oq_otb_hub).disable_loop();
       }
     }
+    oq_otb::telemetry_state.reset_link_session();
+    id(oq_otb_link_initialized) = true;
+    id(oq_otb_link_available_state) = false;
+    id(otb_link_available).publish_state(false);
   oq_boiler_transport_shutdown_extra: "id(oq_otb_ch_enable).turn_off(); { auto call = id(oq_otb_t_set_command).make_call(); call.set_value(0.0f); call.perform(); }" # Withdraw OTB synchronously on every transport edge.
   oq_local_supply_temp_sensor_id: "water_supply_temp_pt1000" # Q-edition local PT1000 source.
   oq_local_supply_temp_selector_id: "oq_local_supply_temp_source" # Explicit local physical-sensor selection.

--- a/tests/host/ot_boiler_off_flush_test.cpp
+++ b/tests/host/ot_boiler_off_flush_test.cpp
@@ -1,0 +1,74 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "openquatt/includes/boiler/oq_otb_off_flush.h"
+
+using oq_otb::OffFlushState;
+
+int main() {
+  OffFlushState state;
+
+  assert(!state.active());
+  assert(!state.complete());
+
+  state.begin();
+  assert(state.active());
+
+  // Acknowledgements from requests that were already in flight before begin()
+  // must not complete the shutdown handshake.
+  state.record_response(
+      oq_otb::OFF_FLUSH_ID_STATUS,
+      oq_otb::OFF_FLUSH_TYPE_READ_ACK, 0, 0);
+  state.record_response(
+      oq_otb::OFF_FLUSH_ID_CH_SETPOINT,
+      oq_otb::OFF_FLUSH_TYPE_WRITE_ACK, 0, 0);
+  assert(!state.status_off_acknowledged());
+  assert(!state.setpoint_zero_acknowledged());
+
+  // An active STATUS request and a non-zero setpoint are not off commands.
+  state.record_request(
+      oq_otb::OFF_FLUSH_ID_STATUS,
+      oq_otb::OFF_FLUSH_TYPE_READ_DATA, 1, 0);
+  state.record_request(
+      oq_otb::OFF_FLUSH_ID_CH_SETPOINT,
+      oq_otb::OFF_FLUSH_TYPE_WRITE_DATA, 60, 0);
+  state.record_response(
+      oq_otb::OFF_FLUSH_ID_STATUS,
+      oq_otb::OFF_FLUSH_TYPE_READ_ACK, 0, 0);
+  state.record_response(
+      oq_otb::OFF_FLUSH_ID_CH_SETPOINT,
+      oq_otb::OFF_FLUSH_TYPE_WRITE_ACK, 60, 0);
+  assert(!state.complete());
+
+  state.record_request(
+      oq_otb::OFF_FLUSH_ID_STATUS,
+      oq_otb::OFF_FLUSH_TYPE_READ_DATA, 0, 0);
+  state.record_response(
+      oq_otb::OFF_FLUSH_ID_STATUS,
+      oq_otb::OFF_FLUSH_TYPE_READ_ACK, 0, 0);
+  assert(state.status_off_acknowledged());
+  assert(!state.complete());
+
+  state.record_request(
+      oq_otb::OFF_FLUSH_ID_CH_SETPOINT,
+      oq_otb::OFF_FLUSH_TYPE_WRITE_DATA, 0, 0);
+  state.record_response(
+      oq_otb::OFF_FLUSH_ID_CH_SETPOINT,
+      oq_otb::OFF_FLUSH_TYPE_WRITE_ACK, 0, 1);
+  assert(!state.setpoint_zero_acknowledged());
+  state.record_response(
+      oq_otb::OFF_FLUSH_ID_CH_SETPOINT,
+      oq_otb::OFF_FLUSH_TYPE_WRITE_ACK, 0, 0);
+  assert(state.setpoint_zero_acknowledged());
+  assert(state.complete());
+
+  state.end();
+  assert(!state.active());
+
+  // A new flush generation may not reuse acknowledgements from the previous one.
+  state.begin();
+  assert(!state.complete());
+  state.end();
+
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Stuurt vóór normale shutdown en een wissel van OpenTherm naar R1 expliciet nieuwe `STATUS(CH Enable=false)`- en `CH_SETPOINT(TSet=0)`-requests.
- Volgt uitsluitend acknowledgements die ná het begin van deze off-flush bij die nieuwe requests horen.
- Stopt na beide ACKs, of altijd begrensd na maximaal 3,5 seconde, en voegt gerichte hostregressiedekking toe.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De lokale ketelvraag wordt nog steeds direct ingetrokken. Nieuw is dat de actieve OpenTherm-sessie vóór het stoppen een begrensde kans krijgt om de twee off-opdrachten daadwerkelijk af te leveren en te bevestigen. Bij een ontbrekende of niet-reagerende link blijft de afloop fail-silent; een harde stroomuitval kan inherent geen laatste frame versturen.

## Achtergrond

Voorheen werden alleen de lokale ESPHome-entities op uit/0 gezet en werd de hub direct daarna gestopt. Zonder een extra hubcyclus bewees dat niet dat de ketel een laatste off-frame had ontvangen.

`OffFlushState` accepteert geen oude of niet-passende response: eerst moet in de actuele flush een STATUS-request met CH uit respectievelijk een zero-TSet-write zijn waargenomen. Daarna zijn een `READ_ACK` en een zero-`WRITE_ACK` vereist.

Deze PR is bewust gestapeld op #375. De core-RMT/idle-outputwijziging blijft daardoor apart reviewbaar van de productlifecycle.

Cold/adversarial audit omvatte:

- een reeds in-flight request bij het starten van de flush;
- response-uitval, time-out en ontbrekende ACK;
- routewissel met verse en onbeschikbare link;
- normale reboot/OTA versus harde stroomuitval;
- R1/OTB-exclusiviteit en stoppen van de hub na de wissel;
- runtime enable/disable-interleaving. HIL toonde aan dat `Component::is_in_loop_state()` hier geen betrouwbare gate is; hub-ready plus een verse OTB-link vormen daarom de bevestigingsgate.

Open releasegates blijven de bestaande master-TX/bus/simulator-RX-timingafwijking, echte-ketel-HIL en de voorbereide scopemeting.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit verandert uitsluitend de interne lifecycle-afbouw en introduceert geen bediening, entity of installatiekeuze. De lokale OTB-implementatie- en HIL-tracker is wel bijgewerkt.

## Validatie

- `./scripts/run_host_regression_tests.sh` — 4/4 hosttests groen.
- `npm run check:web` — 75/75 webtests, gegenereerde bundles en budgetten groen.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — style/docs/webcontract/config groen met ESPHome 2026.7.0.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — groen; DIRAM 215.607/341.760 B (63,1%), image 1.959.251 B.
- Simulator-HIL, normaal ACK-pad: OT→R1 leverde vier nieuwe requests, eindigde met `CH Enable=OFF` en `TSet=0`, waarna de requestteller vlak bleef.
- Simulator-HIL, response-uitval: negen best-effort requests binnen de 3,5 s-grens; daarna bleef requestcount exact `210158` gedurende tien seconden vlak. Responses vervolgens hersteld.
- Actieve rebootcapture: bij een commissioningopdracht van 60 °C zag de simulator vóór de reboot CH uit en `TSet=0`; na boot bleef de route fail-safe uit.
- Exact gerebaseerde topbinary: R1-bootrequestcount `210158 → 210158`; afsluitende OT→R1-smoke `210207 → 210216 → 210216`, R1/CH uit, `TSet=0`, simulatorresponses aan.

Geteste OTA SHA-256: `c9fe387445124c1b189266533b57d135c550c16a7ac5f64a6f59205b1c2d2b3b`.
