### PR TITLE
fix(flow): prevent CM100 flow dip from stale PI ramp seed

### DIFF
--- a/openquatt/includes/control/oq_flow_control_logic.h
+++ b/openquatt/includes/control/oq_flow_control_logic.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+
+namespace oq_flow_control {
+
+// iPWM limits shared with YAML.
+inline int clamp_ipwm(int value) {
+  constexpr int kMin = 50;
+  constexpr int kMax = 850;
+  if (value < kMin) return kMin;
+  if (value > kMax) return kMax;
+  return value;
+}
+
+// CM100 boiler-test should start from learned last_good PWM instead of
+// the fixed 400 commissioning seed so flow is closer to target and the
+// stale sp_f transient from #464 is not amplified. Other CM100 tasks keep
+// the fixed commissioning seed for reproducibility.
+inline int compute_start_pwm(bool commissioning_start, int commissioning_task_code,
+                             int commissioning_start_pwm, int last_good_pwm,
+                             int fallback_pwm, bool cooling_target,
+                             int last_good_pwm_cooling) {
+  const int fallback = clamp_ipwm(fallback_pwm);
+  // TASK_BOILER_POWER_TEST == 1, keep dependency local to avoid header cycle.
+  constexpr int kTaskBoiler = 1;
+  const bool is_boiler_test = commissioning_start && commissioning_task_code == kTaskBoiler;
+  if (is_boiler_test) {
+    // Boiler test: prefer learned pwm for the active bank (cooling vs normal).
+    const int candidate = cooling_target ? last_good_pwm_cooling : last_good_pwm;
+    if (candidate >= 50 && candidate <= 850) return clamp_ipwm(candidate);
+    return fallback;
+  }
+  if (commissioning_start) return clamp_ipwm(commissioning_start_pwm);
+  const int candidate = cooling_target ? last_good_pwm_cooling : last_good_pwm;
+  if (candidate >= 50 && candidate <= 850) return clamp_ipwm(candidate);
+  return fallback;
+}
+
+struct State {
+  float sp_f = NAN;        // filtered setpoint, NAN means not yet seeded
+  float integral = 0.0f;   // oq_flow_i
+  float last_e = 0.0f;     // last_pi_e
+  int startup_hold = 0;    // ticks remaining in AUTO(starting)
+  int stable_cnt = 0;
+  bool pi_failsafe = false;
+};
+
+struct PiInputs {
+  float pv = NAN;
+  float sp_target = NAN;
+  int pwm_seed = 400;
+  float kp = 0.03f;
+  float ki = 0.0008f;
+  float dt = 10.0f;
+};
+
+struct PiResult {
+  int pwm = 400;
+  bool in_startup_hold = false;
+  bool failsafe = false;
+  float sp_f = NAN;
+  float error = 0.0f;
+  float integral = 0.0f;
+};
+
+// Pure helper that mirrors openquatt/oq_flow_control.yaml:run_auto_pi
+// but is fully host-testable. The fix for #464 is that sp_f is kept NAN
+// during startup_hold instead of being seeded with a stale/zero pv each
+// tick, so the first real PI step seeds sp_f from the actual pv.
+inline PiResult update_pi(State &state, const PiInputs &in) {
+  PiResult res{};
+  res.sp_f = state.sp_f;
+  res.integral = state.integral;
+  int pwm_local = clamp_ipwm(in.pwm_seed);
+
+  const bool flow_signal_valid = !isnan(in.pv);
+  const bool failsafe = (isnan(in.sp_target) || in.sp_target <= 0.0f || !flow_signal_valid);
+  state.pi_failsafe = failsafe;
+  res.failsafe = failsafe;
+
+  if (failsafe) {
+    constexpr int kFailsafeIpwm = 850;
+    pwm_local = kFailsafeIpwm;
+    state.integral = 0.0f;
+    state.last_e = 0.0f;
+    state.stable_cnt = 0;
+    state.sp_f = NAN;
+    res.pwm = pwm_local;
+    res.sp_f = NAN;
+    res.error = 0.0f;
+    res.integral = state.integral;
+    return res;
+  }
+
+  const bool in_startup_hold = (state.startup_hold > 0);
+  res.in_startup_hold = in_startup_hold;
+  if (in_startup_hold) {
+    // Fix #464: do NOT seed sp_f with a possibly stale pv (e.g. 0 at
+    // hydraulic start). Keep NAN so the first post-hold cycle seeds from
+    // the actual flow.
+    state.startup_hold--;
+    state.stable_cnt = 0;
+    res.pwm = clamp_ipwm(pwm_local);
+    res.sp_f = state.sp_f;  // remains NAN
+    return res;
+  }
+
+  // Setpoint ramp
+  constexpr float sp_ramp_up = 25.0f;
+  constexpr float sp_ramp_dn = 15.0f;
+  if (isnan(state.sp_f)) {
+    state.sp_f = flow_signal_valid ? in.pv : in.sp_target;
+  }
+  float d = in.sp_target - state.sp_f;
+  const float max_step = ((d >= 0.0f) ? sp_ramp_up : sp_ramp_dn) * in.dt;
+  if (d > max_step) d = max_step;
+  if (d < -max_step) d = -max_step;
+  state.sp_f += d;
+  res.sp_f = state.sp_f;
+
+  float e = state.sp_f - in.pv;
+  constexpr float deadband_lph = 10.0f;
+  if (fabsf(e) < deadband_lph) e = 0.0f;
+  res.error = e;
+
+  // Anti-windup (mirrors YAML)
+  constexpr float i_active_band_lph = 60.0f;
+  constexpr float i_cross_keep = 0.25f;
+  constexpr float i_deadband_keep = 0.60f;
+  constexpr float i_large_err_keep = 0.35f;
+  const bool have_e = (e > 0.0f) || (e < 0.0f);
+  const bool have_last_e = (state.last_e > 0.0f) || (state.last_e < 0.0f);
+  const bool sign_flip = have_e && have_last_e && ((e > 0.0f) != (state.last_e > 0.0f));
+  if (sign_flip) {
+    state.integral *= i_cross_keep;
+  }
+  if (!have_e) {
+    state.integral *= i_deadband_keep;
+  } else if (fabsf(e) <= i_active_band_lph) {
+    state.integral += e * in.dt;
+  } else {
+    state.integral *= i_large_err_keep;
+  }
+  state.integral = fmaxf(-4000.0f, fminf(4000.0f, state.integral));
+  state.last_e = e;
+  res.integral = state.integral;
+
+  float u = in.kp * e + in.ki * state.integral;
+  constexpr float u_up_s = 12.0f;
+  constexpr float u_down_s = 8.0f;
+  const float u_up = u_up_s * in.dt;
+  const float u_down = u_down_s * in.dt;
+  const float u_lim = (e >= 0.0f) ? u_up : u_down;
+  if (u > u_lim) u = u_lim;
+  if (u < -u_lim) u = -u_lim;
+
+  pwm_local = (int)roundf((float)pwm_local - u);
+  pwm_local = clamp_ipwm(pwm_local);
+  res.pwm = pwm_local;
+
+  // Stability counter (kept for completeness, not needed for #464)
+  constexpr float stable_err_lph = 15.0f;
+  constexpr int stable_time_s = 60;
+  const int stable_time_ticks = (stable_time_s <= 0) ? 0 : (int)roundf((float)stable_time_s / in.dt);
+  if (state.startup_hold <= 0 && !state.pi_failsafe) {
+    const float e_target = in.sp_target - in.pv;
+    if (fabsf(e_target) < stable_err_lph) {
+      state.stable_cnt++;
+    } else {
+      state.stable_cnt = 0;
+    }
+    if (state.stable_cnt >= stable_time_ticks) {
+      state.stable_cnt = stable_time_ticks;
+    }
+  } else {
+    state.stable_cnt = 0;
+  }
+
+  return res;
+}
+
+}  // namespace oq_flow_control

