### PR TITLE
Support safe test firmware builds for fork PRs

### DIFF
--- a/.github/workflows/esphome-build.yml
+++ b/.github/workflows/esphome-build.yml
@@ -6,6 +6,18 @@ on:
       artifact_suffix:
         required: true
         type: string
+      checkout_ref:
+        required: false
+        type: string
+        default: ""
+      checkout_repository:
+        required: false
+        type: string
+        default: ""
+      checkout_persist_credentials:
+        required: false
+        type: boolean
+        default: true
       include_firmware_bin:
         required: false
         type: boolean
@@ -35,6 +47,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_ref }}
+          persist-credentials: ${{ inputs.checkout_persist_credentials }}
 
       - name: Build target matrix
         id: targets
@@ -53,6 +69,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_ref }}
+          persist-credentials: ${{ inputs.checkout_persist_credentials }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-test-firmware-publish.yml
+++ b/.github/workflows/pr-test-firmware-publish.yml
@@ -1,0 +1,295 @@
+name: PR Test Firmware Publish
+
+on:
+  workflow_run:
+    workflows: [PR Test Firmware Build]
+    types: [completed]
+  pull_request_target:
+    types: [unlabeled, closed]
+
+permissions: {}
+
+jobs:
+  validate-pr-test-build:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success'
+      }}
+    permissions:
+      actions: read
+      pull-requests: read
+    outputs:
+      base_sha: ${{ steps.gate.outputs.base_sha }}
+      head_sha: ${{ steps.gate.outputs.head_sha }}
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      should_publish: ${{ steps.metadata.outputs.found }}
+      short_sha: ${{ steps.gate.outputs.short_sha }}
+      version: ${{ steps.gate.outputs.version }}
+    steps:
+      - name: Find build metadata artifact
+        id: metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          ARTIFACT_COUNT="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}/artifacts?per_page=100" \
+            --jq '[.artifacts[] | select(.name == "pr-test-firmware-meta")] | length')"
+          if [[ "${ARTIFACT_COUNT}" == "0" ]]; then
+            echo "No test-firmware metadata found; publication was not requested."
+            echo "found=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [[ "${ARTIFACT_COUNT}" != "1" ]]; then
+            echo "Expected one test-firmware metadata artifact; found ${ARTIFACT_COUNT}." >&2
+            exit 1
+          fi
+          echo "found=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Download build metadata
+        if: ${{ steps.metadata.outputs.found == 'true' }}
+        uses: actions/download-artifact@v7
+        with:
+          name: pr-test-firmware-meta
+          path: ${{ runner.temp }}/metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate build and current PR state
+        if: ${{ steps.metadata.outputs.found == 'true' }}
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          META_FILE: ${{ runner.temp }}/metadata/pr-test-firmware-meta.json
+          SOURCE_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          SOURCE_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          SOURCE_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          SOURCE_WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
+        run: |
+          if [[ ! -f "${META_FILE}" ]]; then
+            echo "Missing build metadata." >&2
+            exit 1
+          fi
+
+          PR_NUMBER="$(jq -er '.pr_number | select(type == "number" and . > 0 and floor == .)' "${META_FILE}")"
+          HEAD_SHA="$(jq -er '.head_sha | select(type == "string")' "${META_FILE}")"
+          HEAD_REPOSITORY="$(jq -er '.head_repository | select(type == "string")' "${META_FILE}")"
+          BASE_VERSION="$(jq -er '.base_version | select(type == "string")' "${META_FILE}")"
+          BUILD_RUN_NUMBER="$(jq -er '.run_number | select(type == "number" and . > 0 and floor == .)' "${META_FILE}")"
+          VERSION="$(jq -er '.version | select(type == "string")' "${META_FILE}")"
+
+          if [[ "${SOURCE_WORKFLOW_PATH}" != ".github/workflows/pr-test-firmware.yml" &&
+                "${SOURCE_WORKFLOW_PATH}" != ".github/workflows/pr-test-firmware.yml@"* ]]; then
+            echo "Unexpected triggering workflow path: ${SOURCE_WORKFLOW_PATH}" >&2
+            exit 1
+          fi
+          if [[ ! "${SOURCE_HEAD_SHA}" =~ ^[0-9a-f]{40}$ || "${HEAD_SHA}" != "${SOURCE_HEAD_SHA}" ]]; then
+            echo "Metadata head SHA does not match the triggering workflow." >&2
+            exit 1
+          fi
+          if [[ ! "${SOURCE_HEAD_REPOSITORY}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ||
+                "${HEAD_REPOSITORY}" != "${SOURCE_HEAD_REPOSITORY}" ]]; then
+            echo "Metadata head repository does not match the triggering workflow." >&2
+            exit 1
+          fi
+          if [[ ! "${BASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "Metadata contains an invalid base version." >&2
+            exit 1
+          fi
+          if [[ "${BUILD_RUN_NUMBER}" != "${SOURCE_RUN_NUMBER}" ]]; then
+            echo "Metadata run number does not match the triggering workflow." >&2
+            exit 1
+          fi
+
+          SHORT_SHA="${HEAD_SHA::7}"
+          EXPECTED_VERSION="${BASE_VERSION}-pr.${PR_NUMBER}.${SOURCE_RUN_NUMBER}+${SHORT_SHA}"
+          if [[ "${VERSION}" != "${EXPECTED_VERSION}" ]]; then
+            echo "Metadata version does not match the triggering workflow." >&2
+            exit 1
+          fi
+
+          PR_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          BASE_SHA="$(jq -er '.base.sha | select(type == "string")' <<< "${PR_JSON}")"
+          if [[ ! "${BASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "PR #${PR_NUMBER} has an invalid base SHA." >&2
+            exit 1
+          fi
+          if [[ "$(jq -r '.state' <<< "${PR_JSON}")" != "open" ]]; then
+            echo "PR #${PR_NUMBER} is no longer open." >&2
+            exit 1
+          fi
+          if ! jq -e '.labels | any(.name == "test-firmware")' <<< "${PR_JSON}" >/dev/null; then
+            echo "PR #${PR_NUMBER} no longer has the test-firmware label." >&2
+            exit 1
+          fi
+          if [[ "$(jq -r '.head.sha' <<< "${PR_JSON}")" != "${HEAD_SHA}" ]]; then
+            echo "PR #${PR_NUMBER} has moved since this firmware was built." >&2
+            exit 1
+          fi
+          if [[ "$(jq -r '.head.repo.full_name' <<< "${PR_JSON}")" != "${HEAD_REPOSITORY}" ]]; then
+            echo "PR #${PR_NUMBER} head repository does not match the build metadata." >&2
+            exit 1
+          fi
+          if [[ "$(jq -r '.base.repo.full_name' <<< "${PR_JSON}")" != "${GITHUB_REPOSITORY}" ]]; then
+            echo "PR #${PR_NUMBER} does not target this repository." >&2
+            exit 1
+          fi
+
+          echo "base_sha=${BASE_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "head_sha=${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+          echo "short_sha=${SHORT_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+  publish-pr-test-release:
+    runs-on: ubuntu-latest
+    needs: validate-pr-test-build
+    if: ${{ needs.validate-pr-test-build.outputs.should_publish == 'true' }}
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: read
+    concurrency:
+      group: pr-test-firmware-${{ needs.validate-pr-test-build.outputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout trusted base code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate-pr-test-build.outputs.base_sha }}
+          fetch-depth: 0
+
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: openquatt-*-pr-${{ needs.validate-pr-test-build.outputs.pr_number }}
+          path: ${{ runner.temp }}/firmware
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Prepare PR test firmware assets
+        env:
+          ARTIFACT_ROOT: ${{ runner.temp }}/firmware
+          HEAD_SHA: ${{ needs.validate-pr-test-build.outputs.head_sha }}
+          PR_NUMBER: ${{ needs.validate-pr-test-build.outputs.pr_number }}
+          VERSION: ${{ needs.validate-pr-test-build.outputs.version }}
+        run: |
+          TAG="pr-${PR_NUMBER}"
+          BASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG}"
+          python3 scripts/build_targets.py prepare-pr-test-assets \
+            "${PR_NUMBER}" "${VERSION}" "${HEAD_SHA}" "${BASE_URL}" "${RELEASE_URL}" \
+            --artifact-root "${ARTIFACT_ROOT}"
+
+      - name: Publish current PR test release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.validate-pr-test-build.outputs.head_sha }}
+          PR_NUMBER: ${{ needs.validate-pr-test-build.outputs.pr_number }}
+          SHORT_SHA: ${{ needs.validate-pr-test-build.outputs.short_sha }}
+          VERSION: ${{ needs.validate-pr-test-build.outputs.version }}
+        run: |
+          PR_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          if [[ "$(jq -r '.state' <<< "${PR_JSON}")" != "open" ]] || \
+             ! jq -e '.labels | any(.name == "test-firmware")' <<< "${PR_JSON}" >/dev/null || \
+             [[ "$(jq -r '.head.sha' <<< "${PR_JSON}")" != "${HEAD_SHA}" ]]; then
+            echo "PR publication gate changed while assets were prepared." >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"
+          if [[ "$(git rev-parse FETCH_HEAD)" != "${HEAD_SHA}" ]]; then
+            echo "Fetched PR head does not match the built commit." >&2
+            exit 1
+          fi
+
+          TAG="pr-${PR_NUMBER}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if gh release view "${TAG}" >/dev/null 2>release-view.err; then
+            gh release delete "${TAG}" --yes --cleanup-tag
+          elif ! grep -qi "not found" release-view.err; then
+            cat release-view.err >&2
+            exit 1
+          fi
+
+          PUBLISH_COMPLETE=false
+          cleanup_partial_publish() {
+            if [[ "${PUBLISH_COMPLETE}" != "true" ]]; then
+              echo "Removing incomplete PR test release ${TAG}." >&2
+              gh release delete "${TAG}" --yes --cleanup-tag >/dev/null 2>&1 ||
+                git push origin ":refs/tags/${TAG}" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup_partial_publish EXIT
+
+          git tag -fa "${TAG}" -m "PR ${PR_NUMBER} test firmware" "${HEAD_SHA}"
+          git push origin "refs/tags/${TAG}" --force
+
+          NOTES=$(cat <<EOF
+          Mutable test-firmware release for PR #${PR_NUMBER}.
+
+          PR: https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}
+          Commit: \`${HEAD_SHA}\`
+          Version: \`${VERSION}\`
+
+          Add or keep the \`test-firmware\` label on the PR to rebuild this release after new commits.
+          EOF
+          )
+
+          gh release create "${TAG}" \
+            --title "PR #${PR_NUMBER} Test Firmware (${SHORT_SHA})" \
+            --notes "${NOTES}" \
+            --prerelease
+
+          gh release upload "${TAG}" \
+            dist/*.firmware.ota.bin \
+            dist/*.firmware.ota.bin.md5 \
+            dist/pr-firmware.json \
+            --clobber
+
+          EXPECTED_ASSET_COUNT="$(find dist -maxdepth 1 -type f \
+            \( -name '*.firmware.ota.bin' -o -name '*.firmware.ota.bin.md5' -o -name 'pr-firmware.json' \) \
+            | wc -l | tr -d ' ')"
+          PUBLISHED_ASSET_COUNT="$(gh release view "${TAG}" --json assets --jq '.assets | length')"
+          if [[ "${PUBLISHED_ASSET_COUNT}" != "${EXPECTED_ASSET_COUNT}" ]]; then
+            echo "Published ${PUBLISHED_ASSET_COUNT} assets; expected ${EXPECTED_ASSET_COUNT}." >&2
+            exit 1
+          fi
+
+          PUBLISH_COMPLETE=true
+
+  delete-pr-test-release:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name == 'pull_request_target' &&
+        (
+          github.event.action == 'closed' ||
+          (github.event.action == 'unlabeled' && github.event.label.name == 'test-firmware')
+        )
+      }}
+    permissions:
+      contents: write
+    concurrency:
+      group: pr-test-firmware-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Delete PR test release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          TAG="pr-${PR_NUMBER}"
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>release-view.err; then
+            gh release delete "${TAG}" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag
+          elif grep -qi "not found" release-view.err; then
+            echo "No PR test release ${TAG} found."
+          else
+            cat release-view.err >&2
+            exit 1
+          fi

--- a/.github/workflows/pr-test-firmware.yml
+++ b/.github/workflows/pr-test-firmware.yml
@@ -1,11 +1,11 @@
-name: PR Test Firmware
+name: PR Test Firmware Build
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize, closed]
+    types: [opened, reopened, labeled, synchronize]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: pr-test-firmware-${{ github.event.pull_request.number }}
@@ -14,148 +14,67 @@ concurrency:
 jobs:
   compute-meta:
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.action != 'closed' &&
-        github.event.action != 'unlabeled' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(github.event.pull_request.labels.*.name, 'test-firmware')
-      }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test-firmware') }}
     outputs:
       version: ${{ steps.pr_meta.outputs.version }}
-      short_sha: ${{ steps.pr_meta.outputs.short_sha }}
     steps:
-      - name: Checkout
+      - name: Checkout PR head
         uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
-      - name: Compute PR test version
+      - name: Compute PR test metadata
         id: pr_meta
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           BASE_VERSION="$(awk -F'"' '/^project_version: / { print $2 }' openquatt/oq_substitutions_common.yaml)"
+          if [[ ! "${BASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "Unexpected project_version: ${BASE_VERSION}" >&2
+            exit 1
+          fi
+
           SHORT_SHA="${HEAD_SHA::7}"
           PR_VERSION="${BASE_VERSION}-pr.${PR_NUMBER}.${GITHUB_RUN_NUMBER}+${SHORT_SHA}"
-          echo "version=${PR_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "version=${PR_VERSION}" >> "${GITHUB_OUTPUT}"
+
+          jq -n \
+            --arg base_version "${BASE_VERSION}" \
+            --arg head_repository "${HEAD_REPOSITORY}" \
+            --arg head_sha "${HEAD_SHA}" \
+            --argjson pr_number "${PR_NUMBER}" \
+            --argjson run_number "${GITHUB_RUN_NUMBER}" \
+            --arg version "${PR_VERSION}" \
+            '{
+              base_version: $base_version,
+              head_repository: $head_repository,
+              head_sha: $head_sha,
+              pr_number: $pr_number,
+              run_number: $run_number,
+              version: $version
+            }' > "${RUNNER_TEMP}/pr-test-firmware-meta.json"
+
+      - name: Upload build metadata
+        uses: actions/upload-artifact@v6
+        with:
+          name: pr-test-firmware-meta
+          if-no-files-found: error
+          retention-days: 1
+          path: ${{ runner.temp }}/pr-test-firmware-meta.json
 
   compile-profiles:
     needs: compute-meta
+    permissions:
+      contents: read
     uses: ./.github/workflows/esphome-build.yml
     with:
       artifact_suffix: pr-${{ github.event.pull_request.number }}
+      checkout_persist_credentials: false
+      checkout_ref: ${{ github.event.pull_request.head.sha }}
+      checkout_repository: ${{ github.event.pull_request.head.repo.full_name }}
       project_version: ${{ needs.compute-meta.outputs.version }}
       include_factory_bin: false
-
-  publish-pr-test-release:
-    runs-on: ubuntu-latest
-    needs: [compute-meta, compile-profiles]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Download firmware artifacts
-        uses: actions/download-artifact@v7
-        with:
-          pattern: openquatt-*-pr-${{ github.event.pull_request.number }}
-          path: dist
-
-      - name: Prepare PR test firmware assets
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          VERSION: ${{ needs.compute-meta.outputs.version }}
-        run: |
-          TAG="pr-${PR_NUMBER}"
-          REPO="${GITHUB_REPOSITORY}"
-          BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
-          RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
-          python3 scripts/build_targets.py prepare-pr-test-assets "${PR_NUMBER}" "${VERSION}" "${HEAD_SHA}" "${BASE_URL}" "${RELEASE_URL}"
-
-      - name: Move PR test release tag
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          TAG="pr-${PR_NUMBER}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -fa "${TAG}" -m "PR ${PR_NUMBER} test firmware" "${HEAD_SHA}"
-          git push origin "refs/tags/${TAG}" --force
-
-      - name: Create or update PR test release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          SHORT_SHA: ${{ needs.compute-meta.outputs.short_sha }}
-          VERSION: ${{ needs.compute-meta.outputs.version }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          TAG="pr-${PR_NUMBER}"
-          NOTES=$(cat <<EOF
-          Mutable test-firmware release for PR #${PR_NUMBER}.
-
-          PR: ${PR_URL}
-          Commit: \`${HEAD_SHA}\`
-          Version: \`${VERSION}\`
-
-          Add or keep the \`test-firmware\` label on the PR to rebuild this release after new commits.
-          EOF
-          )
-
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            gh release edit "${TAG}" \
-              --title "PR #${PR_NUMBER} Test Firmware (${SHORT_SHA})" \
-              --notes "$NOTES" \
-              --prerelease
-          else
-            gh release create "${TAG}" \
-              --title "PR #${PR_NUMBER} Test Firmware (${SHORT_SHA})" \
-              --notes "$NOTES" \
-              --prerelease
-          fi
-
-      - name: Upload PR test firmware assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh release upload "pr-${PR_NUMBER}" \
-            dist/*.firmware.ota.bin \
-            dist/*.firmware.ota.bin.md5 \
-            dist/pr-firmware.json \
-            --clobber
-
-  delete-pr-test-release:
-    runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        (
-          (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'test-firmware')) ||
-          (github.event.action == 'unlabeled' && github.event.label.name == 'test-firmware')
-        )
-      }}
-    steps:
-      - name: Delete PR test release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          TAG="pr-${PR_NUMBER}"
-          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>release-view.err; then
-            gh release delete "${TAG}" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag
-          elif grep -qi "not found" release-view.err; then
-            echo "No PR test release ${TAG} found."
-          else
-            cat release-view.err >&2
-            exit 1
-          fi

--- a/scripts/build_targets.py
+++ b/scripts/build_targets.py
@@ -80,9 +80,13 @@ def md5sum(path: Path) -> str:
 def find_artifact_dir(dist_dir: Path, artifact_name: str) -> Path:
     direct = dist_dir / artifact_name
     if direct.is_dir():
+        if direct.is_symlink():
+            raise SystemExit(f"Artifact directory must not be a symlink: {direct}")
         return direct
 
-    matches = sorted(path for path in dist_dir.glob(f"{artifact_name}-*") if path.is_dir())
+    matches = sorted(
+        path for path in dist_dir.glob(f"{artifact_name}-*") if path.is_dir() and not path.is_symlink()
+    )
     if len(matches) == 1:
         return matches[0]
     if not matches:
@@ -130,17 +134,25 @@ def prepare_release_assets(version: str, base_url: str, release_url: str) -> Non
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
 
-def prepare_pr_test_assets(pr_number: str, version: str, head_sha: str, base_url: str, release_url: str) -> None:
+def prepare_pr_test_assets(
+    pr_number: str,
+    version: str,
+    head_sha: str,
+    base_url: str,
+    release_url: str,
+    artifact_root: Path | None = None,
+) -> None:
     dist_dir = REPO_ROOT / "dist"
     dist_dir.mkdir(parents=True, exist_ok=True)
+    artifact_root = artifact_root or dist_dir
     short_sha = head_sha[:7] if head_sha else ""
     assets: list[dict[str, str]] = []
 
     for target in filter_targets(load_targets(), "enabled"):
         artifact_name = target["artifact_name"]
-        artifact_dir = find_artifact_dir(dist_dir, artifact_name)
+        artifact_dir = find_artifact_dir(artifact_root, artifact_name)
         ota_source = artifact_dir / "firmware.ota.bin"
-        if not ota_source.is_file():
+        if ota_source.is_symlink() or not ota_source.is_file():
             raise SystemExit(f"Artifact {artifact_name} is missing firmware.ota.bin")
 
         ota_name = f"{artifact_name}.firmware.ota.bin"
@@ -200,7 +212,14 @@ def command_prepare_release_assets(args: argparse.Namespace) -> int:
 
 
 def command_prepare_pr_test_assets(args: argparse.Namespace) -> int:
-    prepare_pr_test_assets(args.pr_number, args.version, args.head_sha, args.base_url, args.release_url)
+    prepare_pr_test_assets(
+        args.pr_number,
+        args.version,
+        args.head_sha,
+        args.base_url,
+        args.release_url,
+        artifact_root=args.artifact_root,
+    )
     return 0
 
 
@@ -240,6 +259,7 @@ def create_parser() -> argparse.ArgumentParser:
     pr_prepare_parser.add_argument("head_sha")
     pr_prepare_parser.add_argument("base_url")
     pr_prepare_parser.add_argument("release_url")
+    pr_prepare_parser.add_argument("--artifact-root", type=Path)
     pr_prepare_parser.set_defaults(func=command_prepare_pr_test_assets)
 
     return parser

--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+from scripts import build_targets
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILD_WORKFLOW = (ROOT / ".github/workflows/pr-test-firmware.yml").read_text(encoding="utf-8")
+PUBLISH_WORKFLOW = (ROOT / ".github/workflows/pr-test-firmware-publish.yml").read_text(encoding="utf-8")
+REUSABLE_BUILD_WORKFLOW = (ROOT / ".github/workflows/esphome-build.yml").read_text(encoding="utf-8")
+
+
+class PrTestFirmwareWorkflowTests(unittest.TestCase):
+    def test_untrusted_build_has_read_only_repository_access(self) -> None:
+        self.assertIn("permissions:\n  contents: read", BUILD_WORKFLOW)
+        self.assertNotIn("contents: write", BUILD_WORKFLOW)
+        self.assertIn("persist-credentials: false", BUILD_WORKFLOW)
+        self.assertNotIn("github.event.pull_request.head.repo.full_name == github.repository", BUILD_WORKFLOW)
+
+    def test_pr_head_is_explicit_for_every_reusable_build_checkout(self) -> None:
+        self.assertIn("checkout_ref: ${{ github.event.pull_request.head.sha }}", BUILD_WORKFLOW)
+        self.assertIn(
+            "checkout_repository: ${{ github.event.pull_request.head.repo.full_name }}",
+            BUILD_WORKFLOW,
+        )
+        self.assertEqual(2, REUSABLE_BUILD_WORKFLOW.count("ref: ${{ inputs.checkout_ref }}"))
+        self.assertEqual(
+            2,
+            REUSABLE_BUILD_WORKFLOW.count(
+                "repository: ${{ inputs.checkout_repository || github.repository }}"
+            ),
+        )
+
+    def test_privileged_workflow_revalidates_before_publishing(self) -> None:
+        self.assertIn("workflow_run:", PUBLISH_WORKFLOW)
+        self.assertIn("pull_request_target:", PUBLISH_WORKFLOW)
+        self.assertIn("run-id: ${{ github.event.workflow_run.id }}", PUBLISH_WORKFLOW)
+        self.assertIn("path: ${{ runner.temp }}/firmware", PUBLISH_WORKFLOW)
+        self.assertIn("should_publish: ${{ steps.metadata.outputs.found }}", PUBLISH_WORKFLOW)
+        self.assertGreaterEqual(PUBLISH_WORKFLOW.count(".head.sha"), 2)
+        self.assertGreaterEqual(PUBLISH_WORKFLOW.count('any(.name == "test-firmware")'), 2)
+        self.assertNotIn("github.event.pull_request.head.sha", PUBLISH_WORKFLOW)
+        self.assertIn(
+            "group: pr-test-firmware-${{ needs.validate-pr-test-build.outputs.pr_number }}\n"
+            "      cancel-in-progress: false",
+            PUBLISH_WORKFLOW,
+        )
+
+    def test_artifact_root_option_is_available(self) -> None:
+        args = build_targets.create_parser().parse_args(
+            [
+                "prepare-pr-test-assets",
+                "423",
+                "v1.2.3-pr.423.1+1234567",
+                "1234567890abcdef1234567890abcdef12345678",
+                "https://example.invalid/download",
+                "https://example.invalid/release",
+                "--artifact-root",
+                "/tmp/firmware",
+            ]
+        )
+
+        self.assertEqual(Path("/tmp/firmware"), args.artifact_root)
+
+    def test_symlinked_artifact_directory_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            real_artifact = root / "real"
+            real_artifact.mkdir()
+            (root / "openquatt-test").symlink_to(real_artifact, target_is_directory=True)
+
+            with self.assertRaisesRegex(SystemExit, "must not be a symlink"):
+                build_targets.find_artifact_dir(root, "openquatt-test")
+
+    def test_pr_assets_are_normalized_from_external_artifact_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            repo_root = temp_root / "repo"
+            artifact_root = temp_root / "artifacts"
+            artifact_dir = artifact_root / "openquatt-test-pr-423"
+            artifact_dir.mkdir(parents=True)
+            repo_root.mkdir()
+            (artifact_dir / "firmware.ota.bin").write_bytes(b"firmware")
+
+            targets_file = repo_root / "build_targets.yaml"
+            targets_file.write_text(
+                """targets:
+  - id: test
+    status: enabled
+    artifact_name: openquatt-test
+    hardware: test-hardware
+    topology: single
+    connection: wifi
+    display_name: Test target
+""",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(build_targets, "REPO_ROOT", repo_root),
+                mock.patch.object(build_targets, "TARGETS_FILE", targets_file),
+            ):
+                build_targets.prepare_pr_test_assets(
+                    "423",
+                    "v1.2.3-pr.423.1+1234567",
+                    "1234567890abcdef1234567890abcdef12345678",
+                    "https://example.invalid/download",
+                    "https://example.invalid/release",
+                    artifact_root=artifact_root,
+                )
+
+            self.assertEqual(b"firmware", (repo_root / "dist/openquatt-test.firmware.ota.bin").read_bytes())
+            self.assertTrue((repo_root / "dist/openquatt-test.firmware.ota.bin.md5").is_file())
+            self.assertTrue((repo_root / "dist/pr-firmware.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Splitst PR-testfirmware in een read-only `pull_request`-build en een privileged `workflow_run`-publisher.
- Ondersteunt fork-PR's door exact de head-repository en head-SHA te bouwen zonder credentials in de checkout achter te laten.
- Valideert bronrun, PR-status, `test-firmware`-label en actuele head-SHA vóór publicatie; cleanup gebruikt een beperkte `pull_request_target`-job.

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alle wijzigingen zijn beperkt tot GitHub Actions, release-assetvoorbereiding en gerichte contracttests. Firmware-runtimegedrag verandert niet.

## Achtergrond

Implementeert #423.

Fork-code krijgt uitsluitend een read-only token en geen persisted checkout-credentials. De publisher draait vanuit vertrouwde base-repositorycode, downloadt artifacts uit exact de bronrun en bindt aangeleverde metadata aan de door GitHub geleverde workflow-SHA en head-repository. Publicatie en cleanup delen een PR-specifieke concurrencygroep. Een mislukte of geannuleerde publicatie verwijdert een gedeeltelijke release zodat de stabiele `pr-<nummer>`-tag niet half bijgewerkt achterblijft.

De rollout naar de default branch is afgerond via [#436](https://github.com/OpenQuatt/OpenQuatt/pull/436) (publisher-bootstrap) en [#439](https://github.com/OpenQuatt/OpenQuatt/pull/439) (activatie van de bronworkflow en bijbehorende tooling). Een echte fork-PR is daarna end-to-end gevalideerd in [#438](https://github.com/OpenQuatt/OpenQuatt/pull/438).

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit wijzigt alleen de interne CI/releaseflow; installatie, configuratie en firmwarebediening blijven gelijk.

## Validatie

- `python3 -m unittest discover -s scripts/tests` — 27 tests geslaagd.
- `actionlint -color` (v1.7.12) — alle workflows geldig.
- Ruby YAML-parse van de drie gewijzigde workflows — geslaagd.
- `python3 -m py_compile scripts/build_targets.py scripts/tests/test_pr_test_firmware_workflows.py` — geslaagd.
- `git diff --check` — geslaagd.
- Volledige diff tegen `origin/dev` afzonderlijk beoordeeld op permissions, artifact trust, SHA/label/status-gates, retries, concurrency, partial publication en fork/same-repository compatibility.
- Reguliere GitHub CI-run #1432 — alle checks en alle acht firmwareprofielen geslaagd; geen lokale firmwarecompile uitgevoerd.
- Echte fork-PR [#438](https://github.com/OpenQuatt/OpenQuatt/pull/438) vanuit `jeroen85/OpenQuatt-fork-test`: `PR Test Firmware Build` run #679 slaagde voor alle acht profielen; metadata bevatte de juiste fork-repository, head-SHA `344f501b1c542dbdcdd8865da5d2e99337d33227`, runnummer en versie.
- [Publisher-run #31886238547](https://github.com/OpenQuatt/OpenQuatt/actions/runs/31886238547) — geslaagd; prerelease `pr-438` bevatte acht OTA-bestanden, acht MD5-bestanden en `pr-firmware.json`. De annotated tag wees naar exact de fork-SHA.
- [Unlabel-cleanup #31886305207](https://github.com/OpenQuatt/OpenQuatt/actions/runs/31886305207) — geslaagd; release en tag waren daarna beide verwijderd.
- [Close-cleanup #31886340508](https://github.com/OpenQuatt/OpenQuatt/actions/runs/31886340508) — geslaagd en idempotent toen de test-PR zonder merge werd gesloten.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; uitsluitend CI/tooling.
