### PR TITLE
Load supply calibration status in integrations

### DIFF
--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -264,6 +264,9 @@ import { fetchWithTimeout } from "./browser-utils.js";
       ...CIC_POLLING_DIAGNOSTIC_KEYS,
       ...SENSOR_SELECTION_KEYS,
       ...SENSOR_SELECTION_STATE_KEYS,
+      "waterSupplyCalibrationOffset",
+      "waterSupplyCalibrationRequired",
+      "waterSupplyCalibrationStatus",
       ...CIC_COMPATIBILITY_KEYS,
     ],
     system: [

--- a/openquatt/web/tests/settings-integrations.test.mjs
+++ b/openquatt/web/tests/settings-integrations.test.mjs
@@ -9,6 +9,7 @@ globalThis.window = {
 };
 
 const { state } = await import("../js/src/core/state.js");
+const { SETTINGS_GROUP_KEY_MAP } = await import("../js/src/core/entity-sync.js");
 const { renderSettingsSensorSelectionSection } = await import("../js/src/settings/integrations.js");
 
 const MQTT_SOURCE_SELECT_KEYS = [
@@ -61,6 +62,12 @@ function setSourceSelectionState(mqttEnabled) {
     mqttCoolingDewPointValid: { value: true, state: "ON" },
   };
 }
+
+test("integraties laden de aanvoerkalibratiestatus direct", () => {
+  assert.ok(SETTINGS_GROUP_KEY_MAP.integrations.includes("waterSupplyCalibrationOffset"));
+  assert.ok(SETTINGS_GROUP_KEY_MAP.integrations.includes("waterSupplyCalibrationRequired"));
+  assert.ok(SETTINGS_GROUP_KEY_MAP.integrations.includes("waterSupplyCalibrationStatus"));
+});
 
 test("MQTT verdwijnt uit alle bronselecties en metingen wanneer de integratie uitstaat", () => {
   setSourceSelectionState(true);


### PR DESCRIPTION
# Wat verandert deze PR?

- Laadt de drie brongebonden aanvoerkalibratievelden direct in Bronnen/integraties.
- Voorkomt dat een opgeslagen kalibratie eerst rood en pas na het openen van Watertemperatuurcorrecties groen wordt.
- Voegt een regressietest toe voor de hydratie van deze velden.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de bestaande web-UI-hydratie wordt uitgebreid. Firmware, opgeslagen offsets en regelgedrag veranderen niet.

## Achtergrond

De integratiepagina berekende de kalibratiebadge al uit `waterSupplyCalibrationOffset`, `waterSupplyCalibrationRequired` en `waterSupplyCalibrationStatus`, maar vroeg deze entiteiten niet op. Daardoor werd bij de eerste weergave fail-closed een rode badge getoond. Een ander scherm laadde de waarden later alsnog, waarna de badge groen werd.

De volledige diff is gecontroleerd op initiële laadvolgorde, groepswissels, ontbrekende optionele entiteiten en compatibiliteit met bestaande firmware. De wijziging blijft beperkt tot de drie reeds bestaande entiteiten.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt uitsluitend een onjuiste tijdelijke UI-status; er verandert geen gebruikersworkflow of configuratie.

## Validatie

- [x] `npm run check:web` — 165 tests geslaagd en webkwaliteit geslaagd
- [x] Gerichte regressietest bevestigt dat Integraties alle drie kalibratiestatusvelden hydrateert
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; uitsluitend een kleine wijziging in de web-UI-ophaalset.