### PR TITLE
Curate OpenTherm boiler entities for Home Assistant

### DIFF
--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -239,6 +239,10 @@ switch:
       restore_mode: ALWAYS_OFF
       icon: mdi:radiator
 
+# Keep Home Assistant lean: expose primary operational values by default,
+# publish secondary status as disabled-by-default, and keep service/protocol
+# telemetry internal. The OpenQuatt entity endpoint deliberately includes
+# internal entities, so local diagnostics retain access to that telemetry.
 binary_sensor:
   - platform: template
     id: otb_link_available
@@ -255,35 +259,36 @@ binary_sensor:
       id: otb_fault_indication
       name: "OTB - Fault Indication"
       entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
     ch_active:
       id: otb_ch_active
       name: "OTB - Central Heating Active"
-      entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
     dhw_active:
       id: otb_dhw_active
       name: "OTB - Domestic Hot Water Active"
-      entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
     flame_on:
       id: otb_flame_on
       name: "OTB - Flame On"
-      entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
     diagnostic_indication:
       id: otb_diagnostic_indication
       name: "OTB - Diagnostic Indication"
       entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
     dhw_present:
       id: otb_dhw_present
       name: "OTB - DHW Present"
+      internal: true
       entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
@@ -291,11 +296,13 @@ binary_sensor:
       id: otb_service_request
       name: "OTB - Service Required"
       entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
     lockout_reset:
       id: otb_lockout_reset
       name: "OTB - Lockout Reset"
+      internal: true
       entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
@@ -303,24 +310,28 @@ binary_sensor:
       id: otb_low_water_pressure
       name: "OTB - Low Water Pressure"
       entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
     flame_fault:
       id: otb_flame_fault
       name: "OTB - Flame Fault"
       entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
     air_pressure_fault:
       id: otb_air_pressure_fault
       name: "OTB - Air Pressure Fault"
       entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
     water_over_temp:
       id: otb_water_over_temp
       name: "OTB - Water Overtemperature"
       entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
 
@@ -330,48 +341,47 @@ sensor:
     rel_mod_level:
       id: otb_relative_modulation
       name: "OTB - Relative Modulation"
-      entity_category: diagnostic
+      disabled_by_default: true
       web_server:
         sorting_group_id: oq_boiler
     ch_pressure:
       id: otb_ch_pressure
       name: "OTB - CH Water Pressure"
-      entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
     t_boiler:
       id: otb_boiler_water_temp
       name: "OTB - Boiler Water Temperature"
-      entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
     t_ret:
       id: otb_return_water_temp
       name: "OTB - Return Water Temperature"
-      entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
     t_dhw:
       id: otb_dhw_temp
       name: "OTB - Domestic Hot Water Temperature"
-      entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
     oem_fault_code:
       id: otb_oem_fault_code
       name: "OTB - OEM Fault Code"
+      internal: true
       entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
     oem_diagnostic_code:
       id: otb_oem_diagnostic_code
       name: "OTB - OEM Diagnostic Code"
+      internal: true
       entity_category: diagnostic
       web_server:
         sorting_group_id: oq_boiler
     max_capacity:
       id: otb_max_capacity
       name: "OTB - Maximum Boiler Capacity"
+      internal: true
       entity_category: diagnostic
       disabled_by_default: true
       web_server:
@@ -379,6 +389,7 @@ sensor:
     min_mod_level:
       id: otb_min_modulation
       name: "OTB - Minimum Modulation"
+      internal: true
       entity_category: diagnostic
       disabled_by_default: true
       web_server:
@@ -386,6 +397,7 @@ sensor:
     opentherm_version_device:
       id: otb_opentherm_version
       name: "OTB - OpenTherm Device Version"
+      internal: true
       entity_category: diagnostic
       disabled_by_default: true
       web_server:
@@ -393,6 +405,7 @@ sensor:
     device_type:
       id: otb_device_type
       name: "OTB - Device Type"
+      internal: true
       entity_category: diagnostic
       disabled_by_default: true
       web_server:
@@ -400,6 +413,7 @@ sensor:
     device_version:
       id: otb_device_version
       name: "OTB - Device Product Version"
+      internal: true
       entity_category: diagnostic
       disabled_by_default: true
       web_server:
@@ -408,6 +422,7 @@ sensor:
   - platform: template
     id: otb_last_response_age
     name: "OTB - Last Response Age"
+    internal: true
     icon: mdi:timer-outline
     unit_of_measurement: "s"
     accuracy_decimals: 1
@@ -423,6 +438,7 @@ sensor:
   - platform: template
     id: otb_response_count
     name: "OTB - Valid Response Count"
+    internal: true
     icon: mdi:counter
     accuracy_decimals: 0
     state_class: total_increasing
@@ -436,6 +452,7 @@ sensor:
   - platform: template
     id: otb_complete_response_count
     name: "OTB - Complete Response Count"
+    internal: true
     icon: mdi:counter
     accuracy_decimals: 0
     state_class: total_increasing
