### PR TITLE
fix(boiler): add thermal headroom for CM100 power test

### DIFF
--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -62,6 +62,28 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
   return out;
 }
 
+inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected, float otb_max_capacity_w,
+                                                        float rated_power_w, float inlet_c, float max_c,
+                                                        float flow_lph, float cp_j_per_kgk, float headroom_c = 5.0f) {
+  if (!opentherm_selected) {
+    // R1: keep existing behavior, no dynamic flow, just headroom-capped target
+    OperatingPoint out{};
+    out.feasible = true;
+    out.headroom_c = headroom_c;
+    out.required_flow_lph = flow_lph;
+    float max_target = max_c - headroom_c;
+    if (isnan(max_target) || max_target <= inlet_c) max_target = inlet_c + 1.0f;
+    out.target_temperature_c = max_target;
+    out.reason = nullptr;
+    return out;
+  }
+  float power_for_calc = rated_power_w;
+  if (!isnan(otb_max_capacity_w) && otb_max_capacity_w > 0.0f) {
+    power_for_calc = otb_max_capacity_w;
+  }
+  return compute_operating_point(power_for_calc, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c);
+}
+
 inline bool has_sufficient_headroom(float rated_power_w, float inlet_c, float max_c, float flow_lph, float cp_j_per_kgk,
                                     float headroom_c = 5.0f) {
   return compute_operating_point(rated_power_w, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c).feasible;

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -63,8 +63,8 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
 }
 
 inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected, float otb_max_capacity_w,
