### PR TITLE
Stop stray OpenTherm polling in R1 mode

### DIFF
--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -151,15 +151,14 @@ void OpenthermHub::setup() {
     return;
   }
 
-  // Ensure that there is at least one request, as we are required to
-  // communicate at least once every second. Sending the status request is
-  // good practice anyway.
+  // Ensure that, once the runtime owner starts polling, there is at least one
+  // request. Sending the status request once per second is good practice.
   this->add_repeating_message(MessageId::STATUS);
   this->write_initial_messages_(this->messages_);
   this->message_iterator_ = this->messages_.begin();
 }
 
-void OpenthermHub::on_shutdown() { this->opentherm_->stop(); }
+void OpenthermHub::on_shutdown() { this->suspend_polling(); }
 
 void OpenthermHub::prioritize_messages(MessageId first, MessageId second) {
   this->opentherm_->stop();
@@ -171,7 +170,14 @@ void OpenthermHub::prioritize_messages(MessageId first, MessageId second) {
   this->last_conversation_end_ = 0;
 }
 
+void OpenthermHub::start_priority_polling(MessageId first, MessageId second) {
+  this->polling_enabled_ = true;
+  this->prioritize_messages(first, second);
+  this->enable_loop();
+}
+
 void OpenthermHub::resume_polling() {
+  this->polling_enabled_ = true;
   this->opentherm_->stop();
   this->sending_initial_ = true;
   this->priority_sequence_active_ = false;
@@ -180,6 +186,14 @@ void OpenthermHub::resume_polling() {
   this->last_conversation_start_ = 0;
   this->last_conversation_end_ = 0;
   this->enable_loop();
+}
+
+void OpenthermHub::suspend_polling() {
+  this->polling_enabled_ = false;
+  if (this->opentherm_ != nullptr) {
+    this->opentherm_->stop();
+  }
+  this->disable_loop();
 }
 
 // Disabling clang-tidy for this particular line since it keeps removing the trailing underscore (bug?)
@@ -208,6 +222,9 @@ void OpenthermHub::write_repeating_messages_(std::vector<MessageId> &target) {  
 }
 
 void OpenthermHub::loop() {
+  if (!this->polling_enabled_) {
+    return;
+  }
   this->opentherm_->process();
   if (this->sync_mode_) {
     this->sync_loop_();

--- a/components/opentherm/hub.h
+++ b/components/opentherm/hub.h
@@ -64,6 +64,8 @@ class OpenthermHub final : public Component {
 
   bool sending_initial_ = true;
   bool priority_sequence_active_ = false;
+  // The OpenQuatt transport owner explicitly starts polling after restore.
+  bool polling_enabled_ = false;
   std::unordered_map<MessageId, uint8_t> configured_messages_;
   std::vector<MessageId> messages_;
   std::vector<MessageId>::const_iterator message_iterator_;
@@ -161,7 +163,10 @@ class OpenthermHub final : public Component {
   void set_sync_mode(bool sync_mode) { this->sync_mode_ = sync_mode; }
 
   void prioritize_messages(MessageId first, MessageId second);
+  void start_priority_polling(MessageId first, MessageId second);
   void resume_polling();
+  void suspend_polling();
+  bool is_polling_enabled() const { return this->polling_enabled_; }
 
   template<typename F> void add_on_before_send_callback(F &&callback) {
     this->before_send_callback_.add(std::forward<F>(callback));

--- a/openquatt/includes/boiler/oq_otb_startup_probe.h
+++ b/openquatt/includes/boiler/oq_otb_startup_probe.h
@@ -22,6 +22,12 @@ inline bool should_auto_select_opentherm(
   return result == STARTUP_PROBE_OPENTHERM_DETECTED && !setup_complete;
 }
 
+inline bool should_keep_opentherm_polling(
+    bool opentherm_selected, bool startup_probe_active,
+    bool connection_mismatch) {
+  return opentherm_selected || startup_probe_active || connection_mismatch;
+}
+
 class StartupProbeState {
  public:
   void begin(uint32_t now_ms) {

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -39,7 +39,7 @@ esphome:
             id(oq_otb_startup_probe_active) = false;
             id(oq_boiler_connection_mismatch_state) = false;
             id(oq_boiler_connection_mismatch).publish_state(false);
-            id(oq_otb_hub).enable_loop();
+            id(oq_otb_hub).resume_polling();
           } else {
             // Before R1 can become available, actively check whether an
             // OpenTherm boiler is physically responding. STATUS(CH=off) and
@@ -50,10 +50,9 @@ esphome:
             id(oq_boiler_connection_mismatch_state) = false;
             id(oq_boiler_connection_mismatch).publish_state(false);
             id(boiler_relay).turn_off();
-            id(oq_otb_hub).prioritize_messages(
+            id(oq_otb_hub).start_priority_polling(
                 esphome::opentherm::MessageId::STATUS,
                 esphome::opentherm::MessageId::CH_SETPOINT);
-            id(oq_otb_hub).enable_loop();
           }
   on_shutdown:
     priority: 700
@@ -666,7 +665,32 @@ interval:
     startup_delay: 1s
     then:
       - lambda: |-
-          if (!id(oq_otb_startup_probe_active)) return;
+          const bool startup_probe_active =
+              oq_otb::startup_probe_state.active();
+          if (id(oq_otb_startup_probe_active) != startup_probe_active) {
+            ESP_LOGW(
+                "quatt.boiler",
+                "Correcting stale OpenTherm startup-probe mirror");
+            id(oq_otb_startup_probe_active) = startup_probe_active;
+          }
+
+          const bool opentherm_selected =
+              id(oq_boiler_connection).has_state() &&
+              id(oq_boiler_connection).current_option() == "OpenTherm";
+          const bool keep_polling = oq_otb::should_keep_opentherm_polling(
+              opentherm_selected,
+              startup_probe_active,
+              id(oq_boiler_connection_mismatch_state));
+          if (!keep_polling) {
+            if (id(oq_otb_hub).is_polling_enabled()) {
+              ESP_LOGW(
+                  "quatt.boiler",
+                  "Stopping stray OpenTherm polling while R1 is selected");
+              id(oq_otb_hub).suspend_polling();
+            }
+            return;
+          }
+          if (!startup_probe_active) return;
 
           const uint32_t now_ms = millis();
           const auto result = oq_otb::startup_probe_state.result(
@@ -725,8 +749,7 @@ interval:
           id(oq_boiler_connection_auto_selected).publish_state(false);
           id(oq_boiler_connection_mismatch_state) = false;
           id(oq_boiler_connection_mismatch).publish_state(false);
-          id(oq_otb_hub).on_shutdown();
-          id(oq_otb_hub).disable_loop();
+          id(oq_otb_hub).suspend_polling();
           oq_otb::telemetry_state.reset_link_session();
           id(oq_otb_link_initialized) = true;
           id(oq_otb_link_available_state) = false;

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -22,10 +22,9 @@ substitutions:
         id(oq_boiler_connection_mismatch_state) = false;
         id(oq_boiler_connection_mismatch).publish_state(false);
         id(boiler_relay).turn_off();
-        id(oq_otb_hub).prioritize_messages(
+        id(oq_otb_hub).start_priority_polling(
             esphome::opentherm::MessageId::STATUS,
             esphome::opentherm::MessageId::CH_SETPOINT);
-        id(oq_otb_hub).enable_loop();
       }
     }
     oq_otb::telemetry_state.reset_link_session();

--- a/scripts/run_host_regression_tests.sh
+++ b/scripts/run_host_regression_tests.sh
@@ -39,4 +39,7 @@ python3 "${repo_root}/scripts/tests/test_incident_manager_action_contract.py"
 echo "[run] internal heap placement contract"
 python3 "${repo_root}/scripts/tests/test_internal_heap_contract.py"
 
+echo "[run] OTB polling lifecycle contract"
+python3 "${repo_root}/scripts/tests/test_otb_polling_lifecycle_contract.py"
+
 echo "Host regression tests passed (${#sources[@]})."

--- a/scripts/tests/test_otb_polling_lifecycle_contract.py
+++ b/scripts/tests/test_otb_polling_lifecycle_contract.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HUB_HEADER = (ROOT / "components" / "opentherm" / "hub.h").read_text()
+HUB_CPP = (ROOT / "components" / "opentherm" / "hub.cpp").read_text()
+OTB_PACKAGE = (ROOT / "openquatt" / "oq_boiler_opentherm.yaml").read_text()
+Q_PROFILE = (
+    ROOT / "openquatt" / "profiles" / "heatpump_controller_q.yaml"
+).read_text()
+
+
+class OtbPollingLifecycleContractTest(unittest.TestCase):
+    def test_hub_owns_a_hard_polling_gate(self) -> None:
+        self.assertIn("bool polling_enabled_ = false;", HUB_HEADER)
+        self.assertIn("void suspend_polling();", HUB_HEADER)
+        self.assertIn("this->polling_enabled_ = false;", HUB_CPP)
+        self.assertIn("if (!this->polling_enabled_) {", HUB_CPP)
+        self.assertIn("this->disable_loop();", HUB_CPP)
+
+    def test_probe_state_is_authoritative_for_r1_polling(self) -> None:
+        self.assertIn(
+            "oq_otb::startup_probe_state.active()",
+            OTB_PACKAGE,
+        )
+        self.assertIn(
+            "oq_otb::should_keep_opentherm_polling(",
+            OTB_PACKAGE,
+        )
+        self.assertIn(
+            "id(oq_otb_hub).is_polling_enabled()",
+            OTB_PACKAGE,
+        )
+        self.assertIn(
+            "id(oq_otb_hub).suspend_polling();",
+            OTB_PACKAGE,
+        )
+
+    def test_transport_transitions_use_hub_lifecycle_methods(self) -> None:
+        lifecycle_yaml = OTB_PACKAGE + Q_PROFILE
+        self.assertIn(
+            "id(oq_otb_hub).start_priority_polling(",
+            lifecycle_yaml,
+        )
+        self.assertIn(
+            "id(oq_otb_hub).resume_polling();",
+            lifecycle_yaml,
+        )
+        self.assertNotIn(
+            "id(oq_otb_hub).enable_loop();",
+            lifecycle_yaml,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host/ot_boiler_startup_probe_test.cpp
+++ b/tests/host/ot_boiler_startup_probe_test.cpp
@@ -15,9 +15,19 @@ int main() {
   assert(!oq_otb::should_auto_select_opentherm(
       oq_otb::STARTUP_PROBE_TIMED_OUT, false));
 
+  // R1 must leave the master completely idle outside the bounded startup
+  // probe. A proven physical mismatch deliberately keeps safe polling active.
+  assert(!oq_otb::should_keep_opentherm_polling(false, false, false));
+  assert(oq_otb::should_keep_opentherm_polling(true, false, false));
+  assert(oq_otb::should_keep_opentherm_polling(false, true, false));
+  assert(oq_otb::should_keep_opentherm_polling(false, false, true));
+
   assert(state.result(0, 8000) == oq_otb::STARTUP_PROBE_IDLE);
   state.begin(1000);
   assert(state.active());
+  // The probe object is authoritative even if a diagnostic mirror is stale.
+  assert(oq_otb::should_keep_opentherm_polling(
+      false, state.active(), false));
   assert(state.result(1000, 8000) == oq_otb::STARTUP_PROBE_RUNNING);
 
   // A response cannot prove the link unless this probe first emitted its own
@@ -62,6 +72,8 @@ int main() {
 
   state.end();
   assert(!state.active());
+  assert(!oq_otb::should_keep_opentherm_polling(
+      false, state.active(), false));
   assert(state.result(1002, 8000) == oq_otb::STARTUP_PROBE_IDLE);
 
   // A valid negative acknowledgement still proves that a boiler is connected.


### PR DESCRIPTION
# Wat verandert deze PR?

- Maakt de OpenTherm-master fail-closed: polling start alleen expliciet voor OpenTherm, de begrensde startup-probe of een bewezen transportmismatch.
- Laat de hub zelf polling starten en stoppen, inclusief het beëindigen van de onderliggende OpenTherm/RMT-transactie.
- Gebruikt de werkelijke startup-probestatus als bron en voegt regressietests toe voor de R1-lifecycle.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Bij een normale R1-selectie pollt de boiler-OpenTherm-master voortaan uitsluitend tijdens de bestaande verificatieperiode van 8 seconden. Daarna stopt zowel de ESPHome-componentloop als de onderliggende protocoltransactie. Een geselecteerde OpenTherm-verbinding en een bewezen fysieke mismatch blijven bewust veilig pollen met CH uit.

## Achtergrond

De hub startte standaard actief en de R1-lifecycle vertrouwde op `disable_loop()` plus een afzonderlijke mirror van de startup-probestatus. Als een boot-hook niet liep of lifecycle-state uit elkaar liep, bleef de master iedere seconde een OpenTherm-request sturen terwijl `Boiler connection` op `R1` stond en OTB-link/mismatch beide uit waren.

Dit werd op een Q v1.0-HIL-controller gereproduceerd als continue `Timeout while waiting for response from device`-meldingen. De testoverlay bleek daarnaast zijn eigen `esphome.on_boot` te plaatsen; de nieuwe fail-closed hub-invariant voorkomt ook in zo'n gemiste boottransitie onbeperkte polling. De PR zelf blijft gebaseerd op de actuele Q v1.1-pinmapping; de v1.0-HIL-config zit niet in deze diff.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit corrigeert een interne transportlifecycle zonder nieuwe instellingen, entities of gebruikersworkflow.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen dynamische allocaties, nieuwe task of stackwijzigingen. Alleen één kleine componentstatusflag en lifecyclemethoden zijn toegevoegd.

Lokaal:

- `CXX=g++-15 ./scripts/run_host_regression_tests.sh` — alle 14 C++-hosttests en alle contracttests geslaagd.
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml` — stijl, docs-contract, configuratie en volledige Q v1.1-firmwarecompile geslaagd met ESPHome 2026.7.3 / ESP-IDF 5.5.5.
- Volledige diff tegen actuele `dev` gecontroleerd op boot/restore, OpenTherm→R1, R1→OpenTherm, probe-timeout, mismatch, shutdown, mislukte lifecycletransities en afwezigheid van v1.0-pinwijzigingen.

HIL op afzonderlijke Q v1.0-testbranch en hardware:

- Vóór de fix: onbeperkt circa één OpenTherm-timeout per seconde bij `R1`, link `OFF`, mismatch `OFF`.
- Na boot: 8 timeout-events binnen de bedoelde 8-secondenprobe, daarna een expliciete stop en 0 nieuwe timeouts.
- OpenTherm→R1: 9 probe-events, één stopmelding en daarna opnieuw 0 timeouts tijdens de nacontrole.
- Eindtoestand: `R1`, OTB-link `OFF`, mismatch `OFF`.

Nog niet hardwarematig getest: detectie van een werkelijk aangesloten OTB-ketel en het mismatchpad; de policy- en startup-probetests dekken deze tak wel.