### PR TITLE
Protect internal heap during incident and telemetry workloads

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@
 - [ ] Runtime/control gedrag gewijzigd
 - [ ] User-facing entities/configuratie gewijzigd
 - [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
+- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt
 
 Toelichting:
 
@@ -42,3 +43,16 @@ Docs-impact motivatie:
 ## Validatie
 
 <!-- Wat is lokaal getest? Noem commando's/configs waar relevant. -->
+
+- [ ] Geheugenimpact gemeten op representatieve hardware
+- [ ] Geen runtime-geheugenimpact
+
+Heap/stack-impact:
+
+<!-- Indien relevant invullen:
+- static RAM-delta per relevante build:
+- baseline/candidate current + minimum internal heap:
+- largest block + fragmentatie + vrij PSRAM:
+- relevante task-stack-watermarks:
+- geteste worst-case overlap:
+-->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,17 @@
 - For docs/tooling changes, prefer the specific script touched by the task.
 - Summarize build/test output by command, pass/fail, and the few relevant error lines.
 
+## Embedded Memory Safety
+
+- Treat internal DRAM as a constrained runtime resource required by Wi-Fi, lwIP, TLS, DMA and FreeRTOS task stacks; total free memory or free PSRAM alone is not evidence of safety.
+- Distinguish current free heap from the cumulative minimum-since-boot watermark. Also inspect the largest internal free block, fragmentation and relevant task-stack high-watermarks.
+- Put large, long-lived state, history and request scratch buffers in PSRAM with an explicit failure policy. Do not silently fall back to internal RAM when preserving internal heap is part of the safety budget.
+- Remember that globals, `new`, `std::string` and `std::vector` do not automatically use PSRAM; objects stored in PSRAM may still own internal allocations.
+- Keep ISR/DMA data, cache-disabled paths and low-level Wi-Fi/TLS/ESP-MQTT stacks in compatible internal memory unless the platform contract and HIL prove external-stack use is safe.
+- Prefer a persistent worker task over repeated task create/delete cycles. Avoid globally changing malloc-placement thresholds as a substitute for targeted ownership.
+- For memory-affecting changes, compare identical baseline and candidate firmware through cold boot and realistic HA/web/API/MQTT/Modbus/OpenTherm/OTA load. A compile-time RAM report is not sufficient.
+- Treat unexplained regressions, allocation failures or a minimum/largest-block result without demonstrated margin for the worst simultaneous allocation as release-blocking. Maintain profile-specific budgets once healthy HIL baselines are established.
+
 ## GitHub And PRs
 
 - Do not prefix PR titles with `[codex]`; use a concise human-readable title instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,33 @@ Not everything is checked automatically. These rules remain leading during revie
 - Add comments only where intent is not immediately clear.
 - Write new and changed code comments in English, including YAML comments and `//` comments inside ESPHome lambdas.
 
+## Embedded Memory and Heap
+
+Internal DRAM is a safety and availability budget, not interchangeable with free PSRAM. Wi-Fi, lwIP, TLS, ESP-MQTT, DMA and several FreeRTOS paths still require internal memory and often a sufficiently large contiguous block.
+
+For new runtime features and material changes:
+
+- Prefer strict PSRAM allocation for large, long-lived state, history, payload and response scratch buffers when the access path is PSRAM-safe.
+- Do not silently fall back to internal RAM when that would consume reserved network or control headroom. Allocation failure must degrade explicitly and safety-relevant control must fail closed.
+- Remember that globals, `new`, `std::string` and `std::vector` do not automatically allocate in PSRAM. A containing object in PSRAM can still own internal allocations.
+- Keep ISR/DMA buffers, cache-disabled code paths and platform-restricted task stacks in compatible internal memory.
+- Reuse bounded buffers and persistent worker tasks instead of per-request large copies or repeated task create/delete cycles, but do not keep MQTT/TLS/socket resources alive merely to preserve a worker.
+- Use targeted placement before changing global options such as `CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL`.
+- Review the maximum simultaneous peak across components, not only each component in isolation.
+
+Validate memory-sensitive work with identical baseline and candidate firmware. Record at least:
+
+- current internal free heap;
+- cumulative minimum internal heap since boot;
+- largest internal free block and fragmentation;
+- free PSRAM;
+- relevant task-stack high-watermarks;
+- whether values recover after the tested operation.
+
+Measure during cold boot and realistic combined load, including the applicable HA, web, API, MQTT, Modbus, OpenTherm and OTA/flash paths. Avoid high-frequency diagnostic polling that materially changes the result. The linker RAM summary is useful for static deltas, but does not expose transient task stacks, TLS buffers or allocation peaks.
+
+An unexplained regression, allocation failure, or minimum/largest-block result without measured margin for the worst simultaneous allocation is release-blocking until investigated. Establish healthy HIL baselines per hardware profile and turn those into explicit profile budgets rather than relying on one global magic number. See `docs/system-overview.md` for the project memory model.
+
 ## Lambda Style
 
 For ESPHome lambdas, we use a narrow but strict style:

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -2,6 +2,11 @@
 
 - Custom ESPHome components mix Python codegen/validation with C++ runtime code.
 - Inspect only the touched component directory plus `openquatt_common` when shared helpers are needed.
-- Be conservative with RAM/flash use; avoid unnecessary dynamic allocation on ESP targets.
+- Be conservative with internal DRAM. Move large, long-lived buffers or state to strict PSRAM where task/ISR/cache constraints permit it, and define a fail-closed allocation-failure path.
+- Use `PsramBuffer::allocate_external()` for budget-critical trivial storage and `PsramObjectArray` for constructed objects. Use fallback allocation only when consuming internal RAM is an explicit design choice.
+- Do not assume `static`, `new`, `std::string` or `std::vector` uses PSRAM; inspect nested ownership as well as the containing object.
+- Avoid large per-request copies, repeated task create/delete cycles and hidden internal-RAM fallback. Reuse bounded scratch buffers and persistent workers where practical.
+- Preserve internal memory for Wi-Fi, lwIP, TLS, DMA and low-level task stacks; do not change global malloc-placement thresholds without profile-wide evidence.
+- For memory-affecting changes, measure current/minimum internal heap, largest free block, fragmentation and relevant task-stack high-watermarks on representative hardware.
 - Keep Python schemas/codegen aligned with C++ headers and runtime behavior.
 - Prefer target-specific config validation before any full compile.

--- a/components/openquatt_common/PsramBuffer.h
+++ b/components/openquatt_common/PsramBuffer.h
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <new>
 
 #include "esphome/core/helpers.h"
 
@@ -18,26 +19,13 @@ template<typename T> class PsramBuffer {
   PsramBuffer &operator=(const PsramBuffer &) = delete;
 
   bool allocate(size_t count) {
-    this->release();
-    if (count == 0) {
-      return true;
-    }
+    return this->allocate_(count, true);
+  }
 
-    RAMAllocator<T> external_allocator(RAMAllocator<T>::ALLOC_EXTERNAL);
-    this->data_ = external_allocator.allocate(count);
-    if (this->data_ == nullptr) {
-      RAMAllocator<T> internal_allocator(RAMAllocator<T>::ALLOC_INTERNAL);
-      this->data_ = internal_allocator.allocate(count);
-      this->external_ = false;
-      if (this->data_ == nullptr) {
-        return false;
-      }
-    } else {
-      this->external_ = true;
-    }
-
-    this->size_ = count;
-    return true;
+  /// Allocate strictly from PSRAM. This intentionally does not fall back to
+  /// internal RAM when preserving internal heap is part of the safety budget.
+  bool allocate_external(size_t count) {
+    return this->allocate_(count, false);
   }
 
   void release() {
@@ -59,9 +47,88 @@ template<typename T> class PsramBuffer {
   const T &operator[](size_t index) const { return this->data_[index]; }
 
  private:
+  bool allocate_(size_t count, bool allow_internal_fallback) {
+    this->release();
+    if (count == 0) {
+      return true;
+    }
+
+    RAMAllocator<T> external_allocator(RAMAllocator<T>::ALLOC_EXTERNAL);
+    this->data_ = external_allocator.allocate(count);
+    if (this->data_ == nullptr) {
+      if (!allow_internal_fallback) {
+        return false;
+      }
+      RAMAllocator<T> internal_allocator(RAMAllocator<T>::ALLOC_INTERNAL);
+      this->data_ = internal_allocator.allocate(count);
+      this->external_ = false;
+      if (this->data_ == nullptr) {
+        return false;
+      }
+    } else {
+      this->external_ = true;
+    }
+
+    this->size_ = count;
+    return true;
+  }
+
   T *data_{nullptr};
   size_t size_{0};
   bool external_{false};
+};
+
+/// Fixed-size object storage that is placement-constructed strictly in PSRAM.
+///
+/// Unlike PsramBuffer, this helper never falls back to internal RAM and manages
+/// the lifetime of non-trivial objects. Allocate it from setup(), after PSRAM
+/// initialization, and keep all accesses in normal task context.
+template<typename T, size_t Count> class PsramObjectArray {
+ public:
+  PsramObjectArray() = default;
+  ~PsramObjectArray() { this->release(); }
+
+  PsramObjectArray(const PsramObjectArray &) = delete;
+  PsramObjectArray &operator=(const PsramObjectArray &) = delete;
+
+  bool allocate() {
+    this->release();
+    if constexpr (Count == 0U) {
+      return true;
+    }
+
+    RAMAllocator<T> allocator(RAMAllocator<T>::ALLOC_EXTERNAL);
+    this->data_ = allocator.allocate(Count);
+    if (this->data_ == nullptr) {
+      return false;
+    }
+    for (size_t index = 0U; index < Count; ++index) {
+      new (&this->data_[index]) T{};
+    }
+    return true;
+  }
+
+  void release() {
+    if (this->data_ == nullptr) {
+      return;
+    }
+    for (size_t index = Count; index > 0U; --index) {
+      this->data_[index - 1U].~T();
+    }
+    free(this->data_);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+    this->data_ = nullptr;
+  }
+
+  T *data() { return this->data_; }
+  const T *data() const { return this->data_; }
+  static constexpr size_t size() { return Count; }
+  explicit operator bool() const { return this->data_ != nullptr; }
+
+  T &operator[](size_t index) { return this->data_[index]; }
+  const T &operator[](size_t index) const { return this->data_[index]; }
+
+ private:
+  T *data_{nullptr};
 };
 
 }  // namespace esphome::openquatt_common

--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
@@ -5,8 +5,6 @@
 #include <cstdio>
 #include <cstring>
 #include <limits>
-#include <memory>
-#include <new>
 
 #include "esp_random.h"
 #include "esphome/components/web_server/web_server.h"
@@ -409,6 +407,12 @@ class IncidentManagerRequestHandler : public AsyncWebHandler {
       request->requestAuthentication();
       return;
     }
+    if (!this->parent_->storage_ready()) {
+      request->send(
+          503, "application/json",
+          R"({"error":"snapshot_unavailable"})");
+      return;
+    }
     char url_buf[AsyncWebServerRequest::URL_BUF_SIZE];
     request->url_to(url_buf);
     const bool retry_start = url_path_matches(
@@ -505,39 +509,71 @@ float OpenQuattIncidentManager::get_setup_priority() const {
 }
 
 void OpenQuattIncidentManager::setup() {
-  this->units_[0].configured = true;
-  this->units_[1].configured = OQ_TOPOLOGY_DUO != 0;
+  const auto register_handler = [this]() {
+    if (web_server_base::global_web_server_base == nullptr) {
+      ESP_LOGW(TAG,
+               "web_server_base is unavailable; incident endpoint disabled");
+    } else if (this->web_auth_ == nullptr) {
+      ESP_LOGE(TAG,
+               "Runtime web auth is unavailable; incident endpoint disabled");
+    } else {
+      web_server_base::global_web_server_base->add_handler(
+          new IncidentManagerRequestHandler(this));
+    }
+  };
+
+  if (!this->external_state_.allocate()) {
+    ESP_LOGE(
+        TAG,
+        "Could not allocate %u-byte incident state arena in PSRAM; "
+        "incident control remains fail-closed",
+        static_cast<unsigned>(sizeof(ExternalState)));
+    register_handler();
+    this->mark_failed();
+    return;
+  }
+  this->action_mutex_ =
+      xSemaphoreCreateMutexStatic(&this->action_mutex_storage_);
+  this->snapshot_mutex_ =
+      xSemaphoreCreateMutexStatic(&this->snapshot_mutex_storage_);
+  if (this->action_mutex_ == nullptr || this->snapshot_mutex_ == nullptr) {
+    ESP_LOGE(TAG,
+             "Could not initialize incident state synchronization; "
+             "incident control remains fail-closed");
+    this->external_state_.release();
+    this->action_mutex_ = nullptr;
+    this->snapshot_mutex_ = nullptr;
+    register_handler();
+    this->mark_failed();
+    return;
+  }
+
+  this->units_()[0].configured = true;
+  this->units_()[1].configured = OQ_TOPOLOGY_DUO != 0;
   const uint32_t now_ms = millis();
   this->rotate_action_csrf_token_();
-  for (UnitState &unit : this->units_) {
+  for (UnitState &unit : this->units_()) {
     unit.last_link_round_ms = now_ms;
   }
   this->setup_manual_reset_persistence_(now_ms);
-  for (size_t slot = 0U; slot < this->units_.size(); ++slot) {
-    if (this->units_[slot].configured) {
-      this->publish_transitions_(this->units_[slot], slot, now_ms);
+  for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
+    if (this->units_()[slot].configured) {
+      this->publish_transitions_(this->units_()[slot], slot, now_ms);
     }
   }
   this->publish_snapshot_(now_ms);
+  register_handler();
 
-  if (web_server_base::global_web_server_base == nullptr) {
-    ESP_LOGW(TAG, "web_server_base is unavailable; incident endpoint disabled");
-  } else if (this->web_auth_ == nullptr) {
-    ESP_LOGE(TAG,
-             "Runtime web auth is unavailable; incident endpoint disabled");
-  } else {
-    web_server_base::global_web_server_base->add_handler(
-        new IncidentManagerRequestHandler(this));
-  }
 }
 
 void OpenQuattIncidentManager::loop() {
+  if (!this->storage_ready_()) return;
   const uint32_t now_ms = millis();
   if (elapsed_ms_(now_ms, this->last_loop_ms_) < 1000U) return;
   this->last_loop_ms_ = now_ms;
 
-  for (size_t slot = 0U; slot < this->units_.size(); ++slot) {
-    UnitState &unit = this->units_[slot];
+  for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
+    UnitState &unit = this->units_()[slot];
     if (!unit.configured) continue;
 
     bool has_pending_fault_word = false;
@@ -574,19 +610,22 @@ void OpenQuattIncidentManager::dump_config() {
       TAG,
       "  ODU confirmation: POST "
       "/openquatt/incidents/confirm-odu-power-cycle");
-  ESP_LOGCONFIG(TAG, "  Snapshot heap copy: %u bytes",
+  ESP_LOGCONFIG(TAG, "  Internal control object: %u bytes",
+                static_cast<unsigned>(sizeof(OpenQuattIncidentManager)));
+  ESP_LOGCONFIG(TAG, "  PSRAM incident arena: %u bytes",
+                static_cast<unsigned>(sizeof(ExternalState)));
+  ESP_LOGCONFIG(TAG, "  PSRAM response scratch: %u bytes (preallocated)",
                 static_cast<unsigned>(sizeof(PublishedSnapshot)));
 }
 
 void OpenQuattIncidentManager::rotate_action_csrf_token_() {
-  char token[33];
   std::snprintf(
-      token, sizeof(token), "%08x%08x%08x%08x",
+      this->action_csrf_token_.data(), this->action_csrf_token_.size(),
+      "%08x%08x%08x%08x",
       static_cast<unsigned>(esp_random()),
       static_cast<unsigned>(esp_random()),
       static_cast<unsigned>(esp_random()),
       static_cast<unsigned>(esp_random()));
-  this->action_csrf_token_ = token;
 }
 
 void OpenQuattIncidentManager::record_action_result_(
@@ -601,7 +640,11 @@ void OpenQuattIncidentManager::record_action_result_(
   unit.last_action_at_ms = now_ms;
 
   if (request_id == 0U) return;
-  portENTER_CRITICAL(&this->action_mux_);
+  if (this->action_mutex_ == nullptr ||
+      xSemaphoreTake(this->action_mutex_, portMAX_DELAY) != pdTRUE) {
+    ESP_LOGE(TAG, "Could not lock incident action state");
+    return;
+  }
   const size_t insert_index =
       (unit.action_result_head + unit.action_result_count) %
       ACTION_RESULT_HISTORY_SIZE;
@@ -619,7 +662,7 @@ void OpenQuattIncidentManager::record_action_result_(
     unit.pending_action_request_id = 0U;
     unit.pending_action_kind = DeferredActionKind::NONE;
   }
-  portEXIT_CRITICAL(&this->action_mux_);
+  xSemaphoreGive(this->action_mutex_);
 }
 
 OpenQuattIncidentManager::DeferredActionQueueResult
@@ -631,7 +674,10 @@ OpenQuattIncidentManager::queue_deferred_action_(
   const char *action = deferred_action_name(kind);
   DeferredActionQueueResult result =
       DeferredActionQueueResult::ACCEPTED;
-  portENTER_CRITICAL(&this->action_mux_);
+  if (this->action_mutex_ == nullptr ||
+      xSemaphoreTake(this->action_mutex_, portMAX_DELAY) != pdTRUE) {
+    return DeferredActionQueueResult::BUSY;
+  }
   for (size_t offset = 0U; offset < unit.action_result_count;
        ++offset) {
     const size_t index =
@@ -656,7 +702,7 @@ OpenQuattIncidentManager::queue_deferred_action_(
     unit.pending_action_request_id = request_id;
     unit.pending_action_kind = kind;
   }
-  portEXIT_CRITICAL(&this->action_mux_);
+  xSemaphoreGive(this->action_mutex_);
   return result;
 }
 
@@ -673,17 +719,57 @@ uint32_t OpenQuattIncidentManager::elapsed_ms_(uint32_t now_ms,
   return static_cast<uint32_t>(now_ms - since_ms);
 }
 
+bool OpenQuattIncidentManager::storage_ready_() const {
+  return static_cast<bool>(this->external_state_) &&
+         this->action_mutex_ != nullptr &&
+         this->snapshot_mutex_ != nullptr;
+}
+
+std::array<OpenQuattIncidentManager::UnitState, 2U> &
+OpenQuattIncidentManager::units_() {
+  return this->external_state_[0].units;
+}
+
+const std::array<OpenQuattIncidentManager::UnitState, 2U> &
+OpenQuattIncidentManager::units_() const {
+  return this->external_state_[0].units;
+}
+
+OpenQuattIncidentManager::PublishedSnapshot &
+OpenQuattIncidentManager::published_snapshot_() {
+  return this->external_state_[0].snapshots[
+      this->published_snapshot_index_];
+}
+
+const OpenQuattIncidentManager::PublishedSnapshot &
+OpenQuattIncidentManager::published_snapshot_() const {
+  return this->external_state_[0].snapshots[
+      this->published_snapshot_index_];
+}
+
+OpenQuattIncidentManager::PublishedSnapshot &
+OpenQuattIncidentManager::staging_snapshot_() {
+  return this->external_state_[0].snapshots[
+      this->staging_snapshot_index_];
+}
+
+OpenQuattIncidentManager::PublishedSnapshot &
+OpenQuattIncidentManager::response_snapshot_() const {
+  return const_cast<PublishedSnapshot &>(
+      this->external_state_[0].snapshots[2U]);
+}
+
 OpenQuattIncidentManager::UnitState *OpenQuattIncidentManager::unit_(
     uint8_t hp_index) {
-  if (!valid_hp_index_(hp_index)) return nullptr;
-  UnitState &unit = this->units_[hp_slot_(hp_index)];
+  if (!this->storage_ready_() || !valid_hp_index_(hp_index)) return nullptr;
+  UnitState &unit = this->units_()[hp_slot_(hp_index)];
   return unit.configured ? &unit : nullptr;
 }
 
 const OpenQuattIncidentManager::UnitState *OpenQuattIncidentManager::unit_(
     uint8_t hp_index) const {
-  if (!valid_hp_index_(hp_index)) return nullptr;
-  const UnitState &unit = this->units_[hp_slot_(hp_index)];
+  if (!this->storage_ready_() || !valid_hp_index_(hp_index)) return nullptr;
+  const UnitState &unit = this->units_()[hp_slot_(hp_index)];
   return unit.configured ? &unit : nullptr;
 }
 
@@ -810,7 +896,7 @@ void OpenQuattIncidentManager::process_fault_snapshot_(
       ++unit.initialization_fault_snapshot_count;
     }
     bool all_snapshots_complete = true;
-    for (const UnitState &candidate : this->units_) {
+    for (const UnitState &candidate : this->units_()) {
       if (candidate.configured &&
           candidate.initialization_fault_snapshot_count <
               INITIALIZATION_FAULT_SNAPSHOT_COUNT) {
@@ -979,10 +1065,11 @@ bool OpenQuattIncidentManager::acknowledge(
 }
 
 uint8_t OpenQuattIncidentManager::acknowledge_all_cleared() {
+  if (!this->storage_ready_()) return 0U;
   uint8_t acknowledged = 0U;
   const uint32_t now_ms = millis();
-  for (size_t hp_slot = 0U; hp_slot < this->units_.size(); ++hp_slot) {
-    UnitState &unit = this->units_[hp_slot];
+  for (size_t hp_slot = 0U; hp_slot < this->units_().size(); ++hp_slot) {
+    UnitState &unit = this->units_()[hp_slot];
     if (!unit.configured) continue;
 
     for (size_t incident_slot = 0U;
@@ -1343,7 +1430,7 @@ void OpenQuattIncidentManager::publish_incident_transition_(
   const size_t bank = static_cast<size_t>(
       definition.register_address - oq_incidents::kFirstFaultRegister);
   const int16_t raw_word =
-      static_cast<int16_t>(this->units_[slot].fault_words[bank]);
+      static_cast<int16_t>(this->units_()[slot].fault_words[bank]);
 
   if (!previous.confirmed_active && current.confirmed_active) {
     this->decision_log_->emit(
@@ -1619,15 +1706,22 @@ void OpenQuattIncidentManager::publish_transitions_(
 
 oq_incidents::DerivedOutputs OpenQuattIncidentManager::get_outputs(
     uint8_t hp_index) const {
-  if (!valid_hp_index_(hp_index) ||
-      !this->units_[hp_slot_(hp_index)].configured) {
+  if (!valid_hp_index_(hp_index)) {
     return {};
   }
+  if (!this->storage_ready_()) {
+    return incident_storage_failure_outputs();
+  }
+  if (!this->units_()[hp_slot_(hp_index)].configured) return {};
+
   const size_t slot = hp_slot_(hp_index);
-  oq_incidents::DerivedOutputs outputs;
-  portENTER_CRITICAL(&this->snapshot_mux_);
-  outputs = this->published_.units[slot].outputs;
-  portEXIT_CRITICAL(&this->snapshot_mux_);
+  oq_incidents::DerivedOutputs outputs =
+      incident_storage_failure_outputs();
+  if (xSemaphoreTake(this->snapshot_mutex_, portMAX_DELAY) != pdTRUE) {
+    return outputs;
+  }
+  outputs = this->published_snapshot_().units[slot].outputs;
+  xSemaphoreGive(this->snapshot_mutex_);
   return outputs;
 }
 
@@ -1649,6 +1743,7 @@ uint8_t OpenQuattIncidentManager::available_hp_count() const {
 }
 
 bool OpenQuattIncidentManager::availability_complete() const {
+  if (!this->storage_ready_()) return false;
   const uint8_t configured_mask =
       this->configured_hp_count() == 2U
           ? oq_incidents::kManualResetAllHpMask
@@ -1771,14 +1866,14 @@ void OpenQuattIncidentManager::setup_manual_reset_persistence_(
       oq_incidents::incident_id(2120U, 4U);
   const uint8_t restored_mask =
       this->manual_reset_persistence_.persisted_mask();
-  for (size_t slot = 0U; slot < this->units_.size(); ++slot) {
-    if (!this->units_[slot].configured ||
+  for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
+    if (!this->units_()[slot].configured ||
         (restored_mask & (1U << slot)) == 0U) {
       continue;
     }
-    this->units_[slot].engine.restore_power_cycle_latch(
+    this->units_()[slot].engine.restore_power_cycle_latch(
         power_cycle_incident);
-    this->units_[slot].restored_manual_reset_pending = true;
+    this->units_()[slot].restored_manual_reset_pending = true;
     ESP_LOGW(TAG, "Restored persistent manual-reset latch for HP%u",
              static_cast<unsigned>(slot + 1U));
   }
@@ -1792,13 +1887,13 @@ void OpenQuattIncidentManager::reconcile_manual_reset_persistence_(
       this->manual_reset_persistence_.persisted_mask();
   const oq_incidents::IncidentId power_cycle_incident =
       oq_incidents::incident_id(2120U, 4U);
-  for (size_t slot = 0U; slot < this->units_.size(); ++slot) {
-    if (!this->units_[slot].configured ||
+  for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
+    if (!this->units_()[slot].configured ||
         (persisted_mask & (1U << slot)) == 0U ||
-        this->units_[slot].engine.has_power_cycle_latch()) {
+        this->units_()[slot].engine.has_power_cycle_latch()) {
       continue;
     }
-    this->units_[slot].engine.restore_power_cycle_latch(
+    this->units_()[slot].engine.restore_power_cycle_latch(
         power_cycle_incident);
   }
 
@@ -1869,9 +1964,10 @@ bool OpenQuattIncidentManager::persist_manual_reset_mask_(
 
 uint8_t OpenQuattIncidentManager::runtime_manual_reset_mask_() const {
   uint8_t mask = 0U;
-  for (size_t slot = 0U; slot < this->units_.size(); ++slot) {
-    if (this->units_[slot].configured &&
-        this->units_[slot].engine.has_power_cycle_latch()) {
+  if (!this->storage_ready_()) return 0U;
+  for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
+    if (this->units_()[slot].configured &&
+        this->units_()[slot].engine.has_power_cycle_latch()) {
       mask |= static_cast<uint8_t>(1U << slot);
     }
   }
@@ -1880,11 +1976,12 @@ uint8_t OpenQuattIncidentManager::runtime_manual_reset_mask_() const {
 
 oq_incidents::DerivedOutputs
 OpenQuattIncidentManager::outputs_for_slot_(size_t slot) const {
-  if (slot >= this->units_.size() || !this->units_[slot].configured) {
+  if (!this->storage_ready_() || slot >= this->units_().size() ||
+      !this->units_()[slot].configured) {
     return {};
   }
   oq_incidents::DerivedOutputs outputs =
-      this->units_[slot].engine.outputs();
+      this->units_()[slot].engine.outputs();
   const uint8_t hp_mask = static_cast<uint8_t>(1U << slot);
   outputs = apply_persistence_initialization_gate(
       outputs, this->manual_reset_persistence_.initialization_pending());
@@ -1896,8 +1993,9 @@ OpenQuattIncidentManager::outputs_for_slot_(size_t slot) const {
 }
 
 void OpenQuattIncidentManager::publish_snapshot_(uint32_t now_ms) {
+  if (!this->storage_ready_()) return;
   this->reconcile_manual_reset_persistence_(now_ms);
-  PublishedSnapshot &next = this->staging_;
+  PublishedSnapshot &next = this->staging_snapshot_();
   next = {};
   next.control_mode =
       this->control_mode_code_ != nullptr
@@ -1912,65 +2010,94 @@ void OpenQuattIncidentManager::publish_snapshot_(uint32_t now_ms) {
   next.boiler_output_continuous = this->boiler_output_continuous_;
   next.generated_at_ms = now_ms;
   next.generated_at_epoch_s = this->current_epoch_s_();
-  for (size_t slot = 0U; slot < this->units_.size(); ++slot) {
-    if (!this->units_[slot].configured) continue;
+  for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
+    if (!this->units_()[slot].configured) continue;
     next.units[slot].outputs = this->outputs_for_slot_(slot);
     for (size_t incident_slot = 0U;
          incident_slot < oq_incidents::kRawIncidentSlotCount;
          ++incident_slot) {
       next.units[slot].incidents[incident_slot] =
-          this->units_[slot].engine.incident(
+          this->units_()[slot].engine.incident(
               static_cast<oq_incidents::IncidentId>(incident_slot + 1U));
     }
     next.units[slot].synthetic_incidents =
-        this->units_[slot].synthetic_incidents;
+        this->units_()[slot].synthetic_incidents;
     next.units[slot].last_action =
-        this->units_[slot].last_action;
+        this->units_()[slot].last_action;
     next.units[slot].last_action_result =
-        this->units_[slot].last_action_result;
+        this->units_()[slot].last_action_result;
     next.units[slot].last_action_ok =
-        this->units_[slot].last_action_ok;
+        this->units_()[slot].last_action_ok;
     next.units[slot].last_action_seq =
-        this->units_[slot].last_action_seq;
+        this->units_()[slot].last_action_seq;
     next.units[slot].last_action_request_id =
-        this->units_[slot].last_action_request_id;
+        this->units_()[slot].last_action_request_id;
     next.units[slot].last_action_at_ms =
-        this->units_[slot].last_action_at_ms;
-    portENTER_CRITICAL(&this->action_mux_);
-    next.units[slot].action_result_count =
-        this->units_[slot].action_result_count;
-    for (size_t offset = 0U;
-         offset < next.units[slot].action_result_count;
-         ++offset) {
-      const size_t source_index =
-          (this->units_[slot].action_result_head + offset) %
-          ACTION_RESULT_HISTORY_SIZE;
-      next.units[slot].action_results[offset] =
-          this->units_[slot].action_results[source_index];
+        this->units_()[slot].last_action_at_ms;
+    if (xSemaphoreTake(this->action_mutex_, portMAX_DELAY) == pdTRUE) {
+      next.units[slot].action_result_count =
+          this->units_()[slot].action_result_count;
+      for (size_t offset = 0U;
+           offset < next.units[slot].action_result_count;
+           ++offset) {
+        const size_t source_index =
+            (this->units_()[slot].action_result_head + offset) %
+            ACTION_RESULT_HISTORY_SIZE;
+        next.units[slot].action_results[offset] =
+            this->units_()[slot].action_results[source_index];
+      }
+      xSemaphoreGive(this->action_mutex_);
+    } else {
+      next.units[slot].action_result_count = 0U;
+      ESP_LOGE(TAG, "Could not lock incident action snapshot");
     }
-    portEXIT_CRITICAL(&this->action_mux_);
   }
-  portENTER_CRITICAL(&this->snapshot_mux_);
-  this->published_ = next;
-  portEXIT_CRITICAL(&this->snapshot_mux_);
+  if (xSemaphoreTake(this->snapshot_mutex_, portMAX_DELAY) != pdTRUE) {
+    ESP_LOGE(TAG, "Could not publish incident snapshot");
+    return;
+  }
+  std::swap(this->published_snapshot_index_,
+            this->staging_snapshot_index_);
+  xSemaphoreGive(this->snapshot_mutex_);
 }
 
 void OpenQuattIncidentManager::write_snapshot(httpd_req_t *req) const {
-  std::unique_ptr<PublishedSnapshot> snapshot_storage{
-      new (std::nothrow) PublishedSnapshot{}};
-  if (snapshot_storage == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate incident snapshot response copy");
+  if (!this->storage_ready_()) {
+    ESP_LOGE(TAG, "Incident snapshot storage is unavailable");
     httpd_resp_set_status(req, "503 Service Unavailable");
     httpd_resp_set_type(req, "application/json; charset=utf-8");
     httpd_resp_send(
-        req, R"({"error":"snapshot_allocation_failed"})",
+        req, R"({"error":"snapshot_unavailable"})",
         HTTPD_RESP_USE_STRLEN);
     return;
   }
-  PublishedSnapshot &snapshot = *snapshot_storage;
-  portENTER_CRITICAL(&this->snapshot_mux_);
-  snapshot = this->published_;
-  portEXIT_CRITICAL(&this->snapshot_mux_);
+  if (this->response_snapshot_in_use_.exchange(true)) {
+    httpd_resp_set_status(req, "503 Service Unavailable");
+    httpd_resp_set_type(req, "application/json; charset=utf-8");
+    httpd_resp_send(
+        req, R"({"error":"snapshot_busy"})",
+        HTTPD_RESP_USE_STRLEN);
+    return;
+  }
+  struct ResponseSnapshotClaim {
+    explicit ResponseSnapshotClaim(std::atomic<bool> *claimed)
+        : claimed(claimed) {}
+    ~ResponseSnapshotClaim() { this->claimed->store(false); }
+    std::atomic<bool> *claimed;
+  } response_claim(&this->response_snapshot_in_use_);
+
+  PublishedSnapshot &snapshot = this->response_snapshot_();
+  if (xSemaphoreTake(this->snapshot_mutex_, portMAX_DELAY) != pdTRUE) {
+    ESP_LOGE(TAG, "Could not lock incident response snapshot");
+    httpd_resp_set_status(req, "503 Service Unavailable");
+    httpd_resp_set_type(req, "application/json; charset=utf-8");
+    httpd_resp_send(
+        req, R"({"error":"snapshot_unavailable"})",
+        HTTPD_RESP_USE_STRLEN);
+    return;
+  }
+  snapshot = this->published_snapshot_();
+  xSemaphoreGive(this->snapshot_mutex_);
 
   const uint32_t generated_epoch_s =
       snapshot.generated_at_epoch_s != 0U
@@ -1980,7 +2107,7 @@ void OpenQuattIncidentManager::write_snapshot(httpd_req_t *req) const {
       write_raw(req, R"({"schema_version":1,"catalog_version":1,"generated_at_s":)") &&
       write_uint(req, generated_epoch_s) &&
       write_raw(req, R"(,"action_csrf_token":)") &&
-      write_json_string(req, this->action_csrf_token_.c_str()) &&
+      write_json_string(req, this->action_csrf_token_.data()) &&
       write_raw(req, R"(,"system":{"control_mode":)") &&
       write_uint(req, snapshot.control_mode) &&
       write_raw(req, R"(,"action":)") &&
@@ -2003,8 +2130,8 @@ void OpenQuattIncidentManager::write_snapshot(httpd_req_t *req) const {
       write_raw(req, R"(},"heat_pumps":[)");
 
   bool first_hp = true;
-  for (size_t slot = 0U; ok && slot < this->units_.size(); ++slot) {
-    if (!this->units_[slot].configured) continue;
+  for (size_t slot = 0U;
+       ok && slot < this->configured_hp_count(); ++slot) {
     const oq_incidents::DerivedOutputs &outputs =
         snapshot.units[slot].outputs;
     ok = (first_hp || write_raw(req, ",")) &&

--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.h
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <string>
 
 #include <esp_http_server.h>
 #include <freertos/FreeRTOS.h>
-#include <freertos/portmacro.h>
+#include <freertos/semphr.h>
 
 #include "esphome/components/globals/globals_component.h"
 #include "esphome/components/openquatt_decision_log/OpenQuattDecisionLog.h"
@@ -16,6 +16,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "OpenQuattIncidentPolicy.h"
+#include "PsramBuffer.h"
 #include "includes/incidents/oq_hp_incident_engine.h"
 #include "includes/incidents/oq_manual_reset_latch_policy.h"
 
@@ -86,8 +87,9 @@ class OpenQuattIncidentManager : public Component {
   void set_boiler_status(uint8_t role, bool command_active, bool output_continuous);
 
   void write_snapshot(httpd_req_t *req) const;
-  const std::string &get_action_csrf_token() const {
-    return this->action_csrf_token_;
+  bool storage_ready() const { return this->storage_ready_(); }
+  const char *get_action_csrf_token() const {
+    return this->action_csrf_token_.data();
   }
   bool request_is_authenticated(
       AsyncWebServerRequest *request) const {
@@ -202,6 +204,11 @@ class OpenQuattIncidentManager : public Component {
     uint32_t generated_at_epoch_s{0U};
   };
 
+  struct ExternalState {
+    std::array<UnitState, 2U> units{};
+    std::array<PublishedSnapshot, 3U> snapshots{};
+  };
+
   static bool valid_hp_index_(uint8_t hp_index);
   static size_t hp_slot_(uint8_t hp_index);
   static uint32_t elapsed_ms_(uint32_t now_ms, uint32_t since_ms);
@@ -220,6 +227,13 @@ class OpenQuattIncidentManager : public Component {
                                         uint32_t generated_at_ms,
                                         uint32_t runtime_ms);
 
+  bool storage_ready_() const;
+  std::array<UnitState, 2U> &units_();
+  const std::array<UnitState, 2U> &units_() const;
+  PublishedSnapshot &published_snapshot_();
+  const PublishedSnapshot &published_snapshot_() const;
+  PublishedSnapshot &staging_snapshot_();
+  PublishedSnapshot &response_snapshot_() const;
   UnitState *unit_(uint8_t hp_index);
   const UnitState *unit_(uint8_t hp_index) const;
   void process_fault_snapshot_(UnitState &unit, size_t slot, uint32_t now_ms,
@@ -253,7 +267,7 @@ class OpenQuattIncidentManager : public Component {
   void publish_snapshot_(uint32_t now_ms);
   uint32_t current_epoch_s_() const;
 
-  std::array<UnitState, 2U> units_{};
+  openquatt_common::PsramObjectArray<ExternalState, 1U> external_state_{};
   time::RealTimeClock *clock_{nullptr};
   IntGlobal *control_mode_code_{nullptr};
   openquatt_decision_log::OpenQuattDecisionLog *decision_log_{nullptr};
@@ -272,12 +286,19 @@ class OpenQuattIncidentManager : public Component {
   ESPPreferenceObject manual_reset_pref_a_{};
   ESPPreferenceObject manual_reset_pref_b_{};
   ESPPreferenceObject manual_reset_marker_pref_{};
-  std::string action_csrf_token_;
-  PublishedSnapshot published_{};
-  PublishedSnapshot staging_{};
-  mutable portMUX_TYPE action_mux_ = portMUX_INITIALIZER_UNLOCKED;
-  mutable portMUX_TYPE snapshot_mux_ = portMUX_INITIALIZER_UNLOCKED;
+  std::array<char, 33U> action_csrf_token_{};
+  StaticSemaphore_t action_mutex_storage_{};
+  StaticSemaphore_t snapshot_mutex_storage_{};
+  SemaphoreHandle_t action_mutex_{nullptr};
+  mutable SemaphoreHandle_t snapshot_mutex_{nullptr};
+  uint8_t published_snapshot_index_{0U};
+  uint8_t staging_snapshot_index_{1U};
+  mutable std::atomic<bool> response_snapshot_in_use_{false};
 };
+
+static_assert(
+    sizeof(OpenQuattIncidentManager) <= 512U,
+    "Large incident state must remain in the external PSRAM arena");
 
 }  // namespace openquatt_incident_manager
 }  // namespace esphome

--- a/components/openquatt_incident_manager/OpenQuattIncidentPolicy.h
+++ b/components/openquatt_incident_manager/OpenQuattIncidentPolicy.h
@@ -129,6 +129,23 @@ inline bool all_hp_outputs_safe_for_fallback(
   return true;
 }
 
+inline oq_incidents::DerivedOutputs incident_storage_failure_outputs() {
+  oq_incidents::DerivedOutputs outputs{};
+  outputs.protection_state =
+      oq_incidents::ProtectionState::FAULT_ACTIVE;
+  outputs.active_effects =
+      oq_incidents::IncidentEffect::DISPLAY |
+      oq_incidents::IncidentEffect::BLOCK_START |
+      oq_incidents::IncidentEffect::STOP_COMPRESSOR |
+      oq_incidents::IncidentEffect::MARK_HP_UNAVAILABLE |
+      oq_incidents::IncidentEffect::BLOCK_BOILER;
+  outputs.must_stop = true;
+  outputs.fault_active = true;
+  outputs.protection_active = true;
+  outputs.stop_unconfirmed = true;
+  return outputs;
+}
+
 inline oq_incidents::DerivedOutputs apply_persistence_safety_gate(
     oq_incidents::DerivedOutputs outputs, bool persistence_blocks) {
   if (!persistence_blocks) return outputs;

--- a/components/openquatt_incident_manager/__init__.py
+++ b/components/openquatt_incident_manager/__init__.py
@@ -5,6 +5,7 @@ from esphome.const import CONF_ID
 
 AUTO_LOAD = ["globals", "time", "web_server_base"]
 DEPENDENCIES = [
+    "psram",
     "web_server",
     "openquatt_decision_log",
     "openquatt_web_auth",

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -9,6 +9,8 @@
 
 #include "esp_crt_bundle.h"
 #include "esp_heap_caps.h"
+#include "esp_memory_utils.h"
+#include "freertos/idf_additions.h"
 #if defined(CONFIG_IDF_TARGET_ESP32S3) && __has_include("heatpump_controller_q_hardware_revision.h")
 #include "heatpump_controller_q_hardware_revision.h"
 #define OPENQUATT_HAS_Q_HARDWARE_REVISION
@@ -28,63 +30,49 @@ namespace {
 
 static const char *const TAG = "openquatt.usage_telemetry";
 static const uint32_t STORAGE_KEY = fnv1_hash("openquatt_usage_telemetry_store");
+static constexpr size_t TELEMETRY_PAYLOAD_CAPACITY = 2048U;
 
-std::string json_escape_(const std::string &input) {
-  std::string output;
-  output.reserve(input.size() + 4);
-  for (char c : input) {
-    switch (c) {
-      case '"':
-        output += "\\\"";
-        break;
-      case '\\':
-        output += "\\\\";
-        break;
-      case '\b':
-        output += "\\b";
-        break;
-      case '\f':
-        output += "\\f";
-        break;
-      case '\n':
-        output += "\\n";
-        break;
-      case '\r':
-        output += "\\r";
-        break;
-      case '\t':
-        output += "\\t";
-        break;
-      default:
-        if (static_cast<unsigned char>(c) < 0x20U) {
-          char buffer[7];
-          std::snprintf(buffer, sizeof(buffer), "\\u%04x", static_cast<unsigned char>(c));
-          output += buffer;
-        } else {
-          output += c;
-        }
-        break;
-    }
-  }
-  return output;
+void log_heap_state_(const char *phase) {
+  const size_t free_internal =
+      heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+  const size_t largest_internal =
+      heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+  const size_t fragmentation_percent =
+      free_internal == 0U
+          ? 0U
+          : 100U - std::min<size_t>(
+                       100U,
+                       (largest_internal * 100U) / free_internal);
+  ESP_LOGD(
+      TAG,
+      "%s: heap free=%u, min=%u, largest=%u, fragmentation=%u%%, "
+      "PSRAM free=%u",
+      phase, static_cast<unsigned>(free_internal),
+      static_cast<unsigned>(
+          heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL)),
+      static_cast<unsigned>(largest_internal),
+      static_cast<unsigned>(fragmentation_percent),
+      static_cast<unsigned>(
+          heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
 }
 
 bool uuid_is_present_(const std::array<uint8_t, 16> &bytes) {
   return std::any_of(bytes.begin(), bytes.end(), [](uint8_t byte) { return byte != 0U; });
 }
 
-void append_json_key_(std::string &payload, const char *key) {
+void append_json_key_(FixedBufferWriter &payload, const char *key) {
   payload += R"(,")";
   payload += key;
   payload += R"(":)";
 }
 
-void append_json_uint_(std::string &payload, const char *key, size_t value) {
+void append_json_uint_(FixedBufferWriter &payload, const char *key,
+                       size_t value) {
   append_json_key_(payload, key);
-  payload += std::to_string(static_cast<uint64_t>(value));
+  payload.append_uint(static_cast<uint64_t>(value));
 }
 
-void append_json_optional_number_(std::string &payload, const char *key, const sensor::Sensor *source,
+void append_json_optional_number_(FixedBufferWriter &payload, const char *key, const sensor::Sensor *source,
                                   unsigned decimals) {
   append_json_key_(payload, key);
   if (source == nullptr || !source->has_state() || !std::isfinite(source->state)) {
@@ -96,7 +84,7 @@ void append_json_optional_number_(std::string &payload, const char *key, const s
   payload += value;
 }
 
-void append_json_optional_bool_(std::string &payload, const char *key, const switch_::Switch *source) {
+void append_json_optional_bool_(FixedBufferWriter &payload, const char *key, const switch_::Switch *source) {
   append_json_key_(payload, key);
   if (source == nullptr) {
     payload += "null";
@@ -105,7 +93,7 @@ void append_json_optional_bool_(std::string &payload, const char *key, const swi
   payload += source->state ? "true" : "false";
 }
 
-void append_json_optional_bool_(std::string &payload, const char *key, bool available, bool value) {
+void append_json_optional_bool_(FixedBufferWriter &payload, const char *key, bool available, bool value) {
   append_json_key_(payload, key);
   if (!available) {
     payload += "null";
@@ -114,7 +102,7 @@ void append_json_optional_bool_(std::string &payload, const char *key, bool avai
   payload += value ? "true" : "false";
 }
 
-void append_json_boiler_connection_(std::string &payload, const select::Select *source) {
+void append_json_boiler_connection_(FixedBufferWriter &payload, const select::Select *source) {
   append_json_key_(payload, "boiler_connection");
   if (source == nullptr) {
     // Firmware without the OTB transport selector can only drive the R1 on/off route.
@@ -166,10 +154,14 @@ const char *reset_reason_name_(esp_reset_reason_t reason) {
 float OpenQuattUsageTelemetry::get_setup_priority() const { return setup_priority::LATE; }
 
 void OpenQuattUsageTelemetry::setup() {
-  this->runtime_lock_ = xSemaphoreCreateMutex();
-  if (this->runtime_lock_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to create usage telemetry runtime lock");
+  this->consent_mutex_ =
+      xSemaphoreCreateMutexStatic(&this->consent_mutex_storage_);
+  if (this->consent_mutex_ == nullptr) {
+    ESP_LOGE(TAG,
+             "Failed to initialize usage telemetry consent gate; "
+             "usage statistics remain disabled");
     this->publish_state(false);
+    this->mark_failed();
     return;
   }
   if (global_preferences == nullptr) {
@@ -214,13 +206,35 @@ void OpenQuattUsageTelemetry::setup() {
     }
   }
 
-  this->apply_storage_(storage);
+  if (!this->apply_storage_(storage)) {
+    ESP_LOGE(TAG,
+             "Failed to apply usage telemetry consent state; "
+             "usage statistics remain disabled");
+    this->publish_state(false);
+    this->mark_failed();
+    return;
+  }
   this->boot_publish_pending_ = this->enabled_.load();
   this->next_publish_ms_ = 0;
 }
 
 void OpenQuattUsageTelemetry::loop() {
+  if (this->start_task_complete_.exchange(false)) {
+    this->start_task_running_.store(false);
+  }
   if (this->cleanup_task_complete_.exchange(false)) {
+    if (!MQTT_WORKER_STACK_IN_PSRAM) {
+      const TaskHandle_t handle = this->worker_task_state_.get_handle();
+      if (handle != nullptr && eTaskGetState(handle) != eSuspended) {
+        // The classic-ESP32 worker publishes completion immediately before it
+        // parks itself. Do not free a static stack that may still be executing
+        // on the other core.
+        this->cleanup_task_complete_.store(true);
+        return;
+      }
+      this->worker_task_state_.deallocate();
+      this->worker_task_region_valid_ = false;
+    }
     this->complete_publish_session_();
   }
   if (this->finishing_session_.load()) {
@@ -278,10 +292,18 @@ void OpenQuattUsageTelemetry::dump_config() {
   ESP_LOGCONFIG(TAG, "  Quick Start complete: %s", YESNO(this->is_setup_complete_()));
   ESP_LOGCONFIG(TAG, "  Publish interval: %" PRIu32 " seconds", this->interval_ms_ / 1000U);
   ESP_LOGCONFIG(TAG, "  Installation ID present: %s", YESNO(!this->installation_id_.empty()));
+  ESP_LOGCONFIG(TAG, "  OpenQuatt worker stack: %u bytes in %s",
+                static_cast<unsigned>(MQTT_WORKER_TASK_STACK_SIZE),
+                MQTT_WORKER_STACK_IN_PSRAM ? "PSRAM" : "internal RAM");
 }
 
 void OpenQuattUsageTelemetry::write_state(bool state) {
   const bool current_state = this->enabled_.load();
+  if (!state && !this->set_consent_publish_blocked_(true)) {
+    ESP_LOGE(TAG, "Could not close usage telemetry consent gate");
+    this->publish_state(current_state);
+    return;
+  }
   Storage storage{};
   if (!this->load_storage_(&storage)) {
     storage.magic = STORAGE_MAGIC;
@@ -306,11 +328,30 @@ void OpenQuattUsageTelemetry::write_state(bool state) {
   storage.choice_configured = 1U;
   if (!this->save_storage_(storage)) {
     ESP_LOGE(TAG, "Could not persist usage statistics preference");
-    this->publish_state(current_state);
+    if (state) {
+      this->publish_state(current_state);
+      return;
+    }
+    // A failed opt-out write must not reopen telemetry for this boot. Keep the
+    // publish gate closed and stop any active session even though durability
+    // could not be confirmed.
+    this->enabled_.store(false);
+    this->publish_state(false);
+    this->boot_publish_pending_ = false;
+    this->next_publish_ms_ = 0U;
+    if (!this->session_active_.load()) {
+      this->clear_payload_();
+      this->payload_message_id_.clear();
+    }
+    App.wake_loop_threadsafe();
     return;
   }
 
-  this->apply_storage_(storage);
+  if (!this->apply_storage_(storage)) {
+    ESP_LOGE(TAG, "Could not apply usage statistics preference");
+    this->publish_state(current_state);
+    return;
+  }
   if (state) {
     this->consecutive_failures_ = 0;
     if (this->is_setup_complete_()) {
@@ -327,7 +368,7 @@ void OpenQuattUsageTelemetry::write_state(bool state) {
     this->boot_publish_pending_ = false;
     this->next_publish_ms_ = 0;
     if (!this->session_active_.load()) {
-      this->payload_.clear();
+      this->clear_payload_();
       this->payload_message_id_.clear();
     }
     App.wake_loop_threadsafe();
@@ -367,6 +408,22 @@ bool OpenQuattUsageTelemetry::save_storage_(const Storage &storage) {
   return this->pref_.save(&storage) && global_preferences != nullptr && global_preferences->sync();
 }
 
+bool OpenQuattUsageTelemetry::set_consent_publish_blocked_(
+    bool blocked) {
+  if (blocked) {
+    // Close the gate before waiting for an in-flight start/enqueue critical
+    // section. This makes revocation fail closed from the first instruction.
+    this->consent_publish_blocked_.store(true);
+  }
+  if (this->consent_mutex_ == nullptr ||
+      xSemaphoreTake(this->consent_mutex_, portMAX_DELAY) != pdTRUE) {
+    return false;
+  }
+  this->consent_publish_blocked_.store(blocked);
+  xSemaphoreGive(this->consent_mutex_);
+  return true;
+}
+
 bool OpenQuattUsageTelemetry::ensure_installation_id_(Storage *storage) {
   if (storage == nullptr) {
     return false;
@@ -387,7 +444,11 @@ bool OpenQuattUsageTelemetry::is_setup_complete_() const {
          this->setup_complete_sensor_->state;
 }
 
-void OpenQuattUsageTelemetry::apply_storage_(const Storage &storage) {
+bool OpenQuattUsageTelemetry::apply_storage_(const Storage &storage) {
+  if (this->consent_mutex_ == nullptr ||
+      xSemaphoreTake(this->consent_mutex_, portMAX_DELAY) != pdTRUE) {
+    return false;
+  }
   // The ID is immutable across enable/disable writes. Avoid rewriting the string while MQTT callbacks may read it.
   if (this->installation_id_bytes_ != storage.installation_id) {
     this->installation_id_bytes_ = storage.installation_id;
@@ -396,7 +457,10 @@ void OpenQuattUsageTelemetry::apply_storage_(const Storage &storage) {
   const bool enabled = storage.enabled != 0U && !this->installation_id_.empty();
   const bool choice_configured = storage.choice_configured != 0U;
   this->enabled_.store(enabled);
+  this->consent_publish_blocked_.store(!enabled);
   this->choice_configured_.store(choice_configured);
+  xSemaphoreGive(this->consent_mutex_);
+
   this->publish_state(enabled);
   if (this->installation_id_sensor_ != nullptr) {
     this->installation_id_sensor_->publish_state(this->installation_id_);
@@ -404,6 +468,7 @@ void OpenQuattUsageTelemetry::apply_storage_(const Storage &storage) {
   if (this->choice_configured_sensor_ != nullptr) {
     this->choice_configured_sensor_->publish_state(choice_configured);
   }
+  return true;
 }
 
 void OpenQuattUsageTelemetry::schedule_initial_publish_() {
@@ -437,40 +502,95 @@ void OpenQuattUsageTelemetry::start_publish_session_() {
   }
 
   this->boot_publish_pending_ = false;
+  log_heap_state_("Usage telemetry session begin");
 
-  // Reserve the cleanup worker before MQTT/TLS can consume the remaining heap.
-  // If this allocation fails, no client resources exist yet and retrying is safe.
-  if (!this->prepare_cleanup_task_()) {
+  if (this->payload_size_ == 0U && !this->build_payload_()) {
     this->start_task_running_.store(false);
     this->schedule_retry_();
     return;
   }
 
-  if (this->payload_.empty()) {
-    this->build_payload_();
+  // The same worker owns both client startup and teardown. On S3 its stack is
+  // persistent in PSRAM; classic ESP32 uses a per-session internal stack.
+  if (!this->ensure_worker_task_()) {
+    this->clear_payload_();
+    this->start_task_running_.store(false);
+    this->schedule_retry_();
+    return;
   }
+  log_heap_state_("Usage telemetry worker ready");
   this->publish_succeeded_.store(false);
   this->publish_failed_.store(false);
   this->pending_message_id_.store(-1);
   this->finishing_session_.store(false);
+  this->start_task_complete_.store(false);
   this->cleanup_task_complete_.store(false);
   this->cleanup_succeeded_.store(false);
+  this->mqtt_connected_seen_.store(false);
+  this->mqtt_disconnected_seen_.store(false);
+  this->cleanup_stop_failures_ = 0U;
+  this->cleanup_disconnect_requested_ = false;
   this->session_started_ms_ = millis();
   this->session_active_.store(true);
 
-  const BaseType_t created = xTaskCreatePinnedToCore(&OpenQuattUsageTelemetry::start_client_task_,
-                                                     "oq_usage_mqtt", MQTT_START_TASK_STACK_SIZE, this, 4, nullptr,
-                                                     tskNO_AFFINITY);
-  if (created != pdPASS) {
+  if (!this->notify_worker_(WorkerCommand::START)) {
+    this->session_active_.store(false);
     this->start_task_running_.store(false);
-    this->publish_failed_.store(true);
-    ESP_LOGE(TAG, "Failed to create usage telemetry MQTT start task");
+    this->clear_payload_();
+    this->schedule_retry_();
+    ESP_LOGE(TAG, "Failed to notify usage telemetry MQTT worker");
   }
+}
+
+bool OpenQuattUsageTelemetry::ensure_worker_task_() {
+  if (this->worker_task_state_.is_created()) {
+    return this->worker_task_region_valid_;
+  }
+  this->worker_task_region_valid_ = false;
+  if (!this->worker_task_state_.create(
+          &OpenQuattUsageTelemetry::worker_task_, "oq_usage_mqtt",
+          MQTT_WORKER_TASK_STACK_SIZE, this, 4,
+          MQTT_WORKER_STACK_IN_PSRAM)) {
+    ESP_LOGE(
+        TAG,
+        "Failed to create %u-byte usage telemetry worker in %s",
+        static_cast<unsigned>(MQTT_WORKER_TASK_STACK_SIZE),
+        MQTT_WORKER_STACK_IN_PSRAM ? "PSRAM" : "internal RAM");
+    return false;
+  }
+
+  const bool stack_is_external = esp_ptr_external_ram(
+      pxTaskGetStackStart(this->worker_task_state_.get_handle()));
+  if (stack_is_external != MQTT_WORKER_STACK_IN_PSRAM) {
+    ESP_LOGE(TAG,
+             "Usage telemetry worker stack was allocated in the wrong "
+             "memory region; worker remains parked");
+    // StaticTask owns a static stack. It must not free that stack while the
+    // freshly created task may still be entering its notification wait on the
+    // other core. Treat this impossible allocator-contract violation as a
+    // permanent telemetry failure and leave the parked task intact.
+    this->mark_failed();
+    return false;
+  }
+  this->worker_task_region_valid_ = true;
+  ESP_LOGD(TAG, "Usage telemetry worker stack: %u bytes in %s",
+           static_cast<unsigned>(MQTT_WORKER_TASK_STACK_SIZE),
+           stack_is_external ? "PSRAM" : "internal RAM");
+  return true;
+}
+
+bool OpenQuattUsageTelemetry::notify_worker_(WorkerCommand command) {
+  const TaskHandle_t handle = this->worker_task_state_.get_handle();
+  if (handle == nullptr) return false;
+  return xTaskNotify(
+             handle, static_cast<uint32_t>(command),
+             eSetValueWithOverwrite) == pdPASS;
 }
 
 bool OpenQuattUsageTelemetry::start_client_() {
   if (!this->enabled_.load() || !this->session_active_.load() || !this->is_setup_complete_() ||
-      !this->is_configured()) {
+      !this->is_configured() || this->mqtt_client_ != nullptr ||
+      this->consent_publish_blocked_.load()) {
     return false;
   }
 
@@ -497,33 +617,105 @@ bool OpenQuattUsageTelemetry::start_client_() {
     mqtt_config.credentials.authentication.password = this->password_.c_str();
   }
 
+  if (this->consent_mutex_ == nullptr ||
+      xSemaphoreTake(this->consent_mutex_, portMAX_DELAY) != pdTRUE) {
+    return false;
+  }
+  if (!this->enabled_.load() || !this->session_active_.load() ||
+      this->consent_publish_blocked_.load()) {
+    xSemaphoreGive(this->consent_mutex_);
+    return false;
+  }
+
   esp_mqtt_client_handle_t client = esp_mqtt_client_init(&mqtt_config);
   if (client == nullptr) {
+    xSemaphoreGive(this->consent_mutex_);
     ESP_LOGW(TAG, "Failed to initialize usage telemetry MQTT client");
     return false;
   }
 
-  if (xSemaphoreTake(this->runtime_lock_, portMAX_DELAY) != pdTRUE) {
-    esp_mqtt_client_destroy(client);
-    return false;
-  }
-  if (!this->enabled_.load() || !this->session_active_.load() || this->mqtt_client_ != nullptr) {
-    xSemaphoreGive(this->runtime_lock_);
+  if (!this->enabled_.load() || !this->session_active_.load() ||
+      this->consent_publish_blocked_.load()) {
+    xSemaphoreGive(this->consent_mutex_);
     esp_mqtt_client_destroy(client);
     return false;
   }
   this->mqtt_client_ = client;
-  xSemaphoreGive(this->runtime_lock_);
+  this->mqtt_client_started_ = false;
 
   esp_err_t error = esp_mqtt_client_register_event(client, MQTT_EVENT_ANY,
                                                     &OpenQuattUsageTelemetry::mqtt_event_handler_, this);
   if (error == ESP_OK) {
     error = esp_mqtt_client_start(client);
   }
+  xSemaphoreGive(this->consent_mutex_);
   if (error != ESP_OK) {
     ESP_LOGW(TAG, "Failed to start usage telemetry MQTT client: %s", esp_err_to_name(error));
+    esp_mqtt_client_destroy(client);
+    this->mqtt_client_ = nullptr;
     return false;
   }
+  this->mqtt_client_started_ = true;
+  return true;
+}
+
+bool OpenQuattUsageTelemetry::cleanup_client_() {
+  esp_mqtt_client_handle_t client = this->mqtt_client_;
+  if (client == nullptr) return true;
+
+  if (this->mqtt_client_started_) {
+    const esp_err_t error = esp_mqtt_client_stop(client);
+    if (error != ESP_OK && error != ESP_FAIL) {
+      ESP_LOGE(TAG, "Unexpected usage telemetry MQTT stop error: %s",
+               esp_err_to_name(error));
+      return false;
+    }
+    if (error != ESP_OK) {
+      ++this->cleanup_stop_failures_;
+      const MqttCleanupDecision decision = mqtt_cleanup_decision(
+          false, this->mqtt_connected_seen_.load(),
+          this->mqtt_disconnected_seen_.load(),
+          this->cleanup_stop_failures_);
+      if (decision == MqttCleanupDecision::FORCE_DISCONNECT) {
+        // A connected client may fail to construct its graceful DISCONNECT
+        // packet under memory pressure. Its own task handles DISCONNECT_BIT by
+        // aborting the transport without allocating that packet.
+        if (!this->cleanup_disconnect_requested_) {
+          ESP_LOGW(TAG,
+                   "Usage telemetry MQTT stop failed (%s); forcing "
+                   "disconnect before retry",
+                   esp_err_to_name(error));
+        }
+        esp_mqtt_client_disconnect(client);
+        this->cleanup_disconnect_requested_ = true;
+        return false;
+      }
+
+      // ESP-IDF also returns ESP_FAIL when the mqtt task has already stopped
+      // itself (for example after a transport-allocation failure). Allow one
+      // full worker interval for its STOPPED tail to finish before destroy.
+      if (decision == MqttCleanupDecision::RETRY_STOP) {
+        ESP_LOGD(TAG,
+                 "Usage telemetry MQTT task may already be stopped; "
+                 "verifying before destroy");
+        return false;
+      }
+      ESP_LOGW(TAG,
+               "Usage telemetry MQTT task stopped before cleanup; "
+               "releasing its client resources");
+    }
+  }
+
+  const esp_err_t error = esp_mqtt_client_destroy(client);
+  if (error != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to destroy usage telemetry MQTT client: %s",
+             esp_err_to_name(error));
+    return false;
+  }
+  this->mqtt_client_ = nullptr;
+  this->mqtt_client_started_ = false;
+  this->cleanup_stop_failures_ = 0U;
+  this->cleanup_disconnect_requested_ = false;
   return true;
 }
 
@@ -533,25 +725,11 @@ void OpenQuattUsageTelemetry::finish_publish_session_(bool succeeded) {
     return;
   }
   this->cleanup_succeeded_.store(succeeded);
-  xTaskNotifyGive(this->cleanup_task_handle_.load());
-}
-
-bool OpenQuattUsageTelemetry::prepare_cleanup_task_() {
-  if (this->cleanup_task_running_.exchange(true)) {
-    return false;
+  if (!this->notify_worker_(WorkerCommand::CLEANUP)) {
+    this->finishing_session_.store(false);
+    this->publish_failed_.store(true);
+    ESP_LOGE(TAG, "Failed to notify usage telemetry MQTT cleanup");
   }
-
-  TaskHandle_t task_handle = nullptr;
-  const BaseType_t created = xTaskCreatePinnedToCore(&OpenQuattUsageTelemetry::cleanup_client_task_,
-                                                     "oq_usage_cleanup", MQTT_CLEANUP_TASK_STACK_SIZE, this, 4,
-                                                     &task_handle, tskNO_AFFINITY);
-  if (created != pdPASS || task_handle == nullptr) {
-    this->cleanup_task_running_.store(false);
-    ESP_LOGE(TAG, "Failed to create usage telemetry MQTT cleanup task");
-    return false;
-  }
-  this->cleanup_task_handle_.store(task_handle);
-  return true;
 }
 
 void OpenQuattUsageTelemetry::complete_publish_session_() {
@@ -565,14 +743,14 @@ void OpenQuattUsageTelemetry::complete_publish_session_() {
   this->cleanup_succeeded_.store(false);
 
   if (!this->enabled_.load()) {
-    this->payload_.clear();
+    this->clear_payload_();
     this->payload_message_id_.clear();
     this->next_publish_ms_ = 0;
     this->consecutive_failures_ = 0;
     return;
   }
   if (succeeded) {
-    this->payload_.clear();
+    this->clear_payload_();
     this->payload_message_id_.clear();
     this->consecutive_failures_ = 0;
     this->schedule_regular_publish_();
@@ -580,82 +758,129 @@ void OpenQuattUsageTelemetry::complete_publish_session_() {
   } else {
     // Refresh volatile observations for the retry, but retain the logical
     // message ID so a lost QoS 1 PUBACK remains idempotent for ingestion.
-    this->payload_.clear();
+    this->clear_payload_();
     this->schedule_retry_();
     ESP_LOGW(TAG, "Usage statistics publish failed; a bounded retry was scheduled");
   }
 }
 
-void OpenQuattUsageTelemetry::build_payload_() {
+bool OpenQuattUsageTelemetry::build_payload_() {
   const uint64_t uptime_s = static_cast<uint64_t>(esp_timer_get_time()) / 1000000ULL;
   const std::string hardware_revision = this->read_hardware_revision_();
   if (this->payload_message_id_.empty()) {
     this->payload_message_id_ = random_message_id_();
   }
 
-  this->payload_.clear();
-  this->payload_.reserve(960);
-  this->payload_ += R"({"schema_version":1,"message_id":")";
-  this->payload_ += this->payload_message_id_;
-  this->payload_ += R"(","installation_id":")";
-  this->payload_ += this->installation_id_;
-  this->payload_ += '"';
-  append_json_key_(this->payload_, "timestamp_s");
+  if (!this->publish_topic_) {
+    const char *const suffix = "/telemetry";
+    const size_t publish_topic_size =
+        this->topic_.size() + 1U + this->installation_id_.size() +
+        std::strlen(suffix);
+    if (!this->publish_topic_.allocate_external(
+            publish_topic_size + 1U)) {
+      ESP_LOGE(TAG,
+               "Failed to allocate %u-byte usage telemetry topic in PSRAM",
+               static_cast<unsigned>(publish_topic_size + 1U));
+      return false;
+    }
+    FixedBufferWriter publish_topic(
+        this->publish_topic_.data(), this->publish_topic_.size());
+    publish_topic += this->topic_;
+    publish_topic += '/';
+    publish_topic += this->installation_id_;
+    publish_topic += suffix;
+    if (!publish_topic.ok()) {
+      ESP_LOGE(TAG, "Usage telemetry topic exceeded its PSRAM buffer");
+      this->publish_topic_.release();
+      return false;
+    }
+  }
+
+  this->clear_payload_();
+  if (!this->payload_.allocate_external(
+          TELEMETRY_PAYLOAD_CAPACITY + 1U)) {
+    ESP_LOGE(TAG,
+             "Failed to allocate %u-byte usage telemetry payload in PSRAM",
+             static_cast<unsigned>(TELEMETRY_PAYLOAD_CAPACITY + 1U));
+    return false;
+  }
+  FixedBufferWriter payload(this->payload_.data(), this->payload_.size());
+  payload += R"({"schema_version":1,"message_id":")";
+  payload += this->payload_message_id_;
+  payload += R"(","installation_id":")";
+  payload += this->installation_id_;
+  payload += '"';
+  append_json_key_(payload, "timestamp_s");
   if (this->clock_ == nullptr) {
-    this->payload_ += "null";
+    payload += "null";
   } else {
     const auto now = this->clock_->now();
     if (now.is_valid()) {
-      this->payload_ += std::to_string(static_cast<uint64_t>(now.timestamp));
+      payload.append_uint(static_cast<uint64_t>(now.timestamp));
     } else {
-      this->payload_ += "null";
+      payload += "null";
     }
   }
-  this->payload_ += R"(,"uptime_s":)";
-  this->payload_ += std::to_string(uptime_s);
-  this->payload_ += R"(,"firmware_version":")";
-  this->payload_ += json_escape_(this->firmware_version_);
-  this->payload_ += R"(","release_channel":")";
-  this->payload_ += json_escape_(this->release_channel_);
-  this->payload_ += R"(","hardware_profile":")";
-  this->payload_ += json_escape_(this->hardware_profile_);
-  this->payload_ += R"(","hardware_revision":)";
+  payload += R"(,"uptime_s":)";
+  payload.append_uint(uptime_s);
+  payload += R"(,"firmware_version":")";
+  append_json_escaped(payload, this->firmware_version_);
+  payload += R"(","release_channel":")";
+  append_json_escaped(payload, this->release_channel_);
+  payload += R"(","hardware_profile":")";
+  append_json_escaped(payload, this->hardware_profile_);
+  payload += R"(","hardware_revision":)";
   if (hardware_revision.empty()) {
-    this->payload_ += "null";
+    payload += "null";
   } else {
-    this->payload_ += '"';
-    this->payload_ += hardware_revision;
-    this->payload_ += '"';
+    payload += '"';
+    payload += hardware_revision;
+    payload += '"';
   }
-  this->payload_ += R"(,"topology":")";
-  this->payload_ += json_escape_(this->topology_);
-  this->payload_ += R"(","connection":")";
-  this->payload_ += json_escape_(this->connection_);
-  this->payload_ += '"';
-  append_json_uint_(this->payload_, "heap_free_b", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
-  append_json_uint_(this->payload_, "heap_min_free_b", heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL));
-  append_json_uint_(this->payload_, "heap_largest_block_b", heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
-  append_json_uint_(this->payload_, "psram_free_b", heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
-  append_json_optional_number_(this->payload_, "loop_time_ms", this->loop_time_sensor_, 0);
-  append_json_optional_number_(this->payload_, "esp_internal_temp_c", this->internal_temperature_sensor_, 1);
-  append_json_optional_number_(this->payload_, "wifi_rssi_dbm", this->wifi_signal_sensor_, 1);
-  append_json_key_(this->payload_, "reset_reason");
-  this->payload_ += '"';
-  this->payload_ += reset_reason_name_(esp_reset_reason());
-  this->payload_ += '"';
-  append_json_optional_bool_(this->payload_, "cic_polling_enabled", this->cic_polling_switch_);
-  append_json_optional_bool_(this->payload_, "cic_compatibility_enabled", this->cic_compatibility_switch_);
-  append_json_optional_bool_(this->payload_, "ot_thermostat_enabled", this->ot_thermostat_switch_);
-  append_json_optional_bool_(this->payload_, "boiler_assist_enabled", this->boiler_assist_switch_);
-  append_json_boiler_connection_(this->payload_, this->boiler_connection_select_);
-  append_json_optional_bool_(this->payload_, "mqtt_inputs_enabled", this->mqtt_config_ != nullptr,
+  payload += R"(,"topology":")";
+  append_json_escaped(payload, this->topology_);
+  payload += R"(","connection":")";
+  append_json_escaped(payload, this->connection_);
+  payload += '"';
+  append_json_uint_(payload, "heap_free_b", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+  append_json_uint_(payload, "heap_min_free_b", heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL));
+  append_json_uint_(payload, "heap_largest_block_b", heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
+  append_json_uint_(payload, "psram_free_b", heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+  append_json_optional_number_(payload, "loop_time_ms", this->loop_time_sensor_, 0);
+  append_json_optional_number_(payload, "esp_internal_temp_c", this->internal_temperature_sensor_, 1);
+  append_json_optional_number_(payload, "wifi_rssi_dbm", this->wifi_signal_sensor_, 1);
+  append_json_key_(payload, "reset_reason");
+  payload += '"';
+  payload += reset_reason_name_(esp_reset_reason());
+  payload += '"';
+  append_json_optional_bool_(payload, "cic_polling_enabled", this->cic_polling_switch_);
+  append_json_optional_bool_(payload, "cic_compatibility_enabled", this->cic_compatibility_switch_);
+  append_json_optional_bool_(payload, "ot_thermostat_enabled", this->ot_thermostat_switch_);
+  append_json_optional_bool_(payload, "boiler_assist_enabled", this->boiler_assist_switch_);
+  append_json_boiler_connection_(payload, this->boiler_connection_select_);
+  append_json_optional_bool_(payload, "mqtt_inputs_enabled", this->mqtt_config_ != nullptr,
                              this->mqtt_config_ != nullptr && this->mqtt_config_->is_enabled());
-  append_json_optional_bool_(this->payload_, "trend_ram_enabled", this->trend_ram_switch_);
-  append_json_optional_bool_(this->payload_, "trend_flash_enabled", this->trend_flash_switch_);
-  append_json_optional_bool_(this->payload_, "decision_log_flash_enabled", this->decision_log_flash_switch_);
-  append_json_optional_bool_(this->payload_, "energy_history_flash_enabled", this->energy_history_flash_switch_);
-  append_json_optional_bool_(this->payload_, "ram_log_history_enabled", this->ram_log_history_switch_);
-  this->payload_ += '}';
+  append_json_optional_bool_(payload, "trend_ram_enabled", this->trend_ram_switch_);
+  append_json_optional_bool_(payload, "trend_flash_enabled", this->trend_flash_switch_);
+  append_json_optional_bool_(payload, "decision_log_flash_enabled", this->decision_log_flash_switch_);
+  append_json_optional_bool_(payload, "energy_history_flash_enabled", this->energy_history_flash_switch_);
+  append_json_optional_bool_(payload, "ram_log_history_enabled", this->ram_log_history_switch_);
+  payload += '}';
+
+  if (!payload.ok()) {
+    ESP_LOGE(TAG,
+             "Usage telemetry JSON exceeded its %u-byte PSRAM buffer",
+             static_cast<unsigned>(TELEMETRY_PAYLOAD_CAPACITY));
+    this->clear_payload_();
+    return false;
+  }
+  this->payload_size_ = payload.size();
+  return true;
+}
+
+void OpenQuattUsageTelemetry::clear_payload_() {
+  this->payload_.release();
+  this->payload_size_ = 0U;
 }
 
 std::string OpenQuattUsageTelemetry::read_hardware_revision_() const {
@@ -698,39 +923,56 @@ std::string OpenQuattUsageTelemetry::random_message_id_() {
   return format_uuid_(bytes);
 }
 
-void OpenQuattUsageTelemetry::start_client_task_(void *arg) {
+void OpenQuattUsageTelemetry::worker_task_(void *arg) {
   auto *self = static_cast<OpenQuattUsageTelemetry *>(arg);
-  if (self != nullptr) {
-    if (!self->start_client_()) {
-      self->publish_failed_.store(true);
+  if (self == nullptr) {
+    while (true) {
+      vTaskSuspend(nullptr);
     }
-    self->start_task_running_.store(false);
-    App.wake_loop_threadsafe();
   }
-  vTaskDelete(nullptr);
-}
 
-void OpenQuattUsageTelemetry::cleanup_client_task_(void *arg) {
-  auto *self = static_cast<OpenQuattUsageTelemetry *>(arg);
-  while (self != nullptr) {
-    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-    esp_mqtt_client_handle_t client = nullptr;
-    if (self->runtime_lock_ != nullptr && xSemaphoreTake(self->runtime_lock_, portMAX_DELAY) == pdTRUE) {
-      client = self->mqtt_client_;
-      self->mqtt_client_ = nullptr;
-      xSemaphoreGive(self->runtime_lock_);
+  while (true) {
+    uint32_t command_value = 0U;
+    if (xTaskNotifyWait(0U, UINT32_MAX, &command_value,
+                        portMAX_DELAY) != pdTRUE) {
+      continue;
     }
-    if (client != nullptr) {
-      esp_mqtt_client_stop(client);
-      esp_mqtt_client_destroy(client);
+
+    const WorkerCommand command =
+        static_cast<WorkerCommand>(command_value);
+    if (command == WorkerCommand::START) {
+      if (!self->start_client_()) {
+        self->publish_failed_.store(true);
+      }
+      self->start_task_complete_.store(true);
+      log_heap_state_("Usage telemetry MQTT start complete");
+      ESP_LOGD(TAG, "Usage telemetry worker stack free after start: %u bytes",
+               static_cast<unsigned>(
+                   uxTaskGetStackHighWaterMark(nullptr)));
+      App.wake_loop_threadsafe();
+      continue;
     }
-    self->cleanup_task_handle_.store(nullptr);
-    self->cleanup_task_running_.store(false);
-    self->cleanup_task_complete_.store(true);
-    App.wake_loop_threadsafe();
-    break;
+
+    if (command == WorkerCommand::CLEANUP) {
+      while (!self->cleanup_client_()) {
+        vTaskDelay(pdMS_TO_TICKS(1000U));
+      }
+      ESP_LOGD(
+          TAG,
+          "Usage telemetry worker stack free after cleanup: %u bytes",
+          static_cast<unsigned>(uxTaskGetStackHighWaterMark(nullptr)));
+      log_heap_state_("Usage telemetry MQTT cleanup complete");
+      self->cleanup_task_complete_.store(true);
+      App.wake_loop_threadsafe();
+      if (!MQTT_WORKER_STACK_IN_PSRAM) {
+        vTaskSuspend(nullptr);
+      }
+      continue;
+    }
+
+    ESP_LOGE(TAG, "Usage telemetry worker received invalid command: %u",
+             static_cast<unsigned>(command_value));
   }
-  vTaskDelete(nullptr);
 }
 
 void OpenQuattUsageTelemetry::mqtt_event_handler_(void *handler_args, esp_event_base_t base, int32_t event_id,
@@ -738,20 +980,38 @@ void OpenQuattUsageTelemetry::mqtt_event_handler_(void *handler_args, esp_event_
   (void) base;
   auto *self = static_cast<OpenQuattUsageTelemetry *>(handler_args);
   auto *event = static_cast<esp_mqtt_event_handle_t>(event_data);
-  if (self == nullptr || event == nullptr || !self->session_active_.load() || self->finishing_session_.load()) {
+  if (self == nullptr || event == nullptr) {
+    return;
+  }
+  if (event_id == MQTT_EVENT_CONNECTED) {
+    self->mqtt_connected_seen_.store(true);
+  } else if (event_id == MQTT_EVENT_DISCONNECTED) {
+    self->mqtt_disconnected_seen_.store(true);
+  }
+  if (!self->session_active_.load() || self->finishing_session_.load()) {
     return;
   }
 
   switch (event_id) {
     case MQTT_EVENT_CONNECTED: {
-      if (!self->enabled_.load()) {
+      if (self->consent_mutex_ == nullptr ||
+          xSemaphoreTake(self->consent_mutex_, portMAX_DELAY) != pdTRUE) {
         self->publish_failed_.store(true);
         break;
       }
-      self->publish_topic_ = self->topic_ + "/" + self->installation_id_ + "/telemetry";
-      const int message_id = esp_mqtt_client_enqueue(event->client, self->publish_topic_.c_str(),
-                                                     self->payload_.c_str(), static_cast<int>(self->payload_.size()),
-                                                     1, 1, true);
+      int message_id = -1;
+      if (self->enabled_.load() && self->session_active_.load() &&
+          !self->finishing_session_.load() &&
+          !self->consent_publish_blocked_.load()) {
+        message_id = esp_mqtt_client_enqueue(
+            event->client, self->publish_topic_.data(),
+            self->payload_.data(), static_cast<int>(self->payload_size_),
+            1, 1, true);
+      }
+      xSemaphoreGive(self->consent_mutex_);
+      ESP_LOGD(
+          TAG, "esp-mqtt task stack free after enqueue: %u bytes",
+          static_cast<unsigned>(uxTaskGetStackHighWaterMark(nullptr)));
       if (message_id < 0) {
         self->publish_failed_.store(true);
       } else {
@@ -762,6 +1022,10 @@ void OpenQuattUsageTelemetry::mqtt_event_handler_(void *handler_args, esp_event_
     }
     case MQTT_EVENT_PUBLISHED:
       if (event->msg_id == self->pending_message_id_.load()) {
+        ESP_LOGD(
+            TAG, "esp-mqtt task stack free after publish: %u bytes",
+            static_cast<unsigned>(
+                uxTaskGetStackHighWaterMark(nullptr)));
         self->publish_succeeded_.store(true);
         App.wake_loop_threadsafe();
       }

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -16,7 +17,10 @@
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
+#include "esphome/core/static_task.h"
 #include "mqtt_client.h"
+#include "OpenQuattUsageTelemetryPolicy.h"
+#include "PsramBuffer.h"
 
 namespace esphome {
 namespace openquatt_mqtt_config {
@@ -83,12 +87,25 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   static constexpr uint32_t SESSION_TIMEOUT_MS = 30000;
   static constexpr uint32_t RETRY_MIN_MS = 5UL * 60UL * 1000UL;
   static constexpr uint32_t RETRY_MAX_MS = 60UL * 60UL * 1000UL;
-  // HIL boot measurements leave >22 kB unused with the former 24 kB stack.
-  // Eight kB retains >5 kB measured headroom without splitting the largest
-  // internal-heap block before esp-mqtt requests its own 12 kB task stack.
-  static constexpr uint32_t MQTT_START_TASK_STACK_SIZE = 8192;
-  static constexpr uint32_t MQTT_CLEANUP_TASK_STACK_SIZE = 6144;
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+  // PSRAM is abundant, so keep a conservative stack until HIL watermarks
+  // demonstrate that this can safely be reduced.
+  static constexpr uint32_t MQTT_WORKER_TASK_STACK_SIZE = 16384;
+  static constexpr bool MQTT_WORKER_STACK_IN_PSRAM = true;
+#else
+  // Classic ESP32 cannot safely run Wi-Fi/ROM-using tasks from a PSRAM stack.
+  static constexpr uint32_t MQTT_WORKER_TASK_STACK_SIZE = 8192;
+  static constexpr bool MQTT_WORKER_STACK_IN_PSRAM = false;
+#endif
   static constexpr int MQTT_TASK_STACK_SIZE = 12288;
+  static_assert(
+      sizeof(StackType_t) == 1U,
+      "ESP-IDF StaticTask stack sizes are configured in bytes");
+
+  enum class WorkerCommand : uint32_t {
+    START = 1U,
+    CLEANUP = 2U,
+  };
 
   struct StorageV1 {
     uint32_t magic;
@@ -114,25 +131,28 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   bool load_storage_(Storage *storage);
   bool load_legacy_storage_(StorageV1 *storage);
   bool save_storage_(const Storage &storage);
+  bool set_consent_publish_blocked_(bool blocked);
   bool ensure_installation_id_(Storage *storage);
   bool is_setup_complete_() const;
-  void apply_storage_(const Storage &storage);
+  bool apply_storage_(const Storage &storage);
   void schedule_initial_publish_();
   void schedule_immediate_publish_();
   void schedule_regular_publish_();
   void schedule_retry_();
   void start_publish_session_();
+  bool ensure_worker_task_();
+  bool notify_worker_(WorkerCommand command);
   bool start_client_();
+  bool cleanup_client_();
   void finish_publish_session_(bool succeeded);
-  bool prepare_cleanup_task_();
   void complete_publish_session_();
-  void build_payload_();
+  bool build_payload_();
+  void clear_payload_();
   std::string read_hardware_revision_() const;
   static bool time_reached_(uint32_t now_ms, uint32_t target_ms);
   static std::string format_uuid_(const std::array<uint8_t, 16> &bytes);
   static std::string random_message_id_();
-  static void start_client_task_(void *arg);
-  static void cleanup_client_task_(void *arg);
+  static void worker_task_(void *arg);
   static void mqtt_event_handler_(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
 
   std::string broker_;
@@ -169,19 +189,29 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   ESPPreferenceObject pref_;
   std::array<uint8_t, 16> installation_id_bytes_{};
   std::string installation_id_;
-  std::string publish_topic_;
-  std::string payload_;
+  openquatt_common::PsramBuffer<char> publish_topic_;
+  openquatt_common::PsramBuffer<char> payload_;
+  size_t payload_size_{0U};
   std::string payload_message_id_;
   esp_mqtt_client_handle_t mqtt_client_{nullptr};
-  SemaphoreHandle_t runtime_lock_{nullptr};
+  bool mqtt_client_started_{false};
+  uint8_t cleanup_stop_failures_{0U};
+  bool cleanup_disconnect_requested_{false};
+  bool worker_task_region_valid_{false};
+  StaticSemaphore_t consent_mutex_storage_{};
+  SemaphoreHandle_t consent_mutex_{nullptr};
+  StaticTask worker_task_state_{};
   std::atomic<bool> enabled_{false};
+  std::atomic<bool> consent_publish_blocked_{true};
   std::atomic<bool> choice_configured_{false};
   std::atomic<bool> session_active_{false};
   std::atomic<bool> finishing_session_{false};
   std::atomic<bool> start_task_running_{false};
-  std::atomic<bool> cleanup_task_running_{false};
+  std::atomic<bool> start_task_complete_{false};
   std::atomic<bool> cleanup_task_complete_{false};
   std::atomic<bool> cleanup_succeeded_{false};
+  std::atomic<bool> mqtt_connected_seen_{false};
+  std::atomic<bool> mqtt_disconnected_seen_{false};
   std::atomic<bool> publish_succeeded_{false};
   std::atomic<bool> publish_failed_{false};
   std::atomic<int> pending_message_id_{-1};
@@ -189,7 +219,6 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   uint32_t next_publish_ms_{0};
   uint8_t consecutive_failures_{0};
   bool boot_publish_pending_{false};
-  std::atomic<TaskHandle_t> cleanup_task_handle_{nullptr};
 };
 
 }  // namespace openquatt_usage_telemetry

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <cinttypes>
+#include <cstddef>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace esphome {
+namespace openquatt_usage_telemetry {
+
+enum class MqttCleanupDecision : uint8_t {
+  DESTROY = 0U,
+  FORCE_DISCONNECT = 1U,
+  RETRY_STOP = 2U,
+  DESTROY_ALREADY_STOPPED = 3U,
+};
+
+class FixedBufferWriter {
+ public:
+  FixedBufferWriter(char *data, size_t capacity)
+      : data_(data), capacity_(capacity) {
+    if (this->data_ == nullptr || this->capacity_ == 0U) {
+      this->ok_ = false;
+    } else {
+      this->data_[0] = '\0';
+    }
+  }
+
+  FixedBufferWriter &operator+=(const char *value) {
+    if (value != nullptr) {
+      this->append_(value, std::strlen(value));
+    }
+    return *this;
+  }
+
+  FixedBufferWriter &operator+=(const std::string &value) {
+    this->append_(value.data(), value.size());
+    return *this;
+  }
+
+  FixedBufferWriter &operator+=(char value) {
+    this->append_(&value, 1U);
+    return *this;
+  }
+
+  void append_uint(uint64_t value) {
+    char buffer[24];
+    const int length = std::snprintf(
+        buffer, sizeof(buffer), "%" PRIu64, value);
+    if (length <= 0) {
+      this->ok_ = false;
+      return;
+    }
+    this->append_(buffer, static_cast<size_t>(length));
+  }
+
+  bool ok() const { return this->ok_; }
+  size_t size() const { return this->size_; }
+
+ private:
+  void append_(const char *value, size_t length) {
+    if (!this->ok_ || value == nullptr ||
+        length >= this->capacity_ - this->size_) {
+      this->ok_ = false;
+      return;
+    }
+    std::memcpy(this->data_ + this->size_, value, length);
+    this->size_ += length;
+    this->data_[this->size_] = '\0';
+  }
+
+  char *data_{nullptr};
+  size_t capacity_{0U};
+  size_t size_{0U};
+  bool ok_{true};
+};
+
+inline void append_json_escaped(FixedBufferWriter &output,
+                                const std::string &input) {
+  for (char c : input) {
+    switch (c) {
+      case '"':
+        output += "\\\"";
+        break;
+      case '\\':
+        output += "\\\\";
+        break;
+      case '\b':
+        output += "\\b";
+        break;
+      case '\f':
+        output += "\\f";
+        break;
+      case '\n':
+        output += "\\n";
+        break;
+      case '\r':
+        output += "\\r";
+        break;
+      case '\t':
+        output += "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20U) {
+          char buffer[7];
+          std::snprintf(
+              buffer, sizeof(buffer), "\\u%04x",
+              static_cast<unsigned char>(c));
+          output += buffer;
+        } else {
+          output += c;
+        }
+        break;
+    }
+  }
+}
+
+inline MqttCleanupDecision mqtt_cleanup_decision(
+    bool stop_succeeded, bool connected_seen, bool disconnected_seen,
+    uint8_t consecutive_stop_failures) {
+  if (stop_succeeded) {
+    return MqttCleanupDecision::DESTROY;
+  }
+  if (connected_seen && !disconnected_seen) {
+    return MqttCleanupDecision::FORCE_DISCONNECT;
+  }
+  if (consecutive_stop_failures < 2U) {
+    return MqttCleanupDecision::RETRY_STOP;
+  }
+  return MqttCleanupDecision::DESTROY_ALREADY_STOPPED;
+}
+
+}  // namespace openquatt_usage_telemetry
+}  // namespace esphome

--- a/components/openquatt_usage_telemetry/__init__.py
+++ b/components/openquatt_usage_telemetry/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.components import (
     binary_sensor,
     openquatt_mqtt_config,
+    psram,
     select,
     sensor,
     socket,
@@ -13,11 +14,15 @@ from esphome.components import (
 from esphome.components.esp32 import (
     add_idf_sdkconfig_option,
     add_idf_component,
+    get_esp32_variant,
     idf_version,
     include_builtin_idf_component,
 )
+from esphome.components.esp32.const import VARIANT_ESP32S3
 from esphome.const import ENTITY_CATEGORY_CONFIG
 from esphome.core import CORE
+
+DEPENDENCIES = ["psram"]
 
 
 CONF_BROKER = "broker"
@@ -114,6 +119,8 @@ CONFIG_SCHEMA = cv.All(
 
 async def to_code(config):
     if CORE.is_esp32:
+        if get_esp32_variant() == VARIANT_ESP32S3:
+            psram.request_external_task_stack()
         if idf_version() >= cv.Version(6, 0, 0):
             add_idf_component(name="espressif/mqtt", ref="1.0.0")
         else:

--- a/dev/README.md
+++ b/dev/README.md
@@ -8,3 +8,11 @@ not release firmware entrypoints.
 Minimal ESP32-S3 OpenTherm validation config. It is intended for local component
 testing without pulling in the full OpenQuatt package stack, and is not part of
 the release build matrix.
+
+## Memory-sensitive validation
+
+Minimal configs are useful for component isolation, but cannot establish the
+internal-heap safety of release firmware. Memory-affecting changes must also be
+tested with the applicable full release profile and combined network/control
+load. Follow the runtime heap method and release criteria documented in
+`docs/system-overview.md` and `CONTRIBUTING.md`.

--- a/docs/ontwikkelen-op-mac.md
+++ b/docs/ontwikkelen-op-mac.md
@@ -46,6 +46,12 @@ python3 scripts/dev.py validate --jobs 2
 Begin bij voorkeur met `--jobs 2`. Meer parallelisme kan sneller zijn, maar gebruikt ook meer CPU, RAM en schijfcache.
 De eerste full-validate na een lege of opgeschoonde cache kan tijdelijk sequentieel lopen; de helper doet dat automatisch om ESP-IDF component-cache races te vermijden.
 
+## Geheugenvalidatie
+
+Een geslaagde compile en het linker-RAM-percentage bewijzen niet dat de runtimeheap veilig is. Meet bij nieuwe runtimefeatures ook de actuele en minimale interne heap, het grootste vrije block, fragmentatie, vrij PSRAM en relevante task-stack-watermarks op representatieve hardware.
+
+Vergelijk dezelfde releaseconfiguratie vóór en na de wijziging, vanaf een koude boot en onder gecombineerde HA-, web-, API-, MQTT-, Modbus-, OpenTherm- en waar relevant OTA/flashbelasting. Zie `CONTRIBUTING.md` en `docs/system-overview.md` voor de allocatieregels, meetmethode en releasecriteria.
+
 ## Flashen En Hardware
 
 Gebruik voor ESPHome upload- en logtaken de ESPHome executable uit de lokale venv:

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -321,6 +321,24 @@ OpenTherm thermostat support is part of the Heatpump Controller Q profile only. 
 
 All active hardware profiles configure PSRAM with `ignore_not_found: false`. OpenQuatt therefore treats PSRAM as required hardware for supported profiles, not as an optional acceleration path. Missing PSRAM should surface as a hardware or profile mismatch instead of silently degrading Trends and LogHistory behavior.
 
+#### Runtime heap discipline
+
+PSRAM capacity does not replace internal DRAM headroom. Wi-Fi, lwIP, TLS, ESP-MQTT, DMA and several FreeRTOS operations still require internal memory, sometimes as one contiguous allocation. Large long-lived state, histories, payloads and response scratch buffers should therefore use explicit PSRAM ownership where their execution context permits it. ISR/DMA data, cache-disabled paths and platform-restricted network task stacks must remain in compatible internal memory.
+
+Heap diagnostics have distinct meanings:
+
+- current internal free heap describes one moment;
+- minimum internal free heap is the cumulative low watermark since boot;
+- largest internal free block shows whether a contiguous allocation can still succeed;
+- fragmentation is derived from the gap between total free internal heap and that largest block;
+- task-stack high-watermarks show the unused stack at the worst observed point.
+
+A low minimum watermark is not by itself a leak, but it proves that the firmware entered that allocation state at least once. Static linker RAM totals also cannot reveal transient task stacks, TLS buffers or overlapping network allocations.
+
+Memory-sensitive changes require an identical baseline/candidate comparison with cold-boot checkpoints and realistic combined load. Measurements should cover the applicable HA, web, API, MQTT, Modbus, OpenTherm and OTA/flash paths without aggressive polling that distorts the heap. After a temporary operation, current heap and largest-block values should recover without a continuing downward trend.
+
+OpenQuatt treats allocation failures, unexplained regressions or a minimum/largest-block result without measured margin for the worst simultaneous allocation as release-blocking. Healthy HIL baselines should be maintained per hardware profile and converted into explicit profile budgets; one global heap number is not sufficient. Prefer targeted PSRAM placement, bounded reusable buffers and persistent workers over a global malloc-threshold change. When strict PSRAM allocation fails, the feature must degrade explicitly and safety-relevant control must fail closed.
+
 Persistent histories use separate, sector-aligned regions inside `openquatt_data`. The shared layout is defined in
 `components/openquatt_common/OpenQuattFlashLayout.h` so one archive cannot silently grow into another:
 

--- a/scripts/run_host_regression_tests.sh
+++ b/scripts/run_host_regression_tests.sh
@@ -33,4 +33,7 @@ done
 echo "[run] incident manager action contract"
 python3 "${repo_root}/scripts/tests/test_incident_manager_action_contract.py"
 
+echo "[run] internal heap placement contract"
+python3 "${repo_root}/scripts/tests/test_internal_heap_contract.py"
+
 echo "Host regression tests passed (${#sources[@]})."

--- a/scripts/tests/test_internal_heap_contract.py
+++ b/scripts/tests/test_internal_heap_contract.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMON_HEADER = (
+    ROOT / "components" / "openquatt_common" / "PsramBuffer.h"
+).read_text()
+INCIDENT_HEADER = (
+    ROOT
+    / "components"
+    / "openquatt_incident_manager"
+    / "OpenQuattIncidentManager.h"
+).read_text()
+INCIDENT_CPP = (
+    ROOT
+    / "components"
+    / "openquatt_incident_manager"
+    / "OpenQuattIncidentManager.cpp"
+).read_text()
+TELEMETRY_HEADER = (
+    ROOT
+    / "components"
+    / "openquatt_usage_telemetry"
+    / "OpenQuattUsageTelemetry.h"
+).read_text()
+TELEMETRY_CPP = (
+    ROOT
+    / "components"
+    / "openquatt_usage_telemetry"
+    / "OpenQuattUsageTelemetry.cpp"
+).read_text()
+TELEMETRY_CODEGEN = (
+    ROOT / "components" / "openquatt_usage_telemetry" / "__init__.py"
+).read_text()
+TELEMETRY_POLICY = (
+    ROOT
+    / "components"
+    / "openquatt_usage_telemetry"
+    / "OpenQuattUsageTelemetryPolicy.h"
+).read_text()
+
+
+class InternalHeapPlacementContractTest(unittest.TestCase):
+    def test_incident_runtime_and_snapshots_are_external_only(self) -> None:
+        self.assertIn("class PsramObjectArray", COMMON_HEADER)
+        self.assertIn(
+            "PsramObjectArray<ExternalState, 1U> external_state_",
+            INCIDENT_HEADER,
+        )
+        self.assertIn(
+            "std::array<PublishedSnapshot, 3U> snapshots",
+            INCIDENT_HEADER,
+        )
+        self.assertIn("sizeof(OpenQuattIncidentManager) <= 512U", INCIDENT_HEADER)
+        self.assertNotIn(
+            "std::unique_ptr<PublishedSnapshot>",
+            INCIDENT_CPP,
+        )
+        self.assertNotIn(
+            "new (std::nothrow) PublishedSnapshot",
+            INCIDENT_CPP,
+        )
+
+    def test_snapshot_publication_avoids_large_spinlock_copy(self) -> None:
+        self.assertIn(
+            "xSemaphoreCreateMutexStatic(&this->snapshot_mutex_storage_)",
+            INCIDENT_CPP,
+        )
+        self.assertIn(
+            "std::swap(this->published_snapshot_index_",
+            INCIDENT_CPP,
+        )
+        self.assertNotIn("portENTER_CRITICAL", INCIDENT_CPP)
+
+    def test_s3_telemetry_worker_and_payload_use_psram(self) -> None:
+        self.assertIn("StaticTask worker_task_state_", TELEMETRY_HEADER)
+        self.assertIn(
+            "MQTT_WORKER_STACK_IN_PSRAM = true",
+            TELEMETRY_HEADER,
+        )
+        self.assertIn("TELEMETRY_PAYLOAD_CAPACITY + 1U", TELEMETRY_CPP)
+        self.assertIn(
+            "FixedBufferWriter payload(this->payload_.data()",
+            TELEMETRY_CPP,
+        )
+        self.assertNotIn("std::string payload;", TELEMETRY_CPP)
+        self.assertIn("psram.request_external_task_stack()", TELEMETRY_CODEGEN)
+        self.assertIn(
+            "get_esp32_variant() == VARIANT_ESP32S3",
+            TELEMETRY_CODEGEN,
+        )
+        self.assertNotIn("xTaskCreatePinnedToCore(", TELEMETRY_CPP)
+        self.assertNotIn("vTaskDelete(nullptr)", TELEMETRY_CPP)
+
+    def test_classic_esp32_worker_remains_internal(self) -> None:
+        self.assertIn(
+            "MQTT_WORKER_STACK_IN_PSRAM = false",
+            TELEMETRY_HEADER,
+        )
+        self.assertIn(
+            "this->worker_task_state_.deallocate();",
+            TELEMETRY_CPP,
+        )
+        self.assertIn("eTaskGetState(handle) != eSuspended", TELEMETRY_CPP)
+
+    def test_telemetry_cleanup_and_consent_fail_closed(self) -> None:
+        self.assertIn("mqtt_cleanup_decision(", TELEMETRY_POLICY)
+        self.assertIn("DESTROY_ALREADY_STOPPED", TELEMETRY_POLICY)
+        self.assertIn("xSemaphoreCreateMutexStatic", TELEMETRY_CPP)
+        self.assertIn("consent_mutex_", TELEMETRY_HEADER)
+        self.assertIn("consent_publish_blocked_", TELEMETRY_HEADER)
+        self.assertIn(
+            "this->set_consent_publish_blocked_(true)",
+            TELEMETRY_CPP,
+        )
+        self.assertIn(
+            "A failed opt-out write must not reopen telemetry",
+            TELEMETRY_CPP,
+        )
+        self.assertIn("eSetValueWithOverwrite", TELEMETRY_CPP)
+        self.assertNotIn("eSetValueWithoutOverwrite", TELEMETRY_CPP)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host/openquatt_incident_runtime_policy_test.cpp
+++ b/tests/host/openquatt_incident_runtime_policy_test.cpp
@@ -19,6 +19,8 @@ using esphome::openquatt_incident_manager::
     apply_persistence_safety_gate;
 using esphome::openquatt_incident_manager::
     apply_persistence_initialization_gate;
+using esphome::openquatt_incident_manager::
+    incident_storage_failure_outputs;
 using esphome::openquatt_incident_manager::HpThermalCommand;
 using esphome::openquatt_incident_manager::
     link_round_timeout_elapsed;
@@ -177,6 +179,38 @@ void test_duo_fallback_coverage_fails_closed() {
                                              outputs.size()));
   assert(!all_unavailable_hps_allow_fallback(nullptr, outputs.size()));
   assert(!all_unavailable_hps_allow_fallback(outputs.data(), 0U));
+}
+
+void test_incident_storage_failure_forces_safe_outputs() {
+  const oq_incidents::DerivedOutputs outputs =
+      incident_storage_failure_outputs();
+  assert(outputs.link_state == oq_incidents::LinkState::BOOTSTRAP);
+  assert(outputs.protection_state ==
+         oq_incidents::ProtectionState::FAULT_ACTIVE);
+  assert(!outputs.available_for_start);
+  assert(outputs.must_stop);
+  assert(outputs.fault_active);
+  assert(outputs.protection_active);
+  assert(!outputs.stop_confirmed);
+  assert(outputs.stop_unconfirmed);
+  assert(!outputs.fallback_cause_present);
+  assert(!outputs.fallback_eligible);
+  assert(oq_incidents::has_effect(
+      outputs.active_effects,
+      oq_incidents::IncidentEffect::BLOCK_START));
+  assert(oq_incidents::has_effect(
+      outputs.active_effects,
+      oq_incidents::IncidentEffect::STOP_COMPRESSOR));
+  assert(oq_incidents::has_effect(
+      outputs.active_effects,
+      oq_incidents::IncidentEffect::BLOCK_BOILER));
+
+  const std::array<oq_incidents::DerivedOutputs, 1U> failed{
+      outputs};
+  assert(!all_unavailable_hps_allow_fallback(
+      failed.data(), failed.size()));
+  assert(!all_hp_outputs_safe_for_fallback(
+      failed.data(), failed.size()));
 }
 
 void test_persistence_failure_vetoes_real_fault_fallback() {
@@ -511,6 +545,7 @@ int main() {
   test_start_failure_retry_production_policy();
   test_link_round_timeout_tolerates_scan_jitter();
   test_duo_fallback_coverage_fails_closed();
+  test_incident_storage_failure_forces_safe_outputs();
   test_fallback_output_confirmation();
   test_persistence_overlay_is_fail_closed_and_causally_consistent();
   test_persistence_failure_vetoes_real_fault_fallback();

--- a/tests/host/openquatt_usage_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_usage_telemetry_policy_test.cpp
@@ -1,0 +1,54 @@
+#include <array>
+#include <cassert>
+#include <cstring>
+#include <string>
+
+#include "components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h"
+
+using esphome::openquatt_usage_telemetry::MqttCleanupDecision;
+using esphome::openquatt_usage_telemetry::FixedBufferWriter;
+using esphome::openquatt_usage_telemetry::append_json_escaped;
+using esphome::openquatt_usage_telemetry::mqtt_cleanup_decision;
+
+int main() {
+  assert(mqtt_cleanup_decision(true, false, false, 0U) ==
+         MqttCleanupDecision::DESTROY);
+  assert(mqtt_cleanup_decision(false, true, false, 1U) ==
+         MqttCleanupDecision::FORCE_DISCONNECT);
+  assert(mqtt_cleanup_decision(false, false, false, 1U) ==
+         MqttCleanupDecision::RETRY_STOP);
+  assert(mqtt_cleanup_decision(false, false, false, 2U) ==
+         MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
+  assert(mqtt_cleanup_decision(false, true, true, 2U) ==
+         MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
+
+  std::array<char, 128U> escaped{};
+  FixedBufferWriter json(escaped.data(), escaped.size());
+  json += R"({"value":")";
+  append_json_escaped(
+      json, std::string{"\"\\\b\f\n\r\t"} + '\x01' + "x");
+  json += R"("})";
+  assert(json.ok());
+  assert(std::strcmp(
+             escaped.data(),
+             R"({"value":"\"\\\b\f\n\r\t\u0001x"})") == 0);
+
+  std::array<char, 5U> exact{};
+  FixedBufferWriter exact_writer(exact.data(), exact.size());
+  exact_writer += "1234";
+  assert(exact_writer.ok());
+  assert(exact_writer.size() == 4U);
+  assert(std::strcmp(exact.data(), "1234") == 0);
+  exact_writer += '5';
+  assert(!exact_writer.ok());
+  assert(std::strcmp(exact.data(), "1234") == 0);
+
+  std::array<char, 2049U> maximum{};
+  FixedBufferWriter maximum_writer(maximum.data(), maximum.size());
+  maximum_writer += std::string(2048U, 'x');
+  assert(maximum_writer.ok());
+  assert(maximum_writer.size() == 2048U);
+  maximum_writer += 'y';
+  assert(!maximum_writer.ok());
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst incidentruntime en snapshots naar strikt PSRAM met vooraf toegewezen, begrensde response-opslag en fail-closed gedrag.
- Vervangt per-publicatie usage-telemetry-tasks door één herbruikbare worker; op ESP32-S3 staan de 16 kB workerstack en payload/topicbuffers strikt in PSRAM.
- Voegt heap-placement-, lifecycle- en policytests toe en legt interne-heaprichtlijnen vast in de ontwikkelaarsdocumentatie.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting: normaal incident- en regelgedrag blijft gelijk. Als de verplichte incidentarena niet in PSRAM kan worden toegewezen, blokkeert de manager nieuwe starts en boilerfallback, vraagt compressorstop en retourneert het incidentendpoint HTTP 503. Gelijktijdige incident-GETs kunnen bewust `503 snapshot_busy` krijgen in plaats van een extra grote heapkopie. Telemetry-opt-out sluit de publish-gate voordat een lopende enqueue-sectie wordt afgewacht.

## Achtergrond

De Q `duo_wifi`-build hield grote incident-state/snapshot-objecten intern en maakte voor iedere usage-telemetry-sessie aparte interne start- en cleanupstacks. Daardoor overlapten incidentopslag, ESP-MQTT en netwerkallocaties in de schaarse interne heap. Deze PR gebruikt gerichte PSRAM-eigendom. Globale mallocdrempels, lwIP-socketlimieten, Wi-Fi/RMT/OpenTherm-buffers en de manifesttask blijven ongemoeid.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie: `CONTRIBUTING.md`, `AGENTS.md`, componentrichtlijnen, ontwikkelnotes, system-overview en PR-template beschrijven nu interne-heapbudgetten en de vereiste HIL-metingen.

## Validatie

- `CXX=/opt/homebrew/bin/g++-15 ./scripts/run_host_regression_tests.sh` — geslaagd: 13 C++-hosttests plus beide Python-contracttests.
- `python3 scripts/dev.py validate --config-only` — alle 8 releaseprofielen geslaagd.
- `python3 scripts/dev.py validate --jobs 2` — alle 8 releaseprofielen en artifactchecks geslaagd met ESPHome 2026.7.3 / ESP-IDF 5.5.5.
- OTA/HIL — Q-controller v1.1, `duo_wifi`, volledige OTB/Modbus-installatie, usage telemetry ingeschakeld en manifestcheck na 300 s.

Heap/stack-impact:

- Q `duo_wifi` static DIRAM: 229.443 → 218.939 B (-10.504 B).
- Interne heap na telemetry/manifest-cleanup: circa 71.299 B.
- Minimum vóór manifest: 25.972 B; minimum na manifest: 16.744 B.
- Grootste interne vrije block: 31.744 B; fragmentatie circa 55,5%.
- Usage-workerstack: 16.384 B in PSRAM op ESP32-S3; ESP-MQTT-stack blijft 12.288 B intern. Stack-watermarklogging toegevoegd.
- Geen allocatiefout, watchdog of reset waargenomen.

Resterende pre-release HIL-risico's: de classic-ESP32-workerlifecycle is alleen compilematig gevalideerd; echte PSRAM-allocatiefouten en MQTT stop/destroy-interleavings zijn niet runtime-geïnjecteerd; overlap van de externe S3-workerstack met OTA/flashwrites verdient nog een gerichte test.
