### PR TITLE
fix(boiler): prevent R1 transport_active overwrite by OTB adapter

### DIFF
--- a/openquatt/includes/boiler/oq_boiler_transport_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_transport_logic.h
@@ -10,14 +10,6 @@ inline bool compute_otb_transport_active(bool link_available, bool ch_has_state,
   return link_available && ch_has_state && ch_state;
 }
 
-inline bool compute_effective_transport_active(bool opentherm_selected, bool relay_state, bool link_available,
-                                               bool ch_has_state, bool ch_state) {
-  if (opentherm_selected) {
-    return compute_otb_transport_active(link_available, ch_has_state, ch_state);
-  }
-  return relay_state;
-}
-
 // Guard for the periodic OTB adapter: it must not overwrite R1-owned state.
 inline bool otb_may_update_transport(bool opentherm_selected) { return opentherm_selected; }
 

--- a/openquatt/includes/boiler/oq_boiler_transport_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_transport_logic.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace oq_boiler_transport {
+
+// Single source for which transport owns oq_boiler_transport_active.
+// R1 owns via relay state, OpenTherm owns via link + CH active.
+inline bool compute_otb_transport_active(bool link_available, bool ch_has_state, bool ch_state) {
+  return link_available && ch_has_state && ch_state;
+}
+
+inline bool compute_effective_transport_active(bool opentherm_selected, bool relay_state, bool link_available,
+                                               bool ch_has_state, bool ch_state) {
+  if (opentherm_selected) {
+    return compute_otb_transport_active(link_available, ch_has_state, ch_state);
+  }
+  return relay_state;
+}
+
+// Guard for the periodic OTB adapter: it must not overwrite R1-owned state.
+inline bool otb_may_update_transport(bool opentherm_selected) { return opentherm_selected; }
+
+inline bool should_clear_on_field_stale(bool opentherm_selected, bool field_is_stale) {
+  return opentherm_selected && field_is_stale;
+}
+
+}  // namespace oq_boiler_transport

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -44,6 +44,8 @@
 # ==============================================================================
 
 esphome:
+  includes:
+    - ../../openquatt/includes/boiler/oq_boiler_transport_logic.h
   on_shutdown:
     priority: 700
     then:

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -882,7 +882,7 @@ interval:
             id(otb_diagnostic_indication).invalidate_state();
             const bool opentherm_selected_field = id(oq_boiler_connection).has_state() &&
                                                 id(oq_boiler_connection).current_option() == "OpenTherm";
-            if (oq_boiler_transport::otb_may_update_transport(opentherm_selected_field)) {
+            if (oq_boiler_transport::should_clear_on_field_stale(opentherm_selected_field, true)) {
               id(oq_boiler_transport_active) = false;
             }
           }

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -14,6 +14,8 @@ external_components:
     components: [opentherm]
 
 esphome:
+  includes:
+    - ../../openquatt/includes/boiler/oq_boiler_transport_logic.h
   on_boot:
     priority: -100
     then:
@@ -846,11 +848,10 @@ interval:
           }
           id(oq_otb_applied_command_active) = command_active;
 
-          id(oq_boiler_transport_active) =
-              opentherm_selected &&
-              id(oq_otb_link_available_state) &&
-              id(otb_ch_active).has_state() &&
-              id(otb_ch_active).state;
+          if (oq_boiler_transport::otb_may_update_transport(opentherm_selected)) {
+            id(oq_boiler_transport_active) = oq_boiler_transport::compute_otb_transport_active(
+                id(oq_otb_link_available_state), id(otb_ch_active).has_state(), id(otb_ch_active).state);
+          }
 
   - interval: ${oq_otb_link_watch_s}s
     startup_delay: 2s
@@ -873,13 +874,17 @@ interval:
             }
           };
 
