### PR TITLE
Keep optional history buffers out of internal heap

### DIFF
--- a/components/openquatt_debug_recorder/OpenQuattDebugRecorder.cpp
+++ b/components/openquatt_debug_recorder/OpenQuattDebugRecorder.cpp
@@ -786,9 +786,10 @@ void OpenQuattDebugRecorder::setup() {
     return;
   }
 
-  const bool allocated = this->samples_.allocate(SAMPLE_CAPACITY) && this->fields_.allocate(FIELD_CAPACITY) &&
-                         this->string_entries_.allocate(STRING_ENTRY_CAPACITY) &&
-                         this->string_data_.allocate(STRING_DATA_BYTES);
+  const bool allocated = this->samples_.allocate_external(SAMPLE_CAPACITY) &&
+                         this->fields_.allocate_external(FIELD_CAPACITY) &&
+                         this->string_entries_.allocate_external(STRING_ENTRY_CAPACITY) &&
+                         this->string_data_.allocate_external(STRING_DATA_BYTES);
   if (!allocated || !this->available_()) {
     this->samples_.release();
     this->fields_.release();

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -332,6 +332,10 @@ class OpenQuattLogHistoryRequestHandler : public AsyncWebHandler {
         request->send(403, "application/json", R"({"ok":false,"error":"forbidden"})");
         return;
       }
+      if (!this->parent_->storage_available()) {
+        request->send(503, "application/json", R"({"ok":false,"available":false,"error":"psram_unavailable"})");
+        return;
+      }
       this->parent_->clear_history();
       request->send(200, "application/json", R"({"ok":true})");
       return;
@@ -713,7 +717,7 @@ void OpenQuattLogHistory::setup() {
     this->enabled_ = this->enabled_switch_->state;
   }
 
-  if (!this->entries_.allocate(ENTRY_CAPACITY)) {
+  if (!this->entries_.allocate_external(ENTRY_CAPACITY)) {
     ESP_LOGE(TAG, "Failed to allocate log history buffer in PSRAM");
   }
   this->rotate_csrf_token_();
@@ -765,6 +769,11 @@ void OpenQuattLogHistory::write_recent_logs(httpd_req_t *req) const {
   if (req == nullptr) {
     return;
   }
+  if (!this->storage_available()) {
+    httpd_resp_set_status(req, "503 Service Unavailable");
+    httpd_resp_sendstr(req, R"({"ok":false,"available":false,"error":"psram_unavailable"})");
+    return;
+  }
 
   size_t snapshot_capacity = 0;
   if (!this->lock_history_()) {
@@ -776,7 +785,7 @@ void OpenQuattLogHistory::write_recent_logs(httpd_req_t *req) const {
   this->unlock_history_();
 
   PsramBuffer<LogEntry> snapshot;
-  if (!snapshot.allocate(snapshot_capacity)) {
+  if (!snapshot.allocate_external(snapshot_capacity)) {
     ESP_LOGW(TAG, "Failed to allocate recent log snapshot");
     httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Unable to snapshot recent logs");
     return;

--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -33,6 +33,7 @@ class OpenQuattLogHistory : public Component {
   void set_enabled(bool enabled);
   void clear_history();
   const std::string &get_csrf_token() const { return this->csrf_token_; }
+  bool storage_available() const { return static_cast<bool>(this->entries_); }
   void write_recent_logs(httpd_req_t *req) const;
 
  protected:

--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -198,10 +198,10 @@ void OpenQuattTrends::setup() {
     return;
   }
 
-  if (!this->ram_history_.allocate(RAM_CAPACITY)) {
+  if (!this->ram_history_.allocate_external(RAM_CAPACITY)) {
     ESP_LOGE(TAG, "Failed to allocate trend history buffer in PSRAM");
   }
-  if (!this->flash_index_.allocate(FLASH_SLOT_COUNT)) {
+  if (!this->flash_index_.allocate_external(FLASH_SLOT_COUNT)) {
     ESP_LOGW(TAG, "Failed to allocate trend flash index");
   }
 
@@ -226,7 +226,7 @@ void OpenQuattTrends::setup() {
 
 void OpenQuattTrends::loop() {
   this->sync_time_state_();
-  if (!this->flash_switch_enabled_() || this->flash_partition_ == nullptr) {
+  if (!this->flash_switch_enabled_() || !this->flash_archive_available_()) {
     return;
   }
 
@@ -251,14 +251,18 @@ void OpenQuattTrends::dump_config() {
   ESP_LOGCONFIG(TAG, "  RAM samples: %u / %u", static_cast<unsigned>(this->ram_count_), static_cast<unsigned>(RAM_CAPACITY));
   ESP_LOGCONFIG(TAG, "  RAM history buffer: %s",
                 !this->ram_history_ ? "missing" : (this->ram_history_.is_external() ? "PSRAM" : "internal"));
+  ESP_LOGCONFIG(TAG, "  Flash index: %s",
+                !this->flash_index_ ? "missing" : (this->flash_index_.is_external() ? "PSRAM" : "internal"));
   ESP_LOGCONFIG(TAG, "  Flash enabled: %s", YESNO(this->flash_switch_enabled_()));
+  ESP_LOGCONFIG(TAG, "  Flash archive available: %s", YESNO(this->flash_archive_available_()));
   ESP_LOGCONFIG(TAG, "  Flash archive scanned: %s", YESNO(this->flash_archive_scanned_));
 }
 
 float OpenQuattTrends::get_setup_priority() const { return setup_priority::WIFI; }
 
 bool OpenQuattTrends::capture_enabled_() const {
-  return this->ram_history_ && this->capture_switch_ != nullptr && this->capture_switch_->state;
+  return this->storage_capabilities_().ram_history_available && this->capture_switch_ != nullptr &&
+         this->capture_switch_->state;
 }
 
 bool OpenQuattTrends::flash_switch_enabled_() const {
@@ -266,6 +270,15 @@ bool OpenQuattTrends::flash_switch_enabled_() const {
     return this->flash_switch_->state;
   }
   return this->flash_enabled_;
+}
+
+TrendStorageCapabilities OpenQuattTrends::storage_capabilities_() const {
+  return trend_storage_capabilities(static_cast<bool>(this->ram_history_), static_cast<bool>(this->flash_index_),
+                                    this->flash_partition_ != nullptr);
+}
+
+bool OpenQuattTrends::flash_archive_available_() const {
+  return this->storage_capabilities_().flash_archive_available;
 }
 
 bool OpenQuattTrends::time_is_valid_() const {
@@ -434,7 +447,7 @@ void OpenQuattTrends::sync_time_state_() {
 }
 
 void OpenQuattTrends::load_archive_if_needed_() {
-  if (!this->ram_history_ || !this->flash_switch_enabled_() || this->flash_partition_ == nullptr ||
+  if (!this->ram_history_ || !this->flash_switch_enabled_() || !this->flash_archive_available_() ||
       !this->time_is_valid_()) {
     return;
   }
@@ -491,7 +504,7 @@ bool OpenQuattTrends::scan_flash_archive_() {
   this->next_flash_sequence_ = 0;
   this->flash_index_count_ = 0;
 
-  if (this->flash_partition_ == nullptr) {
+  if (!this->flash_archive_available_()) {
     return false;
   }
 
@@ -538,7 +551,7 @@ bool OpenQuattTrends::scan_flash_archive_() {
 }
 
 bool OpenQuattTrends::merge_flash_history_into_ram_() {
-  if (!this->ram_history_) {
+  if (!this->ram_history_ || !this->flash_archive_available_()) {
     return false;
   }
   if (!this->flash_archive_scanned_) {
@@ -573,11 +586,11 @@ bool OpenQuattTrends::merge_flash_history_into_ram_() {
 }
 
 bool OpenQuattTrends::clear_flash_archive_() {
-  if (this->flash_partition_ == nullptr) {
+  if (!this->flash_archive_available_()) {
     this->reset_flash_metadata_();
     this->next_flash_sequence_ = 0;
-    this->flash_archive_scanned_ = true;
-    return true;
+    this->flash_archive_scanned_ = false;
+    return false;
   }
 
   const esp_err_t erase_result = esp_partition_erase_range(this->flash_partition_, 0, FLASH_TOTAL_BYTES);
@@ -599,7 +612,7 @@ void OpenQuattTrends::reset_flash_builder_() {
 }
 
 bool OpenQuattTrends::append_sample_to_flash_(const TrendSample &sample) {
-  if (!this->flash_switch_enabled_() || this->flash_partition_ == nullptr || !this->time_is_valid_()) {
+  if (!this->flash_switch_enabled_() || !this->flash_archive_available_() || !this->time_is_valid_()) {
     return false;
   }
 
@@ -630,7 +643,7 @@ bool OpenQuattTrends::append_sample_to_flash_(const TrendSample &sample) {
 }
 
 bool OpenQuattTrends::write_flash_block_(const FlashBlockBuilder &builder) {
-  if (this->flash_partition_ == nullptr || builder.sample_count == 0) {
+  if (!this->flash_archive_available_() || builder.sample_count == 0) {
     return false;
   }
 
@@ -699,7 +712,7 @@ bool OpenQuattTrends::write_flash_block_(const FlashBlockBuilder &builder) {
 }
 
 bool OpenQuattTrends::flush_flash_builder_(bool force) {
-  if (!this->flash_switch_enabled_() || this->flash_partition_ == nullptr || !this->time_is_valid_()) {
+  if (!this->flash_switch_enabled_() || !this->flash_archive_available_() || !this->time_is_valid_()) {
     return false;
   }
 
@@ -1080,7 +1093,7 @@ bool OpenQuattTrends::write_sample_line_(ChunkedTextWriter *writer, const TrendS
 void OpenQuattTrends::write_samples_for_history_(ChunkedTextWriter *writer, uint32_t window_hours) {
   const uint64_t cutoff_ms = this->get_window_cutoff_ms_(window_hours);
   const uint32_t stride = this->get_window_stride_(window_hours);
-  if (this->flash_partition_ != nullptr && !this->flash_archive_scanned_) {
+  if (this->flash_archive_available_() && !this->flash_archive_scanned_) {
     this->scan_flash_archive_();
   }
   const uint64_t oldest_ram_timestamp_ms = this->get_ram_oldest_timestamp_ms_();
@@ -1188,7 +1201,7 @@ void OpenQuattTrends::write_metadata(httpd_req_t *req) {
 }
 
 std::string OpenQuattTrends::get_flash_available_label() const {
-  if (this->flash_partition_ == nullptr) {
+  if (!this->flash_archive_available_()) {
     return "Niet beschikbaar";
   }
 
@@ -1198,32 +1211,35 @@ std::string OpenQuattTrends::get_flash_available_label() const {
 }
 
 std::string OpenQuattTrends::get_flash_oldest_point_label() const {
-  if (this->flash_partition_ == nullptr) {
+  if (!this->flash_archive_available_()) {
     return "—";
   }
   return this->format_flash_absolute_time_(this->get_flash_oldest_timestamp_ms_());
 }
 
 std::string OpenQuattTrends::get_flash_newest_point_label() const {
-  if (this->flash_partition_ == nullptr) {
+  if (!this->flash_archive_available_()) {
     return "—";
   }
   return this->format_flash_relative_age_(this->get_flash_newest_timestamp_ms_());
 }
 
 std::string OpenQuattTrends::get_flash_last_flush_label() const {
-  if (this->flash_partition_ == nullptr) {
+  if (!this->flash_archive_available_()) {
     return "—";
   }
   return this->format_flash_absolute_time_(this->get_flash_last_flush_timestamp_ms_());
 }
 
 float OpenQuattTrends::get_flash_storage_kib() const {
+  if (!this->flash_archive_available_()) {
+    return 0.0f;
+  }
   return static_cast<float>(static_cast<uint32_t>(this->flash_valid_block_count_) * FLASH_SLOT_SIZE) / 1024.0f;
 }
 
 uint32_t OpenQuattTrends::get_flash_write_count() const {
-  return this->next_flash_sequence_;
+  return this->flash_archive_available_() ? this->next_flash_sequence_ : 0U;
 }
 
 }  // namespace openquatt_trends

--- a/components/openquatt_trends/OpenQuattTrends.h
+++ b/components/openquatt_trends/OpenQuattTrends.h
@@ -6,6 +6,7 @@
 
 #include <esp_http_server.h>
 #include "OpenQuattFlashLayout.h"
+#include "OpenQuattTrendsStoragePolicy.h"
 #include "esp_partition.h"
 #include "PsramBuffer.h"
 #include "esphome/components/switch/switch.h"
@@ -125,6 +126,8 @@ class OpenQuattTrends : public Component {
 
   bool capture_enabled_() const;
   bool flash_switch_enabled_() const;
+  TrendStorageCapabilities storage_capabilities_() const;
+  bool flash_archive_available_() const;
   bool time_is_valid_() const;
   uint64_t current_time_ms_() const;
   uint64_t current_epoch_offset_ms_() const;

--- a/components/openquatt_trends/OpenQuattTrendsStoragePolicy.h
+++ b/components/openquatt_trends/OpenQuattTrendsStoragePolicy.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace esphome {
+namespace openquatt_trends {
+
+struct TrendStorageCapabilities {
+  bool ram_history_available;
+  bool flash_archive_available;
+};
+
+constexpr TrendStorageCapabilities trend_storage_capabilities(bool ram_history_allocated,
+                                                              bool flash_index_allocated,
+                                                              bool flash_partition_available) {
+  return TrendStorageCapabilities{
+      ram_history_allocated,
+      flash_index_allocated && flash_partition_available,
+  };
+}
+
+}  // namespace openquatt_trends
+}  // namespace esphome

--- a/scripts/tests/test_internal_heap_contract.py
+++ b/scripts/tests/test_internal_heap_contract.py
@@ -39,6 +39,27 @@ TELEMETRY_POLICY = (
     / "openquatt_usage_telemetry"
     / "OpenQuattUsageTelemetryPolicy.h"
 ).read_text()
+LOG_HISTORY_CPP = (
+    ROOT
+    / "components"
+    / "openquatt_log_history"
+    / "OpenQuattLogHistory.cpp"
+).read_text()
+DEBUG_RECORDER_CPP = (
+    ROOT
+    / "components"
+    / "openquatt_debug_recorder"
+    / "OpenQuattDebugRecorder.cpp"
+).read_text()
+TRENDS_CPP = (
+    ROOT / "components" / "openquatt_trends" / "OpenQuattTrends.cpp"
+).read_text()
+LOG_HISTORY_HEADER = (
+    ROOT
+    / "components"
+    / "openquatt_log_history"
+    / "OpenQuattLogHistory.h"
+).read_text()
 
 
 class InternalHeapPlacementContractTest(unittest.TestCase):
@@ -120,6 +141,60 @@ class InternalHeapPlacementContractTest(unittest.TestCase):
         )
         self.assertIn("eSetValueWithOverwrite", TELEMETRY_CPP)
         self.assertNotIn("eSetValueWithoutOverwrite", TELEMETRY_CPP)
+
+    def test_large_diagnostic_buffers_never_fall_back_to_internal_heap(self) -> None:
+        self.assertIn(
+            "this->entries_.allocate_external(ENTRY_CAPACITY)",
+            LOG_HISTORY_CPP,
+        )
+        self.assertIn(
+            "snapshot.allocate_external(snapshot_capacity)",
+            LOG_HISTORY_CPP,
+        )
+        self.assertIn(
+            "this->samples_.allocate_external(SAMPLE_CAPACITY)",
+            DEBUG_RECORDER_CPP,
+        )
+        self.assertIn(
+            "this->fields_.allocate_external(FIELD_CAPACITY)",
+            DEBUG_RECORDER_CPP,
+        )
+        self.assertIn(
+            "this->string_entries_.allocate_external(STRING_ENTRY_CAPACITY)",
+            DEBUG_RECORDER_CPP,
+        )
+        self.assertIn(
+            "this->string_data_.allocate_external(STRING_DATA_BYTES)",
+            DEBUG_RECORDER_CPP,
+        )
+        self.assertIn(
+            "this->ram_history_.allocate_external(RAM_CAPACITY)",
+            TRENDS_CPP,
+        )
+        self.assertIn(
+            "this->flash_index_.allocate_external(FLASH_SLOT_COUNT)",
+            TRENDS_CPP,
+        )
+
+    def test_optional_history_allocation_failures_are_explicit(self) -> None:
+        self.assertIn("bool storage_available() const", LOG_HISTORY_HEADER)
+        self.assertIn('"503 Service Unavailable"', LOG_HISTORY_CPP)
+        self.assertIn('"psram_unavailable"', LOG_HISTORY_CPP)
+
+        load_archive = TRENDS_CPP[
+            TRENDS_CPP.index("void OpenQuattTrends::load_archive_if_needed_()"):
+            TRENDS_CPP.index("void OpenQuattTrends::push_ram_sample_")
+        ]
+        merge_archive = TRENDS_CPP[
+            TRENDS_CPP.index("bool OpenQuattTrends::merge_flash_history_into_ram_()"):
+            TRENDS_CPP.index("bool OpenQuattTrends::clear_flash_archive_()")
+        ]
+        self.assertIn("!this->flash_archive_available_()", load_archive)
+        self.assertIn("!this->flash_archive_available_()", merge_archive)
+        self.assertLess(
+            merge_archive.index("!this->flash_archive_available_()"),
+            merge_archive.index("this->ram_head_ = 0"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/host/openquatt_trends_storage_policy_test.cpp
+++ b/tests/host/openquatt_trends_storage_policy_test.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+
+#include "components/openquatt_trends/OpenQuattTrendsStoragePolicy.h"
+
+using esphome::openquatt_trends::trend_storage_capabilities;
+
+int main() {
+  const auto full = trend_storage_capabilities(true, true, true);
+  assert(full.ram_history_available);
+  assert(full.flash_archive_available);
+
+  // A missing flash index must degrade to RAM-only history. Flash restore and
+  // writes stay unavailable, so they cannot repeatedly clear the RAM ring.
+  const auto missing_index = trend_storage_capabilities(true, false, true);
+  assert(missing_index.ram_history_available);
+  assert(!missing_index.flash_archive_available);
+
+  const auto missing_partition = trend_storage_capabilities(true, true, false);
+  assert(missing_partition.ram_history_available);
+  assert(!missing_partition.flash_archive_available);
+
+  // Existing flash history remains readable when only RAM capture is
+  // unavailable.
+  const auto flash_only = trend_storage_capabilities(false, true, true);
+  assert(!flash_only.ram_history_available);
+  assert(flash_only.flash_archive_available);
+
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat grote optionele log-, trend- en debugbuffers uitsluitend uit PSRAM alloceren; er is geen verborgen fallback naar interne heap meer.
- Degradeert bij allocatiefouten expliciet: loghistory retourneert HTTP 503, trends blijft veilig in RAM-only/flash-only modus en debug recording wordt unavailable.
- Voegt regressiecontracten en een hosttest toe voor de afzonderlijke trendopslagcapaciteiten.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

Toelichting:

Bij werkende PSRAM verandert het functionele gedrag niet. Als PSRAM niet beschikbaar is, gebruiken de grote optionele buffers niet langer interne heap. Loghistory en debug recording worden dan expliciet unavailable; trends behoudt de beschikbare RAM- of flashfunctie zonder de RAM-ring herhaaldelijk te wissen.

## Achtergrond

`PsramBuffer::allocate()` probeerde eerst PSRAM maar kon bij een fout grote buffers in interne DRAM plaatsen:

- loghistory: circa 59 kB, plus maximaal circa 59 kB per HTTP-snapshot;
- debug recorder: ruim 1,1 MB;
- trends: circa 44 kB RAM-history en circa 29 kB flashindex.

Die fallback kan juist bij PSRAM- of allocatiedruk de interne heap uitputten die Wi-Fi, lwIP, TLS en tasks nodig hebben. De wijziging gebruikt daarom `allocate_external()` en faalt gesloten.

De cold review vond dat een ontbrekende trend-flashindex de RAM-ring kon blijven legen en opnieuw alle flashslots kon scannen. Dat pad is gecorrigeerd met expliciete storage capabilities. Een ontbrekende logbuffer wordt niet langer als een lege maar succesvolle historie gerapporteerd.

Resterend risico: de allocatiefoutpaden zijn op policy-/contractniveau getest, maar niet via echte allocator-fault-injection op hardware. De normale hardware-path is inmiddels HIL-getest; een echte PSRAM-allocatiefout is nog niet geïnjecteerd.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit wijzigt alleen interne memory-placement en expliciete degradatie bij een PSRAM-allocatiefout; normale gebruikersconfiguratie en bediening blijven gelijk.

## Validatie

- `CXX=g++-15 ./scripts/run_host_regression_tests.sh` — PASS, 14 C++-hosttests plus incident- en heapcontracttests.
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml --config configs/heatpump_listener/duo_wifi.yaml --jobs 2` — PASS voor configvalidatie en volledige ESP32-S3/classic ESP32-compiles.
- `git diff --check origin/dev...HEAD` — PASS.
- Afzonderlijke cold adversarial review van allocatiefouten, flash/RAM-degradatie, HTTP-status en testdekking uitgevoerd; alle medium/low codefindings opgelost.


### Hardware A/B-validatie (29 juli 2026)

- Geïsoleerde PR401-build: bij t60 circa `77,4 kB` vrije heap, `39,828 kB` minimumheap en `31,744 kB` grootste vrije block.
- Bij t300 stond de cumulatieve minimumwatermark in deze run op `15,35 kB`. Dit is een runtimepiek uit één run en niet aan PR401 zelf toegeschreven.
- Loghistory, trends en debug recording bleven functioneel.
- Zoals bedoeld levert PR401 op het normale pad geen permanente interne-DRAM-winst; de winst is fail-closed gedrag en het voorkomen van een grote interne-heapfallback bij PSRAM-allocatiefalen.

De metingen zijn uitgevoerd op een OpenQuatt Q-controller v1.1 (ESP32-S3), profiel `configs/heatpump_controller_q/duo_wifi.yaml`, met de volledige installatie aangesloten, ESPHome 2026.7.3 en ESP-IDF 5.5.5. Elke A/B-image gebruikte dezelfde lokale test-only heap-probe; de probe en de lokaal gecombineerde testbuild maken geen deel uit van deze PR.

Cross-PR-context, niet aan één wijziging toe te schrijven:

- De lokaal gecombineerde PR401–PR404-build mat bij t60 `120,3 kB` current / `39,948 kB` minimum / `63,488 kB` largest block; bij t120 `121,1 kB` / `39,948 kB`; bij t300 `122,5 kB` / `39,948 kB`.
- Na functionele validatie rapporteerden de sensoren `118,855 kB` vrije heap en `46,6%` fragmentatie. Usage telemetry stond aan; Energy History, trends, debug en MQTT-status functioneerden. Ping: 0% verlies, gemiddeld 55 ms.
- Een latere live-read van dezelfde gecombineerde build mat `92,355 kB` current, `39,948 kB` minimum en `49,152 kB` largest block, terwijl ping 10% verlies en gemiddeld 983 ms liet zien. MQTT-ingress rapporteerde toen `enabled=false`, `connected=false`, `runtime_pending=false`. Netwerkdegradatie kan dus ook met ruime heap en MQTT-ingress uit optreden; dit is geen bewijs tegen of voor één afzonderlijke PR.
- Safe Mode-OTA duurde 53–54 seconden, terwijl OTA onder de volledige applicatieruntime herhaaldelijk na 3–5 minuten time-outte. Dit toont invloed van de totale applicatieruntime op netwerkdoorvoer, maar bewijst geen oorzaak in deze afzonderlijke PR.
