### PR TITLE
Use RMT for OpenTherm request transmission

### DIFF
--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -274,8 +274,13 @@ void OpenthermHub::sync_loop_() {
     return;
   }
 
-  // Check for errors and ensure we are in the right state (message sent successfully)
+  // ESP32 RMT closes the TX-to-RX handover in the TX-complete ISR, so the
+  // first spin can cover the complete request/response exchange. Other
+  // platforms still stop at SENT and enter the existing listen phase below.
   if (this->handle_error_(this->opentherm_->get_mode())) {
+    return;
+  } else if (this->opentherm_->has_message()) {
+    this->read_response_();
     return;
   } else if (!this->opentherm_->is_sent()) {
     ESP_LOGW(TAG, "Unexpected state after sending request: %s",

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -53,7 +53,7 @@ bool OpenTherm::initialize() {
   this->out_pin_->digital_write(true);
 
 #ifdef USE_ESP32
-  return this->init_esp32_timer_() && this->init_esp32_rmt_();
+  return this->init_esp32_timer_() && this->init_esp32_rmt_() && this->init_esp32_rmt_tx_();
 #else
   return true;
 #endif
@@ -95,11 +95,17 @@ void OpenTherm::send(OpenthermData &data) {
     this->data_ = this->data_ | 0x80000000;
   }
 
-  this->clock_ = 1;     // clock starts at HIGH
-  this->bit_pos_ = 33;  // count down (33 == start bit, 32-1 data, 0 == stop bit)
   this->mode_ = OperationMode::WRITE;
 
+#ifdef USE_ESP32
+  if (!this->start_esp32_rmt_tx_()) {
+    this->mode_ = OperationMode::ERROR_TIMER;
+  }
+#else
+  this->clock_ = 1;     // clock starts at HIGH
+  this->bit_pos_ = 33;  // count down (33 == start bit, 32-1 data, 0 == stop bit)
   this->start_write_timer_();
+#endif
 }
 
 bool OpenTherm::get_message(OpenthermData &data) {
@@ -131,6 +137,7 @@ void OpenTherm::stop() {
   this->stop_timer_();
 #ifdef USE_ESP32
   this->cancel_esp32_rmt_();
+  this->cancel_esp32_rmt_tx_();
 #endif
   // A runtime transport change can stop an in-flight request. Always restore
   // the master output to its initialized idle level instead of leaving the
@@ -353,6 +360,163 @@ bool OpenTherm::init_esp32_rmt_() {
   return true;
 }
 
+bool OpenTherm::init_esp32_rmt_tx_() {
+  rmt_tx_channel_config_t config{};
+  config.gpio_num = static_cast<gpio_num_t>(this->out_pin_->get_pin());
+  config.clk_src = RMT_CLK_SRC_DEFAULT;
+  config.resolution_hz = 1000000;
+  config.mem_block_symbols = 48;
+  config.trans_queue_depth = 1;
+  config.intr_priority = 0;
+  config.flags.invert_out = false;
+  config.flags.with_dma = false;
+  config.flags.init_level = true;
+  config.flags.io_loop_back = false;
+  config.flags.io_od_mode = false;
+  config.flags.allow_pd = false;
+
+  esp_err_t result = rmt_new_tx_channel(&config, &this->rmt_tx_channel_);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to create RMT TX channel: %s", esp_err_to_name(result));
+    this->rmt_tx_channel_ = nullptr;
+    return false;
+  }
+
+  rmt_copy_encoder_config_t encoder_config{};
+  result = rmt_new_copy_encoder(&encoder_config, &this->rmt_tx_encoder_);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to create RMT TX encoder: %s", esp_err_to_name(result));
+    rmt_del_channel(this->rmt_tx_channel_);
+    this->rmt_tx_channel_ = nullptr;
+    return false;
+  }
+
+  rmt_tx_event_callbacks_t callbacks{};
+  callbacks.on_trans_done = OpenTherm::rmt_tx_done_callback_;
+  result = rmt_tx_register_event_callbacks(this->rmt_tx_channel_, &callbacks, this);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to register RMT TX callback: %s", esp_err_to_name(result));
+    rmt_del_encoder(this->rmt_tx_encoder_);
+    this->rmt_tx_encoder_ = nullptr;
+    rmt_del_channel(this->rmt_tx_channel_);
+    this->rmt_tx_channel_ = nullptr;
+    return false;
+  }
+
+  result = rmt_enable(this->rmt_tx_channel_);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to enable RMT TX channel: %s", esp_err_to_name(result));
+    rmt_del_encoder(this->rmt_tx_encoder_);
+    this->rmt_tx_encoder_ = nullptr;
+    rmt_del_channel(this->rmt_tx_channel_);
+    this->rmt_tx_channel_ = nullptr;
+    return false;
+  }
+
+  if (!this->restore_esp32_rmt_tx_idle_()) {
+    return false;
+  }
+
+  ESP_LOGCONFIG(TAG, "OpenTherm RMT transmit active on GPIO%u",
+                static_cast<unsigned>(this->out_pin_->get_pin()));
+  return true;
+}
+
+bool OpenTherm::restore_esp32_rmt_tx_idle_() {
+  if (this->rmt_tx_channel_ == nullptr || this->rmt_tx_encoder_ == nullptr) {
+    return false;
+  }
+
+  // Attach or recover the RMT peripheral without producing an OpenTherm edge.
+  rmt_symbol_word_t idle_symbol{};
+  idle_symbol.level0 = 1;
+  idle_symbol.duration0 = 10;
+  idle_symbol.level1 = 1;
+  idle_symbol.duration1 = 10;
+  rmt_transmit_config_t transmit_config{};
+  transmit_config.loop_count = 0;
+  transmit_config.flags.eot_level = 1;
+  esp_err_t result = rmt_transmit(this->rmt_tx_channel_, this->rmt_tx_encoder_, &idle_symbol,
+                                  sizeof(idle_symbol), &transmit_config);
+  if (result == ESP_OK) {
+    result = rmt_tx_wait_all_done(this->rmt_tx_channel_, 100);
+  }
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to restore RMT TX idle level: %s", esp_err_to_name(result));
+    return false;
+  }
+  return true;
+}
+
+bool OpenTherm::start_esp32_rmt_tx_() {
+  if (this->rmt_tx_channel_ == nullptr || this->rmt_tx_encoder_ == nullptr) {
+    ESP_LOGE(TAG, "RMT TX is not initialized");
+    return false;
+  }
+
+  auto encode_bit = [](bool bit) {
+    rmt_symbol_word_t symbol{};
+    symbol.level0 = bit ? 0 : 1;
+    symbol.duration0 = 500;
+    symbol.level1 = bit ? 1 : 0;
+    symbol.duration1 = 500;
+    return symbol;
+  };
+
+  this->rmt_tx_symbols_[0] = encode_bit(true);
+  for (int bit = 31; bit >= 0; bit--) {
+    this->rmt_tx_symbols_[32 - bit] = encode_bit(read_bit(this->data_, bit) != 0);
+  }
+  this->rmt_tx_symbols_[33] = encode_bit(true);
+
+  portENTER_CRITICAL(&this->rmt_mux_);
+  this->rmt_tx_active_ = true;
+  portEXIT_CRITICAL(&this->rmt_mux_);
+
+  rmt_transmit_config_t config{};
+  config.loop_count = 0;
+  config.flags.eot_level = 1;
+  const esp_err_t result =
+      rmt_transmit(this->rmt_tx_channel_, this->rmt_tx_encoder_, this->rmt_tx_symbols_,
+                   sizeof(this->rmt_tx_symbols_), &config);
+  if (result != ESP_OK) {
+    portENTER_CRITICAL(&this->rmt_mux_);
+    this->rmt_tx_active_ = false;
+    portEXIT_CRITICAL(&this->rmt_mux_);
+    ESP_LOGE(TAG, "Failed to start RMT TX: %s", esp_err_to_name(result));
+    this->timer_error_ = result;
+    this->timer_error_type_ = TimerErrorType::TIMER_START_ERROR;
+    return false;
+  }
+  return true;
+}
+
+void OpenTherm::cancel_esp32_rmt_tx_() {
+  bool active = false;
+  portENTER_CRITICAL(&this->rmt_mux_);
+  active = this->rmt_tx_active_;
+  this->rmt_tx_active_ = false;
+  portEXIT_CRITICAL(&this->rmt_mux_);
+
+  if (!active || this->rmt_tx_channel_ == nullptr) {
+    return;
+  }
+
+  const esp_err_t disable_result = rmt_disable(this->rmt_tx_channel_);
+  if (disable_result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to cancel RMT TX: %s", esp_err_to_name(disable_result));
+    return;
+  }
+  const esp_err_t enable_result = rmt_enable(this->rmt_tx_channel_);
+  if (enable_result != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to re-enable RMT TX: %s", esp_err_to_name(enable_result));
+    return;
+  }
+  if (!this->restore_esp32_rmt_tx_idle_()) {
+    ESP_LOGE(TAG, "Failed to recover the RMT TX idle level after cancellation");
+  }
+}
+
 bool OpenTherm::arm_esp32_rmt_() {
   if (this->rmt_rx_channel_ == nullptr) {
     return false;
@@ -420,6 +584,22 @@ bool IRAM_ATTR OpenTherm::rmt_rx_done_callback_(rmt_channel_handle_t,
     // Claim the completed frame immediately while keeping the bounded
     // Manchester decode in the main loop.
     instance->mode_ = OperationMode::RMT_PENDING;
+  }
+  portEXIT_CRITICAL_ISR(&instance->rmt_mux_);
+  return false;
+}
+
+bool IRAM_ATTR OpenTherm::rmt_tx_done_callback_(rmt_channel_handle_t,
+                                                const rmt_tx_done_event_data_t *, void *user_ctx) {
+  auto *instance = static_cast<OpenTherm *>(user_ctx);
+  if (instance == nullptr) {
+    return false;
+  }
+
+  portENTER_CRITICAL_ISR(&instance->rmt_mux_);
+  if (instance->rmt_tx_active_ && instance->mode_ == OperationMode::WRITE) {
+    instance->rmt_tx_active_ = false;
+    instance->mode_ = OperationMode::SENT;
   }
   portEXIT_CRITICAL_ISR(&instance->rmt_mux_);
   return false;

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -136,6 +136,11 @@ bool OpenTherm::get_protocol_error(OpenThermError &error) {
 void OpenTherm::stop() {
   this->stop_timer_();
 #ifdef USE_ESP32
+  // Invalidate both RMT callbacks before cancelling either channel. Without
+  // this claim, a TX-complete ISR could arm RX between the two cancellations.
+  portENTER_CRITICAL(&this->rmt_mux_);
+  this->mode_ = OperationMode::IDLE;
+  portEXIT_CRITICAL(&this->rmt_mux_);
   this->cancel_esp32_rmt_();
   this->cancel_esp32_rmt_tx_();
 #endif
@@ -355,6 +360,10 @@ bool OpenTherm::init_esp32_rmt_() {
     return false;
   }
 
+  this->rmt_rx_config_.signal_range_min_ns = 3187;
+  this->rmt_rx_config_.signal_range_max_ns = 2500000;
+  this->rmt_rx_config_.flags.en_partial_rx = false;
+
   ESP_LOGCONFIG(TAG, "OpenTherm RMT receive capture active on GPIO%u",
                 static_cast<unsigned>(this->in_pin_->get_pin()));
   return true;
@@ -465,7 +474,12 @@ bool OpenTherm::start_esp32_rmt_tx_() {
 
   portENTER_CRITICAL(&this->rmt_mux_);
   this->rmt_tx_active_ = true;
-  this->rmt_tx_deadline_us_ = micros() + RMT_TX_TIMEOUT_US;
+  const uint32_t tx_started_us = micros();
+  this->rmt_tx_deadline_us_ = tx_started_us + RMT_TX_TIMEOUT_US;
+  this->receive_deadline_us_ =
+      tx_started_us +
+      static_cast<uint32_t>(RMT_TX_SYMBOLS * 2U * rmt_encoder::HALF_BIT_DURATION_US) +
+      static_cast<uint32_t>(this->device_timeout_) * 1000U;
   portEXIT_CRITICAL(&this->rmt_mux_);
 
   rmt_transmit_config_t config{};
@@ -523,11 +537,6 @@ bool OpenTherm::arm_esp32_rmt_() {
     return false;
   }
 
-  rmt_receive_config_t config{};
-  config.signal_range_min_ns = 3187;
-  config.signal_range_max_ns = 2500000;
-  config.flags.en_partial_rx = false;
-
   portENTER_CRITICAL(&this->rmt_mux_);
   this->rmt_symbol_count_ = 0;
   this->rmt_frame_ready_ = false;
@@ -535,7 +544,8 @@ bool OpenTherm::arm_esp32_rmt_() {
   portEXIT_CRITICAL(&this->rmt_mux_);
 
   const esp_err_t result =
-      rmt_receive(this->rmt_rx_channel_, this->rmt_rx_symbols_, sizeof(this->rmt_rx_symbols_), &config);
+      rmt_receive(this->rmt_rx_channel_, this->rmt_rx_symbols_, sizeof(this->rmt_rx_symbols_),
+                  &this->rmt_rx_config_);
   if (result != ESP_OK) {
     portENTER_CRITICAL(&this->rmt_mux_);
     this->rmt_armed_ = false;
@@ -600,7 +610,26 @@ bool IRAM_ATTR OpenTherm::rmt_tx_done_callback_(rmt_channel_handle_t,
   portENTER_CRITICAL_ISR(&instance->rmt_mux_);
   if (instance->rmt_tx_active_ && instance->mode_ == OperationMode::WRITE) {
     instance->rmt_tx_active_ = false;
-    instance->mode_ = OperationMode::SENT;
+    instance->rmt_symbol_count_ = 0;
+    instance->rmt_frame_ready_ = false;
+    // Close the request/response handover inside the TX-complete ISR. Waiting
+    // for the application loop to observe SENT can miss an early boiler
+    // response when another component temporarily delays that loop.
+    // ESP-IDF explicitly permits rmt_receive() from ISR context. Keep the
+    // component lock until the handover is armed so stop() cannot cancel the
+    // channel between our state claim and the driver call.
+    const esp_err_t result =
+        rmt_receive(instance->rmt_rx_channel_, instance->rmt_rx_symbols_,
+                    sizeof(instance->rmt_rx_symbols_), &instance->rmt_rx_config_);
+    if (result == ESP_OK) {
+      instance->rmt_armed_ = true;
+      instance->mode_ = OperationMode::LISTEN;
+    } else {
+      instance->rmt_armed_ = false;
+      instance->timer_error_ = result;
+      instance->timer_error_type_ = TimerErrorType::TIMER_START_ERROR;
+      instance->mode_ = OperationMode::ERROR_TIMER;
+    }
   }
   portEXIT_CRITICAL_ISR(&instance->rmt_mux_);
   return false;

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -370,7 +370,7 @@ bool OpenTherm::init_esp32_rmt_tx_() {
   config.intr_priority = 0;
   config.flags.invert_out = false;
   config.flags.with_dma = false;
-  config.flags.init_level = true;
+  config.flags.init_level = rmt_encoder::IDLE_LEVEL;
   config.flags.io_loop_back = false;
   config.flags.io_od_mode = false;
   config.flags.allow_pd = false;
@@ -429,13 +429,13 @@ bool OpenTherm::restore_esp32_rmt_tx_idle_() {
 
   // Attach or recover the RMT peripheral without producing an OpenTherm edge.
   rmt_symbol_word_t idle_symbol{};
-  idle_symbol.level0 = 1;
+  idle_symbol.level0 = rmt_encoder::IDLE_LEVEL;
   idle_symbol.duration0 = 10;
-  idle_symbol.level1 = 1;
+  idle_symbol.level1 = rmt_encoder::IDLE_LEVEL;
   idle_symbol.duration1 = 10;
   rmt_transmit_config_t transmit_config{};
   transmit_config.loop_count = 0;
-  transmit_config.flags.eot_level = 1;
+  transmit_config.flags.eot_level = rmt_encoder::IDLE_LEVEL;
   esp_err_t result = rmt_transmit(this->rmt_tx_channel_, this->rmt_tx_encoder_, &idle_symbol,
                                   sizeof(idle_symbol), &transmit_config);
   if (result == ESP_OK) {
@@ -454,28 +454,23 @@ bool OpenTherm::start_esp32_rmt_tx_() {
     return false;
   }
 
-  auto encode_bit = [](bool bit) {
-    rmt_symbol_word_t symbol{};
-    symbol.level0 = bit ? 0 : 1;
-    symbol.duration0 = 500;
-    symbol.level1 = bit ? 1 : 0;
-    symbol.duration1 = 500;
-    return symbol;
-  };
-
-  this->rmt_tx_symbols_[0] = encode_bit(true);
-  for (int bit = 31; bit >= 0; bit--) {
-    this->rmt_tx_symbols_[32 - bit] = encode_bit(read_bit(this->data_, bit) != 0);
+  for (size_t index = 0; index < RMT_TX_SYMBOLS; index++) {
+    const auto encoded = rmt_encoder::encode_frame_symbol(this->data_, index);
+    auto &symbol = this->rmt_tx_symbols_[index];
+    symbol.level0 = encoded.level0;
+    symbol.duration0 = encoded.duration0_us;
+    symbol.level1 = encoded.level1;
+    symbol.duration1 = encoded.duration1_us;
   }
-  this->rmt_tx_symbols_[33] = encode_bit(true);
 
   portENTER_CRITICAL(&this->rmt_mux_);
   this->rmt_tx_active_ = true;
+  this->rmt_tx_deadline_us_ = micros() + RMT_TX_TIMEOUT_US;
   portEXIT_CRITICAL(&this->rmt_mux_);
 
   rmt_transmit_config_t config{};
   config.loop_count = 0;
-  config.flags.eot_level = 1;
+  config.flags.eot_level = rmt_encoder::IDLE_LEVEL;
   const esp_err_t result =
       rmt_transmit(this->rmt_tx_channel_, this->rmt_tx_encoder_, this->rmt_tx_symbols_,
                    sizeof(this->rmt_tx_symbols_), &config);
@@ -502,19 +497,25 @@ void OpenTherm::cancel_esp32_rmt_tx_() {
     return;
   }
 
+  this->reset_esp32_rmt_tx_();
+}
+
+bool OpenTherm::reset_esp32_rmt_tx_() {
   const esp_err_t disable_result = rmt_disable(this->rmt_tx_channel_);
   if (disable_result != ESP_OK) {
     ESP_LOGE(TAG, "Failed to cancel RMT TX: %s", esp_err_to_name(disable_result));
-    return;
+    return false;
   }
   const esp_err_t enable_result = rmt_enable(this->rmt_tx_channel_);
   if (enable_result != ESP_OK) {
     ESP_LOGE(TAG, "Failed to re-enable RMT TX: %s", esp_err_to_name(enable_result));
-    return;
+    return false;
   }
   if (!this->restore_esp32_rmt_tx_idle_()) {
     ESP_LOGE(TAG, "Failed to recover the RMT TX idle level after cancellation");
+    return false;
   }
+  return true;
 }
 
 bool OpenTherm::arm_esp32_rmt_() {
@@ -606,6 +607,21 @@ bool IRAM_ATTR OpenTherm::rmt_tx_done_callback_(rmt_channel_handle_t,
 }
 
 void OpenTherm::process_esp32_rmt_() {
+  bool transmit_timed_out = false;
+  portENTER_CRITICAL(&this->rmt_mux_);
+  if (this->mode_ == OperationMode::WRITE && this->rmt_tx_active_ &&
+      static_cast<int32_t>(micros() - this->rmt_tx_deadline_us_) >= 0) {
+    this->rmt_tx_active_ = false;
+    this->mode_ = OperationMode::ERROR_TIMEOUT;
+    transmit_timed_out = true;
+  }
+  portEXIT_CRITICAL(&this->rmt_mux_);
+  if (transmit_timed_out) {
+    this->reset_esp32_rmt_tx_();
+    ESP_LOGW(TAG, "RMT transmit completion timed out");
+    return;
+  }
+
   if (this->mode_ != OperationMode::LISTEN && this->mode_ != OperationMode::RMT_PENDING) {
     return;
   }

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -12,6 +12,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include "opentherm_rmt_encoder.h"
+
 #ifdef USE_ESP32
 #include "driver/gptimer.h"
 #include "driver/rmt_rx.h"
@@ -44,7 +46,7 @@ enum OperationMode {
   RMT_PENDING = 6,  // ESP32 hardware captured a frame; main-loop decode pending
 
   ERROR_PROTOCOL = 8,  // protocol error, can happed only during READ
-  ERROR_TIMEOUT = 9,   // timeout while waiting for response from device, only during LISTEN
+  ERROR_TIMEOUT = 9,   // timeout while sending or waiting for a response
   ERROR_TIMER = 10     // error operating the ESP32 timer
 };
 
@@ -375,7 +377,8 @@ class OpenTherm {
 
 #ifdef USE_ESP32
   static constexpr size_t RMT_CAPTURE_SYMBOLS = 96;
-  static constexpr size_t RMT_TX_SYMBOLS = 34;
+  static constexpr size_t RMT_TX_SYMBOLS = rmt_encoder::FRAME_SYMBOLS;
+  static constexpr uint32_t RMT_TX_TIMEOUT_US = 100000;
   gptimer_handle_t timer_handle_{nullptr};
   gptimer_alarm_config_t alarm_config_{
       .alarm_count = 0,
@@ -392,6 +395,7 @@ class OpenTherm {
   volatile bool rmt_armed_{false};
   volatile bool rmt_frame_ready_{false};
   volatile bool rmt_tx_active_{false};
+  uint32_t rmt_tx_deadline_us_{0};
   uint32_t receive_deadline_us_{0};
 #endif
 
@@ -414,6 +418,7 @@ class OpenTherm {
   bool arm_esp32_rmt_();
   bool start_esp32_rmt_tx_();
   bool restore_esp32_rmt_tx_idle_();
+  bool reset_esp32_rmt_tx_();
   void cancel_esp32_rmt_();
   void cancel_esp32_rmt_tx_();
   void process_esp32_rmt_();

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -15,6 +15,7 @@
 #ifdef USE_ESP32
 #include "driver/gptimer.h"
 #include "driver/rmt_rx.h"
+#include "driver/rmt_tx.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/portmacro.h"
 #endif
@@ -356,6 +357,8 @@ class OpenTherm {
   static bool timer_isr(gptimer_handle_t timer, const gptimer_alarm_event_data_t *edata, void *user_ctx);
   static bool IRAM_ATTR rmt_rx_done_callback_(rmt_channel_handle_t channel,
                                              const rmt_rx_done_event_data_t *event, void *user_ctx);
+  static bool IRAM_ATTR rmt_tx_done_callback_(rmt_channel_handle_t channel,
+                                             const rmt_tx_done_event_data_t *event, void *user_ctx);
 #else
   static bool timer_isr(OpenTherm *arg);
 #endif
@@ -372,6 +375,7 @@ class OpenTherm {
 
 #ifdef USE_ESP32
   static constexpr size_t RMT_CAPTURE_SYMBOLS = 96;
+  static constexpr size_t RMT_TX_SYMBOLS = 34;
   gptimer_handle_t timer_handle_{nullptr};
   gptimer_alarm_config_t alarm_config_{
       .alarm_count = 0,
@@ -380,10 +384,14 @@ class OpenTherm {
   };
   rmt_channel_handle_t rmt_rx_channel_{nullptr};
   rmt_symbol_word_t rmt_rx_symbols_[RMT_CAPTURE_SYMBOLS]{};
+  rmt_channel_handle_t rmt_tx_channel_{nullptr};
+  rmt_encoder_handle_t rmt_tx_encoder_{nullptr};
+  rmt_symbol_word_t rmt_tx_symbols_[RMT_TX_SYMBOLS]{};
   portMUX_TYPE rmt_mux_ = portMUX_INITIALIZER_UNLOCKED;
   volatile size_t rmt_symbol_count_{0};
   volatile bool rmt_armed_{false};
   volatile bool rmt_frame_ready_{false};
+  volatile bool rmt_tx_active_{false};
   uint32_t receive_deadline_us_{0};
 #endif
 
@@ -402,8 +410,12 @@ class OpenTherm {
 
   bool init_esp32_timer_();
   bool init_esp32_rmt_();
+  bool init_esp32_rmt_tx_();
   bool arm_esp32_rmt_();
+  bool start_esp32_rmt_tx_();
+  bool restore_esp32_rmt_tx_idle_();
   void cancel_esp32_rmt_();
+  void cancel_esp32_rmt_tx_();
   void process_esp32_rmt_();
   void start_esp32_timer_(uint64_t alarm_value, bool auto_reload);
 #endif

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -386,6 +386,7 @@ class OpenTherm {
       .flags = {.auto_reload_on_alarm = true},
   };
   rmt_channel_handle_t rmt_rx_channel_{nullptr};
+  rmt_receive_config_t rmt_rx_config_{};
   rmt_symbol_word_t rmt_rx_symbols_[RMT_CAPTURE_SYMBOLS]{};
   rmt_channel_handle_t rmt_tx_channel_{nullptr};
   rmt_encoder_handle_t rmt_tx_encoder_{nullptr};

--- a/components/opentherm/opentherm_rmt_encoder.h
+++ b/components/opentherm/opentherm_rmt_encoder.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace esphome::opentherm::rmt_encoder {
+
+static constexpr size_t FRAME_SYMBOLS = 34;
+static constexpr uint16_t HALF_BIT_DURATION_US = 500;
+static constexpr bool IDLE_LEVEL = true;
+
+struct Symbol {
+  bool level0;
+  uint16_t duration0_us;
+  bool level1;
+  uint16_t duration1_us;
+};
+
+inline Symbol encode_bit(bool bit) {
+  return Symbol{
+      .level0 = !bit,
+      .duration0_us = HALF_BIT_DURATION_US,
+      .level1 = bit,
+      .duration1_us = HALF_BIT_DURATION_US,
+  };
+}
+
+inline bool frame_bit(uint32_t data, size_t symbol_index) {
+  if (symbol_index == 0 || symbol_index == FRAME_SYMBOLS - 1U) {
+    return true;
+  }
+  if (symbol_index >= FRAME_SYMBOLS) {
+    return false;
+  }
+  return ((data >> (32U - symbol_index)) & 0x1U) != 0;
+}
+
+inline Symbol encode_frame_symbol(uint32_t data, size_t symbol_index) {
+  return encode_bit(frame_bit(data, symbol_index));
+}
+
+}  // namespace esphome::opentherm::rmt_encoder

--- a/tests/host/opentherm_rmt_encoder_test.cpp
+++ b/tests/host/opentherm_rmt_encoder_test.cpp
@@ -1,0 +1,41 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../../components/opentherm/opentherm_rmt_encoder.h"
+
+namespace {
+
+namespace encoder = esphome::opentherm::rmt_encoder;
+
+void assert_symbol(const encoder::Symbol &symbol, bool bit) {
+  assert(symbol.level0 == !bit);
+  assert(symbol.duration0_us == 500U);
+  assert(symbol.level1 == bit);
+  assert(symbol.duration1_us == 500U);
+}
+
+}  // namespace
+
+int main() {
+  static_assert(encoder::FRAME_SYMBOLS == 34U);
+  static_assert(encoder::HALF_BIT_DURATION_US == 500U);
+  static_assert(encoder::IDLE_LEVEL);
+
+  assert_symbol(encoder::encode_bit(false), false);
+  assert_symbol(encoder::encode_bit(true), true);
+
+  const uint32_t data = 0xA5963CC3U;
+  assert(encoder::frame_bit(data, 0U));
+  assert(encoder::frame_bit(data, encoder::FRAME_SYMBOLS - 1U));
+  for (size_t symbol_index = 1; symbol_index < encoder::FRAME_SYMBOLS - 1U; symbol_index++) {
+    const bool expected = ((data >> (32U - symbol_index)) & 0x1U) != 0;
+    assert(encoder::frame_bit(data, symbol_index) == expected);
+    assert_symbol(encoder::encode_frame_symbol(data, symbol_index), expected);
+  }
+  assert(!encoder::frame_bit(data, encoder::FRAME_SYMBOLS));
+
+  assert_symbol(encoder::encode_frame_symbol(data, 0U), true);
+  assert_symbol(encoder::encode_frame_symbol(data, encoder::FRAME_SYMBOLS - 1U), true);
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Vervangt op ESP32 alleen de OpenTherm-mastertransmissie door hardware-RMT; RMT-RX uit #375 blijft ongewijzigd.
- Encodeert startbit, 32 databits en stopbit als 34 vaste Manchester-symbolen van 500/500 µs en houdt de uitgang vóór en na transmissie idle-high.
- Activeert RMT-RX direct vanuit de TX-completioncallback, zodat een belaste application loop het begin van een vroeg ketelantwoord niet kan missen.
- Voegt een recoverable TX-watchdog van 100 ms, veilige abort/reset en een pure hosttest voor bitvolgorde, polariteit en timing toe.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de fysieke OpenTherm-master-TX-timing en de aansluitende RX-arm op ESP32 wijzigen. De berichtinhoud, pollset, heating strategies, ketelcommando's, R1-interlock en gebruikersconfiguratie blijven gelijk. Een uitblijvende RMT-completion wordt na 100 ms fail-closed afgebroken, naar idle-high hersteld en via de bestaande recoverable timeoutroute opnieuw geprobeerd.

## Achtergrond

De GPTimer-transmitter leverde onder async simulatorbelasting incidenteel een niet-decodeerbaar masterrequest op. De simulator stuurde dan terecht geen antwoord, waarna de OpenQuatt-master een response-timeout registreerde. Een hogere GPTimer-interruptprioriteit hielp niet.

Gecontroleerde A/B op dezelfde OpenQuatt Q en simulator:

- GPTimer: circa 508 requests, `+4` simulator invalid/RX-decode/RX-timing en `+2` master transport/response-timeouts.
- RMT-TX verwijderde deze requestfouten, maar de eerste versie kon bij 50 ms responsevertraging onder circa 800 L/h en Modbusbelasting nog een geldig simulatorantwoord missen.
- Dezelfde belasting was bij 100 ms foutvrij. De oorzaak was de application-loopovergang van TX-completion naar RX-arm; RX wordt daarom nu direct in de TX-completioncallback gestart.
- Definitieve implementatie: circa 929 responses bij 50 ms en circa 1.100 responses bij de OpenTherm-minimumvertraging 20 ms zonder nieuwe master- of simulatorfout.

Deze PR is de bovenste laag van de gestapelde OTB-reeks:
**#347 → #348 → #349 → #350 → #351 → #363 → #375 → #376 → #377**.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een interne transportimplementatie. De volledige OTB-productroute gaat eerst via `dev` naar echte-keteltests. Definitieve gebruikersdocumentatie en HA-entitycuratie volgen vóór vrijgave naar `main`.

## Audit

De volledige samengestelde stack tegen actuele `origin/dev` is opnieuw koud/adversarieel beoordeeld op:

- startup, restore, transportselectie en verse installatie;
- R1/OTB-exclusiviteit en break-before-make;
- stale of ongeldige strategy-output;
- linkverlies, herstel, OTA/runtime-pauze en shutdown;
- off-flush, timeouts, retry en harde stroomuitval;
- RMT TX/RX-lifecycle, ISR/main-loop-interleaving, bufferlevensduur en watchdog;
- CM3-eigenaarschap, minimumtijden, demotie en CM100;
- DHW-permissie, telemetryprivacy en non-Q-compilatie.

Geen nieuwe blokkerende finding resteert voor opname in `dev`. De lage bootheapwatermark wordt apart onderzocht: de gemeten runtimeheap bleef stabiel rond 78 kB, maar `Heap Min Free` bereikte 5.539 B. Dit is een expliciete observatie- en releasegate vóór `main`, geen aangetoonde OpenTherm-transportfout.

Scopekarakterisering blijft nuttig als elektrische bevestiging, maar is na de foutloze RMT-soaks geen software-mergegate meer. Echte-ketel-HIL blijft verplicht vóór productvrijgave.

## Validatie

- `git diff --check origin/dev...HEAD` — groen.
- `./scripts/run_host_regression_tests.sh` — 5/5 groen.
- `npm run check:web` — 75/75 groen; gegenereerde bundles en budgetten actueel.
- Configvalidatie groen voor Q single/duo wifi/ethernet.
- GitHub CI op #377 groen voor hosttests, docs, websettings en de volledige profielmatrix.
- Heating Curve-HIL: ruim vijf minuten CM3; exact `TSet=38,0 °C`; R1 uit; geen master- of simulatorfoutdelta.
- Power House-HIL: ruim vijf minuten CM3; doel circa 42,3–42,5 °C; simulator binnen circa 0,02 °C; R1 uit; geen steady-state foutdelta.
- Geselecteerde OpenTherm-route: negen uur passief groen zonder master- of simulatorfoutdelta.
- Gecombineerde OTT+OTB-test: eerst passief, daarna meerdere echte CM100-OTB-cycli op 60 °C met circa 800 L/h Modbus/flowbelasting; beide warmtepompen bleven 0 Hz/Standby.
- Actieve einddelta: `+16.604` complete OTB-responses en `+16.629` simulatorrequests; alle gevolgde master- en simulatorfoutdelta's 0.
- Herstelcontrole: `CM0`, flow 0 L/h, command/CH uit, `TSet=0`, R1 uit, OTT/OTB-links geldig en fouttellers vlak terwijl responses doorliepen.

Veilige eindstatus: Boiler connection `OpenTherm`, `CM0`, R1 uit, ketelcommando uit, simulator `CH Enable=OFF` en `TSet=0`.
