### PR TITLE
Relax dashboard documentation impact check

### DIFF
--- a/.github/docs-impact.json
+++ b/.github/docs-impact.json
@@ -66,16 +66,6 @@
       ]
     },
     {
-      "name": "Home Assistant-dashboards",
-      "source_patterns": [
-        "docs/dashboard/*.yaml"
-      ],
-      "docs_any_of": [
-        "docs/dashboard/README.md",
-        "docs/dashboardoverzicht.md"
-      ]
-    },
-    {
       "name": "Regelstrategieën en flow",
       "source_patterns": [
         "openquatt/oq_boiler_control.yaml",

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -383,24 +383,8 @@ def main() -> int:
             if phrase not in home_text:
                 add(findings, "docs/dashboardoverzicht.md", 1, f"Missing dashboard docs phrase: {phrase}")
 
-    # 3) Advisory changed-file guards for likely doc drift.
+    # 3) Changed-file documentation impact guards.
     if args.changed_only and changed:
-        if any_changed(
-            changed,
-            {
-                "docs/dashboard/openquatt_ha_dashboard_duo_en.yaml",
-                "docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml",
-                "docs/dashboard/openquatt_ha_dashboard_single_nl.yaml",
-                "docs/dashboard/openquatt_ha_dashboard_single_en.yaml",
-            },
-        ) and not any_changed(changed, {"docs/dashboardoverzicht.md"}):
-            add(
-                findings,
-                "docs/dashboardoverzicht.md",
-                1,
-                "Dashboard YAML changed; consider updating docs/dashboardoverzicht.md.",
-                severity="warning",
-            )
         check_docs_impact(findings, changed, docs_impact_rules)
 
     if not findings:

--- a/scripts/tests/test_check_docs_consistency.py
+++ b/scripts/tests/test_check_docs_consistency.py
@@ -79,6 +79,37 @@ Docs-impact motivatie:
         self.assertIn("Gebruikersentiteiten en instellingen raakt gebruikersdocumentatie", output)
         self.assertNotIn("Service/debug entities changed", output)
 
+    def test_dashboard_yaml_change_does_not_require_markdown_change(self) -> None:
+        exit_code, output = self.run_strict_check(
+            "",
+            changed_file="docs/dashboard/openquatt_ha_dashboard_duo_en.yaml",
+        )
+
+        self.assertEqual(0, exit_code, output)
+        self.assertIn("Docs consistency checks passed.", output)
+
+    def test_dashboard_view_contract_still_fails_on_title_drift(self) -> None:
+        parse_titles = check_docs_consistency.parse_dashboard_titles
+
+        def titles_with_drift(path: Path) -> list[str]:
+            titles = parse_titles(path)
+            if path.name == "openquatt_ha_dashboard_duo_en.yaml":
+                return [*titles, "Unexpected"]
+            return titles
+
+        with mock.patch.object(
+            check_docs_consistency,
+            "parse_dashboard_titles",
+            side_effect=titles_with_drift,
+        ):
+            exit_code, output = self.run_strict_check(
+                "",
+                changed_file="docs/dashboard/openquatt_ha_dashboard_duo_en.yaml",
+            )
+
+        self.assertEqual(1, exit_code, output)
+        self.assertIn("View titles differ from expected", output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert de generieke verplichting om bij iedere wijziging in `docs/dashboard/*.yaml` ook Markdown-documentatie aan te passen.
- Behoudt de inhoudelijke dashboardcontroles op verwachte viewtitels en vereiste documentatiefrasen.
- Voegt regressietests toe voor beide gedragingen.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de docs-impactcontrole in CI verandert. Firmware, dashboards en gebruikersfunctionaliteit blijven ongewijzigd.

## Achtergrond

De bestaande check behandelde iedere dashboard-YAML-wijziging als documentatie-impact. Daardoor faalden ook URL-, afbeeldings- en andere onderhoudswijzigingen tenzij een inhoudelijk overbodige Markdown-wijziging of PR-uitzondering werd toegevoegd.

De volledige diff tegen `main` is gecontroleerd op PR- en pushgedrag, configuratievaliditeit en behoud van de bestaande semantische dashboardcontracten. De docs-impactregels voor andere onderdelen blijven ongewijzigd. Bekend gevolg is dat dashboardwijzigingen buiten de expliciete contractcontroles niet automatisch om Markdown vragen; documentatie-impact daarvan blijft een reviewbeslissing.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit verandert alleen wanneer CI aanvullende dashboarddocumentatie afdwingt; er verandert geen gebruikersgericht dashboardgedrag of documentatiecontract.

## Validatie

- `npm run check:docs`
- `python3 scripts/check_docs_consistency.py --changed-only --strict --changed-file docs/dashboard/openquatt_ha_dashboard_duo_en.yaml`
- `git diff --check origin/main...HEAD`