### PR TITLE
Reduce startup heap pressure

### DIFF
--- a/components/openquatt_debug_recorder/OpenQuattDebugRecorder.cpp
+++ b/components/openquatt_debug_recorder/OpenQuattDebugRecorder.cpp
@@ -546,11 +546,11 @@ uint32_t OpenQuattDebugRecorder::capture_value_(const DebugField &field) {
     case FieldType::SYSTEM_UPTIME_MS:
       return millis();
     case FieldType::SYSTEM_FREE_HEAP:
-      return heap_caps_get_free_size(MALLOC_CAP_8BIT);
+      return heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
     case FieldType::SYSTEM_FREE_PSRAM:
       return heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
     case FieldType::SYSTEM_MIN_FREE_HEAP:
-      return heap_caps_get_minimum_free_size(MALLOC_CAP_8BIT);
+      return heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL);
 #ifdef USE_SENSOR
     case FieldType::SENSOR: {
       auto *entity = static_cast<sensor::Sensor *>(field.source);

--- a/components/openquatt_decision_log/OpenQuattDecisionLog.cpp
+++ b/components/openquatt_decision_log/OpenQuattDecisionLog.cpp
@@ -1008,8 +1008,8 @@ void OpenQuattDecisionLog::write_decision_log(httpd_req_t *req) const {
   ChunkedJsonWriter writer(req);
   const uint64_t boot_epoch_s = this->boot_epoch_s_();
   const uint64_t uptime_s = this->monotonic_uptime_s_();
-  const uint32_t internal_free = heap_caps_get_free_size(MALLOC_CAP_8BIT);
-  const uint32_t internal_min = heap_caps_get_minimum_free_size(MALLOC_CAP_8BIT);
+  const uint32_t internal_free = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+  const uint32_t internal_min = heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL);
   const uint32_t psram_free = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
 
   size_t event_count = 0;

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -83,7 +83,10 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   static constexpr uint32_t SESSION_TIMEOUT_MS = 30000;
   static constexpr uint32_t RETRY_MIN_MS = 5UL * 60UL * 1000UL;
   static constexpr uint32_t RETRY_MAX_MS = 60UL * 60UL * 1000UL;
-  static constexpr uint32_t MQTT_START_TASK_STACK_SIZE = 24576;
+  // HIL boot measurements leave >22 kB unused with the former 24 kB stack.
+  // Eight kB retains >5 kB measured headroom without splitting the largest
+  // internal-heap block before esp-mqtt requests its own 12 kB task stack.
+  static constexpr uint32_t MQTT_START_TASK_STACK_SIZE = 8192;
   static constexpr uint32_t MQTT_CLEANUP_TASK_STACK_SIZE = 6144;
   static constexpr int MQTT_TASK_STACK_SIZE = 12288;
 

--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -24,6 +24,17 @@ Hier kom je meestal pas aan als:
 
 Voor gewone gebruikers geldt dus meestal: eerst runtime, bijna nooit compile-time.
 
+### Firmware-updates
+
+Na een herstart wacht OpenQuatt met de eerste automatische firmwarecontrole tot
+de netwerkverbinding vijf minuten stabiel is en er geen OTA-update actief is.
+Daarna controleert de firmware iedere vier uur opnieuw. Dit uitstel is normaal
+opstartgedrag en geen teken dat de updatefunctie niet werkt.
+
+`Check Firmware Updates` voert wel direct een controle uit. Een echte
+runtimewijziging van het firmwarekanaal of updatedoel controleert eveneens
+direct; alleen de tijdens het opstarten herstelde keuze volgt de wachttijd.
+
 Voor flowdiagnose zijn er wel twee compile-time constanten die je soms in discussies of issues terugziet:
 
 - `oq_flow_mismatch_threshold_lph`

--- a/docs/releaseproces.md
+++ b/docs/releaseproces.md
@@ -76,8 +76,10 @@ Keep the source-controlled `project_version` aligned with the next intended stab
 - `project_version` in `openquatt/oq_substitutions_common.yaml` remains the user-facing firmware version.
 - `release_channel` in `openquatt/oq_substitutions_common.yaml` identifies the running channel (`main` or `dev`).
 - `release_manifest_url` selects which OTA manifest the built-in update entity uses.
-- `Firmware Update` checks the selected OTA manifest every `4h`.
-- `Firmware Update Channel` is a runtime select that switches the OTA manifest between the baked-in `main` and `dev` URLs and immediately refreshes the update entity.
+- `Firmware Update` checks the selected OTA manifest every `${oq_firmware_periodic_check_interval}` (default `4h`) through the explicit OpenQuatt scheduler; the ESPHome update component's own boot-time scheduler is disabled.
+- The first automatic manifest check waits for `${oq_firmware_initial_check_delay_s}` (default 300s) of stable network connectivity without an active OTA so it does not overlap the boot-time API, web and usage-telemetry publication waves.
+- `Firmware Update Channel` is a runtime select that switches the OTA manifest between the baked-in `main` and `dev` URLs. Restored boot state uses the delayed initial check; a real runtime change refreshes the update entity immediately.
+- `Check Firmware Updates` always requests an immediate refresh and cancels a still-pending delayed initial check.
 
 The running firmware exposes both `OpenQuatt Version` and `OpenQuatt Release Channel` in diagnostics, while `Firmware Update Channel` controls which OTA track the device should follow next.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -100,6 +100,22 @@ This prevents hidden control coupling and keeps debugging deterministic.
 | Boiler control | `${oq_boiler_loop_s}` (default 5s) | CM3 gating plus CM100 boiler test under the shared water-temperature guardrail |
 | CIC polling tick | `${cic_poll_tick_ms}` (default 5s) | Poll scheduler, stale detection, feed invalidation |
 
+### 3.1 Boot and first-run timing
+
+Configured startup delays are relative to the ESPHome scheduler becoming active. Network association, restored-state callbacks and physical bus responses make their observed wall-clock time variable.
+
+| Subsystem | First configured activity after scheduler start | Steady cadence / gate |
+|---|---:|---|
+| HP1 Modbus | `${oq_modbus_startup_delay_ms}` (default 0ms) | Base poll every `${oq_modbus_update_interval_s}` (default 5s), commands throttled by `${oq_modbus_command_throttle_ms}` (default 500ms) |
+| HP2 Modbus (Duo) | 2500ms | Same base cadence; the offset intentionally stages HP1 and HP2 traffic |
+| OpenTherm thermostat slave (OTT) | Component setup | Runtime validation every 2s |
+| OpenTherm boiler master (OTB) | Enabled at late boot only when `Boiler connection` is `OpenTherm` | Link/freshness checks start after 2s and run every `${oq_otb_link_watch_s}` (default 1s); command application starts after 3s and runs every `${oq_otb_command_apply_s}` (default 1s) |
+| CIC | First scheduler tick after `${cic_poll_tick_ms}` (default 5s) | Fetching only runs when CIC polling is enabled |
+| MQTT usage statistics | 90s after setup-complete, opt-in, broker configuration and network gates are all satisfied | Publishes every 1h; a boot-time network loss restarts the 90s delay |
+| Firmware manifest | `${oq_firmware_initial_check_delay_s}` (default 300s) of continuously available network without an active OTA, sampled every 5s | Automatic checks every `${oq_firmware_periodic_check_interval}` (default 4h); manual checks and real runtime channel/target changes remain immediate |
+
+These offsets spread network and bus work; they are not readiness guarantees. A successful Modbus or OpenTherm exchange can only occur once the corresponding external equipment is connected and responsive.
+
 ## 4. Data Pipeline
 
 ### 4.1 Input layer

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -33,6 +33,7 @@ esphome:
           #endif
           id(oq_hardware_profile_text).publish_state("${oq_hardware_profile}");
           id(oq_connection_text).publish_state("${oq_connection}");
+          id(oq_fw_select_callbacks_runtime_ready) = true;
           id(oq_firmware_update).add_on_state_callback([]() {
             const uint32_t request_generation = id(oq_fw_check_request_generation);
             if (request_generation == 0 || id(oq_fw_check_completed_generation) == request_generation) {
@@ -78,6 +79,7 @@ esphome:
                      (unsigned long) request_generation,
                      id(oq_fw_check_target_ready) ? "ready" : "mismatch");
           });
+      - script.execute: oq_initial_firmware_update_check
 
 logger:
   level: DEBUG
@@ -256,6 +258,18 @@ globals:
     type: uint32_t
     restore_value: false
     initial_value: '0'
+  - id: oq_fw_select_callbacks_runtime_ready
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+  - id: oq_fw_boot_check_pending
+    type: bool
+    restore_value: false
+    initial_value: 'true'
+  - id: oq_fw_boot_check_network_since_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
   - id: oq_fw_check_request_generation
     type: uint32_t
     restore_value: false
@@ -336,6 +350,88 @@ script:
                    target.c_str(), channel.c_str(), source_url);
           id(oq_firmware_update).set_source_url(source_url);
 
