### PR TITLE
Remove unused web sorting metadata

### DIFF
--- a/docs/onderhoudsgids.md
+++ b/docs/onderhoudsgids.md
@@ -29,9 +29,11 @@ This guide keeps the configuration maintainable and predictable while preserving
   - `oq_ha_inputs`: fixed Home Assistant proxy sensor ingest
   - `oq_local_sensors`: local DS18B20 ingest
   - `oq_sensor_sources`: runtime source selectors and selected-source synthesis (`*_selected`)
-  - `oq_webserver`: grouping/exposure for ESPHome web UI
+  - `oq_webserver`: authenticated OpenQuatt web UI
   - `oq_HP_io`: per-HP Modbus IO entities and actuators
 - Keep one change type per batch: formatting, comments, or logic.
+- Do not add `web_server.sorting_groups`, `sorting_group_id` or `sorting_weight`. The OpenQuatt SPA owns entity
+  layout, while ESPHome stores this unused metadata in dynamic internal-heap maps.
 - Preserve package include order in `openquatt/oq_packages.yaml` unless dependencies are intentionally redesigned.
 - If you add/remove packages or user-facing entities, update the affected docs in the same PR:
   - `README.md`

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -360,16 +360,12 @@ smallest partition and at runtime against the partition actually present.
 
 ## 10. UI and Observability Organization
 
-`oq_webserver.yaml` defines stable sorting groups used across packages:
+The OpenQuatt SPA owns the layout of built-in entities. Built-in packages deliberately do not attach ESPHome
+`sorting_group_id` or `sorting_weight` metadata: ESPHome stores one dynamic map entry for every expanded entity
+assignment, while the OpenQuatt SPA does not consume that metadata.
 
-- Quick Start and Overview
-- System Control, Heating Strategy, Heating Curve, Power House, Cooling
-- Sensor Selection, OpenTherm, CIC Feed, HA Inputs
-- Temperatures, Flow & Pump, Flow Tuning, Performance, Boiler
-- HP1, HP2, Advanced HP Levels
-- System Diagnostics and HP Diagnostics
-
-This keeps ESPHome web UI and Home Assistant mapping coherent.
+`oq_webserver.yaml` therefore defines no ESPHome sorting groups. The native ESPHome fallback remains functional but
+uses its default order. Home Assistant entity mapping is unaffected.
 
 ## 11. Engineering Notes
 

--- a/docs/templates/heating-strategy-template.yaml
+++ b/docs/templates/heating-strategy-template.yaml
@@ -75,8 +75,6 @@ text_sensor:
     update_interval: never
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return std::string("init");
 

--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -96,5 +96,3 @@ sensor:
       entity_category: diagnostic
       disabled_by_default: true
       accuracy_decimals: 0
-      web_server:
-        sorting_group_id: oq_system_diagnostics

--- a/openquatt/connection/eth.yaml
+++ b/openquatt/connection/eth.yaml
@@ -22,5 +22,3 @@ text_sensor:
       name: IP Address
       icon: mdi:ip-network-outline
       entity_category: diagnostic
-      web_server:
-        sorting_group_id: oq_system_diagnostics

--- a/openquatt/connection/wifi.yaml
+++ b/openquatt/connection/wifi.yaml
@@ -27,8 +27,6 @@ sensor:
     icon: mdi:wifi-arrow-left-right
     update_interval: 300s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 openquatt_usage_telemetry:
   wifi_signal_sensor: oq_wifi_signal
@@ -39,11 +37,7 @@ text_sensor:
       name: IP Address
       icon: mdi:ip-network-outline
       entity_category: diagnostic
-      web_server:
-        sorting_group_id: oq_system_diagnostics
     ssid:
       name: WiFi SSID
       icon: mdi:wifi
       entity_category: diagnostic
-      web_server:
-        sorting_group_id: oq_system_diagnostics

--- a/openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml
+++ b/openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml
@@ -30,8 +30,6 @@ switch:
     optimistic: true
     restore_mode: ALWAYS_OFF
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
 number:
   # Editable desired runtime table. Defaults mirror the known ODU factory table;
@@ -49,8 +47,6 @@ number:
     optimistic: true
     initial_value: 0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f1
@@ -65,8 +61,6 @@ number:
     optimistic: true
     initial_value: 30
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f2
@@ -81,8 +75,6 @@ number:
     optimistic: true
     initial_value: 36
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f3
@@ -97,8 +89,6 @@ number:
     optimistic: true
     initial_value: 42
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f4
@@ -113,8 +103,6 @@ number:
     optimistic: true
     initial_value: 47
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f5
@@ -129,8 +117,6 @@ number:
     optimistic: true
     initial_value: 52
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f6
@@ -145,8 +131,6 @@ number:
     optimistic: true
     initial_value: 56
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f7
@@ -161,8 +145,6 @@ number:
     optimistic: true
     initial_value: 61
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f8
@@ -177,8 +159,6 @@ number:
     optimistic: true
     initial_value: 66
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f9
@@ -193,8 +173,6 @@ number:
     optimistic: true
     initial_value: 71
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f10
@@ -209,8 +187,6 @@ number:
     optimistic: true
     initial_value: 74
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f0
@@ -225,8 +201,6 @@ number:
     optimistic: true
     initial_value: 0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f1
@@ -241,8 +215,6 @@ number:
     optimistic: true
     initial_value: 30
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f2
@@ -257,8 +229,6 @@ number:
     optimistic: true
     initial_value: 39
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f3
@@ -273,8 +243,6 @@ number:
     optimistic: true
     initial_value: 49
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f4
@@ -289,8 +257,6 @@ number:
     optimistic: true
     initial_value: 55
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f5
@@ -305,8 +271,6 @@ number:
     optimistic: true
     initial_value: 61
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f6
@@ -321,8 +285,6 @@ number:
     optimistic: true
     initial_value: 67
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f7
@@ -337,8 +299,6 @@ number:
     optimistic: true
     initial_value: 72
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f8
@@ -353,8 +313,6 @@ number:
     optimistic: true
     initial_value: 79
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f9
@@ -369,8 +327,6 @@ number:
     optimistic: true
     initial_value: 85
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f10
@@ -385,8 +341,6 @@ number:
     optimistic: true
     initial_value: 90
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
 
 button:
   - platform: template
