### PR TITLE
Expose compressor cycling warnings to Home Assistant

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -202,6 +202,20 @@ Alleen als het probleem daar lijkt te zitten:
 - power cap;
 - gedrag rond stille uren of begrenzing.
 
+### Voor compressorpendelen
+
+Home Assistant toont `Compressor cycling warning` zodra minimaal één actuele
+pendelwaarschuwing actief is. Gebruik dit samengestelde signaal als eenvoudige
+trigger voor een automation. De oorzaak blijft afzonderlijk zichtbaar via:
+
+- `Compressor cycling warning 2h`;
+- `Compressor cycling warning 72h`;
+- `Alternating compressor starts warning` bij een duo-installatie.
+
+De signalen kunnen gelijktijdig actief zijn en worden weer inactief zodra de
+bijbehorende actuele conditie is hersteld. Een eerder gedetecteerde maar alleen
+nog gelatchte melding houdt `Compressor cycling warning` niet actief.
+
 ## Wanneer zit je waarschijnlijk in de verkeerde laag?
 
 Gebruik deze vuistregels:

--- a/openquatt/oq_installation_monitoring.yaml
+++ b/openquatt/oq_installation_monitoring.yaml
@@ -323,7 +323,6 @@ binary_sensor:
   - platform: template
     id: oq_compressor_cycling_warning_2h
     name: "Compressor cycling warning 2h"
-    internal: true
     icon: mdi:alert-decagram-outline
     device_class: problem
     entity_category: diagnostic
@@ -333,7 +332,6 @@ binary_sensor:
   - platform: template
     id: oq_compressor_cycling_warning_72h
     name: "Compressor cycling warning 72h"
-    internal: true
     icon: mdi:calendar-alert-outline
     device_class: problem
     entity_category: diagnostic
@@ -344,8 +342,19 @@ binary_sensor:
     id: oq_compressor_alternating_warning
     name: "Alternating compressor starts warning"
     icon: mdi:swap-horizontal-bold
-    internal: true
+    internal: ${monitoring_hp2_internal}
     device_class: problem
     entity_category: diagnostic
     lambda: |-
       return oq_diagnostics::logged_alternating_cycling_warning(millis());
+
+  - platform: template
+    id: oq_compressor_cycling_warning
+    name: "Compressor cycling warning"
+    icon: mdi:alert-decagram
+    device_class: problem
+    entity_category: diagnostic
+    lambda: |-
+      return id(oq_compressor_cycling_warning_2h).state ||
+             id(oq_compressor_cycling_warning_72h).state ||
+             id(oq_compressor_alternating_warning).state;


### PR DESCRIPTION
# Wat verandert deze PR?

- Exposeert één samengestelde `Compressor cycling warning` binary sensor aan Home Assistant.
- Exposeert de 2h- en 72h-oorzaken afzonderlijk; de alternating-oorzaak alleen bij duo-installaties.
- Documenteert het onderscheid tussen het hoofdsignaal, de actuele oorzaken en de interne gelatchte melding.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Home Assistant krijgt een publieke OR-sensor voor actuele compressorpendelwaarschuwingen. De bestaande detectielogica, drempels, web-appweergave en gelatchte incidentstatus blijven ongewijzigd. De 2h- en 72h-signalen blijven afzonderlijk zichtbaar; `Alternating compressor starts warning` wordt alleen bij duo-topologieën gepubliceerd.

## Achtergrond

Closes #427.

De samengestelde sensor gebruikt uitsluitend de actuele states van de bestaande 2h-, 72h- en alternating-waarschuwingen. Een alleen nog gelatchte, herstelde melding houdt de publieke sensor daardoor niet actief.

Volledige diff tegen `dev` is gecontroleerd op logica, lifecycle, single/duo-compatibiliteit, Home Assistant-entitygedrag, upgrade/fresh-install en documentatieconsistentie. Er zijn geen state writes, controlpaden, persistence, callbacks of netwerkpaden toegevoegd. Bij reboot blijft de bestaande eigenschap gelden dat de compressorstarthistorie opnieuw wordt opgebouwd.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/instellingen-en-meetwaarden.md` beschrijft het samengestelde HA-signaal, de afzonderlijke oorzaken en dat meerdere oorzaken tegelijk actief kunnen zijn.

## Validatie

- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- [x] `git diff --check origin/dev...HEAD`
- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet op hardware gemeten. Er is één template binary sensor toegevoegd en drie bestaande sensors zijn voor relevante topologieën publiek gemaakt; er zijn geen buffers, taken, stacks of dynamische allocatiepaden toegevoegd.
