### PR TITLE
Use PSRAM for TLS and disable Wi-Fi power saving

### DIFF
--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -82,6 +82,10 @@ esp32:
       CONFIG_SPIRAM_USE_MALLOC: y
       CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL: "8192"
       CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL: "65536"
+      # Keep transient TLS allocations out of the scarce internal heap.
+      # Every supported hardware profile requires PSRAM.
+      CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC: y
+      CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC: n
 
 sensor:
   - platform: debug

--- a/openquatt/connection/wifi.yaml
+++ b/openquatt/connection/wifi.yaml
@@ -8,6 +8,7 @@ substitutions:
   oq_connection: "wifi"
 
 wifi:
+  power_save_mode: none
   min_auth_mode: wpa2
   ap:
     ssid: "OpenQuatt"


### PR DESCRIPTION
# Wat verandert deze PR?

- Allocateert tijdelijk mbedTLS-werkgeheugen vanuit PSRAM via de gedeelde ESP32-basis.
- Zet `wifi.power_save_mode` voor alle Wi-Fi-profielen op `none`.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De wijziging vergroot de vrije interne heap tijdens TLS-werk en voorkomt Wi-Fi power-save-latency. Alle ondersteunde hardwareprofielen verplichten PSRAM. `power_save_mode: none` verhoogt het Wi-Fi-energiegebruik enigszins.

## Achtergrond

Op de Q-controller verlaagde de HTTPS-manifestcheck met interne mbedTLS-allocatie de minimumheap tot circa 10 kB. mbedTLS-werkgeheugen in PSRAM hield in dezelfde volledige firmware circa 37 kB minimumheap over. Een gecontroleerde Wi-Fi A/B-test liet bij `power_save_mode: none` duidelijk lagere ping- en HTTP-latency zien.

Omdat Q, classic listener en Waveshare allemaal PSRAM verplichten, staan beide instellingen nu in de gedeelde basis respectievelijk het gedeelde Wi-Fi-profiel. Alleen Q is HIL-getest; de andere chip-/hardwareprofielen zijn volledig gecompileerd.

Securitytrade-off: tijdelijk TLS-werkgeheugen staat nu op alle profielen in PSRAM. Zonder PSRAM-encryptie kan fysieke extractie daarvan niet worden uitgesloten.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit zijn interne firmware-instellingen zonder nieuwe gebruikersconfiguratie, entiteiten of installatiehandelingen.

## Validatie

- `esphome config` geslaagd voor alle acht release-entrypoints: Q/listener/Waveshare, single/duo en Wi-Fi/ethernet.
- `esphome compile configs/heatpump_listener/duo_wifi.yaml` geslaagd met ESPHome 2026.7.0 en ESP-IDF 5.5.4.
- `esphome compile configs/waveshare/duo_wifi.yaml` geslaagd met ESPHome 2026.7.0 en ESP-IDF 5.5.4.
- Gegenereerde SDK-configs bevestigen `CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y`, uitgeschakelde interne mbedTLS-allocatie en ongewijzigde PSRAM-reserves.
- Gegenereerde firmware voor classic listener en Waveshare bevestigt `WIFI_POWER_SAVE_NONE`.
- Volledige diff tegen `dev` gecontroleerd op scope, configuratiecompatibiliteit, securitytrade-offs en upgrade-/restartgedrag.
