### PR TITLE
fix(boiler): preserve R1 boilerActive on Q hardware

### DIFF
--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -846,11 +846,12 @@ interval:
           }
           id(oq_otb_applied_command_active) = command_active;
 
-          id(oq_boiler_transport_active) =
-              opentherm_selected &&
-              id(oq_otb_link_available_state) &&
-              id(otb_ch_active).has_state() &&
-              id(otb_ch_active).state;
+          if (opentherm_selected) {
+            id(oq_boiler_transport_active) =
+                id(oq_otb_link_available_state) &&
+                id(otb_ch_active).has_state() &&
+                id(otb_ch_active).state;
+          }
 
   - interval: ${oq_otb_link_watch_s}s
     startup_delay: 2s

--- a/scripts/tests/test_otb_polling_lifecycle_contract.py
+++ b/scripts/tests/test_otb_polling_lifecycle_contract.py
@@ -198,6 +198,26 @@ class OtbPollingLifecycleContractTest(unittest.TestCase):
             start_block.index("esphome::opentherm::MessageId::STATUS"),
         )
 
+    def test_periodic_otb_loop_does_not_overwrite_r1_transport_activity(self) -> None:
+        apply_start = OTB_PACKAGE.index("- interval: ${oq_otb_command_apply_s}s")
+        apply_end = OTB_PACKAGE.index(
+            "- interval: ${oq_otb_link_watch_s}s", apply_start
+        )
+        apply_block = OTB_PACKAGE[apply_start:apply_end]
+        assignment = "id(oq_boiler_transport_active) ="
+        self.assertEqual(apply_block.count(assignment), 1)
+        assignment_pos = apply_block.index(assignment)
+        owner_guard_pos = apply_block.rfind(
+            "if (opentherm_selected) {", 0, assignment_pos
+        )
+        self.assertGreaterEqual(owner_guard_pos, 0)
+        self.assertLess(owner_guard_pos, assignment_pos)
+        self.assertNotIn(
+            "id(oq_boiler_transport_active) =\n"
+            "              opentherm_selected &&",
+            apply_block,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Fixt #465: de periodieke OpenTherm-adapter schrijft `oq_boiler_transport_active` alleen nog wanneer **OpenTherm geselecteerd** is.
- Bij **R1** blijft de centrale boiler-controller eigenaar van `boilerActive` via `boiler_relay.state`, zodat de OTB-loop een actieve R1-status niet meer kan overschrijven naar `false`.
- Breidt `scripts/tests/test_otb_polling_lifecycle_contract.py` uit om dit ownership-contract expliciet te borgen.

Reproduceerbare projectcommando's:
- `./scripts/run_host_regression_tests.sh`
- `python scripts/dev.py validate --config-only --jobs 2`

Closes #465

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De wijziging raakt alleen ownership van de gedeelde boiler transport-active status op Q-hardware. De R1-controller blijft eigenaar zolang R1 geselecteerd is; de periodieke OTB command-apply loop mag de status alleen bijwerken wanneer OpenTherm geselecteerd is. Expliciete lifecycle/fail-safe clears bij startup probe, shutdown, transportwissel en OpenTherm link-loss blijven ongewijzigd.

## Achtergrond

Op Q-hardware kon de centrale R1-controller een actief relais correct publiceren als `oq_boiler_transport_active=true`, waarna de 1-s OpenTherm-adapter dezelfde global opnieuw schreef met:

```cpp
opentherm_selected && ...
```

Bij R1 is `opentherm_selected=false`, waardoor `boilerActive` direct weer `false` werd. De fysieke R1-output kon daardoor actief zijn terwijl de CM100 boiler power test na 30 s faalde met `boiler active state not confirmed`.

De fix is bewust bij de ownership-bron gehouden; er is geen workaround toegevoegd aan de CM100 state-machine, R1-relaislogica of boilerstrategie.

Na groene CI volgt HIL-validatie op Heatpump Controller Q v1.2 / Duo / Wi-Fi met OTB fysiek losgekoppeld en `Boiler connection = R1`:

1. CM100 boiler power test starten;
2. flowfase rond 800 L/h laten settelen;
3. R1 moet worden ingeschakeld (`output_req=1`);
4. `boilerActive` moet `true` blijven;
5. test moet doorgaan van `BOILER_SETTLING` naar `MEASURE` in plaats van te falen met `boiler active state not confirmed`.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne bugfix zonder nieuwe instellingen, entities of gewijzigde gebruikersflow. De bestaande documentatie voor R1/OpenTherm-selectie en CM100 blijft inhoudelijk ongewijzigd.

## Validatie

- Contracttest uitgebreid in `scripts/tests/test_otb_polling_lifecycle_contract.py`:
  - periodieke OTB command-apply loop bevat de transport-active assignment alleen achter `if (opentherm_selected)`;
  - het oude patroon `oq_boiler_transport_active = opentherm_selected && ...` kan niet terugkomen;
  - expliciete lifecycle/fail-safe clears buiten deze periodieke ownership blijven toegestaan.
- CI draait op de PR; hardwarevalidatie volgt na groene build met OTB fysiek losgekoppeld en R1 geselecteerd.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe buffers, globals, allocaties of tasks. De wijziging voegt alleen een bestaande boolean assignment achter een selectieguard en breidt een Python contracttest uit; geen heap-, PSRAM- of stack-impact verwacht.