### PR TITLE
Extend usage telemetry configuration and disable retained publishes

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -91,6 +91,40 @@ void append_json_optional_bool_(FixedBufferWriter& payload, const char* key, boo
   payload += value ? "true" : "false";
 }
 
+void append_json_wire_value_(FixedBufferWriter& payload, const char* key, const char* value) {
+  append_json_key_(payload, key);
+  if (value == nullptr) {
+    payload += "null";
+    return;
+  }
+  payload += '"';
+  payload += value;
+  payload += '"';
+}
+
+void append_json_optional_select_(FixedBufferWriter& payload, const char* key, const select::Select* source,
+                                  const char* (*wire_value)(const std::string&)) {
+  if (source == nullptr || !source->has_state()) {
+    append_json_wire_value_(payload, key, nullptr);
+    return;
+  }
+  append_json_wire_value_(payload, key, wire_value(source->current_option()));
+}
+
+void append_json_flow_source_(FixedBufferWriter& payload, const select::Select* flow_source,
+                              const select::Select* q_flow_source) {
+  const std::string empty_option;
+  const std::string& flow_option =
+      flow_source != nullptr && flow_source->has_state() ? flow_source->current_option() : empty_option;
+  const bool q_source_available = q_flow_source != nullptr;
+  const std::string& q_flow_option =
+      q_source_available && q_flow_source->has_state() ? q_flow_source->current_option() : empty_option;
+  append_json_wire_value_(payload, "flow_source_config",
+                          flow_source_config_wire_value(flow_option, q_source_available, q_flow_option));
+  append_json_wire_value_(payload, "flow_source_mode",
+                          flow_source_mode_wire_value(flow_option, q_source_available, q_flow_option));
+}
+
 void append_json_boiler_connection_(FixedBufferWriter& payload, const select::Select* source) {
   append_json_key_(payload, "boiler_connection");
   if (source == nullptr) {
@@ -797,6 +831,23 @@ bool OpenQuattUsageTelemetry::build_payload_() {
   payload += R"(","connection":")";
   append_json_escaped(payload, this->connection_);
   payload += '"';
+  append_json_optional_select_(payload, "quatt_hybrid_generation_config", this->quatt_hybrid_generation_select_,
+                               quatt_hybrid_generation_wire_value);
+  append_json_flow_source_(payload, this->flow_source_select_, this->q_flow_source_select_);
+  append_json_optional_select_(payload, "heating_strategy", this->heating_strategy_select_,
+                               heating_strategy_wire_value);
+  append_json_optional_select_(payload, "room_temperature_source", this->room_temperature_source_select_,
+                               configured_source_wire_value);
+  append_json_optional_select_(payload, "room_setpoint_source", this->room_setpoint_source_select_,
+                               configured_source_wire_value);
+  append_json_optional_select_(payload, "outside_temperature_source", this->outside_temperature_source_select_,
+                               configured_source_wire_value);
+  append_json_optional_select_(payload, "heating_enable_source", this->heating_enable_source_select_,
+                               configured_source_wire_value);
+  append_json_optional_select_(payload, "cooling_enable_source", this->cooling_enable_source_select_,
+                               configured_source_wire_value);
+  append_json_optional_select_(payload, "cooling_dew_point_source", this->cooling_dew_point_source_select_,
+                               configured_source_wire_value);
   append_json_uint_(payload, "heap_free_b", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
   append_json_uint_(payload, "heap_min_free_b", heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL));
   append_json_uint_(payload, "heap_largest_block_b", heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -999,7 +999,7 @@ void OpenQuattUsageTelemetry::mqtt_event_handler_(void* handler_args, esp_event_
       if (self->enabled_.load() && self->session_active_.load() && !self->finishing_session_.load() &&
           !self->consent_publish_blocked_.load()) {
         message_id = esp_mqtt_client_enqueue(event->client, self->publish_topic_.data(), self->payload_.data(),
-                                             static_cast<int>(self->payload_size_), 1, 1, true);
+                                             static_cast<int>(self->payload_size_), 1, MQTT_PUBLISH_RETAIN, true);
       }
       xSemaphoreGive(self->consent_mutex_);
       ESP_LOGD(TAG, "esp-mqtt task stack free after enqueue: %u bytes",

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.h
@@ -46,6 +46,18 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   void set_hardware_profile(const std::string& profile) { this->hardware_profile_ = profile; }
   void set_topology(const std::string& topology) { this->topology_ = topology; }
   void set_connection(const std::string& connection) { this->connection_ = connection; }
+  void set_quatt_hybrid_generation_select(select::Select* source) { this->quatt_hybrid_generation_select_ = source; }
+  void set_flow_source_select(select::Select* source) { this->flow_source_select_ = source; }
+  void set_q_flow_source_select(select::Select* source) { this->q_flow_source_select_ = source; }
+  void set_heating_strategy_select(select::Select* source) { this->heating_strategy_select_ = source; }
+  void set_room_temperature_source_select(select::Select* source) { this->room_temperature_source_select_ = source; }
+  void set_room_setpoint_source_select(select::Select* source) { this->room_setpoint_source_select_ = source; }
+  void set_outside_temperature_source_select(select::Select* source) {
+    this->outside_temperature_source_select_ = source;
+  }
+  void set_heating_enable_source_select(select::Select* source) { this->heating_enable_source_select_ = source; }
+  void set_cooling_enable_source_select(select::Select* source) { this->cooling_enable_source_select_ = source; }
+  void set_cooling_dew_point_source_select(select::Select* source) { this->cooling_dew_point_source_select_ = source; }
   void set_loop_time_sensor(sensor::Sensor* sensor) { this->loop_time_sensor_ = sensor; }
   void set_internal_temperature_sensor(sensor::Sensor* sensor) { this->internal_temperature_sensor_ = sensor; }
   void set_wifi_signal_sensor(sensor::Sensor* sensor) { this->wifi_signal_sensor_ = sensor; }
@@ -167,6 +179,16 @@ class OpenQuattUsageTelemetry : public switch_::Switch, public Component {
   std::string hardware_profile_;
   std::string topology_;
   std::string connection_;
+  select::Select* quatt_hybrid_generation_select_{nullptr};
+  select::Select* flow_source_select_{nullptr};
+  select::Select* q_flow_source_select_{nullptr};
+  select::Select* heating_strategy_select_{nullptr};
+  select::Select* room_temperature_source_select_{nullptr};
+  select::Select* room_setpoint_source_select_{nullptr};
+  select::Select* outside_temperature_source_select_{nullptr};
+  select::Select* heating_enable_source_select_{nullptr};
+  select::Select* cooling_enable_source_select_{nullptr};
+  select::Select* cooling_dew_point_source_select_{nullptr};
   sensor::Sensor* loop_time_sensor_{nullptr};
   sensor::Sensor* internal_temperature_sensor_{nullptr};
   sensor::Sensor* wifi_signal_sensor_{nullptr};

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
@@ -10,6 +10,8 @@
 namespace esphome {
 namespace openquatt_usage_telemetry {
 
+inline constexpr int MQTT_PUBLISH_RETAIN = 0;
+
 enum class MqttCleanupDecision : uint8_t {
   DESTROY = 0U,
   FORCE_DISCONNECT = 1U,

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
@@ -111,6 +111,100 @@ inline void append_json_escaped(FixedBufferWriter& output, const std::string& in
   }
 }
 
+inline const char* quatt_hybrid_generation_wire_value(const std::string& option) {
+  if (option == "V1") {
+    return "v1";
+  }
+  if (option == "V1.5") {
+    return "v1_5";
+  }
+  if (option == "V2") {
+    return "v2";
+  }
+  return nullptr;
+}
+
+inline const char* heating_strategy_wire_value(const std::string& option) {
+  if (option == "Power House") {
+    return "power_house";
+  }
+  if (option == "Water Temperature Control (heating curve)") {
+    return "heating_curve";
+  }
+  return nullptr;
+}
+
+inline const char* configured_source_wire_value(const std::string& option) {
+  if (option == "Auto") {
+    return "auto";
+  }
+  if (option == "Local") {
+    return "local";
+  }
+  if (option == "Outdoor unit") {
+    return "outdoor_unit";
+  }
+  if (option == "CIC") {
+    return "cic";
+  }
+  if (option == "OT thermostat") {
+    return "opentherm";
+  }
+  if (option == "HA input" || option == "Home Assistant") {
+    return "home_assistant";
+  }
+  if (option == "MQTT") {
+    return "mqtt";
+  }
+  if (option == "CIC or HA input") {
+    return "cic_or_home_assistant";
+  }
+  if (option == "Disabled") {
+    return "disabled";
+  }
+  return nullptr;
+}
+
+inline const char* flow_source_config_wire_value(const std::string& flow_source, bool q_source_available,
+                                                 const std::string& q_flow_source) {
+  if (flow_source == "CIC") {
+    return "cic";
+  }
+  if (flow_source != "Outdoor unit") {
+    return nullptr;
+  }
+  if (!q_source_available) {
+    return "outdoor_unit";
+  }
+  if (q_flow_source == "Local") {
+    return "controller_local";
+  }
+  if (q_flow_source == "Auto" || q_flow_source == "Outdoor unit") {
+    return "outdoor_unit";
+  }
+  return nullptr;
+}
+
+inline const char* flow_source_mode_wire_value(const std::string& flow_source, bool q_source_available,
+                                               const std::string& q_flow_source) {
+  if (flow_source == "CIC") {
+    return "explicit";
+  }
+  if (flow_source != "Outdoor unit") {
+    return nullptr;
+  }
+  if (!q_source_available) {
+    return "explicit";
+  }
+  if (q_flow_source == "Auto") {
+    return "auto";
+  }
+  if (q_flow_source == "Local" || q_flow_source == "Outdoor unit") {
+    return "explicit";
+  }
+  return nullptr;
+}
+
 inline MqttCleanupDecision mqtt_cleanup_decision(bool stop_succeeded, bool connected_seen, bool disconnected_seen,
                                                  uint8_t consecutive_stop_failures) {
   if (stop_succeeded) {

--- a/components/openquatt_usage_telemetry/__init__.py
+++ b/components/openquatt_usage_telemetry/__init__.py
@@ -41,6 +41,16 @@ CONF_RELEASE_CHANNEL = "release_channel"
 CONF_HARDWARE_PROFILE = "hardware_profile"
 CONF_TOPOLOGY = "topology"
 CONF_CONNECTION = "connection"
+CONF_QUATT_HYBRID_GENERATION_SELECT = "quatt_hybrid_generation_select"
+CONF_FLOW_SOURCE_SELECT = "flow_source_select"
+CONF_Q_FLOW_SOURCE_SELECT = "q_flow_source_select"
+CONF_HEATING_STRATEGY_SELECT = "heating_strategy_select"
+CONF_ROOM_TEMPERATURE_SOURCE_SELECT = "room_temperature_source_select"
+CONF_ROOM_SETPOINT_SOURCE_SELECT = "room_setpoint_source_select"
+CONF_OUTSIDE_TEMPERATURE_SOURCE_SELECT = "outside_temperature_source_select"
+CONF_HEATING_ENABLE_SOURCE_SELECT = "heating_enable_source_select"
+CONF_COOLING_ENABLE_SOURCE_SELECT = "cooling_enable_source_select"
+CONF_COOLING_DEW_POINT_SOURCE_SELECT = "cooling_dew_point_source_select"
 CONF_LOOP_TIME_SENSOR = "loop_time_sensor"
 CONF_INTERNAL_TEMPERATURE_SENSOR = "internal_temperature_sensor"
 CONF_WIFI_SIGNAL_SENSOR = "wifi_signal_sensor"
@@ -95,6 +105,16 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_HARDWARE_PROFILE): cv.All(cv.string_strict, cv.Length(max=32)),
             cv.Required(CONF_TOPOLOGY): cv.All(cv.string_strict, cv.Length(max=16)),
             cv.Required(CONF_CONNECTION): cv.All(cv.string_strict, cv.Length(max=16)),
+            cv.Required(CONF_QUATT_HYBRID_GENERATION_SELECT): cv.use_id(select.Select),
+            cv.Required(CONF_FLOW_SOURCE_SELECT): cv.use_id(select.Select),
+            cv.Optional(CONF_Q_FLOW_SOURCE_SELECT): cv.use_id(select.Select),
+            cv.Required(CONF_HEATING_STRATEGY_SELECT): cv.use_id(select.Select),
+            cv.Required(CONF_ROOM_TEMPERATURE_SOURCE_SELECT): cv.use_id(select.Select),
+            cv.Required(CONF_ROOM_SETPOINT_SOURCE_SELECT): cv.use_id(select.Select),
+            cv.Required(CONF_OUTSIDE_TEMPERATURE_SOURCE_SELECT): cv.use_id(select.Select),
+            cv.Required(CONF_HEATING_ENABLE_SOURCE_SELECT): cv.use_id(select.Select),
+            cv.Required(CONF_COOLING_ENABLE_SOURCE_SELECT): cv.use_id(select.Select),
+            cv.Required(CONF_COOLING_DEW_POINT_SOURCE_SELECT): cv.use_id(select.Select),
             cv.Required(CONF_LOOP_TIME_SENSOR): cv.use_id(sensor.Sensor),
             cv.Required(CONF_INTERNAL_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
             cv.Optional(CONF_WIFI_SIGNAL_SENSOR): cv.use_id(sensor.Sensor),
@@ -152,6 +172,41 @@ async def to_code(config):
     cg.add(var.set_hardware_profile(config[CONF_HARDWARE_PROFILE]))
     cg.add(var.set_topology(config[CONF_TOPOLOGY]))
     cg.add(var.set_connection(config[CONF_CONNECTION]))
+    quatt_hybrid_generation_select = await cg.get_variable(
+        config[CONF_QUATT_HYBRID_GENERATION_SELECT]
+    )
+    cg.add(var.set_quatt_hybrid_generation_select(quatt_hybrid_generation_select))
+    flow_source_select = await cg.get_variable(config[CONF_FLOW_SOURCE_SELECT])
+    cg.add(var.set_flow_source_select(flow_source_select))
+    if q_flow_source_select_id := config.get(CONF_Q_FLOW_SOURCE_SELECT):
+        q_flow_source_select = await cg.get_variable(q_flow_source_select_id)
+        cg.add(var.set_q_flow_source_select(q_flow_source_select))
+    heating_strategy_select = await cg.get_variable(config[CONF_HEATING_STRATEGY_SELECT])
+    cg.add(var.set_heating_strategy_select(heating_strategy_select))
+    room_temperature_source_select = await cg.get_variable(
+        config[CONF_ROOM_TEMPERATURE_SOURCE_SELECT]
+    )
+    cg.add(var.set_room_temperature_source_select(room_temperature_source_select))
+    room_setpoint_source_select = await cg.get_variable(
+        config[CONF_ROOM_SETPOINT_SOURCE_SELECT]
+    )
+    cg.add(var.set_room_setpoint_source_select(room_setpoint_source_select))
+    outside_temperature_source_select = await cg.get_variable(
+        config[CONF_OUTSIDE_TEMPERATURE_SOURCE_SELECT]
+    )
+    cg.add(var.set_outside_temperature_source_select(outside_temperature_source_select))
+    heating_enable_source_select = await cg.get_variable(
+        config[CONF_HEATING_ENABLE_SOURCE_SELECT]
+    )
+    cg.add(var.set_heating_enable_source_select(heating_enable_source_select))
+    cooling_enable_source_select = await cg.get_variable(
+        config[CONF_COOLING_ENABLE_SOURCE_SELECT]
+    )
+    cg.add(var.set_cooling_enable_source_select(cooling_enable_source_select))
+    cooling_dew_point_source_select = await cg.get_variable(
+        config[CONF_COOLING_DEW_POINT_SOURCE_SELECT]
+    )
+    cg.add(var.set_cooling_dew_point_source_select(cooling_dew_point_source_select))
     loop_time_sensor = await cg.get_variable(config[CONF_LOOP_TIME_SENSOR])
     cg.add(var.set_loop_time_sensor(loop_time_sensor))
     internal_temperature_sensor = await cg.get_variable(config[CONF_INTERNAL_TEMPERATURE_SENSOR])

--- a/docs/q-edition.md
+++ b/docs/q-edition.md
@@ -160,7 +160,7 @@ Volg de route die de web-app voor jouw installatie toont. De basisstappen zijn:
 8. **Flowregeling en afstelling:** leg vast hoe de pomp geregeld moet worden en welke waarden daarbij horen.
 9. **Watertemperatuur beveiligen:** controleer de normale bovengrens en de tripgrens.
 10. **Stille uren en niveaus:** stel het stille venster en de compressorlimieten voor dag en nacht in.
-11. **Gebruiksstatistieken:** controleer of OpenQuatt beperkte technische systeemstatus en aan/uit-statussen van functies mag delen; tijdens een nieuwe Quick Start staat dit standaard aan en kan het hier worden uitgezet. Wifi-gegevens, gebruikersnamen en wachtwoorden worden nooit meegestuurd.
+11. **Gebruiksstatistieken:** controleer of OpenQuatt beperkte technische systeemstatus, aan/uit-statussen van functies en configuratiekeuzes zoals Quatt Hybrid-versie, verwarmingsstrategie, flowbron en regelbronnen mag delen; tijdens een nieuwe Quick Start staat dit standaard aan en kan het hier worden uitgezet. Gemeten of ingestelde temperaturen, wifi-gegevens, gebruikersnamen en wachtwoorden worden nooit meegestuurd.
 12. **Bevestigen en afronden:** controleer je keuzes en markeer Quick Start als voltooid.
 
 ## Je installatie is klaar wanneer

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -248,6 +248,10 @@ Het bericht bevat uitsluitend:
 - firmwareversie en releasekanaal;
 - hardwareprofiel en, als beschikbaar, hardwarerevisie;
 - `Single` of `Duo` en `Wi-Fi` of `Ethernet`;
+- `quatt_hybrid_generation_config`: `v1`, `v1_5` of `v2` volgens de ingestelde Quatt Hybrid-versie;
+- `flow_source_config`: `cic`, `controller_local` of `outdoor_unit`, plus `flow_source_mode`: `auto` of `explicit`;
+- `heating_strategy`: `power_house` of `heating_curve`;
+- de gekozen regelbronnen in `room_temperature_source`, `room_setpoint_source`, `outside_temperature_source`, `heating_enable_source`, `cooling_enable_source` en `cooling_dew_point_source`, genormaliseerd naar vaste waarden zoals `auto`, `local`, `outdoor_unit`, `cic`, `opentherm`, `home_assistant`, `mqtt`, `cic_or_home_assistant` en `disabled`;
 - vrij heapgeheugen, het minimum sinds de start, het grootste vrije heapblok en vrij PSRAM;
 - maximale looptijd van de firmwareloop, ESP-chiptemperatuur en reden van de laatste herstart;
 - bij Wi-Fi: de signaalsterkte in dBm;
@@ -257,13 +261,13 @@ Het bericht bevat uitsluitend:
 - of MQTT inputbronnen als geheel aanstaan;
 - of RAM-trends, flashtrends, beslisloghistorie, lifetime-energiehistorie en RAM-loghistorie aanstaan.
 
-Een niet-ondersteunde functie, tijdelijk nog niet geïnitialiseerde keuze of niet-beschikbare sensor krijgt de waarde `null`; `false` betekent dat de functie beschikbaar maar uitgeschakeld is. Zo is de Wi-Fi-signaalsterkte bij Ethernet `null`. `boiler_connection` is alleen `null` wanneer de OTB-select bestaat maar tijdelijk nog geen geldige toestand heeft, of een onbekende optie bevat.
+Een niet-ondersteunde functie, tijdelijk nog niet geïnitialiseerde keuze, onbekende keuze of niet-beschikbare sensor krijgt de waarde `null`; `false` betekent dat de functie beschikbaar maar uitgeschakeld is. Dit geldt ook afzonderlijk voor de nieuwe configuratievelden. De twee flowvelden zijn beide `null` zolang de benodigde flowselect nog geen bekende toestand heeft. Zo is de Wi-Fi-signaalsterkte bij Ethernet `null`. `boiler_connection` is alleen `null` wanneer de OTB-select bestaat maar tijdelijk nog geen geldige toestand heeft, of een onbekende optie bevat.
 
 Het bericht bevat nooit een MAC-adres, lokaal IP-adres, wifi-netwerknaam, wifi-wachtwoord, gebruikersnaam, ander wachtwoord of andere inloggegevens. Ook MQTT-servergegevens, topics, ontvangen MQTT-waarden, ingestelde temperaturen of grenzen, verwarmingsmetingen, regelwaarden en loginhoud gaan niet mee. De OpenQuatt-loggingserver ziet bij een netwerkverbinding technisch wel het bron-IP-adres, maar dit staat niet in de payload en OpenQuatt slaat het niet op. In de web-app staat onder **Wat gaat er mee?** een uitklapbaar voorbeeld van de volledige JSON-vorm.
 
 Wanneer delen voor het eerst actief wordt, maakt de controller met de hardware-randomgenerator een UUIDv4 aan en bewaart die lokaal. Een UUIDv4 heeft 122 willekeurige bits; zelfs bij één miljoen installaties is de kans op minstens één dubbel ID kleiner dan ongeveer `10^-25`. Dit ID blijft gelijk na een OTA-update en wanneer je delen tijdelijk uitzet. Je kunt het bekijken via **Instellingen → Systeem → Gebruiksstatistieken**. Een fabrieksreset maakt een nieuw ID. De keuze en het ID worden niet via een instellingenbackup naar een andere controller gekopieerd. Uitzetten stopt nieuwe berichten direct; er wordt geen wachtrij voor later opgeslagen. Na een mislukte verzending maakt iedere retry een verse momentopname, maar behoudt binnen dezelfde retryreeks het `message_id` zodat een verloren QoS 1-bevestiging kan worden gededupliceerd.
 
-De statistiekenclient staat los van de configureerbare [MQTT inputbronnen](mqtt.md): hij publiceert alleen dit ene bericht, subscribed nergens op en schakelt ESPHome MQTT-discovery, entiteitspublicaties en logexport niet in. Het JSON-bericht wordt met QoS 1 retained gepubliceerd op `openquatt/devices/<installation-id>/telemetry`, zodat de loggingserver per installatie alleen de laatste payload bewaart. Een build zonder geconfigureerde centrale loggingserver maakt ook wanneer delen aanstaat geen externe verbinding.
+De statistiekenclient staat los van de configureerbare [MQTT inputbronnen](mqtt.md): hij publiceert alleen dit ene bericht, subscribed nergens op en schakelt ESPHome MQTT-discovery, entiteitspublicaties en logexport niet in. Het JSON-bericht wordt met QoS 1 en zonder retain gepubliceerd op `openquatt/devices/<installation-id>/telemetry`. De broker bewaart het daardoor niet als retained state voor later verbindende subscribers; de loggingserver slaat ieder ontvangen bericht zelf op. Een eerder door oude firmware retained opgeslagen payload wordt door een non-retained publicatie niet gewist en moet zo nodig eenmalig op de centrale broker worden verwijderd. Een build zonder geconfigureerde centrale loggingserver maakt ook wanneer delen aanstaat geen externe verbinding.
 
 #### Debugopname voor support
 

--- a/openquatt/oq_usage_telemetry.yaml
+++ b/openquatt/oq_usage_telemetry.yaml
@@ -39,6 +39,15 @@ openquatt_usage_telemetry:
   hardware_profile: "${oq_hardware_profile}"
   topology: "${oq_topology}"
   connection: "${oq_connection}"
+  quatt_hybrid_generation_select: hp_generation
+  flow_source_select: flow_source
+  heating_strategy_select: oq_heat_control_mode
+  room_temperature_source_select: room_temp_source
+  room_setpoint_source_select: room_setpoint_source
+  outside_temperature_source_select: outside_temp_source
+  heating_enable_source_select: heating_enable_source
+  cooling_enable_source_select: cooling_enable_source
+  cooling_dew_point_source_select: cooling_dew_point_source
   loop_time_sensor: oq_loop_time
   internal_temperature_sensor: oq_esp_internal_temperature
   cic_polling_switch: cic_enable

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -87,6 +87,7 @@ openquatt_usage_telemetry:
   cic_compatibility_switch: cic_compatibility_enable
   ot_thermostat_switch: oq_ot_slave_enabled
   boiler_connection_select: oq_boiler_connection
+  q_flow_source_select: oq_q_flow_source
 
 psram:
   mode: octal

--- a/openquatt/web/js/src/features/usage-telemetry.js
+++ b/openquatt/web/js/src/features/usage-telemetry.js
@@ -16,6 +16,16 @@ const USAGE_TELEMETRY_EXAMPLE_JSON = JSON.stringify({
   hardware_revision: "1.0 (batch 42)",
   topology: "duo",
   connection: "wifi",
+  quatt_hybrid_generation_config: "v1_5",
+  flow_source_config: "outdoor_unit",
+  flow_source_mode: "explicit",
+  heating_strategy: "power_house",
+  room_temperature_source: "opentherm",
+  room_setpoint_source: "opentherm",
+  outside_temperature_source: "auto",
+  heating_enable_source: "disabled",
+  cooling_enable_source: "disabled",
+  cooling_dew_point_source: "auto",
   heap_free_b: 178432,
   heap_min_free_b: 151008,
   heap_largest_block_b: 98304,
@@ -85,6 +95,7 @@ export function renderUsageTelemetryDisclosure({ collapsible = false, idPrefix =
           <li><strong>Installatie</strong><span>Willekeurig ID, tijdstip en uptime</span></li>
           <li><strong>Software</strong><span>Versie en releasekanaal</span></li>
           <li><strong>Platform</strong><span>Hardware, opstelling, verbinding en wifi-signaal</span></li>
+          <li><strong>Configuratie</strong><span>Quatt Hybrid-versie, verwarmingsstrategie, flowbron en regelbronnen</span></li>
           <li><strong>Systeemstatus</strong><span>Geheugen, looptijd, chiptemperatuur en herstartreden</span></li>
           <li><strong>Functies</strong><span>Aan/uit-status van CiC, OpenTherm-thermostaat, ketelondersteuning, MQTT-inputs en lokale historie; plus de ketelaansluiting (aan/uit of OpenTherm)</span></li>
         </ul>
@@ -98,7 +109,7 @@ export function renderUsageTelemetryDisclosure({ collapsible = false, idPrefix =
           <li><strong>Identiteit</strong><span>Geen MAC-adres of netwerkadres</span></li>
           <li><strong>Wifi en toegang</strong><span>Nooit een wifi-netwerknaam, wifi-wachtwoord, gebruikersnaam, ander wachtwoord of inloggegevens</span></li>
           <li><strong>Installatiegedrag</strong><span>Geen verwarmingsmetingen of regelwaarden</span></li>
-          <li><strong>Lokale data</strong><span>Geen ingestelde temperaturen, grenzen, MQTT-topics of logs</span></li>
+          <li><strong>Lokale data</strong><span>Geen gemeten of ingestelde temperaturen, grenzen, MQTT-topics of logs</span></li>
         </ul>
       </section>
     </div>

--- a/openquatt/web/tests/usage-telemetry-hydration.test.mjs
+++ b/openquatt/web/tests/usage-telemetry-hydration.test.mjs
@@ -173,6 +173,7 @@ test("usage telemetry disclosure matches the hourly payload scope", async () => 
   const settingsSource = await readFile(new URL("../js/src/settings/privacy.js", import.meta.url), "utf8");
   const disclosureSource = await readFile(new URL("../js/src/features/usage-telemetry.js", import.meta.url), "utf8");
   const telemetryYaml = await readFile(new URL("../../oq_usage_telemetry.yaml", import.meta.url), "utf8");
+  const telemetryCpp = await readFile(new URL("../../../components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp", import.meta.url), "utf8");
 
   assert.match(quickStartSource, /renderUsageTelemetryDisclosure\(\)/);
   assert.match(quickStartSource, /data-oq-action="confirm-no-usage-telemetry"/);
@@ -194,13 +195,30 @@ test("usage telemetry disclosure matches the hourly payload scope", async () => 
   assert.match(disclosureSource, /vrijwel direct en daarna ongeveer elk uur/);
   assert.match(disclosureSource, /OpenQuatt-loggingserver/);
   assert.match(disclosureSource, /wifi-signaal/);
+  assert.match(disclosureSource, /Quatt Hybrid-versie, verwarmingsstrategie, flowbron en regelbronnen/);
   assert.match(disclosureSource, /Aan\/uit-status van CiC, OpenTherm-thermostaat, ketelondersteuning, MQTT-inputs en lokale historie/);
   assert.match(disclosureSource, /ketelaansluiting \(aan\/uit of OpenTherm\)/);
-  assert.match(disclosureSource, /Geen ingestelde temperaturen, grenzen, MQTT-topics of logs/);
+  assert.match(disclosureSource, /Geen gemeten of ingestelde temperaturen, grenzen, MQTT-topics of logs/);
   assert.match(disclosureSource, /Nooit een wifi-netwerknaam, wifi-wachtwoord, gebruikersnaam, ander wachtwoord of inloggegevens/);
   assert.match(disclosureSource, /Voorbeeld van het verzonden bericht \(JSON\)/);
   assert.match(disclosureSource, /schema_version/);
   assert.match(disclosureSource, /timestamp_s/);
+  const configFields = [
+    "quatt_hybrid_generation_config",
+    "flow_source_config",
+    "flow_source_mode",
+    "heating_strategy",
+    "room_temperature_source",
+    "room_setpoint_source",
+    "outside_temperature_source",
+    "heating_enable_source",
+    "cooling_enable_source",
+    "cooling_dew_point_source",
+  ];
+  for (const field of configFields) {
+    assert.match(disclosureSource, new RegExp(field));
+    assert.match(telemetryCpp, new RegExp(`"${field}"`));
+  }
   assert.match(disclosureSource, /oq-usage-disclosure--collapsible/);
   assert.match(disclosureSource, /data-oq-action="toggle-usage-telemetry-details"/);
   assert.match(disclosureSource, /technisch wel het bron-IP-adres zien/);

--- a/tests/host/openquatt_usage_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_usage_telemetry_policy_test.cpp
@@ -12,10 +12,13 @@ using esphome::openquatt_usage_telemetry::flow_source_config_wire_value;
 using esphome::openquatt_usage_telemetry::flow_source_mode_wire_value;
 using esphome::openquatt_usage_telemetry::heating_strategy_wire_value;
 using esphome::openquatt_usage_telemetry::mqtt_cleanup_decision;
+using esphome::openquatt_usage_telemetry::MQTT_PUBLISH_RETAIN;
 using esphome::openquatt_usage_telemetry::MqttCleanupDecision;
 using esphome::openquatt_usage_telemetry::quatt_hybrid_generation_wire_value;
 
 int main() {
+  assert(MQTT_PUBLISH_RETAIN == 0);
+
   assert(mqtt_cleanup_decision(true, false, false, 0U) == MqttCleanupDecision::DESTROY);
   assert(mqtt_cleanup_decision(false, true, false, 1U) == MqttCleanupDecision::FORCE_DISCONNECT);
   assert(mqtt_cleanup_decision(false, false, false, 1U) == MqttCleanupDecision::RETRY_STOP);

--- a/tests/host/openquatt_usage_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_usage_telemetry_policy_test.cpp
@@ -6,9 +6,14 @@
 #include "components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h"
 
 using esphome::openquatt_usage_telemetry::append_json_escaped;
+using esphome::openquatt_usage_telemetry::configured_source_wire_value;
 using esphome::openquatt_usage_telemetry::FixedBufferWriter;
+using esphome::openquatt_usage_telemetry::flow_source_config_wire_value;
+using esphome::openquatt_usage_telemetry::flow_source_mode_wire_value;
+using esphome::openquatt_usage_telemetry::heating_strategy_wire_value;
 using esphome::openquatt_usage_telemetry::mqtt_cleanup_decision;
 using esphome::openquatt_usage_telemetry::MqttCleanupDecision;
+using esphome::openquatt_usage_telemetry::quatt_hybrid_generation_wire_value;
 
 int main() {
   assert(mqtt_cleanup_decision(true, false, false, 0U) == MqttCleanupDecision::DESTROY);
@@ -16,6 +21,40 @@ int main() {
   assert(mqtt_cleanup_decision(false, false, false, 1U) == MqttCleanupDecision::RETRY_STOP);
   assert(mqtt_cleanup_decision(false, false, false, 2U) == MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
   assert(mqtt_cleanup_decision(false, true, true, 2U) == MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
+
+  assert(std::strcmp(quatt_hybrid_generation_wire_value("V1"), "v1") == 0);
+  assert(std::strcmp(quatt_hybrid_generation_wire_value("V1.5"), "v1_5") == 0);
+  assert(std::strcmp(quatt_hybrid_generation_wire_value("V2"), "v2") == 0);
+  assert(quatt_hybrid_generation_wire_value("unknown") == nullptr);
+
+  assert(std::strcmp(heating_strategy_wire_value("Power House"), "power_house") == 0);
+  assert(std::strcmp(heating_strategy_wire_value("Water Temperature Control (heating curve)"), "heating_curve") == 0);
+  assert(heating_strategy_wire_value("unknown") == nullptr);
+
+  assert(std::strcmp(configured_source_wire_value("Auto"), "auto") == 0);
+  assert(std::strcmp(configured_source_wire_value("Local"), "local") == 0);
+  assert(std::strcmp(configured_source_wire_value("Outdoor unit"), "outdoor_unit") == 0);
+  assert(std::strcmp(configured_source_wire_value("CIC"), "cic") == 0);
+  assert(std::strcmp(configured_source_wire_value("OT thermostat"), "opentherm") == 0);
+  assert(std::strcmp(configured_source_wire_value("HA input"), "home_assistant") == 0);
+  assert(std::strcmp(configured_source_wire_value("Home Assistant"), "home_assistant") == 0);
+  assert(std::strcmp(configured_source_wire_value("MQTT"), "mqtt") == 0);
+  assert(std::strcmp(configured_source_wire_value("CIC or HA input"), "cic_or_home_assistant") == 0);
+  assert(std::strcmp(configured_source_wire_value("Disabled"), "disabled") == 0);
+  assert(configured_source_wire_value("unknown") == nullptr);
+
+  assert(std::strcmp(flow_source_config_wire_value("CIC", false, ""), "cic") == 0);
+  assert(std::strcmp(flow_source_config_wire_value("Outdoor unit", false, ""), "outdoor_unit") == 0);
+  assert(std::strcmp(flow_source_config_wire_value("Outdoor unit", true, "Local"), "controller_local") == 0);
+  assert(std::strcmp(flow_source_config_wire_value("Outdoor unit", true, "Auto"), "outdoor_unit") == 0);
+  assert(std::strcmp(flow_source_config_wire_value("Outdoor unit", true, "Outdoor unit"), "outdoor_unit") == 0);
+  assert(flow_source_config_wire_value("Outdoor unit", true, "") == nullptr);
+  assert(flow_source_config_wire_value("unknown", false, "") == nullptr);
+  assert(std::strcmp(flow_source_mode_wire_value("CIC", true, "Auto"), "explicit") == 0);
+  assert(std::strcmp(flow_source_mode_wire_value("Outdoor unit", false, ""), "explicit") == 0);
+  assert(std::strcmp(flow_source_mode_wire_value("Outdoor unit", true, "Auto"), "auto") == 0);
+  assert(std::strcmp(flow_source_mode_wire_value("Outdoor unit", true, "Local"), "explicit") == 0);
+  assert(flow_source_mode_wire_value("Outdoor unit", true, "") == nullptr);
 
   std::array<char, 128U> escaped{};
   FixedBufferWriter json(escaped.data(), escaped.size());


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt genormaliseerde configuratievelden toe aan de vrijwillige MQTT-gebruikstelemetrie: Quatt Hybrid-generatie, verwarmingsstrategie, flowbron/-modus en geselecteerde regelbronnen.
- Leidt de Q-flowbron af uit zowel `flow_source` als `oq_q_flow_source`; ontbrekende, nog niet geladen of onbekende opties worden fail-closed als `null` verzonden.
- Publiceert nieuwe telemetryberichten met QoS 1 zonder MQTT-retain, conform #444. Retry, idempotency en offline queueing blijven behouden.
- Werkt de telemetry-disclosure, voorbeeldpayload, gedetailleerde web-appdocumentatie, Q-edition-handleiding en regressietests bij. Compressorstarts blijven buiten scope.

Closes #444.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De verwarmingsregeling verandert niet; bestaande selectwaarden worden uitsluitend gelezen bij het opbouwen van een telemetrybericht. MQTT-transportgedrag verandert wel: nieuwe berichten worden niet meer retained gepubliceerd. De bestaande vaste PSRAM-payloadbuffer van 2049 bytes blijft ongewijzigd. Het component bewaart tien extra `Select*`-referenties (circa 40 bytes op ESP32); er komen geen taken, callbacks of dynamische buffers bij.

## Achtergrond

De wirewaarden zijn vaste enums en daardoor onafhankelijk van gebruikersgerichte labels. De keuze `V1` blijft ook de bestaande gemengde V1/V1.5-Duo-configuratie omvatten. Voor Q wordt `flow_source_config` gecombineerd uit de algemene en Q-specifieke selector en geeft `flow_source_mode` aan of de keuze automatisch of expliciet is.

De uitbreiding blijft binnen configuratietelemetrie: er worden geen gemeten temperaturen, setpoints, grenzen, topics of logs toegevoegd. `schema_version` blijft 1 omdat dit een additieve uitbreiding is; de ontvanger moet onbekende/additionele velden accepteren.

Voor #444 verandert alleen de MQTT-retainvlag van 1 naar 0. Al op de broker aanwezige retained records worden door een gewone non-retained publish niet verwijderd en vragen zo nodig een eenmalige server-side opschoning.

De volledige diff tegen `dev` is beoordeeld op scope, privacy/consent, configuratievarianten, onbekende of nog niet geladen selectwaarden, payload-overflow, MQTT QoS/retain/retrygedrag en embedded lifecycle. Een afzonderlijke koude review leverde geen aanvullende bevindingen op.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De ingebouwde privacy-disclosure, voorbeeldpayload, gedetailleerde web-appdocumentatie en Q-edition-handleiding beschrijven de nieuw verzonden configuratievelden, hun `null`-gedrag en de non-retained levering expliciet.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- Payloadallocatie blijft vast op 2049 bytes PSRAM.
- Verwachte objectgroei: tien pointers, circa 40 bytes op ESP32; geen nieuwe task-stack of netwerkbuffer.
- Geen hardwaremeting van internal heap, largest block, fragmentatie of stack-watermarks uitgevoerd; de PR is daarom als draft geopend.

Uitgevoerd:

- `npm run check:cpp-format` — geslaagd.
- `npm run check:docs` — 28 tests en docs/web-contractcontroles geslaagd.
- `npm run build:web` — geslaagd; gegenereerde bundles zijn consistent.
- `node --test openquatt/web/tests/*.test.mjs` — 154 tests geslaagd.
- `./scripts/run_host_regression_tests.sh` — 14 hosttests geslaagd met GCC 15, inclusief retain-policy; de lokale standaard-Apple-CLT mistte C++-headers.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_listener/single_wifi.yaml` — geslaagd.
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/single_wifi.yaml` — configuratie en volledige firmwarecompile geslaagd na de retainwijziging.
