### PR TITLE
Fail CM100 boiler test early when required flow is unreachable

### DIFF
--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -99,6 +99,57 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
   return op;
 }
 
+class FlowReachabilityMonitor {
+ public:
+  void reset() {
+    saturated_since_ms_ = 0;
+    reference_flow_lph_ = NAN;
+    best_flow_lph_ = NAN;
+  }
+
+  bool update(uint32_t now_ms, float flow_lph, float target_flow_lph, float flow_band_lph, float output_ipwm,
+              uint32_t hold_ms = 60000UL, float saturation_ipwm = 60.0f, float progress_lph = 20.0f) {
+    if (isnan(flow_lph) || isnan(target_flow_lph) || isnan(flow_band_lph) || isnan(output_ipwm) || flow_lph <= 0.0f ||
+        target_flow_lph <= 0.0f || flow_band_lph < 0.0f || hold_ms == 0 || progress_lph < 0.0f) {
+      reset();
+      return false;
+    }
+
+    const float lower_flow_lph = target_flow_lph - flow_band_lph;
+    if (flow_lph >= lower_flow_lph || output_ipwm > saturation_ipwm) {
+      reset();
+      return false;
+    }
+
+    if (saturated_since_ms_ == 0) {
+      saturated_since_ms_ = now_ms;
+      reference_flow_lph_ = flow_lph;
+      best_flow_lph_ = flow_lph;
+      return false;
+    }
+
+    if (isnan(best_flow_lph_) || flow_lph > best_flow_lph_) best_flow_lph_ = flow_lph;
+    if (best_flow_lph_ >= reference_flow_lph_ + progress_lph) {
+      saturated_since_ms_ = now_ms;
+      reference_flow_lph_ = best_flow_lph_;
+      return false;
+    }
+
+    return (uint32_t)(now_ms - saturated_since_ms_) >= hold_ms;
+  }
+
+  float best_flow_lph() const { return best_flow_lph_; }
+
+  uint32_t saturated_duration_ms(uint32_t now_ms) const {
+    return saturated_since_ms_ == 0 ? 0UL : (uint32_t)(now_ms - saturated_since_ms_);
+  }
+
+ private:
+  uint32_t saturated_since_ms_{0};
+  float reference_flow_lph_{NAN};
+  float best_flow_lph_{NAN};
+};
+
 inline bool result_apply_allowed(bool opentherm_selected, bool capacity_verified, bool flow_limited) {
   return !opentherm_selected || (capacity_verified && !flow_limited);
 }

