### PR TITLE
Preserve RAM trends when flash archive is empty

### DIFF
--- a/components/openquatt_trends/OpenQuattTrends.cpp
+++ b/components/openquatt_trends/OpenQuattTrends.cpp
@@ -445,7 +445,14 @@ void OpenQuattTrends::load_archive_if_needed_() {
     this->scan_flash_archive_();
   }
 
-  if (this->flash_archive_seeded_) {
+  const TrendArchiveLoadAction load_action =
+      trend_archive_load_action(this->flash_archive_scanned_, this->flash_index_count_, this->flash_archive_seeded_);
+  if (load_action == TrendArchiveLoadAction::WAIT) {
+    return;
+  }
+
+  if (load_action == TrendArchiveLoadAction::MARK_EMPTY_AS_SEEDED) {
+    this->flash_archive_seeded_ = true;
     return;
   }
 

--- a/components/openquatt_trends/OpenQuattTrendsStoragePolicy.h
+++ b/components/openquatt_trends/OpenQuattTrendsStoragePolicy.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
 namespace esphome {
 namespace openquatt_trends {
 
@@ -8,12 +11,29 @@ struct TrendStorageCapabilities {
   bool flash_archive_available;
 };
 
+enum class TrendArchiveLoadAction : uint8_t {
+  WAIT = 0U,
+  MARK_EMPTY_AS_SEEDED = 1U,
+  MERGE_FLASH_INTO_RAM = 2U,
+};
+
 constexpr TrendStorageCapabilities trend_storage_capabilities(bool ram_history_allocated, bool flash_index_allocated,
                                                               bool flash_partition_available) {
   return TrendStorageCapabilities{
       ram_history_allocated,
       flash_index_allocated && flash_partition_available,
   };
+}
+
+constexpr TrendArchiveLoadAction trend_archive_load_action(bool archive_scanned, size_t indexed_block_count,
+                                                           bool archive_seeded) {
+  if (!archive_scanned || archive_seeded) {
+    return TrendArchiveLoadAction::WAIT;
+  }
+  if (indexed_block_count == 0U) {
+    return TrendArchiveLoadAction::MARK_EMPTY_AS_SEEDED;
+  }
+  return TrendArchiveLoadAction::MERGE_FLASH_INTO_RAM;
 }
 
 }  // namespace openquatt_trends

--- a/tests/host/openquatt_trends_storage_policy_test.cpp
+++ b/tests/host/openquatt_trends_storage_policy_test.cpp
@@ -2,7 +2,9 @@
 
 #include "components/openquatt_trends/OpenQuattTrendsStoragePolicy.h"
 
+using esphome::openquatt_trends::trend_archive_load_action;
 using esphome::openquatt_trends::trend_storage_capabilities;
+using esphome::openquatt_trends::TrendArchiveLoadAction;
 
 int main() {
   const auto full = trend_storage_capabilities(true, true, true);
@@ -24,6 +26,14 @@ int main() {
   const auto flash_only = trend_storage_capabilities(false, true, true);
   assert(!flash_only.ram_history_available);
   assert(flash_only.flash_archive_available);
+
+  // Enabling flash persistence on a fresh controller completes archive seeding
+  // without merging an empty archive over newly captured RAM history.
+  assert(trend_archive_load_action(true, 0U, false) == TrendArchiveLoadAction::MARK_EMPTY_AS_SEEDED);
+
+  assert(trend_archive_load_action(true, 1U, false) == TrendArchiveLoadAction::MERGE_FLASH_INTO_RAM);
+  assert(trend_archive_load_action(false, 0U, false) == TrendArchiveLoadAction::WAIT);
+  assert(trend_archive_load_action(true, 1U, true) == TrendArchiveLoadAction::WAIT);
 
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Behandel een volledig gescand maar leeg trendarchief als afgehandeld, zodat het RAM-trendbuffer niet iedere loop opnieuw wordt gewist.
- Voeg een pure lifecycle-beslissing en host-regressietest toe voor een verse controller waarop flashhistorie via backup-restore wordt ingeschakeld.
- Bestaande flashhistorie blijft bij opstarten of inschakelen zoals voorheen naar RAM worden samengevoegd.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Op een verse controller met lege trendflash kon het inschakelen van flashhistorie via settings-restore de nieuw verzamelde RAM-metingen iedere loop wissen. Diagnosegrafieken bleven daardoor leeg totdat `Nu opslaan` het eerste flashblok maakte. De wijziging beperkt zich tot deze opslaglifecycle en raakt de warmtepompregeling niet.

## Achtergrond

Root cause: `load_archive_if_needed_()` bleef een leeg archief naar RAM proberen samen te voegen. `merge_flash_history_into_ram_()` maakt daarvoor eerst de RAM-ring leeg, maar retourneert bij nul flashblokken `false`; daardoor werd `flash_archive_seeded_` nooit gezet en herhaalde de destructieve poging zich.

De volledige diff is gecontroleerd op fresh install, backup-restore, herstart, flash uit/aan, handmatig flushen, corrupte/onleesbare flashblokken en write failures. Een lege of volledig ongeldige scan bewaart nu RAM-data zonder ongeldige historie te laden. Bestaande archieven volgen het ongewijzigde mergepad. Er wijzigen geen persistente formaten, API's, entiteiten of migraties.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt het bestaande gedrag van Diagnose en verandert geen gebruikersflow of configuratie.

## Validatie

- `npm run check:cpp-format`
- `CXX=/opt/homebrew/opt/gcc/bin/g++-15 ./scripts/run_host_regression_tests.sh` — 14 hosttests geslaagd
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml` — volledige firmwarecompile geslaagd

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen een `constexpr` lifecycle-beslissing en bestaande statusvelden worden gebruikt; er komen geen buffers, heapallocaties of task-stackwijzigingen bij.
