### PR TITLE
Fix telemetry source mapping for API input

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
@@ -155,6 +155,9 @@ inline const char* configured_source_wire_value(const std::string& option) {
   if (option == "HA input" || option == "Home Assistant") {
     return "home_assistant";
   }
+  if (option == "API input") {
+    return "api_input";
+  }
   if (option == "MQTT") {
     return "mqtt";
   }

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -254,7 +254,7 @@ Het bericht bevat uitsluitend:
 - `quatt_hybrid_generation_config`: `v1`, `v1_5` of `v2` volgens de ingestelde Quatt Hybrid-versie;
 - `flow_source_config`: `cic`, `controller_local` of `outdoor_unit`, afgeleid uit de algemene en (bij Q) Q-specifieke flowselectie;
 - `heating_strategy`: `power_house` of `heating_curve`;
-- de gekozen regelbronnen in `room_temperature_source`, `room_setpoint_source`, `outside_temperature_source`, `heating_enable_source`, `cooling_enable_source` en `cooling_dew_point_source`, genormaliseerd naar vaste waarden zoals `auto`, `local`, `outdoor_unit`, `cic`, `opentherm`, `home_assistant`, `mqtt`, `cic_or_home_assistant` en `disabled`;
+- de gekozen regelbronnen in `room_temperature_source`, `room_setpoint_source`, `outside_temperature_source`, `heating_enable_source`, `cooling_enable_source` en `cooling_dew_point_source`, genormaliseerd naar vaste waarden zoals `auto`, `local`, `outdoor_unit`, `cic`, `opentherm`, `home_assistant`, `api_input`, `mqtt`, `cic_or_home_assistant` en `disabled`;
 - vrij heapgeheugen, het minimum sinds de start, het grootste vrije heapblok en vrij PSRAM;
 - maximale looptijd van de firmwareloop, ESP-chiptemperatuur en reden van de laatste herstart;
 - bij Wi-Fi: de signaalsterkte in dBm;

--- a/tests/host/openquatt_usage_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_usage_telemetry_policy_test.cpp
@@ -40,6 +40,7 @@ int main() {
   assert(std::strcmp(configured_source_wire_value("OT thermostat"), "opentherm") == 0);
   assert(std::strcmp(configured_source_wire_value("HA input"), "home_assistant") == 0);
   assert(std::strcmp(configured_source_wire_value("Home Assistant"), "home_assistant") == 0);
+  assert(std::strcmp(configured_source_wire_value("API input"), "api_input") == 0);
   assert(std::strcmp(configured_source_wire_value("MQTT"), "mqtt") == 0);
   assert(std::strcmp(configured_source_wire_value("CIC or HA input"), "cic_or_home_assistant") == 0);
   assert(std::strcmp(configured_source_wire_value("Disabled"), "disabled") == 0);


### PR DESCRIPTION
# Wat verandert deze PR?

- Voeg `API input` -> `api_input` mapping toe in de usage-telemetry source normalisatie.
- Voeg host-regressietest toe om deze mapping af te dekken.
- Werk docs bij met `api_input` als geldige genormaliseerde source-waarde.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Deze wijziging herstelt alleen de telemetrie-wire-value normalisatie voor een bestaande, configureerbare bronoptie (`API input`).

## Achtergrond

Bij selectie van `API input` kon een aantal `*_source` velden in usage-telemetrie als `null` uitkomen, omdat deze optie niet in `configured_source_wire_value` stond.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

N.v.t.

## Validatie

- Geprobeerd: `bash scripts/run_host_regression_tests.sh`.
- Resultaat op deze machine: faalt vroeg met `c++: command not found` (tooling ontbreekt lokaal), waardoor de host tests hier niet volledig konden draaien.
- Wel geverifieerd: compileerbare wijziging beperkt tot mapping + testassert + docs update.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen (alleen string mapping en test/docs).