@@ -395,8 +349,6 @@ button:
     internal: true
     icon: mdi:download-alert-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
     on_press:
       - lambda: |-
           oq_odu_runtime_frequency::RuntimeFrequencyTableRefs refs = {
@@ -439,8 +391,6 @@ button:
     internal: true
     icon: mdi:alert-circle-check-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
     on_press:
       - lambda: |-
           oq_odu_runtime_frequency::RuntimeFrequencyTableRefs refs = {
@@ -487,5 +437,3 @@ text_sensor:
     icon: mdi:alert-decagram-outline
     entity_category: diagnostic
     update_interval: never
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -124,8 +124,6 @@ select:
       "Cooling": 1
       "Heating": 2
     skip_updates: ${oq_modbus_target_readback_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -150,8 +148,6 @@ select:
       "9": 9
       "10": 10
     skip_updates: ${oq_modbus_control_readback_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -167,8 +163,6 @@ select:
       "Off": 0
       "On": 1
     skip_updates: ${oq_modbus_control_readback_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -184,8 +178,6 @@ select:
       "Off": 0
       "On": 4096
     skip_updates: ${oq_modbus_control_readback_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
 # Per-HP compressor level exclusions are modeled as up to two explicit blocked levels.
   - platform: template
@@ -209,9 +201,6 @@ select:
       - "L8 (H79/C66)"
       - "L9 (H85/C71)"
       - "L10 (H90/C74)"
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
-      sorting_weight: 41
 
   - platform: template
     id: ${hp_id}_excluded_level_b
@@ -234,9 +223,6 @@ select:
       - "L8 (H79/C66)"
       - "L9 (H85/C71)"
       - "L10 (H90/C74)"
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
-      sorting_weight: 42
 
 # ----------------------------
 # NUMBER
@@ -255,8 +241,6 @@ number:
     max_value: 1000
     mode: slider
     skip_updates: ${oq_modbus_control_readback_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
 # ----------------------------
 # SENSOR
@@ -275,8 +259,6 @@ sensor:
       const float pump_speed = id(${hp_id}_pump_speed).state;
       if (isnan(pump_speed)) return {};
       return pump_speed;
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -293,8 +275,6 @@ sensor:
             id(${hp_id}_outside_temp_activity_ms) = millis();
             id(oq_incident_manager).observe_working_mode(
                 ${hp_index}, x, millis());
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -315,8 +295,6 @@ sensor:
           max_value: 300
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -337,8 +315,6 @@ sensor:
           max_value: 16
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -358,8 +334,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -389,8 +363,6 @@ sensor:
               ESP_LOGI("oq_diag", "%sMeasured compressor start.", "${prefix}");
               id(oq_capture_compressor_cycling_alert).execute();
             }
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -410,8 +382,6 @@ sensor:
           max_value: 1000
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -431,8 +401,6 @@ sensor:
           max_value: 1000
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -451,8 +419,6 @@ sensor:
           max_value: 1000
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -480,8 +446,6 @@ sensor:
             const uint32_t now_ms = millis();
             id(${hp_id}_outside_temp_last_change_ms) = now_ms;
             id(${hp_id}_outside_temp_activity_ms) = now_ms;
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -502,8 +466,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -524,8 +486,6 @@ sensor:
           max_value: 150
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -547,8 +507,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -568,8 +526,6 @@ sensor:
           max_value: 20
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -590,8 +546,6 @@ sensor:
           max_value: 60
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -612,8 +566,6 @@ sensor:
     register_count: 4  # 2123 - 2127
     address: 2123
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -625,8 +577,6 @@ sensor:
     register_count: 4  # 2127 - 2131
     address: 2127
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -648,8 +598,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -670,8 +618,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -696,8 +642,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -726,8 +670,6 @@ sensor:
         - lambda: |-
             id(${hp_id}_water_out_temp_last_update_ms) = millis();
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_water_in_temp
@@ -743,8 +685,6 @@ sensor:
       const float offset_c = id(${hp_id}_water_in_temp_offset).state;
       if (isnan(raw_c) || isnan(offset_c)) return NAN;
       return raw_c + offset_c;
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_water_out_temp
@@ -760,8 +700,6 @@ sensor:
       const float offset_c = id(${hp_id}_water_out_temp_offset).state;
       if (isnan(raw_c) || isnan(offset_c)) return NAN;
       return raw_c + offset_c;
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -783,8 +721,6 @@ sensor:
           max_value: 100
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -802,8 +738,6 @@ sensor:
     filters:
       - multiply: 0.1
     skip_updates: ${oq_modbus_telemetry_skip}
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -824,8 +758,6 @@ sensor:
       then:
         - lambda: |-
             id(${hp_id}_outside_temp_activity_ms) = millis();
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_runtime_hours
@@ -837,8 +769,6 @@ sensor:
     icon: mdi:timer-outline
     lambda: |-
       return static_cast<float>(id(${hp_id}_minutes)) / 60.0f;
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_power_input
@@ -849,8 +779,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       // Keep model coefficients exactly as before; only readability/safety is improved.
       const float standby_power_w = 5.150232354845286f;
@@ -892,8 +820,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       // Heat power follows measured HP working mode (2 = Heating), not supervisory CM.
       const float working_mode = id(${hp_id}_working_mode).state;
@@ -919,8 +845,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       // Cooling power follows measured HP working mode (1 = Cooling), not supervisory CM.
       const float working_mode = id(${hp_id}_working_mode).state;
@@ -948,8 +872,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float p_el_w = id(${hp_id}_power_input).state;
       const float p_th_w = id(${hp_id}_heat_power).state;
@@ -969,8 +891,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float p_el_w = id(${hp_id}_power_input).state;
       const float p_cool_w = id(${hp_id}_cooling_power).state;
@@ -1064,16 +984,12 @@ binary_sensor:
     disabled_by_default: true
     icon: mdi:fan-speed-1
     device_class: running
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_bottom_plate_heater
     name: "${prefix}Bottom plate heater"
     icon: mdi:radiator
     device_class: heat
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_crankcase_heater
@@ -1081,8 +997,6 @@ binary_sensor:
     icon: mdi:radiator
     device_class: heat
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_fan_defrost_mode
@@ -1091,8 +1005,6 @@ binary_sensor:
     disabled_by_default: true
     icon: mdi:snowflake-melt
     device_class: running
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_fan_high_speed_mode
@@ -1101,8 +1013,6 @@ binary_sensor:
     disabled_by_default: true
     icon: mdi:fan-speed-3
     device_class: running
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_4_way_valve
@@ -1113,8 +1023,6 @@ binary_sensor:
       then:
         - lambda: |-
             id(${hp_id}_outside_temp_activity_ms) = millis();
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: template
     id: ${hp_id}_pump_relay
@@ -1122,8 +1030,6 @@ binary_sensor:
     icon: mdi:electric-switch
     device_class: running
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -1138,8 +1044,6 @@ binary_sensor:
       then:
         - lambda: |-
             id(${hp_id}_outside_temp_activity_ms) = millis();
-    web_server:
-      sorting_group_id: oq_${hp_id}
 
   # Derived from the raw 2119 status word; this one remains a standalone binary
   # sensor because it is used by the heating strategies.
@@ -1156,8 +1060,6 @@ binary_sensor:
         return false;
       }
       return (static_cast<uint16_t>(lroundf(raw)) & 0x0008u) != 0;
-    web_server:
-      sorting_group_id: oq_hp_diagnostics
 
   - platform: template
     id: ${hp_id}_ot_fault_active
@@ -1212,8 +1114,6 @@ text_sensor:
     name: "${prefix}Working Mode Label"
     icon: mdi:state-machine
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_${hp_id}
     lambda: |-
       // Map the raw numeric Modbus mode to a dashboard-friendly label.
       const float working_mode_raw = id(${hp_id}_working_mode).state;
@@ -1241,9 +1141,6 @@ text_sensor:
     name: "${prefix}Excluded compressor levels"
     icon: mdi:speedometer-slow
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_advanced_hp_levels
-      sorting_weight: 43
     lambda: |-
       // Summarize the two exclusion selectors into one compact diagnostic label.
       const std::string a = id(${hp_id}_excluded_level_a).has_state()
@@ -1269,8 +1166,6 @@ text_sensor:
     name: "${prefix}Active Failures List"
     entity_category: diagnostic
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_hp_diagnostics
     icon: mdi:alert-circle-outline
     lambda: |-
       char s[384];
@@ -1369,8 +1264,6 @@ text_sensor:
       snprintf(buf, sizeof(buf), "%u.%u", major, minor);
       return std::string(buf);
     update_interval: never
-    web_server:
-      sorting_group_id: oq_hp_diagnostics
 
 interval:
   - interval: ${oq_modbus_update_interval_s}s

--- a/openquatt/oq_air_purge.yaml
+++ b/openquatt/oq_air_purge.yaml
@@ -62,8 +62,6 @@ button:
     internal: true
     icon: mdi:water-pump
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     on_press:
       - lambda: |-
           oq_air_purge::runtime().start(
@@ -76,8 +74,6 @@ button:
     internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     on_press:
       - lambda: |-
           oq_air_purge::runtime().abort_or_clear();
@@ -91,8 +87,6 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
-    web_server:
-      sorting_group_id: oq_hydraulics
 
 # ----------------------------
 # MAIN LOOP

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -145,8 +145,6 @@ select:
       - R1
       - OpenTherm
     initial_option: R1
-    web_server:
-      sorting_group_id: oq_control
     on_value:
       then:
         - lambda: |-
@@ -198,8 +196,6 @@ switch:
     icon: mdi:water-boiler
     restore_mode: ALWAYS_OFF
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_boiler
 
 binary_sensor:
   - platform: template
@@ -208,8 +204,6 @@ binary_sensor:
     icon: mdi:fire
     device_class: heat
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return id(oq_boiler_transport_active);
 
@@ -218,8 +212,6 @@ binary_sensor:
     name: "Boiler command valid"
     icon: mdi:check-decagram
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       // Report validity and freshness as one diagnostic contract.
       return id(oq_boiler_command_valid) &&
@@ -242,8 +234,6 @@ binary_sensor:
     icon: mdi:radiator
     device_class: heat
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return id(oq_boiler_output_request);
 
@@ -259,8 +249,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 1s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return id(oq_boiler_command_target_temperature_c);
 
@@ -275,8 +263,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 1s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return id(oq_boiler_command_requested_power_w);
 
@@ -289,8 +275,6 @@ sensor:
     entity_category: diagnostic
     internal: true
     update_interval: 1s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       const uint32_t updated_ms = id(oq_boiler_command_updated_ms);
       if (updated_ms == 0) return NAN;
@@ -305,8 +289,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       // Diagnostic estimate only; transport activity is the confirmation
       // signal for both R1 and OpenTherm and also covers CM4 fallback.
@@ -335,8 +317,6 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 1s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       // Keep the diagnostic label aligned with the transport-neutral source.
       switch (id(oq_boiler_command_source_code)) {
@@ -359,8 +339,6 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 1s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       const char *reason = oq_boiler::block_reason_text(id(oq_boiler_block_reason_code));
       return {reason[0] == '\0' ? "None" : reason};

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -329,8 +329,6 @@ binary_sensor:
     internal: true
     entity_category: diagnostic
     icon: mdi:auto-fix
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return id(oq_boiler_connection_auto_selected_state);
 
@@ -341,8 +339,6 @@ binary_sensor:
     device_class: problem
     entity_category: diagnostic
     icon: mdi:connection
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return id(oq_boiler_connection_mismatch_state);
 
@@ -352,8 +348,6 @@ binary_sensor:
     icon: mdi:link-variant
     device_class: connectivity
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_boiler
 
   - platform: opentherm
     opentherm_id: oq_otb_hub
@@ -362,80 +356,56 @@ binary_sensor:
       name: "OTB - Fault Indication"
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     ch_active:
       id: otb_ch_active
       name: "OTB - Central Heating Active"
-      web_server:
-        sorting_group_id: oq_boiler
     dhw_active:
       id: otb_dhw_active
       name: "OTB - Domestic Hot Water Active"
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     flame_on:
       id: otb_flame_on
       name: "OTB - Flame On"
-      web_server:
-        sorting_group_id: oq_boiler
     diagnostic_indication:
       id: otb_diagnostic_indication
       name: "OTB - Diagnostic Indication"
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     dhw_present:
       id: otb_dhw_present
       name: "OTB - DHW Present"
       internal: true
       entity_category: diagnostic
-      web_server:
-        sorting_group_id: oq_boiler
     service_request:
       id: otb_service_request
       name: "OTB - Service Required"
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     lockout_reset:
       id: otb_lockout_reset
       name: "OTB - Lockout Reset"
       internal: true
       entity_category: diagnostic
-      web_server:
-        sorting_group_id: oq_boiler
     low_water_pressure:
       id: otb_low_water_pressure
       name: "OTB - Low Water Pressure"
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     flame_fault:
       id: otb_flame_fault
       name: "OTB - Flame Fault"
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     air_pressure_fault:
       id: otb_air_pressure_fault
       name: "OTB - Air Pressure Fault"
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     water_over_temp:
       id: otb_water_over_temp
       name: "OTB - Water Overtemperature"
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
 
 sensor:
   - platform: opentherm
@@ -444,82 +414,58 @@ sensor:
       id: otb_relative_modulation
       name: "OTB - Relative Modulation"
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     ch_pressure:
       id: otb_ch_pressure
       name: "OTB - CH Water Pressure"
-      web_server:
-        sorting_group_id: oq_boiler
     t_boiler:
       id: otb_boiler_water_temp
       name: "OTB - Boiler Water Temperature"
-      web_server:
-        sorting_group_id: oq_boiler
     t_ret:
       id: otb_return_water_temp
       name: "OTB - Return Water Temperature"
-      web_server:
-        sorting_group_id: oq_boiler
     t_dhw:
       id: otb_dhw_temp
       name: "OTB - Domestic Hot Water Temperature"
-      web_server:
-        sorting_group_id: oq_boiler
     oem_fault_code:
       id: otb_oem_fault_code
       name: "OTB - OEM Fault Code"
       internal: true
       entity_category: diagnostic
-      web_server:
-        sorting_group_id: oq_boiler
     oem_diagnostic_code:
       id: otb_oem_diagnostic_code
       name: "OTB - OEM Diagnostic Code"
       internal: true
       entity_category: diagnostic
-      web_server:
-        sorting_group_id: oq_boiler
     max_capacity:
       id: otb_max_capacity
       name: "OTB - Maximum Boiler Capacity"
       internal: true
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     min_mod_level:
       id: otb_min_modulation
       name: "OTB - Minimum Modulation"
       internal: true
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     opentherm_version_device:
       id: otb_opentherm_version
       name: "OTB - OpenTherm Device Version"
       internal: true
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     device_type:
       id: otb_device_type
       name: "OTB - Device Type"
       internal: true
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
     device_version:
       id: otb_device_version
       name: "OTB - Device Product Version"
       internal: true
       entity_category: diagnostic
       disabled_by_default: true
-      web_server:
-        sorting_group_id: oq_boiler
 
   - platform: template
     id: otb_last_response_age
@@ -530,8 +476,6 @@ sensor:
     accuracy_decimals: 1
     entity_category: diagnostic
     update_interval: ${oq_otb_link_watch_s}s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       if (!oq_otb::telemetry_state.session_has_response()) return NAN;
       return (float) ((uint32_t) (
@@ -546,8 +490,6 @@ sensor:
     state_class: total_increasing
     entity_category: diagnostic
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.acknowledged_response_count();
 
@@ -561,8 +503,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.accepted_response_count();
 
@@ -576,8 +516,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.data_invalid_response_count();
 
@@ -591,8 +529,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.unknown_data_id_response_count();
 
@@ -606,8 +542,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.unexpected_response_type_count();
 
@@ -621,8 +555,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.transport_error_count();
 
@@ -636,8 +568,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.protocol_error_count();
 
@@ -651,8 +581,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.response_timeout_count();
 
@@ -666,8 +594,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.no_transition_count();
 
@@ -681,8 +607,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return (float) oq_otb::telemetry_state.no_change_too_long_count();
 
@@ -696,8 +620,6 @@ sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       if (oq_otb::telemetry_state.transport_error_count() == 0) return NAN;
       return (float) ((uint32_t) (
@@ -712,8 +634,6 @@ sensor:
     accuracy_decimals: 0
     entity_category: diagnostic
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       const int message_id = oq_otb::telemetry_state.last_response_id();
       return message_id >= 0 ? (float) message_id : NAN;
@@ -727,8 +647,6 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return {oq_otb::telemetry_state.last_response_type_name()};
 
@@ -740,8 +658,6 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_boiler
     lambda: |-
       return {oq_otb::telemetry_state.last_transport_error_name()};
 

--- a/openquatt/oq_boiler_test.yaml
+++ b/openquatt/oq_boiler_test.yaml
@@ -47,8 +47,6 @@ button:
     internal: true
     icon: mdi:play-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
           oq_boiler_task::runtime().start(oq_boiler_task::default_config(), (uint32_t) millis());
@@ -59,8 +57,6 @@ button:
     internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
           oq_boiler_task::runtime().abort_or_clear();
@@ -71,8 +67,6 @@ button:
     internal: true
     icon: mdi:check-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
           // Round the applied boiler rating to the nearest 100 W for a cleaner persistent setting.
@@ -103,8 +97,6 @@ number:
     optimistic: true
     initial_value: 6000
     entity_category: config
-    web_server:
-      sorting_group_id: oq_boiler
 
 # ----------------------------
 # MAIN LOOP

--- a/openquatt/oq_cic.yaml
+++ b/openquatt/oq_cic.yaml
@@ -33,8 +33,6 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: ${oq_cic_restore_mode_default}
-    web_server:
-      sorting_group_id: oq_cic
 
 # ----------------------------
 # FEED CONFIG
@@ -50,8 +48,6 @@ text:
     optimistic: true
     restore_value: true
     initial_value: "http://192.168.2.117:8080/beta/feed/data.json"
-    web_server:
-      sorting_group_id: oq_cic
 
 # ----------------------------
 # TELEMETRY
@@ -66,8 +62,6 @@ sensor:
     accuracy_decimals: 2
     icon: mdi:water-thermometer
     update_interval: never
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: cic_control_setpoint
@@ -79,8 +73,6 @@ sensor:
     icon: mdi:thermostat
     disabled_by_default: true
     update_interval: never
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: cic_room_setpoint
@@ -91,8 +83,6 @@ sensor:
     accuracy_decimals: 1
     icon: mdi:home-thermometer
     update_interval: never
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: cic_room_temp
@@ -103,8 +93,6 @@ sensor:
     accuracy_decimals: 3
     icon: mdi:thermometer
     update_interval: never
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: flow_rate_cic
@@ -115,8 +103,6 @@ sensor:
     accuracy_decimals: 1
     icon: mdi:water-pump
     update_interval: never
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: cic_backoff_s
@@ -129,8 +115,6 @@ sensor:
     icon: mdi:timer-sand
     disabled_by_default: true
     update_interval: never
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: cic_last_success_age_s
@@ -143,8 +127,6 @@ sensor:
     disabled_by_default: true
     icon: mdi:timeline-clock-outline
     update_interval: never
-    web_server:
-      sorting_group_id: oq_cic
 
 binary_sensor:
   - platform: template
@@ -153,8 +135,6 @@ binary_sensor:
     icon: mdi:radiator
     device_class: heat
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: cic_ch_enable_valid
@@ -162,8 +142,6 @@ binary_sensor:
     icon: mdi:check-decagram
     entity_category: diagnostic
     internal: true
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: cic_cooling_enabled
@@ -171,8 +149,6 @@ binary_sensor:
     icon: mdi:snowflake
     device_class: cold
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: feed_ok
@@ -180,8 +156,6 @@ binary_sensor:
     icon: mdi:cloud-check
     device_class: connectivity
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_cic
 
   - platform: template
     id: cic_data_stale
@@ -189,8 +163,6 @@ binary_sensor:
     icon: mdi:cloud-alert
     device_class: problem
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_cic
 
 # ----------------------------
 # CUSTOM CIC FETCHER

--- a/openquatt/oq_cic_compatibility.yaml
+++ b/openquatt/oq_cic_compatibility.yaml
@@ -28,5 +28,3 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: ${oq_cic_compat_restore_mode_default}
-    web_server:
-      sorting_group_id: oq_cic_compatibility

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -73,8 +73,6 @@ button:
     internal: true
     icon: mdi:play-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
           // Request CM100 as a neutral service state with no task yet.
@@ -103,8 +101,6 @@ button:
     internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_boiler
     on_press:
       - lambda: |-
           // Stop CM100 immediately when no task is active; otherwise abort the running task.

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -637,8 +637,6 @@ text:
     max_length: 255
     disabled_by_default: true
     entity_category: config
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     name: "Firmware Test OTA MD5 URL"
@@ -651,8 +649,6 @@ text:
     max_length: 255
     disabled_by_default: true
     entity_category: config
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 # ==============================================================================
 # DIAGNOSTIC ENTITIES
@@ -662,8 +658,6 @@ select:
     name: "Firmware Update Channel"
     id: oq_firmware_update_channel
     icon: mdi:source-branch
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     entity_category: config
     optimistic: true
     restore_value: true
@@ -735,8 +729,6 @@ select:
     icon: mdi:swap-horizontal
     internal: true
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     entity_category: config
     optimistic: true
     restore_value: false
@@ -803,8 +795,6 @@ select:
     name: "Quatt Hybrid version"
     id: hp_generation
     icon: mdi:factory
-    web_server:
-      sorting_group_id: oq_heating_strategy
     entity_category: config
     optimistic: true
     restore_value: true
@@ -817,8 +807,6 @@ select:
     internal: true
     disabled_by_default: true
     icon: mdi:lan
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     entity_category: diagnostic
     optimistic: true
     # Always recover to INFO after a reboot; DEBUG can overwhelm busy Duo installations.
@@ -843,8 +831,6 @@ select:
     name: "Uurdetail bewaren"
     id: oq_lifetime_energy_hour_retention
     icon: mdi:chart-bar
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     entity_category: config
     optimistic: true
     restore_value: true
@@ -863,8 +849,6 @@ button:
     icon: mdi:test-tube
     disabled_by_default: true
     entity_category: config
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     on_press:
       then:
         - if:
@@ -916,15 +900,11 @@ button:
     name: Restart
     icon: mdi:restart
     id: restart_switch
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: safe_mode
     name: Safe mode
     icon: mdi:shield-alert
     id: safe_mode_button
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_trend_history_flush_button
@@ -933,8 +913,6 @@ button:
     disabled_by_default: true
     icon: mdi:content-save
     entity_category: config
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     on_press:
       - lambda: |-
           id(oq_trend_capture_force_once) = true;
@@ -950,8 +928,6 @@ button:
     disabled_by_default: true
     icon: mdi:content-save
     entity_category: config
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     on_press:
       - lambda: |-
           id(oq_decision_log).force_flush();
@@ -963,8 +939,6 @@ button:
     disabled_by_default: true
     icon: mdi:delete-clock
     entity_category: config
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     on_press:
       - lambda: |-
           id(oq_decision_log).clear_flash_history();
@@ -976,8 +950,6 @@ button:
     disabled_by_default: true
     icon: mdi:delete-clock
     entity_category: config
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     on_press:
       - lambda: |-
           id(oq_energy_history_endpoint).clear_history();
@@ -989,8 +961,6 @@ button:
     disabled_by_default: true
     icon: mdi:content-save
     entity_category: config
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     on_press:
       - script.execute: oq_capture_energy_history_sample
       - script.wait: oq_capture_energy_history_sample
@@ -1002,8 +972,6 @@ button:
     name: Check Firmware Updates
     icon: mdi:update
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     on_press:
       - script.execute: oq_apply_firmware_update_source
       - script.wait: oq_apply_firmware_update_source
@@ -1034,8 +1002,6 @@ button:
     disabled_by_default: true
     icon: mdi:swap-horizontal-bold
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     on_press:
       - if:
           condition:
@@ -1063,8 +1029,6 @@ switch:
     turn_off_action:
       - lambda: |-
           id(oq_trends_endpoint).clear_history();
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_trend_history_flash_switch
@@ -1080,8 +1044,6 @@ switch:
     turn_off_action:
       - lambda: |-
           id(oq_trends_endpoint).set_flash_enabled(false);
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_decision_log_flash_switch
@@ -1097,8 +1059,6 @@ switch:
     turn_off_action:
       - lambda: |-
           id(oq_decision_log).set_flash_enabled(false);
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_lifetime_energy_history_switch
@@ -1110,16 +1070,12 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     turn_on_action:
       - script.execute: oq_capture_energy_history_sample
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 binary_sensor:
   - platform: status
     name: Status
     icon: mdi:check-circle-outline
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
   - platform: template
     id: oq_runtime_polling_paused
     name: Runtime polling paused
@@ -1199,8 +1155,6 @@ sensor:
     entity_category: diagnostic
     lambda: |-
       return id(oq_ota_progress_pct);
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: uptime
     name: Uptime raw
@@ -1211,8 +1165,6 @@ sensor:
     device_class: duration
     unit_of_measurement: s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     name: Uptime
@@ -1229,8 +1181,6 @@ sensor:
         return NAN;
       }
       return id(uptime_sensor).state / 3600.0f;
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: internal_temperature
     id: oq_esp_internal_temperature
@@ -1238,8 +1188,6 @@ sensor:
     icon: mdi:thermometer
     update_interval: 60s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 text_sensor:
   - platform: template
@@ -1269,8 +1217,6 @@ text_sensor:
         default:
           return {"Idle"};
       }
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_project_version_text
@@ -1280,8 +1226,6 @@ text_sensor:
     update_interval: never
     lambda: |-
       return {"${project_version}"};
-    web_server:
-      sorting_group_id: oq_system_diagnostics
   - platform: template
     id: oq_installation_topology_text
     name: OpenQuatt Installation Topology
@@ -1295,8 +1239,6 @@ text_sensor:
       #else
       return {"single"};
       #endif
-    web_server:
-      sorting_group_id: oq_system_diagnostics
   - platform: template
     id: oq_hardware_profile_text
     name: OpenQuatt Hardware Profile
@@ -1306,8 +1248,6 @@ text_sensor:
     update_interval: never
     lambda: |-
       return {"${oq_hardware_profile}"};
-    web_server:
-      sorting_group_id: oq_system_diagnostics
   - platform: template
     id: oq_connection_text
     name: OpenQuatt Connection
@@ -1317,8 +1257,6 @@ text_sensor:
     update_interval: never
     lambda: |-
       return {"${oq_connection}"};
-    web_server:
-      sorting_group_id: oq_system_diagnostics
   - platform: template
     id: oq_release_channel_text
     name: OpenQuatt Release Channel
@@ -1327,15 +1265,11 @@ text_sensor:
     update_interval: never
     lambda: |-
       return {"${release_channel}"};
-    web_server:
-      sorting_group_id: oq_system_diagnostics
   - platform: version
     name: ESPHome Version
     icon: mdi:information-outline
     hide_timestamp: true
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: uptime_readable_text
@@ -1370,8 +1304,6 @@ text_sensor:
         snprintf(buffer, sizeof(buffer), "%us", static_cast<unsigned>(seconds));
       }
       return {buffer};
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 update:
   - platform: http_request
@@ -1383,8 +1315,6 @@ update:
     update_interval: never
     icon: mdi:update
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 # ==============================================================================
 # OVERVIEW TRENDS

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -67,8 +67,6 @@ switch:
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
 number:
   - platform: template
@@ -84,8 +82,6 @@ number:
     restore_value: true
     initial_value: 1.0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: cooling_request_on_delta
@@ -100,8 +96,6 @@ number:
     restore_value: true
     initial_value: 0.4
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: cooling_request_off_delta
@@ -116,8 +110,6 @@ number:
     restore_value: true
     initial_value: 0.1
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
 select:
   - platform: template
@@ -132,8 +124,6 @@ select:
       - "Home Assistant"
       - "MQTT"
     initial_option: Auto
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_without_dew_point_mode
@@ -147,8 +137,6 @@ select:
       - "Allow without dew point, use dew point approximation"
       - "Allow without dew point, user responsibility"
     initial_option: Dew point required
-    web_server:
-      sorting_group_id: oq_cooling
 
 binary_sensor:
   - platform: template
@@ -173,8 +161,6 @@ binary_sensor:
     device_class: running
     lambda: |-
       return oq_cooling_safety::runtime().fallback_active();
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_permitted_core
@@ -191,8 +177,6 @@ binary_sensor:
     device_class: running
     lambda: |-
       return oq_cooling_safety::runtime().request_active();
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_permitted
@@ -202,8 +186,6 @@ binary_sensor:
     lambda: |-
       // User-facing permission includes both the core cooling prerequisites and the live flow guard.
       return oq_cooling_safety::runtime().permitted((float) ${oq_cm_min_flow_lph});
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_dew_point_available
@@ -212,8 +194,6 @@ binary_sensor:
     device_class: connectivity
     lambda: |-
       return id(cooling_dew_point_selected).has_state() && !isnan(id(cooling_dew_point_selected).state);
-    web_server:
-      sorting_group_id: oq_cooling
 
 text_sensor:
   - platform: template
@@ -225,8 +205,6 @@ text_sensor:
     lambda: |-
       // Summarize which cooling safety route is currently active.
       return {oq_cooling_safety::runtime().guard_mode()};
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_block_reason
@@ -237,8 +215,6 @@ text_sensor:
     lambda: |-
       // Report the first blocking condition in operator-friendly terms.
       return {oq_cooling_safety::runtime().block_reason((float) ${oq_cm_min_flow_lph})};
-    web_server:
-      sorting_group_id: oq_cooling
 
 sensor:
   - platform: template
@@ -250,8 +226,6 @@ sensor:
     update_interval: 10s
     lambda: |-
       return oq_cooling_safety::runtime().safety_margin_selected();
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_dew_point_selected
@@ -275,8 +249,6 @@ sensor:
           alpha: 0.3
           send_every: 1
           send_first_at: 1
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: minimum_safe_supply_temp
@@ -290,8 +262,6 @@ sensor:
     lambda: |-
       // This is the central cooling guardrail: never target water below dew point + margin.
       return oq_cooling_safety::runtime().minimum_safe_supply();
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_fallback_night_min_outdoor_temp
@@ -306,8 +276,6 @@ sensor:
     update_interval: 60s
     lambda: |-
       return oq_cooling_safety::runtime().fallback_night_min_outdoor_temp();
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_fallback_min_supply_temp
@@ -323,8 +291,6 @@ sensor:
     lambda: |-
       // Conservative fallback floor for systems without a dew-point source.
       return oq_cooling_safety::runtime().fallback_min_supply_temp();
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_effective_min_supply_temp
@@ -338,8 +304,6 @@ sensor:
     lambda: |-
       // Publish the active floor that raises the configured cooling target.
       return oq_cooling_safety::runtime().effective_min_supply_temp();
-    web_server:
-      sorting_group_id: oq_cooling
 
 interval:
   - interval: 60s

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -237,8 +237,6 @@ number:
     restore_value: true
     initial_value: 14.0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_demand_max_f
@@ -253,8 +251,6 @@ number:
     restore_value: true
     initial_value: 4
     entity_category: config
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_restart_delta
@@ -269,8 +265,6 @@ number:
     restore_value: true
     initial_value: 1.0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_pid_kp
@@ -284,8 +278,6 @@ number:
     restore_value: true
     initial_value: 3.0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_pid_ki
@@ -299,8 +291,6 @@ number:
     restore_value: true
     initial_value: 0.12
     entity_category: config
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_pid_kd
@@ -314,8 +304,6 @@ number:
     restore_value: true
     initial_value: 0.0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_cooling
 
 sensor:
   - platform: template
@@ -335,8 +323,6 @@ sensor:
         base_floor_c = fmaxf(base_floor_c, id(cooling_effective_min_supply_temp).state);
       }
       return base_floor_c;
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: cooling_supply_error
@@ -351,8 +337,6 @@ sensor:
       if (!id(oq_system_supply_temp).has_state() || isnan(id(oq_system_supply_temp).state)) return NAN;
       // Positive error means the supply is warmer than target, so more cooling may be requested.
       return id(oq_system_supply_temp).state - id(cooling_supply_target).state;
-    web_server:
-      sorting_group_id: oq_cooling
 
   - platform: template
     id: oq_cooling_demand_raw_sensor
@@ -362,8 +346,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_demand_raw);
 
@@ -376,8 +358,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_base_demand_raw);
 
@@ -390,8 +370,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_limited_demand);
 
@@ -404,8 +382,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_limiter_allowed_max);
 
@@ -418,8 +394,6 @@ sensor:
     accuracy_decimals: 2
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return id(oq_cooling_buffer_gap_filtered_c);
 
@@ -432,8 +406,6 @@ sensor:
     accuracy_decimals: 2
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return id(oq_cooling_buffer_gap_rate_c_per_min);
 
@@ -446,8 +418,6 @@ sensor:
     accuracy_decimals: 2
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return id(oq_cooling_projected_gap_c);
 
@@ -459,8 +429,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return id(oq_cooling_projection_brake_active) ? 1.0f : 0.0f;
 
@@ -473,8 +441,6 @@ sensor:
     accuracy_decimals: 2
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return id(oq_cooling_dew_gap_c);
 
@@ -487,8 +453,6 @@ sensor:
     accuracy_decimals: 2
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return id(oq_cooling_stop_buffer_gap_c);
 
@@ -500,8 +464,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_limiter_reason_code);
 
@@ -513,8 +475,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_stop_reason_code);
 
@@ -526,8 +486,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_request_reason_code);
 
