### PR TITLE
Curate Home Assistant entity exposure

### DIFF
--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1935,12 +1935,11 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              This tab shows the value OpenQuatt uses per signal and the available raw sources. Configure sensor selection in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
+              This tab shows the value and effective source OpenQuatt uses per signal. Configure sensor selection and inspect raw source diagnostics in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
 
               Use this block for:
-              - quick comparison between CIC, local, and HA Input
               - validation of the effective control input
-              - diagnosis of missing or unexpected source values
+              - confirmation of the selected local or OpenTherm value
 
               HA input source mapping remains further down on this tab.
 
@@ -1962,8 +1961,6 @@ views:
                     name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Selected room temperature
-                  - entity: sensor.openquatt_cic_room_temperature
-                    name: Room temperature (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1971,8 +1968,6 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_temperature
                       name: Room temperature (OT thermostat)
-                  - entity: sensor.openquatt_ha_thermostat_room_temperature
-                    name: Room temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1989,10 +1984,6 @@ views:
                     name: Selected water supply temperature
                   - entity: sensor.openquatt_water_supply_temp
                     name: Water supply temperature (ESP)
-                  - entity: sensor.openquatt_cic_water_supply_temp
-                    name: Water supply temperature (CIC)
-                  - entity: sensor.openquatt_ha_water_supply_temperature
-                    name: Water supply temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2009,8 +2000,6 @@ views:
                     name: Selected flow rate
                   - entity: sensor.openquatt_flow_average_local
                     name: Flow rate (Outdoor unit)
-                  - entity: sensor.openquatt_cic_flowrate_filtered
-                    name: Flow rate (CIC)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2027,8 +2016,6 @@ views:
                     name: Selected outside temperature
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
                     name: Outside temperature (Outdoor unit)
-                  - entity: sensor.openquatt_ha_outside_temperature
-                    name: Outside temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2045,8 +2032,6 @@ views:
                     name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Selected room setpoint
-                  - entity: sensor.openquatt_cic_room_setpoint
-                    name: Room setpoint (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -2054,8 +2039,6 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_setpoint
                       name: Room setpoint (OT thermostat)
-                  - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: Room setpoint (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2083,10 +2066,6 @@ views:
                     row:
                       entity: binary_sensor.openquatt_ot_thermostat_ch_enable
                       name: Heating enable (OT thermostat)
-                  - entity: binary_sensor.openquatt_cic_ch_enabled
-                    name: Heating enable (CIC)
-                  - entity: binary_sensor.openquatt_ha_heating_enable
-                    name: Heating enable (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2105,10 +2084,6 @@ views:
                     name: Effective cooling enable source
                   - entity: binary_sensor.openquatt_cooling_enable_selected
                     name: Selected cooling enable
-                  - entity: binary_sensor.openquatt_cic_cooling_enabled
-                    name: Cooling enable (CIC)
-                  - entity: binary_sensor.openquatt_ha_cooling_enable
-                    name: Cooling enable (HA Input)
         column_span: 3
       - type: grid
         cards:
@@ -2203,38 +2178,6 @@ views:
                     name: Proxy cooling enable
                   - entity: binary_sensor.openquatt_ext_cooling_enable_valid
                     name: Cooling enable source valid
-          - type: vertical-stack
-            cards:
-              - type: heading
-                icon: mdi:chip
-                heading: OpenQuatt HA input signals
-                heading_style: subtitle
-              - type: markdown
-                content: |-
-                  <details>
-                  <summary><strong>Explanation</strong></summary>
-
-                  These are the six HA input signals as received by OpenQuatt. They should follow the proxy values shown in the middle panel.
-
-                  If a value stays `Unknown`, first check whether the matching `... source valid` sensor is `on`.
-
-                  </details>
-                text_only: true
-              - type: entities
-                show_header_toggle: false
-                entities:
-                  - entity: sensor.openquatt_ha_outside_temperature
-                    name: HA - Outside Temperature
-                  - entity: sensor.openquatt_ha_water_supply_temperature
-                    name: HA - Water Supply Temperature
-                  - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: HA - Thermostat Setpoint
-                  - entity: sensor.openquatt_ha_thermostat_room_temperature
-                    name: HA - Thermostat Room Temperature
-                  - entity: binary_sensor.openquatt_ha_heating_enable
-                    name: HA - Heating Enable
-                  - entity: binary_sensor.openquatt_ha_cooling_enable
-                    name: HA - Cooling Enable
         column_span: 3
         visibility:
           - condition: state
@@ -2534,31 +2477,11 @@ views:
             icon: mdi:cloud-check
             heading_style: title
             heading: Quatt CiC configuration
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Explanation</strong></summary>
-
-              This block shows CiC feed health. If feed health degrades or data becomes stale, CIC-backed sources may become unusable for selected signals.
-
-              Check these first when values look wrong:
-              - `JSON feed OK`
-              - `Data stale`
-              - `Last success age`
-
-              </details>
-            text_only: true
           - type: entities
             show_header_toggle: false
             entities:
               - entity: switch.openquatt_cic_enable_polling
                 name: Enable polling
-              - entity: binary_sensor.openquatt_cic_json_feed_ok
-                name: JSON feed OK
-              - entity: binary_sensor.openquatt_cic_data_stale
-                name: Data stale
-              - entity: text.openquatt_cic_feed_url
-                name: CIC feed URL
     cards: []
     header:
       card:
@@ -2566,7 +2489,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensor configuration
 
-          Review which value OpenQuatt uses per signal and whether the source status looks healthy. Configure sensor selection in the OpenQuatt web app: `http://openquatt.local`.
+          Review which value and effective source OpenQuatt uses per signal. Configure sources and inspect advanced diagnostics in the OpenQuatt web app: `http://openquatt.local`.
     top_margin: false
     dense_section_placement: false
   - title: Tuning
@@ -2892,7 +2815,7 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - Select up to two compressor levels per HP that allocation logic should skip.
+              - Configure up to two excluded compressor levels per HP in the OpenQuatt web app.
 
               - `None` means: no exclusion for that slot.
 
@@ -2912,20 +2835,12 @@ views:
             title: HP1 excluded levels
             show_header_toggle: false
             entities:
-              - entity: select.openquatt_hp1_excluded_compressor_level_a
-                name: Excluded level A
-              - entity: select.openquatt_hp1_excluded_compressor_level_b
-                name: Excluded level B
               - entity: sensor.openquatt_hp1_excluded_compressor_levels
                 name: Active exclusions
           - type: entities
             title: HP2 excluded levels
             show_header_toggle: false
             entities:
-              - entity: select.openquatt_hp2_excluded_compressor_level_a
-                name: Excluded level A
-              - entity: select.openquatt_hp2_excluded_compressor_level_b
-                name: Excluded level B
               - entity: sensor.openquatt_hp2_excluded_compressor_levels
                 name: Active exclusions
     header:
@@ -2955,9 +2870,6 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Reset runtime counters**. Note: it can take up to 1 minute before the effect is visible.
-
-              - **Reset cumulative energy counters** sets cumulative electricity and thermal energy counters back to 0.
 
               - **HP1/HP2 Runtime counters** show the current counters used for runtime balancing.
 
@@ -2969,10 +2881,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: button.openquatt_reset_runtime_counters_hp1_hp2
-                name: Reset runtime counters
-              - entity: button.openquatt_reset_cumulative_energy_counters
-                name: Reset cumulative energy counters
               - entity: sensor.openquatt_hp1_runtime_hours
                 name: HP1 Runtime
               - entity: sensor.openquatt_hp2_runtime_hours

--- a/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_en.yaml
@@ -1935,11 +1935,12 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              This tab shows the value and effective source OpenQuatt uses per signal. Configure sensor selection and inspect raw source diagnostics in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
+              This tab shows the value OpenQuatt uses per signal and the key raw sources. Configure sensor selection and inspect full source diagnostics in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
 
               Use this block for:
+              - quick comparison between CIC, local, OpenTherm, and HA Input
               - validation of the effective control input
-              - confirmation of the selected local or OpenTherm value
+              - diagnosis of missing or unexpected source values
 
               HA input source mapping remains further down on this tab.
 
@@ -1961,6 +1962,8 @@ views:
                     name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Selected room temperature
+                  - entity: sensor.openquatt_cic_room_temperature
+                    name: Room temperature (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1968,6 +1971,8 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_temperature
                       name: Room temperature (OT thermostat)
+                  - entity: sensor.openquatt_ha_thermostat_room_temperature
+                    name: Room temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1984,6 +1989,10 @@ views:
                     name: Selected water supply temperature
                   - entity: sensor.openquatt_water_supply_temp
                     name: Water supply temperature (ESP)
+                  - entity: sensor.openquatt_cic_water_supply_temp
+                    name: Water supply temperature (CIC)
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: Water supply temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2000,6 +2009,8 @@ views:
                     name: Selected flow rate
                   - entity: sensor.openquatt_flow_average_local
                     name: Flow rate (Outdoor unit)
+                  - entity: sensor.openquatt_cic_flowrate_filtered
+                    name: Flow rate (CIC)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2016,6 +2027,8 @@ views:
                     name: Selected outside temperature
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
                     name: Outside temperature (Outdoor unit)
+                  - entity: sensor.openquatt_ha_outside_temperature
+                    name: Outside temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2032,6 +2045,8 @@ views:
                     name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Selected room setpoint
+                  - entity: sensor.openquatt_cic_room_setpoint
+                    name: Room setpoint (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -2039,6 +2054,8 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_setpoint
                       name: Room setpoint (OT thermostat)
+                  - entity: sensor.openquatt_ha_thermostat_setpoint
+                    name: Room setpoint (HA Input)
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2028,11 +2028,11 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              Deze tab toont per signaal de waarde die OpenQuatt gebruikt en de beschikbare ruwe bronnen.
+              Deze tab toont per signaal de waarde en effectieve bron die OpenQuatt gebruikt.
 
-              Sensorselectie wijzig je in de OpenQuatt web-app via `http://openquatt.local`, zodat hardwareprofiel, CIC-status en geldige opties daar samen worden bewaakt.
+              Sensorselectie en ruwe brondiagnostiek vind je in de OpenQuatt web-app via `http://openquatt.local`, waar hardwareprofiel, CIC-status en geldige opties samen worden bewaakt.
 
-              Zo zie je snel of de effectieve regelinput overeenkomt met wat je verwacht.
+              Zo controleer je of de effectieve regelinput overeenkomt met wat je verwacht.
 
 
               Gebruik dit blok voor:
@@ -2066,8 +2066,6 @@ views:
                     name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Geselecteerde kamertemperatuur
-                  - entity: sensor.openquatt_cic_room_temperature
-                    name: Kamertemperatuur (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -2075,8 +2073,6 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_temperature
                       name: Kamertemperatuur (OT-thermostaat)
-                  - entity: sensor.openquatt_ha_thermostat_room_temperature
-                    name: Kamertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2093,10 +2089,6 @@ views:
                     name: Geselecteerde aanvoertemperatuur
                   - entity: sensor.openquatt_water_supply_temp
                     name: Aanvoertemperatuur (ESP)
-                  - entity: sensor.openquatt_cic_water_supply_temp
-                    name: Aanvoertemperatuur (CIC)
-                  - entity: sensor.openquatt_ha_water_supply_temperature
-                    name: Aanvoertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2113,8 +2105,6 @@ views:
                     name: Geselecteerde flow
                   - entity: sensor.openquatt_flow_average_local
                     name: Flow (buitenunit)
-                  - entity: sensor.openquatt_cic_flowrate_filtered
-                    name: Flow (CIC)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2131,8 +2121,6 @@ views:
                     name: Geselecteerde buitentemperatuur
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
                     name: Buitentemperatuur (buitenunit)
-                  - entity: sensor.openquatt_ha_outside_temperature
-                    name: Buitentemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2149,8 +2137,6 @@ views:
                     name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Geselecteerd kamer setpoint
-                  - entity: sensor.openquatt_cic_room_setpoint
-                    name: Kamer setpoint (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -2158,8 +2144,6 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_setpoint
                       name: Kamer setpoint (OT-thermostaat)
-                  - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: Kamer setpoint (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2187,10 +2171,6 @@ views:
                     row:
                       entity: binary_sensor.openquatt_ot_thermostat_ch_enable
                       name: Warmtetoestemming (OT-thermostaat)
-                  - entity: binary_sensor.openquatt_cic_ch_enabled
-                    name: Warmtetoestemming (CIC)
-                  - entity: binary_sensor.openquatt_ha_heating_enable
-                    name: Warmtetoestemming (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2209,10 +2189,6 @@ views:
                     name: Effectieve koeltoestemmingsbron
                   - entity: binary_sensor.openquatt_cooling_enable_selected
                     name: Geselecteerde koeltoestemming
-                  - entity: binary_sensor.openquatt_cic_cooling_enabled
-                    name: Koeltoestemming (CIC)
-                  - entity: binary_sensor.openquatt_ha_cooling_enable
-                    name: Koeltoestemming (HA-invoer)
         column_span: 3
       - type: grid
         cards:
@@ -2319,38 +2295,6 @@ views:
                     name: Proxy koeltoestemming
                   - entity: binary_sensor.openquatt_ext_cooling_enable_valid
                     name: Koeltoestemmingsbron geldig
-          - type: vertical-stack
-            cards:
-              - type: heading
-                icon: mdi:chip
-                heading: OpenQuatt HA-invoerwaarden
-                heading_style: subtitle
-              - type: markdown
-                content: |-
-                  <details>
-                  <summary><strong>Uitleg</strong></summary>
-
-                  Dit zijn de zes HA-invoerwaarden zoals OpenQuatt ze ontvangt. Deze horen de proxywaarden uit het middelste blok te volgen.
-
-                  Blijft een waarde op `Unknown`, controleer dan eerst of de bijbehorende `...bron geldig` op `on` staat.
-
-                  </details>
-                text_only: true
-              - type: entities
-                show_header_toggle: false
-                entities:
-                  - entity: sensor.openquatt_ha_outside_temperature
-                    name: HA - Buitentemperatuur
-                  - entity: sensor.openquatt_ha_water_supply_temperature
-                    name: HA - Aanvoertemperatuur
-                  - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: HA - Thermostaat doeltemperatuur
-                  - entity: sensor.openquatt_ha_thermostat_room_temperature
-                    name: HA - Thermostaat kamertemperatuur
-                  - entity: binary_sensor.openquatt_ha_heating_enable
-                    name: HA - Warmtetoestemming
-                  - entity: binary_sensor.openquatt_ha_cooling_enable
-                    name: HA - Koeltoestemming
         column_span: 3
         visibility:
           - condition: state
@@ -2650,31 +2594,11 @@ views:
             icon: mdi:cloud-check
             heading_style: title
             heading: Quatt CiC-configuratie
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Uitleg</strong></summary>
-
-              Dit blok toont de status van de CiC-feed. Als de feed niet OK is of data stale wordt, kunnen CIC-bronnen onbruikbaar worden voor de geselecteerde signalen.
-
-              Controleer bij afwijkingen:
-              - `JSON feed OK`
-              - `Data verouderd`
-              - `Tijd sinds laatste succes`
-
-              </details>
-            text_only: true
           - type: entities
             show_header_toggle: false
             entities:
               - entity: switch.openquatt_cic_enable_polling
                 name: Polling inschakelen
-              - entity: binary_sensor.openquatt_cic_json_feed_ok
-                name: JSON feed OK
-              - entity: binary_sensor.openquatt_cic_data_stale
-                name: Data verouderd
-              - entity: text.openquatt_cic_feed_url
-                name: CIC feed URL
     cards: []
     header:
       card:
@@ -2683,7 +2607,7 @@ views:
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensorconfiguratie
 
 
-          Bekijk hier per signaal welke waarde OpenQuatt gebruikt en of de bronstatus klopt. Sensorselectie doe je in de OpenQuatt web-app: `http://openquatt.local`.
+          Bekijk hier per signaal welke waarde en effectieve bron OpenQuatt gebruikt. Configureer bronnen en bekijk uitgebreide diagnostiek in de OpenQuatt web-app: `http://openquatt.local`.
     top_margin: false
     dense_section_placement: false
   - title: Instellingen
@@ -3027,7 +2951,7 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - Kies hier maximaal twee compressorlevels per HP die de verdelingslogica moet overslaan.
+              - Configureer maximaal twee uitgesloten compressorlevels per HP in de OpenQuatt web-app.
 
               - `None` betekent: geen uitsluiting in dat slot.
 
@@ -3047,20 +2971,12 @@ views:
             title: HP1 uitgesloten levels
             show_header_toggle: false
             entities:
-              - entity: select.openquatt_hp1_excluded_compressor_level_a
-                name: Excluded level A
-              - entity: select.openquatt_hp1_excluded_compressor_level_b
-                name: Excluded level B
               - entity: sensor.openquatt_hp1_excluded_compressor_levels
                 name: Actieve uitsluitingen
           - type: entities
             title: HP2 uitgesloten levels
             show_header_toggle: false
             entities:
-              - entity: select.openquatt_hp2_excluded_compressor_level_a
-                name: Excluded level A
-              - entity: select.openquatt_hp2_excluded_compressor_level_b
-                name: Excluded level B
               - entity: sensor.openquatt_hp2_excluded_compressor_levels
                 name: Actieve uitsluitingen
     header:
@@ -3090,9 +3006,6 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Reset draaitellers**. Let op: het kan maximaal 1 minuut duren voordat je effect ziet.
-
-              - **Reset cumulatieve energietellers** zet cumulatieve elektriciteits- en warmte-energiemeters terug naar 0.
 
               - **HP1/HP2 draaitijd counters** tonen de actuele teller waarop de runtime-balans wordt gebaseerd.
 
@@ -3104,10 +3017,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: button.openquatt_reset_runtime_counters_hp1_hp2
-                name: Reset draaitellers
-              - entity: button.openquatt_reset_cumulative_energy_counters
-                name: Reset cumulatieve energietellers
               - entity: sensor.openquatt_hp1_runtime_hours
                 name: HP1 draaitijd
               - entity: sensor.openquatt_hp2_runtime_hours

--- a/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_duo_nl.yaml
@@ -2028,16 +2028,16 @@ views:
               <summary><strong>Uitleg</strong></summary>
 
 
-              Deze tab toont per signaal de waarde en effectieve bron die OpenQuatt gebruikt.
+              Deze tab toont per signaal de waarde die OpenQuatt gebruikt en de belangrijkste ruwe bronnen.
 
-              Sensorselectie en ruwe brondiagnostiek vind je in de OpenQuatt web-app via `http://openquatt.local`, waar hardwareprofiel, CIC-status en geldige opties samen worden bewaakt.
+              Sensorselectie en volledige brondiagnostiek vind je in de OpenQuatt web-app via `http://openquatt.local`, waar hardwareprofiel, CIC-status en geldige opties samen worden bewaakt.
 
               Zo controleer je of de effectieve regelinput overeenkomt met wat je verwacht.
 
 
               Gebruik dit blok voor:
 
-              - snelle vergelijking tussen CIC, lokaal en HA input
+              - snelle vergelijking tussen CIC, lokaal, OpenTherm en HA-invoer
 
               - validatie van de effectieve regelinput
 
@@ -2066,6 +2066,8 @@ views:
                     name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Geselecteerde kamertemperatuur
+                  - entity: sensor.openquatt_cic_room_temperature
+                    name: Kamertemperatuur (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -2073,6 +2075,8 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_temperature
                       name: Kamertemperatuur (OT-thermostaat)
+                  - entity: sensor.openquatt_ha_thermostat_room_temperature
+                    name: Kamertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2089,6 +2093,10 @@ views:
                     name: Geselecteerde aanvoertemperatuur
                   - entity: sensor.openquatt_water_supply_temp
                     name: Aanvoertemperatuur (ESP)
+                  - entity: sensor.openquatt_cic_water_supply_temp
+                    name: Aanvoertemperatuur (CIC)
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: Aanvoertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2105,6 +2113,8 @@ views:
                     name: Geselecteerde flow
                   - entity: sensor.openquatt_flow_average_local
                     name: Flow (buitenunit)
+                  - entity: sensor.openquatt_cic_flowrate_filtered
+                    name: Flow (CIC)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2121,6 +2131,8 @@ views:
                     name: Geselecteerde buitentemperatuur
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
                     name: Buitentemperatuur (buitenunit)
+                  - entity: sensor.openquatt_ha_outside_temperature
+                    name: Buitentemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -2137,6 +2149,8 @@ views:
                     name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Geselecteerd kamer setpoint
+                  - entity: sensor.openquatt_cic_room_setpoint
+                    name: Kamer setpoint (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -2144,6 +2158,8 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_setpoint
                       name: Kamer setpoint (OT-thermostaat)
+                  - entity: sensor.openquatt_ha_thermostat_setpoint
+                    name: Kamer setpoint (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1594,12 +1594,11 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              This tab shows the value OpenQuatt uses per signal and the available raw sources. Configure sensor selection in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
+              This tab shows the value and effective source OpenQuatt uses per signal. Configure sensor selection and inspect raw source diagnostics in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
 
               Use this block for:
-              - quick comparison between CIC, local, and HA Input
               - validation of the effective control input
-              - diagnosis of missing or unexpected source values
+              - confirmation of the selected local or OpenTherm value
 
               HA input source mapping remains further down on this tab.
 
@@ -1621,8 +1620,6 @@ views:
                     name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Selected room temperature
-                  - entity: sensor.openquatt_cic_room_temperature
-                    name: Room temperature (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1630,8 +1627,6 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_temperature
                       name: Room temperature (OT thermostat)
-                  - entity: sensor.openquatt_ha_thermostat_room_temperature
-                    name: Room temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1648,10 +1643,6 @@ views:
                     name: Selected water supply temperature
                   - entity: sensor.openquatt_water_supply_temp
                     name: Water supply temperature (ESP)
-                  - entity: sensor.openquatt_cic_water_supply_temp
-                    name: Water supply temperature (CIC)
-                  - entity: sensor.openquatt_ha_water_supply_temperature
-                    name: Water supply temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1668,8 +1659,6 @@ views:
                     name: Selected flow rate
                   - entity: sensor.openquatt_flow_average_local
                     name: Flow rate (Outdoor unit)
-                  - entity: sensor.openquatt_cic_flowrate_filtered
-                    name: Flow rate (CIC)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1686,8 +1675,6 @@ views:
                     name: Selected outside temperature
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
                     name: Outside temperature (Outdoor unit)
-                  - entity: sensor.openquatt_ha_outside_temperature
-                    name: Outside temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1704,8 +1691,6 @@ views:
                     name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Selected room setpoint
-                  - entity: sensor.openquatt_cic_room_setpoint
-                    name: Room setpoint (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1713,8 +1698,6 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_setpoint
                       name: Room setpoint (OT thermostat)
-                  - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: Room setpoint (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1742,10 +1725,6 @@ views:
                     row:
                       entity: binary_sensor.openquatt_ot_thermostat_ch_enable
                       name: Heating enable (OT thermostat)
-                  - entity: binary_sensor.openquatt_cic_ch_enabled
-                    name: Heating enable (CIC)
-                  - entity: binary_sensor.openquatt_ha_heating_enable
-                    name: Heating enable (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1764,10 +1743,6 @@ views:
                     name: Effective cooling enable source
                   - entity: binary_sensor.openquatt_cooling_enable_selected
                     name: Selected cooling enable
-                  - entity: binary_sensor.openquatt_cic_cooling_enabled
-                    name: Cooling enable (CIC)
-                  - entity: binary_sensor.openquatt_ha_cooling_enable
-                    name: Cooling enable (HA Input)
         column_span: 3
       - type: grid
         cards:
@@ -1862,38 +1837,6 @@ views:
                     name: Proxy cooling enable
                   - entity: binary_sensor.openquatt_ext_cooling_enable_valid
                     name: Cooling enable source valid
-          - type: vertical-stack
-            cards:
-              - type: heading
-                icon: mdi:chip
-                heading: OpenQuatt HA input signals
-                heading_style: subtitle
-              - type: markdown
-                content: |-
-                  <details>
-                  <summary><strong>Explanation</strong></summary>
-
-                  These are the six HA input signals as received by OpenQuatt. They should follow the proxy values shown in the middle panel.
-
-                  If a value stays `Unknown`, first check whether the matching `... source valid` sensor is `on`.
-
-                  </details>
-                text_only: true
-              - type: entities
-                show_header_toggle: false
-                entities:
-                  - entity: sensor.openquatt_ha_outside_temperature
-                    name: HA - Outside Temperature
-                  - entity: sensor.openquatt_ha_water_supply_temperature
-                    name: HA - Water Supply Temperature
-                  - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: HA - Thermostat Setpoint
-                  - entity: sensor.openquatt_ha_thermostat_room_temperature
-                    name: HA - Thermostat Room Temperature
-                  - entity: binary_sensor.openquatt_ha_heating_enable
-                    name: HA - Heating Enable
-                  - entity: binary_sensor.openquatt_ha_cooling_enable
-                    name: HA - Cooling Enable
         column_span: 3
         visibility:
           - condition: state
@@ -2193,31 +2136,11 @@ views:
             icon: mdi:cloud-check
             heading_style: title
             heading: Quatt CiC configuration
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Explanation</strong></summary>
-
-              This block shows CiC feed health. If feed health degrades or data becomes stale, CIC-backed sources may become unusable for selected signals.
-
-              Check these first when values look wrong:
-              - `JSON feed OK`
-              - `Data stale`
-              - `Last success age`
-
-              </details>
-            text_only: true
           - type: entities
             show_header_toggle: false
             entities:
               - entity: switch.openquatt_cic_enable_polling
                 name: Enable polling
-              - entity: binary_sensor.openquatt_cic_json_feed_ok
-                name: JSON feed OK
-              - entity: binary_sensor.openquatt_cic_data_stale
-                name: Data stale
-              - entity: text.openquatt_cic_feed_url
-                name: CIC feed URL
     cards: []
     header:
       card:
@@ -2225,7 +2148,7 @@ views:
         content: |-
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensor configuration
 
-          Review which value OpenQuatt uses per signal and whether the source status looks healthy. Configure sensor selection in the OpenQuatt web app: `http://openquatt.local`.
+          Review which value and effective source OpenQuatt uses per signal. Configure sources and inspect advanced diagnostics in the OpenQuatt web app: `http://openquatt.local`.
     top_margin: false
     dense_section_placement: false
   - title: Tuning
@@ -2548,7 +2471,7 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - Select up to two compressor levels per HP that allocation logic should skip.
+              - Configure up to two excluded compressor levels per HP in the OpenQuatt web app.
 
               - `None` means: no exclusion for that slot.
 
@@ -2568,10 +2491,6 @@ views:
             title: HP1 excluded levels
             show_header_toggle: false
             entities:
-              - entity: select.openquatt_hp1_excluded_compressor_level_a
-                name: Excluded level A
-              - entity: select.openquatt_hp1_excluded_compressor_level_b
-                name: Excluded level B
               - entity: sensor.openquatt_hp1_excluded_compressor_levels
                 name: Active exclusions
     header:
@@ -2601,9 +2520,6 @@ views:
               <summary><strong>Parameter explanation</strong></summary>
 
 
-              - **Reset runtime counters**. Note: it can take up to 1 minute before the effect is visible.
-
-              - **Reset cumulative energy counters** sets cumulative electricity and thermal energy counters back to 0.
               - **HP1 Runtime counter** shows the current counter used for runtime balancing.
 
               - **Runtime lead HP** shows which unit is currently selected as lead based on the lowest runtime.
@@ -2614,10 +2530,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: button.openquatt_reset_runtime_counters_hp1
-                name: Reset runtime counters
-              - entity: button.openquatt_reset_cumulative_energy_counters
-                name: Reset cumulative energy counters
               - entity: sensor.openquatt_hp1_runtime_hours
                 name: HP1 Runtime
               - entity: sensor.openquatt_runtime_lead_hp

--- a/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_en.yaml
@@ -1594,11 +1594,12 @@ views:
               <details>
               <summary><strong>Explanation</strong></summary>
 
-              This tab shows the value and effective source OpenQuatt uses per signal. Configure sensor selection and inspect raw source diagnostics in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
+              This tab shows the value OpenQuatt uses per signal and the key raw sources. Configure sensor selection and inspect full source diagnostics in the OpenQuatt web app at `http://openquatt.local`, where hardware profile, CIC status, and valid options are evaluated together.
 
               Use this block for:
+              - quick comparison between CIC, local, OpenTherm, and HA Input
               - validation of the effective control input
-              - confirmation of the selected local or OpenTherm value
+              - diagnosis of missing or unexpected source values
 
               HA input source mapping remains further down on this tab.
 
@@ -1620,6 +1621,8 @@ views:
                     name: Effective room temperature source
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Selected room temperature
+                  - entity: sensor.openquatt_cic_room_temperature
+                    name: Room temperature (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1627,6 +1630,8 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_temperature
                       name: Room temperature (OT thermostat)
+                  - entity: sensor.openquatt_ha_thermostat_room_temperature
+                    name: Room temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1643,6 +1648,10 @@ views:
                     name: Selected water supply temperature
                   - entity: sensor.openquatt_water_supply_temp
                     name: Water supply temperature (ESP)
+                  - entity: sensor.openquatt_cic_water_supply_temp
+                    name: Water supply temperature (CIC)
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: Water supply temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1659,6 +1668,8 @@ views:
                     name: Selected flow rate
                   - entity: sensor.openquatt_flow_average_local
                     name: Flow rate (Outdoor unit)
+                  - entity: sensor.openquatt_cic_flowrate_filtered
+                    name: Flow rate (CIC)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1675,6 +1686,8 @@ views:
                     name: Selected outside temperature
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
                     name: Outside temperature (Outdoor unit)
+                  - entity: sensor.openquatt_ha_outside_temperature
+                    name: Outside temperature (HA Input)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1691,6 +1704,8 @@ views:
                     name: Effective room setpoint source
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Selected room setpoint
+                  - entity: sensor.openquatt_cic_room_setpoint
+                    name: Room setpoint (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1698,6 +1713,8 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_setpoint
                       name: Room setpoint (OT thermostat)
+                  - entity: sensor.openquatt_ha_thermostat_setpoint
+                    name: Room setpoint (HA Input)
           - type: vertical-stack
             cards:
               - type: heading

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1639,12 +1639,11 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Deze tab toont per signaal de waarde die OpenQuatt gebruikt en de beschikbare ruwe bronnen. Sensorselectie wijzig je in de OpenQuatt web-app via `http://openquatt.local`, zodat hardwareprofiel, CIC-status en geldige opties daar samen worden bewaakt.
+              Deze tab toont per signaal de waarde en effectieve bron die OpenQuatt gebruikt. Sensorselectie en ruwe brondiagnostiek vind je in de OpenQuatt web-app via `http://openquatt.local`, waar hardwareprofiel, CIC-status en geldige opties samen worden bewaakt.
 
               Gebruik dit blok voor:
-              - snelle vergelijking tussen CIC, lokaal en HA input
               - validatie van de effectieve regelinput
-              - diagnose van ontbrekende of afwijkende bronwaarden
+              - bevestiging van de geselecteerde lokale of OpenTherm-waarde
 
               Voor HA-invoer blijft de HA bronconfiguratie verderop op deze tab staan.
 
@@ -1668,8 +1667,6 @@ views:
                     name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Geselecteerde kamertemperatuur
-                  - entity: sensor.openquatt_cic_room_temperature
-                    name: Kamertemperatuur (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1677,8 +1674,6 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_temperature
                       name: Kamertemperatuur (OT-thermostaat)
-                  - entity: sensor.openquatt_ha_thermostat_room_temperature
-                    name: Kamertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1695,10 +1690,6 @@ views:
                     name: Geselecteerde aanvoertemperatuur
                   - entity: sensor.openquatt_water_supply_temp
                     name: Aanvoertemperatuur (ESP)
-                  - entity: sensor.openquatt_cic_water_supply_temp
-                    name: Aanvoertemperatuur (CIC)
-                  - entity: sensor.openquatt_ha_water_supply_temperature
-                    name: Aanvoertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1715,8 +1706,6 @@ views:
                     name: Geselecteerde flow
                   - entity: sensor.openquatt_flow_average_local
                     name: Flow (buitenunit)
-                  - entity: sensor.openquatt_cic_flowrate_filtered
-                    name: Flow (CIC)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1733,8 +1722,6 @@ views:
                     name: Geselecteerde buitentemperatuur
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
                     name: Buitentemperatuur (buitenunit)
-                  - entity: sensor.openquatt_ha_outside_temperature
-                    name: Buitentemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1751,8 +1738,6 @@ views:
                     name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Geselecteerd kamer setpoint
-                  - entity: sensor.openquatt_cic_room_setpoint
-                    name: Kamer setpoint (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1760,8 +1745,6 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_setpoint
                       name: Kamer setpoint (OT-thermostaat)
-                  - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: Kamer setpoint (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1789,10 +1772,6 @@ views:
                     row:
                       entity: binary_sensor.openquatt_ot_thermostat_ch_enable
                       name: Warmtetoestemming (OT-thermostaat)
-                  - entity: binary_sensor.openquatt_cic_ch_enabled
-                    name: Warmtetoestemming (CIC)
-                  - entity: binary_sensor.openquatt_ha_heating_enable
-                    name: Warmtetoestemming (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1811,10 +1790,6 @@ views:
                     name: Effectieve koeltoestemmingsbron
                   - entity: binary_sensor.openquatt_cooling_enable_selected
                     name: Geselecteerde koeltoestemming
-                  - entity: binary_sensor.openquatt_cic_cooling_enabled
-                    name: Koeltoestemming (CIC)
-                  - entity: binary_sensor.openquatt_ha_cooling_enable
-                    name: Koeltoestemming (HA-invoer)
         column_span: 3
       - type: grid
         cards:
@@ -1921,38 +1896,6 @@ views:
                     name: Proxy koeltoestemming
                   - entity: binary_sensor.openquatt_ext_cooling_enable_valid
                     name: Koeltoestemmingsbron geldig
-          - type: vertical-stack
-            cards:
-              - type: heading
-                icon: mdi:chip
-                heading: OpenQuatt HA-invoerwaarden
-                heading_style: subtitle
-              - type: markdown
-                content: |-
-                  <details>
-                  <summary><strong>Uitleg</strong></summary>
-
-                  Dit zijn de zes HA-invoerwaarden zoals OpenQuatt ze ontvangt. Deze horen de proxywaarden uit het middelste blok te volgen.
-
-                  Blijft een waarde op `Unknown`, controleer dan eerst of de bijbehorende `...bron geldig` op `on` staat.
-
-                  </details>
-                text_only: true
-              - type: entities
-                show_header_toggle: false
-                entities:
-                  - entity: sensor.openquatt_ha_outside_temperature
-                    name: HA - Buitentemperatuur
-                  - entity: sensor.openquatt_ha_water_supply_temperature
-                    name: HA - Aanvoertemperatuur
-                  - entity: sensor.openquatt_ha_thermostat_setpoint
-                    name: HA - Thermostaat doeltemperatuur
-                  - entity: sensor.openquatt_ha_thermostat_room_temperature
-                    name: HA - Thermostaat kamertemperatuur
-                  - entity: binary_sensor.openquatt_ha_heating_enable
-                    name: HA - Warmtetoestemming
-                  - entity: binary_sensor.openquatt_ha_cooling_enable
-                    name: HA - Koeltoestemming
         column_span: 3
         visibility:
           - condition: state
@@ -2252,31 +2195,11 @@ views:
             icon: mdi:cloud-check
             heading_style: title
             heading: Quatt CiC-configuratie
-          - type: markdown
-            content: |-
-              <details>
-              <summary><strong>Uitleg</strong></summary>
-
-              Dit blok toont de status van de CiC-feed. Als de feed niet OK is of data stale wordt, kunnen CIC-bronnen onbruikbaar worden voor de geselecteerde signalen.
-
-              Controleer bij afwijkingen:
-              - `JSON feed OK`
-              - `Data verouderd`
-              - `Tijd sinds laatste succes`
-
-              </details>
-            text_only: true
           - type: entities
             show_header_toggle: false
             entities:
               - entity: switch.openquatt_cic_enable_polling
                 name: Polling inschakelen
-              - entity: binary_sensor.openquatt_cic_json_feed_ok
-                name: JSON feed OK
-              - entity: binary_sensor.openquatt_cic_data_stale
-                name: Data verouderd
-              - entity: text.openquatt_cic_feed_url
-                name: CIC feed URL
     cards: []
     header:
       card:
@@ -2285,7 +2208,7 @@ views:
           # <ha-icon icon="mdi:source-branch"></ha-icon> Sensorconfiguratie
 
 
-          Bekijk hier per signaal welke waarde OpenQuatt gebruikt en of de bronstatus klopt. Sensorselectie doe je in de OpenQuatt web-app: `http://openquatt.local`.
+          Bekijk hier per signaal welke waarde en effectieve bron OpenQuatt gebruikt. Configureer bronnen en bekijk uitgebreide diagnostiek in de OpenQuatt web-app: `http://openquatt.local`.
     top_margin: false
     dense_section_placement: false
   - title: Instellingen
@@ -2612,7 +2535,7 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - Kies hier maximaal twee compressorlevels per HP die de verdelingslogica moet overslaan.
+              - Configureer maximaal twee uitgesloten compressorlevels per HP in de OpenQuatt web-app.
 
               - `None` betekent: geen uitsluiting in dat slot.
 
@@ -2632,10 +2555,6 @@ views:
             title: HP1 uitgesloten levels
             show_header_toggle: false
             entities:
-              - entity: select.openquatt_hp1_excluded_compressor_level_a
-                name: Excluded level A
-              - entity: select.openquatt_hp1_excluded_compressor_level_b
-                name: Excluded level B
               - entity: sensor.openquatt_hp1_excluded_compressor_levels
                 name: Actieve uitsluitingen
     header:
@@ -2665,9 +2584,6 @@ views:
               <summary><strong>Uitleg parameters</strong></summary>
 
 
-              - **Reset draaitellers**. Let op: het kan maximaal 1 minuut duren voordat je effect ziet.
-
-              - **Reset cumulatieve energietellers** zet cumulatieve elektriciteits-en warmte-energiemeters terug naar 0.
 
               - **HP1 draaitijd counter** toont de actuele teller waarop de runtime-balans wordt gebaseerd.
 
@@ -2679,10 +2595,6 @@ views:
           - type: entities
             show_header_toggle: false
             entities:
-              - entity: button.openquatt_reset_runtime_counters_hp1
-                name: Reset draaitellers
-              - entity: button.openquatt_reset_cumulative_energy_counters
-                name: Reset cumulatieve energietellers
               - entity: sensor.openquatt_hp1_runtime_hours
                 name: HP1 draaitijd
               - entity: sensor.openquatt_runtime_lead_hp

--- a/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
+++ b/docs/dashboard/openquatt_ha_dashboard_single_nl.yaml
@@ -1639,11 +1639,12 @@ views:
               <details>
               <summary><strong>Uitleg</strong></summary>
 
-              Deze tab toont per signaal de waarde en effectieve bron die OpenQuatt gebruikt. Sensorselectie en ruwe brondiagnostiek vind je in de OpenQuatt web-app via `http://openquatt.local`, waar hardwareprofiel, CIC-status en geldige opties samen worden bewaakt.
+              Deze tab toont per signaal de waarde die OpenQuatt gebruikt en de belangrijkste ruwe bronnen. Sensorselectie en volledige brondiagnostiek vind je in de OpenQuatt web-app via `http://openquatt.local`, waar hardwareprofiel, CIC-status en geldige opties samen worden bewaakt.
 
               Gebruik dit blok voor:
+              - snelle vergelijking tussen CIC, lokaal, OpenTherm en HA-invoer
               - validatie van de effectieve regelinput
-              - bevestiging van de geselecteerde lokale of OpenTherm-waarde
+              - diagnose van ontbrekende of afwijkende bronwaarden
 
               Voor HA-invoer blijft de HA bronconfiguratie verderop op deze tab staan.
 
@@ -1667,6 +1668,8 @@ views:
                     name: Effectieve kamertemperatuurbron
                   - entity: sensor.openquatt_room_temperature_selected
                     name: Geselecteerde kamertemperatuur
+                  - entity: sensor.openquatt_cic_room_temperature
+                    name: Kamertemperatuur (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1674,6 +1677,8 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_temperature
                       name: Kamertemperatuur (OT-thermostaat)
+                  - entity: sensor.openquatt_ha_thermostat_room_temperature
+                    name: Kamertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1690,6 +1695,10 @@ views:
                     name: Geselecteerde aanvoertemperatuur
                   - entity: sensor.openquatt_water_supply_temp
                     name: Aanvoertemperatuur (ESP)
+                  - entity: sensor.openquatt_cic_water_supply_temp
+                    name: Aanvoertemperatuur (CIC)
+                  - entity: sensor.openquatt_ha_water_supply_temperature
+                    name: Aanvoertemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1706,6 +1715,8 @@ views:
                     name: Geselecteerde flow
                   - entity: sensor.openquatt_flow_average_local
                     name: Flow (buitenunit)
+                  - entity: sensor.openquatt_cic_flowrate_filtered
+                    name: Flow (CIC)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1722,6 +1733,8 @@ views:
                     name: Geselecteerde buitentemperatuur
                   - entity: sensor.openquatt_outside_temperature_local_aggregated
                     name: Buitentemperatuur (buitenunit)
+                  - entity: sensor.openquatt_ha_outside_temperature
+                    name: Buitentemperatuur (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading
@@ -1738,6 +1751,8 @@ views:
                     name: Effectieve setpointbron
                   - entity: sensor.openquatt_room_setpoint_selected
                     name: Geselecteerd kamer setpoint
+                  - entity: sensor.openquatt_cic_room_setpoint
+                    name: Kamer setpoint (CIC)
                   - type: conditional
                     conditions:
                       - entity: switch.openquatt_opentherm_enabled
@@ -1745,6 +1760,8 @@ views:
                     row:
                       entity: sensor.openquatt_ot_room_setpoint
                       name: Kamer setpoint (OT-thermostaat)
+                  - entity: sensor.openquatt_ha_thermostat_setpoint
+                    name: Kamer setpoint (HA-invoer)
           - type: vertical-stack
             cards:
               - type: heading

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -185,6 +185,8 @@ select:
     id: ${hp_id}_excluded_level_a
     name: "${prefix}Excluded compressor level A"
     icon: mdi:speedometer-slow
+    entity_category: config
+    disabled_by_default: true
     optimistic: true
     restore_value: true
     initial_option: "None"
@@ -208,6 +210,8 @@ select:
     id: ${hp_id}_excluded_level_b
     name: "${prefix}Excluded compressor level B"
     icon: mdi:speedometer-slow
+    entity_category: config
+    disabled_by_default: true
     optimistic: true
     restore_value: true
     initial_option: "None"
@@ -288,6 +292,7 @@ sensor:
     id: ${hp_id}_voltage
     name: "${prefix}AC voltage"
     icon: mdi:flash
+    disabled_by_default: true
     register_type: holding
     address: 2100
     unit_of_measurement: "V"
@@ -309,6 +314,7 @@ sensor:
     id: ${hp_id}_current
     name: "${prefix}AC current"
     icon: mdi:current-ac
+    disabled_by_default: true
     register_type: holding
     address: 2101
     unit_of_measurement: "A"
@@ -380,6 +386,7 @@ sensor:
     id: ${hp_id}_fan_speed_max
     name: "${prefix}Fan speed max"
     icon: mdi:fan
+    disabled_by_default: true
     register_type: holding
     address: 2104
     unit_of_measurement: "RPM"
@@ -615,6 +622,7 @@ sensor:
     id: ${hp_id}_condensing_temp
     name: "${prefix}Condensing temperature"
     icon: mdi:thermometer
+    disabled_by_default: true
     register_type: holding
     address: 2131
     unit_of_measurement: "°C"
@@ -768,6 +776,7 @@ sensor:
     id: ${hp_id}_pump_power
     name: "${prefix}Pump Power"
     icon: mdi:pump
+    disabled_by_default: true
     register_type: holding
     address: 2137
     # force_new_range: true
@@ -1038,6 +1047,7 @@ binary_sensor:
     name: "${prefix}Crankcase heater"
     icon: mdi:radiator
     device_class: heat
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_${hp_id}
 
@@ -1078,6 +1088,7 @@ binary_sensor:
     name: "${prefix}DC Pump Relay"
     icon: mdi:electric-switch
     device_class: running
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_${hp_id}
 

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -241,6 +241,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: 1s
     web_server:
       sorting_group_id: oq_boiler
@@ -256,6 +257,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: 1s
     web_server:
       sorting_group_id: oq_boiler
@@ -269,6 +271,7 @@ sensor:
     unit_of_measurement: "s"
     accuracy_decimals: 1
     entity_category: diagnostic
+    internal: true
     update_interval: 1s
     web_server:
       sorting_group_id: oq_boiler
@@ -313,6 +316,7 @@ text_sensor:
     name: "Boiler command source"
     icon: mdi:source-branch
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: 1s
     web_server:
       sorting_group_id: oq_boiler
@@ -333,6 +337,7 @@ text_sensor:
     name: "Boiler block reason"
     icon: mdi:shield-alert-outline
     entity_category: diagnostic
+    disabled_by_default: true
     update_interval: 1s
     web_server:
       sorting_group_id: oq_boiler

--- a/openquatt/oq_cic.yaml
+++ b/openquatt/oq_cic.yaml
@@ -65,7 +65,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     icon: mdi:water-thermometer
-    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_temperatures
@@ -91,7 +90,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     icon: mdi:home-thermometer
-    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_cic
@@ -104,7 +102,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 3
     icon: mdi:thermometer
-    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_cic
@@ -117,7 +114,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     icon: mdi:water-pump
-    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_cic

--- a/openquatt/oq_cic.yaml
+++ b/openquatt/oq_cic.yaml
@@ -30,6 +30,7 @@ switch:
     id: cic_enable
     name: "CIC - Enable polling"
     icon: mdi:cloud-sync
+    entity_category: config
     optimistic: true
     restore_mode: ${oq_cic_restore_mode_default}
     web_server:
@@ -43,6 +44,8 @@ text:
     id: cic_feed_url
     name: "CIC - Feed URL"
     icon: mdi:link-variant
+    entity_category: config
+    disabled_by_default: true
     mode: text
     optimistic: true
     restore_value: true
@@ -62,6 +65,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     icon: mdi:water-thermometer
+    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_temperatures
@@ -74,6 +78,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     icon: mdi:thermostat
+    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_cic
@@ -86,6 +91,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     icon: mdi:home-thermometer
+    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_cic
@@ -98,6 +104,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 3
     icon: mdi:thermometer
+    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_cic
@@ -110,6 +117,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     icon: mdi:water-pump
+    disabled_by_default: true
     update_interval: never
     web_server:
       sorting_group_id: oq_cic
@@ -148,6 +156,7 @@ binary_sensor:
     name: "CIC - CH enabled"
     icon: mdi:radiator
     device_class: heat
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_cic
 
@@ -156,6 +165,7 @@ binary_sensor:
     name: "CIC - CH enable valid"
     icon: mdi:check-decagram
     entity_category: diagnostic
+    internal: true
     web_server:
       sorting_group_id: oq_cic
 
@@ -164,6 +174,7 @@ binary_sensor:
     name: "CIC - Cooling enabled"
     icon: mdi:snowflake
     device_class: cold
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_cic
 
@@ -172,6 +183,7 @@ binary_sensor:
     name: "CIC - JSON Feed OK"
     icon: mdi:cloud-check
     device_class: connectivity
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_cic
 
@@ -180,6 +192,7 @@ binary_sensor:
     name: "CIC - Data stale"
     icon: mdi:cloud-alert
     device_class: problem
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_cic
 

--- a/openquatt/oq_energy.yaml
+++ b/openquatt/oq_energy.yaml
@@ -11,6 +11,8 @@ button:
     id: oq_reset_cumulative_energy_counters
     name: "Reset Cumulative Energy Counters"
     icon: mdi:restart
+    entity_category: config
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_performance
     on_press:

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -86,6 +86,7 @@ number:
     id: oq_flow_setpoint_lph
     name: "Flow Setpoint"
     icon: mdi:waves-arrow-right
+    entity_category: config
     unit_of_measurement: "L/h"
     mode: slider
     web_server:
@@ -101,6 +102,7 @@ number:
     id: oq_cooling_flow_setpoint_lph
     name: "Cooling Flow Setpoint"
     icon: mdi:snowflake-thermometer
+    entity_category: config
     unit_of_measurement: "L/h"
     mode: slider
     web_server:
@@ -116,6 +118,7 @@ number:
     id: oq_flow_manual_pwm
     name: "Manual iPWM"
     icon: mdi:fan
+    entity_category: config
     unit_of_measurement: "iPWM"
     mode: slider
     min_value: 50
@@ -166,6 +169,7 @@ number:
     id: oq_flow_kp
     name: "Flow PI Kp"
     icon: mdi:alpha-k-circle-outline
+    entity_category: config
     mode: slider
     web_server:
       sorting_group_id: oq_tuning_flow
@@ -181,6 +185,7 @@ number:
     id: oq_flow_ki
     name: "Flow PI Ki"
     icon: mdi:alpha-i-circle-outline
+    entity_category: config
     mode: slider
     web_server:
       sorting_group_id: oq_tuning_flow
@@ -201,6 +206,7 @@ select:
     id: oq_flow_control_mode
     name: "Flow Control Mode"
     icon: mdi:tune-variant
+    entity_category: config
     options:
       - Flow Setpoint
       - Manual PWM

--- a/openquatt/oq_ha_inputs.yaml
+++ b/openquatt/oq_ha_inputs.yaml
@@ -22,7 +22,6 @@ sensor:
     name: "HA - Outside Temperature"
     entity_id: ${ha_outside_temp_entity_id}
     internal: false
-    disabled_by_default: true
     icon: mdi:thermometer
     unit_of_measurement: "°C"
     device_class: temperature
@@ -36,7 +35,6 @@ sensor:
     name: "HA - Water Supply Temperature"
     entity_id: ${ha_water_supply_temp_entity_id}
     internal: false
-    disabled_by_default: true
     icon: mdi:water-thermometer
     unit_of_measurement: "°C"
     device_class: temperature
@@ -50,7 +48,6 @@ sensor:
     name: "HA - Thermostat Setpoint"
     entity_id: ${ha_room_setpoint_entity_id}
     internal: false
-    disabled_by_default: true
     icon: mdi:thermostat
     unit_of_measurement: "°C"
     device_class: temperature
@@ -64,7 +61,6 @@ sensor:
     name: "HA - Thermostat Room Temperature"
     entity_id: ${ha_room_temp_entity_id}
     internal: false
-    disabled_by_default: true
     icon: mdi:home-thermometer
     unit_of_measurement: "°C"
     device_class: temperature

--- a/openquatt/oq_ha_inputs.yaml
+++ b/openquatt/oq_ha_inputs.yaml
@@ -22,6 +22,7 @@ sensor:
     name: "HA - Outside Temperature"
     entity_id: ${ha_outside_temp_entity_id}
     internal: false
+    disabled_by_default: true
     icon: mdi:thermometer
     unit_of_measurement: "°C"
     device_class: temperature
@@ -35,6 +36,7 @@ sensor:
     name: "HA - Water Supply Temperature"
     entity_id: ${ha_water_supply_temp_entity_id}
     internal: false
+    disabled_by_default: true
     icon: mdi:water-thermometer
     unit_of_measurement: "°C"
     device_class: temperature
@@ -48,6 +50,7 @@ sensor:
     name: "HA - Thermostat Setpoint"
     entity_id: ${ha_room_setpoint_entity_id}
     internal: false
+    disabled_by_default: true
     icon: mdi:thermostat
     unit_of_measurement: "°C"
     device_class: temperature
@@ -61,6 +64,7 @@ sensor:
     name: "HA - Thermostat Room Temperature"
     entity_id: ${ha_room_temp_entity_id}
     internal: false
+    disabled_by_default: true
     icon: mdi:home-thermometer
     unit_of_measurement: "°C"
     device_class: temperature
@@ -88,6 +92,7 @@ binary_sensor:
     name: "HA - Heating Enable"
     entity_id: ${ha_heating_enable_entity_id}
     internal: false
+    disabled_by_default: true
     icon: mdi:radiator
     device_class: heat
     web_server:
@@ -98,6 +103,7 @@ binary_sensor:
     name: "HA - Cooling Enable"
     entity_id: ${ha_cooling_enable_entity_id}
     internal: false
+    disabled_by_default: true
     icon: mdi:snowflake-check
     device_class: cold
     web_server:

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -167,6 +167,7 @@ number:
     id: curve_tsupply_m20
     name: "Curve Tsupply @ -20°C"
     icon: mdi:thermometer
+    entity_category: config
     unit_of_measurement: "°C"
     min_value: 20
     max_value: 70
@@ -181,6 +182,7 @@ number:
     id: curve_tsupply_m10
     name: "Curve Tsupply @ -10°C"
     icon: mdi:thermometer
+    entity_category: config
     unit_of_measurement: "°C"
     min_value: 20
     max_value: 70
@@ -195,6 +197,7 @@ number:
     id: curve_tsupply_0
     name: "Curve Tsupply @ 0°C"
     icon: mdi:thermometer
+    entity_category: config
     unit_of_measurement: "°C"
     min_value: 20
     max_value: 70
@@ -209,6 +212,7 @@ number:
     id: curve_tsupply_5
     name: "Curve Tsupply @ 5°C"
     icon: mdi:thermometer
+    entity_category: config
     unit_of_measurement: "°C"
     min_value: 20
     max_value: 70
@@ -223,6 +227,7 @@ number:
     id: curve_tsupply_10
     name: "Curve Tsupply @ 10°C"
     icon: mdi:thermometer
+    entity_category: config
     unit_of_measurement: "°C"
     min_value: 20
     max_value: 70
@@ -237,6 +242,7 @@ number:
     id: curve_tsupply_15
     name: "Curve Tsupply @ 15°C"
     icon: mdi:thermometer
+    entity_category: config
     unit_of_measurement: "°C"
     min_value: 20
     max_value: 70
@@ -251,6 +257,7 @@ number:
     id: heating_curve_pid_kp
     name: "Heating Curve PID Kp"
     icon: mdi:alpha-k-circle-outline
+    entity_category: config
     min_value: 0.000
     max_value: 0.800
     step: 0.010
@@ -273,6 +280,7 @@ number:
     id: heating_curve_pid_ki
     name: "Heating Curve PID Ki"
     icon: mdi:alpha-i-circle-outline
+    entity_category: config
     min_value: 0.00000
     max_value: 0.00300
     step: 0.00010
@@ -295,6 +303,7 @@ number:
     id: heating_curve_pid_kd
     name: "Heating Curve PID Kd"
     icon: mdi:alpha-d-circle-outline
+    entity_category: config
     min_value: 0.000
     max_value: 0.400
     step: 0.010
@@ -317,6 +326,7 @@ number:
     id: curve_fallback_supply_temp
     name: "Curve Fallback Tsupply (No Outside Temp)"
     icon: mdi:thermometer-alert
+    entity_category: config
     unit_of_measurement: "°C"
     min_value: 25
     max_value: 70

--- a/openquatt/oq_mqtt_ingress.yaml
+++ b/openquatt/oq_mqtt_ingress.yaml
@@ -62,6 +62,7 @@ sensor:
     id: mqtt_cooling_dew_point
     name: "MQTT Cooling Dew Point"
     icon: mdi:water-thermometer
+    disabled_by_default: true
     unit_of_measurement: "°C"
     device_class: temperature
     state_class: measurement
@@ -74,6 +75,7 @@ sensor:
     id: mqtt_cooling_dew_point_age
     name: "MQTT Cooling Dew Point Age"
     icon: mdi:timer-outline
+    internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
@@ -84,6 +86,7 @@ sensor:
     id: mqtt_outside_temperature
     name: "MQTT Outside Temperature"
     icon: mdi:thermometer
+    disabled_by_default: true
     unit_of_measurement: "°C"
     device_class: temperature
     state_class: measurement
@@ -96,6 +99,7 @@ sensor:
     id: mqtt_outside_temperature_age
     name: "MQTT Outside Temperature Age"
     icon: mdi:timer-outline
+    internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
@@ -106,6 +110,7 @@ sensor:
     id: mqtt_room_temperature
     name: "MQTT Room Temperature"
     icon: mdi:home-thermometer
+    disabled_by_default: true
     unit_of_measurement: "°C"
     device_class: temperature
     state_class: measurement
@@ -118,6 +123,7 @@ sensor:
     id: mqtt_room_temperature_age
     name: "MQTT Room Temperature Age"
     icon: mdi:timer-outline
+    internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
@@ -128,6 +134,7 @@ sensor:
     id: mqtt_room_setpoint
     name: "MQTT Room Setpoint"
     icon: mdi:thermostat
+    disabled_by_default: true
     unit_of_measurement: "°C"
     device_class: temperature
     state_class: measurement
@@ -140,6 +147,7 @@ sensor:
     id: mqtt_room_setpoint_age
     name: "MQTT Room Setpoint Age"
     icon: mdi:timer-outline
+    internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
@@ -150,6 +158,7 @@ sensor:
     id: mqtt_heating_enable_age
     name: "MQTT Heating Enable Age"
     icon: mdi:timer-outline
+    internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
@@ -160,6 +169,7 @@ sensor:
     id: mqtt_cooling_enable_age
     name: "MQTT Cooling Enable Age"
     icon: mdi:timer-outline
+    internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
@@ -171,6 +181,7 @@ binary_sensor:
     id: mqtt_cooling_dew_point_valid
     name: "MQTT Cooling Dew Point Valid"
     icon: mdi:water-check
+    internal: true
     device_class: connectivity
     web_server:
       sorting_group_id: oq_ha_inputs
@@ -179,6 +190,7 @@ binary_sensor:
     id: mqtt_outside_temperature_valid
     name: "MQTT Outside Temperature Valid"
     icon: mdi:check-decagram
+    internal: true
     device_class: connectivity
     web_server:
       sorting_group_id: oq_ha_inputs
@@ -187,6 +199,7 @@ binary_sensor:
     id: mqtt_room_temperature_valid
     name: "MQTT Room Temperature Valid"
     icon: mdi:check-decagram
+    internal: true
     device_class: connectivity
     web_server:
       sorting_group_id: oq_ha_inputs
@@ -195,6 +208,7 @@ binary_sensor:
     id: mqtt_room_setpoint_valid
     name: "MQTT Room Setpoint Valid"
     icon: mdi:check-decagram
+    internal: true
     device_class: connectivity
     web_server:
       sorting_group_id: oq_ha_inputs
@@ -203,6 +217,7 @@ binary_sensor:
     id: mqtt_heating_enable
     name: "MQTT Heating Enable"
     icon: mdi:radiator
+    disabled_by_default: true
     device_class: heat
     web_server:
       sorting_group_id: oq_ha_inputs
@@ -211,6 +226,7 @@ binary_sensor:
     id: mqtt_heating_enable_valid
     name: "MQTT Heating Enable Valid"
     icon: mdi:check-decagram
+    internal: true
     device_class: connectivity
     web_server:
       sorting_group_id: oq_ha_inputs
@@ -219,6 +235,7 @@ binary_sensor:
     id: mqtt_cooling_enable
     name: "MQTT Cooling Enable"
     icon: mdi:snowflake-check
+    disabled_by_default: true
     device_class: cold
     web_server:
       sorting_group_id: oq_ha_inputs
@@ -227,6 +244,7 @@ binary_sensor:
     id: mqtt_cooling_enable_valid
     name: "MQTT Cooling Enable Valid"
     icon: mdi:check-decagram
+    internal: true
     device_class: connectivity
     web_server:
       sorting_group_id: oq_ha_inputs

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -248,6 +248,7 @@ number:
     id: oq_demand_filter_ramp_up_step_min
     name: "Demand filter ramp up"
     disabled_by_default: true
+    entity_category: config
     icon: mdi:stairs-up
     unit_of_measurement: "step/min"
     min_value: 1

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -134,6 +134,7 @@ switch:
     id: oq_manual_cooling_enable
     name: "Manual Cooling Enable"
     icon: mdi:snowflake-check
+    entity_category: config
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     web_server:

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -110,6 +110,7 @@ select:
     id: oq_heat_control_mode
     name: "Heating Control Mode"
     icon: mdi:tune-variant
+    entity_category: config
     optimistic: true
     restore_value: true
     options:

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -223,6 +223,7 @@ select:
     id: oq_silent_mode_override
     name: "Silent Mode Override"
     icon: mdi:weather-night
+    entity_category: config
     options:
       - "Schedule"
       - "On"
@@ -248,6 +249,7 @@ switch:
     id: oq_enabled
     name: "OpenQuatt Enabled"
     icon: mdi:power-standby
+    entity_category: config
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
     on_turn_on:

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -248,6 +248,7 @@ number:
     id: oq_min_runtime_min
     name: "Minimum runtime"
     icon: mdi:timer-cog-outline
+    entity_category: config
     unit_of_measurement: "s"
     min_value: 300
     max_value: 3600
@@ -265,6 +266,7 @@ number:
     name: "Dual HP Enable Hold"
     internal: ${hc_dual_tuning_internal}
     disabled_by_default: true
+    entity_category: config
     icon: mdi:timer-plus-outline
     unit_of_measurement: "min"
     min_value: 1
@@ -283,6 +285,7 @@ number:
     name: "Dual HP Disable Hold"
     internal: ${hc_dual_tuning_internal}
     disabled_by_default: true
+    entity_category: config
     icon: mdi:timer-minus-outline
     unit_of_measurement: "min"
     min_value: 1
@@ -303,6 +306,8 @@ button:
     id: oq_reset_runtime
     name: "${hc_runtime_reset_button_name}"
     icon: mdi:restart
+    entity_category: config
+    disabled_by_default: true
     web_server:
       sorting_group_id: oq_heating_strategy
     on_press:


### PR DESCRIPTION
# Wat verandert deze PR?

- Markeert technische `Valid`/`Age`-waarden als `internal` en optionele ruwe ingress-, service- en reset-entities als `disabled_by_default`.
- Geeft de afgesproken instelbare entities `entity_category: config`.
- Werkt de vier meegeleverde HA-dashboards bij; de belangrijkste CIC/HA-bronwaarden blijven zichtbaar en voor volledige diagnose/configuratie wordt naar de OpenQuatt web-app verwezen.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Voor Q Duo Wi-Fi gaat een verse installatie van 296 naar 244 standaard actieve HA-entities. Het totale HA-aanbod gaat van 315 naar 301: 14 technische entities worden `internal` en 38 optionele entities worden `disabled_by_default`. Bestaande HA-registrykeuzes voor `disabled_by_default` blijven door Home Assistant behouden; de 14 nieuwe internal entities verdwijnen wel uit de ESPHome API. Alle waarden blijven intern bruikbaar en de OpenQuatt web-app kan expliciet gevraagde internal entities via het bestaande bulk-endpoint uitlezen.

De acht CIC/HA-bronwaarden die in de standaarddashboardvergelijking staan, blijven bewust standaard actief: kamertemperatuur, aanvoertemperatuur, flow, buitentemperatuur en kamer-setpoint waar van toepassing.

## Achtergrond

De selectie is per groep gecontroleerd tegen de vier dashboard-YAML's in de repository. Primaire operationele waarden, de acht bronwaarden uit de dashboardvergelijking en de zeven systeemmetadata-/diagnose-entities blijven standaard actief. Alleen de overige door de gebruiker goedgekeurde ruwe ingresswaarden, secundaire HP/Modbus-servicewaarden, boilerdiagnostiek, CIC Feed URL, compressorleveluitsluitingen en resetacties worden opgeruimd.

Volledige diff-audit en afzonderlijke koude review uitgevoerd op correctness, lifecycle, compatibiliteit, fresh-install/upgradegedrag en dashboardconsumers. De firmwarewijzigingen voegen uitsluitend entity-metadata toe; regelgedrag, restorewaarden en componentlifecycle blijven ongewijzigd. Er zijn geen resterende dashboardreferenties naar de 52 entities waarvan de exposure verandert.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De vier Engelse/Nederlandse Single/Duo dashboards zijn bijgewerkt. De belangrijkste CIC/HA-bronwaarden blijven zichtbaar voor directe vergelijking; verwijderde/opt-in entities zijn uit de overige kaarten gehaald en de toelichting verwijst voor volledige brondiagnostiek en geavanceerde configuratie naar de lokale web-app.

## Validatie

- `python3 scripts/dev.py validate --config-only --venv-dir .venv` met alle acht enabled configs uit `build_targets.yaml`: geslaagd op ESPHome 2026.7.0, inclusief style consistency, docs consistency en web/docs contract.
- Alle vier dashboard-YAML's afzonderlijk geparsed; alle acht behouden bronreferenties zijn in iedere dashboardvariant aanwezig.
- Uitgewerkte Q Duo Wi-Fi-config opnieuw geïnventariseerd: 597 totaal, 296 internal, 244 standaard actief en 57 disabled-by-default; 0 resterende afgesproken `entity_category: config`-gaten.
- Gecontroleerd dat geen van de 52 resterende internal/disabled-wijzigingen nog door de repo-dashboards wordt gebruikt.
- `git diff --check`: geslaagd.