--- a/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_commissioning_logic.h
@@ -5,6 +5,21 @@
 
 namespace oq_boiler_commissioning {
 
+static constexpr float kDefaultMaxWaterTemperatureC = 60.0f;
+static constexpr float kMinMaxWaterTemperatureC = 25.0f;
+static constexpr float kMaxMaxWaterTemperatureC = 75.0f;
+static constexpr float kBoilerTestHeadroomC = 5.0f;
+
+inline float normalize_max_water_temperature_c(float max_c) {
+  if (isnan(max_c)) max_c = kDefaultMaxWaterTemperatureC;
+  return fmaxf(kMinMaxWaterTemperatureC, fminf(max_c, kMaxMaxWaterTemperatureC));
+}
+
+inline float commissioning_target_temperature_c(float max_c, float headroom_c = kBoilerTestHeadroomC) {
+  if (isnan(headroom_c) || headroom_c < 0.0f) return NAN;
+  return normalize_max_water_temperature_c(max_c) - headroom_c;
+}
+
 struct OperatingPoint {
   bool feasible = false;
   bool flow_limited = false;
@@ -16,17 +31,17 @@ struct OperatingPoint {
 };
 
 inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c, float max_c, float flow_lph,
-                                              float cp_j_per_kgk, float headroom_c = 5.0f) {
+                                              float cp_j_per_kgk, float headroom_c = kBoilerTestHeadroomC) {
   OperatingPoint out{};
   out.headroom_c = headroom_c;
 
   if (isnan(rated_power_w) || isnan(inlet_c) || isnan(max_c) || isnan(flow_lph) || isnan(cp_j_per_kgk) ||
-      rated_power_w <= 0.0f || flow_lph <= 0.0f || cp_j_per_kgk <= 0.0f) {
+      isnan(headroom_c) || rated_power_w <= 0.0f || flow_lph <= 0.0f || cp_j_per_kgk <= 0.0f || headroom_c < 0.0f) {
     out.reason = "invalid input";
     return out;
   }
 
-  const float max_target = max_c - headroom_c;
+  const float max_target = commissioning_target_temperature_c(max_c, headroom_c);
   const float available_headroom_c = max_target - inlet_c;
   if (available_headroom_c <= 0.0f) {
     out.reason = "insufficient thermal headroom for boiler power test";
@@ -45,8 +60,14 @@ inline OperatingPoint compute_operating_point(float rated_power_w, float inlet_c
 inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected, float otb_max_capacity_w,
                                                         float rated_power_w, float inlet_c, float max_c,
                                                         float base_flow_lph, float cp_j_per_kgk = 4180.0f,
-                                                        float headroom_c = 5.0f) {
-  const float max_target = max_c - headroom_c;
+                                                        float headroom_c = kBoilerTestHeadroomC) {
+  if (isnan(max_c) || isnan(headroom_c) || headroom_c < 0.0f) {
+    OperatingPoint out{};
+    out.headroom_c = headroom_c;
+    out.reason = "invalid input";
+    return out;
+  }
+  const float max_target = commissioning_target_temperature_c(max_c, headroom_c);
 
   if (!opentherm_selected) {
     (void)otb_max_capacity_w;
@@ -54,7 +75,7 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
     (void)cp_j_per_kgk;
     OperatingPoint out{};
     out.headroom_c = headroom_c;
-    if (isnan(inlet_c) || isnan(max_c) || isnan(base_flow_lph) || base_flow_lph <= 0.0f) {
+    if (isnan(inlet_c) || isnan(base_flow_lph) || base_flow_lph <= 0.0f) {
       out.reason = "invalid input";
       return out;
     }
@@ -65,7 +86,7 @@ inline OperatingPoint compute_opentherm_operating_point(bool opentherm_selected,
     return out;
   }
 
-  if (isnan(inlet_c) || isnan(max_c) || isnan(base_flow_lph) || base_flow_lph <= 0.0f) {
+  if (isnan(inlet_c) || isnan(base_flow_lph) || base_flow_lph <= 0.0f) {
     OperatingPoint out{};
     out.headroom_c = headroom_c;
     out.reason = "invalid input";
@@ -155,7 +176,7 @@ inline bool result_apply_allowed(bool opentherm_selected, bool capacity_verified
 }
 
 inline bool has_sufficient_headroom(float rated_power_w, float inlet_c, float max_c, float flow_lph, float cp_j_per_kgk,
-                                    float headroom_c = 5.0f) {
+                                    float headroom_c = kBoilerTestHeadroomC) {
   return compute_operating_point(rated_power_w, inlet_c, max_c, flow_lph, cp_j_per_kgk, headroom_c).feasible;
 }
 

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -12,6 +12,7 @@
 namespace oq_boiler_task {
 
 using oq_boiler_commissioning::compute_opentherm_operating_point;
+using oq_boiler_commissioning::normalize_max_water_temperature_c;
 using oq_boiler_commissioning::result_apply_allowed;
 
 static constexpr int TASK_NONE = oq_commissioning::TASK_NONE;
@@ -90,9 +91,7 @@ class BoilerPowerTestRuntime {
     active_test_opentherm_ =
         id(oq_boiler_connection).has_state() && id(oq_boiler_connection).current_option() == "OpenTherm";
     if (active_test_opentherm_) {
-      float max_c = id(max_water_temp_limit_c).state;
-      if (isnan(max_c)) max_c = 60.0f;
-      max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
+      const float max_c = normalize_max_water_temperature_c(id(max_water_temp_limit_c).state);
       float inlet_c = NAN;
       if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
         inlet_c = id(otb_return_water_temp).state;
@@ -289,6 +288,7 @@ class BoilerPowerTestRuntime {
   bool active_test_capacity_verified_{false};
   bool active_test_flow_limited_{false};
   bool active_test_result_apply_allowed_{false};
+  oq_boiler_commissioning::FlowReachabilityMonitor flow_reachability_{};
   int stable_flow_count_{0};
   int sample_count_{0};
   float sum_w_{0.0f};
@@ -337,6 +337,7 @@ class BoilerPowerTestRuntime {
 
   void reset_test_state() {
     reset_measurement_accumulators();
+    flow_reachability_.reset();
     active_test_flow_target_lph_ = NAN;
     active_test_capacity_w_ = NAN;
     active_test_theoretical_flow_lph_ = NAN;
@@ -400,6 +401,7 @@ class BoilerPowerTestRuntime {
     id(oq_commissioning_started_ms) = now_ms;
     id(oq_commissioning_state_since_ms) = now_ms;
     id(oq_commissioning_state_code) = STATE_FLOW_SETTLE;
+    flow_reachability_.reset();
     publish_status("FLOW_SETTLING");
   }
 
@@ -422,7 +424,28 @@ class BoilerPowerTestRuntime {
     return true;
   }
 
+  bool flow_reachable(const RuntimeConfig& cfg, uint32_t now_ms, float flow_lph) {
+    const uint32_t state_age_ms = now_ms - id(oq_commissioning_state_since_ms);
+    if (state_age_ms < cfg.flow_settle_min_ms) {
+      flow_reachability_.reset();
+      return true;
+    }
+    const float output_ipwm = id(oq_flow_output_ipwm).has_state() ? id(oq_flow_output_ipwm).state : NAN;
+    if (!flow_reachability_.update(now_ms, flow_lph, active_test_flow_target_lph_, cfg.flow_band_lph, output_ipwm)) {
+      return true;
+    }
+
+    ESP_LOGW("quatt.cm100.boiler",
+             "Boiler test flow unreachable (target=%.0fL/h flow=%.0fL/h best=%.0fL/h iPWM=%.0f saturated=%lus)",
+             active_test_flow_target_lph_, flow_lph, flow_reachability_.best_flow_lph(), output_ipwm,
+             (unsigned long)(flow_reachability_.saturated_duration_ms(now_ms) / 1000UL));
+    finish_task("FAILED: required boiler test flow cannot be reached", STATE_FAILED, false, true);
+    return false;
+  }
+
   void run_flow_settle(const RuntimeConfig& cfg, uint32_t now_ms, float flow_lph, bool flow_stable_now) {
+    if (!flow_reachable(cfg, now_ms, flow_lph)) return;
+
     stable_flow_count_ = flow_stable_now ? stable_flow_count_ + 1 : 0;
     if (stable_flow_count_ < cfg.stable_flow_samples ||
         (uint32_t)(now_ms - id(oq_commissioning_state_since_ms)) < cfg.flow_settle_min_ms) {
@@ -432,9 +455,7 @@ class BoilerPowerTestRuntime {
 
 #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
     if (active_test_opentherm_) {
-      float max_c = id(max_water_temp_limit_c).state;
-      if (isnan(max_c)) max_c = 60.0f;
-      max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
+      const float max_c = normalize_max_water_temperature_c(id(max_water_temp_limit_c).state);
       float inlet_c = NAN;
       if (id(otb_return_water_temp).has_state() && !isnan(id(otb_return_water_temp).state)) {
         inlet_c = id(otb_return_water_temp).state;
@@ -457,6 +478,7 @@ class BoilerPowerTestRuntime {
         active_test_flow_target_lph_ = op.target_flow_lph;
         set_number_value(id(oq_flow_setpoint_lph), active_test_flow_target_lph_);
         stable_flow_count_ = 0;
+        flow_reachability_.reset();
         id(oq_commissioning_state_since_ms) = now_ms;
         publish_status("FLOW_SETTLING");
         return;
@@ -464,6 +486,7 @@ class BoilerPowerTestRuntime {
     }
 #endif
 
+    flow_reachability_.reset();
     id(oq_commissioning_boiler_request_updated_ms) = now_ms;
     id(oq_commissioning_boiler_request) = true;
     id(oq_commissioning_state_code) = STATE_BOILER_SETTLE;

--- a/openquatt/oq_boiler_dispatch.yaml
+++ b/openquatt/oq_boiler_dispatch.yaml
@@ -146,10 +146,8 @@ interval:
             command.demand_present = true;
             command.heat_request = id(oq_commissioning_boiler_request);
             command.requested_power_w = id(oq_boiler_rated_heat_power).state;
-            float max_c = id(max_water_temp_limit_c).state;
-            if (isnan(max_c)) max_c = 60.0f;
-            max_c = fmaxf(25.0f, fminf(max_c, 75.0f));
-            command.target_temperature_c = max_c - 5.0f;
+            command.target_temperature_c = oq_boiler_commissioning::commissioning_target_temperature_c(
+                id(max_water_temp_limit_c).state);
             command.source = oq_boiler::COMMAND_SOURCE_COMMISSIONING;
             // Keep the authorization timestamp stable. A dispatcher pass is
             // not a fresh commissioning decision and must not re-arm the

--- a/openquatt/oq_boiler_test.yaml
+++ b/openquatt/oq_boiler_test.yaml
@@ -95,4 +95,45 @@ interval:
     then:
       - lambda: |-
           // Boiler power-test task runtime: owns flow settle, boiler settle, measurement and cooldown.
-          oq_boiler_task::runtime().tick(oq_boiler_task::default_config(), (uint32_t) millis());
+          // A separate reachability monitor only intervenes after the normal minimum preflow time when
+          // the pump has remained at (near) maximum output without meaningful flow progress.
+          static oq_boiler_commissioning::FlowReachabilityMonitor flow_reachability;
+          const auto cfg = oq_boiler_task::default_config();
+          const uint32_t now_ms = (uint32_t) millis();
+          const bool flow_settling =
+              id(oq_commissioning_active) &&
+              id(oq_commissioning_task_code) == oq_commissioning::TASK_BOILER_POWER_TEST &&
+              id(oq_commissioning_state_code) == oq_commissioning::TASK_STATE_FLOW_SETTLE;
+
+          if (flow_settling) {
+            const uint32_t state_age_ms = now_ms - id(oq_commissioning_state_since_ms);
+            const float flow_lph = id(flow_rate_selected).state;
+            const float target_flow_lph = id(oq_flow_setpoint_lph).state;
+            const float output_ipwm =
+                id(oq_flow_output_ipwm).has_state() ? id(oq_flow_output_ipwm).state : NAN;
+
+            if (state_age_ms >= cfg.flow_settle_min_ms &&
+                flow_reachability.update(now_ms, flow_lph, target_flow_lph, cfg.flow_band_lph, output_ipwm)) {
+              const float best_flow_lph = flow_reachability.best_flow_lph();
+              const uint32_t saturated_ms = flow_reachability.saturated_duration_ms(now_ms);
+              ESP_LOGW("quatt.cm100.boiler",
+                       "Boiler test flow unreachable (target=%.0fL/h flow=%.0fL/h best=%.0fL/h iPWM=%.0f saturated=%lus)",
+                       target_flow_lph, flow_lph, best_flow_lph, output_ipwm,
+                       (unsigned long)(saturated_ms / 1000UL));
+
+              // Reuse the normal abort path for fail-safe cleanup and restoration of the pre-test flow
+              // setpoint, then publish this guard as a failure rather than a user abort.
+              oq_boiler_task::runtime().abort_or_clear();
+              oq_boiler_task::runtime().tick(cfg, now_ms);
+              id(oq_commissioning_result_w) = NAN;
+              id(oq_commissioning_result_confidence) = 0.0f;
+              id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_FAILED;
+              oq_service_status::set_boiler_power_test("FAILED: required boiler test flow cannot be reached");
+              flow_reachability.reset();
+              return;
+            }
+          } else {
+            flow_reachability.reset();
+          }
+
+          oq_boiler_task::runtime().tick(cfg, now_ms);

--- a/openquatt/oq_boiler_test.yaml
+++ b/openquatt/oq_boiler_test.yaml
@@ -94,46 +94,6 @@ interval:
     startup_delay: 4600ms
     then:
       - lambda: |-
-          // Boiler power-test task runtime: owns flow settle, boiler settle, measurement and cooldown.
-          // A separate reachability monitor only intervenes after the normal minimum preflow time when
-          // the pump has remained at (near) maximum output without meaningful flow progress.
-          static oq_boiler_commissioning::FlowReachabilityMonitor flow_reachability;
-          const auto cfg = oq_boiler_task::default_config();
-          const uint32_t now_ms = (uint32_t) millis();
-          const bool flow_settling =
-              id(oq_commissioning_active) &&
-              id(oq_commissioning_task_code) == oq_commissioning::TASK_BOILER_POWER_TEST &&
-              id(oq_commissioning_state_code) == oq_commissioning::TASK_STATE_FLOW_SETTLE;
-
-          if (flow_settling) {
-            const uint32_t state_age_ms = now_ms - id(oq_commissioning_state_since_ms);
-            const float flow_lph = id(flow_rate_selected).state;
-            const float target_flow_lph = id(oq_flow_setpoint_lph).state;
-            const float output_ipwm =
-                id(oq_flow_output_ipwm).has_state() ? id(oq_flow_output_ipwm).state : NAN;
-
-            if (state_age_ms >= cfg.flow_settle_min_ms &&
-                flow_reachability.update(now_ms, flow_lph, target_flow_lph, cfg.flow_band_lph, output_ipwm)) {
-              const float best_flow_lph = flow_reachability.best_flow_lph();
-              const uint32_t saturated_ms = flow_reachability.saturated_duration_ms(now_ms);
-              ESP_LOGW("quatt.cm100.boiler",
-                       "Boiler test flow unreachable (target=%.0fL/h flow=%.0fL/h best=%.0fL/h iPWM=%.0f saturated=%lus)",
-                       target_flow_lph, flow_lph, best_flow_lph, output_ipwm,
-                       (unsigned long)(saturated_ms / 1000UL));
-
-              // Reuse the normal abort path for fail-safe cleanup and restoration of the pre-test flow
-              // setpoint, then publish this guard as a failure rather than a user abort.
-              oq_boiler_task::runtime().abort_or_clear();
-              oq_boiler_task::runtime().tick(cfg, now_ms);
-              id(oq_commissioning_result_w) = NAN;
-              id(oq_commissioning_result_confidence) = 0.0f;
-              id(oq_commissioning_state_code) = oq_commissioning::TASK_STATE_FAILED;
-              oq_service_status::set_boiler_power_test("FAILED: required boiler test flow cannot be reached");
-              flow_reachability.reset();
-              return;
-            }
-          } else {
-            flow_reachability.reset();
-          }
-
-          oq_boiler_task::runtime().tick(cfg, now_ms);
+          // BoilerPowerTestRuntime is the single owner of the CM100 boiler-test state machine,
+          // including flow reachability, boiler settle, measurement, failure cleanup and cooldown.
+          oq_boiler_task::runtime().tick(oq_boiler_task::default_config(), (uint32_t) millis());

--- a/scripts/run_host_regression_tests.sh
+++ b/scripts/run_host_regression_tests.sh
@@ -42,6 +42,9 @@ python3 "${repo_root}/scripts/tests/test_internal_heap_contract.py"
 echo "[run] OTB polling lifecycle contract"
 python3 "${repo_root}/scripts/tests/test_otb_polling_lifecycle_contract.py"
 
+echo "[run] boiler commissioning ownership contract"
+python3 "${repo_root}/scripts/tests/test_boiler_commissioning_ownership_contract.py"
+
 echo "[run] MQTT ingress lifecycle contract"
 python3 "${repo_root}/scripts/tests/test_mqtt_ingress_lifecycle_contract.py"
 

--- a/scripts/tests/test_boiler_commissioning_ownership_contract.py
+++ b/scripts/tests/test_boiler_commissioning_ownership_contract.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import unittest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BOILER_TEST_PACKAGE = (REPO_ROOT / "openquatt/oq_boiler_test.yaml").read_text(encoding="utf-8")
+BOILER_RUNTIME = (REPO_ROOT / "openquatt/includes/service/tasks/oq_boiler_task_logic.h").read_text(encoding="utf-8")
+BOILER_DISPATCH = (REPO_ROOT / "openquatt/oq_boiler_dispatch.yaml").read_text(encoding="utf-8")
+
+
+class BoilerCommissioningOwnershipContract(unittest.TestCase):
+    def test_yaml_only_delegates_runtime_tick(self) -> None:
+        self.assertIn("oq_boiler_task::runtime().tick", BOILER_TEST_PACKAGE)
+        self.assertNotIn("FlowReachabilityMonitor", BOILER_TEST_PACKAGE)
+        self.assertNotIn("oq_commissioning_state_code) =", BOILER_TEST_PACKAGE)
+        self.assertNotIn("abort_or_clear();\n              oq_boiler_task::runtime().tick", BOILER_TEST_PACKAGE)
+
+    def test_runtime_owns_flow_reachability_failure(self) -> None:
+        self.assertIn("FlowReachabilityMonitor flow_reachability_", BOILER_RUNTIME)
+        self.assertIn("bool flow_reachable", BOILER_RUNTIME)
+        self.assertIn('finish_task("FAILED: required boiler test flow cannot be reached"', BOILER_RUNTIME)
+        self.assertIn("if (!flow_reachable(cfg, now_ms, flow_lph)) return;", BOILER_RUNTIME)
+
+    def test_dispatch_reuses_commissioning_temperature_policy(self) -> None:
+        self.assertIn("oq_boiler_commissioning::commissioning_target_temperature_c", BOILER_DISPATCH)
+        commissioning_start = BOILER_DISPATCH.index("} else if (commissioning_task_active) {")
+        commissioning_block = BOILER_DISPATCH[commissioning_start:]
+        self.assertNotIn("max_c - 5.0f", commissioning_block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host/boiler_commissioning_logic_test.cpp
+++ b/tests/host/boiler_commissioning_logic_test.cpp
@@ -106,6 +106,43 @@ void test_apply_policy() {
   assert(!result_apply_allowed(true, false, true));
 }
 
+void test_unreachable_flow_after_sustained_saturation() {
+  FlowReachabilityMonitor monitor;
+  assert(!monitor.update(1000, 700.0f, 800.0f, 40.0f, 50.0f));
+  assert(!monitor.update(31000, 704.0f, 800.0f, 40.0f, 50.0f));
+  assert(monitor.update(61000, 703.0f, 800.0f, 40.0f, 50.0f));
+  assert(monitor.best_flow_lph() == 704.0f);
+}
+
+void test_reachability_monitor_allows_meaningful_progress() {
+  FlowReachabilityMonitor monitor;
+  assert(!monitor.update(1000, 680.0f, 800.0f, 40.0f, 55.0f));
+  assert(!monitor.update(31000, 690.0f, 800.0f, 40.0f, 55.0f));
+  assert(!monitor.update(61000, 701.0f, 800.0f, 40.0f, 55.0f));
+  assert(!monitor.update(91000, 715.0f, 800.0f, 40.0f, 55.0f));
+  assert(!monitor.update(121000, 725.0f, 800.0f, 40.0f, 55.0f));
+}
+
+void test_reachability_monitor_resets_when_actuator_not_saturated() {
+  FlowReachabilityMonitor monitor;
+  assert(!monitor.update(1000, 700.0f, 800.0f, 40.0f, 50.0f));
+  assert(!monitor.update(31000, 704.0f, 800.0f, 40.0f, 100.0f));
+  assert(!monitor.update(91000, 704.0f, 800.0f, 40.0f, 50.0f));
+}
+
+void test_reachability_monitor_resets_when_target_band_reached() {
+  FlowReachabilityMonitor monitor;
+  assert(!monitor.update(1000, 700.0f, 800.0f, 40.0f, 50.0f));
+  assert(!monitor.update(31000, 765.0f, 800.0f, 40.0f, 50.0f));
+  assert(!monitor.update(91000, 700.0f, 800.0f, 40.0f, 50.0f));
+}
+
+void test_reachability_monitor_rejects_invalid_flow() {
+  FlowReachabilityMonitor monitor;
+  assert(!monitor.update(1000, NAN, 800.0f, 40.0f, 50.0f));
+  assert(!monitor.update(61000, NAN, 800.0f, 40.0f, 50.0f));
+}
+
 }  // namespace
 
 int main() {
@@ -120,5 +157,10 @@ int main() {
   test_dynamic_flow_after_initial_800_preflow();
   test_very_high_theoretical_flow_is_limited_not_refused();
   test_apply_policy();
+  test_unreachable_flow_after_sustained_saturation();
+  test_reachability_monitor_allows_meaningful_progress();
+  test_reachability_monitor_resets_when_actuator_not_saturated();
+  test_reachability_monitor_resets_when_target_band_reached();
+  test_reachability_monitor_rejects_invalid_flow();
   return 0;
 }

--- a/tests/host/boiler_commissioning_logic_test.cpp
+++ b/tests/host/boiler_commissioning_logic_test.cpp
@@ -7,6 +7,15 @@ namespace {
 
 using namespace oq_boiler_commissioning;
 
+void test_commissioning_temperature_policy() {
+  assert(normalize_max_water_temperature_c(NAN) == 60.0f);
+  assert(normalize_max_water_temperature_c(10.0f) == 25.0f);
+  assert(normalize_max_water_temperature_c(90.0f) == 75.0f);
+  assert(commissioning_target_temperature_c(50.0f) == 45.0f);
+  assert(commissioning_target_temperature_c(NAN) == 55.0f);
+  assert(isnan(commissioning_target_temperature_c(50.0f, -1.0f)));
+}
+
 void test_sufficient_headroom() {
   auto op = compute_operating_point(6000.0f, 20.0f, 50.0f, 800.0f, 4180.0f, 5.0f);
   assert(op.feasible);
@@ -146,6 +155,7 @@ void test_reachability_monitor_rejects_invalid_flow() {
 }  // namespace
 
 int main() {
+  test_commissioning_temperature_policy();
   test_sufficient_headroom();
   test_insufficient_headroom_inlet_high();
   test_generic_helper_preserves_theoretical_flow();


### PR DESCRIPTION
## Wat verandert deze PR?

Voegt een vroege failure toe voor de CM100-ketelvermogentest wanneer het vereiste testdebiet hydraulisch niet haalbaar blijkt.

De bestaande flowregelaar blijft volledig eigenaar van de pompaansturing. Tijdens `FLOW_SETTLING` bewaakt de boiler-test-runtime alleen of de pomp gedurende langere tijd vrijwel maximaal wordt aangestuurd zonder betekenisvolle flowverbetering. In dat geval stopt commissioning gecontroleerd met:

`FAILED: required boiler test flow cannot be reached`

in plaats van tot de algemene 15-minuten-timeout te blijven wachten.

Closes #490

## Aanpak

Nieuwe pure `FlowReachabilityMonitor` in `oq_boiler_commissioning_logic.h`:

- beoordeling begint pas nadat de bestaande minimale preflowtijd is verstreken;
- alleen actief wanneer flow onder de onderste testband blijft;
- actuator geldt als verzadigd bij iPWM ≤ 60 (50 is maximale pompaansturing);
- failure pas na 60 s continue saturatie zonder minimaal 20 L/h betekenisvolle vooruitgang;
- bij voldoende progressie wordt het 60-s venster opnieuw gestart;
- monitor reset bij bereik van de testband, minder harde pompaansturing, ongeldige flow of een nieuw flowdoel.

### State-machine ownership

`BoilerPowerTestRuntime` is en blijft de enige eigenaar van de CM100-keteltest-state-machine. De reachability-monitor is onderdeel van die runtime en een failure loopt rechtstreeks via het bestaande `finish_task()`-pad voor fail-safe cleanup en herstel van het oorspronkelijke flowsetpoint.

`oq_boiler_test.yaml` bevat daardoor geen eigen reachability-state of directe commissioning-statewrites meer en delegeert alleen naar:

`oq_boiler_task::runtime().tick(...)`

### Commissioning temperature policy

Als beperkte cleanup van de bestaande #487-logica is ook de boiler-testtemperatuurpolicy gecentraliseerd in `oq_boiler_commissioning_logic.h`:

- ontbrekende maximum-watertemperatuur → 60 °C default;
- normalisatie naar 25–75 °C;
- commissioning target = genormaliseerde maximumtemperatuur − 5 °C.

Zowel de operating-pointlogica als `oq_boiler_dispatch.yaml` gebruiken nu dezelfde helper. Hiermee verdwijnt de dubbele `max - 5 °C`-implementatie; er is geen bedoelde gedragswijziging ten opzichte van #487.

De OpenTherm telemetry/session-lifecycle blijft bewust buiten deze PR en behoudt de bestaande implementatie uit #487.

## Achtergrond / velddata

Op `v0.48.0-dev.680+4fda4b8`, Single/Ethernet:

- CM100-target: 800 L/h;
- PI stuurt correct steeds harder;
- iPWM bereikt uiteindelijk 50;
- flow plateauert langdurig rond 702–704 L/h;
- 760 L/h ondergrens wordt nooit bereikt;
- ketel wordt daardoor nooit aangestuurd;
- zonder ingreep resteert alleen de algemene 15-minuten-timeout.

Dit is nadrukkelijk niet de stale-PI-seedbug uit #464: de regelrichting is in deze opname correct, maar de hydraulische installatie kan het gevraagde debiet niet halen.

## Tests

`boiler_commissioning_logic_test.cpp` dekt:

- sustained saturation + plateau → failure;
- betekenisvolle flowprogressie → geen false positive / venster herstart;
- actuator niet meer verzadigd → reset;
- targetband bereikt → reset;
- NaN/ongeldige flow → reset / geen failure;
- centrale maximumtemperatuur-/headroompolicy en grenswaarden.

Daarnaast borgt `test_boiler_commissioning_ownership_contract.py` dat:

- `oq_boiler_test.yaml` alleen naar de runtime delegeert en geen reachability/state-machine-logica bevat;
- `BoilerPowerTestRuntime` eigenaar is van de reachability-failure en `finish_task()` gebruikt;
- boiler dispatch dezelfde commissioning-temperature helper gebruikt en geen eigen `max - 5 °C`-policy introduceert.

De ownership-contracttest is toegevoegd aan `scripts/run_host_regression_tests.sh`.

## Safety

- Flowtarget wordt niet automatisch verlaagd.
- Bestaande low-flow- en temperatuurbeveiligingen blijven ongewijzigd.
- #467/#487 thermal-headroom- en Apply-policy blijven intact.
- Ketel wordt in de failure-case nooit gestart.
- Cleanup en flowsetpoint-herstel lopen via het bestaande `finish_task()`-pad van de boiler-test-runtime.

## Impact

- [x] Runtime/control gedrag gewijzigd
- [x] Boiler/flow commissioning geraakt
- [ ] Normale CM1/CM2/CM3/CM4/CM5 flowregeling gewijzigd
- [ ] Nieuwe entities/configuratie
