### PR TITLE
Add C/C++ formatting checks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,4 @@
 ---
-BasedOnStyle: LLVM
-IndentWidth: 2
-TabWidth: 2
-UseTab: Never
+BasedOnStyle: Google
 ColumnLimit: 120
 SortIncludes: false
-PointerAlignment: Left
-ReferenceAlignment: Left

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+ColumnLimit: 120
+SortIncludes: false
+PointerAlignment: Left
+ReferenceAlignment: Left

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,15 @@
+# Build/output and local environments
+.esphome/**
+.pio/**
+.venv*/**
+.cache/**
+.tmp/**
+tmp/**
+output/**
+
+# Dependencies and VCS internals
+node_modules/**
+.git/**
+
+# Python caches
+**/__pycache__/**

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,6 +9,23 @@ permissions:
   contents: read
 
 jobs:
+  cpp-format-warning:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check C/C++ formatting (warning only)
+        run: |
+          if ! python3 scripts/cpp_format.py check; then
+            echo "::warning title=C/C++ formatting::Formatting differences detected in C/C++ files. Run 'npm run fix:cpp-format'."
+          fi
+
   docs-consistency:
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +75,7 @@ jobs:
         run: ./scripts/run_host_regression_tests.sh
 
   validate-and-compile:
-    needs: [docs-consistency, validate-web-settings-backup, host-regression-tests]
+    needs: [cpp-format-warning, docs-consistency, validate-web-settings-backup, host-regression-tests]
     uses: ./.github/workflows/esphome-build.yml
     with:
       artifact_suffix: firmware-${{ github.sha }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,16 @@ Use the project helper for normal local checks:
 - `python3 scripts/dev.py validate --config-only`
 - `python3 scripts/dev.py validate --jobs 2`
 
+For C/C++ source files, install `clang-format` locally and use the repository formatting commands:
+
+- Windows: `winget install LLVM.LLVM`
+- macOS: `brew install clang-format`
+- Linux: install `clang-format` with your distribution package manager
+- `npm run check:cpp-format`
+- `npm run fix:cpp-format`
+
+If `clang-format` is installed but not in `PATH`, set `CLANG_FORMAT_BIN` to the executable path before running the npm command. The CI formatting job currently reports formatting differences as warnings, but contributors should run the local fix command before opening or updating a pull request.
+
 For quick iterations, the standalone checks remain useful:
 
 - `python3 scripts/check_style_consistency.py`

--- a/docs/ontwikkelen-op-mac.md
+++ b/docs/ontwikkelen-op-mac.md
@@ -7,7 +7,14 @@ De GitHub Actions blijven op Linux draaien; lokaal gebruik je dezelfde Python- e
 
 1. Clone de repo in je normale home-directory.
 2. Zorg dat Python 3.12 of nieuwer als `python3` beschikbaar is.
-3. Maak de lokale ESPHome-omgeving aan:
+3. Installeer `clang-format` voor lokale C/C++ formattingchecks:
+
+```bash
+brew install clang-format
+clang-format --version
+```
+
+4. Maak de lokale ESPHome-omgeving aan:
 
 ```bash
 python3 scripts/dev.py bootstrap
@@ -25,7 +32,11 @@ Gebruik deze commando's als primaire lokale workflow:
 python3 scripts/dev.py validate
 python3 scripts/dev.py validate --config-only
 python3 scripts/dev.py preview-pages --no-serve
+npm run check:cpp-format
 ```
+
+Gebruik `npm run fix:cpp-format` om C/C++ formatting lokaal toe te passen voordat je een pull request bijwerkt.
+Als Homebrew `clang-format` niet automatisch in `PATH` zet, kun je tijdelijk `CLANG_FORMAT_BIN=/opt/homebrew/bin/clang-format` voor het npm-commando zetten.
 
 De bash-wrappers blijven beschikbaar voor de meest gebruikte taken:
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build:web": "node openquatt/web/build-assets.mjs",
     "build:web:preview": "node openquatt/web/build-assets.mjs --preview",
     "check:docs": "python3 -m unittest discover -s scripts/tests -p 'test_*.py' && python3 scripts/check_docs_consistency.py && node scripts/check_web_docs_sync.mjs",
+    "check:cpp-format": "python3 scripts/cpp_format.py check",
     "check:web": "npm run build:web && node openquatt/web/run-web-tests.mjs && node openquatt/web/check-web-quality.mjs",
+    "fix:cpp-format": "python3 scripts/cpp_format.py fix",
     "smoke:web": "npm run build:web:preview && node openquatt/web/smoke-web.mjs",
     "stats:web": "node openquatt/web/web-stats.mjs"
   },

--- a/scripts/check_cpp_format.sh
+++ b/scripts/check_cpp_format.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v clang-format >/dev/null 2>&1; then
+  echo "clang-format was not found in PATH." >&2
+  echo "Install clang-format and run this check again." >&2
+  exit 2
+fi
+
+mapfile -d '' files < <(git ls-files -z -- '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx')
+
+if (( ${#files[@]} == 0 )); then
+  echo "No C/C++ source files found to check."
+  exit 0
+fi
+
+echo "Checking ${#files[@]} C/C++ files with clang-format..."
+if ! printf '%s\0' "${files[@]}" | xargs -0 -r clang-format --style=file --dry-run --Werror; then
+  echo
+  echo "Formatting differences detected." >&2
+  echo "Run: npm run fix:cpp-format" >&2
+  exit 1
+fi
+
+echo "C/C++ formatting check passed."

--- a/scripts/cpp_format.py
+++ b/scripts/cpp_format.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+PATTERNS = ["*.c", "*.cc", "*.cpp", "*.cxx", "*.h", "*.hh", "*.hpp", "*.hxx"]
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def resolve_clang_format_binary() -> str | None:
+    env_override = os.environ.get("CLANG_FORMAT_BIN", "").strip()
+    if env_override:
+        candidate = Path(env_override).expanduser()
+        if candidate.exists():
+            return str(candidate)
+        return None
+
+    in_path = shutil.which("clang-format")
+    if in_path:
+        return in_path
+
+    if os.name != "nt":
+        return None
+
+    windows_candidates = [
+        Path("C:/Program Files/LLVM/bin/clang-format.exe"),
+        Path("C:/Program Files (x86)/LLVM/bin/clang-format.exe"),
+    ]
+    local_app_data = os.environ.get("LOCALAPPDATA", "").strip()
+    if local_app_data:
+        windows_candidates.extend(
+            [
+                Path(local_app_data) / "Programs" / "LLVM" / "bin" / "clang-format.exe",
+                Path(local_app_data) / "Microsoft" / "WinGet" / "Packages",
+            ]
+        )
+
+    for candidate in windows_candidates:
+        if candidate.is_file():
+            return str(candidate)
+
+    if local_app_data:
+        winget_packages = Path(local_app_data) / "Microsoft" / "WinGet" / "Packages"
+        if winget_packages.is_dir():
+            matches = list(winget_packages.glob("**/clang-format.exe"))
+            if matches:
+                return str(matches[0])
+
+    return None
+
+
+def list_tracked_cpp_files(root: Path) -> list[str]:
+    command = ["git", "ls-files", "--", *PATTERNS]
+    completed = subprocess.run(command, cwd=root, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        message = completed.stderr.strip() or completed.stdout.strip() or "git ls-files failed"
+        raise SystemExit(message)
+    files = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    return files
+
+
+def chunked(items: list[str], size: int) -> list[list[str]]:
+    return [items[index : index + size] for index in range(0, len(items), size)]
+
+
+def run_clang_format(clang_format_bin: str, root: Path, files: list[str], mode: str) -> int:
+    if mode == "check":
+        base_command = [clang_format_bin, "--style=file", "--dry-run", "--Werror"]
+    else:
+        base_command = [clang_format_bin, "--style=file", "-i"]
+
+    max_batch_size = 100
+    overall_return_code = 0
+    for group in chunked(files, max_batch_size):
+        command = [*base_command, *group]
+        completed = subprocess.run(command, cwd=root, check=False)
+        if completed.returncode != 0:
+            overall_return_code = completed.returncode
+
+    return overall_return_code
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check or apply clang-format on tracked C/C++ files.")
+    parser.add_argument("mode", choices=["check", "fix"], help="Use 'check' for verification and 'fix' to rewrite.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root()
+    clang_format_bin = resolve_clang_format_binary()
+    if not clang_format_bin:
+        print("clang-format was not found in PATH.", file=sys.stderr)
+        print("Install clang-format or set CLANG_FORMAT_BIN to its executable path.", file=sys.stderr)
+        return 2
+
+    files = list_tracked_cpp_files(root)
+    if not files:
+        print("No C/C++ source files found.")
+        return 0
+
+    verb = "Checking" if args.mode == "check" else "Formatting"
+    print(f"{verb} {len(files)} C/C++ files with clang-format...")
+    return_code = run_clang_format(clang_format_bin, root, files, args.mode)
+    if return_code != 0:
+        if args.mode == "check":
+            print("Formatting differences detected.", file=sys.stderr)
+            print("Run: npm run fix:cpp-format", file=sys.stderr)
+            return 1
+        return return_code
+
+    if args.mode == "check":
+        print("C/C++ formatting check passed.")
+    else:
+        print("C/C++ formatting updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fix_cpp_format.sh
+++ b/scripts/fix_cpp_format.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v clang-format >/dev/null 2>&1; then
+  echo "clang-format was not found in PATH." >&2
+  echo "Install clang-format and run this command again." >&2
+  exit 2
+fi
+
+mapfile -d '' files < <(git ls-files -z -- '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx')
+
+if (( ${#files[@]} == 0 )); then
+  echo "No C/C++ source files found to format."
+  exit 0
+fi
+
+echo "Formatting ${#files[@]} C/C++ files with clang-format..."
+printf '%s\0' "${files[@]}" | xargs -0 -r clang-format --style=file -i
+echo "C/C++ formatting updated."


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt `.clang-format` en `.clang-format-ignore` toe voor C/C++ formatting volgens Google style-richtlijnen.
- Voegt scripts en npm-commando's toe om C/C++ formatting te controleren en automatisch te herstellen.
- Integreert de formatting-check in CI en documenteert installatie/gebruik in `CONTRIBUTING.md` en `docs/ontwikkelen-op-mac.md`.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Deze PR wijzigt alleen ontwikkeltooling, CI-validatie en documentatie rond C/C++ code formatting.

## Achtergrond

Deze branch introduceert reproduceerbare C/C++ formatting-infrastructuur zodat lokale checks en CI dezelfde clang-format regels gebruiken.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

`CONTRIBUTING.md` en `docs/ontwikkelen-op-mac.md` beschrijven de installatie en het gebruik van de nieuwe formatting-commando's.

## Validatie

- `npm run fix:cpp-format`

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; geen firmware/runtime-wijziging.