@@ -450,6 +467,7 @@ sensor:
   - platform: template
     id: otb_data_invalid_response_count
     name: "OTB - DATA_INVALID Response Count"
+    internal: true
     icon: mdi:alert-circle-outline
     accuracy_decimals: 0
     state_class: total_increasing
@@ -464,6 +482,7 @@ sensor:
   - platform: template
     id: otb_unknown_data_id_response_count
     name: "OTB - UNKNOWN_DATAID Response Count"
+    internal: true
     icon: mdi:help-circle-outline
     accuracy_decimals: 0
     state_class: total_increasing
@@ -478,6 +497,7 @@ sensor:
   - platform: template
     id: otb_unexpected_response_type_count
     name: "OTB - Unexpected Response Type Count"
+    internal: true
     icon: mdi:message-alert-outline
     accuracy_decimals: 0
     state_class: total_increasing
@@ -492,6 +512,7 @@ sensor:
   - platform: template
     id: otb_transport_error_count
     name: "OTB - Transport Error Count"
+    internal: true
     icon: mdi:alert-octagon-outline
     accuracy_decimals: 0
     state_class: total_increasing
@@ -506,6 +527,7 @@ sensor:
   - platform: template
     id: otb_protocol_error_count
     name: "OTB - Protocol Error Count"
+    internal: true
     icon: mdi:pulse
     accuracy_decimals: 0
     state_class: total_increasing
@@ -520,6 +542,7 @@ sensor:
   - platform: template
     id: otb_response_timeout_count
     name: "OTB - Response Timeout Count"
+    internal: true
     icon: mdi:timer-alert-outline
     accuracy_decimals: 0
     state_class: total_increasing
@@ -534,6 +557,7 @@ sensor:
   - platform: template
     id: otb_no_transition_count
     name: "OTB - NO_TRANSITION Count"
+    internal: true
     icon: mdi:chart-timeline-variant-shimmer
     accuracy_decimals: 0
     state_class: total_increasing
@@ -548,6 +572,7 @@ sensor:
   - platform: template
     id: otb_no_change_too_long_count
     name: "OTB - NO_CHANGE_TOO_LONG Count"
+    internal: true
     icon: mdi:chart-timeline-variant-shimmer
     accuracy_decimals: 0
     state_class: total_increasing
@@ -562,6 +587,7 @@ sensor:
   - platform: template
     id: otb_last_transport_error_age
     name: "OTB - Last Transport Error Age"
+    internal: true
     icon: mdi:timer-alert-outline
     unit_of_measurement: "s"
     accuracy_decimals: 1
@@ -579,6 +605,7 @@ sensor:
   - platform: template
     id: otb_last_response_id
     name: "OTB - Last Response Message ID"
+    internal: true
     icon: mdi:identifier
     accuracy_decimals: 0
     entity_category: diagnostic
@@ -593,6 +620,7 @@ text_sensor:
   - platform: template
     id: otb_last_response_type
     name: "OTB - Last Response Type"
+    internal: true
     icon: mdi:message-text-outline
     entity_category: diagnostic
     disabled_by_default: true
@@ -605,6 +633,7 @@ text_sensor:
   - platform: template
     id: otb_last_transport_error
     name: "OTB - Last Transport Error"
+    internal: true
     icon: mdi:alert-decagram-outline
     entity_category: diagnostic
     disabled_by_default: true


### PR DESCRIPTION
# Wat verandert deze PR?

- Houdt zeven primaire OpenTherm-ketelwaarden standaard zichtbaar in Home Assistant.
- Markeert negen secundaire bedrijfs- en storingssignalen als `disabled_by_default`.
- Houdt 24 service-, capability- en protocolentiteiten intern; de eigen `/openquatt/entities`-endpoint blijft deze interne diagnosewaarden uitlezen.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Deze PR wijzigt uitsluitend ESPHome-entitymetadata. OpenTherm-polling, ketelcommando's, interlocks, lokale diagnostiek en entity-ID's/namen blijven ongewijzigd.

De standaard HA-set bestaat na deze wijziging uit Boiler Link Available, Central Heating Active, Flame On, CH Water Pressure en de drie keteltemperaturen. Secundaire signalen blijven optioneel inschakelbaar. Continu veranderende responsetellers en laag-niveau protocolgegevens worden niet meer via de native HA-API gepubliceerd.

## Achtergrond

De eerste OTB-versie publiceerde vrijwel alle ketel- en transportdiagnostiek aan Home Assistant. Dat maakte de devicepagina onnodig groot en liet snel veranderende servicetellers door HA verwerken. De OpenQuatt-webapp gebruikt `/openquatt/entities`, die bewust ook interne entiteiten retourneert; lokale diagnosefunctionaliteit blijft daarom behouden.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een curation van standaard entity-exposure vóór de eerste OTB-release op `main`; er veranderen geen gebruikersinstellingen, entitynamen of bedieningsmogelijkheden.

## Validatie

- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — pass met ESPHome 2026.7.0.
- `git diff --check` — pass.
- Volledige diff gecontroleerd op HA-exposure, lokale interne entitytoegang, entitycompatibiliteit en afwezigheid van runtime/controlwijzigingen.
