### PR TITLE
Apply cooling restart hysteresis after PI zero stops

### DIFF
--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -24,6 +24,37 @@ enum ReasonCode {
   REASON_CAPACITY_CAP = 14,
 };
 
+enum WaterStopReasonCode {
+  WATER_STOP_NONE = 0,
+  WATER_STOP_LIMITER = 1,
+  WATER_STOP_DEW = 2,
+  WATER_STOP_FALLBACK = 3,
+  WATER_STOP_PROJECTED_FLOOR = 4,
+  WATER_STOP_REQUEST_CLEARED = 5,
+  WATER_STOP_FLOW_PERMISSION_LOST = 6,
+  WATER_STOP_CORE_PERMISSION_LOST = 7,
+};
+
+struct WaterCycleState {
+  bool active = false;
+  float stop_buffer_gap_c = 0.0f;
+  int stop_reason_code = WATER_STOP_NONE;
+};
+
+inline bool record_pi_zero_stop(int previous_demand, int demand, float filtered_gap_c, WaterCycleState& state) {
+  if (!state.active || previous_demand <= 0 || demand > 0) return false;
+
+  state.active = false;
+  state.stop_buffer_gap_c = filtered_gap_c;
+  if (state.stop_reason_code == WATER_STOP_NONE) state.stop_reason_code = WATER_STOP_LIMITER;
+  return true;
+}
+
+inline bool water_restart_gap_recovered(const WaterCycleState& state, float filtered_gap_c, float restart_delta_c) {
+  if (state.stop_reason_code == WATER_STOP_NONE || state.stop_reason_code == WATER_STOP_PROJECTED_FLOOR) return true;
+  return filtered_gap_c >= state.stop_buffer_gap_c + restart_delta_c;
+}
+
 struct LimiterTuning {
   float hard_dew_stop_base_gap_c = 0.15f;
   float hard_dew_stop_margin_gain_c = 0.30f;

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -1003,9 +1003,14 @@ interval:
             }
             const bool restart_after_water_stop = stop_reason_code != 0;
             const bool projected_floor_pause = stop_reason_code == 4;
-            const float restart_threshold_c = id(oq_cooling_stop_buffer_gap_c) + restart_delta_c;
+            const oq_cooling::WaterCycleState stopped_cycle{
+                false,
+                id(oq_cooling_stop_buffer_gap_c),
+                stop_reason_code,
+            };
+            const float restart_threshold_c = stopped_cycle.stop_buffer_gap_c + restart_delta_c;
             const bool restart_gap_recovered =
-                !restart_after_water_stop || projected_floor_pause || filtered_gap_c >= restart_threshold_c;
+                oq_cooling::water_restart_gap_recovered(stopped_cycle, filtered_gap_c, restart_delta_c);
             const bool dew_recovered = !dew_mode || isnan(dew_gap_c) || dew_gap_c > hard_dew_restart_gap_c;
             const bool fallback_recovered =
                 !fallback_mode || !restart_after_water_stop || projected_floor_pause ||
@@ -1140,12 +1145,28 @@ interval:
           if (demand > allowed_max) demand = allowed_max;
           if (demand < 0) demand = 0;
           if (demand != prev_limited) id(oq_cooling_last_demand_change_ms) = now_ms;
+
+          oq_cooling::WaterCycleState water_cycle_state{
+              water_cycle_active,
+              id(oq_cooling_stop_buffer_gap_c),
+              id(oq_cooling_stop_reason_code),
+          };
+          const bool pi_zero_stop =
+              oq_cooling::record_pi_zero_stop(prev_limited, demand, filtered_gap_c, water_cycle_state);
+          if (pi_zero_stop) {
+            id(oq_cooling_water_cycle_active) = water_cycle_state.active;
+            id(oq_cooling_stop_buffer_gap_c) = water_cycle_state.stop_buffer_gap_c;
+            id(oq_cooling_stop_reason_code) = water_cycle_state.stop_reason_code;
+            reason_code = oq_cooling::REASON_BUFFER_STOP;
+            integral = fminf(integral, 0.0f);
+          }
+
           id(oq_cooling_limited_demand) = demand;
           id(oq_cooling_limiter_reason_code) = reason_code;
           id(oq_cooling_pid_integral) = integral;
           id(oq_cooling_pid_last_error_c) = buffer_gap_c;
           id(oq_cooling_demand_raw) = demand;