@@ -540,8 +498,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_request_hp1_level);
 
@@ -554,8 +510,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_request_hp2_level);
 
@@ -567,8 +521,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_request_owner_hp);
 
@@ -580,8 +532,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return (float) id(oq_cooling_owner_hp);
 
@@ -593,8 +543,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_cooling
     lambda: |-
       return id(oq_cooling_water_cycle_active) ? 1.0f : 0.0f;
 

--- a/openquatt/oq_energy.yaml
+++ b/openquatt/oq_energy.yaml
@@ -13,8 +13,6 @@ button:
     icon: mdi:restart
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_performance
     on_press:
       - lambda: |-
           id(oq_electrical_energy_cumulative).reset();
@@ -40,8 +38,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # Heating electrical input energy (daily, kWh). Keeps COP heating-only when cooling is active.
   - platform: total_daily_energy
@@ -56,8 +52,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # Cooling electrical input energy (daily, kWh). Used for cooling-only EER.
   - platform: total_daily_energy
@@ -72,8 +66,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # Electrical input energy (cumulative, kWh).
   - platform: integration
@@ -88,8 +80,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # Heating electrical input energy (cumulative, kWh).
   - platform: integration
@@ -104,8 +94,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # Cooling electrical input energy (cumulative, kWh).
   - platform: integration
