### PR TITLE
Explain silent-mode cooling limit

### DIFF
--- a/openquatt/web/css/src/11-settings-climate.css
+++ b/openquatt/web/css/src/11-settings-climate.css
@@ -35,6 +35,35 @@
   overflow-wrap: anywhere;
 }
 
+.oq-settings-cooling-limit-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--oq-settings-warning-border, rgba(234, 88, 12, 0.24));
+  border-radius: 10px;
+  background: var(--oq-theme-surface-1vxv, rgba(255, 247, 237, 0.86));
+  color: var(--oq-helper-soft);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.oq-settings-cooling-limit-warning-icon {
+  display: inline-grid;
+  flex: 0 0 18px;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  border-radius: 50%;
+  background: rgba(234, 88, 12, 0.14);
+  color: var(--oq-helper-accent-deep);
+  font-size: 0.72rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
 .oq-settings-field--cooling-guard-choice .oq-settings-choice-card {
   gap: 8px;
   padding: 14px;

--- a/openquatt/web/js/src/core/config.js
+++ b/openquatt/web/js/src/core/config.js
@@ -1641,6 +1641,7 @@
     "usageTelemetryEnabled",
     "usageTelemetryInstallationId",
     "silentModeOverride",
+    "silentActive",
     "trendHistoryEnabled",
     "trendHistoryFlashEnabled",
     "trendHistoryFlush",

--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -249,6 +249,9 @@ import { fetchWithTimeout } from "./browser-utils.js";
       "coolingMinimumSafeSupplyTemp",
       "coolingSupplyTarget",
       "coolingSupplyError",
+      "silentModeOverride",
+      "silentActive",
+      "silentMax",
       ...COOLING_SETTING_KEYS,
     ],
     integrations: [

--- a/openquatt/web/js/src/settings/controls.js
+++ b/openquatt/web/js/src/settings/controls.js
@@ -461,7 +461,7 @@ export function renderSettingsSliderField(key, title, copy, className = "", opti
   const minLabel = options.minLabel || `${meta.min}${meta.uom || ""}`;
   const maxLabel = options.maxLabel || `${meta.max}${meta.uom || ""}`;
   const valueLabel = options.valueLabel || formatValue(key, value);
-  return renderSettingsFieldCard(key, title, copy, `<label class="oq-helper-slider-field"><div class="oq-helper-slider-meta"><span>${escapeHtml(minLabel)}</span><strong>${escapeHtml(valueLabel)}</strong><span>${escapeHtml(maxLabel)}</span></div><input class="oq-helper-range" type="range" data-oq-field="${escapeHtml(key)}" min="${meta.min}" max="${meta.max}" step="${meta.step}" value="${value}" ${state.loadingEntities ? "disabled" : ""}></label>`, className);
+  return renderSettingsFieldCard(key, title, copy, `<label class="oq-helper-slider-field"><div class="oq-helper-slider-meta"><span>${escapeHtml(minLabel)}</span><strong>${escapeHtml(valueLabel)}</strong><span>${escapeHtml(maxLabel)}</span></div><input class="oq-helper-range" type="range" data-oq-field="${escapeHtml(key)}" min="${meta.min}" max="${meta.max}" step="${meta.step}" value="${value}" ${state.loadingEntities ? "disabled" : ""}></label>`, className, options.footerMarkup || "");
 }
 
 export function renderSettingsMiniNumberField(key, title, copy, options = {}) {

--- a/openquatt/web/js/src/settings/cooling.js
+++ b/openquatt/web/js/src/settings/cooling.js
@@ -1,4 +1,4 @@
-import { getEntityStateText, hasEntity, isEntityActive } from "../core/app-shared.js";
+import { getEntityNumericValue, getEntityStateText, hasEntity, isEntityActive } from "../core/app-shared.js";
 import { formatValue } from "../core/entity-store.js";
 import { formatSettingsOptionLabel, renderSettingsAdvancedDisclosure, renderSettingsFieldCard, renderSettingsNumberField, renderSettingsOptionCardsField, renderSettingsSection, renderSettingsSliderField, renderSettingsSwitchField } from "./controls.js";
 import { escapeHtml } from "../core/html.js";
@@ -40,6 +40,20 @@ import { escapeHtml } from "../core/html.js";
     return labels[value] || value;
   }
 
+  function renderCoolingSilentLimitWarning() {
+    const coolingDemandMax = getEntityNumericValue("coolingDemandMax");
+    const silentMax = getEntityNumericValue("silentMax");
+    const silentModeOverride = getEntityStateText("silentModeOverride", "").trim().toLowerCase();
+    if (!hasEntity("silentMax") || !Number.isFinite(coolingDemandMax) || !Number.isFinite(silentMax) || coolingDemandMax <= silentMax || silentModeOverride === "off") {
+      return "";
+    }
+
+    const prefix = isEntityActive("silentActive")
+      ? "Stille modus is nu actief. Koelen wordt"
+      : "Tijdens stille modus wordt koelen";
+    return `<p class="oq-settings-cooling-limit-warning"><span class="oq-settings-cooling-limit-warning-icon" aria-hidden="true">!</span><span>${prefix} begrensd op niveau ${escapeHtml(formatValue("silentMax"))}. Deze maximale koelsterkte wordt dan niet volledig gebruikt.</span></p>`;
+  }
+
   export function renderSettingsCoolingSection() {
     const roomRequestRequired = !hasEntity("coolingRoomRequestRequired") || isEntityActive("coolingRoomRequestRequired");
     const tuningFields = [
@@ -48,6 +62,7 @@ import { escapeHtml } from "../core/html.js";
         minLabel: "Rustig",
         maxLabel: "Krachtig",
         valueLabel: `${formatValue("coolingDemandMax")} max`,
+        footerMarkup: renderCoolingSilentLimitWarning(),
       }),
       renderSettingsNumberField("coolingRestartDelta", "Herstartmarge watertemperatuur", "Na het bereiken van het koel-aanvoerdoel start de watercyclus pas opnieuw zodra de aanvoer deze marge boven het doel ligt."),
       renderSettingsNumberField("coolingSafetyMargin", "Dauwpunt veiligheidsmarge", "Extra marge boven het geselecteerde dauwpunt voor de minimale veilige watertemperatuur."),

--- a/openquatt/web/tests/settings-regulation.test.mjs
+++ b/openquatt/web/tests/settings-regulation.test.mjs
@@ -118,6 +118,51 @@ test("nieuwe installatie- en service-entiteiten worden bij het juiste scherm gel
   assert.ok(!SETTINGS_GROUP_KEY_MAP.service.includes("resetCumulativeEnergyCounters"));
 });
 
+test("koelsterkte licht de lagere limiet tijdens stille modus toe", () => {
+  const baseEntities = {
+    coolingDemandMax: numberEntity(8, "", { min_value: 1, max_value: 10, step: 1 }),
+    silentMax: numberEntity(6, "", { min_value: 1, max_value: 10, step: 1 }),
+    silentModeOverride: { value: "Schedule", state: "Schedule" },
+    silentActive: { value: false, state: "OFF" },
+  };
+
+  resetSettingsState(baseEntities);
+  let markup = renderSettingsCoolingSection();
+  assert.match(markup, /Tijdens stille modus wordt koelen begrensd op niveau 6/);
+  assert.match(markup, /Deze maximale koelsterkte wordt dan niet volledig gebruikt/);
+
+  resetSettingsState({
+    ...baseEntities,
+    silentActive: { value: true, state: "ON" },
+  });
+  markup = renderSettingsCoolingSection();
+  assert.match(markup, /Stille modus is nu actief\. Koelen wordt begrensd op niveau 6/);
+
+  resetSettingsState({
+    ...baseEntities,
+    silentModeOverride: { value: "Off", state: "Off" },
+  });
+  assert.doesNotMatch(renderSettingsCoolingSection(), /oq-settings-cooling-limit-warning/);
+
+  resetSettingsState({
+    ...baseEntities,
+    coolingDemandMax: numberEntity(6, "", { min_value: 1, max_value: 10, step: 1 }),
+  });
+  assert.doesNotMatch(renderSettingsCoolingSection(), /oq-settings-cooling-limit-warning/);
+
+  resetSettingsState({
+    coolingDemandMax: baseEntities.coolingDemandMax,
+    silentModeOverride: baseEntities.silentModeOverride,
+  });
+  assert.doesNotMatch(renderSettingsCoolingSection(), /oq-settings-cooling-limit-warning/);
+});
+
+test("koelscherm laadt de stille-moduslimiet en actuele status", () => {
+  assert.ok(SETTINGS_GROUP_KEY_MAP.cooling.includes("silentModeOverride"));
+  assert.ok(SETTINGS_GROUP_KEY_MAP.cooling.includes("silentActive"));
+  assert.ok(SETTINGS_GROUP_KEY_MAP.cooling.includes("silentMax"));
+});
+
 test("Service toont runtime, draaiurenreset en de bevestigde tijdelijke override", () => {
   resetSettingsState({
     controlModeOverride: {


### PR DESCRIPTION
# Wat verandert deze PR?

- Toont onder **Maximale koelsterkte** een compacte waarschuwing wanneer `coolingDemandMax > silentMax` en Silent Mode Override niet expliciet `Off` is.
- Gebruikt actuele tekst wanneer stille modus actief is en schema-tekst wanneer deze later kan ingaan; de instelling blijft volledig vrij bewerkbaar.
- Hydrateert en volgt `silentMax`, `silentModeOverride` en `silentActive` op het koelscherm zodat de hint actueel blijft.

<img width="662" height="205" alt="image" src="https://github.com/user-attachments/assets/307dcb43-9d88-4bf0-98cd-b3e556eca25b" />


## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de web-UI-uitleg en benodigde entity-hydratie wijzigen. Er is geen blokkade, auto-aanpassing of firmware/controlwijziging.

## Achtergrond

Een hogere maximale koelsterkte kan tijdens stille modus effectief door `silentMax` worden begrensd. De inline hint maakt dit zichtbaar zonder de gekozen koelsterkte te wijzigen.

De volledige diff is gecontroleerd op conditielogica, ontbrekende/legacy entity-state, renderverversing, gedeeld slidergedrag en desktop-layout. Ontbrekende `silentMax` toont bewust geen onvolledige waarschuwing.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De wijziging is contextuele uitleg direct onder de betreffende instelling; bestaande documentatie en configuratiecontracten wijzigen niet.

## Validatie

- `npm run check:web` — geslaagd; webbuild, 146 tests en quality/bundle-budgetchecks.
- Lokale demo visueel gecontroleerd met `coolingDemandMax = 8`, `silentMax = 6` en schema-modus.
- Regressietests dekken schema actief/inactief, expliciet `Off`, gelijke limieten, ontbrekende `silentMax` en koelschermhydratie.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; dit betreft uitsluitend de embedded web-UI.