### PR TITLE
Derive PR test firmware channel from base branch

### DIFF
--- a/.github/workflows/pr-test-firmware-publish.yml
+++ b/.github/workflows/pr-test-firmware-publish.yml
@@ -22,6 +22,7 @@ jobs:
       actions: read
       pull-requests: read
     outputs:
+      base_ref: ${{ steps.gate.outputs.base_ref }}
       base_sha: ${{ steps.gate.outputs.base_sha }}
       head_sha: ${{ steps.gate.outputs.head_sha }}
       pr_number: ${{ steps.gate.outputs.pr_number }}
@@ -77,7 +78,9 @@ jobs:
           PR_NUMBER="$(jq -er '.pr_number | select(type == "number" and . > 0 and floor == .)' "${META_FILE}")"
           HEAD_SHA="$(jq -er '.head_sha | select(type == "string")' "${META_FILE}")"
           HEAD_REPOSITORY="$(jq -er '.head_repository | select(type == "string")' "${META_FILE}")"
+          BASE_REF="$(jq -er '.base_ref | select(type == "string")' "${META_FILE}")"
           BASE_VERSION="$(jq -er '.base_version | select(type == "string")' "${META_FILE}")"
+          RELEASE_CHANNEL="$(jq -er '.release_channel | select(type == "string")' "${META_FILE}")"
           BUILD_RUN_NUMBER="$(jq -er '.run_number | select(type == "number" and . > 0 and floor == .)' "${META_FILE}")"
           VERSION="$(jq -er '.version | select(type == "string")' "${META_FILE}")"
 
@@ -97,6 +100,11 @@ jobs:
           fi
           if [[ ! "${BASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
             echo "Metadata contains an invalid base version." >&2
+            exit 1
+          fi
+          if [[ "${BASE_REF}" != "main" && "${BASE_REF}" != "dev" ]] ||
+             [[ "${RELEASE_CHANNEL}" != "${BASE_REF}" ]]; then
+            echo "Metadata contains an invalid PR base branch or release channel." >&2
             exit 1
           fi
           if [[ "${BUILD_RUN_NUMBER}" != "${SOURCE_RUN_NUMBER}" ]]; then
@@ -137,7 +145,12 @@ jobs:
             echo "PR #${PR_NUMBER} does not target this repository." >&2
             exit 1
           fi
+          if [[ "$(jq -r '.base.ref' <<< "${PR_JSON}")" != "${BASE_REF}" ]]; then
+            echo "PR #${PR_NUMBER} base branch changed since this firmware was built." >&2
+            exit 1
+          fi
 
+          echo "base_ref=${BASE_REF}" >> "${GITHUB_OUTPUT}"
           echo "base_sha=${BASE_SHA}" >> "${GITHUB_OUTPUT}"
           echo "head_sha=${HEAD_SHA}" >> "${GITHUB_OUTPUT}"
           echo "pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
@@ -186,6 +199,7 @@ jobs:
 
       - name: Publish current PR test release
         env:
+          BASE_REF: ${{ needs.validate-pr-test-build.outputs.base_ref }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ needs.validate-pr-test-build.outputs.head_sha }}
           PR_NUMBER: ${{ needs.validate-pr-test-build.outputs.pr_number }}
@@ -195,7 +209,8 @@ jobs:
           PR_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
           if [[ "$(jq -r '.state' <<< "${PR_JSON}")" != "open" ]] || \
              ! jq -e '.labels | any(.name == "test-firmware")' <<< "${PR_JSON}" >/dev/null || \
-             [[ "$(jq -r '.head.sha' <<< "${PR_JSON}")" != "${HEAD_SHA}" ]]; then
+             [[ "$(jq -r '.head.sha' <<< "${PR_JSON}")" != "${HEAD_SHA}" ]] || \
+             [[ "$(jq -r '.base.ref' <<< "${PR_JSON}")" != "${BASE_REF}" ]]; then
             echo "PR publication gate changed while assets were prepared." >&2
             exit 1
           fi

--- a/.github/workflows/pr-test-firmware.yml
+++ b/.github/workflows/pr-test-firmware.yml
@@ -2,7 +2,7 @@ name: PR Test Firmware Build
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [opened, reopened, labeled, synchronize, edited]
 
 permissions:
   contents: read
@@ -14,8 +14,13 @@ concurrency:
 jobs:
   compute-meta:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'test-firmware') }}