@@ -120,8 +108,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # Thermal power including HP + boiler contribution (W).
   - platform: template
@@ -133,8 +119,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
       const float hp_heat_w = nz(id(oq_total_heat_power).state);
@@ -149,8 +133,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float heat_kwh = id(oq_heatpump_thermal_energy_daily).state;
       const float elec_kwh = id(oq_heating_electrical_energy_daily).state;
@@ -173,8 +155,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # HeatPump thermal energy (cumulative, kWh).
   - platform: integration
@@ -189,8 +169,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # HeatPump cooling energy (daily, kWh).
   - platform: total_daily_energy
@@ -205,8 +183,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # HeatPump cooling energy (cumulative, kWh).
   - platform: integration
@@ -221,8 +197,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # HeatPump COP based on cumulative thermal/electrical energy (kWh/kWh).
   - platform: template
@@ -232,8 +206,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float heat_kwh = id(oq_heatpump_thermal_energy_cumulative).state;
       const float elec_kwh = id(oq_heating_electrical_energy_cumulative).state;
@@ -251,8 +223,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float cooling_kwh = id(oq_heatpump_cooling_energy_daily).state;
       const float elec_kwh = id(oq_cooling_electrical_energy_daily).state;
@@ -270,8 +240,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float cooling_kwh = id(oq_heatpump_cooling_energy_cumulative).state;
       const float elec_kwh = id(oq_cooling_electrical_energy_cumulative).state;
@@ -294,8 +262,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_boiler
 
   # Boiler thermal energy (cumulative, kWh).
   - platform: integration
@@ -310,8 +276,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_boiler
 
   # System thermal energy (daily, kWh): HeatPump + Boiler.
   - platform: total_daily_energy
@@ -326,8 +290,6 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance
 
   # System thermal energy (cumulative, kWh): HeatPump + Boiler.
   - platform: integration
@@ -342,5 +304,3 @@ sensor:
     filters:
       - multiply: 0.001
     restore: true
