### PR TITLE
Honor compressor minimum runtime during cooling stops

### DIFF
--- a/openquatt/includes/control/oq_thermal_request_logic.h
+++ b/openquatt/includes/control/oq_thermal_request_logic.h
@@ -186,8 +186,13 @@ inline uint32_t capped_loop_dt_ms(uint32_t now_ms, uint32_t last_loop_ms, uint32
 }
 
 inline bool min_runtime_window_active(uint32_t now_ms, uint32_t last_real_start_ms, uint32_t min_runtime_ms) {
-  return last_real_start_ms > 0 && now_ms > last_real_start_ms &&
-         (uint32_t)(now_ms - last_real_start_ms) < min_runtime_ms;
+  return last_real_start_ms > 0 && (uint32_t)(now_ms - last_real_start_ms) < min_runtime_ms;
+}
+
+inline bool min_runtime_hold_required(int requested_level, bool runtime_hold_blocked, bool runtime_window_active,
+                                      int previous_applied_level, bool measured_thermal) {
+  return requested_level == 0 && !runtime_hold_blocked && runtime_window_active &&
+         (previous_applied_level > 0 || measured_thermal);
 }
 
 }  // namespace oq_request

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -984,16 +984,17 @@ interval:
           if (min_rt_s > 0 && min_rt_s < 300) min_rt_s = 300;
           const uint32_t min_rt_ms = (min_rt_s > 0) ? ((uint32_t) min_rt_s * 1000UL) : 0;
           auto min_runtime_hold_level = [&](bool is_hp1)->int {
-            if (id(oq_water_temp_hard_trip_active) || min_rt_ms == 0) return 0;
             const uint32_t last_real_start_ms = is_hp1 ? id(hp1_last_real_heat_start_ms) : id(hp2_last_real_heat_start_ms);
-            if (!oq_request::min_runtime_window_active(now_ms, last_real_start_ms, min_rt_ms)) return 0;
-
+            const bool runtime_window_active =
+                oq_request::min_runtime_window_active(now_ms, last_real_start_ms, min_rt_ms);
             const int last_applied = is_hp1 ? id(hp1_last_applied_level) : id(${secondary_last_applied_level_id});
             const bool measured_thermal = is_hp1 ? hp1_measured_thermal : hp2_measured_thermal;
-            if (!(last_applied > 0 || measured_thermal)) return 0;
-
-            (void) is_hp1;
-            return 1;
+            const bool runtime_hold_blocked =
+                id(oq_water_temp_hard_trip_active) || id(oq_lowflow_fault_active) || startup_inhibit_active;
+            return oq_request::min_runtime_hold_required(
+                       0, runtime_hold_blocked, runtime_window_active, last_applied, measured_thermal)
+                       ? 1
+                       : 0;
           };
 
           // =========================
@@ -1401,11 +1402,12 @@ interval:
           }
 
           // =========================
-          // 5) Absolute water-temperature hard trip
-          // Shared with boiler-control and heating-strategy. This safety stop has
-          // higher priority than compressor minimum runtime.
+          // 5) Absolute water-temperature/low-flow hard stop
+          // These safety stops have higher priority than compressor minimum runtime.
           // =========================
