### PR TITLE
Activate fork PR test firmware on main

### DIFF
--- a/.github/workflows/esphome-build.yml
+++ b/.github/workflows/esphome-build.yml
@@ -6,6 +6,18 @@ on:
       artifact_suffix:
         required: true
         type: string
+      checkout_ref:
+        required: false
+        type: string
+        default: ""
+      checkout_repository:
+        required: false
+        type: string
+        default: ""
+      checkout_persist_credentials:
+        required: false
+        type: boolean
+        default: true
       include_firmware_bin:
         required: false
         type: boolean
@@ -35,6 +47,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_ref }}
+          persist-credentials: ${{ inputs.checkout_persist_credentials }}
 
       - name: Build target matrix
         id: targets
@@ -53,6 +69,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.checkout_repository || github.repository }}
+          ref: ${{ inputs.checkout_ref }}
+          persist-credentials: ${{ inputs.checkout_persist_credentials }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pr-test-firmware.yml
+++ b/.github/workflows/pr-test-firmware.yml
@@ -1,11 +1,11 @@
-name: PR Test Firmware
+name: PR Test Firmware Build
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize, closed]
+    types: [opened, reopened, labeled, synchronize]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: pr-test-firmware-${{ github.event.pull_request.number }}
@@ -14,148 +14,67 @@ concurrency:
 jobs:
   compute-meta:
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.action != 'closed' &&
-        github.event.action != 'unlabeled' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(github.event.pull_request.labels.*.name, 'test-firmware')
-      }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'test-firmware') }}
     outputs:
       version: ${{ steps.pr_meta.outputs.version }}
-      short_sha: ${{ steps.pr_meta.outputs.short_sha }}
     steps:
-      - name: Checkout
+      - name: Checkout PR head
         uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
