### PR TITLE
Bridge brief selected supply temperature dropouts

### DIFF
--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -140,6 +140,11 @@ These offsets spread network and bus work; they are not readiness guarantees. A 
 
 Runtime selectors decide per signal whether selected values come from local, CIC, or HA-input sources.
 
+`water_supply_temp_selected` first uses the configured source and then a fresh heat-pump outlet fallback. If neither is
+available, it briefly holds the last value from that exact source: 15 seconds for Local/CIC sensor dropouts and 300
+seconds for HA input so a Home Assistant restart does not interrupt control. Any source change clears the held value;
+after the applicable timeout the signal returns to the existing `NaN` fail-safe path.
+
 ### 4.3 Demand layer
 
 Strategy packages compute:

--- a/openquatt/includes/control/oq_supply_hold_logic.h
+++ b/openquatt/includes/control/oq_supply_hold_logic.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+
+#include "oq_supply_calibration_logic.h"
+
+namespace oq_supply_hold {
+
+inline bool source_matches(int32_t source_code, uint32_t source_fingerprint,
+                           const oq_supply_calibration::SourceIdentity& current) {
+  return current.ready && source_code == static_cast<int32_t>(current.code) &&
+         source_fingerprint == current.fingerprint;
+}
+
+inline uint32_t timeout_ms(const oq_supply_calibration::SourceIdentity& current, uint32_t local_cic_timeout_ms,
+                           uint32_t ha_timeout_ms) {
+  return current.ready && current.code == oq_supply_calibration::SOURCE_HA_INPUT ? ha_timeout_ms : local_cic_timeout_ms;
+}
+
+inline bool can_hold(float last_valid_c, uint32_t last_valid_ms, int32_t source_code, uint32_t source_fingerprint,
+                     const oq_supply_calibration::SourceIdentity& current, uint32_t now_ms, uint32_t hold_ms) {
+  return isfinite(last_valid_c) && last_valid_ms > 0 && hold_ms > 0 &&
+         source_matches(source_code, source_fingerprint, current) &&
+         static_cast<uint32_t>(now_ms - last_valid_ms) < hold_ms;
+}
+
+struct State {
+  float last_valid_c = NAN;
+  uint32_t last_valid_ms = 0;
+  int32_t source_code = 0;
+  uint32_t source_fingerprint = 0;
+
+  bool has_value() const { return isfinite(last_valid_c) && last_valid_ms > 0 && source_code != 0; }
+
+  bool matches_source(const oq_supply_calibration::SourceIdentity& current) const {
+    return source_matches(source_code, source_fingerprint, current);
+  }
+
+  void reset() {
+    last_valid_c = NAN;
+    last_valid_ms = 0;
+    source_code = 0;
+    source_fingerprint = 0;
+  }
+
+  void remember(float value_c, uint32_t now_ms, const oq_supply_calibration::SourceIdentity& current) {
+    if (!isfinite(value_c) || !current.ready) {
+      reset();
+      return;
+    }
+    last_valid_c = value_c;
+    last_valid_ms = now_ms;
+    source_code = static_cast<int32_t>(current.code);
+    source_fingerprint = current.fingerprint;
+  }
+
+  bool available(const oq_supply_calibration::SourceIdentity& current, uint32_t now_ms, uint32_t hold_ms) const {
+    return can_hold(last_valid_c, last_valid_ms, source_code, source_fingerprint, current, now_ms, hold_ms);
+  }
+};
+
+}  // namespace oq_supply_hold

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -15,14 +15,6 @@ packages:
   oq_cooling_safety: !include oq_cooling_safety.yaml
 
 globals:
-  - id: oq_water_supply_temp_selected_last_valid_c
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-  - id: oq_water_supply_temp_selected_last_valid_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
   - id: oq_water_supply_temp_selected_hold_active
     type: bool
     restore_value: false
@@ -450,15 +442,16 @@ sensor:
     update_interval: 5s
     lambda: |-
       // Prefer the configured source, then the topology's last heat-pump outlet.
-      // If both are unavailable, keep the existing short HA reload hold as a last resort.
+      // If both are unavailable, briefly hold the last value from the exact same source.
       const bool source_available = id(water_supply_source).has_state();
       const std::string source = source_available
           ? id(water_supply_source).current_option()
           : std::string();