+  - id: oq_initial_firmware_update_check
+    mode: single
+    then:
+      # Keep the TLS-heavy manifest request outside the first API/web/MQTT
+      # publication waves. A disconnect restarts the stable-network window.
+      - while:
+          condition:
+            lambda: |-
+              return id(oq_fw_boot_check_pending);
+          then:
+            - if:
+                condition:
+                  lambda: |-
+                    return esphome::network::is_connected()
+                        && !id(oq_runtime_polling_paused).state;
+                then:
+                  - lambda: |-
+                      id(oq_fw_boot_check_network_since_ms) = (uint32_t) millis();
+                      ESP_LOGI("oq_fw", "Initial firmware manifest check scheduled after ${oq_firmware_initial_check_delay_s} seconds of stable network.");
+                  - while:
+                      condition:
+                        lambda: |-
+                          const uint32_t elapsed_ms =
+                              (uint32_t) millis() - id(oq_fw_boot_check_network_since_ms);
+                          return id(oq_fw_boot_check_pending)
+                              && esphome::network::is_connected()
+                              && !id(oq_runtime_polling_paused).state
+                              && elapsed_ms < (uint32_t) ${oq_firmware_initial_check_delay_s} * 1000UL;
+                      then:
+                        # Five-second sampling avoids a hot polling loop while
+                        # still rejecting meaningful connectivity interruptions.
+                        - delay: 5s
+                  - if:
+                      condition:
+                        lambda: |-
+                          const uint32_t elapsed_ms =
+                              (uint32_t) millis() - id(oq_fw_boot_check_network_since_ms);
+                          return id(oq_fw_boot_check_pending)
+                              && esphome::network::is_connected()
+                              && !id(oq_runtime_polling_paused).state
+                              && elapsed_ms >= (uint32_t) ${oq_firmware_initial_check_delay_s} * 1000UL;
+                      then:
+                        - lambda: |-
+                            id(oq_fw_boot_check_pending) = false;
+                            id(oq_fw_check_last_request_ms) = (uint32_t) millis();
+                        - script.execute: oq_apply_firmware_update_source
+                        - script.wait: oq_apply_firmware_update_source
+                        - update.check:
+                            id: oq_firmware_update
+                      else:
+                        - lambda: |-
+                            if (id(oq_fw_boot_check_pending)) {
+                              ESP_LOGI("oq_fw", "Initial firmware manifest check delayed until the network is stable and OTA is inactive again.");
+                            }
+                else:
+                  - delay: 5s
+      # The http_request update component's native scheduler is disabled below
+      # so its built-in network-ready check cannot run during boot. Keep all
+      # subsequent automatic checks on this explicit cadence.
+      - while:
+          condition:
+            lambda: |-
+              return true;
+          then:
+            - delay: ${oq_firmware_periodic_check_interval}
+            - if:
+                condition:
+                  lambda: |-
+                    return esphome::network::is_connected()
+                        && !id(oq_runtime_polling_paused).state
+                        && !id(oq_firmware_target_install_active);
+                then:
+                  - script.execute: oq_apply_firmware_update_source
+                  - script.wait: oq_apply_firmware_update_source
+                  - lambda: |-
+                      id(oq_fw_check_last_request_ms) = (uint32_t) millis();
+                  - update.check:
+                      id: oq_firmware_update
+                else:
+                  - lambda: |-
+                      ESP_LOGI("oq_fw", "Periodic firmware manifest check skipped: network unavailable or OTA active.");
+
   - id: oq_watch_http_ota_start
     mode: restart
     then:
