### PR TITLE
Reload web app after restart

### DIFF
--- a/openquatt/web/js/src/core/device-reconnect.js
+++ b/openquatt/web/js/src/core/device-reconnect.js
@@ -4,8 +4,9 @@ import { updateFirmwareState } from "./feature-state.js";
 
 export const DEVICE_RECONNECT_RECOVERY_CLEAR_DELAY_MS = 1500;
 export const OTA_REFRESH_DELAY_MS = 1500;
+export const RESTART_REFRESH_DELAY_MS = 1500;
 
-function getOtaEvidence() {
+function getRebootEvidence() {
   const uptime = state.entities.uptime;
   const version = state.entities.projectVersionText;
   return [
@@ -15,14 +16,7 @@ function getOtaEvidence() {
   ];
 }
 
-export function armOtaRefresh() {
-  clearOtaRefresh();
-  state.ota.on = true;
-  state.ota.base = [...getOtaEvidence(), performance.now()];
-}
-
-export function clearOtaRefresh() {
-  const refresh = state.ota;
+function clearBrowserRefresh(refresh) {
   if (refresh.id) {
     window.clearTimeout(refresh.id);
     refresh.id = null;
@@ -33,8 +27,13 @@ export function clearOtaRefresh() {
   refresh.base = null;
 }
 
-export function awaitOtaEvidence(timeoutMs = 300000) {
-  const refresh = state.ota;
+function armBrowserRefresh(refresh, clearRefresh) {
+  clearRefresh();
+  refresh.on = true;
+  refresh.base = [...getRebootEvidence(), performance.now()];
+}
+
+function awaitRebootEvidence(refresh, clearRefresh, timeoutMs) {
   if (!refresh.on) {
     return;
   }
@@ -45,31 +44,25 @@ export function awaitOtaEvidence(timeoutMs = 300000) {
   refresh.id = window.setTimeout(() => {
     refresh.id = null;
     if (refresh.wait) {
-      clearOtaRefresh();
+      clearRefresh();
     }
   }, timeoutMs);
 }
 
-export function reconcileOtaEvidence() {
-  const refresh = state.ota;
+function hasRebootEvidence(refresh, acceptVersionChange = false) {
   if (!refresh.on || !refresh.wait) {
-    return;
+    return false;
   }
 
-  const evidence = getOtaEvidence();
-  if (
-    evidence[0] < refresh.base[0]
-    // A low post-boot uptime proves its boot happened after the OTA request.
+  const evidence = getRebootEvidence();
+  return evidence[0] < refresh.base[0]
+    // A low post-boot uptime proves its boot happened after the initiating request.
     || (isNaN(refresh.base[0]) && evidence[0] + 1000 <= performance.now() - refresh.base[2])
     || refresh.ok === 2
-    || (refresh.base[1] && evidence[1] && evidence[1] !== refresh.base[1])
-  ) {
-    scheduleOtaRefresh();
-  }
+    || (acceptVersionChange && refresh.base[1] && evidence[1] && evidence[1] !== refresh.base[1]);
 }
 
-export function scheduleOtaRefresh(delayMs = OTA_REFRESH_DELAY_MS) {
-  const refresh = state.ota;
+function scheduleBrowserRefresh(refresh, clearRefresh, delayMs) {
   if (!refresh.on || (refresh.id && !refresh.wait)) {
     return;
   }
@@ -82,9 +75,53 @@ export function scheduleOtaRefresh(delayMs = OTA_REFRESH_DELAY_MS) {
     if (!refresh.on) {
       return;
     }
-    clearOtaRefresh();
+    clearRefresh();
     window.location.reload();
   }, delayMs);
+}
+
+export function armOtaRefresh() {
+  armBrowserRefresh(state.ota, clearOtaRefresh);
+}
+
+export function clearOtaRefresh() {
+  clearBrowserRefresh(state.ota);
+}
+
+export function awaitOtaEvidence(timeoutMs = 300000) {
+  awaitRebootEvidence(state.ota, clearOtaRefresh, timeoutMs);
+}
+
+export function reconcileOtaEvidence() {
+  if (hasRebootEvidence(state.ota, true)) {
+    scheduleOtaRefresh();
+  }
+}
+
+export function scheduleOtaRefresh(delayMs = OTA_REFRESH_DELAY_MS) {
+  scheduleBrowserRefresh(state.ota, clearOtaRefresh, delayMs);
+}
+
+export function armRestartRefresh() {
+  armBrowserRefresh(state.restartRefresh, clearRestartRefresh);
+}
+
+export function clearRestartRefresh() {
+  clearBrowserRefresh(state.restartRefresh);
+}
+
+export function awaitRestartEvidence(timeoutMs = 300000) {
+  awaitRebootEvidence(state.restartRefresh, clearRestartRefresh, timeoutMs);
+}
+
+export function reconcileRestartEvidence() {
+  if (hasRebootEvidence(state.restartRefresh)) {
+    scheduleRestartRefresh();
+  }
+}
+
+export function scheduleRestartRefresh(delayMs = RESTART_REFRESH_DELAY_MS) {
+  scheduleBrowserRefresh(state.restartRefresh, clearRestartRefresh, delayMs);
 }
 
 export function clearDeviceReconnectRecoveryTimer() {

--- a/openquatt/web/js/src/core/device-reconnect.js
+++ b/openquatt/web/js/src/core/device-reconnect.js
@@ -4,7 +4,7 @@ import { updateFirmwareState } from "./feature-state.js";
 
 export const DEVICE_RECONNECT_RECOVERY_CLEAR_DELAY_MS = 1500;
 export const OTA_REFRESH_DELAY_MS = 1500;
-export const RESTART_REFRESH_DELAY_MS = 1500;
+export const RESTART_REFRESH_DELAY_MS = 0;
 
 function getRebootEvidence() {
   const uptime = state.entities.uptime;
@@ -122,6 +122,10 @@ export function reconcileRestartEvidence() {
 
 export function scheduleRestartRefresh(delayMs = RESTART_REFRESH_DELAY_MS) {
   scheduleBrowserRefresh(state.restartRefresh, clearRestartRefresh, delayMs);
+}
+
+export function isRestartRefreshActive() {
+  return state.restartRefresh.on;
 }
 
 export function clearDeviceReconnectRecoveryTimer() {

--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -606,7 +606,9 @@ import { fetchWithTimeout } from "./browser-utils.js";
   export function noteEntityRefreshFailure(message) {
     if (!isLikelyDeviceConnectionError(message)) {
       state.entitySyncFailureCount = 0;
-      clearDeviceReconnect();
+      if (!state.restartRefresh.on) {
+        clearDeviceReconnect();
+      }
       return;
     }
     if (state.ota.ok === 1) {

--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -8,7 +8,7 @@ import { getDefaultAppView, getUrlAppView, setAppView } from "./navigation.js";
 import { isFirmwareOtaQuietActive } from "./firmware-quiet.js";
 import { getInstallationMonitoringModel, syncInstallationMonitoringDetailsState } from "./installation-monitoring.js";
 import { getIncidentMonitoringFailureUpdate, getIncidentMonitoringSuccessUpdate, getIncidentMonitoringUnsupportedUpdate } from "./incident-monitoring.js";
-import { beginDeviceReconnect, clearDeviceReconnect, markDeviceReconnectRecovered, reconcileOtaEvidence, reconcileRestartEvidence } from "./device-reconnect.js";
+import { beginDeviceReconnect, clearDeviceReconnect, isRestartRefreshActive, markDeviceReconnectRecovered, reconcileOtaEvidence, reconcileRestartEvidence } from "./device-reconnect.js";
 import { getSettingsRenderSignature } from "./render-signatures.js";
 import { isSystemSettingsGroupActive } from "./surface-state.js";
 import { getHeaderRenderSignature, patchHeaderDom } from "./header-render-controls.js";
@@ -561,7 +561,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
     reconcileOtaEvidence();
     reconcileRestartEvidence();
     const wasReconnectActive = Boolean(state.deviceReconnectMode);
-    const reconnectRecovered = wasReconnectActive && typeof markDeviceReconnectRecovered === "function"
+    const reconnectRecovered = wasReconnectActive && !isRestartRefreshActive() && typeof markDeviceReconnectRecovered === "function"
       ? markDeviceReconnectRecovered()
       : false;
     if (reconnectRecovered) {

--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -8,7 +8,7 @@ import { getDefaultAppView, getUrlAppView, setAppView } from "./navigation.js";
 import { isFirmwareOtaQuietActive } from "./firmware-quiet.js";
 import { getInstallationMonitoringModel, syncInstallationMonitoringDetailsState } from "./installation-monitoring.js";
 import { getIncidentMonitoringFailureUpdate, getIncidentMonitoringSuccessUpdate, getIncidentMonitoringUnsupportedUpdate } from "./incident-monitoring.js";
-import { beginDeviceReconnect, clearDeviceReconnect, markDeviceReconnectRecovered, reconcileOtaEvidence } from "./device-reconnect.js";
+import { beginDeviceReconnect, clearDeviceReconnect, markDeviceReconnectRecovered, reconcileOtaEvidence, reconcileRestartEvidence } from "./device-reconnect.js";
 import { getSettingsRenderSignature } from "./render-signatures.js";
 import { isSystemSettingsGroupActive } from "./surface-state.js";
 import { getHeaderRenderSignature, patchHeaderDom } from "./header-render-controls.js";
@@ -559,6 +559,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
     state.lastEntitySyncSuccessAt = now;
     state.entitySyncFailureCount = 0;
     reconcileOtaEvidence();
+    reconcileRestartEvidence();
     const wasReconnectActive = Boolean(state.deviceReconnectMode);
     const reconnectRecovered = wasReconnectActive && typeof markDeviceReconnectRecovered === "function"
       ? markDeviceReconnectRecovered()
@@ -611,6 +612,9 @@ import { fetchWithTimeout } from "./browser-utils.js";
     if (state.ota.ok === 1) {
       state.ota.ok = 2;
     }
+    if (state.restartRefresh.ok === 1) {
+      state.restartRefresh.ok = 2;
+    }
     state.entitySyncFailureCount = Number(state.entitySyncFailureCount || 0) + 1;
     state.deviceReconnectLastError = String(message || "");
     if (
@@ -619,11 +623,13 @@ import { fetchWithTimeout } from "./browser-utils.js";
       || state.updateInstallBusy
       || state.updateInstallPhaseHint
       || state.ota.on
+      || state.restartRefresh.on
       || state.entitySyncFailureCount >= 2
     ) {
       beginDeviceReconnect(
         state.updateInstallBusy || state.updateInstallPhaseHint || state.ota.on
           ? "ota"
+          : state.restartRefresh.on ? "restart"
           : state.busyAction === "restartAction" ? "restart" : "reconnect",
         message,
       );
@@ -1202,7 +1208,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
         }
         return;
       }
-      await refreshEntities([...new Set([...keys, ...(state.ota.wait ? ["uptime", "projectVersionText"] : []), ...quickStartSetupKeys, ...quickStartFlowSourceKeys, ...quickStartThermostatSourceKeys])], isPrefetchOverview ? "state" : appView === "settings" || quickStartSetupKeys.length ? "all" : "state", {
+      await refreshEntities([...new Set([...keys, ...(state.ota.wait || state.restartRefresh.wait ? ["uptime", "projectVersionText"] : []), ...quickStartSetupKeys, ...quickStartFlowSourceKeys, ...quickStartThermostatSourceKeys])], isPrefetchOverview ? "state" : appView === "settings" || quickStartSetupKeys.length ? "all" : "state", {
         concurrency: forceFast && isOverviewLike ? FAST_VIEW_ENTITY_REFRESH_CONCURRENCY : ENTITY_REFRESH_CONCURRENCY,
       });
       state.lastFastEntitySyncAt = Date.now();

--- a/openquatt/web/js/src/core/entity-write-actions.js
+++ b/openquatt/web/js/src/core/entity-write-actions.js
@@ -752,6 +752,7 @@ export async function triggerNamedButton(key, options = {}) {
       state.commissioningTaskLock = "";
     }
     if (refreshAfterRestart && isLikelyDeviceConnectionError(error.message)) {
+      state.restartRefresh.ok = 2;
       awaitRestartEvidence();
       beginDeviceReconnect("restart", error.message);
       state.controlNotice = options.successNotice || `${entity.name} gestart.`;

--- a/openquatt/web/js/src/core/entity-write-actions.js
+++ b/openquatt/web/js/src/core/entity-write-actions.js
@@ -1,9 +1,9 @@
 import { hasEntity } from "./app-shared.js";
 import { CURVE_POINTS, ENTITY_DEFS, FIRMWARE_ENTITY_KEYS, FLOW_SETTING_KEYS, getOduRuntimeFrequencyButtonHp, getOduRuntimeFrequencyHpKeys, HEADER_ENTITY_KEYS, LIMIT_KEYS, ODU_RUNTIME_FREQUENCY_BUTTON_KEYS, OPENQUATT_RESUME_CLEAR_VALUE, OVERVIEW_KEYS, POWER_HOUSE_KEYS, QUICK_STEPS } from "./config.js";
-import { beginDeviceReconnect } from "./device-reconnect.js";
+import { armRestartRefresh, awaitRestartEvidence, beginDeviceReconnect, clearRestartRefresh } from "./device-reconnect.js";
 import { buildEntityPath, isCurveMode } from "./domain-helpers.js";
 import { formatOpenQuattResumeDateTime, getEntityValue, normalizeDateTimeValue, normalizeNumber, normalizeTimeValue, parseLooseNumber, toDateTimeInputValue } from "./entity-store.js";
-import { getSettingsRefreshKeys, refreshEntities, refreshIncidentMonitoringData, syncEntities } from "./entity-sync.js";
+import { getSettingsRefreshKeys, isLikelyDeviceConnectionError, refreshEntities, refreshIncidentMonitoringData, syncEntities } from "./entity-sync.js";
 import {
   createIncidentActionRequestId,
   postIncidentActionRequest,
@@ -662,6 +662,10 @@ export async function triggerNamedButton(key, options = {}) {
   if (!entity) {
     return;
   }
+  const refreshAfterRestart = options.reconnectMode === "restart";
+  if (refreshAfterRestart) {
+    armRestartRefresh();
+  }
   state.busyAction = key;
   state.controlError = "";
   state.controlNotice = "";
@@ -673,6 +677,9 @@ export async function triggerNamedButton(key, options = {}) {
     });
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
+    }
+    if (refreshAfterRestart) {
+      state.restartRefresh.ok = 1;
     }
     const keepCommissioningModalOpen = [
       "commissioningCm100Start",
@@ -708,6 +715,9 @@ export async function triggerNamedButton(key, options = {}) {
     if (options.reconnectMode) {
       beginDeviceReconnect(options.reconnectMode);
     }
+    if (refreshAfterRestart) {
+      awaitRestartEvidence();
+    }
     if (Array.isArray(options.refreshKeys) && options.refreshKeys.length) {
       const refreshDelayMs = Number(options.refreshDelayMs || 0);
       if (Number.isFinite(refreshDelayMs) && refreshDelayMs > 0) {
@@ -741,7 +751,16 @@ export async function triggerNamedButton(key, options = {}) {
       state.pendingManualHpStart = false;
       state.commissioningTaskLock = "";
     }
-    state.controlError = `${options.errorPrefix || `Actie mislukt voor "${entity.name}"`}. ${error.message}`;
+    if (refreshAfterRestart && isLikelyDeviceConnectionError(error.message)) {
+      awaitRestartEvidence();
+      beginDeviceReconnect("restart", error.message);
+      state.controlNotice = options.successNotice || `${entity.name} gestart.`;
+    } else {
+      if (refreshAfterRestart) {
+        clearRestartRefresh();
+      }
+      state.controlError = `${options.errorPrefix || `Actie mislukt voor "${entity.name}"`}. ${error.message}`;
+    }
   } finally {
     state.busyAction = "";
     render();

--- a/openquatt/web/js/src/core/state.js
+++ b/openquatt/web/js/src/core/state.js
@@ -50,6 +50,8 @@ export const state = {
   deviceReconnectLastError: "",
   // OTA refresh lifecycle: ok 0=unconfirmed, 1=accepted, 2=accepted with a later outage.
   ota: { on: false, ok: 0, id: null, wait: false, base: null },
+  // Restart refresh lifecycle: ok 0=unconfirmed, 1=accepted, 2=accepted with a later outage.
+  restartRefresh: { on: false, ok: 0, id: null, wait: false, base: null },
   firmwareOtaQuietUntil: 0,
   firmwareOtaQuietTimer: null,
   entitySyncFailureCount: 0,

--- a/openquatt/web/js/src/core/state.js
+++ b/openquatt/web/js/src/core/state.js
@@ -50,7 +50,7 @@ export const state = {
   deviceReconnectLastError: "",
   // OTA refresh lifecycle: ok 0=unconfirmed, 1=accepted, 2=accepted with a later outage.
   ota: { on: false, ok: 0, id: null, wait: false, base: null },
-  // Restart refresh lifecycle: ok 0=unconfirmed, 1=accepted, 2=accepted with a later outage.
+  // Restart refresh lifecycle: ok 0=unconfirmed, 1=accepted, 2=outage observed after the request.
   restartRefresh: { on: false, ok: 0, id: null, wait: false, base: null },
   firmwareOtaQuietUntil: 0,
   firmwareOtaQuietTimer: null,

--- a/openquatt/web/tests/device-reconnect.test.mjs
+++ b/openquatt/web/tests/device-reconnect.test.mjs
@@ -30,7 +30,6 @@ const { triggerNamedButton } = await import("../js/src/core/entity-write-actions
 const { requestFirmwareOta } = await import("../js/src/features/firmware-actions.js");
 const {
   OTA_REFRESH_DELAY_MS,
-  RESTART_REFRESH_DELAY_MS,
   armOtaRefresh,
   awaitOtaEvidence,
   beginDeviceReconnect,
@@ -203,7 +202,7 @@ test("an OTA entity poll does not reload before install completion", () => {
   assert.equal(state.ota.id, null);
 });
 
-test("an accepted restart waits for an outage before reloading the page", async () => {
+test("an accepted restart reloads immediately when data returns after the outage", async () => {
   state.entities.uptime = { state: "1.00 h", value: 1 };
   globalThis.fetch = async () => ({ ok: true });
 
@@ -220,6 +219,7 @@ test("an accepted restart waits for an outage before reloading the page", async 
   noteEntityRefreshSuccess();
 
   assert.equal(state.restartRefresh.wait, true);
+  assert.equal(state.deviceReconnectRecoveryStartedAt, 0);
   assert.equal(reloadCount, 0);
 
   noteEntityRefreshFailure("Failed to fetch");
@@ -227,14 +227,17 @@ test("an accepted restart waits for an outage before reloading the page", async 
 
   const refreshTimer = state.restartRefresh.id;
   assert.ok(refreshTimer);
-  assert.equal(refreshTimer.delay, RESTART_REFRESH_DELAY_MS);
+  assert.equal(refreshTimer.delay, 0);
+  noteEntityRefreshSuccess();
+  assert.equal(state.restartRefresh.id, refreshTimer);
+  assert.equal(state.deviceReconnectRecoveryStartedAt, 0);
   refreshTimer.callback();
 
   assert.equal(reloadCount, 1);
   assert.equal(state.restartRefresh.on, false);
 });
 
-test("a lost restart acknowledgement reloads only after uptime proves the reboot", async () => {
+test("a lost restart acknowledgement reloads immediately when data returns", async () => {
   state.entities.uptime = { state: "1.00 h", value: 1 };
   globalThis.fetch = async () => {
     throw new TypeError("Failed to fetch");
@@ -247,22 +250,17 @@ test("a lost restart acknowledgement reloads only after uptime proves the reboot
   });
 
   assert.equal(state.restartRefresh.on, true);
-  assert.equal(state.restartRefresh.ok, 0);
+  assert.equal(state.restartRefresh.ok, 2);
   assert.equal(state.restartRefresh.wait, true);
   assert.equal(state.deviceReconnectMode, "restart");
   assert.equal(state.controlError, "");
 
   noteEntityRefreshSuccess();
 
-  assert.equal(state.restartRefresh.wait, true);
-  assert.equal(reloadCount, 0);
-
-  state.entities.uptime = { state: "4 s", value: 4, uom: "h" };
-  noteEntityRefreshSuccess();
-
   const refreshTimer = state.restartRefresh.id;
   assert.ok(refreshTimer);
-  assert.equal(refreshTimer.delay, RESTART_REFRESH_DELAY_MS);
+  assert.equal(refreshTimer.delay, 0);
+  assert.equal(state.deviceReconnectRecoveryStartedAt, 0);
   refreshTimer.callback();
 
   assert.equal(reloadCount, 1);

--- a/openquatt/web/tests/device-reconnect.test.mjs
+++ b/openquatt/web/tests/device-reconnect.test.mjs
@@ -237,6 +237,35 @@ test("an accepted restart reloads immediately when data returns after the outage
   assert.equal(state.restartRefresh.on, false);
 });
 
+test("a transient post-reboot entity error keeps the restart modal open until reload", async () => {
+  state.entities.uptime = { state: "1.00 h", value: 1 };
+  globalThis.fetch = async () => ({ ok: true });
+
+  await triggerNamedButton("restartAction", {
+    successNotice: "OpenQuatt wordt opnieuw opgestart.",
+    errorPrefix: "Herstart mislukt",
+    reconnectMode: "restart",
+  });
+
+  noteEntityRefreshFailure("Uptime HTTP 503");
+
+  assert.equal(state.deviceReconnectMode, "restart");
+  assert.equal(state.deviceReconnectRecoveryStartedAt, 0);
+  assert.equal(state.restartRefresh.wait, true);
+
+  state.entities.uptime = { state: "4 s", value: 4, uom: "h" };
+  noteEntityRefreshSuccess();
+
+  const refreshTimer = state.restartRefresh.id;
+  assert.ok(refreshTimer);
+  assert.equal(refreshTimer.delay, 0);
+  assert.equal(state.deviceReconnectMode, "restart");
+  assert.equal(state.deviceReconnectRecoveryStartedAt, 0);
+  refreshTimer.callback();
+
+  assert.equal(reloadCount, 1);
+});
+
 test("a lost restart acknowledgement reloads immediately when data returns", async () => {
   state.entities.uptime = { state: "1.00 h", value: 1 };
   globalThis.fetch = async () => {

--- a/openquatt/web/tests/device-reconnect.test.mjs
+++ b/openquatt/web/tests/device-reconnect.test.mjs
@@ -26,22 +26,28 @@ globalThis.window = {
 
 const { state } = await import("../js/src/core/state.js");
 const { noteEntityRefreshFailure, noteEntityRefreshSuccess } = await import("../js/src/core/entity-sync.js");
+const { triggerNamedButton } = await import("../js/src/core/entity-write-actions.js");
 const { requestFirmwareOta } = await import("../js/src/features/firmware-actions.js");
 const {
   OTA_REFRESH_DELAY_MS,
+  RESTART_REFRESH_DELAY_MS,
   armOtaRefresh,
   awaitOtaEvidence,
   beginDeviceReconnect,
   clearOtaRefresh,
+  clearRestartRefresh,
   clearDeviceReconnect,
-  markDeviceReconnectRecovered,
   scheduleOtaRefresh,
 } = await import("../js/src/core/device-reconnect.js");
 
 test.afterEach(() => {
   clearDeviceReconnect();
   clearOtaRefresh();
+  clearRestartRefresh();
   state.entities = {};
+  state.busyAction = "";
+  state.controlError = "";
+  state.controlNotice = "";
   timers.length = 0;
   reloadCount = 0;
   globalThis.fetch = originalFetch;
@@ -197,11 +203,83 @@ test("an OTA entity poll does not reload before install completion", () => {
   assert.equal(state.ota.id, null);
 });
 
-test("a normal restart recovery does not reload the page", () => {
-  beginDeviceReconnect("restart");
+test("an accepted restart waits for an outage before reloading the page", async () => {
+  state.entities.uptime = { state: "1.00 h", value: 1 };
+  globalThis.fetch = async () => ({ ok: true });
 
-  assert.equal(markDeviceReconnectRecovered(), true);
-  assert.equal(state.ota.on, false);
+  await triggerNamedButton("restartAction", {
+    successNotice: "OpenQuatt wordt opnieuw opgestart.",
+    errorPrefix: "Herstart mislukt",
+    reconnectMode: "restart",
+  });
+
+  assert.equal(state.restartRefresh.on, true);
+  assert.equal(state.restartRefresh.ok, 1);
+  assert.equal(state.restartRefresh.wait, true);
+
+  noteEntityRefreshSuccess();
+
+  assert.equal(state.restartRefresh.wait, true);
+  assert.equal(reloadCount, 0);
+
+  noteEntityRefreshFailure("Failed to fetch");
+  noteEntityRefreshSuccess();
+
+  const refreshTimer = state.restartRefresh.id;
+  assert.ok(refreshTimer);
+  assert.equal(refreshTimer.delay, RESTART_REFRESH_DELAY_MS);
+  refreshTimer.callback();
+
+  assert.equal(reloadCount, 1);
+  assert.equal(state.restartRefresh.on, false);
+});
+
+test("a lost restart acknowledgement reloads only after uptime proves the reboot", async () => {
+  state.entities.uptime = { state: "1.00 h", value: 1 };
+  globalThis.fetch = async () => {
+    throw new TypeError("Failed to fetch");
+  };
+
+  await triggerNamedButton("restartAction", {
+    successNotice: "OpenQuatt wordt opnieuw opgestart.",
+    errorPrefix: "Herstart mislukt",
+    reconnectMode: "restart",
+  });
+
+  assert.equal(state.restartRefresh.on, true);
+  assert.equal(state.restartRefresh.ok, 0);
+  assert.equal(state.restartRefresh.wait, true);
+  assert.equal(state.deviceReconnectMode, "restart");
+  assert.equal(state.controlError, "");
+
+  noteEntityRefreshSuccess();
+
+  assert.equal(state.restartRefresh.wait, true);
+  assert.equal(reloadCount, 0);
+
+  state.entities.uptime = { state: "4 s", value: 4, uom: "h" };
+  noteEntityRefreshSuccess();
+
+  const refreshTimer = state.restartRefresh.id;
+  assert.ok(refreshTimer);
+  assert.equal(refreshTimer.delay, RESTART_REFRESH_DELAY_MS);
+  refreshTimer.callback();
+
+  assert.equal(reloadCount, 1);
+  assert.equal(state.restartRefresh.on, false);
+});
+
+test("an explicit restart rejection cancels its pending page reload", async () => {
+  globalThis.fetch = async () => ({ ok: false, status: 503 });
+
+  await triggerNamedButton("restartAction", {
+    errorPrefix: "Herstart mislukt",
+    reconnectMode: "restart",
+  });
+
+  assert.equal(state.restartRefresh.on, false);
+  assert.equal(state.deviceReconnectMode, "");
+  assert.match(state.controlError, /HTTP 503/);
   assert.equal(reloadCount, 0);
 });
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Herlaadt de web-app direct zodra na een normale herstart weer geldige controllerdata binnenkomt.
- Houdt `Wachten op gegevens` zichtbaar tijdens vroege pre-reboot-polls en tijdelijke opstartfouten; er verschijnt geen tussentijdse blauwe bevestiging of extra syncfase.
- Gebruikt rebootbewijs via lagere uptime, of via verbindingsuitval en herstel na de herstartrequest.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de browserlifecycle wijzigt. Controllerlogica, configuratie, entities en regeling blijven ongewijzigd.

## Achtergrond

OTA herlaadde de pagina al na bewezen reboot, terwijl de gewone herstart alleen runtime-data in-place ververste. De restart-refresh heeft een eigen timer en baseline, zodat OTA- en herstartcycli elkaar niet beïnvloeden. Zodra herstel is bewezen, wordt de browserreload zonder extra wachttijd uitgevoerd. Tijdelijke HTTP- of bulkfouten tijdens het opkomen mogen de restartmodal niet vroeg sluiten. Vroege succesvolle polls, verloren acknowledgements, expliciete HTTP-fouten, dubbele succescallbacks, retries en timerannulering zijn in de volledige diff-audit gecontroleerd.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De bestaande herstartworkflow en bediening veranderen niet; de pagina wordt na herstel alleen consequent en zonder tussenfase opnieuw geladen.

## Validatie

- [x] `npm run check:web` — 194 tests geslaagd; webbundels gebouwd en kwaliteits-/budgetcontrole geslaagd.
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alle wijzigingen zitten in browser-JavaScript en tests; firmwareheap, PSRAM en task-stacks worden niet geraakt.