-      const bool hold_enabled = source == "HA input";
-      const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
+      const uint32_t local_cic_hold_ms = (uint32_t)(${oq_water_supply_temp_local_cic_hold_s}UL * 1000UL);
+      const uint32_t ha_hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
       const uint32_t fallback_stale_ms = (uint32_t)(${oq_hp_water_temp_stale_s}UL * 1000UL);
       const uint32_t now_ms = (uint32_t) millis();
+      static oq_supply_hold::State selected_hold;
 
       std::string local_source;
       bool local_source_ready = false;
@@ -473,6 +466,13 @@ sensor:
           source.c_str(), OQ_HARDWARE_HEATPUMP_CONTROLLER_Q, local_source.c_str(), local_source_ready,
           cic_url.c_str(), cic_url_ready, "${ha_water_supply_temp_entity_id}");
 
+      auto clear_selected_hold = [&]() {
+        selected_hold.reset();
+        id(oq_water_supply_temp_selected_hold_active) = false;
+      };
+      const bool cached_source_changed = selected_hold.has_value() && !selected_hold.matches_source(source_identity);
+      if (cached_source_changed) clear_selected_hold();
+
       if (source_identity.ready) {
         const bool source_changed = id(oq_water_supply_temp_current_source_ready) &&
             (id(oq_water_supply_temp_current_source_code) != static_cast<int32_t>(source_identity.code) ||
@@ -484,6 +484,7 @@ sensor:
             !oq_supply_calibration::record_matches(
                 calibrated_source, id(oq_water_supply_temp_calibration_source_fingerprint),
                 id(oq_water_supply_temp_calibration_checksum), offset_c, source_identity);
+        if (record_invalid) clear_selected_hold();
         if ((source_changed || record_invalid) && calibrated_source > 0) {
           id(oq_water_supply_temp_calibration_checksum) = 0;
           id(oq_water_supply_temp_calibration_source_code) =
@@ -529,12 +530,10 @@ sensor:
                 id(oq_water_supply_temp_calibration_checksum), offset_c, source_identity)) {
           selected_c += offset_c;
         }
-        if (hold_enabled) {
-          id(oq_water_supply_temp_selected_last_valid_c) = selected_c;
-          id(oq_water_supply_temp_selected_last_valid_ms) = now_ms;
+        if (source_identity.ready) {
+          selected_hold.remember(selected_c, now_ms, source_identity);
         } else {
-          id(oq_water_supply_temp_selected_last_valid_c) = NAN;
-          id(oq_water_supply_temp_selected_last_valid_ms) = 0;
+          clear_selected_hold();
         }
         id(oq_water_supply_temp_selected_hold_active) = false;
         id(oq_water_supply_temp_fallback_runtime_active) = false;
@@ -555,6 +554,10 @@ sensor:
       }
 
       id(oq_water_supply_temp_selected_hold_active) = false;
+      const uint32_t hold_ms = oq_supply_hold::timeout_ms(source_identity, local_cic_hold_ms, ha_hold_ms);
+      const bool selected_hold_available = selected_hold.available(source_identity, now_ms, hold_ms);
+      if (!selected_hold_available) clear_selected_hold();
+
       const uint32_t fallback_last_update_ms = id(${secondary_water_out_last_update_ms_id});
       const bool fallback_fresh =
           fallback_last_update_ms > 0 &&
@@ -569,16 +572,14 @@ sensor:
       }
 
       id(oq_water_supply_temp_fallback_runtime_active) = false;
-      if (hold_enabled &&
-          hold_ms > 0 &&
-          id(oq_water_supply_temp_selected_last_valid_ms) > 0 &&
-          (uint32_t)(now_ms - id(oq_water_supply_temp_selected_last_valid_ms)) < hold_ms &&
-          !isnan(id(oq_water_supply_temp_selected_last_valid_c))) {
+      if (selected_hold_available) {
         id(oq_water_supply_temp_selected_hold_active) = true;
-        publish_effective_source("HA input");
-        return id(oq_water_supply_temp_selected_last_valid_c);
+        publish_effective_source(
+            std::string(oq_supply_calibration::source_label(selected_hold.source_code)) + " (held)");
+        return selected_hold.last_valid_c;
       }
 
+      clear_selected_hold();
       publish_effective_source("Unavailable");
       return NAN;
 

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -154,6 +154,7 @@ oq_strategy_loop_s: "5"                               # Interval for strategy ca
 oq_diagnostic_update_interval_s: "30"                # Shared cadence for slower operator-facing diagnostics [s].
 oq_strategy_demand_max_f: "20.0"                      # Upper bound of demand scale for mapping PID/power -> f.
 oq_selected_input_stale_hold_s: "300"                 # Hold selected HA-backed inputs this long when they briefly disappear during reloads [s].
+oq_water_supply_temp_local_cic_hold_s: "15"            # Hold Local/CIC supply temperature through brief sensor dropouts [s].
 oq_hp_water_temp_stale_s: "60"                        # Maximum age for a heat-pump water temperature used as supply fallback [s].
 oq_temp_guard_delta_c: "0.5"                          # Minimum valid margin between T0 and Tc in the house model [°C].
 oq_outside_temp_stale_s: "1200"                       # Ignore a local outdoor reading when it stays frozen while the same HP still shows fresh activity [s].

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -127,6 +127,8 @@ select:
           }
           id(oq_water_supply_temp_current_source_ready) = false;
           if (id(oq_hp_water_calibration_active)) id(oq_hp_water_calibration_abort) = true;