--- a/openquatt/includes/control/oq_flow_control_logic.h
+++ b/openquatt/includes/control/oq_flow_control_logic.h
@@ -44,6 +44,7 @@ struct PiResult {
   int pwm = 400;
   bool in_startup_hold = false;
   bool failsafe = false;
+  bool stable_ready = false;
   float sp_f = NAN;
   float error = 0.0f;
   float integral = 0.0f;
@@ -144,7 +145,7 @@ inline PiResult update_pi(State& state, const PiInputs& in) {
   pwm_local = clamp_ipwm(pwm_local);
   res.pwm = pwm_local;
 
-  // Stability counter (kept for completeness, not needed for #464)
+  // Stability counter - single source for last_good tracking
   constexpr float stable_err_lph = 15.0f;
   constexpr int stable_time_s = 60;
   const int stable_time_ticks = (stable_time_s <= 0) ? 0 : (int)roundf((float)stable_time_s / in.dt);
@@ -161,6 +162,7 @@ inline PiResult update_pi(State& state, const PiInputs& in) {
   } else {
     state.stable_cnt = 0;
   }
+  res.stable_ready = (state.stable_cnt >= stable_time_ticks);
 
   return res;
 }

--- a/openquatt/includes/control/oq_flow_control_logic.h
+++ b/openquatt/includes/control/oq_flow_control_logic.h
@@ -18,10 +18,8 @@ inline int clamp_ipwm(int value) {
 // the fixed 400 commissioning seed so flow is closer to target and the
 // stale sp_f transient from #464 is not amplified. Other CM100 tasks keep
 // the fixed commissioning seed for reproducibility.
-inline int compute_start_pwm(bool commissioning_start, int commissioning_task_code,
-                             int commissioning_start_pwm, int last_good_pwm,
-                             int fallback_pwm, bool cooling_target,
-                             int last_good_pwm_cooling) {
+inline int compute_start_pwm(bool commissioning_start, int commissioning_task_code, int commissioning_start_pwm,
+                             int last_good_pwm, int fallback_pwm, bool cooling_target, int last_good_pwm_cooling) {
   const int fallback = clamp_ipwm(fallback_pwm);
   // TASK_BOILER_POWER_TEST == 1, keep dependency local to avoid header cycle.
   constexpr int kTaskBoiler = 1;
@@ -39,10 +37,10 @@ inline int compute_start_pwm(bool commissioning_start, int commissioning_task_co
 }
 
 struct State {
-  float sp_f = NAN;        // filtered setpoint, NAN means not yet seeded
-  float integral = 0.0f;   // oq_flow_i
-  float last_e = 0.0f;     // last_pi_e
-  int startup_hold = 0;    // ticks remaining in AUTO(starting)
+  float sp_f = NAN;       // filtered setpoint, NAN means not yet seeded
+  float integral = 0.0f;  // oq_flow_i
+  float last_e = 0.0f;    // last_pi_e
+  int startup_hold = 0;   // ticks remaining in AUTO(starting)
   int stable_cnt = 0;
   bool pi_failsafe = false;
 };
@@ -69,7 +67,7 @@ struct PiResult {
 // but is fully host-testable. The fix for #464 is that sp_f is kept NAN
 // during startup_hold instead of being seeded with a stale/zero pv each
 // tick, so the first real PI step seeds sp_f from the actual pv.
-inline PiResult update_pi(State &state, const PiInputs &in) {
+inline PiResult update_pi(State& state, const PiInputs& in) {
   PiResult res{};
   res.sp_f = state.sp_f;
   res.integral = state.integral;

--- a/openquatt/includes/control/oq_flow_control_logic.h
+++ b/openquatt/includes/control/oq_flow_control_logic.h
@@ -14,26 +14,12 @@ inline int clamp_ipwm(int value) {
   return value;
 }
 
-// CM100 boiler-test should start from learned last_good PWM instead of
-// the fixed 400 commissioning seed so flow is closer to target and the
-// stale sp_f transient from #464 is not amplified. Other CM100 tasks keep
-// the fixed commissioning seed for reproducibility.
-inline int compute_start_pwm(bool commissioning_start, int commissioning_task_code, int commissioning_start_pwm,
-                             int last_good_pwm, int fallback_pwm, bool cooling_target, int last_good_pwm_cooling) {
-  const int fallback = clamp_ipwm(fallback_pwm);
-  // TASK_BOILER_POWER_TEST == 1, keep dependency local to avoid header cycle.
-  constexpr int kTaskBoiler = 1;
-  const bool is_boiler_test = commissioning_start && commissioning_task_code == kTaskBoiler;
-  if (is_boiler_test) {
-    // Boiler test: prefer learned pwm for the active bank (cooling vs normal).
-    const int candidate = cooling_target ? last_good_pwm_cooling : last_good_pwm;
-    if (candidate >= 50 && candidate <= 850) return clamp_ipwm(candidate);
-    return fallback;
-  }
+inline int compute_start_pwm(bool commissioning_start, int commissioning_start_pwm, int last_good_pwm, int fallback_pwm,
+                             bool cooling_target, int last_good_pwm_cooling) {
   if (commissioning_start) return clamp_ipwm(commissioning_start_pwm);
   const int candidate = cooling_target ? last_good_pwm_cooling : last_good_pwm;
   if (candidate >= 50 && candidate <= 850) return clamp_ipwm(candidate);
-  return fallback;
+  return clamp_ipwm(fallback_pwm);
 }
 
 struct State {

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -521,9 +521,8 @@ interval:
             const int last_good_pwm =
               cooling_target ? id(oq_flow_last_good_pwm_cooling) : id(oq_flow_last_good_pwm);
             int start_pwm = oq_flow_control::compute_start_pwm(
-                commissioning_start, id(oq_commissioning_task_code),
-                (int) roundf(id(oq_flow_commissioning_start_pwm).state), id(oq_flow_last_good_pwm),
-                fallback, cooling_target, id(oq_flow_last_good_pwm_cooling));
+                commissioning_start, id(oq_commissioning_task_code), id(oq_flow_commissioning_start_pwm),
+                id(oq_flow_last_good_pwm), fallback, cooling_target, id(oq_flow_last_good_pwm_cooling));
 
             ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d bank=%s fallback=%d commissioning=%s hold %ds, fixed iPWM)",
                      tag, start_pwm, last_good_pwm, cooling_target ? "cooling" : "normal",

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -582,12 +582,9 @@ interval:
 
             int pwm = res.pwm;
 
-            // Last-good tracking uses helper's stable_cnt (single source)
+            // Last-good tracking - single source via helper's stable_ready
             constexpr int good_pwm_step = 10;
-            constexpr int stable_time_s = 60;
-            const int stable_time_ticks =
-                (stable_time_s <= 0) ? 0 : (int) roundf((float) stable_time_s / dt);
-            if (startup_hold <= 0 && !pi_failsafe && stable_cnt >= stable_time_ticks) {
+            if (res.stable_ready) {
               const int prev = cooling_target ? id(oq_flow_last_good_pwm_cooling) : id(oq_flow_last_good_pwm);
               if (abs(prev - pwm) >= good_pwm_step) {
                 if (cooling_target) {
@@ -596,7 +593,6 @@ interval:
                   id(oq_flow_last_good_pwm) = pwm;
                 }
               }
-              stable_cnt = stable_time_ticks;
             }
             return pwm;
           };

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -537,138 +537,69 @@ interval:
             stable_cnt = 0;
           };
           // AUTO PI path only: setpoint ramp, PI, startup-hold, and last_good tracking.
+          // Single source for ramp/PI - delegates to control/oq_flow_control_logic.h
           auto run_auto_pi = [&](int pwm_seed) -> int {
-            int pwm_local = pwm_seed;
             const bool cooling_target =
                 (id(oq_control_mode_code) == 5) ||
                 (oq_manual_hp::owns_control() &&
-                 (id(oq_manual_hp1_mode_code) == 1 ||
-                  id(oq_manual_hp2_mode_code) == 1));
+                 (id(oq_manual_hp1_mode_code) == 1 || id(oq_manual_hp2_mode_code) == 1));
             const bool manual_flow_owns_pi =
-              id(oq_manual_flow_active) &&
-              (id(oq_control_mode_code) == 100) &&
-              (id(oq_commissioning_task_code) == oq_commissioning::TASK_MANUAL_FLOW);
+                id(oq_manual_flow_active) && (id(oq_control_mode_code) == 100) &&
+                (id(oq_commissioning_task_code) == oq_commissioning::TASK_MANUAL_FLOW);
             float sp_target = manual_flow_owns_pi
-              ? id(oq_manual_flow_setpoint_lph).state
-              : (cooling_target
-                  ? id(oq_cooling_flow_setpoint_lph).state
-                  : id(oq_flow_setpoint_lph).state);
+                ? id(oq_manual_flow_setpoint_lph).state
+                : (cooling_target ? id(oq_cooling_flow_setpoint_lph).state : id(oq_flow_setpoint_lph).state);
             float pv = id(flow_rate_selected).state;
 
-            // Treat 0 L/h as a valid measurement (no-flow state), not as sensor failure.
-            // This prevents an AUTO(start) deadlock where PI would stay in failsafe and never build flow.
-            const bool flow_signal_valid = !isnan(pv);
-            pi_failsafe = (isnan(sp_target) || sp_target <= 0.0f || !flow_signal_valid);
+            oq_flow_control::State hs;
+            hs.sp_f = sp_f;
+            hs.integral = id(oq_flow_i);
+            hs.last_e = last_pi_e;
+            hs.startup_hold = startup_hold;
+            hs.stable_cnt = stable_cnt;
+            hs.pi_failsafe = pi_failsafe;
 
-            if (pi_failsafe) {
-              constexpr int kFailsafeIpwm = 850;
-              pwm_local = kFailsafeIpwm;
-              ESP_LOGW("flow", "Flow PI failsafe engaged: sp=%0.1f pv=%0.1f -> forcing iPWM=%d", sp_target, pv, kFailsafeIpwm);
-              id(oq_flow_i) = 0.0f;
-              last_pi_e = 0.0f;
-              stable_cnt = 0;
-              sp_f = NAN;
-              return pwm_local;
+            oq_flow_control::PiInputs inputs;
+            inputs.pv = pv;
+            inputs.sp_target = sp_target;
+            inputs.pwm_seed = pwm_seed;
+            inputs.kp = id(oq_flow_kp).state;
+            inputs.ki = id(oq_flow_ki).state;
+            inputs.dt = dt;
+
+            auto res = oq_flow_control::update_pi(hs, inputs);
+
+            sp_f = hs.sp_f;
+            id(oq_flow_i) = hs.integral;
+            last_pi_e = hs.last_e;
+            startup_hold = hs.startup_hold;
+            stable_cnt = hs.stable_cnt;
+            pi_failsafe = hs.pi_failsafe;
+
+            if (res.failsafe) {
+              ESP_LOGW("flow", "Flow PI failsafe engaged: sp=%0.1f pv=%0.1f -> forcing iPWM=%d", sp_target, pv,
+                       res.pwm);
             }
 
-            const bool in_startup_hold = (startup_hold > 0);
-            if (in_startup_hold) {
-              // Fix #464: keep sp_f NAN during hold so first post-hold cycle
-              // seeds from actual PV instead of a stale 0 from hydraulic start.
-              // Mirrors oq_flow_control::update_pi() in control/oq_flow_control_logic.h
-              startup_hold--;
-              stable_cnt = 0;
-              return clamp_iPWM(pwm_local);
-            }
+            int pwm = res.pwm;
 
-            const float sp_ramp_up = 25.0f;   // L/h per second up
-            const float sp_ramp_dn = 15.0f;   // L/h per second down
-            if (isnan(sp_f)) sp_f = flow_signal_valid ? pv : sp_target;
-
-            float d = sp_target - sp_f;
-            float max_step = ((d >= 0.0f) ? sp_ramp_up : sp_ramp_dn) * dt;
-            if (d >  max_step) d =  max_step;
-            if (d < -max_step) d = -max_step;
-            sp_f += d;
-
-            float e = sp_f - pv;  // positive => more flow needed
-
-            constexpr float deadband_lph = 10.0f;
-            if (fabsf(e) < deadband_lph) e = 0.0f;
-
-            const float kp = id(oq_flow_kp).state;
-            const float ki = id(oq_flow_ki).state;
-
-            // Anti-windup:
-            // - keep I inactive during large setpoint / plant transients
-            // - quickly bleed stored I when we cross the setpoint
-            // - slowly unwind I inside the deadband so it cannot keep pushing past target
-            constexpr float i_active_band_lph = 60.0f;
-            constexpr float i_cross_keep = 0.25f;
-            constexpr float i_deadband_keep = 0.60f;
-            constexpr float i_large_err_keep = 0.35f;
-            const bool have_e = (e > 0.0f) || (e < 0.0f);
-            const bool have_last_e = (last_pi_e > 0.0f) || (last_pi_e < 0.0f);
-            const bool sign_flip = have_e && have_last_e && ((e > 0.0f) != (last_pi_e > 0.0f));
-
-            if (sign_flip) {
-              id(oq_flow_i) *= i_cross_keep;
-            }
-
-            if (!have_e) {
-              id(oq_flow_i) *= i_deadband_keep;
-            } else if (fabsf(e) <= i_active_band_lph) {
-              id(oq_flow_i) += e * dt;
-            } else {
-              id(oq_flow_i) *= i_large_err_keep;
-            }
-
-            id(oq_flow_i) = fmaxf(-4000.0f, fminf(4000.0f, id(oq_flow_i)));
-            last_pi_e = e;
-
-            float u = kp * e + ki * id(oq_flow_i);
-            // Asymmetric action limit: allow faster "pump harder" corrections (u_up)
-            // than "pump softer" corrections (u_down) to recover low-flow sooner.
-            const float u_up_s = 12.0f;
-            const float u_down_s = 8.0f;
-            const float u_up = u_up_s * dt;
-            const float u_down = u_down_s * dt;
-            const float u_lim = (e >= 0.0f) ? u_up : u_down;
-            u = fmaxf(-u_lim, fminf(u_lim, u));
-
-            pwm_local = (int) roundf((float)pwm_local - u);
-            pwm_local = clamp_iPWM(pwm_local);
-
-            const float stable_err_lph = 15.0f;
-            constexpr int stable_time_s = 60;
-            const int stable_time_ticks = (stable_time_s <= 0) ? 0 : (int) roundf((float)stable_time_s / dt);
+            // Last-good tracking uses helper's stable_cnt (single source)
             constexpr int good_pwm_step = 10;
-
-            if (startup_hold <= 0 && !pi_failsafe) {
-              const float e_target = sp_target - pv;
-              if (fabsf(e_target) < stable_err_lph) {
-                stable_cnt++;
-              } else {
-                stable_cnt = 0;
-              }
-
-              if (stable_cnt >= stable_time_ticks) {
-                const int prev = cooling_target
-                  ? id(oq_flow_last_good_pwm_cooling)
-                  : id(oq_flow_last_good_pwm);
-                if (abs(prev - pwm_local) >= good_pwm_step) {
-                  if (cooling_target) {
-                    id(oq_flow_last_good_pwm_cooling) = pwm_local;
-                  } else {
-                    id(oq_flow_last_good_pwm) = pwm_local;
-                  }
+            constexpr int stable_time_s = 60;
+            const int stable_time_ticks =
+                (stable_time_s <= 0) ? 0 : (int) roundf((float) stable_time_s / dt);
+            if (startup_hold <= 0 && !pi_failsafe && stable_cnt >= stable_time_ticks) {
+              const int prev = cooling_target ? id(oq_flow_last_good_pwm_cooling) : id(oq_flow_last_good_pwm);
+              if (abs(prev - pwm) >= good_pwm_step) {
+                if (cooling_target) {
+                  id(oq_flow_last_good_pwm_cooling) = pwm;
+                } else {
+                  id(oq_flow_last_good_pwm) = pwm;
                 }
-                stable_cnt = stable_time_ticks;
               }
-            } else {
-              stable_cnt = 0;
+              stable_cnt = stable_time_ticks;
             }
-            return pwm_local;
+            return pwm;
           };
 
           const int cm_code = id(oq_control_mode_code);

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -33,6 +33,10 @@
 #
 # ==============================================================================
 
+esphome:
+  includes:
+    - ../../openquatt/includes/control/oq_flow_control_logic.h
+
 # ----------------------------
 # INTERNAL STATE (PI)
 # ----------------------------
@@ -516,10 +520,10 @@ interval:
             const bool commissioning_start = (cm_code == 100) && (id(oq_commissioning_task_code) != oq_commissioning::TASK_NONE);
             const int last_good_pwm =
               cooling_target ? id(oq_flow_last_good_pwm_cooling) : id(oq_flow_last_good_pwm);
-            int start_pwm = commissioning_start
-              ? clamp_iPWM(id(oq_flow_commissioning_start_pwm))
-              : last_good_pwm;
-            if (!commissioning_start && (start_pwm < 50 || start_pwm > 850)) start_pwm = fallback;
+            int start_pwm = oq_flow_control::compute_start_pwm(
+                commissioning_start, id(oq_commissioning_task_code),
+                (int) roundf(id(oq_flow_commissioning_start_pwm).state), id(oq_flow_last_good_pwm),
+                fallback, cooling_target, id(oq_flow_last_good_pwm_cooling));
 
             ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d bank=%s fallback=%d commissioning=%s hold %ds, fixed iPWM)",
                      tag, start_pwm, last_good_pwm, cooling_target ? "cooling" : "normal",
@@ -569,9 +573,9 @@ interval:
 
             const bool in_startup_hold = (startup_hold > 0);
             if (in_startup_hold) {
-              // True startup settle: keep iPWM fixed for a short hydraulic delay window.
-              // Keep SP filter aligned to PV so PI starts without a large instantaneous kick.
-              sp_f = pv;
+              // Fix #464: keep sp_f NAN during hold so first post-hold cycle
+              // seeds from actual PV instead of a stale 0 from hydraulic start.
+              // Mirrors oq_flow_control::update_pi() in control/oq_flow_control_logic.h
               startup_hold--;
               stable_cnt = 0;
               return clamp_iPWM(pwm_local);

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -521,8 +521,8 @@ interval:
             const int last_good_pwm =
               cooling_target ? id(oq_flow_last_good_pwm_cooling) : id(oq_flow_last_good_pwm);
             int start_pwm = oq_flow_control::compute_start_pwm(
-                commissioning_start, id(oq_commissioning_task_code), id(oq_flow_commissioning_start_pwm),
-                id(oq_flow_last_good_pwm), fallback, cooling_target, id(oq_flow_last_good_pwm_cooling));
+                commissioning_start, id(oq_flow_commissioning_start_pwm), id(oq_flow_last_good_pwm), fallback,
+                cooling_target, id(oq_flow_last_good_pwm_cooling));
 
             ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d bank=%s fallback=%d commissioning=%s hold %ds, fixed iPWM)",
                      tag, start_pwm, last_good_pwm, cooling_target ? "cooling" : "normal",

--- a/tests/host/flow_control_logic_test.cpp
+++ b/tests/host/flow_control_logic_test.cpp
@@ -44,10 +44,10 @@ void test_stale_zero_should_not_cause_dip() {
   assert(!r3.in_startup_hold);
   assert(!r3.failsafe);
   // sp_f should have been seeded to pv (824) then ramped towards 800 -> 800? or 824->800 ramp limited but close
-  // With pv 824, sp_target 800, sp_f seeded to 824, then ramp down by 15*10=150 towards 800 => sp_f=800? Actually d=800-824=-24, max_step=150, so sp_f=800
-  // Then e = 800-824 = -24 -> deadband? 24 outside deadband 10 -> e=-24
-  // u = kp*e = -2.16 plus small integral, limited to -80 (u_down 80) -> pwm = 400 - (-2) = ~402 (slightly harder)
-  // Crucially NOT 452.
+  // With pv 824, sp_target 800, sp_f seeded to 824, then ramp down by 15*10=150 towards 800 => sp_f=800? Actually
+  // d=800-824=-24, max_step=150, so sp_f=800 Then e = 800-824 = -24 -> deadband? 24 outside deadband 10 -> e=-24 u =
+  // kp*e = -2.16 plus small integral, limited to -80 (u_down 80) -> pwm = 400 - (-2) = ~402 (slightly harder) Crucially
+  // NOT 452.
   assert(r3.pwm < 430);  // no large 452 jump
   assert(r3.pwm > 380 && r3.pwm < 430);
   // Extra tick should stay stable around 400-420, not drift to 477
@@ -75,7 +75,8 @@ void test_low_flow_should_pump_harder() {
   in.pv = 350.0f;
   auto r = update_pi(s, in);
   assert(!r.failsafe);
-  // e = sp_f - pv, sp_f seeded to 350 then ramp to 500 (250 step) => e ~150 -> positive -> u positive -> pwm = 400 - positive = <400 (harder)
+  // e = sp_f - pv, sp_f seeded to 350 then ramp to 500 (250 step) => e ~150 -> positive -> u positive -> pwm = 400 -
+  // positive = <400 (harder)
   assert(r.pwm < 400);
   assert(r.pwm >= 50);
 }

--- a/tests/host/flow_control_logic_test.cpp
+++ b/tests/host/flow_control_logic_test.cpp
@@ -46,7 +46,7 @@ void test_stale_zero_should_not_cause_dip() {
   // sp_f should have been seeded to pv (824) then ramped towards 800 -> 800? or 824->800 ramp limited but close
   // With pv 824, sp_target 800, sp_f seeded to 824, then ramp down by 15*10=150 towards 800 => sp_f=800? Actually
   // d=800-824=-24, max_step=150, so sp_f=800 Then e = 800-824 = -24 -> deadband? 24 outside deadband 10 -> e=-24 u =
-  // kp*e = -2.16 plus small integral, limited to -80 (u_down 80) -> pwm = 400 - (-2) = ~402 (slightly harder) Crucially
+  // kp*e = -2.16 plus small integral, limited to -80 (u_down 80) -> pwm = 400 - (-2) = ~402 (slightly softer) Crucially
   // NOT 452.
   assert(r3.pwm < 430);  // no large 452 jump
   assert(r3.pwm > 380 && r3.pwm < 430);

--- a/tests/host/flow_control_logic_test.cpp
+++ b/tests/host/flow_control_logic_test.cpp
@@ -75,7 +75,7 @@ void test_low_flow_should_pump_harder() {
   in.pv = 350.0f;
   auto r = update_pi(s, in);
   assert(!r.failsafe);
-  // e = sp_f - pv, sp_f seeded to 350 then ramp to 500 (250 step) => e ~150 -> positive -> u positive -> pwm = 400 -
+  // e = sp_f - pv, sp_f seeded to 350 then ramp to 600 (250 step) => e ~250 -> positive -> u positive -> pwm = 400 -
   // positive = <400 (harder)
   assert(r.pwm < 400);
   assert(r.pwm >= 50);
@@ -115,22 +115,22 @@ void test_nan_flow_failsafe() {
   assert(isnan(s.sp_f));
 }
 
-void test_compute_start_pwm_boiler_uses_last_good() {
-  // Boiler test in CM100 should use last_good, not fixed 400
-  int start = compute_start_pwm(true, 1, 400, 440, 440, false, 460);
-  assert(start == 440);
-  // Cooling bank
-  int start_cooling = compute_start_pwm(true, 1, 400, 440, 440, true, 460);
-  assert(start_cooling == 460);
-  // Non-boiler CM100 task keeps fixed
-  int start_other = compute_start_pwm(true, 2, 400, 440, 440, false, 460);
-  assert(start_other == 400);
-  // Outside CM100 uses last_good
-  int start_auto = compute_start_pwm(false, 0, 400, 440, 440, false, 460);
+void test_compute_start_pwm() {
+  // CM100 commissioning always uses commissioning PWM (400), not last_good
+  int start = compute_start_pwm(true, 400, 440, 440, false, 460);
+  assert(start == 400);
+  int start_cooling = compute_start_pwm(true, 400, 440, 440, true, 460);
+  assert(start_cooling == 400);
+  // Outside CM100 uses last_good per bank
+  int start_auto = compute_start_pwm(false, 400, 440, 440, false, 460);
   assert(start_auto == 440);
-  // Invalid last_good falls back
-  int start_fallback = compute_start_pwm(true, 1, 400, 0, 440, false, 460);
+  int start_auto_cooling = compute_start_pwm(false, 400, 440, 440, true, 460);
+  assert(start_auto_cooling == 460);
+  // Invalid last_good falls back to fallback
+  int start_fallback = compute_start_pwm(false, 400, 0, 440, false, 460);
   assert(start_fallback == 440);
+  int start_fallback_comm = compute_start_pwm(true, 400, 0, 440, false, 460);
+  assert(start_fallback_comm == 400);
 }
 
 }  // namespace
@@ -140,6 +140,6 @@ int main() {
   test_low_flow_should_pump_harder();
   test_pv_around_target_no_big_step();
   test_nan_flow_failsafe();
-  test_compute_start_pwm_boiler_uses_last_good();
+  test_compute_start_pwm();
   return 0;
 }

--- a/tests/host/flow_control_logic_test.cpp
+++ b/tests/host/flow_control_logic_test.cpp
@@ -1,0 +1,144 @@
+#include <assert.h>
+#include <math.h>
+
+#include "../../openquatt/includes/control/oq_flow_control_logic.h"
+
+namespace {
+
+using namespace oq_flow_control;
+
+void test_stale_zero_should_not_cause_dip() {
+  // Repro for #464: PV 0 during 20s hold (2 ticks dt=10), then 824 at first PI.
+  // Old logic seeded sp_f=0 -> ramp to 250 -> e=-574 -> iPWM 400->452.
+  // Fixed logic keeps sp_f=NAN during hold -> seeds to 824 -> small error.
+  State s;
+  s.startup_hold = 2;
+  s.sp_f = NAN;
+  s.integral = 0;
+  s.last_e = 0;
+
+  PiInputs in{};
+  in.sp_target = 800.0f;
+  in.kp = 0.09f;
+  in.ki = 0.0012f;
+  in.dt = 10.0f;
+  in.pwm_seed = 400;
+
+  // Two hold ticks with pv 0 (stale)
+  in.pv = 0.0f;
+  auto r1 = update_pi(s, in);
+  assert(r1.in_startup_hold);
+  assert(isnan(s.sp_f));  // fix: remains NAN
+  assert(r1.pwm == 400);
+  assert(s.startup_hold == 1);
+
+  auto r2 = update_pi(s, in);
+  assert(r2.in_startup_hold);
+  assert(isnan(s.sp_f));
+  assert(r2.pwm == 400);
+  assert(s.startup_hold == 0);
+
+  // First real PI with actual flow ~824
+  in.pv = 824.0f;
+  auto r3 = update_pi(s, in);
+  assert(!r3.in_startup_hold);
+  assert(!r3.failsafe);
+  // sp_f should have been seeded to pv (824) then ramped towards 800 -> 800? or 824->800 ramp limited but close
+  // With pv 824, sp_target 800, sp_f seeded to 824, then ramp down by 15*10=150 towards 800 => sp_f=800? Actually d=800-824=-24, max_step=150, so sp_f=800
+  // Then e = 800-824 = -24 -> deadband? 24 outside deadband 10 -> e=-24
+  // u = kp*e = -2.16 plus small integral, limited to -80 (u_down 80) -> pwm = 400 - (-2) = ~402 (slightly harder)
+  // Crucially NOT 452.
+  assert(r3.pwm < 430);  // no large 452 jump
+  assert(r3.pwm > 380 && r3.pwm < 430);
+  // Extra tick should stay stable around 400-420, not drift to 477
+  in.pwm_seed = r3.pwm;
+  in.pv = 816.0f;
+  auto r4 = update_pi(s, in);
+  assert(r4.pwm < 430);
+}
+
+void test_low_flow_should_pump_harder() {
+  // Countercase 1: truly low flow at end of hold should pump harder (lower iPWM)
+  State s;
+  s.startup_hold = 2;
+  s.sp_f = NAN;
+  PiInputs in{};
+  in.sp_target = 800;
+  in.kp = 0.09f;
+  in.ki = 0.0012f;
+  in.dt = 10;
+  in.pwm_seed = 400;
+  in.pv = 0;
+  update_pi(s, in);
+  update_pi(s, in);
+  // Now pv 350 (low)
+  in.pv = 350.0f;
+  auto r = update_pi(s, in);
+  assert(!r.failsafe);
+  // e = sp_f - pv, sp_f seeded to 350 then ramp to 500 (250 step) => e ~150 -> positive -> u positive -> pwm = 400 - positive = <400 (harder)
+  assert(r.pwm < 400);
+  assert(r.pwm >= 50);
+}
+
+void test_pv_around_target_no_big_step() {
+  State s;
+  s.startup_hold = 0;
+  s.sp_f = 800;  // already at target
+  s.integral = 0;
+  PiInputs in{};
+  in.sp_target = 800;
+  in.pv = 805;
+  in.kp = 0.09f;
+  in.ki = 0.0012f;
+  in.dt = 10;
+  in.pwm_seed = 410;
+  auto r = update_pi(s, in);
+  // e = 800-805 = -5 -> deadband -> 0 -> u ~0 -> pwm unchanged
+  assert(r.pwm == 410 || r.pwm == 409 || r.pwm == 411);
+}
+
+void test_nan_flow_failsafe() {
+  State s;
+  s.startup_hold = 0;
+  s.sp_f = 400;
+  PiInputs in{};
+  in.sp_target = 800;
+  in.pv = NAN;
+  in.kp = 0.09f;
+  in.ki = 0.0012f;
+  in.dt = 10;
+  in.pwm_seed = 400;
+  auto r = update_pi(s, in);
+  assert(r.failsafe);
+  assert(r.pwm == 850);
+  assert(isnan(s.sp_f));
+}
+
+void test_compute_start_pwm_boiler_uses_last_good() {
+  // Boiler test in CM100 should use last_good, not fixed 400
+  int start = compute_start_pwm(true, 1, 400, 440, 440, false, 460);
+  assert(start == 440);
+  // Cooling bank
+  int start_cooling = compute_start_pwm(true, 1, 400, 440, 440, true, 460);
+  assert(start_cooling == 460);
+  // Non-boiler CM100 task keeps fixed
+  int start_other = compute_start_pwm(true, 2, 400, 440, 440, false, 460);
+  assert(start_other == 400);
+  // Outside CM100 uses last_good
+  int start_auto = compute_start_pwm(false, 0, 400, 440, 440, false, 460);
+  assert(start_auto == 440);
+  // Invalid last_good falls back
+  int start_fallback = compute_start_pwm(true, 1, 400, 0, 440, false, 460);
+  assert(start_fallback == 440);
+}
+
+}  // namespace
+
+int main() {
+  test_stale_zero_should_not_cause_dip();
+  test_low_flow_should_pump_harder();
+  test_pv_around_target_no_big_step();
+  test_nan_flow_failsafe();
+  test_compute_start_pwm_boiler_uses_last_good();
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Fixt CM100 flow dip na 20s `AUTO(starting)` hold door stale `sp_f` seed (`0 L/h` -> ramp `250` -> `iPWM 400->452`) in `openquatt/oq_flow_control.yaml:570`
- Houdt `sp_f` `NAN` tijdens hold zodat eerste PI cyclus seedt van actuele `pv` (~824 L/h bij target 800)
- Extraheert `startup_hold`/`sp_f`-ramp/PI logica naar pure helper `openquatt/includes/control/oq_flow_control_logic.h` en delegeert `run_auto_pi` daarheen (single source, `openquatt/oq_flow_control.yaml:540` ~48 regels ipv ~165); `compute_start_pwm` blijft generiek zonder task-code
- Voegt host regressie `tests/host/flow_control_logic_test.cpp` toe; `scripts/run_host_regression_tests.sh` dekt stale-zero scenario plus countercases

Reproduceerbare commando's:
- `python scripts/dev.py validate --config-only --jobs 2`
- `python -m esphome config configs/heatpump_controller_q/single_wifi.yaml`
- `c++ -std=c++17 -I. -I./openquatt tests/host/flow_control_logic_test.cpp -o /tmp/t && /tmp/t` (via WSL) / `bash scripts/run_host_regression_tests.sh` (WSL)

Closes #464

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:
Flow PI gedrag wijzigt alleen rond de `AUTO(starting)` -> `AUTO` transitie. Na de 20s hold wordt geen grote tegengestelde `iPWM` stap meer veroorzaakt; boiler-test flow settle verkort zonder kunstmatige dip. Normale `CM1/CM2/CM3/CM4/CM5` en failsafe blijven stabiel. CM100 boiler-test blijft starten vanaf `commissioning_start_pwm 400` zoals acceptatiecriterium #464 voorschrijft.

## Achtergrond

Zie #464 voor logs/`.oqdebug` en root-cause analyse (`sp_f = pv` tijdens hold met `pv=0`). Oplossingsrichting uit issue gevolgd: `sp_f` tijdens hold `NAN` laten en helper `oq_flow_control_logic.h` voor host-test van echte productielogica. Initieel overwogen `last_good` start voor boiler-test is na review bewust uit deze PR gehouden om #464 zuiver te houden (één bug, één gedragswijziging); kan later als aparte optimalisatie. Helper kent geen service task-codes meer.

## Documentatie

- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:
Gedragsfix zonder nieuwe user-facing entities/config; bestaande `docs/problemen-oplossen.md` en `docs/web-app.md` blijven correct. Geen nieuwe instellingen.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:
Geen nieuwe grote buffers; helper is header-only pure logic zonder extra allocaties. Bestaande `CONFIG_SPIRAM_*` onveranderd. Validatie via host suite en `esphome config` voor alle 8 targets; geen RAM-delta verwacht.

Lokaal getest:
- `wsl bash /mnt/c/dev/OpenQuatt/.tmp/run_host_wsl.sh` -> 21 host tests pass incl. nieuwe `flow_control_logic_test`
- `python scripts/dev.py validate --config-only --jobs 2` -> 8/8 configs `ok`
- `npm run build:web` -> `ok` (via validate)
- `python scripts/check_style_consistency.py` / `check_docs_consistency.py` / `node scripts/check_web_docs_sync.mjs` -> `ok`

### Hardwarevalidatie #464 (2026-08-21)

Getest op:
- firmware `v0.48.0-pr.483.823+4d9fb31`
- Heatpump Controller Q v1.2 (batch 1)
- Duo / Wi-Fi
- CM100 boiler power test
- flow target 800 L/h
- PI: Kp 0.09, Ki 0.0012

De praktijktest raakt exact het oorspronkelijke stale-zero scenario: bij het starten van de boiler-test is de flow nog `0 L/h`, waarna `AUTO start(CM100-task)` correct start op `iPWM=400` met de startup-hold. Zodra de hydraulische flow is opgebouwd tot ~821-824 L/h blijft de PI-overname rustig:

| fase | flow | flowOutputIpwm |
|---|---:|---:|
| start / stale PV | 0 L/h | 400 |
| eerste flow rond target | ~821 L/h | 400 |
| eerste PI-correctie | ~824 L/h | 402 |
| vervolg | ~821 L/h | 405 |
| vervolg | ~819 L/h | 408 |
| stabiel richting target | ~813-807 L/h | 411-414 |
| flow settled | 804 L/h | ~414 |

Het oude foutpatroon `400 -> ~452 -> ~477` treedt niet meer op en er is geen kunstmatige flowdip richting ~700 L/h. De flow-settle eindigt na **121 s**, praktisch gelijk aan de ingestelde minimum settle-tijd van 120 s. Daarmee veroorzaakt de stale `sp_f` seed geen extra wachttijd meer.

De boiler-test faalde daarna in de boilerfase met `OpenTherm boiler detected while R1 is selected`. Dit treedt pas op nadat de flowfase succesvol is afgerond en staat los van #464/#483.

CI op head `4d9fb31` is volledig groen, inclusief host-regressions, formatting, docs, target-matrix, firmware compile-matrix en PR Test Firmware Build.