@@ -365,6 +461,7 @@ script:
     then:
       - lambda: |-
           // Clear terminal state before starting a new install attempt.
+          id(oq_fw_boot_check_pending) = false;
           id(oq_http_ota_begin_observed) = false;
           id(oq_ota_phase_code) = 1;
           id(oq_firmware_update_status).publish_state("Starting");
@@ -610,6 +707,11 @@ select:
         - if:
             condition:
               lambda: |-
+                if (!id(oq_fw_select_callbacks_runtime_ready)) {
+                  return false;
+                }
+                // A real runtime selection supersedes the deferred boot check.
+                id(oq_fw_boot_check_pending) = false;
                 // Prevent duplicate update checks when the channel changes repeatedly.
                 constexpr uint32_t fw_check_cooldown_ms = 1000UL;
                 const uint32_t now_ms = (uint32_t) millis();
@@ -675,6 +777,12 @@ select:
         - if:
             condition:
               lambda: |-
+                if (!id(oq_fw_select_callbacks_runtime_ready)) {
+                  return false;
+                }
+                // A real runtime selection supersedes the deferred boot check.
+                id(oq_fw_boot_check_pending) = false;
+                // Prevent duplicate update checks when the target changes repeatedly.
                 constexpr uint32_t fw_check_cooldown_ms = 1000UL;
                 const uint32_t now_ms = (uint32_t) millis();
                 const uint32_t last_request_ms = id(oq_fw_check_last_request_ms);