+          // Refresh the local proxy first so the old physical source cannot be cached under the new identity.
+          id(water_supply_temp_esp).update();
           id(water_supply_temp_selected).update();
 
   - platform: template

--- a/tests/host/oq_supply_hold_logic_test.cpp
+++ b/tests/host/oq_supply_hold_logic_test.cpp
@@ -1,0 +1,65 @@
+#include <assert.h>
+#include <limits.h>
+#include <math.h>
+
+#include "../../openquatt/includes/control/oq_supply_hold_logic.h"
+
+int main() {
+  using namespace oq_supply_calibration;
+  using namespace oq_supply_hold;
+
+  const auto pt1000 = source_identity("Local", true, "PT1000", true, "", false, "sensor.supply");
+  const auto ds18b20 = source_identity("Local", true, "DS18B20", true, "", false, "sensor.supply");
+  const auto cic_a = source_identity("CIC", false, "", false, "http://cic-a/feed", true, "sensor.supply");
+  const auto cic_b = source_identity("CIC", false, "", false, "http://cic-b/feed", true, "sensor.supply");
+  const auto ha = source_identity("HA input", false, "", false, "", false, "sensor.supply");
+
+  constexpr uint32_t short_hold_ms = 15000;
+  constexpr uint32_t ha_hold_ms = 300000;
+  assert(timeout_ms(pt1000, short_hold_ms, ha_hold_ms) == short_hold_ms);
+  assert(timeout_ms(ds18b20, short_hold_ms, ha_hold_ms) == short_hold_ms);
+  assert(timeout_ms(cic_a, short_hold_ms, ha_hold_ms) == short_hold_ms);
+  assert(timeout_ms(ha, short_hold_ms, ha_hold_ms) == ha_hold_ms);
+
+  const int32_t pt1000_code = static_cast<int32_t>(pt1000.code);
+  assert(can_hold(32.5f, 1000, pt1000_code, pt1000.fingerprint, pt1000, 15999, short_hold_ms));
+  assert(!can_hold(32.5f, 1000, pt1000_code, pt1000.fingerprint, pt1000, 16000, short_hold_ms));
+  assert(!can_hold(32.5f, 1000, pt1000_code, pt1000.fingerprint, ds18b20, 5000, short_hold_ms));
+  assert(!can_hold(NAN, 1000, pt1000_code, pt1000.fingerprint, pt1000, 5000, short_hold_ms));
+  assert(!can_hold(32.5f, 0, pt1000_code, pt1000.fingerprint, pt1000, 5000, short_hold_ms));
+
+  const int32_t cic_code = static_cast<int32_t>(cic_a.code);
+  assert(can_hold(28.0f, 1000, cic_code, cic_a.fingerprint, cic_a, 5000, short_hold_ms));
+  assert(!can_hold(28.0f, 1000, cic_code, cic_a.fingerprint, cic_b, 5000, short_hold_ms));
+
+  const int32_t ha_code = static_cast<int32_t>(ha.code);
+  assert(can_hold(31.0f, 1000, ha_code, ha.fingerprint, ha, 300999, ha_hold_ms));
+  assert(!can_hold(31.0f, 1000, ha_code, ha.fingerprint, ha, 301000, ha_hold_ms));
+
+  constexpr uint32_t before_wrap_ms = UINT32_MAX - 4U;
+  assert(can_hold(30.0f, before_wrap_ms, pt1000_code, pt1000.fingerprint, pt1000, 5U, short_hold_ms));
+
+  State state;
+  assert(!state.has_value());
+  state.remember(32.5f, 1000, pt1000);
+  assert(state.has_value());
+  assert(state.available(pt1000, 5000, short_hold_ms));
+  assert(!state.available(ds18b20, 5000, short_hold_ms));
+
+  // A source transition clears the old sample before the new source can recover.
+  if (!state.matches_source(ds18b20)) state.reset();
+  assert(!state.has_value());
+  state.remember(31.75f, 6000, ds18b20);
+  assert(state.available(ds18b20, 10000, short_hold_ms));
+  assert(state.last_valid_c == 31.75f);
+  assert(!state.available(ds18b20, 21000, short_hold_ms));
+  if (!state.available(ds18b20, 21000, short_hold_ms)) state.reset();
+  assert(!state.has_value());
+
+  state.remember(29.0f, 1000, ha);
+  assert(state.available(ha, 300999, ha_hold_ms));
+  assert(!state.available(ha, 301000, ha_hold_ms));
+  state.remember(NAN, 302000, ha);
+  assert(!state.has_value());
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Overbrugt korte uitval van de geselecteerde Local/PT1000-, Local/DS18B20- en CIC-aanvoertemperatuur maximaal 15 seconden.
- Behoudt de bestaande HA-reloadbescherming van 300 seconden en de bestaande verse HP-water-out-fallback als hogere prioriteit.
- Bindt iedere hold aan de exacte bronidentiteit, wist de cache bij bron- of kalibratiewijzigingen en toont `(held)` in de effectieve-brondiagnostiek.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

`water_supply_temp_selected` blijft tijdens korte bronuitval eindig, zodat Heating Curve en CM5 niet onnodig hun regelstate resetten. Een verse HP-water-out-fallback houdt voorrang. Na 15 seconden voor Local/CIC of 300 seconden voor HA volgt zonder fallback opnieuw het bestaande `NaN`-fail-safe-pad.

## Achtergrond

Closes #418.

De bestaande last-known-good-cache werd alleen gevuld voor `HA input`. Daardoor kon een enkele ongeldige MAX31865/PT1000-sample direct doorwerken naar het canonieke regelsignaal wanneer ook de bestaande HP-fallback niet beschikbaar was.

De nieuwe policy hergebruikt de bestaande broncode en fingerprint van de supply-calibratie. PT1000, DS18B20, CIC-URL en HA-entity zijn daardoor afzonderlijke identiteiten. Een bronwissel, onzekere identiteit of ongeldig kalibratierecord wist de cache fail-closed. De cache verloopt ook terwijl de HP-fallback actief is, zodat een oude waarde rond een `millis()`-wrap niet kan herleven.

De volledige diff tegen `dev` is gecontroleerd op correctheid, security/privacy, lifecycle en timing, foutafhandeling, compatibiliteit, upgrades/fresh install en gegenereerde bestanden. Daarbij zijn bronwissels, herstel, timeoutgrenzen, kalibratie-invalidatie, fallbackverlies en timer-wrap expliciet nagelopen.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/system-overview.md` beschrijft de gewijzigde runtimeprioriteit en de bronspecifieke timeouts. Aanvullende installer-, instellingen-, dashboard- of web-appdocumentatie is niet nodig: er veranderen geen user-facing entities, configureerbare runtime-instellingen of firmware-/hardwarematrix.

## Validatie

- [x] `./scripts/run_host_regression_tests.sh` — 19 hosttests geslaagd, inclusief de nieuwe hold-policytest.
- [x] `npm run check:cpp-format` — geslaagd.
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd.
- [x] `python3 scripts/dev.py validate --config configs/heatpump_controller_q/single_wifi.yaml` — configvalidatie en firmwarecompile geslaagd.
- [x] `python3 scripts/dev.py validate --config configs/waveshare/single_wifi.yaml` — configvalidatie en firmwarecompile geslaagd.
- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

De state blijft vaste, boot-lokale opslag zonder heap-, PSRAM-, task- of netwerkallocaties. Ten opzichte van de bestaande waarde/timestamp-cache komen twee 32-bit bronidentiteitsvelden erbij. Geen HIL-geheugenmeting uitgevoerd.

Nog niet uitgevoerd: fysieke foutinjectie op een Controller Q tijdens actieve Heating Curve en CM5. De PR blijft daarom draft.