-    web_server:
-      sorting_group_id: oq_performance

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -72,8 +72,6 @@ button:
     internal: true
     icon: mdi:play-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_flow
     on_press:
       - lambda: |-
           const auto cfg = oq_flow_autotune::make_runtime_config(
@@ -90,8 +88,6 @@ button:
     internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_flow
     on_press:
       - lambda: |-
           id(oq_flow_autotune_abort) = true;
@@ -102,8 +98,6 @@ button:
     internal: true
     icon: mdi:check-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_tuning_flow
     on_press:
       - lambda: |-
           // Read the suggested gains and apply them only when both are valid.

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -89,8 +89,6 @@ number:
     entity_category: config
     unit_of_measurement: "L/h"
     mode: slider
-    web_server:
-      sorting_group_id: oq_control
     min_value: 0
     max_value: 1500
     step: 10
@@ -105,8 +103,6 @@ number:
     entity_category: config
     unit_of_measurement: "L/h"
     mode: slider
-    web_server:
-      sorting_group_id: oq_control
     min_value: 0
     max_value: 1500
     step: 10
@@ -127,8 +123,6 @@ number:
     initial_value: 400
     restore_value: true
     optimistic: true
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_flow_frost_pwm
@@ -138,8 +132,6 @@ number:
     icon: mdi:snowflake
     unit_of_measurement: "iPWM"
     mode: slider
-    web_server:
-      sorting_group_id: oq_tuning_flow
     min_value: 50
     max_value: 850
     step: 10
@@ -155,8 +147,6 @@ number:
     icon: mdi:rocket-launch-outline
     unit_of_measurement: "iPWM"
     mode: slider
-    web_server:
-      sorting_group_id: oq_tuning_flow
     min_value: 50
     max_value: 850
     step: 1
@@ -171,8 +161,6 @@ number:
     icon: mdi:alpha-k-circle-outline
     entity_category: config
     mode: slider
-    web_server:
-      sorting_group_id: oq_tuning_flow
     min_value: ${oq_flow_kp_min}
     max_value: ${oq_flow_kp_max}
     step: 0.001
@@ -187,8 +175,6 @@ number:
     icon: mdi:alpha-i-circle-outline
     entity_category: config
     mode: slider
-    web_server:
-      sorting_group_id: oq_tuning_flow
     min_value: ${oq_flow_ki_min}
     max_value: ${oq_flow_ki_max}
     step: 0.0001
@@ -213,8 +199,6 @@ select:
     initial_option: Flow Setpoint
     restore_value: true
     optimistic: true
-    web_server:
-      sorting_group_id: oq_control
 
 # ----------------------------
 # SENSORS
@@ -228,8 +212,6 @@ sensor:
     unit_of_measurement: "L/h"
     device_class: volume_flow_rate
     state_class: measurement
-    web_server:
-      sorting_group_id: oq_hydraulics
     accuracy_decimals: 0
     update_interval: 1s
     lambda: |-
@@ -282,8 +264,6 @@ binary_sensor:
     icon: mdi:alert-circle-outline
     device_class: problem
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_hydraulics
     lambda: |-
       static bool state = false;
       static bool mismatch_timer_running = false;
@@ -343,8 +323,6 @@ text_sensor:
     id: oq_flow_mode
     name: "Flow Mode"
     icon: mdi:state-machine
-    web_server:
-      sorting_group_id: oq_hydraulics
 
 # ----------------------------
 # CONTROL LOOPS

--- a/openquatt/oq_ha_inputs.yaml
+++ b/openquatt/oq_ha_inputs.yaml
@@ -27,8 +27,6 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: water_supply_temp_ha
@@ -40,8 +38,6 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: thermostat_setpoint_ha
@@ -53,8 +49,6 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: thermostat_room_temp_ha
@@ -66,8 +60,6 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_dew_point_ha
@@ -79,8 +71,6 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
 binary_sensor:
   - platform: homeassistant
@@ -91,8 +81,6 @@ binary_sensor:
     disabled_by_default: true
     icon: mdi:radiator
     device_class: heat
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_enable_ha
@@ -102,8 +90,6 @@ binary_sensor:
     disabled_by_default: true
     icon: mdi:snowflake-check
     device_class: cold
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: outside_temp_valid_ha
@@ -111,8 +97,6 @@ binary_sensor:
     entity_id: ${ha_outside_temp_valid_entity_id}
     internal: true
     icon: mdi:check-decagram
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: water_supply_temp_valid_ha
@@ -120,8 +104,6 @@ binary_sensor:
     entity_id: ${ha_water_supply_temp_valid_entity_id}
     internal: true
     icon: mdi:check-decagram
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: room_setpoint_valid_ha
@@ -129,8 +111,6 @@ binary_sensor:
     entity_id: ${ha_room_setpoint_valid_entity_id}
     internal: true
     icon: mdi:check-decagram
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: room_temp_valid_ha
@@ -138,8 +118,6 @@ binary_sensor:
     entity_id: ${ha_room_temp_valid_entity_id}
     internal: true
     icon: mdi:check-decagram
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: heating_enable_valid_ha
@@ -147,8 +125,6 @@ binary_sensor:
     entity_id: ${ha_heating_enable_valid_entity_id}
     internal: true
     icon: mdi:check-decagram
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_enable_valid_ha
@@ -156,8 +132,6 @@ binary_sensor:
     entity_id: ${ha_cooling_enable_valid_entity_id}
     internal: true
     icon: mdi:check-decagram
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: homeassistant
     id: cooling_dew_point_valid_ha
@@ -165,5 +139,3 @@ binary_sensor:
     entity_id: ${ha_cooling_dew_point_valid_entity_id}
     internal: true
     icon: mdi:check-decagram
-    web_server:
-      sorting_group_id: oq_ha_inputs

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -125,8 +125,6 @@ select:
       - Stable
     initial_option: Balanced
     entity_category: config
-    web_server:
-      sorting_group_id: oq_heating_curve
     on_value:
       then:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
@@ -175,8 +173,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 55
-    web_server:
-      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_m10
@@ -190,8 +186,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 50
-    web_server:
-      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_0
@@ -205,8 +199,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 45
-    web_server:
-      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_5
@@ -220,8 +212,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 40
-    web_server:
-      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_10
@@ -235,8 +225,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 35
-    web_server:
-      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: curve_tsupply_15
@@ -250,8 +238,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 30
-    web_server:
-      sorting_group_id: oq_heating_curve
 
   - platform: template
     id: heating_curve_pid_kp
@@ -265,8 +251,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0.280
-    web_server:
-      sorting_group_id: oq_heating_curve
     on_value:
       then:
         - climate.pid.set_control_parameters:
@@ -288,8 +272,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0.00060
-    web_server:
-      sorting_group_id: oq_heating_curve
     on_value:
       then:
         - climate.pid.set_control_parameters:
@@ -311,8 +293,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0.200
-    web_server:
-      sorting_group_id: oq_heating_curve
     on_value:
       then:
         - climate.pid.set_control_parameters:
@@ -334,8 +314,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 40
-    web_server:
-      sorting_group_id: oq_heating_curve
 
 button:
   - platform: template
@@ -345,8 +323,6 @@ button:
     disabled_by_default: true
     icon: mdi:restart
     entity_category: config
-    web_server:
-      sorting_group_id: oq_heating_curve
     on_press:
       then:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
@@ -373,8 +349,6 @@ climate:
     visual:
       min_temperature: 20
       max_temperature: 70
-    web_server:
-      sorting_group_id: oq_heating_curve
 
 output:
   - platform: template
@@ -689,8 +663,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       // Generate the curve-mode supply target from outside temperature and room trim.
       const float outside_c = id(oq_curve_outside_temp_filtered).state;
@@ -761,8 +733,6 @@ sensor:
     accuracy_decimals: 2
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       return id(oq_curve_demand_continuous);
 
@@ -777,8 +747,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       return (float) id(oq_demand_curve);
 
@@ -793,8 +761,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       return (float) id(oq_curve_request_total_level);
 
@@ -809,8 +775,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       return (float) id(oq_curve_dispatch_hp1_level);
 
@@ -825,8 +789,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       return (float) id(oq_curve_dispatch_hp2_level);
 
@@ -839,8 +801,6 @@ sensor:
     accuracy_decimals: 0
     update_interval: 5s
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       return id(oq_curve_restart_inhibit_active) ? 1.0f : 0.0f;
 
@@ -853,8 +813,6 @@ text_sensor:
     update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       if (!id(oq_curve_heat_request_active)) return std::string("OFF");
       return (id(oq_curve_regime_code) == 1) ? std::string("HEAT") : std::string("COAST");
@@ -867,8 +825,6 @@ text_sensor:
     update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       switch (id(oq_curve_regime_code)) {
         case 1: return std::string("RECOVERY");
@@ -884,8 +840,6 @@ text_sensor:
     update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_curve
     lambda: |-
       const char *mode_name = oq_curve::capacity_mode_name(id(oq_curve_capacity_mode_code));
       return std::string(mode_name);

--- a/openquatt/oq_hp_water_calibration.yaml
+++ b/openquatt/oq_hp_water_calibration.yaml
@@ -117,8 +117,6 @@ number:
     initial_value: 0
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: hp1_water_out_temp_offset
@@ -135,8 +133,6 @@ number:
     initial_value: 0
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: hp2_water_in_temp_offset
@@ -153,8 +149,6 @@ number:
     initial_value: 0
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: hp2_water_out_temp_offset
@@ -171,8 +165,6 @@ number:
     initial_value: 0
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: oq_hp_calibration_hp1_water_in_offset_suggested
@@ -189,8 +181,6 @@ number:
     initial_value: 0
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: oq_hp_calibration_hp1_water_out_offset_suggested
@@ -207,8 +197,6 @@ number:
     initial_value: 0
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: oq_hp_calibration_hp2_water_in_offset_suggested
@@ -225,8 +213,6 @@ number:
     initial_value: 0
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: oq_hp_calibration_hp2_water_out_offset_suggested
@@ -243,8 +229,6 @@ number:
     initial_value: 0
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
 
 button:
   - platform: template
@@ -254,8 +238,6 @@ button:
     icon: mdi:thermometer-sync
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
     on_press:
       - lambda: |-
           oq_hp_water_calibration::runtime().start(
@@ -269,8 +251,6 @@ button:
     icon: mdi:stop-circle-outline
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
     on_press:
       - lambda: |-
           oq_hp_water_calibration::runtime().abort_or_clear();
@@ -282,8 +262,6 @@ button:
     icon: mdi:check-circle-outline
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_temperatures
     on_press:
       - lambda: |-
           oq_hp_water_calibration::runtime().apply(

--- a/openquatt/oq_installation_monitoring.yaml
+++ b/openquatt/oq_installation_monitoring.yaml
@@ -65,8 +65,6 @@ button:
     on_press:
       - lambda: |-
           oq_diagnostics::acknowledge_compressor_cycling_alert();
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_acknowledge_recovered_hp_incidents
@@ -77,8 +75,6 @@ button:
     on_press:
       - lambda: |-
           id(oq_incident_manager).acknowledge_all_cleared();
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
 number:
   - platform: template
@@ -94,8 +90,6 @@ number:
     max_value: 20
     step: 1
     mode: slider
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_starts_warning_limit_72h
@@ -110,8 +104,6 @@ number:
     max_value: 120
     step: 1
     mode: slider
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
 sensor:
   - platform: template
@@ -125,8 +117,6 @@ sensor:
     lambda: |-
       return oq_diagnostics::installation_monitor().start_count(
           1, millis(), oq_diagnostics::InstallationMonitor::kTwoHoursMs);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp1_compressor_starts_6h
@@ -139,8 +129,6 @@ sensor:
     lambda: |-
       return oq_diagnostics::installation_monitor().start_count(
           1, millis(), oq_diagnostics::InstallationMonitor::kSixHoursMs);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp1_compressor_starts_24h
@@ -153,8 +141,6 @@ sensor:
     lambda: |-
       return oq_diagnostics::installation_monitor().start_count(
           1, millis(), oq_diagnostics::InstallationMonitor::kDayMs);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp1_compressor_starts_72h
@@ -167,8 +153,6 @@ sensor:
     lambda: |-
       return oq_diagnostics::installation_monitor().start_count(
           1, millis(), oq_diagnostics::InstallationMonitor::kSeventyTwoHoursMs);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp1_compressor_last_start_age
@@ -182,8 +166,6 @@ sensor:
     lambda: |-
       const float age = oq_diagnostics::installation_monitor().last_start_age_minutes(1, millis());
       return age < 0.0f ? NAN : age;
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp2_compressor_starts_2h
@@ -196,8 +178,6 @@ sensor:
     lambda: |-
       return oq_diagnostics::installation_monitor().start_count(
           2, millis(), oq_diagnostics::InstallationMonitor::kTwoHoursMs);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp2_compressor_starts_6h
@@ -210,8 +190,6 @@ sensor:
     lambda: |-
       return oq_diagnostics::installation_monitor().start_count(
           2, millis(), oq_diagnostics::InstallationMonitor::kSixHoursMs);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp2_compressor_starts_24h
@@ -224,8 +202,6 @@ sensor:
     lambda: |-
       return oq_diagnostics::installation_monitor().start_count(
           2, millis(), oq_diagnostics::InstallationMonitor::kDayMs);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp2_compressor_starts_72h
@@ -238,8 +214,6 @@ sensor:
     lambda: |-
       return oq_diagnostics::installation_monitor().start_count(
           2, millis(), oq_diagnostics::InstallationMonitor::kSeventyTwoHoursMs);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_hp2_compressor_last_start_age
@@ -253,8 +227,6 @@ sensor:
     lambda: |-
       const float age = oq_diagnostics::installation_monitor().last_start_age_minutes(2, millis());
       return age < 0.0f ? NAN : age;
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_alert_first_seen
@@ -269,8 +241,6 @@ sensor:
       return id(oq_compressor_cycling_alert_first_seen_epoch) > 0U
           ? id(oq_compressor_cycling_alert_first_seen_epoch)
           : NAN;
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_alert_last_seen
@@ -285,8 +255,6 @@ sensor:
       return id(oq_compressor_cycling_alert_last_seen_epoch) > 0U
           ? id(oq_compressor_cycling_alert_last_seen_epoch)
           : NAN;
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_alert_hp1_peak_2h
@@ -298,8 +266,6 @@ sensor:
     update_interval: 60s
     lambda: |-
       return id(oq_compressor_cycling_alert_hp1_peak_2h_value);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_alert_hp1_peak_72h
@@ -311,8 +277,6 @@ sensor:
     update_interval: 60s
     lambda: |-
       return id(oq_compressor_cycling_alert_hp1_peak_72h_value);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_alert_hp2_peak_2h
@@ -324,8 +288,6 @@ sensor:
     update_interval: 60s
     lambda: |-
       return id(oq_compressor_cycling_alert_hp2_peak_2h_value);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_alert_hp2_peak_72h
@@ -337,8 +299,6 @@ sensor:
     update_interval: 60s
     lambda: |-
       return id(oq_compressor_cycling_alert_hp2_peak_72h_value);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
 binary_sensor:
   - platform: template
@@ -350,8 +310,6 @@ binary_sensor:
     entity_category: diagnostic
     lambda: |-
       return id(oq_compressor_cycling_alert_latched);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_alert_alternating_sensor
@@ -361,8 +319,6 @@ binary_sensor:
     entity_category: diagnostic
     lambda: |-
       return id(oq_compressor_cycling_alert_alternating);
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_warning_2h
@@ -373,8 +329,6 @@ binary_sensor:
     entity_category: diagnostic
     lambda: |-
       return oq_diagnostics::logged_compressor_cycling_warning_2h(millis());
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_cycling_warning_72h
@@ -385,8 +339,6 @@ binary_sensor:
     entity_category: diagnostic
     lambda: |-
       return oq_diagnostics::logged_compressor_cycling_warning_72h(millis());
-    web_server:
-      sorting_group_id: oq_installation_monitoring
 
   - platform: template
     id: oq_compressor_alternating_warning
@@ -397,5 +349,3 @@ binary_sensor:
     entity_category: diagnostic
     lambda: |-
       return oq_diagnostics::logged_alternating_cycling_warning(millis());
-    web_server:
-      sorting_group_id: oq_installation_monitoring

--- a/openquatt/oq_local_sensors.yaml
+++ b/openquatt/oq_local_sensors.yaml
@@ -29,8 +29,6 @@ sensor:
     update_interval: 5s
     one_wire_id: oq_local_temp_bus
     index: 0
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: water_supply_temp_esp
@@ -55,5 +53,3 @@ sensor:
         return id(water_supply_temp_ds18b20).state;
       }
       return NAN;
-    web_server:
-      sorting_group_id: oq_temperatures

--- a/openquatt/oq_manual_flow.yaml
+++ b/openquatt/oq_manual_flow.yaml
@@ -54,8 +54,6 @@ number:
     optimistic: true
     initial_value: 800
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
 
 button:
   - platform: template
@@ -64,8 +62,6 @@ button:
     internal: true
     icon: mdi:water-pump
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     on_press:
       - lambda: |-
           oq_manual_flow::runtime().start();
@@ -76,8 +72,6 @@ button:
     internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     on_press:
       - lambda: |-
           oq_manual_flow::runtime().abort_or_clear();
@@ -88,8 +82,6 @@ button:
     internal: true
     icon: mdi:radiator
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     on_press:
       - lambda: |-
           oq_manual_flow::runtime().apply_to_heating();
@@ -100,8 +92,6 @@ button:
     internal: true
     icon: mdi:snowflake
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     on_press:
       - lambda: |-
           oq_manual_flow::runtime().apply_to_cooling();
@@ -121,8 +111,6 @@ switch:
     turn_off_action:
       - lambda: |-
           oq_manual_flow::runtime().abort_quick_test();
-    web_server:
-      sorting_group_id: oq_hydraulics
 
 interval:
   - interval: 1s

--- a/openquatt/oq_manual_hp.yaml
+++ b/openquatt/oq_manual_hp.yaml
@@ -58,8 +58,6 @@ select:
       - "Heating"
       - "Cooling"
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     set_action:
       - lambda: |-
           oq_manual_hp::runtime().set_mode(1, x.str(), (float) ${oq_cm_min_flow_lph});
@@ -77,8 +75,6 @@ select:
       - "Heating"
       - "Cooling"
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     set_action:
       - lambda: |-
           oq_manual_hp::runtime().set_mode(2, x.str(), (float) ${oq_cm_min_flow_lph});
@@ -97,8 +93,6 @@ number:
     optimistic: true
     initial_value: 0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
 
   - platform: template
     id: oq_manual_hp2_level
@@ -113,8 +107,6 @@ number:
     optimistic: true
     initial_value: 0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
 
 button:
   - platform: template
@@ -123,8 +115,6 @@ button:
     internal: true
     icon: mdi:heat-pump-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     on_press:
       - lambda: |-
           oq_manual_hp::runtime().start();
@@ -135,8 +125,6 @@ button:
     internal: true
     icon: mdi:stop-circle-outline
     entity_category: config
-    web_server:
-      sorting_group_id: oq_hydraulics
     on_press:
       - lambda: |-
           oq_manual_hp::runtime().abort_or_clear();

--- a/openquatt/oq_mqtt_ingress.yaml
+++ b/openquatt/oq_mqtt_ingress.yaml
@@ -68,8 +68,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_cooling_dew_point_age
@@ -79,8 +77,6 @@ sensor:
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_outside_temperature
@@ -92,8 +88,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_outside_temperature_age
@@ -103,8 +97,6 @@ sensor:
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_room_temperature
@@ -116,8 +108,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_room_temperature_age
@@ -127,8 +117,6 @@ sensor:
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_room_setpoint
@@ -140,8 +128,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_room_setpoint_age
@@ -151,8 +137,6 @@ sensor:
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_heating_enable_age
@@ -162,8 +146,6 @@ sensor:
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_cooling_enable_age
@@ -173,8 +155,6 @@ sensor:
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: never
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
 binary_sensor:
   - platform: template
@@ -183,8 +163,6 @@ binary_sensor:
     icon: mdi:water-check
     internal: true
     device_class: connectivity
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_outside_temperature_valid
@@ -192,8 +170,6 @@ binary_sensor:
     icon: mdi:check-decagram
     internal: true
     device_class: connectivity
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_room_temperature_valid
@@ -201,8 +177,6 @@ binary_sensor:
     icon: mdi:check-decagram
     internal: true
     device_class: connectivity
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_room_setpoint_valid
@@ -210,8 +184,6 @@ binary_sensor:
     icon: mdi:check-decagram
     internal: true
     device_class: connectivity
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_heating_enable
@@ -219,8 +191,6 @@ binary_sensor:
     icon: mdi:radiator
     disabled_by_default: true
     device_class: heat
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_heating_enable_valid
@@ -228,8 +198,6 @@ binary_sensor:
     icon: mdi:check-decagram
     internal: true
     device_class: connectivity
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_cooling_enable
@@ -237,8 +205,6 @@ binary_sensor:
     icon: mdi:snowflake-check
     disabled_by_default: true
     device_class: cold
-    web_server:
-      sorting_group_id: oq_ha_inputs
 
   - platform: template
     id: mqtt_cooling_enable_valid
@@ -246,5 +212,3 @@ binary_sensor:
     icon: mdi:check-decagram
     internal: true
     device_class: connectivity
-    web_server:
-      sorting_group_id: oq_ha_inputs

--- a/openquatt/oq_ot_slave.yaml
+++ b/openquatt/oq_ot_slave.yaml
@@ -44,8 +44,6 @@ switch:
       name: "OpenTherm Enabled"
       entity_category: config
       icon: mdi:thermostat-cog
-      web_server:
-        sorting_group_id: oq_opentherm
 
 binary_sensor:
   - platform: openquatt_ot_slave
@@ -54,28 +52,20 @@ binary_sensor:
       id: ot_thermostat_ch_enable
       name: "OT - Thermostat CH Enable"
       icon: mdi:radiator
-      web_server:
-        sorting_group_id: oq_opentherm
     master_cooling_enable:
       id: ot_thermostat_cooling_enable
       name: "OT - Thermostat Cooling Enable"
       icon: mdi:snowflake
-      web_server:
-        sorting_group_id: oq_opentherm
     master_status_valid:
       id: ot_thermostat_status_valid
       name: "OT - Thermostat Status Valid"
       icon: mdi:check-decagram
       entity_category: diagnostic
-      web_server:
-        sorting_group_id: oq_opentherm
     link_problem:
       id: ot_link_problem
       name: "OT - Link Problem"
       entity_category: diagnostic
       icon: mdi:alert-circle-outline
-      web_server:
-        sorting_group_id: oq_opentherm
 
 sensor:
   - platform: openquatt_ot_slave
@@ -84,20 +74,14 @@ sensor:
       id: ot_thermostat_control_setpoint
       name: "OT - Control Setpoint"
       icon: mdi:thermostat
-      web_server:
-        sorting_group_id: oq_opentherm
     t_roomset:
       id: ot_thermostat_room_setpoint
       name: "OT - Room Setpoint"
       icon: mdi:home-thermometer-outline
-      web_server:
-        sorting_group_id: oq_opentherm
     t_room:
       id: ot_thermostat_room_temp
       name: "OT - Room Temperature"
       icon: mdi:home-thermometer
-      web_server:
-        sorting_group_id: oq_opentherm
 
 interval:
   - interval: 2s

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -89,8 +89,6 @@ select:
       - Custom
     update_interval: 5s
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
     lambda: |-
       const float rise = id(ph_demand_rise_time_min).state;
       const float fall = id(ph_demand_fall_time_min).state;
@@ -136,8 +134,6 @@ number:
     optimistic: true
     initial_value: -10
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
 
   - platform: template
     id: house_rated_power_w
@@ -151,8 +147,6 @@ number:
     optimistic: true
     initial_value: 7020
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
 
   - platform: template
     id: house_zero_power_temp_c
@@ -166,8 +160,6 @@ number:
     optimistic: true
     initial_value: 16
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_kp_w_per_k
@@ -181,8 +173,6 @@ number:
     optimistic: true
     initial_value: 3000
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_comfort_band_below_c
@@ -196,8 +186,6 @@ number:
     optimistic: true
     initial_value: 0.1
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_comfort_band_above_c
@@ -211,8 +199,6 @@ number:
     optimistic: true
     initial_value: 0.3
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_demand_rise_time_min
@@ -226,8 +212,6 @@ number:
     optimistic: true
     initial_value: 8
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
 
   - platform: template
     id: ph_demand_fall_time_min
@@ -241,8 +225,6 @@ number:
     optimistic: true
     initial_value: 3
     entity_category: config
-    web_server:
-      sorting_group_id: oq_power_house
 
   - platform: template
     id: oq_demand_filter_ramp_up_step_min
@@ -258,8 +240,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 1
-    web_server:
-      sorting_group_id: oq_power_house
 
 text_sensor:
   # DEBUG-RUNTIME START: Duo Power House request reason
@@ -271,8 +251,6 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: never
-    web_server:
-      sorting_group_id: oq_power_house
     lambda: |-
       #if OQ_TOPOLOGY_DUO
       return std::string("inactive");
@@ -291,8 +269,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: ${oq_diagnostic_update_interval_s}s
-    web_server:
-      sorting_group_id: oq_power_house
     lambda: |-
       const float Tout = id(outside_temp_selected).state;
       const float Tc = id(house_cold_temp_c).state;
@@ -316,8 +292,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: ${oq_diagnostic_update_interval_s}s
-    web_server:
-      sorting_group_id: oq_power_house
     lambda: |-
       return id(oq_phouse_req_w);
 
@@ -333,8 +307,6 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_power_house
     lambda: |-
       return id(oq_phouse_comfort_memory_c);
 
@@ -350,8 +322,6 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_power_house
     lambda: |-
       return id(room_setpoint_selected).state + id(oq_phouse_comfort_memory_c);
 

--- a/openquatt/oq_sensor_source_selects_no_opentherm.yaml
+++ b/openquatt/oq_sensor_source_selects_no_opentherm.yaml
@@ -19,8 +19,6 @@ select:
       - HA input
       - MQTT
     initial_option: CIC
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Room Setpoint Source"
@@ -34,8 +32,6 @@ select:
       - HA input
       - MQTT
     initial_option: CIC
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Heating Enable Source"
@@ -50,8 +46,6 @@ select:
       - HA input
       - MQTT
     initial_option: Disabled
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Cooling Enable Source"
@@ -67,8 +61,6 @@ select:
       - CIC or HA input
       - Disabled
     initial_option: Disabled
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
 binary_sensor:
   - platform: template

--- a/openquatt/oq_sensor_source_selects_opentherm.yaml
+++ b/openquatt/oq_sensor_source_selects_opentherm.yaml
@@ -21,8 +21,6 @@ select:
       - HA input
       - MQTT
     initial_option: OT thermostat
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Room Setpoint Source"
@@ -37,8 +35,6 @@ select:
       - HA input
       - MQTT
     initial_option: OT thermostat
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Heating Enable Source"
@@ -54,8 +50,6 @@ select:
       - HA input
       - MQTT
     initial_option: Disabled
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Cooling Enable Source"
@@ -72,5 +66,3 @@ select:
       - Disabled
       - OT thermostat
     initial_option: Disabled
-    web_server:
-      sorting_group_id: oq_sensor_selection

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -84,8 +84,6 @@ select:
       - CIC
       - HA input
     initial_option: Local
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Flow Source"
@@ -98,8 +96,6 @@ select:
       - Outdoor unit
       - CIC
     initial_option: Outdoor unit
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Outdoor Unit Flow Mode"
@@ -114,8 +110,6 @@ select:
       - Flowmeter HP2
       - Local aggregate HP1/HP2
     initial_option: Local aggregate HP1/HP2
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     name: "Outside Temperature Source"
@@ -130,8 +124,6 @@ select:
       - HA input
       - MQTT
     initial_option: Auto
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
 switch:
   - platform: template
@@ -141,8 +133,6 @@ switch:
     entity_category: config
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
-    web_server:
-      sorting_group_id: oq_control
 
 binary_sensor:
   - platform: template
@@ -155,8 +145,6 @@ binary_sensor:
       return id(oq_water_supply_temp_fallback_runtime_active);
     filters:
       - delayed_on: 15s
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: heating_enable_valid
@@ -180,8 +168,6 @@ binary_sensor:
       if (source == "MQTT") return id(mqtt_heating_enable_valid).has_state() && id(mqtt_heating_enable_valid).state &&
                                   id(mqtt_heating_enable).has_state();
       return false;
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: heating_enable_selected
@@ -200,8 +186,6 @@ binary_sensor:
       if (source == "HA input") return id(heating_enable_ha).state;
       if (source == "MQTT") return id(mqtt_heating_enable).state;
       return false;
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: cooling_enable_valid
@@ -226,8 +210,6 @@ binary_sensor:
       if (source == "MQTT") return id(mqtt_cooling_enable_valid).has_state() && id(mqtt_cooling_enable_valid).state &&
                                   id(mqtt_cooling_enable).has_state();
       return false;
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: heating_blocked_by_thermostat
@@ -238,8 +220,6 @@ binary_sensor:
     lambda: |-
       if (!id(heating_enable_source).has_state() || id(heating_enable_source).current_option() == "Disabled") return false;
       return id(oq_enabled).state && id(oq_strategy_heat_request_active) && !id(heating_enable_selected).state;
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: cooling_enable_selected
@@ -266,8 +246,6 @@ binary_sensor:
       if (source == "HA input") return id(cooling_enable_ha).state;
       if (source == "MQTT") return id(mqtt_cooling_enable).state;
       return false;
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
 text_sensor:
   - platform: template
@@ -276,8 +254,6 @@ text_sensor:
     icon: mdi:source-branch
     entity_category: diagnostic
     update_interval: never
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_heating_enable_effective_source
@@ -291,8 +267,6 @@ text_sensor:
       if (source == "Disabled") return {"None"};
       if (!id(heating_enable_valid).state) return {"None"};
       return {source.c_str()};
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_room_temperature_effective_source
@@ -303,8 +277,6 @@ text_sensor:
       if (!id(room_temp_source).has_state()) return {"Unknown"};
       return {id(room_temp_source).current_option().c_str()};
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_room_setpoint_effective_source
@@ -315,8 +287,6 @@ text_sensor:
       if (!id(room_setpoint_source).has_state()) return {"Unknown"};
       return {id(room_setpoint_source).current_option().c_str()};
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_cooling_enable_effective_source
@@ -356,8 +326,6 @@ text_sensor:
       if (source == "HA input") return {with_manual(valid && id(cooling_enable_ha).state ? "HA input" : "None")};
       if (source == "MQTT") return {with_manual(valid && id(mqtt_cooling_enable).state ? "MQTT" : "None")};
       return {"Unknown"};
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_selected_input_hold_active
@@ -383,8 +351,6 @@ text_sensor:
 
       if (active.empty()) active = "None";
       return {active};
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
 sensor:
   - platform: template
@@ -484,8 +450,6 @@ sensor:
 
       publish_effective_source("Unavailable");
       return NAN;
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: flow_rate_selected
@@ -531,8 +495,6 @@ sensor:
         return NAN;
       }
       return NAN;
-    web_server:
-      sorting_group_id: oq_hydraulics
 
   - platform: template
     id: outside_temp_selected
@@ -594,8 +556,6 @@ sensor:
       }
 
       return NAN;
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: room_temp_selected
@@ -652,8 +612,6 @@ sensor:
       }
 
       return NAN;
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: template
     id: room_setpoint_selected