-                                                        float rated_power_w, float inlet_c, float max_c,
-                                                        float flow_lph, float cp_j_per_kgk, float headroom_c = 5.0f) {
+                                                        float rated_power_w, float inlet_c, float max_c, float flow_lph,
+                                                        float cp_j_per_kgk, float headroom_c = 5.0f) {
   if (!opentherm_selected) {
     // R1: keep existing behavior, no dynamic flow, just headroom-capped target
     OperatingPoint out{};

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -81,15 +81,14 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
     return out;
   }
   if (isnan(otb_max_capacity_w) || otb_max_capacity_w <= 0.0f) {
-    // OT max capacity unavailable (ID15 not supported): use conservative high flow
-    // Do not refuse; let thermal guard and measurement plateau determine reliability
+    // OT max capacity unavailable (ID15 not supported): keep at 800, don't go to 1500
+    // Many systems cannot reach 1500; use max-5 and let guard/plateau determine reliability
     (void)rated_power_w;
-    (void)flow_lph;
     (void)cp_j_per_kgk;
     OperatingPoint out{};
     out.feasible = true;
     out.headroom_c = headroom_c;
-    out.required_flow_lph = 1500.0f;
+    out.required_flow_lph = flow_lph;
     float max_target = max_c - headroom_c;
     if (isnan(max_target) || max_target <= inlet_c) max_target = inlet_c + 1.0f;
     out.target_temperature_c = max_target;

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -49,9 +49,9 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
   const float max_target = max_c - headroom_c;
 
   if (!opentherm_selected) {
-    (void) otb_max_capacity_w;
-    (void) rated_power_w;
-    (void) cp_j_per_kgk;
+    (void)otb_max_capacity_w;
+    (void)rated_power_w;
+    (void)cp_j_per_kgk;
     OperatingPoint out{};
     out.headroom_c = headroom_c;
     if (isnan(inlet_c) || isnan(max_c) || isnan(base_flow_lph) || base_flow_lph <= 0.0f) {
@@ -79,8 +79,8 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
   }
 
   if (isnan(otb_max_capacity_w) || otb_max_capacity_w <= 0.0f) {
-    (void) rated_power_w;
-    (void) cp_j_per_kgk;
+    (void)rated_power_w;
+    (void)cp_j_per_kgk;
     OperatingPoint out{};
     out.feasible = true;
     out.headroom_c = headroom_c;

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+
+namespace oq_boiler_commissioning {
+
+struct OperatingPoint {
+  bool feasible = false;
+  float target_temperature_c = NAN;
+  float required_flow_lph = NAN;
+  float headroom_c = NAN;
+  const char* reason = nullptr;
+};
+
+inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c, float max_c, float flow_lph,
+                                              float cp_j_per_kgk, float headroom_c = 5.0f) {
+  OperatingPoint out{};
+  out.headroom_c = headroom_c;
+
+  if (isnan(rated_power_w) || isnan(inlet_c) || isnan(max_c) || isnan(flow_lph) || isnan(cp_j_per_kgk) ||
+      rated_power_w <= 0.0f || flow_lph <= 0.0f || cp_j_per_kgk <= 0.0f) {
+    out.reason = "invalid input";
+    return out;
+  }
+
+  if (inlet_c >= max_c) {
+    out.reason = "inlet at or above max";
+    return out;
+  }
+
+  const float available_headroom_c = max_c - headroom_c - inlet_c;
+  if (available_headroom_c <= 0.0f) {
+    out.reason = "insufficient thermal headroom for boiler power test";
+    return out;
+  }
+
+  // Required flow to deliver rated power within headroom
+  const float required_flow_kgps = rated_power_w / (cp_j_per_kgk * available_headroom_c);
+  const float required_flow_lph = required_flow_kgps * 3600.0f;
+  out.required_flow_lph = required_flow_lph;
+
+  // If current flow is sufficient, use it and set target with headroom
+  // Otherwise, signal needed flow increase or infeasibility
+  if (required_flow_lph > 1500.0f) {
+    out.reason = "insufficient thermal headroom for boiler power test";
+    return out;
+  }
+
+  // Target is inlet + deltaT at rated power, capped at max - headroom
+  const float thermal_conductance = (flow_lph / 3600.0f) * cp_j_per_kgk;
+  const float delta_t_at_rated = rated_power_w / thermal_conductance;
+  float target = inlet_c + delta_t_at_rated;
+  const float max_target = max_c - headroom_c;
+  if (target > max_target) target = max_target;
+  if (target <= inlet_c) target = inlet_c + 1.0f;
+  if (target >= max_c) target = max_c - headroom_c;
+
+  out.target_temperature_c = target;
+  out.feasible = true;
+  out.reason = nullptr;
+  return out;
+}
+
+inline bool has_sufficient_headroom(float rated_power_w, float inlet_c, float max_c, float flow_lph, float cp_j_per_kgk,
+                                    float headroom_c = 5.0f) {
+  return compute_operating_point(rated_power_w, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c).feasible;
+}
+
+}  // namespace oq_boiler_commissioning

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -7,6 +7,7 @@ namespace oq_boiler_commissioning {
 
 struct OperatingPoint {
   bool feasible = false;
+  bool flow_limited = false;
   float target_temperature_c = NAN;
   float required_flow_lph = NAN;
   float headroom_c = NAN;
@@ -87,6 +88,7 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
     (void)cp_j_per_kgk;
     OperatingPoint out{};
     out.feasible = true;
+    out.flow_limited = false;
     out.headroom_c = headroom_c;
     out.required_flow_lph = flow_lph;
     float max_target = max_c - headroom_c;
@@ -95,7 +97,18 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
     out.reason = nullptr;
     return out;
   }
-  return compute_operating_point(otb_max_capacity_w, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c);
+  auto op = compute_operating_point(otb_max_capacity_w, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c);
+  // For OT, clamp required flow to 1000 max (800 base, 1000 max) and mark as limited if needed
+  if (op.feasible && op.required_flow_lph > 1000.0f) {
+    if (op.required_flow_lph > 1500.0f) {
+      // Still infeasible if >1500 even with OT
+      return op;
+    }
+    op.flow_limited = true;
+    op.required_flow_lph = 1000.0f;
+    // Target remains max - headroom, but flow is limited
+  }
+  return op;
 }
 
 inline bool has_sufficient_headroom(float rated_power_w, float inlet_c, float max_c, float flow_lph, float cp_j_per_kgk,

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -67,6 +67,9 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
                                                         float cp_j_per_kgk, float headroom_c = 5.0f) {
   if (!opentherm_selected) {
     // R1: keep existing behavior, no dynamic flow, just headroom-capped target
+    (void)otb_max_capacity_w;
+    (void)rated_power_w;
+    (void)cp_j_per_kgk;
     OperatingPoint out{};
     out.feasible = true;
     out.headroom_c = headroom_c;
@@ -77,11 +80,23 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
     out.reason = nullptr;
     return out;
   }
-  float power_for_calc = rated_power_w;
-  if (!isnan(otb_max_capacity_w) && otb_max_capacity_w > 0.0f) {
-    power_for_calc = otb_max_capacity_w;
+  if (isnan(otb_max_capacity_w) || otb_max_capacity_w <= 0.0f) {
+    // OT max capacity unavailable (ID15 not supported): use conservative high flow
+    // Do not refuse; let thermal guard and measurement plateau determine reliability
+    (void)rated_power_w;
+    (void)flow_lph;
+    (void)cp_j_per_kgk;
+    OperatingPoint out{};
+    out.feasible = true;
+    out.headroom_c = headroom_c;
+    out.required_flow_lph = 1500.0f;
+    float max_target = max_c - headroom_c;
+    if (isnan(max_target) || max_target <= inlet_c) max_target = inlet_c + 1.0f;
+    out.target_temperature_c = max_target;
+    out.reason = nullptr;
+    return out;
   }
-  return compute_operating_point(power_for_calc, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c);
+  return compute_operating_point(otb_max_capacity_w, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c);
 }
 
 inline bool has_sufficient_headroom(float rated_power_w, float inlet_c, float max_c, float flow_lph, float cp_j_per_kgk,

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -42,7 +42,7 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
 
 inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected, float otb_max_capacity_w,
                                                         float rated_power_w, float inlet_c, float max_c, float flow_lph,
-                                                        float cp_j_per_kgk, float headroom_c = 5.0f) {
+                                                        float cp_j_per_kgk = 4180.0f, float headroom_c = 5.0f) {
   const float max_target = max_c - headroom_c;
 
   if (!opentherm_selected) {

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -43,8 +43,9 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
 }
 
 inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected, float otb_max_capacity_w,
-                                                        float rated_power_w, float inlet_c, float max_c, float base_flow_lph,
-                                                        float cp_j_per_kgk = 4180.0f, float headroom_c = 5.0f) {
+                                                        float rated_power_w, float inlet_c, float max_c,
+                                                        float base_flow_lph, float cp_j_per_kgk = 4180.0f,
+                                                        float headroom_c = 5.0f) {
   const float max_target = max_c - headroom_c;
 
   if (!opentherm_selected) {

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -9,7 +9,8 @@ struct OperatingPoint {
   bool feasible = false;
   bool flow_limited = false;
   float target_temperature_c = NAN;
-  float required_flow_lph = NAN;
+  float theoretical_flow_lph = NAN;
+  float target_flow_lph = NAN;
   float headroom_c = NAN;
   const char* reason = nullptr;
 };
@@ -33,7 +34,8 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
   }
 
   const float required_flow_kgps = rated_power_w / (cp_j_per_kgk * available_headroom_c);
-  out.required_flow_lph = required_flow_kgps * 3600.0f;
+  out.theoretical_flow_lph = required_flow_kgps * 3600.0f;
+  out.target_flow_lph = out.theoretical_flow_lph;
   out.target_temperature_c = max_target;
   out.feasible = true;
   out.reason = nullptr;
@@ -41,30 +43,28 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
 }
 
 inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected, float otb_max_capacity_w,
-                                                        float rated_power_w, float inlet_c, float max_c, float flow_lph,
+                                                        float rated_power_w, float inlet_c, float max_c, float base_flow_lph,
                                                         float cp_j_per_kgk = 4180.0f, float headroom_c = 5.0f) {
   const float max_target = max_c - headroom_c;
 
   if (!opentherm_selected) {
-    // R1: keep the configured flow and do not apply OT capacity-based flow selection.
-    (void)otb_max_capacity_w;
-    (void)rated_power_w;
-    (void)cp_j_per_kgk;
+    (void) otb_max_capacity_w;
+    (void) rated_power_w;
+    (void) cp_j_per_kgk;
     OperatingPoint out{};
     out.headroom_c = headroom_c;
-    if (isnan(inlet_c) || isnan(max_c) || isnan(flow_lph) || flow_lph <= 0.0f) {
+    if (isnan(inlet_c) || isnan(max_c) || isnan(base_flow_lph) || base_flow_lph <= 0.0f) {
       out.reason = "invalid input";
       return out;
     }
     out.feasible = true;
-    out.required_flow_lph = flow_lph;
+    out.target_flow_lph = base_flow_lph;
     out.target_temperature_c = max_target;
     out.reason = nullptr;
     return out;
   }
 
-  // Thermal headroom is required even when optional OT Data ID 15 is unavailable.
-  if (isnan(inlet_c) || isnan(max_c) || isnan(flow_lph) || flow_lph <= 0.0f) {
+  if (isnan(inlet_c) || isnan(max_c) || isnan(base_flow_lph) || base_flow_lph <= 0.0f) {
     OperatingPoint out{};
     out.headroom_c = headroom_c;
     out.reason = "invalid input";
@@ -78,29 +78,28 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
   }
 
   if (isnan(otb_max_capacity_w) || otb_max_capacity_w <= 0.0f) {
-    // ID15 is optional. Without it, keep the supplied base flow (normally 800 L/h)
-    // and let the normal thermal guards plus plateau quality determine the outcome.
-    (void)rated_power_w;
-    (void)cp_j_per_kgk;
+    (void) rated_power_w;
+    (void) cp_j_per_kgk;
     OperatingPoint out{};
     out.feasible = true;
     out.headroom_c = headroom_c;
-    out.required_flow_lph = flow_lph;
+    out.target_flow_lph = base_flow_lph;
     out.target_temperature_c = max_target;
     out.reason = nullptr;
     return out;
   }
 
-  auto op = compute_operating_point(otb_max_capacity_w, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c);
+  auto op = compute_operating_point(otb_max_capacity_w, inlet_c, max_c, base_flow_lph, cp_j_per_kgk, headroom_c);
   if (!op.feasible) return op;
 
-  // OpenQuatt installations should not be forced beyond the practical commissioning range.
-  // A higher theoretical requirement is a valid but flow-limited test, not an infeasible one.
-  if (op.required_flow_lph > 1000.0f) {
-    op.flow_limited = true;
-    op.required_flow_lph = 1000.0f;
-  }
+  const float selected_flow_lph = fmaxf(base_flow_lph, fminf(op.theoretical_flow_lph, 1000.0f));
+  op.target_flow_lph = selected_flow_lph;
+  op.flow_limited = op.theoretical_flow_lph > 1000.0f;
   return op;
+}
+
+inline bool result_apply_allowed(bool opentherm_selected, bool capacity_verified, bool flow_limited) {
+  return !opentherm_selected || (capacity_verified && !flow_limited);
 }
 
 inline bool has_sufficient_headroom(float rated_power_w, float inlet_c, float max_c, float flow_lph, float cp_j_per_kgk,

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -25,39 +25,16 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
     return out;
   }
 
-  if (inlet_c >= max_c) {
-    out.reason = "inlet at or above max";
-    return out;
-  }
-
-  const float available_headroom_c = max_c - headroom_c - inlet_c;
+  const float max_target = max_c - headroom_c;
+  const float available_headroom_c = max_target - inlet_c;
   if (available_headroom_c <= 0.0f) {
     out.reason = "insufficient thermal headroom for boiler power test";
     return out;
   }
 
-  // Required flow to deliver rated power within headroom
   const float required_flow_kgps = rated_power_w / (cp_j_per_kgk * available_headroom_c);
-  const float required_flow_lph = required_flow_kgps * 3600.0f;
-  out.required_flow_lph = required_flow_lph;
-
-  // If current flow is sufficient, use it and set target with headroom
-  // Otherwise, signal needed flow increase or infeasibility
-  if (required_flow_lph > 1500.0f) {
-    out.reason = "insufficient thermal headroom for boiler power test";
-    return out;
-  }
-
-  // Target is inlet + deltaT at rated power, capped at max - headroom
-  const float thermal_conductance = (flow_lph / 3600.0f) * cp_j_per_kgk;
-  const float delta_t_at_rated = rated_power_w / thermal_conductance;
-  float target = inlet_c + delta_t_at_rated;
-  const float max_target = max_c - headroom_c;
-  if (target > max_target) target = max_target;
-  if (target <= inlet_c) target = inlet_c + 1.0f;
-  if (target >= max_c) target = max_c - headroom_c;
-
-  out.target_temperature_c = target;
+  out.required_flow_lph = required_flow_kgps * 3600.0f;
+  out.target_temperature_c = max_target;
   out.feasible = true;
   out.reason = nullptr;
   return out;
@@ -66,47 +43,62 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
 inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected, float otb_max_capacity_w,
                                                         float rated_power_w, float inlet_c, float max_c, float flow_lph,
                                                         float cp_j_per_kgk, float headroom_c = 5.0f) {
+  const float max_target = max_c - headroom_c;
+
   if (!opentherm_selected) {
-    // R1: keep existing behavior, no dynamic flow, just headroom-capped target
+    // R1: keep the configured flow and do not apply OT capacity-based flow selection.
     (void)otb_max_capacity_w;
     (void)rated_power_w;
     (void)cp_j_per_kgk;
     OperatingPoint out{};
-    out.feasible = true;
     out.headroom_c = headroom_c;
+    if (isnan(inlet_c) || isnan(max_c) || isnan(flow_lph) || flow_lph <= 0.0f) {
+      out.reason = "invalid input";
+      return out;
+    }
+    out.feasible = true;
     out.required_flow_lph = flow_lph;
-    float max_target = max_c - headroom_c;
-    if (isnan(max_target) || max_target <= inlet_c) max_target = inlet_c + 1.0f;
     out.target_temperature_c = max_target;
     out.reason = nullptr;
     return out;
   }
+
+  // Thermal headroom is required even when optional OT Data ID 15 is unavailable.
+  if (isnan(inlet_c) || isnan(max_c) || isnan(flow_lph) || flow_lph <= 0.0f) {
+    OperatingPoint out{};
+    out.headroom_c = headroom_c;
+    out.reason = "invalid input";
+    return out;
+  }
+  if (max_target - inlet_c <= 0.0f) {
+    OperatingPoint out{};
+    out.headroom_c = headroom_c;
+    out.reason = "insufficient thermal headroom for boiler power test";
+    return out;
+  }
+
   if (isnan(otb_max_capacity_w) || otb_max_capacity_w <= 0.0f) {
-    // OT max capacity unavailable (ID15 not supported): keep at 800, don't go to 1500
-    // Many systems cannot reach 1500; use max-5 and let guard/plateau determine reliability
+    // ID15 is optional. Without it, keep the supplied base flow (normally 800 L/h)
+    // and let the normal thermal guards plus plateau quality determine the outcome.
     (void)rated_power_w;
     (void)cp_j_per_kgk;
     OperatingPoint out{};
     out.feasible = true;
-    out.flow_limited = false;
     out.headroom_c = headroom_c;
     out.required_flow_lph = flow_lph;
-    float max_target = max_c - headroom_c;
-    if (isnan(max_target) || max_target <= inlet_c) max_target = inlet_c + 1.0f;
     out.target_temperature_c = max_target;
     out.reason = nullptr;
     return out;
   }
+
   auto op = compute_operating_point(otb_max_capacity_w, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c);
-  // For OT, clamp required flow to 1000 max (800 base, 1000 max) and mark as limited if needed
-  if (op.feasible && op.required_flow_lph > 1000.0f) {
-    if (op.required_flow_lph > 1500.0f) {
-      // Still infeasible if >1500 even with OT
-      return op;
-    }
+  if (!op.feasible) return op;
+
+  // OpenQuatt installations should not be forced beyond the practical commissioning range.
+  // A higher theoretical requirement is a valid but flow-limited test, not an infeasible one.
+  if (op.required_flow_lph > 1000.0f) {
     op.flow_limited = true;
     op.required_flow_lph = 1000.0f;
-    // Target remains max - headroom, but flow is limited
   }
   return op;
 }

--- a/openquatt/includes/boiler/oq_otb_telemetry.h
+++ b/openquatt/includes/boiler/oq_otb_telemetry.h
@@ -45,6 +45,18 @@ struct FieldState {
   bool valid{false};
 };
 
+inline bool field_is_session_scoped(Field field) {
+  switch (field) {
+    case FIELD_DEVICE_CONFIG:
+    case FIELD_MAX_BOILER_CAPACITY:
+    case FIELD_OT_VERSION_DEVICE:
+    case FIELD_VERSION_DEVICE:
+      return true;
+    default:
+      return false;
+  }
+}
+
 class TelemetryState {
  public:
   void reset_link_session() {
@@ -93,7 +105,13 @@ class TelemetryState {
 
   bool field_is_fresh(Field field, uint32_t now_ms, uint32_t max_age_ms) const {
     const auto& state = this->fields_[field];
-    return state.valid && (uint32_t)(now_ms - state.last_valid_ms) <= max_age_ms;
+    if (!state.valid) return false;
+    // Initial/static OpenTherm values are requested once when polling starts.
+    // They remain valid for the lifetime of that link session; applying the
+    // repeating-field timeout to them would erase valid ID15/capability data
+    // a few seconds after boot even though no refresh is scheduled.
+    if (field_is_session_scoped(field)) return true;
+    return (uint32_t)(now_ms - state.last_valid_ms) <= max_age_ms;
   }
 
   bool expire_response_session_if_stale(uint32_t now_ms, uint32_t max_age_ms) {

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -80,7 +80,10 @@ class BoilerPowerTestRuntime {
       oq_service_status::set_boiler_power_test("REFUSED: not CM100");
       return;
     }
-    // Thermal headroom check - OpenTherm only; R1 keeps existing 800 L/h behavior
+
+    reset_test_state();
+
+    // Thermal headroom check - OpenTherm only; R1 keeps existing 800 L/h behavior.
 #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
     const bool opentherm_selected_headroom =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
@@ -88,7 +91,6 @@ class BoilerPowerTestRuntime {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
       max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
-      // Prefer OTB return water temp as boiler inlet if available, fallback to supply
       float inlet_c = NAN;
       if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
         inlet_c = id(otb_return_water_temp).state;
@@ -96,34 +98,27 @@ class BoilerPowerTestRuntime {
         inlet_c = id(water_supply_temp_selected).state;
       }
       const float flow_lph = id(flow_rate_selected).state;
-      float rated_w = id(oq_boiler_rated_heat_power).state;
+      const float rated_w = id(oq_boiler_rated_heat_power).state;
       float otb_max_w = NAN;
       if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) && id(otb_max_capacity).state > 0.0f) {
         otb_max_w = id(otb_max_capacity).state * 1000.0f;
       }
-      const float cp = 4180.0f;
       const float flow_for_check = (!isnan(flow_lph) && flow_lph > 0.0f) ? flow_lph : cfg.target_flow_lph;
-      auto op = oq_boiler_commissioning::compute_opentherm_operating_point(true, otb_max_w, rated_w, inlet_c, max_c,
-                                                                           flow_for_check, cp, 5.0f);
+      auto op = oq_boiler_commissioning::compute_opentherm_operating_point(
+          true, otb_max_w, rated_w, inlet_c, max_c, flow_for_check, 4180.0f, 5.0f);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
         ESP_LOGW("quatt.cm100.boiler",
-                 "Boiler test refused: %s (inlet=%.1fC max=%.1fC flow=%.0fL/h rated=%.0fW headroom=%.1fC)",
-                 op.reason ? op.reason : "unknown", inlet_c, max_c, flow_for_check, rated_w, op.headroom_c);
+                 "Boiler test refused: %s (inlet=%.1fC max=%.1fC flow=%.0fL/h ot_max=%.0fW headroom=%.1fC)",
+                 op.reason ? op.reason : "unknown", inlet_c, max_c, flow_for_check, otb_max_w, op.headroom_c);
         return;
       }
-      if (op.required_flow_lph > flow_for_check + 10.0f) {
-        ESP_LOGI("quatt.cm100.boiler",
-                 "Boiler test headroom requires higher flow: need %.0f L/h vs current %.0f L/h, target remains %.0f",
-                 op.required_flow_lph, flow_for_check, cfg.target_flow_lph);
-      }
-      active_test_capacity_w_ = rated_w;
+      active_test_capacity_w_ = otb_max_w;
+      active_test_flow_limited_ = op.flow_limited;
     } else {
-      // R1 on Q: store rated power as capacity for later consistent use
       active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
     }
 #else
-    // Non-Q: no OT, store rated power
     active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
 #endif
 
@@ -132,7 +127,7 @@ class BoilerPowerTestRuntime {
              id(oq_flow_control_mode).current_option().c_str(), id(oq_flow_setpoint_lph).state,
              id(oq_commissioning_task_code), (int)id(oq_commissioning_active));
 
-    reset_measurement();
+    reset_measurement_accumulators();
     id(oq_commissioning_task_code) = TASK_BOILER_POWER_TEST;
     id(oq_commissioning_request_pending) = false;
     id(oq_commissioning_active) = true;
@@ -146,9 +141,7 @@ class BoilerPowerTestRuntime {
 
     prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
     flow_setpoint_saved_ = true;
-    // Use headroom-aware flow if required flow exceeds default 800 - reuse stored capacity from start()
     float target_flow_to_use = cfg.target_flow_lph;
-    float rated_w_for_calc = active_test_capacity_w_;
 #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
     const bool opentherm_selected =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
@@ -156,36 +149,28 @@ class BoilerPowerTestRuntime {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
       max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
-      float inlet_c2 = NAN;
+      float inlet_c = NAN;
       if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
-        inlet_c2 = id(otb_return_water_temp).state;
+        inlet_c = id(otb_return_water_temp).state;
       } else {
-        inlet_c2 = id(water_supply_temp_selected).state;
+        inlet_c = id(water_supply_temp_selected).state;
       }
-      float otb_max_w2 = NAN;
-      if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) && id(otb_max_capacity).state > 0.0f) {
-        otb_max_w2 = id(otb_max_capacity).state * 1000.0f;
+      auto op = oq_boiler_commissioning::compute_opentherm_operating_point(
+          true, active_test_capacity_w_, id(oq_boiler_rated_heat_power).state, inlet_c, max_c, cfg.target_flow_lph,
+          4180.0f, 5.0f);
+      if (!op.feasible) {
+        oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
+        restore_flow_setpoint();
+        reset_test_state();
+        return;
       }
-      auto op2 = oq_boiler_commissioning::compute_opentherm_operating_point(
-          true, otb_max_w2, rated_w_for_calc, inlet_c2, max_c, cfg.target_flow_lph, 4180.0f, 5.0f);
-      if (!op2.feasible) {
-        // Still infeasible even with OT logic (e.g., >1500) - keep at 800 and let guard handle, but mark limited
-        active_test_flow_limited_ = op2.flow_limited;
-      } else if (op2.flow_limited) {
-        target_flow_to_use = 1000.0f;
-        active_test_flow_limited_ = true;
-        ESP_LOGI("quatt.cm100.boiler",
-                 "Boiler test flow limited to 1000 L/h (required %.0f) - result may be headroom limited",
-                 op2.required_flow_lph);
-      } else if (op2.required_flow_lph > cfg.target_flow_lph) {
-        target_flow_to_use = fminf(op2.required_flow_lph, 1000.0f);
-        if (op2.required_flow_lph > 1000.0f) active_test_flow_limited_ = true;
-        ESP_LOGI("quatt.cm100.boiler", "Boiler test using headroom flow %.0f L/h (required %.0f)", target_flow_to_use,
-                 op2.required_flow_lph);
+      if (op.flow_limited) active_test_flow_limited_ = true;
+      if (op.required_flow_lph > cfg.target_flow_lph) {
+        target_flow_to_use = fminf(op.required_flow_lph, 1000.0f);
+        ESP_LOGI("quatt.cm100.boiler", "Boiler test using headroom flow %.0f L/h%s", target_flow_to_use,
+                 op.flow_limited ? " (flow limited)" : "");
       }
     }
-#else
-    (void)rated_w_for_calc;
 #endif
     active_test_flow_target_lph_ = target_flow_to_use;
     ESP_LOGI("quatt.cm100.boiler", "Boiler test armed: target_flow=%.0fL/h saved_flow=%.0fL/h state=%d",
@@ -234,9 +219,7 @@ class BoilerPowerTestRuntime {
     const bool heat_valid = !isnan(heat_w) && heat_w >= 0.0f;
     log_heartbeat(task_is_boiler, cm_code, flow_lph, heat_w, now_ms, cfg);
 
-    if (task_is_air_purge || task_is_manual_flow || task_is_manual_hp) {
-      return;
-    }
+    if (task_is_air_purge || task_is_manual_flow || task_is_manual_hp) return;
 
     if (id(oq_commissioning_abort_requested)) {
       ESP_LOGW("quatt.cm100.boiler", "Boiler test abort requested (state=%d cm=%d active=%d pending=%d)",
@@ -282,11 +265,7 @@ class BoilerPowerTestRuntime {
     }
     if (!guards_ok()) return;
 
-    // Renew the authorization only from this guarded originating state machine.
-    // The dispatcher deliberately cannot make a commissioning command fresh.
-    if (id(oq_commissioning_boiler_request)) {
-      id(oq_commissioning_boiler_request_updated_ms) = now_ms;
-    }
+    if (id(oq_commissioning_boiler_request)) id(oq_commissioning_boiler_request_updated_ms) = now_ms;
 
     switch (id(oq_commissioning_state_code)) {
       case STATE_FLOW_SETTLE:
@@ -334,7 +313,8 @@ class BoilerPowerTestRuntime {
   }
 
   bool flow_on_target(float flow_lph, float flow_band_lph) const {
-    return !isnan(flow_lph) && flow_lph > 0.0f && fabsf(flow_lph - active_test_flow_target_lph_) <= flow_band_lph;
+    return !isnan(flow_lph) && flow_lph > 0.0f && !isnan(active_test_flow_target_lph_) &&
+           fabsf(flow_lph - active_test_flow_target_lph_) <= flow_band_lph;
   }
 
   void publish_status(const char* status) {
@@ -350,7 +330,7 @@ class BoilerPowerTestRuntime {
     flow_setpoint_saved_ = false;
   }
 
-  void reset_measurement() {
+  void reset_measurement_accumulators() {
     stable_flow_count_ = 0;
     sample_count_ = 0;
     sum_w_ = 0.0f;
@@ -358,6 +338,10 @@ class BoilerPowerTestRuntime {
     max_w_ = NAN;
     peak_w_ = NAN;
     plateau_count_ = 0;
+  }
+
+  void reset_test_state() {
+    reset_measurement_accumulators();
     active_test_flow_target_lph_ = NAN;
     active_test_capacity_w_ = NAN;
     active_test_flow_limited_ = false;
@@ -365,7 +349,7 @@ class BoilerPowerTestRuntime {
 
   void clear_container() {
     restore_flow_setpoint();
-    reset_measurement();
+    reset_test_state();
     oq_commissioning::clear_container(false);
     id(oq_commissioning_boiler_request) = false;
     id(oq_flow_autotune_req) = false;
@@ -382,7 +366,7 @@ class BoilerPowerTestRuntime {
     if (!keep_result) {
       id(oq_commissioning_result_w) = NAN;
       id(oq_commissioning_result_confidence) = 0.0f;
-      reset_measurement();
+      reset_test_state();
     }
     publish_status(status);
   }
@@ -444,7 +428,6 @@ class BoilerPowerTestRuntime {
     if (stable_flow_count_ >= cfg.stable_flow_samples &&
         (uint32_t)(now_ms - id(oq_commissioning_state_since_ms)) >= cfg.flow_settle_min_ms) {
 #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      // Re-evaluate headroom with fresh inlet after preflow (OT return temp may have risen from 22 to 30°C)
       const bool opentherm_selected =
           id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
       if (opentherm_selected) {
@@ -457,21 +440,20 @@ class BoilerPowerTestRuntime {
         } else {
           inlet_c = id(water_supply_temp_selected).state;
         }
-        float rated_w = active_test_capacity_w_;
-        auto op = oq_boiler_commissioning::compute_operating_point(rated_w, inlet_c, max_c, flow_lph, 4180.0f, 5.0f);
+        auto op = oq_boiler_commissioning::compute_opentherm_operating_point(
+            true, active_test_capacity_w_, id(oq_boiler_rated_heat_power).state, inlet_c, max_c, flow_lph, 4180.0f,
+            5.0f);
         if (!op.feasible) {
           finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
           return;
         }
+        if (op.flow_limited) active_test_flow_limited_ = true;
         if (op.required_flow_lph > active_test_flow_target_lph_ + 10.0f) {
-          float new_flow = fminf(op.required_flow_lph, 1000.0f);
-          bool limited = op.flow_limited || op.required_flow_lph > 1000.0f;
+          const float new_flow = fminf(op.required_flow_lph, 1000.0f);
           ESP_LOGI("quatt.cm100.boiler",
-                   "Flow settled at %.0f but headroom now requires %.0f L/h (inlet %.1fC); updating target %sand "
-                   "re-settling",
-                   flow_lph, op.required_flow_lph, inlet_c, limited ? "(limited to 1000) " : "");
+                   "Flow settled at %.0f but headroom now selects %.0f L/h (inlet %.1fC)%s; re-settling", flow_lph,
+                   new_flow, inlet_c, op.flow_limited ? " (flow limited)" : "");
           active_test_flow_target_lph_ = new_flow;
-          if (limited) active_test_flow_limited_ = true;
           set_number_value(id(oq_flow_setpoint_lph), new_flow);
           stable_flow_count_ = 0;
           id(oq_commissioning_state_since_ms) = now_ms;
@@ -520,7 +502,7 @@ class BoilerPowerTestRuntime {
     if (stable_flow_count_ >= cfg.stable_flow_samples && state_age_ms >= cfg.boiler_settle_min_ms) {
       id(oq_commissioning_state_code) = STATE_MEASURE;
       id(oq_commissioning_state_since_ms) = now_ms;
-      reset_measurement();
+      reset_measurement_accumulators();
       ESP_LOGI("quatt.cm100.boiler",
                "Boiler settled; starting measurement window (flow=%.0fL/h heat=%.0fW boiler_active=%d)", flow_lph,
                heat_w, (int)id(boiler_active).state);
@@ -570,12 +552,10 @@ class BoilerPowerTestRuntime {
     if (confidence < 0.0f) confidence = 0.0f;
     if (confidence > 100.0f) confidence = 100.0f;
 
-    // If flow was limited to 1000 due to headroom, mark result as headroom-limited
     if (active_test_flow_limited_) {
       confidence = fminf(confidence, 70.0f);
-      ESP_LOGI("quatt.cm100.boiler",
-               "Measurement headroom limited (flow 1000, capacity %.0fW): avg=%.0fW conf=%.0f%% (penalized)",
-               active_test_capacity_w_, avg_w, confidence);
+      ESP_LOGI("quatt.cm100.boiler", "Measurement flow/headroom limited: avg=%.0fW conf=%.0f%% (penalized)", avg_w,
+               confidence);
     }
 
     id(oq_commissioning_result_w) = avg_w;

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -12,6 +12,7 @@
 namespace oq_boiler_task {
 
 using oq_boiler_commissioning::compute_opentherm_operating_point;
+using oq_boiler_commissioning::result_apply_allowed;
 
 static constexpr int TASK_NONE = oq_commissioning::TASK_NONE;
 static constexpr int TASK_BOILER_POWER_TEST = oq_commissioning::TASK_BOILER_POWER_TEST;
@@ -86,9 +87,9 @@ class BoilerPowerTestRuntime {
     reset_test_state();
 
 #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-    const bool opentherm_selected =
+    active_test_opentherm_ =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
-    if (opentherm_selected) {
+    if (active_test_opentherm_) {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
       max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
@@ -98,68 +99,38 @@ class BoilerPowerTestRuntime {
       } else {
         inlet_c = id(water_supply_temp_selected).state;
       }
-      const float flow_lph = id(flow_rate_selected).state;
-      const float flow_for_check = (!isnan(flow_lph) && flow_lph > 0.0f) ? flow_lph : cfg.target_flow_lph;
-      float otb_max_w = NAN;
       if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) && id(otb_max_capacity).state > 0.0f) {
-        otb_max_w = id(otb_max_capacity).state * 1000.0f;
+        active_test_capacity_w_ = id(otb_max_capacity).state * 1000.0f;
+        active_test_capacity_verified_ = true;
       }
-      const float rated_w = id(oq_boiler_rated_heat_power).state;
-      const auto op = compute_opentherm_operating_point(true, otb_max_w, rated_w, inlet_c, max_c, flow_for_check);
-      if (!op.feasible) {
-        oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
-        ESP_LOGW("quatt.cm100.boiler",
-                 "Boiler test refused: %s (inlet=%.1fC max=%.1fC flow=%.0fL/h ot_max=%.0fW headroom=%.1fC)",
-                 op.reason ? op.reason : "unknown", inlet_c, max_c, flow_for_check, otb_max_w, op.headroom_c);
-        return;
-      }
-      active_test_capacity_w_ = otb_max_w;
-      active_test_flow_limited_ = op.flow_limited;
-    } else {
-      active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
-    }
-#else
-    active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
-#endif
-
-    float target_flow_to_use = cfg.target_flow_lph;
-#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-    if (opentherm_selected) {
-      float max_c = id(max_water_temp_limit_c).state;
-      if (isnan(max_c)) max_c = 60.0f;
-      max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
-      float inlet_c = NAN;
-      if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
-        inlet_c = id(otb_return_water_temp).state;
-      } else {
-        inlet_c = id(water_supply_temp_selected).state;
-      }
-      const float rated_w = id(oq_boiler_rated_heat_power).state;
-      const auto op = compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c,
+      const auto op = compute_opentherm_operating_point(true, active_test_capacity_w_,
+                                                        id(oq_boiler_rated_heat_power).state, inlet_c, max_c,
                                                         cfg.target_flow_lph);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
+        ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: %s (inlet=%.1fC max=%.1fC headroom=%.1fC)",
+                 op.reason ? op.reason : "unknown", inlet_c, max_c, op.headroom_c);
         reset_test_state();
         return;
       }
-      if (op.flow_limited) active_test_flow_limited_ = true;
-      if (op.required_flow_lph > cfg.target_flow_lph) {
-        target_flow_to_use = fminf(op.required_flow_lph, 1000.0f);
-        ESP_LOGI("quatt.cm100.boiler", "Boiler test using headroom flow %.0f L/h%s", target_flow_to_use,
-                 op.flow_limited ? " (flow limited)" : "");
-      }
+    } else {
+      active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
+      active_test_capacity_verified_ = true;
     }
+#else
+    active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
+    active_test_capacity_verified_ = true;
 #endif
 
     ESP_LOGI("quatt.cm100.boiler",
              "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)", cm_code,
              id(oq_flow_control_mode).current_option().c_str(), id(oq_flow_setpoint_lph).state,
-             id(oq_commissioning_task_code), (int)id(oq_commissioning_active));
+             id(oq_commissioning_task_code), (int) id(oq_commissioning_active));
 
     reset_measurement_accumulators();
     prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
     flow_setpoint_saved_ = true;
-    active_test_flow_target_lph_ = target_flow_to_use;
+    active_test_flow_target_lph_ = cfg.target_flow_lph;
 
     id(oq_commissioning_task_code) = TASK_BOILER_POWER_TEST;
     id(oq_commissioning_request_pending) = false;
@@ -172,12 +143,33 @@ class BoilerPowerTestRuntime {
     id(oq_commissioning_result_w) = NAN;
     id(oq_commissioning_result_confidence) = 0.0f;
 
-    ESP_LOGI("quatt.cm100.boiler", "Boiler test armed: target_flow=%.0fL/h saved_flow=%.0fL/h state=%d",
-             target_flow_to_use, prev_flow_setpoint_lph_, id(oq_commissioning_state_code));
-    set_number_value(id(oq_flow_setpoint_lph), target_flow_to_use);
+    ESP_LOGI("quatt.cm100.boiler", "Boiler test armed: initial target_flow=%.0fL/h saved_flow=%.0fL/h state=%d",
+             active_test_flow_target_lph_, prev_flow_setpoint_lph_, id(oq_commissioning_state_code));
+    set_number_value(id(oq_flow_setpoint_lph), active_test_flow_target_lph_);
 
     oq_service_status::set_commissioning("BOILER TEST STARTED");
     publish_status("FLOW_SETTLING");
+  }
+
+  void apply_result() {
+    const float result = id(oq_commissioning_result_w);
+    if (isnan(result) || result <= 0.0f) {
+      publish_status("APPLY_FAILED: invalid result");
+      return;
+    }
+    if (!result_apply_allowed(active_test_opentherm_, active_test_capacity_verified_, active_test_flow_limited_)) {
+      if (active_test_flow_limited_) {
+        publish_status("APPLY_REFUSED: flow limited");
+      } else {
+        publish_status("APPLY_REFUSED: capacity unverified");
+      }
+      return;
+    }
+    const int rounded_result = (int) roundf(result / 100.0f) * 100;
+    set_number_value(id(oq_boiler_rated_heat_power), (float) rounded_result);
+    char msg[64];
+    snprintf(msg, sizeof(msg), "APPLIED: %dW", rounded_result);
+    publish_status(msg);
   }
 
   void abort_or_clear() {
@@ -222,8 +214,8 @@ class BoilerPowerTestRuntime {
 
     if (id(oq_commissioning_abort_requested)) {
       ESP_LOGW("quatt.cm100.boiler", "Boiler test abort requested (state=%d cm=%d active=%d pending=%d)",
-               id(oq_commissioning_state_code), cm_code, (int)id(oq_commissioning_active),
-               (int)id(oq_commissioning_request_pending));
+               id(oq_commissioning_state_code), cm_code, (int) id(oq_commissioning_active),
+               (int) id(oq_commissioning_request_pending));
       finish_task("ABORTED", STATE_ABORT, true, true);
       return;
     }
@@ -292,6 +284,9 @@ class BoilerPowerTestRuntime {
   float prev_flow_setpoint_lph_{NAN};
   float active_test_flow_target_lph_{NAN};
   float active_test_capacity_w_{NAN};
+  float active_test_theoretical_flow_lph_{NAN};
+  bool active_test_opentherm_{false};
+  bool active_test_capacity_verified_{false};
   bool active_test_flow_limited_{false};
   int stable_flow_count_{0};
   int sample_count_{0};
@@ -343,6 +338,9 @@ class BoilerPowerTestRuntime {
     reset_measurement_accumulators();
     active_test_flow_target_lph_ = NAN;
     active_test_capacity_w_ = NAN;
+    active_test_theoretical_flow_lph_ = NAN;
+    active_test_opentherm_ = false;
+    active_test_capacity_verified_ = false;
     active_test_flow_limited_ = false;
   }
 
@@ -424,54 +422,54 @@ class BoilerPowerTestRuntime {
 
   void run_flow_settle(const RuntimeConfig& cfg, uint32_t now_ms, float flow_lph, bool flow_stable_now) {
     stable_flow_count_ = flow_stable_now ? stable_flow_count_ + 1 : 0;
-    if (stable_flow_count_ >= cfg.stable_flow_samples &&
-        (uint32_t)(now_ms - id(oq_commissioning_state_since_ms)) >= cfg.flow_settle_min_ms) {
-#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      const bool opentherm_selected =
-          id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
-      if (opentherm_selected) {
-        float max_c = id(max_water_temp_limit_c).state;
-        if (isnan(max_c)) max_c = 60.0f;
-        max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
-        float inlet_c = NAN;
-        if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
-          inlet_c = id(otb_return_water_temp).state;
-        } else {
-          inlet_c = id(water_supply_temp_selected).state;
-        }
-        const float rated_w = id(oq_boiler_rated_heat_power).state;
-        const auto op =
-            compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c, flow_lph);
-        if (!op.feasible) {
-          finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
-          return;
-        }
-        if (op.flow_limited) active_test_flow_limited_ = true;
-        if (op.required_flow_lph > active_test_flow_target_lph_ + 10.0f) {
-          const float new_flow = fminf(op.required_flow_lph, 1000.0f);
-          ESP_LOGI("quatt.cm100.boiler",
-                   "Flow settled at %.0f but headroom now selects %.0f L/h (inlet %.1fC)%s; re-settling", flow_lph,
-                   new_flow, inlet_c, op.flow_limited ? " (flow limited)" : "");
-          active_test_flow_target_lph_ = new_flow;
-          set_number_value(id(oq_flow_setpoint_lph), new_flow);
-          stable_flow_count_ = 0;
-          id(oq_commissioning_state_since_ms) = now_ms;
-          publish_status("FLOW_SETTLING");
-          return;
-        }
-      }
-#endif
-      id(oq_commissioning_boiler_request_updated_ms) = now_ms;
-      id(oq_commissioning_boiler_request) = true;
-      id(oq_commissioning_state_code) = STATE_BOILER_SETTLE;
-      id(oq_commissioning_state_since_ms) = now_ms;
-      stable_flow_count_ = 0;
-      ESP_LOGI("quatt.cm100.boiler", "Flow settled at %.0fL/h after %lus; requesting boiler relay", flow_lph,
-               (unsigned long)((now_ms - id(oq_commissioning_started_ms)) / 1000UL));
-      publish_status("BOILER_SETTLING");
-    } else {
+    if (stable_flow_count_ < cfg.stable_flow_samples ||
+        (uint32_t)(now_ms - id(oq_commissioning_state_since_ms)) < cfg.flow_settle_min_ms) {
       publish_status("FLOW_SETTLING");
+      return;
     }
+
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+    if (active_test_opentherm_) {
+      float max_c = id(max_water_temp_limit_c).state;
+      if (isnan(max_c)) max_c = 60.0f;
+      max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
+      float inlet_c = NAN;
+      if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
+        inlet_c = id(otb_return_water_temp).state;
+      } else {
+        inlet_c = id(water_supply_temp_selected).state;
+      }
+      const auto op = compute_opentherm_operating_point(true, active_test_capacity_w_,
+                                                        id(oq_boiler_rated_heat_power).state, inlet_c, max_c,
+                                                        cfg.target_flow_lph);
+      if (!op.feasible) {
+        finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
+        return;
+      }
+      active_test_theoretical_flow_lph_ = op.theoretical_flow_lph;
+      active_test_flow_limited_ = op.flow_limited;
+      if (op.target_flow_lph > active_test_flow_target_lph_ + 10.0f) {
+        ESP_LOGI("quatt.cm100.boiler",
+                 "Preflow settled at %.0f L/h; theoretical flow %.0f L/h, selecting %.0f L/h%s and re-settling",
+                 flow_lph, op.theoretical_flow_lph, op.target_flow_lph, op.flow_limited ? " (flow limited)" : "");
+        active_test_flow_target_lph_ = op.target_flow_lph;
+        set_number_value(id(oq_flow_setpoint_lph), active_test_flow_target_lph_);
+        stable_flow_count_ = 0;
+        id(oq_commissioning_state_since_ms) = now_ms;
+        publish_status("FLOW_SETTLING");
+        return;
+      }
+    }
+#endif
+
+    id(oq_commissioning_boiler_request_updated_ms) = now_ms;
+    id(oq_commissioning_boiler_request) = true;
+    id(oq_commissioning_state_code) = STATE_BOILER_SETTLE;
+    id(oq_commissioning_state_since_ms) = now_ms;
+    stable_flow_count_ = 0;
+    ESP_LOGI("quatt.cm100.boiler", "Flow settled at %.0fL/h after %lus; requesting boiler relay", flow_lph,
+             (unsigned long)((now_ms - id(oq_commissioning_started_ms)) / 1000UL));
+    publish_status("BOILER_SETTLING");
   }
 
   void run_boiler_settle(const RuntimeConfig& cfg, uint32_t now_ms, float flow_lph, float heat_w,
@@ -480,8 +478,11 @@ class BoilerPowerTestRuntime {
     const uint32_t state_age_ms = now_ms - id(oq_commissioning_state_since_ms);
     if (!id(boiler_active).state) {
       if (state_age_ms >= cfg.boiler_settle_min_ms) {
-        const bool opentherm_selected =
-            id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+        const bool opentherm_selected = active_test_opentherm_;
+#else
+        const bool opentherm_selected = false;
+#endif
         const char* failure_reason = oq_boiler::commissioning_start_failure_reason(
             id(oq_boiler_block_reason_code), opentherm_selected, id(oq_boiler_output_request),
             id(oq_otb_link_available_state));
@@ -490,8 +491,8 @@ class BoilerPowerTestRuntime {
         ESP_LOGW("quatt.cm100.boiler",
                  "Boiler did not start in time (flow=%.0fL/h boiler_req=%d output_req=%d block=%s otb_link=%d "
                  "elapsed=%lus)",
-                 flow_lph, (int)id(oq_commissioning_boiler_request), (int)id(oq_boiler_output_request), failure_reason,
-                 (int)id(oq_otb_link_available_state), (unsigned long)(state_age_ms / 1000UL));
+                 flow_lph, (int) id(oq_commissioning_boiler_request), (int) id(oq_boiler_output_request), failure_reason,
+                 (int) id(oq_otb_link_available_state), (unsigned long)(state_age_ms / 1000UL));
         finish_task(failure_status, STATE_FAILED, false, true);
       } else {
         publish_status("BOILER_SETTLING");
@@ -504,7 +505,7 @@ class BoilerPowerTestRuntime {
       reset_measurement_accumulators();
       ESP_LOGI("quatt.cm100.boiler",
                "Boiler settled; starting measurement window (flow=%.0fL/h heat=%.0fW boiler_active=%d)", flow_lph,
-               heat_w, (int)id(boiler_active).state);
+               heat_w, (int) id(boiler_active).state);
       publish_status("MEASURING");
     } else {
       publish_status("BOILER_SETTLING");
@@ -541,7 +542,7 @@ class BoilerPowerTestRuntime {
       return;
     }
 
-    const float sample_count_f = (float)sample_count_;
+    const float sample_count_f = (float) sample_count_;
     const float avg_w = sum_w_ / sample_count_f;
     const float spread_w = max_w_ - min_w_;
     float confidence = 100.0f;
@@ -551,10 +552,10 @@ class BoilerPowerTestRuntime {
     if (confidence < 0.0f) confidence = 0.0f;
     if (confidence > 100.0f) confidence = 100.0f;
 
-    if (active_test_flow_limited_) {
+    if (active_test_opentherm_ && (!active_test_capacity_verified_ || active_test_flow_limited_)) {
       confidence = fminf(confidence, 70.0f);
-      ESP_LOGI("quatt.cm100.boiler", "Measurement flow/headroom limited: avg=%.0fW conf=%.0f%% (penalized)", avg_w,
-               confidence);
+      ESP_LOGI("quatt.cm100.boiler", "Measurement result is informational only: %s; avg=%.0fW conf=%.0f%%",
+               active_test_flow_limited_ ? "flow/headroom limited" : "capacity unverified", avg_w, confidence);
     }
 
     id(oq_commissioning_result_w) = avg_w;
@@ -562,11 +563,27 @@ class BoilerPowerTestRuntime {
     id(oq_commissioning_state_code) = STATE_COOLDOWN;
     id(oq_commissioning_state_since_ms) = now_ms;
     id(oq_commissioning_boiler_request) = false;
-    ESP_LOGI("quatt.cm100.boiler", "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%% %s",
-             avg_w, min_w_, max_w_, (unsigned int)sample_count_, confidence,
-             active_test_flow_limited_ ? "(flow limited)" : "");
+    ESP_LOGI("quatt.cm100.boiler", "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%",
+             avg_w, min_w_, max_w_, (unsigned int) sample_count_, confidence);
     restore_flow_setpoint();
     publish_status("COOLDOWN");
+  }
+
+  const char* result_quality_suffix() const {
+    if (active_test_flow_limited_) return "flow limited";
+    if (active_test_opentherm_ && !active_test_capacity_verified_) return "capacity unverified";
+    return nullptr;
+  }
+
+  void build_done_status(char* msg, size_t size) const {
+    const char* suffix = result_quality_suffix();
+    if (suffix != nullptr) {
+      snprintf(msg, size, "DONE: %.0fW (conf %.0f%%) - %s", id(oq_commissioning_result_w),
+               id(oq_commissioning_result_confidence), suffix);
+    } else {
+      snprintf(msg, size, "DONE: %.0fW (conf %.0f%%)", id(oq_commissioning_result_w),
+               id(oq_commissioning_result_confidence));
+    }
   }
 
   void run_cooldown(const RuntimeConfig& cfg, uint32_t now_ms) {
@@ -575,13 +592,7 @@ class BoilerPowerTestRuntime {
       return;
     }
     char msg[128];
-    if (active_test_flow_limited_) {
-      snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%) - flow limited", id(oq_commissioning_result_w),
-               id(oq_commissioning_result_confidence));
-    } else {
-      snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)", id(oq_commissioning_result_w),
-               id(oq_commissioning_result_confidence));
-    }
+    build_done_status(msg, sizeof(msg));
     ESP_LOGI("quatt.cm100.boiler", "Cooldown complete; CM100 idle after boiler test (flow restored, boiler off, %s)",
              msg);
     finish_task(msg, STATE_DONE, true, true);
@@ -589,13 +600,7 @@ class BoilerPowerTestRuntime {
 
   void publish_done_status() {
     char msg[128];
-    if (active_test_flow_limited_) {
-      snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%) - flow limited", id(oq_commissioning_result_w),
-               id(oq_commissioning_result_confidence));
-    } else {
-      snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)", id(oq_commissioning_result_w),
-               id(oq_commissioning_result_confidence));
-    }
+    build_done_status(msg, sizeof(msg));
     publish_status(msg);
   }
 
@@ -606,9 +611,9 @@ class BoilerPowerTestRuntime {
       ESP_LOGI("quatt.cm100.boiler",
                "state=%d cm=%d active=%d pending=%d flow=%.0fL/h target=%.0fL/h stable=%d/%d boiler_req=%d "
                "boiler_active=%d heat=%.0fW elapsed=%lus",
-               id(oq_commissioning_state_code), cm_code, (int)id(oq_commissioning_active),
-               (int)id(oq_commissioning_request_pending), flow_lph, active_test_flow_target_lph_, stable_flow_count_,
-               cfg.stable_flow_samples, (int)id(oq_commissioning_boiler_request), (int)id(boiler_active).state, heat_w,
+               id(oq_commissioning_state_code), cm_code, (int) id(oq_commissioning_active),
+               (int) id(oq_commissioning_request_pending), flow_lph, active_test_flow_target_lph_, stable_flow_count_,
+               cfg.stable_flow_samples, (int) id(oq_commissioning_boiler_request), (int) id(boiler_active).state, heat_w,
                (unsigned long)(elapsed_ms / 1000UL));
       last_state_logged_ = id(oq_commissioning_state_code);
     }

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -104,8 +104,8 @@ class BoilerPowerTestRuntime {
         active_test_capacity_verified_ = true;
       }
       const float rated_w = id(oq_boiler_rated_heat_power).state;
-      const auto op = compute_opentherm_operating_point(
-          true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
+      const auto op = compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c,
+                                                        cfg.target_flow_lph);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
         ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: %s (inlet=%.1fC max=%.1fC headroom=%.1fC)",
@@ -442,8 +442,8 @@ class BoilerPowerTestRuntime {
         inlet_c = id(water_supply_temp_selected).state;
       }
       const float rated_w = id(oq_boiler_rated_heat_power).state;
-      const auto op = compute_opentherm_operating_point(
-          true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
+      const auto op = compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c,
+                                                        cfg.target_flow_lph);
       if (!op.feasible) {
         finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
         return;
@@ -567,7 +567,9 @@ class BoilerPowerTestRuntime {
     id(oq_commissioning_state_code) = STATE_COOLDOWN;
     id(oq_commissioning_state_since_ms) = now_ms;
     id(oq_commissioning_boiler_request) = false;
-    ESP_LOGI("quatt.cm100.boiler", "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%",
+    ESP_LOGI("quatt.cm100.boiler",
+             "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u "
+             "conf=%.0f%%",
              avg_w, min_w_, max_w_, (unsigned int)sample_count_, confidence);
     restore_flow_setpoint();
     publish_status("COOLDOWN");

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -104,8 +104,8 @@ class BoilerPowerTestRuntime {
         active_test_capacity_verified_ = true;
       }
       const float rated_w = id(oq_boiler_rated_heat_power).state;
-      const auto op =
-          compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
+      const auto op = compute_opentherm_operating_point(
+          true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
         ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: %s (inlet=%.1fC max=%.1fC headroom=%.1fC)",
@@ -442,8 +442,8 @@ class BoilerPowerTestRuntime {
         inlet_c = id(water_supply_temp_selected).state;
       }
       const float rated_w = id(oq_boiler_rated_heat_power).state;
-      const auto op =
-          compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
+      const auto op = compute_opentherm_operating_point(
+          true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
       if (!op.feasible) {
         finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
         return;
@@ -567,9 +567,8 @@ class BoilerPowerTestRuntime {
     id(oq_commissioning_state_code) = STATE_COOLDOWN;
     id(oq_commissioning_state_since_ms) = now_ms;
     id(oq_commissioning_boiler_request) = false;
-    ESP_LOGI("quatt.cm100.boiler",
-             "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%", avg_w, min_w_, max_w_,
-             (unsigned int)sample_count_, confidence);
+    ESP_LOGI("quatt.cm100.boiler", "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%",
+             avg_w, min_w_, max_w_, (unsigned int)sample_count_, confidence);
     restore_flow_setpoint();
     publish_status("COOLDOWN");
   }

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -103,9 +103,9 @@ class BoilerPowerTestRuntime {
         active_test_capacity_w_ = id(otb_max_capacity).state * 1000.0f;
         active_test_capacity_verified_ = true;
       }
-      const auto op = compute_opentherm_operating_point(true, active_test_capacity_w_,
-                                                        id(oq_boiler_rated_heat_power).state, inlet_c, max_c,
-                                                        cfg.target_flow_lph);
+      const float rated_w = id(oq_boiler_rated_heat_power).state;
+      const auto op =
+          compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
         ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: %s (inlet=%.1fC max=%.1fC headroom=%.1fC)",
@@ -125,7 +125,7 @@ class BoilerPowerTestRuntime {
     ESP_LOGI("quatt.cm100.boiler",
              "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)", cm_code,
              id(oq_flow_control_mode).current_option().c_str(), id(oq_flow_setpoint_lph).state,
-             id(oq_commissioning_task_code), (int) id(oq_commissioning_active));
+             id(oq_commissioning_task_code), (int)id(oq_commissioning_active));
 
     reset_measurement_accumulators();
     prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
@@ -157,7 +157,7 @@ class BoilerPowerTestRuntime {
       publish_status("APPLY_FAILED: invalid result");
       return;
     }
-    if (!result_apply_allowed(active_test_opentherm_, active_test_capacity_verified_, active_test_flow_limited_)) {
+    if (!active_test_result_apply_allowed_) {
       if (active_test_flow_limited_) {
         publish_status("APPLY_REFUSED: flow limited");
       } else {
@@ -165,8 +165,8 @@ class BoilerPowerTestRuntime {
       }
       return;
     }
-    const int rounded_result = (int) roundf(result / 100.0f) * 100;
-    set_number_value(id(oq_boiler_rated_heat_power), (float) rounded_result);
+    const int rounded_result = (int)roundf(result / 100.0f) * 100;
+    set_number_value(id(oq_boiler_rated_heat_power), (float)rounded_result);
     char msg[64];
     snprintf(msg, sizeof(msg), "APPLIED: %dW", rounded_result);
     publish_status(msg);
@@ -214,8 +214,8 @@ class BoilerPowerTestRuntime {
 
     if (id(oq_commissioning_abort_requested)) {
       ESP_LOGW("quatt.cm100.boiler", "Boiler test abort requested (state=%d cm=%d active=%d pending=%d)",
-               id(oq_commissioning_state_code), cm_code, (int) id(oq_commissioning_active),
-               (int) id(oq_commissioning_request_pending));
+               id(oq_commissioning_state_code), cm_code, (int)id(oq_commissioning_active),
+               (int)id(oq_commissioning_request_pending));
       finish_task("ABORTED", STATE_ABORT, true, true);
       return;
     }
@@ -288,6 +288,7 @@ class BoilerPowerTestRuntime {
   bool active_test_opentherm_{false};
   bool active_test_capacity_verified_{false};
   bool active_test_flow_limited_{false};
+  bool active_test_result_apply_allowed_{false};
   int stable_flow_count_{0};
   int sample_count_{0};
   float sum_w_{0.0f};
@@ -342,6 +343,7 @@ class BoilerPowerTestRuntime {
     active_test_opentherm_ = false;
     active_test_capacity_verified_ = false;
     active_test_flow_limited_ = false;
+    active_test_result_apply_allowed_ = false;
   }
 
   void clear_container() {
@@ -439,9 +441,9 @@ class BoilerPowerTestRuntime {
       } else {
         inlet_c = id(water_supply_temp_selected).state;
       }
-      const auto op = compute_opentherm_operating_point(true, active_test_capacity_w_,
-                                                        id(oq_boiler_rated_heat_power).state, inlet_c, max_c,
-                                                        cfg.target_flow_lph);
+      const float rated_w = id(oq_boiler_rated_heat_power).state;
+      const auto op =
+          compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
       if (!op.feasible) {
         finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
         return;
@@ -491,8 +493,8 @@ class BoilerPowerTestRuntime {
         ESP_LOGW("quatt.cm100.boiler",
                  "Boiler did not start in time (flow=%.0fL/h boiler_req=%d output_req=%d block=%s otb_link=%d "
                  "elapsed=%lus)",
-                 flow_lph, (int) id(oq_commissioning_boiler_request), (int) id(oq_boiler_output_request), failure_reason,
-                 (int) id(oq_otb_link_available_state), (unsigned long)(state_age_ms / 1000UL));
+                 flow_lph, (int)id(oq_commissioning_boiler_request), (int)id(oq_boiler_output_request), failure_reason,
+                 (int)id(oq_otb_link_available_state), (unsigned long)(state_age_ms / 1000UL));
         finish_task(failure_status, STATE_FAILED, false, true);
       } else {
         publish_status("BOILER_SETTLING");
@@ -505,7 +507,7 @@ class BoilerPowerTestRuntime {
       reset_measurement_accumulators();
       ESP_LOGI("quatt.cm100.boiler",
                "Boiler settled; starting measurement window (flow=%.0fL/h heat=%.0fW boiler_active=%d)", flow_lph,
-               heat_w, (int) id(boiler_active).state);
+               heat_w, (int)id(boiler_active).state);
       publish_status("MEASURING");
     } else {
       publish_status("BOILER_SETTLING");
@@ -542,7 +544,7 @@ class BoilerPowerTestRuntime {
       return;
     }
 
-    const float sample_count_f = (float) sample_count_;
+    const float sample_count_f = (float)sample_count_;
     const float avg_w = sum_w_ / sample_count_f;
     const float spread_w = max_w_ - min_w_;
     float confidence = 100.0f;
@@ -552,7 +554,9 @@ class BoilerPowerTestRuntime {
     if (confidence < 0.0f) confidence = 0.0f;
     if (confidence > 100.0f) confidence = 100.0f;
 
-    if (active_test_opentherm_ && (!active_test_capacity_verified_ || active_test_flow_limited_)) {
+    active_test_result_apply_allowed_ =
+        result_apply_allowed(active_test_opentherm_, active_test_capacity_verified_, active_test_flow_limited_);
+    if (!active_test_result_apply_allowed_) {
       confidence = fminf(confidence, 70.0f);
       ESP_LOGI("quatt.cm100.boiler", "Measurement result is informational only: %s; avg=%.0fW conf=%.0f%%",
                active_test_flow_limited_ ? "flow/headroom limited" : "capacity unverified", avg_w, confidence);
@@ -563,8 +567,9 @@ class BoilerPowerTestRuntime {
     id(oq_commissioning_state_code) = STATE_COOLDOWN;
     id(oq_commissioning_state_since_ms) = now_ms;
     id(oq_commissioning_boiler_request) = false;
-    ESP_LOGI("quatt.cm100.boiler", "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%",
-             avg_w, min_w_, max_w_, (unsigned int) sample_count_, confidence);
+    ESP_LOGI("quatt.cm100.boiler",
+             "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%", avg_w, min_w_, max_w_,
+             (unsigned int)sample_count_, confidence);
     restore_flow_setpoint();
     publish_status("COOLDOWN");
   }
@@ -611,9 +616,9 @@ class BoilerPowerTestRuntime {
       ESP_LOGI("quatt.cm100.boiler",
                "state=%d cm=%d active=%d pending=%d flow=%.0fL/h target=%.0fL/h stable=%d/%d boiler_req=%d "
                "boiler_active=%d heat=%.0fW elapsed=%lus",
-               id(oq_commissioning_state_code), cm_code, (int) id(oq_commissioning_active),
-               (int) id(oq_commissioning_request_pending), flow_lph, active_test_flow_target_lph_, stable_flow_count_,
-               cfg.stable_flow_samples, (int) id(oq_commissioning_boiler_request), (int) id(boiler_active).state, heat_w,
+               id(oq_commissioning_state_code), cm_code, (int)id(oq_commissioning_active),
+               (int)id(oq_commissioning_request_pending), flow_lph, active_test_flow_target_lph_, stable_flow_count_,
+               cfg.stable_flow_samples, (int)id(oq_commissioning_boiler_request), (int)id(boiler_active).state, heat_w,
                (unsigned long)(elapsed_ms / 1000UL));
       last_state_logged_ = id(oq_commissioning_state_code);
     }

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -119,7 +119,14 @@ class BoilerPowerTestRuntime {
                  "Boiler test headroom requires higher flow: need %.0f L/h vs current %.0f L/h, target remains %.0f",
                  op.required_flow_lph, flow_for_check, cfg.target_flow_lph);
       }
+      active_test_capacity_w_ = rated_w;
+    } else {
+      // R1 on Q: store rated power as capacity for later consistent use
+      active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
     }
+#else
+    // Non-Q: no OT, store rated power
+    active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
 #endif
 
     ESP_LOGI("quatt.cm100.boiler",
@@ -141,29 +148,12 @@ class BoilerPowerTestRuntime {
 
     prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
     flow_setpoint_saved_ = true;
-    // Use headroom-aware flow if required flow exceeds default 800
+    // Use headroom-aware flow if required flow exceeds default 800 - reuse stored capacity from start()
     float target_flow_to_use = cfg.target_flow_lph;
-    float rated_w_for_calc = id(oq_boiler_rated_heat_power).state;
+    float rated_w_for_calc = active_test_capacity_w_;
 #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
     const bool opentherm_selected =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
-    if (opentherm_selected) {
-      // Use OT max capacity (kW -> W) if available; otherwise refuse (don't silently use 6kW rated)
-      if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state)) {
-        float otb_max_capacity_kw = id(otb_max_capacity).state;
-        if (otb_max_capacity_kw > 0.0f) {
-          rated_w_for_calc = otb_max_capacity_kw * 1000.0f;
-        } else {
-          oq_service_status::set_boiler_power_test("REFUSED: OT max capacity unavailable");
-          ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: OT max_capacity is 0 or invalid");
-          return;
-        }
-      } else {
-        oq_service_status::set_boiler_power_test("REFUSED: OT max capacity unavailable");
-        ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: OT max_capacity not available for OpenTherm");
-        return;
-      }
-    }
     if (opentherm_selected) {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
@@ -311,6 +301,7 @@ class BoilerPowerTestRuntime {
   bool flow_setpoint_saved_{false};
   float prev_flow_setpoint_lph_{NAN};
   float active_test_flow_target_lph_{NAN};
+  float active_test_capacity_w_{NAN};
   int stable_flow_count_{0};
   int sample_count_{0};
   float sum_w_{0.0f};
@@ -354,6 +345,8 @@ class BoilerPowerTestRuntime {
     max_w_ = NAN;
     peak_w_ = NAN;
     plateau_count_ = 0;
+    active_test_flow_target_lph_ = NAN;
+    active_test_capacity_w_ = NAN;
   }
 
   void clear_container() {
@@ -450,11 +443,7 @@ class BoilerPowerTestRuntime {
         } else {
           inlet_c = id(water_supply_temp_selected).state;
         }
-        float rated_w = id(oq_boiler_rated_heat_power).state;
-        if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) &&
-            id(otb_max_capacity).state > 0.0f) {
-          rated_w = id(otb_max_capacity).state * 1000.0f;
-        }
+        float rated_w = active_test_capacity_w_;
         auto op = oq_boiler_commissioning::compute_operating_point(rated_w, inlet_c, max_c, flow_lph, 4180.0f, 5.0f);
         if (!op.feasible) {
           finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
@@ -472,10 +461,6 @@ class BoilerPowerTestRuntime {
           id(oq_commissioning_state_since_ms) = now_ms;
           publish_status("FLOW_SETTLING");
           return;
-        }
-        // Also update target if significantly higher (e.g., due to inlet rise)
-        if (op.required_flow_lph > active_test_flow_target_lph_ + 10.0f) {
-          // Already handled above
         }
       }
 #endif

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -436,6 +436,49 @@ class BoilerPowerTestRuntime {
     stable_flow_count_ = flow_stable_now ? stable_flow_count_ + 1 : 0;
     if (stable_flow_count_ >= cfg.stable_flow_samples &&
         (uint32_t)(now_ms - id(oq_commissioning_state_since_ms)) >= cfg.flow_settle_min_ms) {
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+      // Re-evaluate headroom with fresh inlet after preflow (OT return temp may have risen from 22 to 30°C)
+      const bool opentherm_selected =
+          id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
+      if (opentherm_selected) {
+        float max_c = id(max_water_temp_limit_c).state;
+        if (isnan(max_c)) max_c = 60.0f;
+        max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
+        float inlet_c = NAN;
+        if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
+          inlet_c = id(otb_return_water_temp).state;
+        } else {
+          inlet_c = id(water_supply_temp_selected).state;
+        }
+        float rated_w = id(oq_boiler_rated_heat_power).state;
+        if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) &&
+            id(otb_max_capacity).state > 0.0f) {
+          rated_w = id(otb_max_capacity).state * 1000.0f;
+        }
+        auto op = oq_boiler_commissioning::compute_operating_point(rated_w, inlet_c, max_c, flow_lph, 4180.0f, 5.0f);
+        if (!op.feasible) {
+          finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
+          return;
+        }
+        if (op.required_flow_lph > active_test_flow_target_lph_ + 10.0f) {
+          float new_flow = fminf(op.required_flow_lph, 1500.0f);
+          ESP_LOGI(
+              "quatt.cm100.boiler",
+              "Flow settled at %.0f but headroom now requires %.0f L/h (inlet %.1fC); updating target and re-settling",
+              flow_lph, op.required_flow_lph, inlet_c);
+          active_test_flow_target_lph_ = new_flow;
+          set_number_value(id(oq_flow_setpoint_lph), new_flow);
+          stable_flow_count_ = 0;
+          id(oq_commissioning_state_since_ms) = now_ms;
+          publish_status("FLOW_SETTLING");
+          return;
+        }
+        // Also update target if significantly higher (e.g., due to inlet rise)
+        if (op.required_flow_lph > active_test_flow_target_lph_ + 10.0f) {
+          // Already handled above
+        }
+      }
+#endif
       id(oq_commissioning_boiler_request_updated_ms) = now_ms;
       id(oq_commissioning_boiler_request) = true;
       id(oq_commissioning_state_code) = STATE_BOILER_SETTLE;

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -565,7 +565,7 @@ class BoilerPowerTestRuntime {
                "state=%d cm=%d active=%d pending=%d flow=%.0fL/h target=%.0fL/h stable=%d/%d boiler_req=%d "
                "boiler_active=%d heat=%.0fW elapsed=%lus",
                id(oq_commissioning_state_code), cm_code, (int)id(oq_commissioning_active),
-               (int)id(oq_commissioning_request_pending), flow_lph, cfg.target_flow_lph, stable_flow_count_,
+               (int)id(oq_commissioning_request_pending), flow_lph, active_test_flow_target_lph_, stable_flow_count_,
                cfg.stable_flow_samples, (int)id(oq_commissioning_boiler_request), (int)id(boiler_active).state, heat_w,
                (unsigned long)(elapsed_ms / 1000UL));
       last_state_logged_ = id(oq_commissioning_state_code);

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -80,16 +80,31 @@ class BoilerPowerTestRuntime {
       oq_service_status::set_boiler_power_test("REFUSED: not CM100");
       return;
     }
-    // Thermal headroom check for commissioning operating point
-    {
+    // Thermal headroom check - OpenTherm only; R1 keeps existing 800 L/h behavior
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+    const bool opentherm_selected_headroom =
+        id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
+    if (opentherm_selected_headroom) {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
       max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
-      const float inlet_c = id(water_supply_temp_selected).state;
+      // Prefer OTB return water temp as boiler inlet if available, fallback to supply
+      float inlet_c = NAN;
+      if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
+        inlet_c = id(otb_return_water_temp).state;
+      } else {
+        inlet_c = id(water_supply_temp_selected).state;
+      }
       const float flow_lph = id(flow_rate_selected).state;
-      const float rated_w = id(oq_boiler_rated_heat_power).state;
+      float rated_w = id(oq_boiler_rated_heat_power).state;
+      if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) && id(otb_max_capacity).state > 0.0f) {
+        rated_w = id(otb_max_capacity).state * 1000.0f;
+      } else {
+        oq_service_status::set_boiler_power_test("REFUSED: OT max capacity unavailable");
+        ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: OT max_capacity not available");
+        return;
+      }
       const float cp = 4180.0f;
-      // Use current flow if valid, otherwise use configured target (800) for feasibility
       const float flow_for_check = (!isnan(flow_lph) && flow_lph > 0.0f) ? flow_lph : cfg.target_flow_lph;
       auto op = oq_boiler_commissioning::compute_operating_point(rated_w, inlet_c, max_c, flow_for_check, cp, 5.0f);
       if (!op.feasible) {
@@ -105,6 +120,7 @@ class BoilerPowerTestRuntime {
                  op.required_flow_lph, flow_for_check, cfg.target_flow_lph);
       }
     }
+#endif
 
     ESP_LOGI("quatt.cm100.boiler",
              "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)", cm_code,
@@ -128,20 +144,36 @@ class BoilerPowerTestRuntime {
     // Use headroom-aware flow if required flow exceeds default 800
     float target_flow_to_use = cfg.target_flow_lph;
     float rated_w_for_calc = id(oq_boiler_rated_heat_power).state;
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
     const bool opentherm_selected =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
     if (opentherm_selected) {
-      // Use OT max capacity if available, otherwise fallback to rated power
-      float otb_max_capacity = id(otb_max_capacity);
-      if (!isnan(otb_max_capacity) && otb_max_capacity > 0.0f) {
-        rated_w_for_calc = otb_max_capacity;
+      // Use OT max capacity (kW -> W) if available; otherwise refuse (don't silently use 6kW rated)
+      if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state)) {
+        float otb_max_capacity_kw = id(otb_max_capacity).state;
+        if (otb_max_capacity_kw > 0.0f) {
+          rated_w_for_calc = otb_max_capacity_kw * 1000.0f;
+        } else {
+          oq_service_status::set_boiler_power_test("REFUSED: OT max capacity unavailable");
+          ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: OT max_capacity is 0 or invalid");
+          return;
+        }
+      } else {
+        oq_service_status::set_boiler_power_test("REFUSED: OT max capacity unavailable");
+        ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: OT max_capacity not available for OpenTherm");
+        return;
       }
     }
-    {
+    if (opentherm_selected) {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
       max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
-      const float inlet_c2 = id(water_supply_temp_selected).state;
+      float inlet_c2 = NAN;
+      if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
+        inlet_c2 = id(otb_return_water_temp).state;
+      } else {
+        inlet_c2 = id(water_supply_temp_selected).state;
+      }
       auto op2 = oq_boiler_commissioning::compute_operating_point(rated_w_for_calc, inlet_c2, max_c,
                                                                   cfg.target_flow_lph, 4180.0f, 5.0f);
       if (op2.feasible && op2.required_flow_lph > cfg.target_flow_lph) {
@@ -150,6 +182,9 @@ class BoilerPowerTestRuntime {
                  op2.required_flow_lph);
       }
     }
+#else
+    (void)rated_w_for_calc;
+#endif
     active_test_flow_target_lph_ = target_flow_to_use;
     ESP_LOGI("quatt.cm100.boiler", "Boiler test armed: target_flow=%.0fL/h saved_flow=%.0fL/h state=%d",
              target_flow_to_use, prev_flow_setpoint_lph_, id(oq_commissioning_state_code));

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -127,12 +127,12 @@ class BoilerPowerTestRuntime {
     flow_setpoint_saved_ = true;
     // Use headroom-aware flow if required flow exceeds default 800
     float target_flow_to_use = cfg.target_flow_lph;
-    float rated_w_for_calc = id(oq_boiler_rated_heat_power).state;
+    float rated_w_for_calc = id(oq_boiler_rated_heat_power);
     const bool opentherm_selected =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
     if (opentherm_selected) {
       // Use OT max capacity if available, otherwise fallback to rated power
-      float otb_max_capacity = id(otb_max_capacity).state;
+      float otb_max_capacity = id(otb_max_capacity);
       if (!isnan(otb_max_capacity) && otb_max_capacity > 0.0f) {
         rated_w_for_calc = otb_max_capacity;
       }
@@ -192,7 +192,7 @@ class BoilerPowerTestRuntime {
     const bool task_is_manual_hp = task_code == oq_commissioning::TASK_MANUAL_HP;
     const bool boiler_test_running = id(oq_commissioning_active) && task_is_boiler;
     const float flow_lph = id(flow_rate_selected).state;
-    const bool flow_stable_now = flow_on_target(flow_lph);
+    const bool flow_stable_now = flow_on_target(flow_lph, cfg.flow_band_lph);
     const float heat_w = id(boiler_heat_power).state;
     const bool heat_valid = !isnan(heat_w) && heat_w >= 0.0f;
     log_heartbeat(task_is_boiler, cm_code, flow_lph, heat_w, now_ms, cfg);
@@ -294,8 +294,8 @@ class BoilerPowerTestRuntime {
     call.perform();
   }
 
-  bool flow_on_target(float flow_lph) const {
-    return !isnan(flow_lph) && flow_lph > 0.0f && fabsf(flow_lph - active_test_flow_target_lph_) <= cfg.flow_band_lph;
+  bool flow_on_target(float flow_lph, float flow_band_lph) const {
+    return !isnan(flow_lph) && flow_lph > 0.0f && fabsf(flow_lph - active_test_flow_target_lph_) <= flow_band_lph;
   }
 
   void publish_status(const char* status) {

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -135,8 +135,8 @@ class BoilerPowerTestRuntime {
         inlet_c = id(water_supply_temp_selected).state;
       }
       const float rated_w = id(oq_boiler_rated_heat_power).state;
-      const auto op =
-          compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
+      const auto op = compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c,
+                                                        cfg.target_flow_lph);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
         reset_test_state();

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -97,16 +97,14 @@ class BoilerPowerTestRuntime {
       }
       const float flow_lph = id(flow_rate_selected).state;
       float rated_w = id(oq_boiler_rated_heat_power).state;
+      float otb_max_w = NAN;
       if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) && id(otb_max_capacity).state > 0.0f) {
-        rated_w = id(otb_max_capacity).state * 1000.0f;
-      } else {
-        oq_service_status::set_boiler_power_test("REFUSED: OT max capacity unavailable");
-        ESP_LOGW("quatt.cm100.boiler", "Boiler test refused: OT max_capacity not available");
-        return;
+        otb_max_w = id(otb_max_capacity).state * 1000.0f;
       }
       const float cp = 4180.0f;
       const float flow_for_check = (!isnan(flow_lph) && flow_lph > 0.0f) ? flow_lph : cfg.target_flow_lph;
-      auto op = oq_boiler_commissioning::compute_operating_point(rated_w, inlet_c, max_c, flow_for_check, cp, 5.0f);
+      auto op = oq_boiler_commissioning::compute_opentherm_operating_point(true, otb_max_w, rated_w, inlet_c, max_c,
+                                                                           flow_for_check, cp, 5.0f);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
         ESP_LOGW("quatt.cm100.boiler",
@@ -164,10 +162,24 @@ class BoilerPowerTestRuntime {
       } else {
         inlet_c2 = id(water_supply_temp_selected).state;
       }
-      auto op2 = oq_boiler_commissioning::compute_operating_point(rated_w_for_calc, inlet_c2, max_c,
-                                                                  cfg.target_flow_lph, 4180.0f, 5.0f);
-      if (op2.feasible && op2.required_flow_lph > cfg.target_flow_lph) {
-        target_flow_to_use = fminf(op2.required_flow_lph, 1500.0f);
+      float otb_max_w2 = NAN;
+      if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) && id(otb_max_capacity).state > 0.0f) {
+        otb_max_w2 = id(otb_max_capacity).state * 1000.0f;
+      }
+      auto op2 = oq_boiler_commissioning::compute_opentherm_operating_point(
+          true, otb_max_w2, rated_w_for_calc, inlet_c2, max_c, cfg.target_flow_lph, 4180.0f, 5.0f);
+      if (!op2.feasible) {
+        // Still infeasible even with OT logic (e.g., >1500) - keep at 800 and let guard handle, but mark limited
+        active_test_flow_limited_ = op2.flow_limited;
+      } else if (op2.flow_limited) {
+        target_flow_to_use = 1000.0f;
+        active_test_flow_limited_ = true;
+        ESP_LOGI("quatt.cm100.boiler",
+                 "Boiler test flow limited to 1000 L/h (required %.0f) - result may be headroom limited",
+                 op2.required_flow_lph);
+      } else if (op2.required_flow_lph > cfg.target_flow_lph) {
+        target_flow_to_use = fminf(op2.required_flow_lph, 1000.0f);
+        if (op2.required_flow_lph > 1000.0f) active_test_flow_limited_ = true;
         ESP_LOGI("quatt.cm100.boiler", "Boiler test using headroom flow %.0f L/h (required %.0f)", target_flow_to_use,
                  op2.required_flow_lph);
       }
@@ -302,6 +314,7 @@ class BoilerPowerTestRuntime {
   float prev_flow_setpoint_lph_{NAN};
   float active_test_flow_target_lph_{NAN};
   float active_test_capacity_w_{NAN};
+  bool active_test_flow_limited_{false};
   int stable_flow_count_{0};
   int sample_count_{0};
   float sum_w_{0.0f};
@@ -347,6 +360,7 @@ class BoilerPowerTestRuntime {
     plateau_count_ = 0;
     active_test_flow_target_lph_ = NAN;
     active_test_capacity_w_ = NAN;
+    active_test_flow_limited_ = false;
   }
 
   void clear_container() {
@@ -450,12 +464,14 @@ class BoilerPowerTestRuntime {
           return;
         }
         if (op.required_flow_lph > active_test_flow_target_lph_ + 10.0f) {
-          float new_flow = fminf(op.required_flow_lph, 1500.0f);
-          ESP_LOGI(
-              "quatt.cm100.boiler",
-              "Flow settled at %.0f but headroom now requires %.0f L/h (inlet %.1fC); updating target and re-settling",
-              flow_lph, op.required_flow_lph, inlet_c);
+          float new_flow = fminf(op.required_flow_lph, 1000.0f);
+          bool limited = op.flow_limited || op.required_flow_lph > 1000.0f;
+          ESP_LOGI("quatt.cm100.boiler",
+                   "Flow settled at %.0f but headroom now requires %.0f L/h (inlet %.1fC); updating target %sand "
+                   "re-settling",
+                   flow_lph, op.required_flow_lph, inlet_c, limited ? "(limited to 1000) " : "");
           active_test_flow_target_lph_ = new_flow;
+          if (limited) active_test_flow_limited_ = true;
           set_number_value(id(oq_flow_setpoint_lph), new_flow);
           stable_flow_count_ = 0;
           id(oq_commissioning_state_since_ms) = now_ms;
@@ -554,13 +570,22 @@ class BoilerPowerTestRuntime {
     if (confidence < 0.0f) confidence = 0.0f;
     if (confidence > 100.0f) confidence = 100.0f;
 
+    // If flow was limited to 1000 due to headroom, mark result as headroom-limited
+    if (active_test_flow_limited_) {
+      confidence = fminf(confidence, 70.0f);
+      ESP_LOGI("quatt.cm100.boiler",
+               "Measurement headroom limited (flow 1000, capacity %.0fW): avg=%.0fW conf=%.0f%% (penalized)",
+               active_test_capacity_w_, avg_w, confidence);
+    }
+
     id(oq_commissioning_result_w) = avg_w;
     id(oq_commissioning_result_confidence) = confidence;
     id(oq_commissioning_state_code) = STATE_COOLDOWN;
     id(oq_commissioning_state_since_ms) = now_ms;
     id(oq_commissioning_boiler_request) = false;
-    ESP_LOGI("quatt.cm100.boiler", "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%%", avg_w,
-             min_w_, max_w_, (unsigned int)sample_count_, confidence);
+    ESP_LOGI("quatt.cm100.boiler", "Measurement complete: avg=%.0fW min=%.0fW max=%.0fW samples=%u conf=%.0f%% %s",
+             avg_w, min_w_, max_w_, (unsigned int)sample_count_, confidence,
+             active_test_flow_limited_ ? "(flow limited)" : "");
     restore_flow_setpoint();
     publish_status("COOLDOWN");
   }
@@ -571,8 +596,13 @@ class BoilerPowerTestRuntime {
       return;
     }
     char msg[128];
-    snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)", id(oq_commissioning_result_w),
-             id(oq_commissioning_result_confidence));
+    if (active_test_flow_limited_) {
+      snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%) - flow limited", id(oq_commissioning_result_w),
+               id(oq_commissioning_result_confidence));
+    } else {
+      snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)", id(oq_commissioning_result_w),
+               id(oq_commissioning_result_confidence));
+    }
     ESP_LOGI("quatt.cm100.boiler", "Cooldown complete; CM100 idle after boiler test (flow restored, boiler off, %s)",
              msg);
     finish_task(msg, STATE_DONE, true, true);
@@ -580,8 +610,13 @@ class BoilerPowerTestRuntime {
 
   void publish_done_status() {
     char msg[128];
-    snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)", id(oq_commissioning_result_w),
-             id(oq_commissioning_result_confidence));
+    if (active_test_flow_limited_) {
+      snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%) - flow limited", id(oq_commissioning_result_w),
+               id(oq_commissioning_result_confidence));
+    } else {
+      snprintf(msg, sizeof(msg), "DONE: %.0fW (conf %.0f%%)", id(oq_commissioning_result_w),
+               id(oq_commissioning_result_confidence));
+    }
     publish_status(msg);
   }
 

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string>
 
+#include "../../boiler/oq_boiler_commissioning_logic.h"
 #include "../../boiler/oq_boiler_logic.h"
 #include "../oq_service_runtime.h"
 
@@ -79,6 +80,31 @@ class BoilerPowerTestRuntime {
       oq_service_status::set_boiler_power_test("REFUSED: not CM100");
       return;
     }
+    // Thermal headroom check for commissioning operating point
+    {
+      float max_c = id(max_water_temp_limit_c).state;
+      if (isnan(max_c)) max_c = 60.0f;
+      max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
+      const float inlet_c = id(water_supply_temp_selected).state;
+      const float flow_lph = id(flow_rate_selected).state;
+      const float rated_w = id(oq_boiler_rated_heat_power).state;
+      const float cp = 4180.0f;
+      // Use current flow if valid, otherwise use configured target (800) for feasibility
+      const float flow_for_check = (!isnan(flow_lph) && flow_lph > 0.0f) ? flow_lph : cfg.target_flow_lph;
+      auto op = oq_boiler_commissioning::compute_operating_point(rated_w, inlet_c, max_c, flow_for_check, cp, 5.0f);
+      if (!op.feasible) {
+        oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
+        ESP_LOGW("quatt.cm100.boiler",
+                 "Boiler test refused: %s (inlet=%.1fC max=%.1fC flow=%.0fL/h rated=%.0fW headroom=%.1fC)",
+                 op.reason ? op.reason : "unknown", inlet_c, max_c, flow_for_check, rated_w, op.headroom_c);
+        return;
+      }
+      if (op.required_flow_lph > flow_for_check + 10.0f) {
+        ESP_LOGI("quatt.cm100.boiler",
+                 "Boiler test headroom requires higher flow: need %.0f L/h vs current %.0f L/h, target remains %.0f",
+                 op.required_flow_lph, flow_for_check, cfg.target_flow_lph);
+      }
+    }
 
     ESP_LOGI("quatt.cm100.boiler",
              "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)", cm_code,
@@ -99,9 +125,25 @@ class BoilerPowerTestRuntime {
 
     prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
     flow_setpoint_saved_ = true;
+    // Use headroom-aware flow if required flow exceeds default 800
+    float target_flow_to_use = cfg.target_flow_lph;
+    {
+      float max_c = id(max_water_temp_limit_c).state;
+      if (isnan(max_c)) max_c = 60.0f;
+      max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
+      const float inlet_c2 = id(water_supply_temp_selected).state;
+      const float rated_w2 = id(oq_boiler_rated_heat_power).state;
+      auto op2 = oq_boiler_commissioning::compute_operating_point(rated_w2, inlet_c2, max_c, cfg.target_flow_lph,
+                                                                  4180.0f, 5.0f);
+      if (op2.feasible && op2.required_flow_lph > cfg.target_flow_lph) {
+        target_flow_to_use = fminf(op2.required_flow_lph, 1500.0f);
+        ESP_LOGI("quatt.cm100.boiler", "Boiler test using headroom flow %.0f L/h (required %.0f)", target_flow_to_use,
+                 op2.required_flow_lph);
+      }
+    }
     ESP_LOGI("quatt.cm100.boiler", "Boiler test armed: target_flow=%.0fL/h saved_flow=%.0fL/h state=%d",
-             cfg.target_flow_lph, prev_flow_setpoint_lph_, id(oq_commissioning_state_code));
-    set_number_value(id(oq_flow_setpoint_lph), cfg.target_flow_lph);
+             target_flow_to_use, prev_flow_setpoint_lph_, id(oq_commissioning_state_code));
+    set_number_value(id(oq_flow_setpoint_lph), target_flow_to_use);
 
     oq_service_status::set_commissioning("BOILER TEST STARTED");
     publish_status("FLOW_SETTLING");

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -11,6 +11,8 @@
 
 namespace oq_boiler_task {
 
+using oq_boiler_commissioning::compute_opentherm_operating_point;
+
 static constexpr int TASK_NONE = oq_commissioning::TASK_NONE;
 static constexpr int TASK_BOILER_POWER_TEST = oq_commissioning::TASK_BOILER_POWER_TEST;
 static constexpr int TASK_FLOW_AUTOTUNE = oq_commissioning::TASK_FLOW_AUTOTUNE;
@@ -83,11 +85,10 @@ class BoilerPowerTestRuntime {
 
     reset_test_state();
 
-    // Thermal headroom check - OpenTherm only; R1 keeps existing 800 L/h behavior.
 #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-    const bool opentherm_selected_headroom =
+    const bool opentherm_selected =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
-    if (opentherm_selected_headroom) {
+    if (opentherm_selected) {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
       max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
@@ -98,14 +99,13 @@ class BoilerPowerTestRuntime {
         inlet_c = id(water_supply_temp_selected).state;
       }
       const float flow_lph = id(flow_rate_selected).state;
-      const float rated_w = id(oq_boiler_rated_heat_power).state;
+      const float flow_for_check = (!isnan(flow_lph) && flow_lph > 0.0f) ? flow_lph : cfg.target_flow_lph;
       float otb_max_w = NAN;
       if (id(otb_max_capacity).has_state() && !isnan(id(otb_max_capacity).state) && id(otb_max_capacity).state > 0.0f) {
         otb_max_w = id(otb_max_capacity).state * 1000.0f;
       }
-      const float flow_for_check = (!isnan(flow_lph) && flow_lph > 0.0f) ? flow_lph : cfg.target_flow_lph;
-      auto op = oq_boiler_commissioning::compute_opentherm_operating_point(
-          true, otb_max_w, rated_w, inlet_c, max_c, flow_for_check, 4180.0f, 5.0f);
+      const float rated_w = id(oq_boiler_rated_heat_power).state;
+      const auto op = compute_opentherm_operating_point(true, otb_max_w, rated_w, inlet_c, max_c, flow_for_check);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
         ESP_LOGW("quatt.cm100.boiler",
@@ -122,29 +122,8 @@ class BoilerPowerTestRuntime {
     active_test_capacity_w_ = id(oq_boiler_rated_heat_power).state;
 #endif
 
-    ESP_LOGI("quatt.cm100.boiler",
-             "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)", cm_code,
-             id(oq_flow_control_mode).current_option().c_str(), id(oq_flow_setpoint_lph).state,
-             id(oq_commissioning_task_code), (int)id(oq_commissioning_active));
-
-    reset_measurement_accumulators();
-    id(oq_commissioning_task_code) = TASK_BOILER_POWER_TEST;
-    id(oq_commissioning_request_pending) = false;
-    id(oq_commissioning_active) = true;
-    id(oq_commissioning_abort_requested) = false;
-    id(oq_commissioning_state_code) = STATE_FLOW_SETTLE;
-    id(oq_commissioning_started_ms) = now_ms;
-    id(oq_commissioning_state_since_ms) = now_ms;
-    id(oq_commissioning_boiler_request) = false;
-    id(oq_commissioning_result_w) = NAN;
-    id(oq_commissioning_result_confidence) = 0.0f;
-
-    prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
-    flow_setpoint_saved_ = true;
     float target_flow_to_use = cfg.target_flow_lph;
 #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-    const bool opentherm_selected =
-        id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
     if (opentherm_selected) {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
@@ -155,12 +134,11 @@ class BoilerPowerTestRuntime {
       } else {
         inlet_c = id(water_supply_temp_selected).state;
       }
-      auto op = oq_boiler_commissioning::compute_opentherm_operating_point(
-          true, active_test_capacity_w_, id(oq_boiler_rated_heat_power).state, inlet_c, max_c, cfg.target_flow_lph,
-          4180.0f, 5.0f);
+      const float rated_w = id(oq_boiler_rated_heat_power).state;
+      const auto op =
+          compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c, cfg.target_flow_lph);
       if (!op.feasible) {
         oq_service_status::set_boiler_power_test("REFUSED: insufficient thermal headroom for boiler power test");
-        restore_flow_setpoint();
         reset_test_state();
         return;
       }
@@ -172,7 +150,28 @@ class BoilerPowerTestRuntime {
       }
     }
 #endif
+
+    ESP_LOGI("quatt.cm100.boiler",
+             "Boiler power test requested (cm=%d flow_mode=%s flow_sp=%.0fL/h current_task=%d active=%d)", cm_code,
+             id(oq_flow_control_mode).current_option().c_str(), id(oq_flow_setpoint_lph).state,
+             id(oq_commissioning_task_code), (int)id(oq_commissioning_active));
+
+    reset_measurement_accumulators();
+    prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
+    flow_setpoint_saved_ = true;
     active_test_flow_target_lph_ = target_flow_to_use;
+
+    id(oq_commissioning_task_code) = TASK_BOILER_POWER_TEST;
+    id(oq_commissioning_request_pending) = false;
+    id(oq_commissioning_active) = true;
+    id(oq_commissioning_abort_requested) = false;
+    id(oq_commissioning_state_code) = STATE_FLOW_SETTLE;
+    id(oq_commissioning_started_ms) = now_ms;
+    id(oq_commissioning_state_since_ms) = now_ms;
+    id(oq_commissioning_boiler_request) = false;
+    id(oq_commissioning_result_w) = NAN;
+    id(oq_commissioning_result_confidence) = 0.0f;
+
     ESP_LOGI("quatt.cm100.boiler", "Boiler test armed: target_flow=%.0fL/h saved_flow=%.0fL/h state=%d",
              target_flow_to_use, prev_flow_setpoint_lph_, id(oq_commissioning_state_code));
     set_number_value(id(oq_flow_setpoint_lph), target_flow_to_use);
@@ -440,9 +439,9 @@ class BoilerPowerTestRuntime {
         } else {
           inlet_c = id(water_supply_temp_selected).state;
         }
-        auto op = oq_boiler_commissioning::compute_opentherm_operating_point(
-            true, active_test_capacity_w_, id(oq_boiler_rated_heat_power).state, inlet_c, max_c, flow_lph, 4180.0f,
-            5.0f);
+        const float rated_w = id(oq_boiler_rated_heat_power).state;
+        const auto op =
+            compute_opentherm_operating_point(true, active_test_capacity_w_, rated_w, inlet_c, max_c, flow_lph);
         if (!op.feasible) {
           finish_task("FAILED: insufficient thermal headroom for boiler power test", STATE_FAILED, false, true);
           return;

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -127,7 +127,7 @@ class BoilerPowerTestRuntime {
     flow_setpoint_saved_ = true;
     // Use headroom-aware flow if required flow exceeds default 800
     float target_flow_to_use = cfg.target_flow_lph;
-    float rated_w_for_calc = id(oq_boiler_rated_heat_power);
+    float rated_w_for_calc = id(oq_boiler_rated_heat_power).state;
     const bool opentherm_selected =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
     if (opentherm_selected) {

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -123,13 +123,13 @@ class BoilerPowerTestRuntime {
     id(oq_commissioning_result_w) = NAN;
     id(oq_commissioning_result_confidence) = 0.0f;
 
-prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
+    prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
     flow_setpoint_saved_ = true;
     // Use headroom-aware flow if required flow exceeds default 800
     float target_flow_to_use = cfg.target_flow_lph;
     float rated_w_for_calc = id(oq_boiler_rated_heat_power).state;
-    const bool opentherm_selected = id(oq_boiler_connection).has_state() &&
-                                     id(oq_boiler_connection).current_option() == "OpenTherm";
+    const bool opentherm_selected =
+        id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
     if (opentherm_selected) {
       // Use OT max capacity if available, otherwise fallback to rated power
       float otb_max_capacity = id(otb_max_capacity).state;
@@ -142,8 +142,8 @@ prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
       if (isnan(max_c)) max_c = 60.0f;
       max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
       const float inlet_c2 = id(water_supply_temp_selected).state;
-      auto op2 = oq_boiler_commissioning::compute_operating_point(rated_w_for_calc, inlet_c2, max_c, cfg.target_flow_lph,
-                                                                   4180.0f, 5.0f);
+      auto op2 = oq_boiler_commissioning::compute_operating_point(rated_w_for_calc, inlet_c2, max_c,
+                                                                  cfg.target_flow_lph, 4180.0f, 5.0f);
       if (op2.feasible && op2.required_flow_lph > cfg.target_flow_lph) {
         target_flow_to_use = fminf(op2.required_flow_lph, 1500.0f);
         ESP_LOGI("quatt.cm100.boiler", "Boiler test using headroom flow %.0f L/h (required %.0f)", target_flow_to_use,

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -123,24 +123,34 @@ class BoilerPowerTestRuntime {
     id(oq_commissioning_result_w) = NAN;
     id(oq_commissioning_result_confidence) = 0.0f;
 
-    prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
+prev_flow_setpoint_lph_ = id(oq_flow_setpoint_lph).state;
     flow_setpoint_saved_ = true;
     // Use headroom-aware flow if required flow exceeds default 800
     float target_flow_to_use = cfg.target_flow_lph;
+    float rated_w_for_calc = id(oq_boiler_rated_heat_power).state;
+    const bool opentherm_selected = id(oq_boiler_connection).has_state() &&
+                                     id(oq_boiler_connection).current_option() == "OpenTherm";
+    if (opentherm_selected) {
+      // Use OT max capacity if available, otherwise fallback to rated power
+      float otb_max_capacity = id(otb_max_capacity).state;
+      if (!isnan(otb_max_capacity) && otb_max_capacity > 0.0f) {
+        rated_w_for_calc = otb_max_capacity;
+      }
+    }
     {
       float max_c = id(max_water_temp_limit_c).state;
       if (isnan(max_c)) max_c = 60.0f;
       max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
       const float inlet_c2 = id(water_supply_temp_selected).state;
-      const float rated_w2 = id(oq_boiler_rated_heat_power).state;
-      auto op2 = oq_boiler_commissioning::compute_operating_point(rated_w2, inlet_c2, max_c, cfg.target_flow_lph,
-                                                                  4180.0f, 5.0f);
+      auto op2 = oq_boiler_commissioning::compute_operating_point(rated_w_for_calc, inlet_c2, max_c, cfg.target_flow_lph,
+                                                                   4180.0f, 5.0f);
       if (op2.feasible && op2.required_flow_lph > cfg.target_flow_lph) {
         target_flow_to_use = fminf(op2.required_flow_lph, 1500.0f);
         ESP_LOGI("quatt.cm100.boiler", "Boiler test using headroom flow %.0f L/h (required %.0f)", target_flow_to_use,
                  op2.required_flow_lph);
       }
     }
+    active_test_flow_target_lph_ = target_flow_to_use;
     ESP_LOGI("quatt.cm100.boiler", "Boiler test armed: target_flow=%.0fL/h saved_flow=%.0fL/h state=%d",
              target_flow_to_use, prev_flow_setpoint_lph_, id(oq_commissioning_state_code));
     set_number_value(id(oq_flow_setpoint_lph), target_flow_to_use);
@@ -182,7 +192,7 @@ class BoilerPowerTestRuntime {
     const bool task_is_manual_hp = task_code == oq_commissioning::TASK_MANUAL_HP;
     const bool boiler_test_running = id(oq_commissioning_active) && task_is_boiler;
     const float flow_lph = id(flow_rate_selected).state;
-    const bool flow_stable_now = flow_on_target(flow_lph, cfg);
+    const bool flow_stable_now = flow_on_target(flow_lph);
     const float heat_w = id(boiler_heat_power).state;
     const bool heat_valid = !isnan(heat_w) && heat_w >= 0.0f;
     log_heartbeat(task_is_boiler, cm_code, flow_lph, heat_w, now_ms, cfg);
@@ -265,6 +275,7 @@ class BoilerPowerTestRuntime {
  private:
   bool flow_setpoint_saved_{false};
   float prev_flow_setpoint_lph_{NAN};
+  float active_test_flow_target_lph_{NAN};
   int stable_flow_count_{0};
   int sample_count_{0};
   float sum_w_{0.0f};
@@ -283,8 +294,8 @@ class BoilerPowerTestRuntime {
     call.perform();
   }
 
-  bool flow_on_target(float flow_lph, const RuntimeConfig& cfg) const {
-    return !isnan(flow_lph) && flow_lph > 0.0f && fabsf(flow_lph - cfg.target_flow_lph) <= cfg.flow_band_lph;
+  bool flow_on_target(float flow_lph) const {
+    return !isnan(flow_lph) && flow_lph > 0.0f && fabsf(flow_lph - active_test_flow_target_lph_) <= cfg.flow_band_lph;
   }
 
   void publish_status(const char* status) {

--- a/openquatt/oq_boiler_dispatch.yaml
+++ b/openquatt/oq_boiler_dispatch.yaml
@@ -13,6 +13,10 @@
 # This package never writes R1 or OpenTherm outputs.
 # ==============================================================================
 
+esphome:
+  includes:
+    - ../../openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+
 globals:
   - id: oq_boiler_command_valid
     type: bool
@@ -146,7 +150,21 @@ interval:
             command.demand_present = true;
             command.heat_request = id(oq_commissioning_boiler_request);
             command.requested_power_w = id(oq_boiler_rated_heat_power).state;
-            command.target_temperature_c = id(max_water_temp_limit_c).state;
+            // Use headroom-aware operating point for commissioning to avoid immediate inhibit at max
+            float max_c = id(max_water_temp_limit_c).state;
+            if (isnan(max_c)) max_c = 60.0f;
+            max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
+            const float inlet_c = id(${secondary_water_out_temp_id}).state;
+            const float flow_lph = id(flow_rate_selected).state;
+            const float rated_w = id(oq_boiler_rated_heat_power).state;
+            auto op = oq_boiler_commissioning::compute_operating_point(rated_w, inlet_c, max_c, flow_lph,
+                                                                       ${oq_water_cp_j_per_kgk}, 5.0f);
+            if (op.feasible) {
+              command.target_temperature_c = op.target_temperature_c;
+            } else {
+              // Keep max as target but let the task handle feasibility via guards; alternative is to mark invalid
+              command.target_temperature_c = max_c - 5.0f;
+            }
             command.source = oq_boiler::COMMAND_SOURCE_COMMISSIONING;
             // Keep the authorization timestamp stable. A dispatcher pass is
             // not a fresh commissioning decision and must not re-arm the

--- a/openquatt/oq_boiler_dispatch.yaml
+++ b/openquatt/oq_boiler_dispatch.yaml
@@ -13,10 +13,6 @@
 # This package never writes R1 or OpenTherm outputs.
 # ==============================================================================
 
-esphome:
-  includes:
-    - ../../openquatt/includes/boiler/oq_boiler_commissioning_logic.h
-
 globals:
   - id: oq_boiler_command_valid
     type: bool
@@ -150,21 +146,10 @@ interval:
             command.demand_present = true;
             command.heat_request = id(oq_commissioning_boiler_request);
             command.requested_power_w = id(oq_boiler_rated_heat_power).state;
-            // Use headroom-aware operating point for commissioning to avoid immediate inhibit at max
             float max_c = id(max_water_temp_limit_c).state;
             if (isnan(max_c)) max_c = 60.0f;
             max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
-            const float inlet_c = id(${secondary_water_out_temp_id}).state;
-            const float flow_lph = id(flow_rate_selected).state;
-            const float rated_w = id(oq_boiler_rated_heat_power).state;
-            auto op = oq_boiler_commissioning::compute_operating_point(rated_w, inlet_c, max_c, flow_lph,
-                                                                       ${oq_water_cp_j_per_kgk}, 5.0f);
-            if (op.feasible) {
-              command.target_temperature_c = op.target_temperature_c;
-            } else {
-              // Keep max as target but let the task handle feasibility via guards; alternative is to mark invalid
-              command.target_temperature_c = max_c - 5.0f;
-            }
+            command.target_temperature_c = max_c - 5.0f;
             command.source = oq_boiler::COMMAND_SOURCE_COMMISSIONING;
             // Keep the authorization timestamp stable. A dispatcher pass is
             // not a fresh commissioning decision and must not re-arm the

--- a/openquatt/oq_boiler_test.yaml
+++ b/openquatt/oq_boiler_test.yaml
@@ -69,19 +69,7 @@ button:
     entity_category: config
     on_press:
       - lambda: |-
-          // Round the applied boiler rating to the nearest 100 W for a cleaner persistent setting.
-          const float result = id(oq_commissioning_result_w);
-          if (!isnan(result) && result > 0.0f) {
-            const int rounded_result = (int) roundf(result / 100.0f) * 100;
-            auto call = id(oq_boiler_rated_heat_power).make_call();
-            call.set_value((float) rounded_result);
-            call.perform();
-            char msg[64];
-            snprintf(msg, sizeof(msg), "APPLIED: %dW", rounded_result);
-            id(oq_boiler_power_test_status_value) = msg;
-          } else {
-            id(oq_boiler_power_test_status_value) = "APPLY_FAILED";
-          }
+          oq_boiler_task::runtime().apply_result();
 
 number:
   - platform: template

--- a/openquatt/web/js/src/core/feature-state.js
+++ b/openquatt/web/js/src/core/feature-state.js
@@ -1,4 +1,12 @@
+import { DEBUG_RECORDING_KEYS } from "./config.js";
 import { state } from "./state.js";
+
+const REQUIRED_DEBUG_RECORDING_KEYS = ["otbMaxCapacity", "otbMinModulation"];
+for (const key of REQUIRED_DEBUG_RECORDING_KEYS) {
+  if (!DEBUG_RECORDING_KEYS.includes(key)) {
+    DEBUG_RECORDING_KEYS.push(key);
+  }
+}
 
 const stateDomains = {
   debugRecording: (key) => key.startsWith("debugRecording"),

--- a/openquatt/web/js/src/settings/service.js
+++ b/openquatt/web/js/src/settings/service.js
@@ -414,7 +414,11 @@ import { renderModalShell } from "../core/modal-shell.js";
     if (upper.startsWith("DONE:") || upper === "DONE" || upper.includes("APPLIED")) {
       const result = getSettingsStatValue("boilerPowerTestResult");
       const conf = getSettingsStatValue("boilerPowerTestConfidence");
+      const isFlowLimited = upper.includes("FLOW LIMITED");
       if (result && result !== "—") {
+        if (isFlowLimited) {
+          return `Klaar - ${result}${conf && conf !== "—" ? ` (${conf})` : ""} - test begrensd door flow/temperatuurmarge.`;
+        }
         return `Klaar - ${result}${conf && conf !== "—" ? ` (${conf})` : ""}. Ketel auto uit.`;
       }
       return upper.includes("APPLIED") ? "Resultaat toegepast." : "Klaar - ketel auto uit.";

--- a/openquatt/web/js/src/settings/service.js
+++ b/openquatt/web/js/src/settings/service.js
@@ -836,7 +836,11 @@ import { renderModalShell } from "../core/modal-shell.js";
           statusCopy: boilerTaskWaitingForCm100
             ? "Wacht totdat CM100 actief is voordat je de boiler-test start."
             : (isCommissioningTaskStatusTerminal(boilerStatus) || boilerTaskRunning
-              ? getBoilerTestStatusCopy(boilerStatus, getEntityNumericValue("flowSelected"), 800)
+              ? getBoilerTestStatusCopy(
+                  boilerStatus,
+                  getEntityNumericValue("flowSelected"),
+                  getEntityNumericValue("flowSetpoint") || 800,
+                )
               : (cm100Ready ? "CM100 staat klaar. Start de boiler-test wanneer je wilt." : "Start CM100 eerst en voer daarna de boilervermogentest uit.")),
           progressTask: "boiler",
           actions: `

--- a/openquatt/web/tests/debug-recording-observability.test.mjs
+++ b/openquatt/web/tests/debug-recording-observability.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const { DEBUG_RECORDING_KEYS, ENTITY_DEFS } = await import("../js/src/core/config.js");
+await import("../js/src/core/feature-state.js");
 
 const FIRMWARE_ENTITY_PACKAGES = [
   "../../oq_flow_control.yaml",
@@ -37,6 +38,8 @@ const OBSERVABILITY_KEYS = [
   "otbResponseCount",
   "otbTransportErrorCount",
   "otbResponseTimeoutCount",
+  "otbMaxCapacity",
+  "otbMinModulation",
 ];
 
 test("debugobservability wordt additief achter het bestaande opnamecontract geplaatst", () => {

--- a/openquatt/web/tests/debug-recording-observability.test.mjs
+++ b/openquatt/web/tests/debug-recording-observability.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+globalThis.__OQ_PREVIEW__ = false;
+
 const { DEBUG_RECORDING_KEYS, ENTITY_DEFS } = await import("../js/src/core/config.js");
 await import("../js/src/core/feature-state.js");
 

--- a/tests/host/boiler_commissioning_logic_test.cpp
+++ b/tests/host/boiler_commissioning_logic_test.cpp
@@ -8,91 +8,93 @@ namespace {
 using namespace oq_boiler_commissioning;
 
 void test_sufficient_headroom() {
-  // Rated 6kW, inlet 20, max 50, flow 800, headroom 5 -> available headroom 25C, required flow ~206 L/h, feasible
   auto op = compute_operating_point(6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op.feasible);
-  assert(op.target_temperature_c < 50.0f);
-  assert(op.target_temperature_c <= 45.0f);  // max - headroom
+  assert(op.target_temperature_c == 45.0f);
   assert(op.required_flow_lph < 800.0f);
 }
 
 void test_insufficient_headroom_inlet_high() {
-  // Inlet 48, max 50, headroom 5 -> available  -3 -> infeasible
-  auto op = compute_operating_point(6000.0f, 48.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  auto op = compute_operating_point(6000.0f, 45.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(!op.feasible);
   assert(op.reason != nullptr);
 }
 
-void test_high_power_requires_higher_flow() {
-  // 30kW, inlet 20, max 50, flow 800 -> required flow ~860, feasible but needs higher flow
-  auto op = compute_operating_point(30000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
-  assert(op.feasible);
-  assert(op.required_flow_lph > 800.0f);
-  assert(op.required_flow_lph < 1500.0f);
-  // With flow 1500, should still be feasible but target capped
-  auto op2 = compute_operating_point(30000.0f, 20.0f, 50.0f, 1500.0f, 4180.0f, 5.0f);
-  assert(op2.feasible);
-}
-
-void test_insufficient_headroom_power_too_high() {
-  // 50kW, inlet 20, max 50, flow 800 -> required flow >1500 -> infeasible
+void test_generic_helper_reports_large_required_flow() {
+  // The pure helper reports the theoretical requirement; policy caps belong in the OT wrapper.
   auto op = compute_operating_point(50000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
-  assert(!op.feasible);
+  assert(op.feasible);
+  assert(op.required_flow_lph > 1500.0f);
+  assert(!op.flow_limited);
 }
 
 void test_hard_trip_preserved() {
-  // Hard trip is max +5, not affected by commissioning headroom
-  // This test just ensures our helper doesn't touch hard trip logic
   float max_c = 60.0f;
   float trip_c = max_c + 5.0f;
   assert(trip_c == 65.0f);
-  // Commissioning target must be below max, not trip
   auto op = compute_operating_point(6000.0f, 20.0f, max_c, 800.0f, 4180.0f, 5.0f);
   assert(op.feasible);
+  assert(op.target_temperature_c == 55.0f);
   assert(op.target_temperature_c < max_c);
   assert(op.target_temperature_c < trip_c);
 }
 
 void test_opentherm_uses_ot_max_capacity() {
-  // OT max 30kW should be used instead of rated 6kW -> requires higher flow
+  // 30 kW at 20C return theoretically needs >1000 L/h, so OT policy caps at 1000 and marks limited.
   auto op_ot = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
-  auto op_rated = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op_ot.feasible);
-  assert(op_rated.feasible);
-  // OT missing keeps at 800 (not 1500, many systems cannot reach 1500)
-  assert(op_rated.required_flow_lph == 800.0f);
-  assert(op_ot.required_flow_lph > 800.0f);
-  assert(op_ot.required_flow_lph < 1500.0f);
-  // R1 should not use OT logic
-  auto op_r1 = compute_opentherm_operating_point(false, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
-  assert(op_r1.feasible);
-  assert(op_r1.required_flow_lph == 800.0f);    // R1 keeps configured flow
-  assert(op_r1.target_temperature_c == 45.0f);  // max - headroom
+  assert(op_ot.flow_limited);
+  assert(op_ot.required_flow_lph == 1000.0f);
+  assert(op_ot.target_temperature_c == 45.0f);
 }
 
-void test_opentherm_missing_max_capacity() {
-  // OT max missing -> keep at 800, not 1500 (many systems cannot reach 1500)
+void test_opentherm_missing_max_capacity_keeps_base_flow() {
   auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op.feasible);
+  assert(!op.flow_limited);
   assert(op.required_flow_lph == 800.0f);
   assert(op.target_temperature_c == 45.0f);
+
   auto op_zero = compute_opentherm_operating_point(true, 0.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op_zero.feasible);
   assert(op_zero.required_flow_lph == 800.0f);
 }
 
+void test_missing_max_capacity_still_requires_thermal_headroom() {
+  auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 45.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(!op.feasible);
+}
+
+void test_r1_keeps_configured_flow() {
+  auto op = compute_opentherm_operating_point(false, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op.feasible);
+  assert(!op.flow_limited);
+  assert(op.required_flow_lph == 800.0f);
+  assert(op.target_temperature_c == 45.0f);
+}
+
 void test_dynamic_flow_after_preflow() {
-  // Simulate 800 preflow with OT 30kW, inlet 22 -> required ~860, feasible
-  auto op1 = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 22.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  // 25 kW at 20C fits below 1000 L/h.
+  auto op1 = compute_opentherm_operating_point(true, 25000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op1.feasible);
+  assert(!op1.flow_limited);
   assert(op1.required_flow_lph > 800.0f);
-  assert(op1.required_flow_lph < 1500.0f);
-  // After 2 min, inlet rises to 30 (warmer return), required flow becomes higher
-  // With inlet 30, available headroom = 15C, required flow = 30000/(4180*15)=1722 >1500 -> infeasible
-  auto op2 = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 30.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
-  assert(!op2.feasible);
-  // With a more powerful flow (1200) and same inlet 30, it would still be infeasible, showing need for re-evaluation
-  // The task should detect this and fail with insufficient headroom rather than starting boiler
+  assert(op1.required_flow_lph < 1000.0f);
+
+  // After preflow the return rises. The same boiler now needs >1000, but remains a valid limited test.
+  auto op2 = compute_opentherm_operating_point(true, 25000.0f, 6000.0f, 30.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op2.feasible);
+  assert(op2.flow_limited);
+  assert(op2.required_flow_lph == 1000.0f);
+}
+
+void test_very_high_theoretical_flow_is_limited_not_refused() {
+  // 30 kW at 30C would theoretically require ~1720 L/h. Policy keeps the test at 1000 instead of refusing.
+  auto op = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 30.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op.feasible);
+  assert(op.flow_limited);
+  assert(op.required_flow_lph == 1000.0f);
+  assert(op.target_temperature_c == 45.0f);
 }
 
 }  // namespace
@@ -100,11 +102,13 @@ void test_dynamic_flow_after_preflow() {
 int main() {
   test_sufficient_headroom();
   test_insufficient_headroom_inlet_high();
-  test_high_power_requires_higher_flow();
-  test_insufficient_headroom_power_too_high();
+  test_generic_helper_reports_large_required_flow();
   test_hard_trip_preserved();
   test_opentherm_uses_ot_max_capacity();
-  test_opentherm_missing_max_capacity();
+  test_opentherm_missing_max_capacity_keeps_base_flow();
+  test_missing_max_capacity_still_requires_thermal_headroom();
+  test_r1_keeps_configured_flow();
   test_dynamic_flow_after_preflow();
+  test_very_high_theoretical_flow_is_limited_not_refused();
   return 0;
 }

--- a/tests/host/boiler_commissioning_logic_test.cpp
+++ b/tests/host/boiler_commissioning_logic_test.cpp
@@ -11,7 +11,8 @@ void test_sufficient_headroom() {
   auto op = compute_operating_point(6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op.feasible);
   assert(op.target_temperature_c == 45.0f);
-  assert(op.required_flow_lph < 800.0f);
+  assert(op.theoretical_flow_lph < 800.0f);
+  assert(op.target_flow_lph == op.theoretical_flow_lph);
 }
 
 void test_insufficient_headroom_inlet_high() {
@@ -20,11 +21,11 @@ void test_insufficient_headroom_inlet_high() {
   assert(op.reason != nullptr);
 }
 
-void test_generic_helper_reports_large_required_flow() {
-  // The pure helper reports the theoretical requirement; policy caps belong in the OT wrapper.
+void test_generic_helper_preserves_theoretical_flow() {
   auto op = compute_operating_point(50000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op.feasible);
-  assert(op.required_flow_lph > 1500.0f);
+  assert(op.theoretical_flow_lph > 1500.0f);
+  assert(op.target_flow_lph == op.theoretical_flow_lph);
   assert(!op.flow_limited);
 }
 
@@ -39,62 +40,70 @@ void test_hard_trip_preserved() {
   assert(op.target_temperature_c < trip_c);
 }
 
-void test_opentherm_uses_ot_max_capacity() {
-  // 30 kW at 20C return theoretically needs >1000 L/h, so OT policy caps at 1000 and marks limited.
-  auto op_ot = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
-  assert(op_ot.feasible);
-  assert(op_ot.flow_limited);
-  assert(op_ot.required_flow_lph == 1000.0f);
-  assert(op_ot.target_temperature_c == 45.0f);
+void test_opentherm_known_capacity_selects_max_1000() {
+  auto op = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f);
+  assert(op.feasible);
+  assert(op.flow_limited);
+  assert(op.theoretical_flow_lph > 1000.0f);
+  assert(op.target_flow_lph == 1000.0f);
+  assert(op.target_temperature_c == 45.0f);
 }
 
 void test_opentherm_missing_max_capacity_keeps_base_flow() {
-  auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f);
   assert(op.feasible);
   assert(!op.flow_limited);
-  assert(op.required_flow_lph == 800.0f);
+  assert(isnan(op.theoretical_flow_lph));
+  assert(op.target_flow_lph == 800.0f);
   assert(op.target_temperature_c == 45.0f);
 
-  auto op_zero = compute_opentherm_operating_point(true, 0.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  auto op_zero = compute_opentherm_operating_point(true, 0.0f, 6000.0f, 20.0f, 50.0f, 800.0f);
   assert(op_zero.feasible);
-  assert(op_zero.required_flow_lph == 800.0f);
+  assert(op_zero.target_flow_lph == 800.0f);
 }
 
 void test_missing_max_capacity_still_requires_thermal_headroom() {
-  auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 45.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 45.0f, 50.0f, 800.0f);
   assert(!op.feasible);
 }
 
 void test_r1_keeps_configured_flow() {
-  auto op = compute_opentherm_operating_point(false, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  auto op = compute_opentherm_operating_point(false, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f);
   assert(op.feasible);
   assert(!op.flow_limited);
-  assert(op.required_flow_lph == 800.0f);
+  assert(op.target_flow_lph == 800.0f);
   assert(op.target_temperature_c == 45.0f);
 }
 
-void test_dynamic_flow_after_preflow() {
-  // 25 kW at 20C fits below 1000 L/h.
-  auto op1 = compute_opentherm_operating_point(true, 25000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+void test_dynamic_flow_after_initial_800_preflow() {
+  auto op1 = compute_opentherm_operating_point(true, 25000.0f, 6000.0f, 20.0f, 50.0f, 800.0f);
   assert(op1.feasible);
   assert(!op1.flow_limited);
-  assert(op1.required_flow_lph > 800.0f);
-  assert(op1.required_flow_lph < 1000.0f);
+  assert(op1.target_flow_lph > 800.0f);
+  assert(op1.target_flow_lph < 1000.0f);
+  assert(op1.theoretical_flow_lph == op1.target_flow_lph);
 
-  // After preflow the return rises. The same boiler now needs >1000, but remains a valid limited test.
-  auto op2 = compute_opentherm_operating_point(true, 25000.0f, 6000.0f, 30.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  auto op2 = compute_opentherm_operating_point(true, 25000.0f, 6000.0f, 30.0f, 50.0f, 800.0f);
   assert(op2.feasible);
   assert(op2.flow_limited);
-  assert(op2.required_flow_lph == 1000.0f);
+  assert(op2.theoretical_flow_lph > 1000.0f);
+  assert(op2.target_flow_lph == 1000.0f);
 }
 
 void test_very_high_theoretical_flow_is_limited_not_refused() {
-  // 30 kW at 30C would theoretically require ~1720 L/h. Policy keeps the test at 1000 instead of refusing.
-  auto op = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 30.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  auto op = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 30.0f, 50.0f, 800.0f);
   assert(op.feasible);
   assert(op.flow_limited);
-  assert(op.required_flow_lph == 1000.0f);
-  assert(op.target_temperature_c == 45.0f);
+  assert(op.theoretical_flow_lph > 1500.0f);
+  assert(op.target_flow_lph == 1000.0f);
+}
+
+void test_apply_policy() {
+  assert(result_apply_allowed(false, true, false));
+  assert(result_apply_allowed(true, true, false));
+  assert(!result_apply_allowed(true, false, false));
+  assert(!result_apply_allowed(true, true, true));
+  assert(!result_apply_allowed(true, false, true));
 }
 
 }  // namespace
@@ -102,13 +111,14 @@ void test_very_high_theoretical_flow_is_limited_not_refused() {
 int main() {
   test_sufficient_headroom();
   test_insufficient_headroom_inlet_high();
-  test_generic_helper_reports_large_required_flow();
+  test_generic_helper_preserves_theoretical_flow();
   test_hard_trip_preserved();
-  test_opentherm_uses_ot_max_capacity();
+  test_opentherm_known_capacity_selects_max_1000();
   test_opentherm_missing_max_capacity_keeps_base_flow();
   test_missing_max_capacity_still_requires_thermal_headroom();
   test_r1_keeps_configured_flow();
-  test_dynamic_flow_after_preflow();
+  test_dynamic_flow_after_initial_800_preflow();
   test_very_high_theoretical_flow_is_limited_not_refused();
+  test_apply_policy();
   return 0;
 }

--- a/tests/host/boiler_commissioning_logic_test.cpp
+++ b/tests/host/boiler_commissioning_logic_test.cpp
@@ -59,9 +59,10 @@ void test_opentherm_uses_ot_max_capacity() {
   auto op_rated = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op_ot.feasible);
   assert(op_rated.feasible);
-  // OT 30kW needs more flow than 6kW
-  assert(op_ot.required_flow_lph > op_rated.required_flow_lph);
+  // OT missing is conservative 1500, OT 30kW needs ~1034 which is >800 but <1500
+  assert(op_rated.required_flow_lph == 1500.0f);
   assert(op_ot.required_flow_lph > 800.0f);
+  assert(op_ot.required_flow_lph < 1500.0f);
   // R1 should not use OT logic
   auto op_r1 = compute_opentherm_operating_point(false, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op_r1.feasible);
@@ -70,12 +71,14 @@ void test_opentherm_uses_ot_max_capacity() {
 }
 
 void test_opentherm_missing_max_capacity() {
-  // OT max missing -> should use rated power (fallback)
+  // OT max missing -> conservative high flow (1500) with max-5 target
   auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op.feasible);
-  // With OT max 0, should be infeasible or fallback
+  assert(op.required_flow_lph == 1500.0f);
+  assert(op.target_temperature_c == 45.0f);
   auto op_zero = compute_opentherm_operating_point(true, 0.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
-  assert(op_zero.feasible);  // fallback to rated
+  assert(op_zero.feasible);
+  assert(op_zero.required_flow_lph == 1500.0f);
 }
 
 void test_dynamic_flow_after_preflow() {

--- a/tests/host/boiler_commissioning_logic_test.cpp
+++ b/tests/host/boiler_commissioning_logic_test.cpp
@@ -53,6 +53,45 @@ void test_hard_trip_preserved() {
   assert(op.target_temperature_c < trip_c);
 }
 
+void test_opentherm_uses_ot_max_capacity() {
+  // OT max 30kW should be used instead of rated 6kW -> requires higher flow
+  auto op_ot = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  auto op_rated = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op_ot.feasible);
+  assert(op_rated.feasible);
+  // OT 30kW needs more flow than 6kW
+  assert(op_ot.required_flow_lph > op_rated.required_flow_lph);
+  assert(op_ot.required_flow_lph > 800.0f);
+  // R1 should not use OT logic
+  auto op_r1 = compute_opentherm_operating_point(false, 30000.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op_r1.feasible);
+  assert(op_r1.required_flow_lph == 800.0f);    // R1 keeps configured flow
+  assert(op_r1.target_temperature_c == 45.0f);  // max - headroom
+}
+
+void test_opentherm_missing_max_capacity() {
+  // OT max missing -> should use rated power (fallback)
+  auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op.feasible);
+  // With OT max 0, should be infeasible or fallback
+  auto op_zero = compute_opentherm_operating_point(true, 0.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op_zero.feasible);  // fallback to rated
+}
+
+void test_dynamic_flow_after_preflow() {
+  // Simulate 800 preflow with OT 30kW, inlet 22 -> required ~860, feasible
+  auto op1 = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 22.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op1.feasible);
+  assert(op1.required_flow_lph > 800.0f);
+  assert(op1.required_flow_lph < 1500.0f);
+  // After 2 min, inlet rises to 30 (warmer return), required flow becomes higher
+  // With inlet 30, available headroom = 15C, required flow = 30000/(4180*15)=1722 >1500 -> infeasible
+  auto op2 = compute_opentherm_operating_point(true, 30000.0f, 6000.0f, 30.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(!op2.feasible);
+  // With a more powerful flow (1200) and same inlet 30, it would still be infeasible, showing need for re-evaluation
+  // The task should detect this and fail with insufficient headroom rather than starting boiler
+}
+
 }  // namespace
 
 int main() {
@@ -61,5 +100,8 @@ int main() {
   test_high_power_requires_higher_flow();
   test_insufficient_headroom_power_too_high();
   test_hard_trip_preserved();
+  test_opentherm_uses_ot_max_capacity();
+  test_opentherm_missing_max_capacity();
+  test_dynamic_flow_after_preflow();
   return 0;
 }

--- a/tests/host/boiler_commissioning_logic_test.cpp
+++ b/tests/host/boiler_commissioning_logic_test.cpp
@@ -59,8 +59,8 @@ void test_opentherm_uses_ot_max_capacity() {
   auto op_rated = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op_ot.feasible);
   assert(op_rated.feasible);
-  // OT missing is conservative 1500, OT 30kW needs ~1034 which is >800 but <1500
-  assert(op_rated.required_flow_lph == 1500.0f);
+  // OT missing keeps at 800 (not 1500, many systems cannot reach 1500)
+  assert(op_rated.required_flow_lph == 800.0f);
   assert(op_ot.required_flow_lph > 800.0f);
   assert(op_ot.required_flow_lph < 1500.0f);
   // R1 should not use OT logic
@@ -71,14 +71,14 @@ void test_opentherm_uses_ot_max_capacity() {
 }
 
 void test_opentherm_missing_max_capacity() {
-  // OT max missing -> conservative high flow (1500) with max-5 target
+  // OT max missing -> keep at 800, not 1500 (many systems cannot reach 1500)
   auto op = compute_opentherm_operating_point(true, NAN, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op.feasible);
-  assert(op.required_flow_lph == 1500.0f);
+  assert(op.required_flow_lph == 800.0f);
   assert(op.target_temperature_c == 45.0f);
   auto op_zero = compute_opentherm_operating_point(true, 0.0f, 6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op_zero.feasible);
-  assert(op_zero.required_flow_lph == 1500.0f);
+  assert(op_zero.required_flow_lph == 800.0f);
 }
 
 void test_dynamic_flow_after_preflow() {

--- a/tests/host/boiler_commissioning_logic_test.cpp
+++ b/tests/host/boiler_commissioning_logic_test.cpp
@@ -1,0 +1,65 @@
+#include <assert.h>
+#include <math.h>
+
+#include "../../openquatt/includes/boiler/oq_boiler_commissioning_logic.h"
+
+namespace {
+
+using namespace oq_boiler_commissioning;
+
+void test_sufficient_headroom() {
+  // Rated 6kW, inlet 20, max 50, flow 800, headroom 5 -> available headroom 25C, required flow ~206 L/h, feasible
+  auto op = compute_operating_point(6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op.feasible);
+  assert(op.target_temperature_c < 50.0f);
+  assert(op.target_temperature_c <= 45.0f);  // max - headroom
+  assert(op.required_flow_lph < 800.0f);
+}
+
+void test_insufficient_headroom_inlet_high() {
+  // Inlet 48, max 50, headroom 5 -> available  -3 -> infeasible
+  auto op = compute_operating_point(6000.0f, 48.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(!op.feasible);
+  assert(op.reason != nullptr);
+}
+
+void test_high_power_requires_higher_flow() {
+  // 30kW, inlet 20, max 50, flow 800 -> required flow ~860, feasible but needs higher flow
+  auto op = compute_operating_point(30000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(op.feasible);
+  assert(op.required_flow_lph > 800.0f);
+  assert(op.required_flow_lph < 1500.0f);
+  // With flow 1500, should still be feasible but target capped
+  auto op2 = compute_operating_point(30000.0f, 20.0f, 50.0f, 1500.0f, 4180.0f, 5.0f);
+  assert(op2.feasible);
+}
+
+void test_insufficient_headroom_power_too_high() {
+  // 50kW, inlet 20, max 50, flow 800 -> required flow >1500 -> infeasible
+  auto op = compute_operating_point(50000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
+  assert(!op.feasible);
+}
+
+void test_hard_trip_preserved() {
+  // Hard trip is max +5, not affected by commissioning headroom
+  // This test just ensures our helper doesn't touch hard trip logic
+  float max_c = 60.0f;
+  float trip_c = max_c + 5.0f;
+  assert(trip_c == 65.0f);
+  // Commissioning target must be below max, not trip
+  auto op = compute_operating_point(6000.0f, 20.0f, max_c, 800.0f, 4180.0f, 5.0f);
+  assert(op.feasible);
+  assert(op.target_temperature_c < max_c);
+  assert(op.target_temperature_c < trip_c);
+}
+
+}  // namespace
+
+int main() {
+  test_sufficient_headroom();
+  test_insufficient_headroom_inlet_high();
+  test_high_power_requires_higher_flow();
+  test_insufficient_headroom_power_too_high();
+  test_hard_trip_preserved();
+  return 0;
+}

--- a/tests/host/otb_telemetry_logic_test.cpp
+++ b/tests/host/otb_telemetry_logic_test.cpp
@@ -1,0 +1,70 @@
+#include <assert.h>
+
+#include "../../openquatt/includes/boiler/oq_otb_telemetry.h"
+
+namespace {
+
+using namespace oq_otb;
+
+void test_repeating_field_expires_by_age() {
+  TelemetryState state;
+  state.record_response(1000, 0, MESSAGE_TYPE_READ_ACK);
+  assert(state.field_is_fresh(FIELD_STATUS, 10000, 10000));
+  assert(!state.field_is_fresh(FIELD_STATUS, 11001, 10000));
+}
+
+void test_initial_fields_remain_valid_for_session() {
+  TelemetryState state;
+
+  state.record_response(1000, 3, MESSAGE_TYPE_READ_ACK);
+  state.record_response(1100, 15, MESSAGE_TYPE_READ_ACK);
+  state.record_response(1200, 125, MESSAGE_TYPE_READ_ACK);
+  state.record_response(1300, 127, MESSAGE_TYPE_READ_ACK);
+
+  constexpr uint32_t much_later_ms = 600000;
+  constexpr uint32_t repeating_timeout_ms = 10000;
+  assert(state.field_is_fresh(FIELD_DEVICE_CONFIG, much_later_ms, repeating_timeout_ms));
+  assert(state.field_is_fresh(FIELD_MAX_BOILER_CAPACITY, much_later_ms, repeating_timeout_ms));
+  assert(state.field_is_fresh(FIELD_OT_VERSION_DEVICE, much_later_ms, repeating_timeout_ms));
+  assert(state.field_is_fresh(FIELD_VERSION_DEVICE, much_later_ms, repeating_timeout_ms));
+}
+
+void test_negative_ack_invalidates_initial_field() {
+  TelemetryState state;
+  state.record_response(1000, 15, MESSAGE_TYPE_READ_ACK);
+  assert(state.field_is_valid(FIELD_MAX_BOILER_CAPACITY));
+
+  state.record_response(2000, 15, MESSAGE_TYPE_UNKNOWN_DATA_ID);
+  assert(!state.field_is_valid(FIELD_MAX_BOILER_CAPACITY));
+  assert(!state.field_is_fresh(FIELD_MAX_BOILER_CAPACITY, 3000, 10000));
+}
+
+void test_session_reset_invalidates_initial_field() {
+  TelemetryState state;
+  state.record_response(1000, 15, MESSAGE_TYPE_READ_ACK);
+  assert(state.field_is_valid(FIELD_MAX_BOILER_CAPACITY));
+
+  state.reset_link_session();
+  assert(!state.field_is_valid(FIELD_MAX_BOILER_CAPACITY));
+  assert(!state.field_is_fresh(FIELD_MAX_BOILER_CAPACITY, 2000, 10000));
+}
+
+void test_stale_link_expiry_invalidates_initial_field() {
+  TelemetryState state;
+  state.record_response(1000, 15, MESSAGE_TYPE_READ_ACK);
+  assert(state.field_is_valid(FIELD_MAX_BOILER_CAPACITY));
+
+  assert(state.expire_response_session_if_stale(12001, 10000));
+  assert(!state.field_is_valid(FIELD_MAX_BOILER_CAPACITY));
+}
+
+}  // namespace
+
+int main() {
+  test_repeating_field_expires_by_age();
+  test_initial_fields_remain_valid_for_session();
+  test_negative_ack_invalidates_initial_field();
+  test_session_reset_invalidates_initial_field();
+  test_stale_link_expiry_invalidates_initial_field();
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Voorkomt dat de CM100-ketelvermogentest via **OpenTherm** direct tegen de ingestelde maximale watertemperatuur aanloopt en zichzelf daardoor afbreekt.
- De test gebruikt voortaan `TSet = max_water_temp_limit_c - 5 °C` en begint **altijd op 800 L/h**. Pas nadat die flow minimaal 2 minuten stabiel is, wordt met de actuele retourtemperatuur bekeken of een hoger testdebiet zinvol is; het gekozen flowdoel blijft maximaal **1000 L/h**.
- OpenTherm Data ID 15 (`max_capacity`) is optioneel. Zonder ID15 kan de test nog steeds draaien op 800 L/h, maar het resultaat is dan informatief en kan niet automatisch als `Boiler rated heat power` worden toegepast.

Als ID15 wél beschikbaar is, berekent OpenQuatt de theoretisch benodigde flow uit ketelcapaciteit en beschikbare temperatuurmarge. Die theoretische waarde blijft apart beschikbaar van het daadwerkelijk gekozen flowdoel. Ligt de theoretische behoefte boven 1000 L/h, dan draait de test maximaal op 1000 L/h en wordt het resultaat als **flow limited** gemarkeerd.

Een resultaat is alleen toepasbaar als de OpenTherm-ketelcapaciteit bekend is én de test niet door de 1000 L/h-grens is beperkt. Bij `flow limited` of `capacity unverified` wordt de meting wel getoond, maar de confidence wordt begrensd en de firmware weigert Apply.

Voor betere diagnose zijn de twee waarden uit OpenTherm Data ID 15 toegevoegd aan de standaard debugopname:

- `otbMaxCapacity` — maximum boiler capacity (kW)
- `otbMinModulation` — minimum modulation (%)

Tijdens simulatorvalidatie kwam bovendien een bestaande freshness-bug aan het licht: ID15 en andere `keep_updated=False` OpenTherm-velden werden na 10 seconden als stale gewist, terwijl ze alleen tijdens de initialisatiefase worden opgevraagd. Initial/static OT-velden blijven nu geldig gedurende de actieve linksessie en worden pas ongeldig bij een negatieve response of een echte link/session reset. Repeating telemetry houdt de bestaande 10s freshnessbewaking.

R1 blijft buiten deze OpenTherm-headroomlogica en houdt het bestaande testgedrag met 800 L/h. De bestaande boiler-inhibit en hard-trip blijven ongewijzigd actief.

Reproduceerbare commando's:
- `./scripts/run_host_regression_tests.sh`
- `npm run check:web`
- `python scripts/dev.py validate --config-only --jobs 2`

Closes #467

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

## Achtergrond en aanpak

Tijdens een veldtest met een Intergas HRE 36/30 startte de ketel via OpenTherm correct, maar liep de aanvoertemperatuur vrijwel direct op tot ongeveer 51 °C terwijl zowel de OpenTherm-TSet als de ingestelde maximale watertemperatuur op 50 °C stonden. Daardoor activeerde de bestaande boiler-inhibit en stopte de test voordat een bruikbare vermogensmeting kon worden uitgevoerd.

Tijdens de verdere uitwerking bleek dat OT Data ID 15 niet als verplichte input gebruikt kan worden: niet iedere geldige OpenTherm-ketel hoeft deze optionele Data ID te ondersteunen. Ook is een generiek flowdoel van 1500 L/h niet passend, omdat veel installaties dat hydraulisch niet kunnen halen.

De uiteindelijke aanpak:

- OpenTherm-TSet tijdens commissioning maximaal `max_water_temp_limit_c - 5 °C`;
- iedere test begint op 800 L/h;
- na de eerste stabiele preflow wordt opnieuw gerekend met de actuele retourtemperatuur;
- ID15 wordt gebruikt als optimalisatie wanneer de ketel deze capaciteit meldt;
- theoretisch benodigde flow en daadwerkelijk gekozen flowdoel worden apart bijgehouden;
- gekozen testflow blijft tussen 800 en 1000 L/h;
- theoretische flow >1000 L/h geeft een `flow limited` meting;
- ontbrekende ID15 geeft een `capacity unverified` meting op 800 L/h;
- `flow limited` en `capacity unverified` resultaten worden niet naar de boiler-rating geschreven;
- alleen een geverifieerde, niet-begrensde OT-meting kan via Apply worden overgenomen;
- boiler-inhibit en hard-trip blijven fail-safe actief.

De theoretische flow wordt bepaald uit `required flow = P / (cp × beschikbare ΔT)`. Deze waarde wordt gebruikt om het testpunt te beoordelen, maar wordt niet blind als pompdoel opgelegd.

### OpenTherm static/initial telemetry

`DEVICE_CONFIG`, `MAX_BOILER_CAPACITY` (ID15), `OT_VERSION_DEVICE` en `VERSION_DEVICE` zijn initial/static OT-velden. De telemetriestate onderscheidt deze nu van repeating velden:

- initial/static velden blijven geldig zolang dezelfde OT-linksessie geldig is;
- `UNKNOWN_DATAID`, `DATA_INVALID` of een andere onbruikbare response maakt het betreffende veld direct ongeldig;
- `reset_link_session()` en een verlopen link/session maken de waarden eveneens ongeldig;
- repeating/control-critical velden, waaronder STATUS en temperaturen, behouden hun bestaande freshness-timeout.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit blijft een correctie van de bestaande commissioning-test en OT-telemetrielifecycle. Er komen geen nieuwe gebruikersinstellingen of Home Assistant-entities bij. De bestaande ID15-entities worden alleen toegevoegd aan de debugopname.

## Validatie

### Geautomatiseerd

- host-regressies dekken voldoende/onvoldoende headroom, ontbrekende ID15, bekende OT-capaciteit, theoretische versus gekozen flow, 800 L/h fallback, 1000 L/h cap en Apply-policy;
- debug-observabilitytest borgt `otbMaxCapacity` en `otbMinModulation` in het opnamecontract;
- `otb_telemetry_logic_test` borgt dat repeating STATUS wel op leeftijd expireert, maar initial/static velden geldig blijven gedurende de sessie en alsnog ongeldig worden bij negatieve response, session reset of stale link;
- normale CI op de actuele fix is groen; PR Test Firmware Build is gebruikt voor de HIL-validatie.

### HIL / OT-ketelsimulator

**Functionele commissioningruns** (`v0.48.0-pr.487.869+e37c447`):
- test start op circa **800 L/h** en houdt die flow stabiel tijdens de eerste preflow;
- ketel wordt pas na ongeveer **2 minuten** stabiele preflow geactiveerd;
- bij `Maximum water temperature = 50 °C` wordt **TSet = 45 °C** gestuurd;
- `otbChCommand`, `otbChActive` en `otbFlameOn` worden correct actief;
- geen `water temperature boiler inhibit active`;
- geen OT transport errors of response timeouts;
- ketelvraag wordt aan het einde weer netjes ingetrokken.

**ID15-observability vóór freshnessfix** (`v0.48.0-pr.487.874+6a40962`):
- debugrecording uitgebreid van 164 naar **166 kolommen** met `otbMaxCapacity` en `otbMinModulation`;
- ID15 verscheen tijdens de opname als unavailable/null;
- codeonderzoek wees uit dat OpenQuatt een eenmaal ontvangen initial/static waarde na 10 seconden zelf invalideerde.

**ID15/freshness HIL na fix** (`v0.48.0-pr.487.877+c9c368f`):
- simulator levert ID15 correct als **20 kW maximum capacity / 20% minimum modulation**;
- beide waarden staan direct in de debugrecording en blijven gedurende de volledige opname van ruim **5 minuten** geldig;
- hiermee is de 10s freshnessbug HIL bevestigd als opgelost;
- commissioning start opnieuw op circa **800 L/h**;
- bij 20 kW en de actuele retourtemperatuur is geen hogere flow nodig en blijft het doel terecht 800 L/h;
- na stabiele preflow wordt TSet 45 °C gestuurd en worden CH/flame correct actief;
- response counter loopt normaal door en transport errors/timeouts blijven 0;
- geen ongewenste thermal inhibit.

De simulator genereert geen werkelijk hydraulisch ketelvermogen in het OpenQuatt-watercircuit. Daardoor kan `MEASURING -> DONE` met een realistische vermogensmeting niet volledig end-to-end worden gesimuleerd. De relevante control-, safety-, OT-, ID15- en freshnesspaden voor deze fix zijn wel HIL gevalideerd.

## Resultaat

De oorspronkelijke self-abort uit #467 is opgelost zonder de bestaande temperatuurbeveiligingen af te zwakken. Daarnaast is de tijdens het testen gevonden ID15/static-telemetry freshnessbug gecorrigeerd en met de simulator bevestigd.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

De wijziging voegt alleen beperkte commissioning-state en berekeningslogica toe. Er komen geen nieuwe tasks, grote buffers of dynamische allocatiepaden bij. De twee extra debugvelden gebruiken het bestaande vaste PSRAM-opnamebuffer en zijn in de praktijk statisch, waardoor de retentie-impact verwaarloosbaar is.