### PR TITLE
Register custom network socket usage

### DIFF
--- a/components/openquatt_cic/__init__.py
+++ b/components/openquatt_cic/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, sensor, switch, text
+from esphome.components import binary_sensor, sensor, socket, switch, text
 from esphome.const import CONF_ID
 
 AUTO_LOAD = ["sensor", "binary_sensor", "switch", "text"]
@@ -73,6 +73,10 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_LAST_STATUS_CODE_SENSOR): cv.use_id(sensor.Sensor),
     }
 ).extend(cv.polling_component_schema("5s"))
+CONFIG_SCHEMA = cv.All(
+    CONFIG_SCHEMA,
+    socket.consume_sockets(1, "openquatt_cic"),
+)
 
 
 async def to_code(config):

--- a/components/openquatt_mqtt_config/__init__.py
+++ b/components/openquatt_mqtt_config/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.core import CORE
-from esphome.components import binary_sensor, sensor
+from esphome.components import binary_sensor, sensor, socket
 from esphome.components.esp32 import add_idf_component, idf_version, include_builtin_idf_component
 from esphome.const import CONF_ID
 
@@ -88,6 +88,10 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_DEFAULT_ENABLED, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = cv.All(
+    CONFIG_SCHEMA,
+    socket.consume_sockets(1, "openquatt_mqtt_config"),
+)
 
 
 async def to_code(config):

--- a/components/openquatt_usage_telemetry/__init__.py
+++ b/components/openquatt_usage_telemetry/__init__.py
@@ -5,6 +5,7 @@ from esphome.components import (
     openquatt_mqtt_config,
     select,
     sensor,
+    socket,
     switch,
     text_sensor,
     time,
@@ -107,6 +108,7 @@ CONFIG_SCHEMA = cv.All(
     )
     .extend(cv.COMPONENT_SCHEMA),
     validate_config,
+    socket.consume_sockets(1, "openquatt_usage_telemetry"),
 )
 
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Registreert het maximale socketgebruik van `openquatt_cic`, `openquatt_mqtt_config` en `openquatt_usage_telemetry` bij ESPHome.
- Laat ESPHome `CONFIG_LWIP_MAX_SOCKETS` automatisch berekenen; er wordt geen handmatige LWIP-override toegevoegd.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

De drie custom componenten openen rechtstreeks een ESP-IDF HTTP- of MQTT-client, maar declareerden hun socketbehoefte niet via ESPHome `socket.consume_sockets()`. Daardoor onderschatte ESPHome de worst-case socketcapaciteit met drie descriptors.

Na deze correctie berekent ESPHome voor Wi-Fi-profielen automatisch 20 sockets in plaats van 17: 14 TCP, 3 UDP en 3 TCP-listeners. Voor Ethernet-profielen wordt dit 16 in plaats van 13: 11 TCP, 2 UDP en 3 listeners. De bestaande clientlifecycles, reconnectlogica en gelijktijdigheid veranderen niet; elk component declareert één socket en kan maximaal één client tegelijk hebben.

`CONFIG_LWIP_MAX_ACTIVE_TCP` blijft ongemoeid. Ook wordt geen reserve boven de door ESPHome berekende capaciteit hardgecodeerd.

## Achtergrond

ESPHome 2026.7 gebruikt socketregistraties tijdens codegeneratie om `CONFIG_LWIP_MAX_SOCKETS` af te leiden. Standaardcomponenten zoals API, webserver, OTA, mDNS en captive portal registreerden zich al; de drie OpenQuatt-clients ontbraken nog in die telling.

De volledige diff is gecontroleerd op lifecycle, retries, overlap en fresh-install/upgradegedrag. De wijziging raakt uitsluitend build-time capaciteitsboekhouding: zij opent geen socket, maakt geen verbinding persistent en verandert geen control- of actuatorpad.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is interne ESPHome/ESP-IDF-capaciteitsboekhouding zonder nieuwe gebruikersinstelling of gewijzigd bedieningsgedrag.

## Validatie

- `python3 scripts/dev.py validate --config-only --venv-dir .venv` met alle acht enabled configs uit `build_targets.yaml`: geslaagd op ESPHome 2026.7.0, inclusief style consistency, docs consistency en web/docs contract.
- `esphome compile --only-generate` met alle acht enabled configs: geslaagd.
- Gegenereerde Wi-Fi-capaciteit: `CONFIG_LWIP_MAX_SOCKETS=20` (`TCP=14`, `UDP=3`, `TCP_LISTEN=3`).
- Gegenereerde Ethernet-capaciteit: `CONFIG_LWIP_MAX_SOCKETS=16` (`TCP=11`, `UDP=2`, `TCP_LISTEN=3`).
- Gecontroleerd dat elk custom component maximaal één gelijktijdige client heeft en exact één socket registreert.
- `git diff --check`: geslaagd.