@@ -710,5 +668,3 @@ sensor:
       }
 
       return NAN;
-    web_server:
-      sorting_group_id: oq_temperatures

--- a/openquatt/oq_setup_status.yaml
+++ b/openquatt/oq_setup_status.yaml
@@ -26,8 +26,6 @@ button:
     disabled_by_default: true
     icon: mdi:check-bold
     entity_category: config
-    web_server:
-      sorting_group_id: oq_setup
     on_press:
       - lambda: |-
           id(oq_setup_complete) = true;
@@ -39,8 +37,6 @@ button:
     disabled_by_default: true
     icon: mdi:restart
     entity_category: config
-    web_server:
-      sorting_group_id: oq_setup
     on_press:
       - lambda: |-
           id(oq_setup_complete) = false;
@@ -55,5 +51,3 @@ binary_sensor:
     entity_category: diagnostic
     lambda: |-
       return id(oq_setup_complete);
-    web_server:
-      sorting_group_id: oq_setup

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -117,8 +117,6 @@ select:
       - Power House
       - Water Temperature Control (heating curve)
     initial_option: Power House
-    web_server:
-      sorting_group_id: oq_heating_strategy
     on_value:
       then:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
@@ -173,8 +171,6 @@ text_sensor:
     name: "Heating Strategy"
     icon: mdi:state-machine
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_overview
     lambda: |-
       return std::string(id(oq_heat_control_mode).current_option().c_str());
 