-          if (id(oq_water_temp_hard_trip_active)) {
+          const bool hard_request_stop_active =
+              id(oq_water_temp_hard_trip_active) || id(oq_lowflow_fault_active);
+          if (hard_request_stop_active) {
             hp1_req = 0;
             #if OQ_TOPOLOGY_DUO
             hp2_req = 0;
@@ -1426,42 +1428,46 @@ interval:
             hp2_req = 0;
             #endif
           }
+          const bool runtime_hold_blocked =
+              hard_request_stop_active || startup_inhibit_active;
 
           // =========================
           // 6) Post-request runtime floor
-          // Prevents very short compressor runs in both curve and Power House modes.
+          // Prevents very short compressor runs in cooling, curve and Power House modes.
           // Runtime is per-compressor and user-tunable, with a hard lower bound of 300 s.
-          // Skipped during an absolute water-temperature hard trip.
+          // Normal zero requests, including cooling floor/dew-point stops, keep a
+          // running compressor at its minimum allowed level. Absolute safety stops
+          // here and in the downstream actuator retain higher priority.
           // =========================
-          if (!id(oq_water_temp_hard_trip_active) && min_rt_s > 0) {
-            const bool cooling_floor_trip =
-                is_cooling_mode &&
-                id(cooling_effective_min_supply_temp).has_state() && !isnan(id(cooling_effective_min_supply_temp).state) &&
-                id(oq_system_supply_temp).has_state() && !isnan(id(oq_system_supply_temp).state) &&
-                (id(oq_system_supply_temp).state <= (id(cooling_effective_min_supply_temp).state + 0.10f));
+          if (min_rt_s > 0) {
             // HP1/HP2: if request is 0 but measured heating start is still within
             // the minimum runtime window, keep that compressor alive at >=1.
             // This guard intentionally keys off real heating start instead of the
             // earlier apply transition, so short mode-transition delays do not
             // silently consume most of the runtime window.
             const bool hp1_min_runtime_active =
-                (id(hp1_last_real_heat_start_ms) > 0) &&
-                (now_ms > id(hp1_last_real_heat_start_ms)) &&
-                ((uint32_t)(now_ms - id(hp1_last_real_heat_start_ms)) < min_rt_ms);
+                oq_request::min_runtime_window_active(
+                    now_ms, id(hp1_last_real_heat_start_ms), min_rt_ms);
             const bool hp1_min_runtime_hold =
-                (hp1_req == 0 && !cooling_floor_trip && hp1_min_runtime_active &&
-                 (id(hp1_last_applied_level) > 0 || hp1_measured_thermal));
+                oq_request::min_runtime_hold_required(
+                    hp1_req, runtime_hold_blocked, hp1_min_runtime_active,
+                    id(hp1_last_applied_level), hp1_measured_thermal);
             if (hp1_min_runtime_hold) {
               hp1_req = pick_allowed(1, true);
             }
             static bool last_hp1_min_runtime_hold = false;
             if (hp1_min_runtime_hold != last_hp1_min_runtime_hold) {
               if (hp1_min_runtime_hold) {
-                const uint32_t elapsed_ms = (now_ms > id(hp1_last_real_heat_start_ms))
-                    ? (now_ms - id(hp1_last_real_heat_start_ms)) : 0;
+                const uint32_t elapsed_ms = now_ms - id(hp1_last_real_heat_start_ms);
                 const uint32_t remaining_s =
                     (min_rt_ms > elapsed_ms) ? ((min_rt_ms - elapsed_ms + 999UL) / 1000UL) : 0;
-                ESP_LOGI("quatt.req", "HP1 minimum runtime hold active: keeping level 1 for %u s", (unsigned int) remaining_s);
+                if (is_cooling_mode) {
+                  ESP_LOGI("quatt.req", "HP1 cooling stop deferred by minimum runtime: requesting minimum level for %u s",
+                           (unsigned int) remaining_s);
+                } else {
+                  ESP_LOGI("quatt.req", "HP1 minimum runtime hold active: keeping level 1 for %u s",
+                           (unsigned int) remaining_s);
+                }
               } else {
                 ESP_LOGI("quatt.req", "HP1 minimum runtime hold cleared");
               }
@@ -1470,23 +1476,28 @@ interval:
 
             #if OQ_TOPOLOGY_DUO
             const bool hp2_min_runtime_active =
-                (id(hp2_last_real_heat_start_ms) > 0) &&
-                (now_ms > id(hp2_last_real_heat_start_ms)) &&
-                ((uint32_t)(now_ms - id(hp2_last_real_heat_start_ms)) < min_rt_ms);
+                oq_request::min_runtime_window_active(
+                    now_ms, id(hp2_last_real_heat_start_ms), min_rt_ms);
             const bool hp2_min_runtime_hold =
-                (hp2_req == 0 && !cooling_floor_trip && hp2_min_runtime_active &&
-                 (id(${secondary_last_applied_level_id}) > 0 || hp2_measured_thermal));
+                oq_request::min_runtime_hold_required(
+                    hp2_req, runtime_hold_blocked, hp2_min_runtime_active,
+                    id(${secondary_last_applied_level_id}), hp2_measured_thermal);
             if (hp2_min_runtime_hold) {
               hp2_req = pick_allowed(1, false);
             }
             static bool last_hp2_min_runtime_hold = false;
             if (hp2_min_runtime_hold != last_hp2_min_runtime_hold) {
               if (hp2_min_runtime_hold) {
-                const uint32_t elapsed_ms = (now_ms > id(hp2_last_real_heat_start_ms))
-                    ? (now_ms - id(hp2_last_real_heat_start_ms)) : 0;
+                const uint32_t elapsed_ms = now_ms - id(hp2_last_real_heat_start_ms);
                 const uint32_t remaining_s =
                     (min_rt_ms > elapsed_ms) ? ((min_rt_ms - elapsed_ms + 999UL) / 1000UL) : 0;
-                ESP_LOGI("quatt.req", "HP2 minimum runtime hold active: keeping level 1 for %u s", (unsigned int) remaining_s);
+                if (is_cooling_mode) {
+                  ESP_LOGI("quatt.req", "HP2 cooling stop deferred by minimum runtime: requesting minimum level for %u s",
+                           (unsigned int) remaining_s);
+                } else {
+                  ESP_LOGI("quatt.req", "HP2 minimum runtime hold active: keeping level 1 for %u s",
+                           (unsigned int) remaining_s);
+                }
               } else {
                 ESP_LOGI("quatt.req", "HP2 minimum runtime hold cleared");
               }

--- a/tests/host/thermal_request_logic_test.cpp
+++ b/tests/host/thermal_request_logic_test.cpp
@@ -1,0 +1,41 @@
+#include <assert.h>
+
+#include "../../openquatt/includes/control/oq_thermal_request_logic.h"
+
+int main() {
+  using oq_request::min_runtime_hold_required;
+  using oq_request::min_runtime_window_active;
+
+  constexpr uint32_t start_ms = 1000UL;
+  constexpr uint32_t min_runtime_ms = 300000UL;
+
+  const bool runtime_active = min_runtime_window_active(start_ms + 120000UL, start_ms, min_runtime_ms);
+  assert(runtime_active);
+  assert(min_runtime_window_active(start_ms, start_ms, min_runtime_ms));
+
+  // Unsigned elapsed-time arithmetic keeps the hold valid across millis() wrap.
+  constexpr uint32_t wrap_start_ms = UINT32_MAX - 1000UL;
+  assert(min_runtime_window_active(1000UL, wrap_start_ms, 5000UL));
+  assert(!min_runtime_window_active(1000UL, 0, min_runtime_ms));
+  assert(!min_runtime_window_active(start_ms, start_ms, 0));
+
+  // A normal zero request, including a cooling floor/dew-point stop, keeps an
+  // already running compressor active until its minimum runtime expires.
+  assert(min_runtime_hold_required(0, false, runtime_active, 1, true));
+
+  // The same policy applies independently to either compressor in a duo setup.
+  assert(min_runtime_hold_required(0, false, runtime_active, 4, false));
+
+  // An active request needs no runtime hold, and an idle compressor must never
+  // be started only to satisfy a stale runtime timestamp.
+  assert(!min_runtime_hold_required(1, false, runtime_active, 1, true));
+  assert(!min_runtime_hold_required(0, false, runtime_active, 0, false));
+
+  const bool runtime_expired = min_runtime_window_active(start_ms + min_runtime_ms, start_ms, min_runtime_ms);
+  assert(!runtime_expired);
+  assert(!min_runtime_hold_required(0, false, runtime_expired, 1, true));
+
+  // Absolute safety and startup inhibition retain priority over the runtime floor.
+  assert(!min_runtime_hold_required(0, true, runtime_active, 1, true));
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat een normale koelstop, inclusief dauwpunt- en vloerbeveiliging, een actieve compressor op het minimum toegestane level houden totdat `Minimum runtime` verstreken is.
- Houdt absolute water-temperatuurstop, persistente low-flow, boot-startinhibit en downstream incident-`must_stop` boven de runtime-hold.
- Centraliseert de runtime-holdbeslissing, maakt de tijdrekening `millis()`-wrapbestendig en voegt host-regressiedekking toe voor single/duo en safety-prioriteit.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Een koelvraag van nul werd nabij de effectieve dauwpuntvloer expliciet uitgezonderd van de compressor-minimum-runtime. Daardoor kon de compressor vóór de ingestelde runtime stoppen. Deze PR behandelt de dauwpunt-/vloerstop als een normale regelstop en vraagt gedurende het resterende venster het minimum toegestane compressorlevel. Harde veiligheidsstops blijven fail-closed en stoppen direct.

## Achtergrond

De oorzaak was de aparte `cooling_floor_trip`-voorwaarde in de post-request runtime floor. De volledige diff is aanvullend gecontroleerd op HP1/HP2, CM5-naar-standbyovergangen, reboot/startinhibit, persistente low-flow, downstream incidentstops, exacte runtime-expiratie en `millis()`-wrap. Tijdens die audit is low-flow ook in de centrale requestlaag als harde stop bevestigd, zodat een latere regelcyclus de directe veiligheidsstop niet opnieuw kan overschrijven.

Na het verstrijken van de minimum-runtime blijft de bestaande koel-restartlatch verantwoordelijk voor vrijgave na herstel van temperatuur en hysterese.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Er wijzigen geen instellingen, entiteiten of bedieningsstappen. Dit corrigeert uitsluitend de prioriteitsvolgorde van bestaande compressor- en koelbeveiliging.

## Validatie

- [x] `npm run check:cpp-format`
- [x] `CXX=g++-15 ./scripts/run_host_regression_tests.sh` — 20 hosttests geslaagd
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe globals, buffers, allocaties of taken. Er is geen firmwarecompile of HIL-run uitgevoerd; de wijziging is afgedekt met pure hostlogica en representatieve single/duo-configvalidatie.