+    if: >-
+      ${{
+        contains(github.event.pull_request.labels.*.name, 'test-firmware') &&
+        (github.event.action != 'edited' || github.event.changes.base != null)
+      }}
     outputs:
+      release_channel: ${{ steps.pr_meta.outputs.release_channel }}
       version: ${{ steps.pr_meta.outputs.version }}
     steps:
       - name: Checkout PR head
@@ -28,10 +33,21 @@ jobs:
       - name: Compute PR test metadata
         id: pr_meta
         env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          case "${BASE_REF}" in
+            main|dev)
+              RELEASE_CHANNEL="${BASE_REF}"
+              ;;
+            *)
+              echo "Unsupported PR base branch: ${BASE_REF}" >&2
+              exit 1
+              ;;
+          esac
+
           BASE_VERSION="$(awk -F'"' '/^project_version: / { print $2 }' openquatt/oq_substitutions_common.yaml)"
           if [[ ! "${BASE_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
             echo "Unexpected project_version: ${BASE_VERSION}" >&2
@@ -40,20 +56,25 @@ jobs:
 
           SHORT_SHA="${HEAD_SHA::7}"
           PR_VERSION="${BASE_VERSION}-pr.${PR_NUMBER}.${GITHUB_RUN_NUMBER}+${SHORT_SHA}"
+          echo "release_channel=${RELEASE_CHANNEL}" >> "${GITHUB_OUTPUT}"
           echo "version=${PR_VERSION}" >> "${GITHUB_OUTPUT}"
 
           jq -n \
+            --arg base_ref "${BASE_REF}" \
             --arg base_version "${BASE_VERSION}" \
             --arg head_repository "${HEAD_REPOSITORY}" \
             --arg head_sha "${HEAD_SHA}" \
             --argjson pr_number "${PR_NUMBER}" \
+            --arg release_channel "${RELEASE_CHANNEL}" \
             --argjson run_number "${GITHUB_RUN_NUMBER}" \
             --arg version "${PR_VERSION}" \
             '{
+              base_ref: $base_ref,
               base_version: $base_version,
               head_repository: $head_repository,
               head_sha: $head_sha,
               pr_number: $pr_number,
+              release_channel: $release_channel,
               run_number: $run_number,
               version: $version
             }' > "${RUNNER_TEMP}/pr-test-firmware-meta.json"
@@ -77,4 +98,5 @@ jobs:
       checkout_ref: ${{ github.event.pull_request.head.sha }}
       checkout_repository: ${{ github.event.pull_request.head.repo.full_name }}
       project_version: ${{ needs.compute-meta.outputs.version }}
+      release_channel: ${{ needs.compute-meta.outputs.release_channel }}
       include_factory_bin: false

--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -35,6 +35,35 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
             ),
         )
 