@@ -186,8 +182,6 @@ text_sensor:
     update_interval: never
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return std::string("idle");
 
@@ -202,8 +196,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_temperatures
     lambda: |-
       // Prefer local sensors from HPs that are actively moving air. Idle local
       // sensors remain useful as fallback, but they are more vulnerable to sun,
@@ -259,8 +251,6 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return (float) id(oq_strategy_active_code);
 
@@ -273,8 +263,6 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return (float) id(oq_strategy_phase_code);
 
@@ -289,8 +277,6 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_strategy_requested_power_w);
 
@@ -306,8 +292,6 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_strategy_supply_target_temp);
 
@@ -320,8 +304,6 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_strategy_water_limit_factor);
 
@@ -335,8 +317,6 @@ binary_sensor:
     disabled_by_default: true
     lambda: |-
       return id(oq_strategy_heat_request_active);
-    web_server:
-      sorting_group_id: oq_heating_strategy
 
   - platform: template
     id: oq_strategy_water_trip_active_sensor
@@ -346,8 +326,6 @@ binary_sensor:
     disabled_by_default: true
     lambda: |-
       return id(oq_strategy_water_trip_active);
-    web_server:
-      sorting_group_id: oq_heating_strategy
 
   - platform: template
     id: oq_strategy_water_hard_trip_active_sensor
@@ -357,8 +335,6 @@ binary_sensor:
     disabled_by_default: true
     lambda: |-
       return id(oq_strategy_water_hard_trip_active);
-    web_server:
-      sorting_group_id: oq_heating_strategy
 
 interval:
   - interval: ${oq_strategy_loop_s}s

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -216,8 +216,6 @@ select:
     restore_value: false
     optimistic: true
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_silent_mode_override
@@ -231,8 +229,6 @@ select:
     initial_option: "Schedule"
     restore_value: true
     optimistic: true
-    web_server:
-      sorting_group_id: oq_control
 
 switch:
   - platform: template
@@ -246,8 +242,6 @@ switch:
       # This switch is the installation-level boiler-present permission in
       # the web app. Turning it off must also revoke the hidden CM4 opt-in.
       - switch.turn_off: oq_boiler_fault_fallback_enabled
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_boiler_fault_fallback_enabled
@@ -258,8 +252,6 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_enabled
@@ -273,8 +265,6 @@ switch:
         - datetime.datetime.set:
             id: oq_openquatt_resume_at
             datetime: "2000-01-01 00:00:00"
-    web_server:
-      sorting_group_id: oq_control
 # ----------------------------
 # TUNING
 # ----------------------------
@@ -291,8 +281,6 @@ number:
     restore_value: true
     initial_value: 6
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_day_max_level
@@ -305,8 +293,6 @@ number:
     restore_value: true
     initial_value: 10
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_cm3_deficit_on_w
@@ -320,8 +306,6 @@ number:
     restore_value: true
     initial_value: 1000
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_cm3_deficit_off_w
@@ -335,8 +319,6 @@ number:
     restore_value: true
     initial_value: 400
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_low_load_dyn_off_factor
@@ -351,8 +333,6 @@ number:
     restore_value: true
     initial_value: 0.75
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_low_load_dyn_on_factor
@@ -367,8 +347,6 @@ number:
     restore_value: true
     initial_value: 1.0
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_low_load_min_hysteresis_w
@@ -384,8 +362,6 @@ number:
     restore_value: true
     initial_value: 200
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_low_load_reentry_block_s
@@ -401,8 +377,6 @@ number:
     restore_value: true
     initial_value: 300
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 # ----------------------------
 # SCHEDULE INPUTS
 # ----------------------------
@@ -415,8 +389,6 @@ datetime:
     restore_value: true
     initial_value: "19:00:00"
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_silent_end_time
@@ -426,8 +398,6 @@ datetime:
     restore_value: true
     initial_value: "07:00:00"
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 
   - platform: template
     id: oq_openquatt_resume_at
@@ -437,8 +407,6 @@ datetime:
     restore_value: true
     initial_value: "2000-01-01 00:00:00"
     entity_category: config
-    web_server:
-      sorting_group_id: oq_control
 # ----------------------------
 # DIAGNOSTICS
 # ----------------------------
@@ -449,8 +417,6 @@ binary_sensor:
     icon: mdi:weather-night
     device_class: running
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_overview
 
   - platform: template
     id: oq_sticky_active
@@ -458,8 +424,6 @@ binary_sensor:
     icon: mdi:timer-cog
     device_class: running
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_overview
 
   - platform: template
     id: oq_lowflow_fault_active_bs
@@ -467,8 +431,6 @@ binary_sensor:
     icon: mdi:water-alert
     device_class: problem
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_time_valid
@@ -478,16 +440,12 @@ binary_sensor:
     icon: mdi:clock-check
     device_class: connectivity
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 text_sensor:
   - platform: template
     id: oq_control_mode
     name: "Control Mode"
     icon: mdi:state-machine
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_control_mode_label
@@ -495,8 +453,6 @@ text_sensor:
     icon: mdi:format-list-bulleted
     update_interval: never
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_overview
 
   - platform: template
     id: oq_time_now_hhmm
@@ -505,8 +461,6 @@ text_sensor:
     icon: mdi:clock-outline
     update_interval: never
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_silent_window_hhmm
@@ -516,8 +470,6 @@ text_sensor:
     icon: mdi:calendar-clock
     update_interval: never
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   - platform: template
     id: oq_silent_status
@@ -527,8 +479,6 @@ text_sensor:
     icon: mdi:information-outline
     update_interval: never
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
   # DEBUG-RUNTIME START: Power House low-load diagnostics
   - platform: template
@@ -539,8 +489,6 @@ text_sensor:
     update_interval: ${oq_diagnostic_update_interval_s}s
     entity_category: diagnostic
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_system_diagnostics
     lambda: |-
       // Read the active threshold set from diagnostics.
       const float pmin = id(oq_low_load_pmin_dyn_w);
@@ -571,8 +519,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: ${oq_diagnostic_update_interval_s}s
-    web_server:
-      sorting_group_id: oq_overview
     lambda: |-
       #if OQ_TOPOLOGY_DUO
       return (float) id(oq_power_cap_f);

--- a/openquatt/oq_thermal_limits.yaml
+++ b/openquatt/oq_thermal_limits.yaml
@@ -60,8 +60,6 @@ number:
     optimistic: true
     initial_value: 60
     entity_category: config
-    web_server:
-      sorting_group_id: oq_heating_strategy
 
 sensor:
   # Shared abstractions and derived telemetry.
@@ -75,8 +73,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_temperatures
     lambda: |-
       // The selected supply signal owns source validity and topology fallback.
       if (id(water_supply_temp_selected).has_state()) {

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -257,8 +257,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 300
-    web_server:
-      sorting_group_id: oq_heating_strategy
 
   # Hold time before enabling dual-HP in curve mode.
   - platform: template
@@ -276,8 +274,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 3
-    web_server:
-      sorting_group_id: oq_heating_strategy
 
   # Hold time before disabling dual-HP in curve mode.
   - platform: template
@@ -295,8 +291,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 5
-    web_server:
-      sorting_group_id: oq_heating_strategy
 
 # ----------------------------
 # BUTTON
@@ -308,8 +302,6 @@ button:
     icon: mdi:restart
     entity_category: config
     disabled_by_default: true
-    web_server:
-      sorting_group_id: oq_heating_strategy
     on_press:
       - lambda: |-
           // Reset accumulated runtime counters and measured-start latches together,
@@ -345,8 +337,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
       const float hp1_power_w = nz(id(hp1_power_input).state);
@@ -368,8 +358,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
       if (id(oq_cooling_energy_session_active)) return 0.0f;
@@ -392,8 +380,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
       if (!id(oq_cooling_energy_session_active)) return 0.0f;
@@ -414,8 +400,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float hp1_heat_w = id(hp1_heat_power).state;
       #if OQ_TOPOLOGY_DUO
@@ -440,8 +424,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float hp1_cooling_w = id(hp1_cooling_power).state;
       #if OQ_TOPOLOGY_DUO
@@ -464,8 +446,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float total_input_w = id(oq_total_power_input).state;
       const float total_heat_w = id(oq_total_heat_power).state;
@@ -482,8 +462,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_performance
     lambda: |-
       const float total_input_w = id(oq_cooling_power_input).state;
       const float total_cooling_w = id(oq_total_cooling_power).state;
@@ -501,8 +479,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: ${oq_diagnostic_update_interval_s}s
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return (float) id(oq_demand_raw);
 
@@ -514,8 +490,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: ${oq_diagnostic_update_interval_s}s
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return (float) id(oq_demand_filtered);
 
@@ -527,8 +501,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       if (!id(hp1_compressor_level).has_state()) return NAN;
       auto idx = id(hp1_compressor_level).active_index();
@@ -544,8 +516,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       #if OQ_TOPOLOGY_DUO
       if (!id(${secondary_compressor_level_id}).has_state()) return NAN;
@@ -569,8 +539,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: ${oq_diagnostic_update_interval_s}s
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_P_hp_cap_w);
 
@@ -583,8 +551,6 @@ sensor:
     state_class: measurement
     accuracy_decimals: 0
     update_interval: ${oq_diagnostic_update_interval_s}s
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return id(oq_P_deficit_w);
 
@@ -597,8 +563,6 @@ text_sensor:
     entity_category: diagnostic
     disabled_by_default: true
     update_interval: never
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       return std::string("inactive");
 
@@ -607,8 +571,6 @@ text_sensor:
     name: "Runtime lead HP"
     icon: mdi:source-branch
     update_interval: 10s
-    web_server:
-      sorting_group_id: oq_heating_strategy
     lambda: |-
       #if OQ_TOPOLOGY_DUO
       const bool lead_is_hp1 = (id(hp1_minutes) <= id(${secondary_minutes_id}));

--- a/openquatt/oq_web_access.yaml
+++ b/openquatt/oq_web_access.yaml
@@ -100,8 +100,6 @@ switch:
     turn_off_action:
       - lambda: |-
           id(oq_log_history).set_enabled(false);
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 binary_sensor:
   - platform: gpio

--- a/openquatt/oq_webserver.yaml
+++ b/openquatt/oq_webserver.yaml
@@ -1,9 +1,9 @@
 # ==============================================================================
-# OpenQuatt – Webserver Sorting Groups
+# OpenQuatt – Webserver
 # ==============================================================================
 # Goal:
-#   Central layout of web_server groups so all packages use the same UI structure
-#   (consistent in HA/diagnostics workflow).
+#   Configure the authenticated OpenQuatt web app. The SPA owns entity layout;
+#   ESPHome sorting metadata is intentionally omitted to protect internal heap.
 # ==============================================================================
 web_server:
   port: 80
@@ -15,73 +15,3 @@ web_server:
   css_include: ${oq_webserver_css_include}
   js_include: ${oq_webserver_js_include}
   js_url: "${oq_webserver_js_url}"
