### PR TITLE
Keep PT1000 measurement live when DS18B20 is selected

### DIFF
--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -160,7 +160,7 @@ sensor:
     device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
-    # Poll explicitly below so an unused or disconnected probe cannot flood logs.
+    # Poll explicitly below so a disconnected probe cannot flood logs.
     update_interval: never
     spi_id: oq_hpcq_pt1000_spi
     cs_pin: ${hpcq_pt1000_cs_pin}
@@ -210,30 +210,7 @@ interval:
           static bool read_attempted = false;
           static bool repeated_fault_logs_suppressed = false;
           static bool max31865_log_level_managed = false;
-          // Only touch the MAX31865 while its PT1000 is the active source.
-          const bool pt1000_selected =
-              id(water_supply_source).has_state() &&
-              id(oq_local_supply_temp_source).has_state() &&
-              id(water_supply_source).current_option() == "Local" &&
-              id(oq_local_supply_temp_source).current_option() == "PT1000";
-
-          if (!pt1000_selected) {
-            read_attempted = false;
-            if (id(water_supply_temp_pt1000).has_state() &&
-                !isnan(id(water_supply_temp_pt1000).state)) {
-              id(water_supply_temp_pt1000).publish_state(NAN);
-            }
-            id(water_supply_temp_pt1000).status_clear_warning();
-            id(water_supply_temp_pt1000).status_clear_error();
-            if (max31865_log_level_managed &&
-                esphome::logger::global_logger != nullptr) {
-              esphome::logger::global_logger->set_log_level(
-                  "max31865", esphome::logger::global_logger->get_log_level());
-              repeated_fault_logs_suppressed = false;
-            }
-            return;
-          }
-
+          // Keep the PT1000 live for diagnostics when DS18B20 is selected.
           const bool reading_valid =
               id(water_supply_temp_pt1000).has_state() &&
               !isnan(id(water_supply_temp_pt1000).state);


### PR DESCRIPTION
# Wat verandert deze PR?

- Houdt de aangesloten PT1000 iedere 5 seconden live, ook wanneer DS18B20 als lokale aanvoerbron is geselecteerd.
- Laat de bronselectie uitsluitend bepalen welke sensor voor de regeling wordt gebruikt; beide ruwe metingen blijven zichtbaar.
- Behoudt de bestaande logonderdrukking en meldt een PT1000-leesprobleem alleen wanneer PT1000 de actieve regelbron is.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De MAX31865 werd alleen uitgelezen wanneer PT1000 actief was. Bij selectie van DS18B20 publiceerde de firmware voor PT1000 bewust `NaN`, waardoor de aangesloten sensor als niet beschikbaar verscheen. Deze PR laat de MAX31865 continu uitlezen zonder de actieve bron, kalibratie of regelwaarde te wijzigen.

## Achtergrond

De volledige diff tegen `dev` is gecontroleerd op bronwissels, foutafhandeling en herstel. Een ontbrekende PT1000 logt de eerste fout en blijft daarna stil retryen. De bestaande `PT1000 read problem`-bewaking blijft fail-closed gekoppeld aan PT1000 als actieve lokale regelbron.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt de bestaande betekenis van de twee meetregels; er veranderen geen instellingen, entiteiten of gebruikersstappen.

## Validatie

- `npm run check:cpp-format`
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- Volledige diff en betrokken selectie-, meet- en foutpaden handmatig gecontroleerd
- Hardware-in-the-loop niet uitgevoerd

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe buffers, allocaties, taken of stackgebruik. Alleen de bestaande MAX31865-update wordt voortaan ook uitgevoerd wanneer PT1000 niet als regelbron is geselecteerd.