### PR TITLE
feat(ui): improve CM100 boiler test progress and stop feedback

### DIFF
--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -4219,14 +4219,14 @@
           state.commissioning.boilerStatusText = "FLOW_SETTLING";
           setText("text_sensor", "Boiler power test status", "FLOW_SETTLING");
         });
-        scheduleCommissioningStep(1700, () => {
+        scheduleCommissioningStep(3700, () => {
           setCommissioningPhase("boiler", "boiler_settling");
           state.commissioning.boilerStatusText = "BOILER_SETTLING";
           setText("text_sensor", "Boiler power test status", "BOILER_SETTLING");
           setBinary("Boiler active", true);
           setNumber("Boiler Heat Power", 0, "W");
         });
-        scheduleCommissioningStep(2900, () => {
+        scheduleCommissioningStep(6700, () => {
           setCommissioningPhase("boiler", "measuring");
           state.commissioning.boilerStatusText = "MEASURING";
           setText("text_sensor", "Boiler power test status", "MEASURING");
@@ -4234,7 +4234,7 @@
           setNumber("Boiler Heat Power", 1803, "W");
           setNumber("Flow average (Selected)", 802, "L/h");
         });
-        scheduleCommissioningStep(4300, () => {
+        scheduleCommissioningStep(9700, () => {
           setCommissioningPhase("boiler", "done", {
             boilerResult: 1803,
             boilerConfidence: 65,

--- a/openquatt/web/js/src/settings/service.js
+++ b/openquatt/web/js/src/settings/service.js
@@ -398,38 +398,48 @@ import { renderModalShell } from "../core/modal-shell.js";
     const targetText = Number.isFinite(target) ? `${Math.round(target)} L/h` : "800 L/h";
 
     if (upper.includes("FLOW_SETTLING")) {
-      return `Flow wordt ingesteld op ${targetText}. De ketel wordt daarna gestart. Deze fase duurt minimaal 2 minuten. Huidige flow: ${flowText} (doel ${targetText} ±40).`;
+      return `Flow naar ${targetText} ±40. Ketel start daarna. Min. 2 min. Nu ${flowText}.`;
     }
     if (upper.includes("BOILER_SETTLING")) {
-      return `Warmtevraag naar ketel verstuurd; wachten op ketel. Flow: ${flowText} (doel ${targetText} ±40).`;
+      return `Warmtevraag verstuurd; wachten op ketel. Flow ${flowText} (doel ±40).`;
     }
     if (upper.includes("MEASURING")) {
       const heat = getSettingsStatValue("boilerHeatPower");
-      return `Ketel actief; vermogen wordt gemeten.${heat && heat !== "—" ? ` Actueel: ${heat}.` : ""} De ketel wordt na minimaal 3 minuten automatisch uitgeschakeld.`;
+      return `Ketel actief; meten.${heat && heat !== "—" ? ` Nu ${heat}.` : ""} Auto uit na 3 min.`;
     }
     if (upper.includes("COOLDOWN")) {
       const result = getSettingsStatValue("boilerPowerTestResult");
-      return `Metingen voltooid; ketel wordt uitgeschakeld.${result && result !== "—" ? ` Resultaat: ${result}.` : ""} Afkoelen 15 s.`;
+      return `Metingen klaar; ketel uit.${result && result !== "—" ? ` ${result}.` : ""} 15s afkoelen.`;
     }
     if (upper.startsWith("DONE:") || upper === "DONE" || upper.includes("APPLIED")) {
       const result = getSettingsStatValue("boilerPowerTestResult");
       const conf = getSettingsStatValue("boilerPowerTestConfidence");
       if (result && result !== "—") {
-        return `Klaar - gemeten ${result}${conf && conf !== "—" ? ` (betrouwbaarheid ${conf})` : ""}. Ketel automatisch uitgeschakeld.`;
+        return `Klaar - ${result}${conf && conf !== "—" ? ` (${conf})` : ""}. Ketel auto uit.`;
       }
-      return upper.includes("APPLIED") ? "Resultaat toegepast op boilerinstelling." : "Klaar - ketel automatisch uitgeschakeld.";
+      return upper.includes("APPLIED") ? "Resultaat toegepast." : "Klaar - ketel auto uit.";
     }
-    if (upper.includes("ABORTED") || upper.includes("ABORT")) {
+    if (upper === "ABORTED" || upper === "ABORT") {
       return "Handmatig gestopt. Flow en ketel zijn hersteld naar vorige instelling.";
     }
-    if (upper.includes("FAILED") || upper.includes("REFUSED")) {
-      // Toon specifieke reden indien aanwezig: "FAILED: ..." of "REFUSED: ..."
+    if (upper.startsWith("ABORTED:") || upper.startsWith("ABORT:")) {
+      const reason = status.slice(status.indexOf(":") + 1).trim();
+      return `Afgebroken: ${reason}`;
+    }
+    if (upper.startsWith("REFUSED:")) {
+      const reason = status.slice(status.indexOf(":") + 1).trim();
+      return `Start geweigerd: ${reason}`;
+    }
+    if (upper.includes("FAILED")) {
       const colonIdx = status.indexOf(":");
       if (colonIdx > 0) {
         const reason = status.slice(colonIdx + 1).trim();
         return `Mislukt: ${reason}`;
       }
-      return upper.includes("REFUSED") ? `Start geweigerd: ${status}` : `Mislukt: ${status}`;
+      return `Mislukt: ${status}`;
+    }
+    if (upper === "REFUSED") {
+      return `Start geweigerd: ${status}`;
     }
     return status;
   }
@@ -535,13 +545,18 @@ import { renderModalShell } from "../core/modal-shell.js";
     const flowKiSuggested = getSettingsStatValue("flowKiSuggested", { decimals: 5, trimTrailingZeros: true });
     const boilerResultReady = /DONE|APPLIED/.test(String(boilerStatus || "").toUpperCase());
     const autotuneResultReady = /DONE|APPLIED/.test(String(autotuneStatus || "").toUpperCase());
-    const boilerStatusDisplay = cm100Ready
-      ? (boilerTaskWaitingForCm100
-        ? "Wachten op CM100"
-        : (boilerTaskRunning
-          ? boilerProgress.phase
-          : (boilerResultReady ? "Klaar om toe te passen" : "Klaar om te starten")))
-      : "Wachten op CM100";
+    const boilerStatusDisplay = (() => {
+      const upper = String(boilerStatus || "").toUpperCase();
+      if (upper.includes("FAILED") || upper.startsWith("REFUSED:")) return "Mislukt";
+      if (upper === "REFUSED") return "Start geweigerd";
+      if (upper === "ABORTED" || upper === "ABORT") return "Handmatig gestopt";
+      if (upper.startsWith("ABORTED:") || upper.startsWith("ABORT:")) return "Afgebroken";
+      if (upper.startsWith("DONE:") || upper === "DONE" || upper.includes("APPLIED")) return "Klaar";
+      if (boilerTaskWaitingForCm100) return "Wachten op CM100";
+      if (boilerTaskRunning) return boilerProgress.phase;
+      if (boilerResultReady) return "Klaar om toe te passen";
+      return cm100Ready ? "Klaar om te starten" : "Wachten op CM100";
+    })();
     const autotuneStatusDisplay = cm100Ready
       ? (autotuneTaskWaitingForCm100
         ? "Wachten op CM100"

--- a/openquatt/web/js/src/settings/service.js
+++ b/openquatt/web/js/src/settings/service.js
@@ -405,7 +405,7 @@ import { renderModalShell } from "../core/modal-shell.js";
     }
     if (upper.includes("MEASURING")) {
       const heat = getSettingsStatValue("boilerHeatPower");
-      return `Ketel actief; meten.${heat && heat !== "—" ? ` Nu ${heat}.` : ""} Auto uit na 3 min.`;
+      return `Ketel actief; meten.${heat && heat !== "—" ? ` Nu ${heat}.` : ""} Min. 3 min; daarna auto uit zodra meting compleet is.`;
     }
     if (upper.includes("COOLDOWN")) {
       const result = getSettingsStatValue("boilerPowerTestResult");
@@ -547,8 +547,8 @@ import { renderModalShell } from "../core/modal-shell.js";
     const autotuneResultReady = /DONE|APPLIED/.test(String(autotuneStatus || "").toUpperCase());
     const boilerStatusDisplay = (() => {
       const upper = String(boilerStatus || "").toUpperCase();
-      if (upper.includes("FAILED") || upper.startsWith("REFUSED:")) return "Mislukt";
-      if (upper === "REFUSED") return "Start geweigerd";
+      if (upper.includes("FAILED")) return "Mislukt";
+      if (upper.startsWith("REFUSED:") || upper === "REFUSED") return "Start geweigerd";
       if (upper === "ABORTED" || upper === "ABORT") return "Handmatig gestopt";
       if (upper.startsWith("ABORTED:") || upper.startsWith("ABORT:")) return "Afgebroken";
       if (upper.startsWith("DONE:") || upper === "DONE" || upper.includes("APPLIED")) return "Klaar";

--- a/openquatt/web/js/src/settings/service.js
+++ b/openquatt/web/js/src/settings/service.js
@@ -83,9 +83,9 @@ import { renderModalShell } from "../core/modal-shell.js";
       boiler: [
         { match: ["REQUESTED", "WAITING_FOR_CM100", "REFUSED"], phase: "Voorbereiden", percent: 12 },
         { match: ["FLOW_SETTLING"], phase: "Flow stabiliseren", percent: 28 },
-        { match: ["BOILER_SETTLING"], phase: "Boiler stabiliseren", percent: 48 },
-        { match: ["MEASURING"], phase: "Meten", percent: 72 },
-        { match: ["COOLDOWN"], phase: "Afronden", percent: 90 },
+        { match: ["BOILER_SETTLING"], phase: "Ketel starten", percent: 48 },
+        { match: ["MEASURING"], phase: "Vermogen meten", percent: 72 },
+        { match: ["COOLDOWN"], phase: "Test afronden", percent: 90 },
         { match: ["DONE", "APPLIED"], phase: "Klaar", percent: 100 },
         { match: ["ABORTED", "FAILED", "ABORT"], phase: "Afgebroken", percent: 100 },
       ],
@@ -387,6 +387,51 @@ import { renderModalShell } from "../core/modal-shell.js";
         ` : ""}
       </div>
     `;
+  }
+
+  export function getBoilerTestStatusCopy(boilerStatus, flowLph, targetLph = 800) {
+    const status = String(boilerStatus || "").trim();
+    const upper = status.toUpperCase();
+    const flow = Number(flowLph);
+    const target = Number(targetLph);
+    const flowText = Number.isFinite(flow) ? `${Math.round(flow)} L/h` : "— L/h";
+    const targetText = Number.isFinite(target) ? `${Math.round(target)} L/h` : "800 L/h";
+
+    if (upper.includes("FLOW_SETTLING")) {
+      return `Flow wordt ingesteld op ${targetText}. De ketel wordt daarna gestart. Deze fase duurt minimaal 2 minuten. Huidige flow: ${flowText} (doel ${targetText} ±40).`;
+    }
+    if (upper.includes("BOILER_SETTLING")) {
+      return `Warmtevraag naar ketel verstuurd; wachten op ketel. Flow: ${flowText} (doel ${targetText} ±40).`;
+    }
+    if (upper.includes("MEASURING")) {
+      const heat = getSettingsStatValue("boilerHeatPower");
+      return `Ketel actief; vermogen wordt gemeten.${heat && heat !== "—" ? ` Actueel: ${heat}.` : ""} De ketel wordt na minimaal 3 minuten automatisch uitgeschakeld.`;
+    }
+    if (upper.includes("COOLDOWN")) {
+      const result = getSettingsStatValue("boilerPowerTestResult");
+      return `Metingen voltooid; ketel wordt uitgeschakeld.${result && result !== "—" ? ` Resultaat: ${result}.` : ""} Afkoelen 15 s.`;
+    }
+    if (upper.startsWith("DONE:") || upper === "DONE" || upper.includes("APPLIED")) {
+      const result = getSettingsStatValue("boilerPowerTestResult");
+      const conf = getSettingsStatValue("boilerPowerTestConfidence");
+      if (result && result !== "—") {
+        return `Klaar - gemeten ${result}${conf && conf !== "—" ? ` (betrouwbaarheid ${conf})` : ""}. Ketel automatisch uitgeschakeld.`;
+      }
+      return upper.includes("APPLIED") ? "Resultaat toegepast op boilerinstelling." : "Klaar - ketel automatisch uitgeschakeld.";
+    }
+    if (upper.includes("ABORTED") || upper.includes("ABORT")) {
+      return "Handmatig gestopt. Flow en ketel zijn hersteld naar vorige instelling.";
+    }
+    if (upper.includes("FAILED") || upper.includes("REFUSED")) {
+      // Toon specifieke reden indien aanwezig: "FAILED: ..." of "REFUSED: ..."
+      const colonIdx = status.indexOf(":");
+      if (colonIdx > 0) {
+        const reason = status.slice(colonIdx + 1).trim();
+        return `Mislukt: ${reason}`;
+      }
+      return upper.includes("REFUSED") ? `Start geweigerd: ${status}` : `Mislukt: ${status}`;
+    }
+    return status;
   }
 
   export function getSettingsServiceModel() {
@@ -775,8 +820,8 @@ import { renderModalShell } from "../core/modal-shell.js";
           status: boilerStatusDisplay,
           statusCopy: boilerTaskWaitingForCm100
             ? "Wacht totdat CM100 actief is voordat je de boiler-test start."
-            : (boilerTaskRunning
-              ? "De boiler-test draait op dit moment."
+            : (isCommissioningTaskStatusTerminal(boilerStatus) || boilerTaskRunning
+              ? getBoilerTestStatusCopy(boilerStatus, getEntityNumericValue("flowSelected"), 800)
               : (cm100Ready ? "CM100 staat klaar. Start de boiler-test wanneer je wilt." : "Start CM100 eerst en voer daarna de boilervermogentest uit.")),
           progressTask: "boiler",
           actions: `

--- a/openquatt/web/tests/boiler-test-status.test.mjs
+++ b/openquatt/web/tests/boiler-test-status.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+globalThis.__OQ_PREVIEW__ = false;
+globalThis.window = {
+  location: { pathname: "/" },
+  setTimeout: globalThis.setTimeout,
+  clearTimeout: globalThis.clearTimeout,
+  localStorage: { getItem: () => null },
+};
+
+const { state } = await import("../js/src/core/state.js");
+const { getBoilerTestStatusCopy, getCommissioningProgressModel } = await import("../js/src/settings/service.js");
+
+function setBoilerEntities(heatPower = "—", result = "—", confidence = "—") {
+  state.entities = {
+    boilerHeatPower: { value: heatPower, state: heatPower },
+    boilerPowerTestResult: { value: result, state: result },
+    boilerPowerTestConfidence: { value: confidence, state: confidence },
+  };
+}
+
+test("boiler progress model uses user-friendly phases", () => {
+  assert.equal(getCommissioningProgressModel("FLOW_SETTLING", "boiler").phase, "Flow stabiliseren");
+  assert.equal(getCommissioningProgressModel("BOILER_SETTLING", "boiler").phase, "Ketel starten");
+  assert.equal(getCommissioningProgressModel("MEASURING", "boiler").phase, "Vermogen meten");
+  assert.equal(getCommissioningProgressModel("COOLDOWN", "boiler").phase, "Test afronden");
+  assert.equal(getCommissioningProgressModel("DONE: 2571W (conf 92%)", "boiler").phase, "Klaar");
+  assert.equal(getCommissioningProgressModel("ABORTED", "boiler").phase, "Afgebroken");
+});
+
+test("getBoilerTestStatusCopy FLOW_SETTLING shows target and 2 min hint", () => {
+  setBoilerEntities();
+  const copy = getBoilerTestStatusCopy("FLOW_SETTLING", 812, 800);
+  assert.match(copy, /Flow naar 800 L\/h/);
+  assert.match(copy, /Min\. 2 min/);
+  assert.match(copy, /Nu 812 L\/h/);
+});
+
+test("getBoilerTestStatusCopy BOILER_SETTLING shows flow", () => {
+  const copy = getBoilerTestStatusCopy("BOILER_SETTLING", 805, 800);
+  assert.match(copy, /Warmtevraag verstuurd/);
+  assert.match(copy, /Flow 805 L\/h/);
+});
+
+test("getBoilerTestStatusCopy MEASURING shows heat", () => {
+  setBoilerEntities("2057 W", "—", "—");
+  const copy = getBoilerTestStatusCopy("MEASURING", 807, 800);
+  assert.match(copy, /Ketel actief; meten/);
+  assert.match(copy, /Nu 2057 W/);
+});
+
+test("getBoilerTestStatusCopy COOLDOWN shows result", () => {
+  setBoilerEntities("—", "2571 W", "92%");
+  const copy = getBoilerTestStatusCopy("COOLDOWN", 808, 800);
+  assert.match(copy, /Metingen klaar; ketel uit/);
+});
+
+test("getBoilerTestStatusCopy DONE shows result and confidence", () => {
+  setBoilerEntities("—", "2571 W", "92%");
+  const copy = getBoilerTestStatusCopy("DONE: 2571W (conf 92%)", 800, 800);
+  assert.match(copy, /Klaar - 2571 W/);
+  assert.match(copy, /92%/);
+});
+
+test("getBoilerTestStatusCopy exact ABORTED is handmatig", () => {
+  const copy = getBoilerTestStatusCopy("ABORTED", 800, 800);
+  assert.equal(copy, "Handmatig gestopt. Flow en ketel zijn hersteld naar vorige instelling.");
+});
+
+test("getBoilerTestStatusCopy ABORTED: CM100 exited is afgebroken with reason", () => {
+  const copy = getBoilerTestStatusCopy("ABORTED: CM100 exited", 800, 800);
+  assert.equal(copy, "Afgebroken: CM100 exited");
+});
+
+test("getBoilerTestStatusCopy FAILED shows mislukt with reason", () => {
+  const copy = getBoilerTestStatusCopy("FAILED: boiler active state not confirmed", 800, 800);
+  assert.equal(copy, "Mislukt: boiler active state not confirmed");
+});
+
+test("getBoilerTestStatusCopy REFUSED shows start geweigerd", () => {
+  const copy = getBoilerTestStatusCopy("REFUSED: boiler/CV assist disabled", 800, 800);
+  assert.equal(copy, "Start geweigerd: boiler/CV assist disabled");
+  const copy2 = getBoilerTestStatusCopy("REFUSED", 800, 800);
+  assert.equal(copy2, "Start geweigerd: REFUSED");
+});

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -7,8 +7,9 @@ export const WEB_BUNDLE_BUDGETS = [
     // Includes HCQ R2 settings, bounded usage-telemetry confirmation polling,
     // source-bound supply-temperature calibration status and results,
     // its read-only sensor-correction summary, calibration backup/restore,
-    // the read-only ODU EEPROM service export, and API ingress source controls.
-    raw: 899_000,
+    // the read-only ODU EEPROM service export, API ingress source controls,
+    // and concise CM100 boiler test phase copy (FLOW_SETTLING/BOILER_SETTLING/MEASURING/COOLDOWN).
+    raw: 902_000,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.


### PR DESCRIPTION
# Wat verandert deze PR?

- Maakt de voortgang van de CM100 boiler-test expliciet en begrijpelijk in de web-UI.
- Vertaalt de interne fasen naar gebruikersgerichte statussen:
  - `FLOW_SETTLING` -> **Flow stabiliseren**: doel 800 ±40 L/h, ketel start pas daarna, minimaal 2 minuten;
  - `BOILER_SETTLING` -> **Ketel starten**: warmtevraag is verstuurd en OpenQuatt wacht op bevestiging van de ketel;
  - `MEASURING` -> **Vermogen meten**: actueel vermogen zichtbaar; minimaal 3 minuten meten en daarna automatisch uit zodra voldoende meetdata beschikbaar is;
  - `COOLDOWN` -> **Test afronden**: meting voltooid, ketel uit, 15 s cooldown;
  - `DONE` / `APPLIED` -> **Klaar** met resultaat en confidence.
- Maakt terminale uitkomsten semantisch onderscheidend:
  - exact `ABORTED` -> **Handmatig gestopt**;
  - `ABORTED: <reason>` -> **Afgebroken: <reason>**;
  - `FAILED: <reason>` -> **Mislukt: <reason>**;
  - `REFUSED: <reason>` -> **Start geweigerd: <reason>**.
- Terminale statussen krijgen ook als hoofdstatus dezelfde betekenis en vallen niet meer terug op `Klaar om te starten` / `Wachten op CM100`.
- Verlengt de boiler-fasen in `mock-device.js` naar circa 3 s per stap zodat de nieuwe copy in `dev.html` goed beoordeeld kan worden.
- Voegt gerichte regressietests toe in `openquatt/web/tests/boiler-test-status.test.mjs`.
- Verhoogt het raw JS-budget gemotiveerd van 899 kB naar 902 kB; actuele bundle circa 900.5 kB raw.

Reproduceerbare commando's:
- `npm run check:web`
- `npm run build:web:preview` + `http://127.0.0.1:8001/dev.html?view=settings&section=service`
- `node --test openquatt/web/tests/boiler-test-status.test.mjs`
- `python scripts/dev.py validate --config-only --jobs 2`

Closes #466

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alle wijzigingen zitten in de web-UI, preview/mock, webtests en het web-bundlebudget. Er wijzigen geen firmware-state-machine, boiler-aansturing, entities of veiligheidsgrenzen. De UI blijft backward compatible met de bestaande `boilerPowerTestStatus`-waarden.

## Achtergrond

Tijdens de echte-ketelvalidatie rond #450 bleek de CM100 boiler-test technisch moeilijk te volgen: tijdens de eerste minimaal 2 minuten `FLOW_SETTLING` hoort de ketel bewust nog niet te starten, terwijl de test later na de meetfase juist automatisch uitschakelt. Zonder fasegerichte feedback kan beide gedrag ten onrechte als fout worden geïnterpreteerd.

De uiteindelijke copy volgt de echte state-machine. Vooral `MEASURING` is bewust beschreven als **minimaal 3 minuten** in plaats van exact 3 minuten: naast de minimumtijd zijn ook voldoende geldige meetsamples nodig voordat de test naar cooldown gaat.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit betreft toelichting van een bestaande serviceflow in de web-UI. Er komen geen nieuwe instellingen, entities of bedieningsmogelijkheden bij; de bestaande documentatie blijft inhoudelijk correct.

## Validatie

- `boiler-test-status.test.mjs`: 10 gerichte tests voor fasen en terminale statussen, waaronder `ABORTED` versus `ABORTED: CM100 exited`, `FAILED` en `REFUSED`.
- `npm run check:web`: webbuild, volledige webtestsuite en web-quality check slagen; 184 webtests passeren.
- Web smoke checks slagen.
- Host regression tests slagen.
- `python scripts/dev.py validate --config-only --jobs 2`: configuraties valideren.
- Handmatig beoordeeld in `dev.html` met vertraagde mock-fasen.
- Raw JS bundle circa 900.5 kB en daarmee onder het gemotiveerde budget van 902 kB.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen firmwarewijziging, nieuwe task, buffer, global of runtime-allocatie; alleen web-assets/testcode.