-      - name: Compute PR test version
+      - name: Compute PR test metadata
         id: pr_meta
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           BASE_VERSION="$(awk -F'"' '/^project_version: / { print $2 }' openquatt/oq_substitutions_common.yaml)"
+          if [[ ! "${BASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "Unexpected project_version: ${BASE_VERSION}" >&2
+            exit 1
+          fi
+
           SHORT_SHA="${HEAD_SHA::7}"
           PR_VERSION="${BASE_VERSION}-pr.${PR_NUMBER}.${GITHUB_RUN_NUMBER}+${SHORT_SHA}"
-          echo "version=${PR_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "version=${PR_VERSION}" >> "${GITHUB_OUTPUT}"
+
+          jq -n \
+            --arg base_version "${BASE_VERSION}" \
+            --arg head_repository "${HEAD_REPOSITORY}" \
+            --arg head_sha "${HEAD_SHA}" \
+            --argjson pr_number "${PR_NUMBER}" \
+            --argjson run_number "${GITHUB_RUN_NUMBER}" \
+            --arg version "${PR_VERSION}" \
+            '{
+              base_version: $base_version,
+              head_repository: $head_repository,
+              head_sha: $head_sha,
+              pr_number: $pr_number,
+              run_number: $run_number,
+              version: $version
+            }' > "${RUNNER_TEMP}/pr-test-firmware-meta.json"
+
+      - name: Upload build metadata
+        uses: actions/upload-artifact@v6
+        with:
+          name: pr-test-firmware-meta
+          if-no-files-found: error
+          retention-days: 1
+          path: ${{ runner.temp }}/pr-test-firmware-meta.json
 
   compile-profiles:
     needs: compute-meta
+    permissions:
+      contents: read
     uses: ./.github/workflows/esphome-build.yml
     with:
       artifact_suffix: pr-${{ github.event.pull_request.number }}
+      checkout_persist_credentials: false
+      checkout_ref: ${{ github.event.pull_request.head.sha }}
+      checkout_repository: ${{ github.event.pull_request.head.repo.full_name }}
       project_version: ${{ needs.compute-meta.outputs.version }}
       include_factory_bin: false
-
-  publish-pr-test-release:
-    runs-on: ubuntu-latest
-    needs: [compute-meta, compile-profiles]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
-      - name: Download firmware artifacts
-        uses: actions/download-artifact@v7
-        with:
-          pattern: openquatt-*-pr-${{ github.event.pull_request.number }}
-          path: dist
-
-      - name: Prepare PR test firmware assets
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          VERSION: ${{ needs.compute-meta.outputs.version }}
-        run: |
-          TAG="pr-${PR_NUMBER}"
-          REPO="${GITHUB_REPOSITORY}"
-          BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
-          RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
-          python3 scripts/build_targets.py prepare-pr-test-assets "${PR_NUMBER}" "${VERSION}" "${HEAD_SHA}" "${BASE_URL}" "${RELEASE_URL}"
-
-      - name: Move PR test release tag
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          TAG="pr-${PR_NUMBER}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -fa "${TAG}" -m "PR ${PR_NUMBER} test firmware" "${HEAD_SHA}"
-          git push origin "refs/tags/${TAG}" --force
-
-      - name: Create or update PR test release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          SHORT_SHA: ${{ needs.compute-meta.outputs.short_sha }}
-          VERSION: ${{ needs.compute-meta.outputs.version }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          TAG="pr-${PR_NUMBER}"
-          NOTES=$(cat <<EOF
-          Mutable test-firmware release for PR #${PR_NUMBER}.
-
-          PR: ${PR_URL}
-          Commit: \`${HEAD_SHA}\`
-          Version: \`${VERSION}\`
-
-          Add or keep the \`test-firmware\` label on the PR to rebuild this release after new commits.
-          EOF
-          )
-
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            gh release edit "${TAG}" \
-              --title "PR #${PR_NUMBER} Test Firmware (${SHORT_SHA})" \
-              --notes "$NOTES" \
-              --prerelease
-          else
-            gh release create "${TAG}" \
-              --title "PR #${PR_NUMBER} Test Firmware (${SHORT_SHA})" \
-              --notes "$NOTES" \
-              --prerelease
-          fi
-
-      - name: Upload PR test firmware assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh release upload "pr-${PR_NUMBER}" \
-            dist/*.firmware.ota.bin \
-            dist/*.firmware.ota.bin.md5 \
-            dist/pr-firmware.json \
-            --clobber
-
-  delete-pr-test-release:
-    runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        (
-          (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'test-firmware')) ||
-          (github.event.action == 'unlabeled' && github.event.label.name == 'test-firmware')
-        )
-      }}
-    steps:
-      - name: Delete PR test release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          TAG="pr-${PR_NUMBER}"
-          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>release-view.err; then
-            gh release delete "${TAG}" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag
-          elif grep -qi "not found" release-view.err; then
-            echo "No PR test release ${TAG} found."
-          else
-            cat release-view.err >&2
-            exit 1
-          fi

--- a/scripts/build_targets.py
+++ b/scripts/build_targets.py
@@ -80,9 +80,13 @@ def md5sum(path: Path) -> str:
 def find_artifact_dir(dist_dir: Path, artifact_name: str) -> Path:
     direct = dist_dir / artifact_name
     if direct.is_dir():
+        if direct.is_symlink():
+            raise SystemExit(f"Artifact directory must not be a symlink: {direct}")
         return direct
 
-    matches = sorted(path for path in dist_dir.glob(f"{artifact_name}-*") if path.is_dir())
+    matches = sorted(
+        path for path in dist_dir.glob(f"{artifact_name}-*") if path.is_dir() and not path.is_symlink()
+    )
     if len(matches) == 1:
         return matches[0]
     if not matches:
@@ -130,17 +134,25 @@ def prepare_release_assets(version: str, base_url: str, release_url: str) -> Non
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
 
-def prepare_pr_test_assets(pr_number: str, version: str, head_sha: str, base_url: str, release_url: str) -> None:
+def prepare_pr_test_assets(
+    pr_number: str,
+    version: str,
+    head_sha: str,
+    base_url: str,
+    release_url: str,
+    artifact_root: Path | None = None,
+) -> None:
     dist_dir = REPO_ROOT / "dist"
     dist_dir.mkdir(parents=True, exist_ok=True)
+    artifact_root = artifact_root or dist_dir
     short_sha = head_sha[:7] if head_sha else ""
     assets: list[dict[str, str]] = []
 
     for target in filter_targets(load_targets(), "enabled"):
         artifact_name = target["artifact_name"]
-        artifact_dir = find_artifact_dir(dist_dir, artifact_name)
+        artifact_dir = find_artifact_dir(artifact_root, artifact_name)
         ota_source = artifact_dir / "firmware.ota.bin"
-        if not ota_source.is_file():
+        if ota_source.is_symlink() or not ota_source.is_file():
             raise SystemExit(f"Artifact {artifact_name} is missing firmware.ota.bin")
 
         ota_name = f"{artifact_name}.firmware.ota.bin"
@@ -200,7 +212,14 @@ def command_prepare_release_assets(args: argparse.Namespace) -> int:
 
 
 def command_prepare_pr_test_assets(args: argparse.Namespace) -> int:
-    prepare_pr_test_assets(args.pr_number, args.version, args.head_sha, args.base_url, args.release_url)
+    prepare_pr_test_assets(
+        args.pr_number,
+        args.version,
+        args.head_sha,
+        args.base_url,
+        args.release_url,
+        artifact_root=args.artifact_root,
+    )
     return 0
 
 
@@ -240,6 +259,7 @@ def create_parser() -> argparse.ArgumentParser:
     pr_prepare_parser.add_argument("head_sha")
     pr_prepare_parser.add_argument("base_url")
     pr_prepare_parser.add_argument("release_url")
+    pr_prepare_parser.add_argument("--artifact-root", type=Path)
     pr_prepare_parser.set_defaults(func=command_prepare_pr_test_assets)
 
     return parser

--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+from scripts import build_targets
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILD_WORKFLOW = (ROOT / ".github/workflows/pr-test-firmware.yml").read_text(encoding="utf-8")
+PUBLISH_WORKFLOW = (ROOT / ".github/workflows/pr-test-firmware-publish.yml").read_text(encoding="utf-8")
+REUSABLE_BUILD_WORKFLOW = (ROOT / ".github/workflows/esphome-build.yml").read_text(encoding="utf-8")
+
+
+class PrTestFirmwareWorkflowTests(unittest.TestCase):
+    def test_untrusted_build_has_read_only_repository_access(self) -> None:
+        self.assertIn("permissions:\n  contents: read", BUILD_WORKFLOW)
+        self.assertNotIn("contents: write", BUILD_WORKFLOW)
+        self.assertIn("persist-credentials: false", BUILD_WORKFLOW)
+        self.assertNotIn("github.event.pull_request.head.repo.full_name == github.repository", BUILD_WORKFLOW)
+
+    def test_pr_head_is_explicit_for_every_reusable_build_checkout(self) -> None:
+        self.assertIn("checkout_ref: ${{ github.event.pull_request.head.sha }}", BUILD_WORKFLOW)
+        self.assertIn(
+            "checkout_repository: ${{ github.event.pull_request.head.repo.full_name }}",
+            BUILD_WORKFLOW,
+        )
+        self.assertEqual(2, REUSABLE_BUILD_WORKFLOW.count("ref: ${{ inputs.checkout_ref }}"))
+        self.assertEqual(
+            2,
+            REUSABLE_BUILD_WORKFLOW.count(
+                "repository: ${{ inputs.checkout_repository || github.repository }}"
+            ),
+        )
+
+    def test_privileged_workflow_revalidates_before_publishing(self) -> None:
+        self.assertIn("workflow_run:", PUBLISH_WORKFLOW)
+        self.assertIn("pull_request_target:", PUBLISH_WORKFLOW)
+        self.assertIn("run-id: ${{ github.event.workflow_run.id }}", PUBLISH_WORKFLOW)
+        self.assertIn("path: ${{ runner.temp }}/firmware", PUBLISH_WORKFLOW)
+        self.assertIn("should_publish: ${{ steps.metadata.outputs.found }}", PUBLISH_WORKFLOW)
+        self.assertGreaterEqual(PUBLISH_WORKFLOW.count(".head.sha"), 2)
+        self.assertGreaterEqual(PUBLISH_WORKFLOW.count('any(.name == "test-firmware")'), 2)
+        self.assertNotIn("github.event.pull_request.head.sha", PUBLISH_WORKFLOW)
+        self.assertIn(
+            "group: pr-test-firmware-${{ needs.validate-pr-test-build.outputs.pr_number }}\n"
+            "      cancel-in-progress: false",
+            PUBLISH_WORKFLOW,
+        )
+
+    def test_artifact_root_option_is_available(self) -> None:
+        args = build_targets.create_parser().parse_args(
+            [
+                "prepare-pr-test-assets",
+                "423",
+                "v1.2.3-pr.423.1+1234567",
+                "1234567890abcdef1234567890abcdef12345678",
+                "https://example.invalid/download",
+                "https://example.invalid/release",
+                "--artifact-root",
+                "/tmp/firmware",
+            ]
+        )
+
+        self.assertEqual(Path("/tmp/firmware"), args.artifact_root)
+
+    def test_symlinked_artifact_directory_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            real_artifact = root / "real"
+            real_artifact.mkdir()
+            (root / "openquatt-test").symlink_to(real_artifact, target_is_directory=True)
+
+            with self.assertRaisesRegex(SystemExit, "must not be a symlink"):
+                build_targets.find_artifact_dir(root, "openquatt-test")
+
+    def test_pr_assets_are_normalized_from_external_artifact_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            repo_root = temp_root / "repo"
+            artifact_root = temp_root / "artifacts"
+            artifact_dir = artifact_root / "openquatt-test-pr-423"
+            artifact_dir.mkdir(parents=True)
+            repo_root.mkdir()
+            (artifact_dir / "firmware.ota.bin").write_bytes(b"firmware")
+
+            targets_file = repo_root / "build_targets.yaml"
+            targets_file.write_text(
+                """targets:
+  - id: test
+    status: enabled
+    artifact_name: openquatt-test
+    hardware: test-hardware
+    topology: single
+    connection: wifi
+    display_name: Test target
+""",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(build_targets, "REPO_ROOT", repo_root),
+                mock.patch.object(build_targets, "TARGETS_FILE", targets_file),
+            ):
+                build_targets.prepare_pr_test_assets(
+                    "423",
+                    "v1.2.3-pr.423.1+1234567",
+                    "1234567890abcdef1234567890abcdef12345678",
+                    "https://example.invalid/download",
+                    "https://example.invalid/release",
+                    artifact_root=artifact_root,
+                )
+
+            self.assertEqual(b"firmware", (repo_root / "dist/openquatt-test.firmware.ota.bin").read_bytes())
+            self.assertTrue((repo_root / "dist/openquatt-test.firmware.ota.bin.md5").is_file())
+            self.assertTrue((repo_root / "dist/pr-firmware.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Activeert de read-only `PR Test Firmware Build`-workflow op de default branch `main`.
- Brengt de bijbehorende expliciete fork-checkoutinputs en artifactnormalisatie uit #434 naar `main`.
- Laat de reeds via #436 gemergde privileged publisher ongewijzigd.

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Uitsluitend GitHub Actions en release-assettooling wijzigen. De standaardwaarden van de herbruikbare buildworkflow behouden het gedrag van CI-, dev- en releasecallers.

## Achtergrond

Tijdens de echte fork-test in [#438](https://github.com/OpenQuatt/OpenQuatt/pull/438) slaagden checkout, metadata, CI en alle acht firmwarebuilds. De trusted publisher werd niet gedispatcht omdat GitHub op de default branch de bronworkflow nog als `PR Test Firmware` registreert, terwijl de `workflow_run`-listener `PR Test Firmware Build` verwacht.

#436 plaatste bewust eerst alleen de publisher op `main`; #434 bracht de overige wijzigingen naar `dev`. Deze PR voltooit de activation op de default branch met exact de vier nog ontbrekende bestanden. Na merge wordt #438 opnieuw getriggerd om publicatie en cleanup end-to-end te bewijzen.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne CI/releaseflow zonder gebruikersgerichte configuratie- of firmwarewijziging.

## Validatie

- `python3 -m unittest discover -s scripts/tests` — 27 tests geslaagd.
- `python3 -m py_compile scripts/build_targets.py scripts/tests/test_pr_test_firmware_workflows.py` — geslaagd.
- `actionlint -color` — alle workflows geldig.
- Ruby/Psych YAML-parse van build-, PR-build- en publisherworkflow — geslaagd.
- `git diff --check origin/main...HEAD` — geslaagd.
- De vier gewijzigde bestanden zijn byte-identiek aan de reeds gemergde en gevalideerde versies op `dev`.
- Volledige diff en aparte koude review uitgevoerd op permissions, fork-checkout, callercompatibiliteit, metadata/SHA-gates, artifactsymlinks, retries en cleanup.
- Fork-PR #438 — reguliere CI en alle acht firmwareprofielen zijn geslaagd; publisher- en cleanupvalidatie volgen na merge van deze activation-PR.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; uitsluitend CI/tooling.