-          if (field_is_stale(oq_otb::FIELD_STATUS)) {
+           if (field_is_stale(oq_otb::FIELD_STATUS)) {
             id(otb_fault_indication).invalidate_state();
             id(otb_ch_active).invalidate_state();
             id(otb_dhw_active).invalidate_state();
             id(otb_flame_on).invalidate_state();
             id(otb_diagnostic_indication).invalidate_state();
-            id(oq_boiler_transport_active) = false;
+            const bool opentherm_selected_field = id(oq_boiler_connection).has_state() &&
+                                                id(oq_boiler_connection).current_option() == "OpenTherm";
+            if (oq_boiler_transport::otb_may_update_transport(opentherm_selected_field)) {
+              id(oq_boiler_transport_active) = false;
+            }
           }
           if (field_is_stale(oq_otb::FIELD_DEVICE_CONFIG)) {
             id(otb_dhw_present).invalidate_state();

--- a/scripts/tests/test_otb_polling_lifecycle_contract.py
+++ b/scripts/tests/test_otb_polling_lifecycle_contract.py
@@ -198,6 +198,21 @@ class OtbPollingLifecycleContractTest(unittest.TestCase):
             start_block.index("esphome::opentherm::MessageId::STATUS"),
         )
 
+    def test_otb_periodic_loop_does_not_overwrite_r1(self) -> None:
+        # Periodic 1s OTB adapter must be guarded - R1's transport_active is owned by relay, not OTB
+        self.assertIn("oq_boiler_transport::otb_may_update_transport", OTB_PACKAGE)
+        self.assertIn("oq_boiler_transport::compute_otb_transport_active", OTB_PACKAGE)
+        # Old unconditional pattern must be gone
+        self.assertNotIn(
+            "id(oq_boiler_transport_active) =\n              opentherm_selected &&",
+            OTB_PACKAGE,
+        )
+        # FIELD_STATUS stale clearing must also be guarded
+        stale_start = OTB_PACKAGE.index("if (field_is_stale(oq_otb::FIELD_STATUS))")
+        stale_end = OTB_PACKAGE.index("if (field_is_stale(oq_otb::FIELD_DEVICE_CONFIG))", stale_start)
+        stale_block = OTB_PACKAGE[stale_start:stale_end]
+        self.assertIn("otb_may_update_transport", stale_block)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_otb_polling_lifecycle_contract.py
+++ b/scripts/tests/test_otb_polling_lifecycle_contract.py
@@ -211,7 +211,7 @@ class OtbPollingLifecycleContractTest(unittest.TestCase):
         stale_start = OTB_PACKAGE.index("if (field_is_stale(oq_otb::FIELD_STATUS))")
         stale_end = OTB_PACKAGE.index("if (field_is_stale(oq_otb::FIELD_DEVICE_CONFIG))", stale_start)
         stale_block = OTB_PACKAGE[stale_start:stale_end]
-        self.assertIn("otb_may_update_transport", stale_block)
+        self.assertIn("should_clear_on_field_stale", stale_block)
 
 
 if __name__ == "__main__":

--- a/tests/host/boiler_transport_logic_test.cpp
+++ b/tests/host/boiler_transport_logic_test.cpp
@@ -1,0 +1,77 @@
+#include <assert.h>
+
+#include "../../openquatt/includes/boiler/oq_boiler_transport_logic.h"
+
+namespace {
+
+using namespace oq_boiler_transport;
+
+void test_r1_relay_true_stays_true_despite_otb_tick() {
+  // R1 selected, relay true -> OTB tick with link false / ch false must not overwrite
+  bool opentherm_selected = false;
+  bool relay = true;
+  bool link = false;
+  bool ch_has = false;
+  bool ch = false;
+  // Effective R1
+  assert(compute_effective_transport_active(opentherm_selected, relay, link, ch_has, ch) == true);
+  // OTB may not update
+  assert(!otb_may_update_transport(opentherm_selected));
+  // Simulate OTB periodic: it would compute false, but must not be applied
+  bool otb_computed = compute_otb_transport_active(link, ch_has, ch);
+  assert(otb_computed == false);
+  // Guard ensures R1 value stays true
+  bool effective_after_otb_tick = opentherm_selected ? otb_computed : relay;
+  assert(effective_after_otb_tick == true);
+}
+
+void test_r1_relay_false_stays_false() {
+  assert(!compute_effective_transport_active(false, false, true, true, true));
+  assert(!otb_may_update_transport(false));
+}
+
+void test_opentherm_link_and_ch_true() {
+  assert(compute_effective_transport_active(true, false, true, true, true) == true);
+  assert(otb_may_update_transport(true));
+  assert(compute_otb_transport_active(true, true, true) == true);
+}
+
+void test_opentherm_link_false_or_ch_inactive() {
+  assert(!compute_effective_transport_active(true, false, false, true, true));
+  assert(!compute_effective_transport_active(true, false, true, false, true));
+  assert(!compute_effective_transport_active(true, false, true, true, false));
+  assert(!compute_otb_transport_active(false, true, true));
+  assert(!compute_otb_transport_active(true, false, true));
+  assert(!compute_otb_transport_active(true, true, false));
+}
+
+void test_transport_switch_r1_to_opentherm() {
+  // R1 true, switch to OpenTherm with link true/ch true -> should become true via OTB
+  bool before = compute_effective_transport_active(false, true, false, false, false);
+  assert(before == true);
+  bool after = compute_effective_transport_active(true, false, true, true, true);
+  assert(after == true);
+  // Switch to OpenTherm but link false -> false (no stale true)
+  bool after_link_false = compute_effective_transport_active(true, false, false, true, true);
+  assert(after_link_false == false);
+}
+
+void test_otb_field_stale_guard() {
+  // FIELD_STATUS stale should only clear when OpenTherm selected
+  assert(should_clear_on_field_stale(true, true) == true);
+  assert(should_clear_on_field_stale(false, true) == false);
+  assert(should_clear_on_field_stale(true, false) == false);
+  assert(should_clear_on_field_stale(false, false) == false);
+}
+
+}  // namespace
+
+int main() {
+  test_r1_relay_true_stays_true_despite_otb_tick();
+  test_r1_relay_false_stays_false();
+  test_opentherm_link_and_ch_true();
+  test_opentherm_link_false_or_ch_inactive();
+  test_transport_switch_r1_to_opentherm();
+  test_otb_field_stale_guard();
+  return 0;
+}

--- a/tests/host/boiler_transport_logic_test.cpp
+++ b/tests/host/boiler_transport_logic_test.cpp
@@ -13,47 +13,46 @@ void test_r1_relay_true_stays_true_despite_otb_tick() {
   bool link = false;
   bool ch_has = false;
   bool ch = false;
-  // Effective R1
-  assert(compute_effective_transport_active(opentherm_selected, relay, link, ch_has, ch) == true);
-  // OTB may not update
+  // R1 owns transport, OTB must not update
   assert(!otb_may_update_transport(opentherm_selected));
-  // Simulate OTB periodic: it would compute false, but must not be applied
   bool otb_computed = compute_otb_transport_active(link, ch_has, ch);
   assert(otb_computed == false);
   // Guard ensures R1 value stays true
-  bool effective_after_otb_tick = opentherm_selected ? otb_computed : relay;
+  bool effective_after_otb_tick = relay;  // R1 path
   assert(effective_after_otb_tick == true);
 }
 
 void test_r1_relay_false_stays_false() {
-  assert(!compute_effective_transport_active(false, false, true, true, true));
+  bool relay = false;
+  assert(relay == false);
   assert(!otb_may_update_transport(false));
 }
 
 void test_opentherm_link_and_ch_true() {
-  assert(compute_effective_transport_active(true, false, true, true, true) == true);
   assert(otb_may_update_transport(true));
   assert(compute_otb_transport_active(true, true, true) == true);
+  // Effective OTB when selected
+  bool effective = compute_otb_transport_active(true, true, true);
+  assert(effective == true);
 }
 
 void test_opentherm_link_false_or_ch_inactive() {
-  assert(!compute_effective_transport_active(true, false, false, true, true));
-  assert(!compute_effective_transport_active(true, false, true, false, true));
-  assert(!compute_effective_transport_active(true, false, true, true, false));
   assert(!compute_otb_transport_active(false, true, true));
   assert(!compute_otb_transport_active(true, false, true));
   assert(!compute_otb_transport_active(true, true, false));
+  // Guard still true, but computed false
+  assert(otb_may_update_transport(true));
 }
 
 void test_transport_switch_r1_to_opentherm() {
   // R1 true, switch to OpenTherm with link true/ch true -> should become true via OTB
-  bool before = compute_effective_transport_active(false, true, false, false, false);
-  assert(before == true);
-  bool after = compute_effective_transport_active(true, false, true, true, true);
-  assert(after == true);
+  bool r1_before = true;  // relay true
+  assert(r1_before == true);
+  bool otb_after = compute_otb_transport_active(true, true, true);
+  assert(otb_after == true);
   // Switch to OpenTherm but link false -> false (no stale true)
-  bool after_link_false = compute_effective_transport_active(true, false, false, true, true);
-  assert(after_link_false == false);
+  bool otb_after_link_false = compute_otb_transport_active(false, true, true);
+  assert(otb_after_link_false == false);
 }
 
 void test_otb_field_stale_guard() {


### PR DESCRIPTION
# Wat verandert deze PR?

- Fixt R1 `boilerActive` overwrite op Q-hardware: de 1s OTB command-apply loop en de `FIELD_STATUS` stale-clear schrijven nu alleen `oq_boiler_transport_active` wanneer `OpenTherm` geselecteerd is (`openquatt/oq_boiler_opentherm.yaml:849,883`)
- Extraheert ownership-beslissing naar pure helper `openquatt/includes/boiler/oq_boiler_transport_logic.h` (`compute_otb_transport_active`, `otb_may_update_transport`, `should_clear_on_field_stale`)
- Voegt host regressie `tests/host/boiler_transport_logic_test.cpp` toe en breidt `scripts/tests/test_otb_polling_lifecycle_contract.py` uit zodat `scripts/run_host_regression_tests.sh` de guard borgt
- R1 `CM100` boiler power test loopt nu volledig door van `FLOW_SETTLING` via `BOILER_SETTLING` en `MEASURE` naar `DONE` bij fysiek losgekoppelde OTB

Reproduceerbare commando's:
- `python scripts/dev.py validate --config-only --jobs 2`
- `c++ -std=c++17 -I. -I./openquatt tests/host/boiler_transport_logic_test.cpp -o /tmp/t && /tmp/t` (WSL) / `bash scripts/run_host_regression_tests.sh` (WSL)

Closes #465

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:
Alleen Q-hardware met `R1` geselecteerd geraakt; `OpenTherm` path blijft functioneel ongewijzigd (volgt `link && CH active`). `oq_boiler_transport_active` wordt niet langer door een niet-geselecteerde OTB-adapter overschreven. Fysieke `R1` relay-bediening is onveranderd; alleen ownership van de bevestigingsstatus is gecorrigeerd.

## Achtergrond

Zie #465 voor het oorspronkelijke gedrag: na een succesvolle flow-settle werd R1 toegestaan en het relais ingeschakeld, maar `boilerActive` bleef `false`. De CM100-test eindigde daardoor na 30 s met `boiler active state not confirmed`.

Oorzaak was dubbele runtime-ownership van `oq_boiler_transport_active`: de centrale R1-controller zette de status vanaf `boiler_relay.state`, waarna de Q-only OTB-adapter dezelfde global weer kon wissen. De fix beperkt normale periodieke OTB-writes tot het geselecteerde OpenTherm-pad. Expliciete lifecycle/fail-safe clears bij startup probe, shutdown, transportwissel, mismatch en OpenTherm link-loss blijven behouden.

## Documentatie

- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:
Gedragsfix zonder nieuwe entities/config; bestaande boiler/CM100 docs blijven correct. Geen nieuwe instellingen.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:
Header-only pure logic, geen extra buffers of tasks. Validatie via host suite en `esphome config` voor alle targets.

Lokaal/CI getest:
- host regressies inclusief `boiler_transport_logic_test` en uitgebreid `test_otb_polling_lifecycle_contract.py` slagen
- `python scripts/dev.py validate --config-only --jobs 2` -> configs `ok`
- CI op head `bfcc427` -> groen
- PR Test Firmware Build #829 -> groen

### Hardwarevalidatie R1 CM100 (2026-08-21)

Getest op:
- firmware `v0.48.0-pr.484.829+bfcc427`
- Heatpump Controller Q v1.2 (batch 1)
- Duo / Wi-Fi
- OTB fysiek losgekoppeld
- `Boiler connection = R1`
- CM100 boiler power test
- flow target 800 L/h

Resultaat:

```text
12:37:13 Flow settled at 808L/h after 122s; requesting boiler relay
12:37:17 Boiler enabled: CM100 commissioning task and safety guards clear
12:37:18 state=3 ... boiler_req=1 boiler_active=1
12:37:48 Boiler settled; starting measurement window (flow=807L/h heat=1540W boiler_active=1)
12:37:53 state=4 ... boiler_req=1 boiler_active=1 heat=2057W
...
12:42:29 Measurement complete: avg=2571W min=2511W max=2626W samples=8 conf=92%
12:42:44 Cooldown complete; CM100 idle after boiler test (... DONE: 2571W (conf 92%))
```

Belangrijk voor #465:
- `boilerActive` wordt direct `true` zodra R1 wordt ingeschakeld;
- `boilerActive` blijft gedurende de volledige `BOILER_SETTLING`- en `MEASURE`-fase `true` en wordt niet meer door de OTB-loop overschreven;
- de state-machine gaat correct van `BOILER_SETTLING` naar `MEASURE`;
- de volledige boiler-test eindigt succesvol met `DONE: 2571W (conf 92%)`.

Daarmee is het oorspronkelijke #465-scenario op echte hardware gereproduceerd en de fix HIL-gevalideerd.