+    def test_release_channel_follows_supported_pr_base_branch(self) -> None:
+        self.assertIn("types: [opened, reopened, labeled, synchronize, edited]", BUILD_WORKFLOW)
+        self.assertIn("github.event.changes.base != null", BUILD_WORKFLOW)
+        self.assertIn("BASE_REF: ${{ github.event.pull_request.base.ref }}", BUILD_WORKFLOW)
+        self.assertIn('case "${BASE_REF}" in\n            main|dev)', BUILD_WORKFLOW)
+        self.assertIn(
+            "release_channel: ${{ steps.pr_meta.outputs.release_channel }}",
+            BUILD_WORKFLOW,
+        )
+        self.assertIn(
+            'echo "release_channel=${RELEASE_CHANNEL}" >> "${GITHUB_OUTPUT}"',
+            BUILD_WORKFLOW,
+        )
+        self.assertIn(
+            "release_channel: ${{ needs.compute-meta.outputs.release_channel }}",
+            BUILD_WORKFLOW,
+        )
+        self.assertIn('--arg base_ref "${BASE_REF}"', BUILD_WORKFLOW)
+        self.assertIn('--arg release_channel "${RELEASE_CHANNEL}"', BUILD_WORKFLOW)
+
+    def test_release_channel_is_revalidated_before_publishing(self) -> None:
+        self.assertIn('BASE_REF="$(jq -er \'.base_ref', PUBLISH_WORKFLOW)
+        self.assertIn('RELEASE_CHANNEL="$(jq -er \'.release_channel', PUBLISH_WORKFLOW)
+        self.assertIn('[[ "${RELEASE_CHANNEL}" != "${BASE_REF}" ]]', PUBLISH_WORKFLOW)
+        self.assertIn("base branch changed since this firmware was built", PUBLISH_WORKFLOW)
+        self.assertIn("base_ref: ${{ steps.gate.outputs.base_ref }}", PUBLISH_WORKFLOW)
+        self.assertIn("BASE_REF: ${{ needs.validate-pr-test-build.outputs.base_ref }}", PUBLISH_WORKFLOW)
+        self.assertGreaterEqual(PUBLISH_WORKFLOW.count(".base.ref"), 2)
+
     def test_privileged_workflow_revalidates_before_publishing(self) -> None:
         self.assertIn("workflow_run:", PUBLISH_WORKFLOW)
         self.assertIn("pull_request_target:", PUBLISH_WORKFLOW)


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat PR-testfirmware `release_channel` overnemen van de doelbranch: `dev` voor PR's naar `dev`, `main` voor PR's naar `main`.
- Laat onbekende doelbranches fail-closed stoppen en bouwt opnieuw wanneer een PR wordt geretarget.
- Legt doelbranch en releasekanaal vast in de buildmetadata en verifieert de doelbranch opnieuw vóór én vlak vóór publicatie.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen PR-testfirmware verandert. De diagnostische entiteit `OpenQuatt Release Channel` meldt voortaan de doelbranch van de PR. Daardoor initialiseert een PR naar `dev` ook `Firmware Update Channel` als `dev`; een PR naar `main` blijft `main`.

## Achtergrond

De PR-testworkflow overschreef alleen `project_version`. Zonder expliciete `release_channel` gebruikte ESPHome de bronstandaard `main`, ook voor PR's naar `dev`.

De volledige diff tegen `dev` is beoordeeld op workflowrechten, fork-PR's, ondersteunde/ongeldige doelbranches, metadata-integriteit, retargets tijdens een lopende build en wijzigingen tussen validatie en publicatie. Een afzonderlijke koude review vond dat de doelbranch na de eerste gate nog kon veranderen; daarom wordt `base_ref` ook in de laatste publicatiegate gecontroleerd.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/releaseproces.md` beschrijft `release_channel` al als het kanaal waarop de actieve firmware draait. Deze wijziging brengt de PR-build daarmee in lijn.

## Validatie

- [x] `python3 -m unittest scripts.tests.test_pr_test_firmware_workflows` — 8 tests geslaagd.
- [x] Workflow-YAML van beide gewijzigde workflows met Ruby/Psych geparset.
- [x] `git diff --check` — geslaagd.
- [x] `./scripts/validate_local.sh` — stijl, docs, webcontract, webbundles en config-validatie voor alle 8 targets geslaagd; de niet-relevante volledige firmwarematrix is niet afgewacht.
- [x] Volledige diff-audit en afzonderlijke koude review tegen `origin/dev` uitgevoerd.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen firmwarecode, allocaties, buffers of tasks gewijzigd.