@@ -900,6 +1008,9 @@ button:
       - if:
           condition:
             lambda: |-
+              // A manual request supersedes the deferred boot check.
+              id(oq_fw_boot_check_pending) = false;
+              // Prevent duplicate update checks after repeated manual requests.
               constexpr uint32_t fw_check_cooldown_ms = 1000UL;
               const uint32_t now_ms = (uint32_t) millis();
               const uint32_t last_request_ms = id(oq_fw_check_last_request_ms);
@@ -1265,7 +1376,9 @@ update:
     id: oq_firmware_update
     name: Firmware Update
     source: ${release_manifest_url}
-    update_interval: 4h
+    # Prevent ESPHome's built-in network-ready check at about 10 seconds after
+    # boot. oq_initial_firmware_update_check owns both initial and periodic checks.
+    update_interval: never
     icon: mdi:update
     entity_category: diagnostic
     web_server:

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -15,6 +15,8 @@ friendly_name: OpenQuatt                              # Display name in Home Ass
 project_name: "openquatt.openquatt"                   # ESPHome project identifier shown in firmware metadata.
 project_version: "v0.46.0"                            # ESPHome project version shown in firmware metadata.
 release_channel: "main"                               # Firmware release channel shown in diagnostics (`main` or `dev`).
+oq_firmware_initial_check_delay_s: "300"              # Stable-network delay before the first automatic manifest check [s].
+oq_firmware_periodic_check_interval: "4h"              # Automatic manifest-check cadence after the initial boot window.
 oq_hardware_profile: "unknown"                        # Compile-time hardware profile id.
 oq_hardware_build_flag: "-DOQ_HARDWARE_HEATPUMP_CONTROLLER_Q=0" # Hardware capability flag for C++ lambdas.
 oq_boiler_transport_shutdown_extra: ""                 # Optional profile-specific synchronous actuator shutdown statements.


### PR DESCRIPTION
# Wat verandert deze PR?

