### PR TITLE
Update Home Assistant companion links

### DIFF
--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -4,7 +4,7 @@ De Home Assistant-dashboards, optionele packages en bijbehorende handleidingen
 hebben een eigen releasecyclus. De primaire bron staat in de publieke companion-
 repository:
 
-**[OpenQuatt/openquatt-home-assistant](https://github.com/OpenQuatt/openquatt-home-assistant)**
+**[OpenQuatt/home-assistant-openquatt](https://github.com/OpenQuatt/home-assistant-openquatt)**
 
 Daar vind je:
 

--- a/docs/dashboardoverzicht.md
+++ b/docs/dashboardoverzicht.md
@@ -2,7 +2,7 @@
 
 De actuele dashboardhandleiding staat in de Home Assistant companion-repository:
 
-**[Dashboard gebruiken in OpenQuatt Home Assistant](https://github.com/OpenQuatt/openquatt-home-assistant/blob/main/docs/dashboard.md)**
+**[Dashboard gebruiken in OpenQuatt Home Assistant](https://github.com/OpenQuatt/home-assistant-openquatt/blob/main/docs/dashboard.md)**
 
 De companion-repository is de primaire bron voor dashboards, Home Assistant-
 packages en de bijbehorende installatie- en gebruiksdocumentatie. Deze pagina

--- a/docs/problemen-oplossen.md
+++ b/docs/problemen-oplossen.md
@@ -144,7 +144,7 @@ Controleer:
 Koeling is bewust terughoudend. Zonder goede dauwpuntinformatie kan blokkeren precies het veilige gedrag zijn.
 
 Gebruik je dauwpuntbronnen uit Home Assistant, volg dan de actuele
-[handleiding voor dynamische koelbronnen](https://github.com/OpenQuatt/openquatt-home-assistant/blob/main/docs/cooling.md).
+[handleiding voor dynamische koelbronnen](https://github.com/OpenQuatt/home-assistant-openquatt/blob/main/docs/cooling.md).
 
 Gebruik je MQTT voor het dauwpunt, controleer dan ook:
 

--- a/docs/quatt-insights-export/README.md
+++ b/docs/quatt-insights-export/README.md
@@ -3,7 +3,7 @@
 De Home Assistant-exporter voor historische Quatt CiC insights is verplaatst naar
 de companion-repository:
 
-- [Quatt Insights Export in OpenQuatt Home Assistant](https://github.com/OpenQuatt/openquatt-home-assistant/tree/main/tools/quatt-insights-export)
+- [Quatt Insights Export in OpenQuatt Home Assistant](https://github.com/OpenQuatt/home-assistant-openquatt/tree/main/tools/quatt-insights-export)
 
 Daar staan de actuele Pyscript-service, het Home Assistant-script, de
 installatie-instructies en de compatibiliteitsinformatie. Deze

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -194,7 +194,7 @@ Bij `Dauwpuntsbenadering` gebruikt OpenQuatt een echte dauwpuntmeting zodra die 
 Bij `Expliciet toestaan` gebruikt OpenQuatt geen dauwpuntgrens: ook een beschikbare dauwpuntmeting wordt dan genegeerd. Alleen de ingestelde minimale koel-aanvoer blijft gelden. Gebruik dit alleen als je de installatie zelf bewaakt en het condensrisico bewust accepteert.
 
 Wil je dauwpuntbronnen uit Home Assistant gebruiken, volg dan de
-[companion-handleiding voor dynamische koelbronnen](https://github.com/OpenQuatt/openquatt-home-assistant/blob/main/docs/cooling.md).
+[companion-handleiding voor dynamische koelbronnen](https://github.com/OpenQuatt/home-assistant-openquatt/blob/main/docs/cooling.md).
 De web-app kiest daarna welke koelingsdauwpuntbron OpenQuatt gebruikt: `Auto`,
 `Home Assistant` of `MQTT`. In `Auto` gebruikt OpenQuatt de hoogste geldige
 dauwpuntwaarde.

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -243,7 +243,7 @@ def main() -> int:
         docs_impact_rules = []
         add(findings, ".github/docs-impact.json", 1, str(exc))
 
-    companion_repo_url = "https://github.com/OpenQuatt/openquatt-home-assistant"
+    companion_repo_url = "https://github.com/OpenQuatt/home-assistant-openquatt"
     docs_settings = REPO_ROOT / "docs/instellingen-en-meetwaarden.md"
     docs_tuning = REPO_ROOT / "docs/diagnose-en-afstelling.md"
 

--- a/scripts/tests/test_check_docs_consistency.py
+++ b/scripts/tests/test_check_docs_consistency.py
@@ -86,7 +86,7 @@ Docs-impact motivatie:
             text = read_text(path)
             if path == check_docs_consistency.REPO_ROOT / "docs/dashboard/README.md":
                 return text.replace(
-                    "https://github.com/OpenQuatt/openquatt-home-assistant",
+                    "https://github.com/OpenQuatt/home-assistant-openquatt",
                     "",
                 )
             return text


### PR DESCRIPTION
# Wat verandert deze PR?

- Werkt alle actieve documentatielinks bij naar de hernoemde companion-repository [OpenQuatt/home-assistant-openquatt](https://github.com/OpenQuatt/home-assistant-openquatt).
- Werkt de documentatieconsistentiecontrole en regressietest bij naar dezelfde primaire URL.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen repository-URL's in documentatie en documentatievalidatie veranderen. Firmware, Home Assistant-entiteiten en het entity/API-contract blijven ongewijzigd.

## Achtergrond

De companion-repository is hernoemd van `OpenQuatt/openquatt-home-assistant` naar `OpenQuatt/home-assistant-openquatt`, in lijn met `OpenQuatt/homey-openquatt`.

Companion-PR: [OpenQuatt/home-assistant-openquatt#2](https://github.com/OpenQuatt/home-assistant-openquatt/pull/2).

De volledige diff tegen `origin/dev` is gecontroleerd op correctheid, privacy, compatibility, lifecycle, verse installatie en linkgedrag. Een aparte koude review bevestigde dat de zeven wijzigingen uitsluitend de repositoryslug vervangen, dat geen actieve oude URL's overblijven en dat zowel de nieuwe deep links als de raw assets bereikbaar zijn.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dashboard-, koelings-, web-app- en Insights-doorverwijzingen gebruiken nu de nieuwe primaire repositorynaam.

## Validatie

- `npm run check:docs` — 47 tests, docs consistency en web/docs-contractcontrole geslaagd.
- `python3 scripts/build_pages_docs.py <temp-dir>` — Pages-output succesvol opgebouwd.
- `git diff --check origin/dev...HEAD` — geslaagd.
- Nieuwe repository, deep links en raw asset-URL's — HTTP 200.
- Oude repository-URL — HTTP 301 naar de nieuwe naam.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; uitsluitend documentatie-URL's en de bijbehorende validatie veranderen.