### PR TITLE
Fix te hoge flowmeting op Q-edition met PULSE-filtermodus

### DIFF
--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -177,6 +177,7 @@ sensor:
     state_class: measurement
     accuracy_decimals: 1
     timeout: 5s
+    internal_filter_mode: PULSE
     internal_filter: 100us
     pin:
       number: ${hpcq_flow_pin}


### PR DESCRIPTION
# Wat verandert deze PR?

- Zet de Q-edition lokale flowmeter van de standaard `EDGE` filtering naar `internal_filter_mode: PULSE`.
- Houdt de bestaande `internal_filter: 100us` en flow-calibratie ongewijzigd.
- Doel is ongewenste extra flanken/ringing op de flowmeter-ingang niet als afzonderlijke pulsen mee te tellen.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De wijziging raakt uitsluitend de pulsdetectie van de lokale flowmeter op de Q-edition controller. De gemeten flow wordt gebruikt voor flowregeling en hydraulische beveiligingen, waardoor een correctere pulsmeting ook het regelgedrag kan beïnvloeden.

## Achtergrond

Bij een V1-installatie met de flowmeter aangesloten op de Q-edition controller werd circa 2200–3000 L/h gemeten terwijl de originele CiC met dezelfde flowmeter circa 800 L/h rapporteerde.

De bestaande flowconversie en `Kf = 0.05 L/min/Hz` blijven ongewijzigd. De verdenking is dat de standaard `EDGE`-mode ongewenste extra flanken op de ingang meetelt.

Met `internal_filter_mode: PULSE` moet een puls minimaal de ingestelde `100us` geldig blijven voordat deze wordt geaccepteerd. Dit is bedoeld als gerichte test/fix voor mogelijke ringing/bounce, zonder tegelijkertijd de filtertijd of calibratiefactor te wijzigen.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een interne wijziging van de pulsfiltering voor de Q-edition flowmeter. Er veranderen geen user-facing instellingen, entities of bedieningsmogelijkheden.

## Validatie

- [ ] Praktijktest op installatie met eerder foutief hoge flowmeting
- [ ] Controleren dat circa 800 L/h via originele CiC ook ongeveer 800 L/h geeft via OpenQuatt
- [ ] Controleren dat flowregeling en low-flow-detectie normaal blijven functioneren
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe buffers, tasks of runtime-allocaties. De wijziging past alleen de bestaande `pulse_meter` filtermodus aan.