- Verkleint de tijdelijke usage-MQTT-starttask van 24.576 naar 8.192 bytes; HIL liet met 8.192 bytes nog ruim 5 kB stackreserve zien.
- Verplaatst de eerste automatische firmwaremanifestcheck naar 300 seconden stabiel netwerk zonder actieve OTA en houdt daarna een expliciete 4-uurscadans aan. Handmatige checks en echte runtimewijzigingen van kanaal of target blijven direct.
- Laat debug recorder en decision log uitsluitend de interne heap rapporteren, gelijk aan de ESPHome-heapsensoren, en documenteert de relevante boot-timings.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De automatische manifestcheck draait niet meer via de vroege ESPHome-netwerkready-check, maar via de expliciete OpenQuatt-scheduler. De bestaande diagnostiek-entiteiten behouden hun IDs; recorder- en decision-logvelden krijgen dezelfde interne-heapsemantiek als `Heap Free` en `Heap Min Free`.

## Achtergrond

Op een Q-controller v1.1 met ESP32-S3 kon tijdens de eerste usage-publicatie een normale interne allocatie van 12.288 bytes voor de MQTT-clienttask mislukken. Er was nog circa 47–50 kB totaal vrij, maar het grootste aaneengesloten block was kleiner dan 12.288 bytes. De oorspronkelijke tijdelijke starttask reserveerde 24.576 bytes terwijl HIL daarvan meer dan 22 kB ongebruikt liet.

De ingebouwde ESPHome-updateplanning deed daarnaast de eerste TLS-zware manifestcheck circa 10 seconden na netwerkbeschikbaarheid. Daarmee overlapte deze piek de vroege API-, web- en publicatiefasen. `update_interval: never` schakelt alleen die ingebouwde planning uit; de nieuwe script-scheduler bezit zowel de initiële als periodieke automatische checks.

De scheduler is getoetst op restored select-callbacks, netwerkverlies, handmatige checks, OTA-activiteit en mislukte/skipped periodieke checks. Een actieve OTA onderbreekt de stabiele-netwerkperiode en blokkeert periodieke checks. Fresh install en upgrade houden de geselecteerde manifestbron intact; de bron wordt direct vóór iedere automatische check opnieuw toegepast.

Niet gewijzigd:

- `CONFIG_LWIP_MAX_SOCKETS`;
- PSRAM- en malloc-instellingen;
- de per-publicatie-lifecycle van de usage-MQTT-client;
- Modbus-, OpenTherm- en actuatorgedrag.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/releaseproces.md` beschrijft de updatechecksemantiek. `docs/system-overview.md` legt de boot- en first-run-timings van Modbus, OpenTherm, CIC, usage-statistieken en firmwaremanifest vast.

## Validatie

- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml`
  - style, docs, web/docs-contract en config: geslaagd;
  - volledige ESP32-S3-compile: geslaagd;
  - RAM 216.355 / 341.760 bytes; flash 1.963.703 / 5.242.880 bytes.
- `python3 scripts/dev.py validate --config-only --config configs/waveshare/single_wifi.yaml`
  - cross-profile configvalidatie: geslaagd.
- HIL op OpenQuatt Q-controller v1.1, ESPHome 2026.7.0 en ESP-IDF 5.5.4:
  - usage-starttask met 8.192 bytes: 5.840–5.844 bytes gemeten stackreserve;
  - eerste automatische manifestcheck pas na de 300-secondenperiode;
  - definitieve run na manifest: minimumheap 22.187 bytes, actuele heap 84.519 bytes en grootste block 53.248 bytes;
  - HTTP 200 en ESPHome API-listener beschikbaar;
  - bulkresponse van 4.347 bytes in 237 ms; daarna 84.351 bytes actuele heap;
  - geen monotone heapdaling waargenomen.

Resterend risico: een duurtest met aangesloten Modbus/OTT/OTB en normale HA-/webbelasting blijft gewenst voor het afzonderlijke verbindingsincident na circa 23 uur.
