### PR TITLE
Improve mobile source status popovers

### DIFF
--- a/openquatt/web/css/src/17-settings-integrations-controls.css
+++ b/openquatt/web/css/src/17-settings-integrations-controls.css
@@ -368,6 +368,12 @@
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
 }
 
+.oq-settings-source-card:has(.oq-settings-info.is-open) {
+  position: relative;
+  z-index: 5;
+  overflow: visible;
+}
+
 .oq-settings-source-card-head {
   display: flex;
   align-items: center;
@@ -597,14 +603,15 @@
   padding-bottom: 0;
 }
 
-.oq-settings-source-row > span,
+.oq-settings-source-row-label,
 .oq-settings-source-row strong {
   min-width: 0;
   font-size: 0.82rem;
   line-height: 1.25;
 }
 
-.oq-settings-source-row > span {
+.oq-settings-source-row-label {
+  position: relative;
   display: inline-flex;
   align-items: center;
   flex-wrap: wrap;
@@ -618,37 +625,6 @@
   font-weight: 800;
   text-align: right;
   word-break: break-word;
-}
-
-.oq-settings-source-status {
-  display: inline-flex;
-  align-items: center;
-  min-height: 18px;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: rgba(100, 116, 139, 0.1);
-  color: var(--oq-helper-soft);
-  font-size: 0.68rem;
-  font-style: normal;
-  font-weight: 800;
-  line-height: 1;
-  white-space: nowrap;
-  cursor: help;
-}
-
-.oq-settings-source-status--valid {
-  background: rgba(22, 101, 52, 0.11);
-  color: #15803d;
-}
-
-.oq-settings-source-status--invalid {
-  background: rgba(234, 88, 12, 0.12);
-  color: var(--oq-helper-accent-deep);
-}
-
-.oq-settings-source-status--error {
-  background: rgba(220, 38, 38, 0.11);
-  color: #dc2626;
 }
 
 .oq-settings-source-row.is-warning strong {
@@ -822,6 +798,74 @@
   font-size: 0.92rem;
   line-height: 1.55;
   white-space: pre-line;
+}
+
+.oq-settings-source-info {
+  position: static;
+  display: inline-flex;
+  vertical-align: middle;
+}
+
+.oq-settings-source-info .oq-settings-info-button {
+  width: auto;
+  height: auto;
+  min-height: 18px;
+  padding: 2px 6px;
+  border: 0;
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.oq-settings-source-info--circle .oq-settings-info-button {
+  position: relative;
+  width: 22px;
+  height: 22px;
+  min-height: 22px;
+  padding: 0;
+}
+
+.oq-settings-source-info--circle .oq-settings-info-button::after {
+  position: absolute;
+  inset: -8px;
+  content: "";
+}
+
+.oq-settings-source-info--valid .oq-settings-info-button,
+.oq-settings-source-info--valid.is-open .oq-settings-info-button,
+.oq-settings-source-info--valid .oq-settings-info-button:hover,
+.oq-settings-source-info--valid .oq-settings-info-button:focus-visible {
+  background: rgba(22, 101, 52, 0.11);
+  color: #15803d;
+}
+
+.oq-settings-source-info--invalid .oq-settings-info-button,
+.oq-settings-source-info--invalid.is-open .oq-settings-info-button,
+.oq-settings-source-info--invalid .oq-settings-info-button:hover,
+.oq-settings-source-info--invalid .oq-settings-info-button:focus-visible {
+  background: rgba(234, 88, 12, 0.12);
+  color: var(--oq-helper-accent-deep);
+}
+
+.oq-settings-source-info--error .oq-settings-info-button,
+.oq-settings-source-info--error.is-open .oq-settings-info-button,
+.oq-settings-source-info--error .oq-settings-info-button:hover,
+.oq-settings-source-info--error .oq-settings-info-button:focus-visible {
+  background: rgba(220, 38, 38, 0.11);
+  color: #dc2626;
+}
+
+.oq-settings-source-info .oq-settings-info-button:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.oq-settings-source-info .oq-settings-info-popover {
+  right: auto;
+  left: 0;
+  transform: none;
 }
 
 .oq-settings-field--time {

--- a/openquatt/web/js/src/settings/controls.js
+++ b/openquatt/web/js/src/settings/controls.js
@@ -6,13 +6,13 @@ import { escapeHtml } from "../core/html.js";
 import { renderNumberInputControl } from "../core/number-controls.js";
 import { state } from "../core/state.js";
 
-export function renderSettingsInfoToggle(infoId, title, copy) {
+export function renderSettingsInfoToggle(infoId, title, copy, buttonLabel = "i", className = "") {
   if (!copy) {
     return "";
   }
 
   return `
-    <div class="oq-settings-info${state.settingsInfoOpen === infoId ? " is-open" : ""}" data-oq-settings-info="${escapeHtml(infoId)}">
+    <div class="oq-settings-info${className ? ` ${escapeHtml(className)}` : ""}${state.settingsInfoOpen === infoId ? " is-open" : ""}" data-oq-settings-info="${escapeHtml(infoId)}">
       <button
         class="oq-settings-info-button"
         type="button"
@@ -20,7 +20,7 @@ export function renderSettingsInfoToggle(infoId, title, copy) {
         data-info-id="${escapeHtml(infoId)}"
         aria-label="${escapeHtml(`Uitleg bij ${title}`)}"
         aria-expanded="${state.settingsInfoOpen === infoId ? "true" : "false"}"
-      >i</button>
+      >${escapeHtml(buttonLabel)}</button>
       <div class="oq-settings-info-popover" ${state.settingsInfoOpen === infoId ? "" : "hidden"}>
         <p>${escapeHtml(copy)}</p>
       </div>

--- a/openquatt/web/js/src/settings/integrations.js
+++ b/openquatt/web/js/src/settings/integrations.js
@@ -451,13 +451,13 @@ import { escapeHtml } from "../core/html.js";
         return "";
       }
       const safeStatusTone = String(statusTone || "").replace(/[^a-z0-9_-]/gi, "");
-      const safeStatusTitle = statusTitle || status;
+      const infoText = statusTitle || status;
       const statusMarkup = status
-        ? `<em class="oq-settings-source-status${safeStatusTone ? ` oq-settings-source-status--${escapeHtml(safeStatusTone)}` : ""}" title="${escapeHtml(safeStatusTitle)}" aria-label="${escapeHtml(`${status}: ${safeStatusTitle}`)}">${escapeHtml(status)}</em>`
+        ? renderSettingsInfoToggle(`${key}-info`, label, infoText, status, `oq-settings-source-info oq-settings-source-info--${safeStatusTone}${status === "i" ? " oq-settings-source-info--circle" : ""}`)
         : "";
       return `
         <div class="oq-settings-source-row${active ? " is-warning" : ""}${status ? " has-status" : ""}">
-          <span>${escapeHtml(label)}${statusMarkup}</span>
+          <div class="oq-settings-source-row-label">${escapeHtml(label)}${statusMarkup}</div>
           <strong>${escapeHtml(text)}</strong>
         </div>
       `;
@@ -570,7 +570,6 @@ import { escapeHtml } from "../core/html.js";
       secondarySelects = null,
       activeRows = [],
       measurementRows = [],
-      activeCopy = "",
       rows = [],
       warning = "",
     }) => {
@@ -601,8 +600,8 @@ import { escapeHtml } from "../core/html.js";
             ${warningCopy ? `<p class="oq-settings-source-warning">${escapeHtml(warningCopy)}</p>` : ""}
           ` : "",
         }),
-        renderSourceGroup({ title: "Actief", icon: "target", rows: activeRows, copy: activeCopy, className: "oq-settings-source-group--active" }),
-        renderSourceGroup({ title: "Metingen", icon: "activity", rows: measurementRows, className: "oq-settings-source-group--measurements" }),
+        renderSourceGroup({ title: "Actief", icon: "target", rows: activeRows, className: "oq-settings-source-group--active" }),
+        renderSourceGroup({ title: key === "water-supply" ? "Ruwe metingen" : "Metingen", icon: "activity", rows: measurementRows, className: "oq-settings-source-group--measurements" }),
       ].filter(Boolean).join("");
       if (!groupedMarkup && !controlsMarkup && !bodyRows) {
         return "";
@@ -631,9 +630,11 @@ import { escapeHtml } from "../core/html.js";
     const currentOutsideTempSource = String(getEntityValue("outsideTempSource") || "").trim();
     const waterSupplyCorrection = getWaterSupplyCorrectionView();
     const waterSupplyCalibrated = waterSupplyCorrection.calibrationActive;
-    const waterSupplyCalibrationTitle = waterSupplyCalibrated
-      ? "Aanvoertemperatuur gekalibreerd voor de actieve bron"
-      : waterSupplyCorrection.statusLabel;
+    const supplyInfo = waterSupplyCalibrated
+      ? "Gekalibreerd; ruwe metingen hieronder."
+      : waterSupplyCorrection.calibrationRequired
+        ? "Ruwe waarde; kalibreer via Service."
+        : "Ruwe waarde; niet gekalibreerd.";
     const heatingEnableSourceDisabled = String(getEntityValue("heatingEnableSource") || "").trim() === "Disabled";
     const heatingEnableSourceLabel = formattedSourceValue("heatingEnableSource", { optionLabels: { Disabled: "Niet gebruiken" } });
     const coolingEnableSourceDisabled = String(getEntityValue("coolingEnableSource") || "").trim() === "Disabled";
@@ -695,7 +696,13 @@ import { escapeHtml } from "../core/html.js";
           when: currentWaterSupplySource === "Local" && hasEntity("localWaterSupplyTempSource"),
         },
         activeRows: [
-          renderSourceRow({ label: "Waarde", key: "supplyTemp", status: "i", statusTone: waterSupplyCalibrated ? "valid" : "error", statusTitle: waterSupplyCalibrationTitle }),
+          renderSourceRow({
+            label: "Gebruikte waarde",
+            key: "supplyTemp",
+            status: "i",
+            statusTone: waterSupplyCalibrated ? "valid" : "error",
+            statusTitle: supplyInfo,
+          }),
           renderSourceRow({ label: "Bron", value: getWaterSupplyUsedSource() }),
         ],
         warning: waterSupplyCorrection.calibrationRequired

--- a/openquatt/web/tests/settings-integrations.test.mjs
+++ b/openquatt/web/tests/settings-integrations.test.mjs
@@ -68,7 +68,7 @@ test("MQTT verdwijnt uit alle bronselecties en metingen wanneer de integratie ui
   MQTT_SOURCE_SELECT_KEYS.forEach((key) => {
     assert.match(getSelectMarkup(enabledMarkup, key), /<option value="MQTT"/);
   });
-  assert.match(enabledMarkup, /<div class="oq-settings-source-row has-status">\s*<span>MQTT/);
+  assert.match(enabledMarkup, /<div class="oq-settings-source-row has-status">\s*<div class="oq-settings-source-row-label">MQTT/);
 
   setSourceSelectionState(false);
   const disabledMarkup = renderSettingsSensorSelectionSection();
@@ -105,6 +105,18 @@ test("MQTT als buitentemperatuurbron waarschuwt voor ontbrekende opstartwaarde e
   assert.doesNotMatch(outdoorUnitMarkup, /kan OpenQuatt naar CM98 \(antivriescirculatie\) gaan/);
 });
 
+test("bronstatusbadges openen hun uitleg op aanraken", () => {
+  setSourceSelectionState(true);
+  const markup = renderSettingsSensorSelectionSection();
+  assert.match(markup, /data-info-id="mqttRoomTemperature-info"[^>]*aria-expanded="false"[^>]*>Geldig<\/button>/s);
+
+  state.settingsInfoOpen = "mqttRoomTemperature-info";
+  const openMarkup = renderSettingsSensorSelectionSection();
+  assert.match(openMarkup, /data-info-id="mqttRoomTemperature-info"[^>]*aria-expanded="true"[^>]*>Geldig<\/button>/s);
+  assert.match(openMarkup, /MQTT heeft een geldige, recente waarde ontvangen\./);
+  state.settingsInfoOpen = "";
+});
+
 test("ongeldige PT1000 toont geen misleidende nulwaarde", () => {
   setSourceSelectionState(false);
   Object.assign(state.entities, {
@@ -120,10 +132,10 @@ test("ongeldige PT1000 toont geen misleidende nulwaarde", () => {
 
   const markup = renderSettingsSensorSelectionSection();
 
-  assert.match(markup, /<span>PT1000<\/span>\s*<strong>—<\/strong>/);
-  assert.doesNotMatch(markup, /<span>PT1000<\/span>\s*<strong>0 °C<\/strong>/);
-  assert.match(markup, /<span>DS18B20<\/span>\s*<strong>0 °C<\/strong>/);
-  assert.match(markup, /<span>Bron<\/span>\s*<strong>HP2 uitgaand water \(fallback\)<\/strong>/);
+  assert.match(markup, /<div class="oq-settings-source-row-label">PT1000<\/div>\s*<strong>—<\/strong>/);
+  assert.doesNotMatch(markup, /<div class="oq-settings-source-row-label">PT1000<\/div>\s*<strong>0 °C<\/strong>/);
+  assert.match(markup, /<div class="oq-settings-source-row-label">DS18B20<\/div>\s*<strong>0 °C<\/strong>/);
+  assert.match(markup, /<div class="oq-settings-source-row-label">Bron<\/div>\s*<strong>HP2 uitgaand water \(fallback\)<\/strong>/);
 });
 
 test("gewijzigde bronconfiguratie toont dat de aanvoerkalibratie opnieuw moet", () => {
@@ -138,7 +150,10 @@ test("gewijzigde bronconfiguratie toont dat de aanvoerkalibratie opnieuw moet", 
 
   const markup = renderSettingsSensorSelectionSection();
 
-  assert.match(markup, /Waarde<em class="oq-settings-source-status oq-settings-source-status--error" title="Opnieuw kalibreren"[^>]*>i<\/em>/);
+  assert.match(markup, /Gebruikte waarde\s*<div class="oq-settings-info oq-settings-source-info oq-settings-source-info--error oq-settings-source-info--circle"/);
+  assert.match(markup, /<button[^>]*data-oq-action="toggle-settings-info"[^>]*data-info-id="supplyTemp-info"[^>]*aria-expanded="false"[^>]*>i<\/button>/s);
+  assert.match(markup, /Ruwe waarde; kalibreer via Service\./);
+  assert.match(markup, /Ruwe metingen/);
   assert.doesNotMatch(markup, /<span>Kalibratie<\/span>/);
   assert.match(markup, /De aanvoerbron of bronconfiguratie is gewijzigd\./);
   assert.match(markup, /voer de temperatuurkalibratie opnieuw uit/);
@@ -148,6 +163,14 @@ test("gewijzigde bronconfiguratie toont dat de aanvoerkalibratie opnieuw moet", 
   state.entities.waterSupplyCalibrationOffset = { value: -0.6, uom: "°C" };
   const calibratedMarkup = renderSettingsSensorSelectionSection();
 
-  assert.match(calibratedMarkup, /Waarde<em class="oq-settings-source-status oq-settings-source-status--valid" title="Aanvoertemperatuur gekalibreerd voor de actieve bron"[^>]*>i<\/em>/);
+  assert.match(calibratedMarkup, /Gebruikte waarde\s*<div class="oq-settings-info oq-settings-source-info oq-settings-source-info--valid oq-settings-source-info--circle"/);
+  assert.match(calibratedMarkup, /aria-label="Uitleg bij Gebruikte waarde"/);
+  assert.match(calibratedMarkup, /Gekalibreerd; ruwe metingen hieronder\./);
   assert.doesNotMatch(calibratedMarkup, /<span>Kalibratie<\/span>|voer de temperatuurkalibratie opnieuw uit/);
+
+  state.settingsInfoOpen = "supplyTemp-info";
+  const openInfoMarkup = renderSettingsSensorSelectionSection();
+  assert.match(openInfoMarkup, /data-info-id="supplyTemp-info"[^>]*aria-expanded="true"/s);
+  assert.match(openInfoMarkup, /class="oq-settings-info-popover"\s*>/);
+  state.settingsInfoOpen = "";
 });


### PR DESCRIPTION
# Wat verandert deze PR?

- Verduidelijkt bij de aanvoertemperatuur welke waarde actief wordt gebruikt en welke metingen ruw zijn.
- Maakt de kalibratie-indicator en bronstatusbadges aanklikbaar op touchapparaten.
- Houdt de bijbehorende infopopovers binnen de mobiele kaart/viewport.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen markup, labels, styling en bestaande client-side popoverstate in de embedded webinterface wijzigen. Sensorselectie, kalibratiestatus en firmwarewaarden blijven ongewijzigd.

## Achtergrond

De bestaande statusuitleg gebruikte op desktop een hover-tooltip. Op mobiel was die niet betrouwbaar te openen en kon de nieuwe popup buiten de kaart of viewport vallen. De volledige diff is aanvullend gecontroleerd op HTML-escaping, unieke info-id's, open/dicht-transities, klik-buiten-gedrag, compatibiliteit van bestaande info-toggles en viewport-clipping.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een kleine toegankelijkheids- en presentatiewijziging in een bestaand scherm. Er veranderen geen instellingen, entiteiten, configuratiecontracten of bedieningsstappen; de aangepaste labels en uitleg staan direct in de interface.

## Validatie

- [x] `npm run check:web` — 164 webtests en bundlekwaliteitscontrole geslaagd
- [x] `npm run smoke:web` — web-smokecheck geslaagd
- [x] `npm run check:docs` — docs-contracten en 47 script-tests geslaagd
- [x] `node --check openquatt/web/js/src/settings/controls.js`
- [x] `node --check openquatt/web/js/src/settings/integrations.js`
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen firmware-, heap-, PSRAM-, task-stack- of netwerkallocatiewijzigingen; uitsluitend statische webassets.