-          publish_cooling_limiter_event(reason_code != 1, reason_code, demand, base_demand, dew_gap_c);
+          publish_cooling_limiter_event(reason_code != 1, reason_code, demand, base_demand, dew_gap_c, pi_zero_stop);
 
           static int last_reason = -1;
           if (reason_code != last_reason) {

--- a/tests/host/cooling_limiter_logic_test.cpp
+++ b/tests/host/cooling_limiter_logic_test.cpp
@@ -1,0 +1,71 @@
+#include <assert.h>
+
+#include "../../openquatt/includes/control/oq_cooling_limiter_logic.h"
+
+namespace {
+
+using oq_cooling::record_pi_zero_stop;
+using oq_cooling::water_restart_gap_recovered;
+using oq_cooling::WATER_STOP_DEW;
+using oq_cooling::WATER_STOP_LIMITER;
+using oq_cooling::WATER_STOP_NONE;
+using oq_cooling::WATER_STOP_PROJECTED_FLOOR;
+using oq_cooling::WaterCycleState;
+
+void test_pi_zero_stop_requires_an_active_nonzero_run() {
+  WaterCycleState inactive;
+  assert(!record_pi_zero_stop(1, 0, 0.0f, inactive));
+
+  WaterCycleState not_started{true, 0.0f, WATER_STOP_NONE};
+  assert(!record_pi_zero_stop(0, 0, 0.0f, not_started));
+  assert(not_started.active);
+
+  WaterCycleState still_running{true, 0.0f, WATER_STOP_NONE};
+  assert(!record_pi_zero_stop(1, 1, 0.0f, still_running));
+  assert(still_running.active);
+}
+
+void test_low_load_pi_zero_stop_waits_for_restart_delta() {
+  constexpr float stop_gap_c = 0.05f;
+  constexpr float restart_delta_c = 1.0f;
+  WaterCycleState cycle{true, 0.0f, WATER_STOP_NONE};
+
+  assert(record_pi_zero_stop(1, 0, stop_gap_c, cycle));
+  assert(!cycle.active);
+  assert(cycle.stop_reason_code == WATER_STOP_LIMITER);
+  assert(cycle.stop_buffer_gap_c == stop_gap_c);
+
+  // Repeated PI recovery attempts stay blocked, so no Duo owner can receive a
+  // new request while the just-stopped owner is still in minimum off-time.
+  assert(!water_restart_gap_recovered(cycle, 0.20f, restart_delta_c));
+  assert(!water_restart_gap_recovered(cycle, 0.60f, restart_delta_c));
+  assert(!water_restart_gap_recovered(cycle, 1.04f, restart_delta_c));
+  assert(water_restart_gap_recovered(cycle, 1.05f, restart_delta_c));
+}
+
+void test_pi_zero_stop_preserves_higher_priority_reason() {
+  WaterCycleState dew_stop{true, 0.0f, WATER_STOP_DEW};
+
+  assert(record_pi_zero_stop(1, 0, 0.10f, dew_stop));
+  assert(!dew_stop.active);
+  assert(dew_stop.stop_reason_code == WATER_STOP_DEW);
+  assert(dew_stop.stop_buffer_gap_c == 0.10f);
+}
+
+void test_existing_restart_exceptions_remain_unchanged() {
+  const WaterCycleState no_water_stop{false, 0.0f, WATER_STOP_NONE};
+  assert(water_restart_gap_recovered(no_water_stop, -1.0f, 1.0f));
+
+  const WaterCycleState projected_floor_pause{false, 0.0f, WATER_STOP_PROJECTED_FLOOR};
+  assert(water_restart_gap_recovered(projected_floor_pause, -1.0f, 1.0f));
+}
+
+}  // namespace
+
+int main() {
+  test_pi_zero_stop_requires_an_active_nonzero_run();
+  test_low_load_pi_zero_stop_waits_for_restart_delta();
+  test_pi_zero_stop_preserves_higher_priority_reason();
+  test_existing_restart_exceptions_remain_unchanged();
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Behandel een PI-gedreven overgang van actieve koelvraag naar `f = 0` als een expliciete waterzijdige koelstop.
- Bewaar de gefilterde stop-gap en blokkeer een nieuwe koelrun totdat `Cooling Restart Delta` is hersteld.
- Voeg een host-regressietest toe voor herhaalde low-load nuldoorgangen en behoud van bestaande stopprioriteiten.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Een actieve koelrun die door de PI-regelaar van `f > 0` naar `f = 0` gaat, zet nu `coolingWaterCycleActive` uit, bewaart de stop-gap en gebruikt stopreden `limiter`. Daardoor blijft de request naar beide Duo-warmtepompen nul totdat de bestaande waterzijdige herstartdrempel is bereikt.

## Achtergrond

Issue #426 liet zien dat de PI-regelaar wel de compressorvraag naar nul bracht, maar de watercyclus actief liet. Daardoor werd `Cooling Restart Delta` overgeslagen en kon de Duo-ownerlogica na 20–40 seconden de andere warmtepomp kiezen terwijl de vorige nog in minimum off-time zat.

De volledige diff is afzonderlijk geaudit op:

- PI-overgangen, eerste starts, herhaalde retries en de exacte restart-drempel;
- prioriteit van dauwpunt-, fallback-, flow-permission- en core-permission-stops;
- request-cleared en de bestaande projected-floor-uitzondering;
- Duo-ownerinteractie en minimum off-time;
- fresh boot, ontbrekende state en geheugen-/allocatie-impact.

De stoplatch wordt alleen gezet bij een actieve `>0 → 0`-overgang. Hogere stopredenen worden niet overschreven en alle bestaande vroege safety-/permission-paden blijven ongewijzigd.

Fixes #426

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne control-state bugfix zonder wijziging aan instellingen, entities of gebruikersworkflow.

## Validatie

- [x] `npm run check:cpp-format`
- [x] `./scripts/run_host_regression_tests.sh` (21 hosttests)
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- [x] `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml --jobs 2` (inclusief firmwarecompile)
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen persistente allocaties of bufferwijzigingen. De wijziging gebruikt alleen kleine lokale scalars/state op de bestaande 5s-control-lambda; heap- en task-stackgedrag blijven materieel ongewijzigd.
