### PR TITLE
Bump firmware version to v0.45.0

### DIFF
--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -13,7 +13,7 @@
 device_name: "openquatt"                              # Internal ESPHome device ID / hostname base.
 friendly_name: OpenQuatt                              # Display name in Home Assistant / UI.
 project_name: "openquatt.openquatt"                   # ESPHome project identifier shown in firmware metadata.
-project_version: "v0.44.2"                            # ESPHome project version shown in firmware metadata.
+project_version: "v0.45.0"                            # ESPHome project version shown in firmware metadata.
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
 oq_hardware_profile: "unknown"                        # Compile-time hardware profile id.
 oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=0" # Hardware capability flag for C++ lambdas.


### PR DESCRIPTION
# Wat verandert deze PR?

- Zet `project_version` op `v0.45.0` op de actuele, reeds gemergde `main`-releasekandidaat.
- Bereidt exact die commit voor op de stabiele tag `v0.45.0`.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [x] Anders

Versiebump voor een stabiele release.

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Alleen de user-facing firmwaremetadata verandert van `v0.44.2` naar `v0.45.0`. De backports zelf zijn al via #383 in `main` gemergd.

## Achtergrond

#383 werd al gemergd voordat de versiecommit aan de branch was toegevoegd. Deze aparte PR zorgt ervoor dat de stabiele tag naar een `main`-commit wijst die ook intern `v0.45.0` rapporteert.

## Audit

De complete diff tegen de actuele `origin/main` is integraal en daarna koud gecontroleerd: exact één regel wijzigt, `release_channel: main` blijft behouden, de stabiele manifestselectie blijft ongewijzigd en de tag `v0.45.0` bestaat nog niet. De bron-tree is identiek aan de eerder volledig gecompileerde releasekandidaat (`ed377ce42e815b771f48dc516a8bcd892a99f267`).

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is uitsluitend de geplande releaseversie; er verandert geen gebruikersworkflow of configuratiecontract.

## Validatie

- `esphome config configs/heatpump_controller_q/duo_wifi.yaml` met ESPHome 2026.7.0 — groen; bevestigt `project_version: v0.45.0` en `release_channel: main`.
- Volledige Q Duo Wi-Fi-compile op dezelfde bron-tree — groen; RAM 210.407/341.760 B (61,6%), flash 1.916.155/5.242.880 B (36,5%).
- `git diff --check origin/main...HEAD` — groen.