-  sorting_groups:
-    - id: oq_setup
-      name: "Quick Start"
-      sorting_weight: 2
-    - id: oq_overview
-      name: "Overview"
-      sorting_weight: 5
-    - id: oq_control
-      name: "System Control"
-      sorting_weight: 10
-    - id: oq_heating_strategy
-      name: "Heating Strategy"
-      sorting_weight: 20
-    - id: oq_heating_curve
-      name: "Heating Curve"
-      sorting_weight: 25
-    - id: oq_power_house
-      name: "Power House"
-      sorting_weight: 30
-    - id: oq_cooling
-      name: "Cooling"
-      sorting_weight: 35
-    - id: oq_sensor_selection
-      name: "Sensor Selection"
-      sorting_weight: 40
-    - id: oq_opentherm
-      name: "OpenTherm"
-      sorting_weight: 45
-    - id: oq_boiler
-      name: "Boiler"
-      sorting_weight: 50
-    - id: oq_cic
-      name: "CIC Feed"
-      sorting_weight: 55
-    - id: oq_ha_inputs
-      name: "HA Inputs"
-      sorting_weight: 60
-    - id: oq_temperatures
-      name: "Temperatures"
-      sorting_weight: 70
-    - id: oq_hydraulics
-      name: "Flow & Pump"
-      sorting_weight: 80
-    - id: oq_tuning_flow
-      name: "Flow Tuning"
-      sorting_weight: 85
-    - id: oq_performance
-      name: "Performance"
-      sorting_weight: 90
-    - id: oq_hp1
-      name: "HP1"
-      sorting_weight: 100
-    - id: oq_hp2
-      name: "HP2"
-      sorting_weight: 105
-    - id: oq_advanced_hp_levels
-      name: "Advanced - HP Levels"
-      sorting_weight: 110
-    - id: oq_system_diagnostics
-      name: "System Diagnostics"
-      sorting_weight: 180
-    - id: oq_installation_monitoring
-      name: "Installation Monitoring"
-      sorting_weight: 185
-    - id: oq_hp_diagnostics
-      name: "HP Diagnostics"
-      sorting_weight: 190
-    - id: oq_raw
-      name: "RAW"
-      sorting_weight: 999

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -105,8 +105,6 @@ select:
       - PT1000
       - DS18B20
     initial_option: PT1000
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
   - platform: template
     id: oq_q_flow_source
@@ -120,8 +118,6 @@ select:
       - Local
       - Outdoor unit
     initial_option: Auto
-    web_server:
-      sorting_group_id: oq_sensor_selection
 
 spi:
   - id: oq_hpcq_pt1000_spi
@@ -152,8 +148,6 @@ sensor:
           if (isnan(x)) return x;
           if (x < -10.0f || x > 100.0f) return NAN;
           return x;
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: pulse_meter
     id: flow_rate_controller
@@ -182,8 +176,6 @@ sensor:
           const float lph = lpm * 60.0f;
           return lph > 0.0f ? lph : 0.0f;
       - throttle_average: 10s
-    web_server:
-      sorting_group_id: oq_hydraulics
 
 interval:
   - interval: 5s

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
@@ -38,9 +38,3 @@ packages:
       cic_compat_hp_id: "hp1"
       cic_compat_label: "HP1"
       cic_compat_device_address: "${cic_compat_modbus_address_hp1}"
-
-web_server:
-  sorting_groups:
-    - id: oq_cic_compatibility
-      name: "CiC Compatibility"
-      sorting_weight: 52

--- a/openquatt/profiles/heatpump_controller_q_hardware_revision.yaml
+++ b/openquatt/profiles/heatpump_controller_q_hardware_revision.yaml
@@ -49,5 +49,3 @@ text_sensor:
     icon: mdi:developer-board
     entity_category: diagnostic
     update_interval: never
-    web_server:
-      sorting_group_id: oq_system_diagnostics

--- a/openquatt/profiles/heatpump_controller_q_status_leds.yaml
+++ b/openquatt/profiles/heatpump_controller_q_status_leds.yaml
@@ -35,8 +35,6 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
-    web_server:
-      sorting_group_id: oq_system_diagnostics
 
 binary_sensor:
   - platform: template

--- a/openquatt/profiles/heatpump_listener_extras.yaml
+++ b/openquatt/profiles/heatpump_listener_extras.yaml
@@ -39,8 +39,6 @@ sensor:
     entity_category: diagnostic
     one_wire_id: listener_temp_t1_bus
     index: 0
-    web_server:
-      sorting_group_id: oq_temperatures
 
   - platform: dallas_temp
     id: listener_temp_t2
@@ -55,8 +53,6 @@ sensor:
     entity_category: diagnostic
     one_wire_id: listener_temp_t2_bus
     index: 0
-    web_server:
-      sorting_group_id: oq_temperatures
 
 output:
   - platform: gpio
@@ -72,5 +68,3 @@ switch:
     icon: mdi:electric-switch
     restore_mode: ALWAYS_OFF
     entity_category: diagnostic
-    web_server:
-      sorting_group_id: oq_system_diagnostics

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -47,6 +47,15 @@ PACKAGE_ORDER_PATTERNS = (
     "openquatt/*.yaml",
 )
 
+BUILTIN_YAML_PATTERNS = (
+    "configs/**/*.yaml",
+    "docs/templates/**/*.yaml",
+    "openquatt/**/*.yaml",
+)
+BUILTIN_WEB_SORTING_KEY_RE = re.compile(
+    r"""(?:^|[,{]\s*)["']?(?:sorting_groups|sorting_group_id|sorting_weight)["']?\s*:"""
+)
+
 STRICT_TOP_LEVEL_ORDER_RULES = {
     "configs/waveshare/single_wifi.yaml": (
         "substitutions",
@@ -164,7 +173,6 @@ STRICT_TOP_LEVEL_ORDER_RULES = {
         "uart",
         "modbus",
         "packages",
-        "web_server",
     ),
     "openquatt/profiles/heatpump_controller_q_cic_compatibility_duo.yaml": (
         "packages",
@@ -417,6 +425,21 @@ def check_whitespace(path: Path, findings: list[Finding]) -> None:
             add(findings, rel, idx, "Tab character found; use spaces only.")
         if line.rstrip(" ") != line:
             add(findings, rel, idx, "Trailing whitespace found.")
+
+
+def check_no_builtin_web_sorting(path: Path, findings: list[Finding]) -> None:
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    for idx, line in enumerate(read_lines(path), start=1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if BUILTIN_WEB_SORTING_KEY_RE.search(stripped):
+            add(
+                findings,
+                rel,
+                idx,
+                "ESPHome web sorting metadata allocates internal heap; keep layout in the OpenQuatt SPA.",
+            )
 
 
 def check_yaml_banner(path: Path, findings: list[Finding]) -> None:
@@ -691,6 +714,9 @@ def main() -> int:
 
     for path in expand_patterns(TEXT_PATTERNS):
         check_whitespace(path, findings)
+
+    for path in expand_patterns(BUILTIN_YAML_PATTERNS):
+        check_no_builtin_web_sorting(path, findings)
 
     for path in expand_patterns(YAML_BANNER_PATTERNS):
         check_yaml_banner(path, findings)


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert alle ongebruikte ESPHome `sorting_groups`, `sorting_group_id` en `sorting_weight`-metadata uit de acht firmwareprofielen en de meegeleverde template.
- Laat de OpenQuatt-SPA volledig eigenaar zijn van de entity-layout; de native ESPHome-fallback gebruikt voortaan standaardvolgorde.
- Voegt een stijlguard toe die block-, flow- en quoted-YAML-vormen van deze metadata afkeurt.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [x] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Besturing, entities, Home Assistant-mapping en de OpenQuatt-SPA veranderen niet. Alleen de native ESPHome-webinterface verliest de OpenQuatt-groepsvolgorde en toont zijn standaardvolgorde.

## Achtergrond

De Q `duo_wifi`-build registreerde 574 entityconfiguraties en 24 groepen in dynamische `std::map`-opslag. De OpenQuatt-SPA leest deze metadata niet.

A/B op dezelfde ESPHome/ESP-IDF-basis:

- baseline: 574 `add_entity_config`, 24 `add_sorting_group`, image 2.027.971 B, DIRAM 229.515 B;
- alleen entitymetadata weg: image 2.016.295 B, DIRAM 229.515 B;
- gekozen volledige verwijdering: 0 `add_entity_config`, 0 `add_sorting_group`, image 2.012.435 B, DIRAM 229.467 B.

Op basis van de ESP32-S3-ABI en allocatoroverhead is de verwachte dynamische interne-heapwinst circa 29.088 B, plus eventuele groupnaamallocaties. De image wordt 15.536 B kleiner en statische DIRAM 48 B kleiner.

Compatibiliteit: externe YAML die nog naar de verwijderde OpenQuatt-group-ID’s verwijst moet die verwijzing verwijderen. De repositorytemplate is bijgewerkt. De native fallback blijft functioneel, maar zonder custom sorting.

De cold review vond één lage guard-omzeiling voor inline/quoted YAML; die is opgelost. De werkelijke bootheapwinst is inmiddels HIL-gemeten; de native ESPHome-fallback is niet afzonderlijk op hardware doorgelopen.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De gewijzigde bron-YAML raakt technisch meerdere docs-impactcategorieën, maar wijzigt geen besturing, entities, instellingen of OpenQuatt-SPA. Alleen ongebruikte metadata voor de vervangen native ESPHome-webinterface verdwijnt. De relevante ontwikkelaarsdocumentatie en repositorytemplate zijn wel bijgewerkt; aanvullende gebruikersdocumentatie zou geen waarneembaar gebruikersgedrag beschrijven.

## Validatie

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- static RAM-delta Q `duo_wifi`: -48 B DIRAM;
- verwachte dynamische interne-heapwinst: circa 29.088 B plus groupnaamallocaties;
- firmware-image: -15.536 B;
- actuele/minimumheap, largest block, fragmentatie en task-stack-watermarks moeten nog op hardware worden gemeten;
- worst-case overlap moet nog op hardware worden getest.

- `python3 scripts/dev.py validate --config-only` — PASS voor alle acht actuele profielen op `origin/dev`.
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml --jobs 1` — volledige Q ESP32-S3-compile PASS.
- `python3 scripts/check_style_consistency.py` — PASS.
- `python3 scripts/check_docs_consistency.py` — PASS.
- `node scripts/check_web_docs_sync.mjs` — PASS.
- Gegenereerde Q-code bevat geen `USE_WEBSERVER_SORTING`, `add_sorting_group` of `add_entity_config`.
- `git diff --check origin/dev...HEAD` — PASS.
- Onafhankelijke cold review van alle 47 bestanden, YAML-semantiek, SPA/native fallback, guard en compatibiliteit uitgevoerd; finding opgelost.


### Hardware A/B-validatie (29 juli 2026)

- Geïsoleerde PR403-build: tijdens setup circa `26,9 kB` meer vrije interne heap en `20,5 kB` groter largest block dan de baseline.
- Bij t60 was circa `102,2 kB` vrije heap beschikbaar.
- Bij t300 stond de cumulatieve minimumwatermark op `24,24 kB`. De verwijderde runtime-`std::map`-metadata levert dus aantoonbaar structurele reserve, maar verwijdert niet de diepste tijdelijke allocatiepiek.
- De OpenQuatt-SPA en normale firmwarefuncties bleven werken; de native ESPHome-fallbackvolgorde is niet afzonderlijk HIL-gevalideerd.

De metingen zijn uitgevoerd op een OpenQuatt Q-controller v1.1 (ESP32-S3), profiel `configs/heatpump_controller_q/duo_wifi.yaml`, met de volledige installatie aangesloten, ESPHome 2026.7.3 en ESP-IDF 5.5.5. Elke A/B-image gebruikte dezelfde lokale test-only heap-probe; de probe en de lokaal gecombineerde testbuild maken geen deel uit van deze PR.

Cross-PR-context, niet aan één wijziging toe te schrijven:

- De lokaal gecombineerde PR401–PR404-build mat bij t60 `120,3 kB` current / `39,948 kB` minimum / `63,488 kB` largest block; bij t120 `121,1 kB` / `39,948 kB`; bij t300 `122,5 kB` / `39,948 kB`.
- Na functionele validatie rapporteerden de sensoren `118,855 kB` vrije heap en `46,6%` fragmentatie. Usage telemetry stond aan; Energy History, trends, debug en MQTT-status functioneerden. Ping: 0% verlies, gemiddeld 55 ms.
- Een latere live-read van dezelfde gecombineerde build mat `92,355 kB` current, `39,948 kB` minimum en `49,152 kB` largest block, terwijl ping 10% verlies en gemiddeld 983 ms liet zien. MQTT-ingress rapporteerde toen `enabled=false`, `connected=false`, `runtime_pending=false`. Netwerkdegradatie kan dus ook met ruime heap en MQTT-ingress uit optreden; dit is geen bewijs tegen of voor één afzonderlijke PR.
- Safe Mode-OTA duurde 53–54 seconden, terwijl OTA onder de volledige applicatieruntime herhaaldelijk na 3–5 minuten time-outte. Dit toont invloed van de totale applicatieruntime op netwerkdoorvoer, maar bewijst geen oorzaak in deze afzonderlijke PR.
