### PR TITLE
Maak stopherbevestiging een neutrale status

### DIFF
--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
@@ -719,7 +719,8 @@ void OpenQuattIncidentManager::observe_compressor_frequency(uint8_t hp_index, fl
       post_command_feedback_complete(unit->working_mode_generation, unit->command_mode_generation,
                                      unit->compressor_frequency_generation, unit->command_frequency_generation);
   observation.fresh =
-      run_observation_is_fresh(waiting_for_start, waiting_for_stop, unit->stop_feedback_armed, post_command_feedback);
+      run_observation_is_fresh(waiting_for_start, waiting_for_stop, unit->engine.outputs().stop_confirmation_pending,
+                               unit->stop_feedback_armed, post_command_feedback);
   observation.mode_matches_request =
       unit->working_mode_valid && static_cast<uint8_t>(std::lround(unit->working_mode)) == unit->expected_mode;
   observation.stop_mode_confirmed =
@@ -1745,6 +1746,7 @@ void OpenQuattIncidentManager::write_snapshot(httpd_req_t* req) const {
          write_raw(req, R"(,"protection_active":)") && write_bool(req, outputs.protection_active) &&
          write_raw(req, R"(,"running_confirmed":)") && write_bool(req, outputs.running_confirmed) &&
          write_raw(req, R"(,"stop_confirmed":)") && write_bool(req, outputs.stop_confirmed) &&
+         write_raw(req, R"(,"stop_confirmation_pending":)") && write_bool(req, outputs.stop_confirmation_pending) &&
          write_raw(req, R"(,"stop_unconfirmed":)") && write_bool(req, outputs.stop_unconfirmed) &&
          write_raw(req, R"(,"fallback_cause_present":)") && write_bool(req, outputs.fallback_cause_present) &&
          write_raw(req, R"(,"fallback_eligible":)") && write_bool(req, outputs.fallback_eligible) &&

--- a/components/openquatt_incident_manager/OpenQuattIncidentPolicy.h
+++ b/components/openquatt_incident_manager/OpenQuattIncidentPolicy.h
@@ -21,11 +21,12 @@ inline bool post_command_feedback_complete(uint32_t mode_generation, uint32_t mo
          feedback_generation_is_newer(frequency_generation, frequency_baseline);
 }
 
-inline bool run_observation_is_fresh(bool waiting_for_start, bool waiting_for_stop, bool stop_feedback_armed,
+inline bool run_observation_is_fresh(bool waiting_for_start, bool waiting_for_stop,
+                                     bool stop_confirmation_requires_command, bool stop_feedback_armed,
                                      bool post_command_feedback) {
   if (waiting_for_start) return post_command_feedback;
-  if (waiting_for_stop && stop_feedback_armed) {
-    return post_command_feedback;
+  if (waiting_for_stop && (stop_confirmation_requires_command || stop_feedback_armed)) {
+    return stop_feedback_armed && post_command_feedback;
   }
   return true;
 }

--- a/openquatt/includes/control/oq_incident_actuator_logic.h
+++ b/openquatt/includes/control/oq_incident_actuator_logic.h
@@ -40,6 +40,11 @@ inline bool safe_stop_write_retry_due(bool stop_confirmation_pending, uint32_t n
   return static_cast<uint32_t>(now_ms - last_write_ms) >= retry_interval_ms;
 }
 
+inline bool requires_stop_notification(bool initial_stop_registration_required, bool must_stop, bool stop_confirmed,
+                                       bool stop_confirmation_pending) {
+  return initial_stop_registration_required || stop_confirmation_pending || (must_stop && !stop_confirmed);
+}
+
 // Establish the incident manager's fresh-observation baseline before the
 // first active mode/level command. A denied start produces only a safe write.
 template <typename StartGate, typename ActiveWrite, typename SafeWrite>

--- a/openquatt/includes/incidents/oq_hp_incident_engine.h
+++ b/openquatt/includes/incidents/oq_hp_incident_engine.h
@@ -92,6 +92,7 @@ class HpIncidentEngine {
     start_mode_ack_timed_out_ = false;
     start_timed_out_ = false;
     wrong_mode_compressor_active_ = false;
+    stop_confirmation_pending_ = false;
     refresh_derived();
     return true;
   }
@@ -122,6 +123,12 @@ class HpIncidentEngine {
       refresh_derived();
       return;
     }
+    if (stop_confirmation_pending_ && !stop_request_initialized_) {
+      // Revalidation may only consume observations after the new safe-stop
+      // command has established its feedback baseline.
+      refresh_derived();
+      return;
+    }
 
     if (observation.mode_matches_request) {
       start_mode_seen_ = true;
@@ -131,7 +138,7 @@ class HpIncidentEngine {
     if (compressor_active) {
       stopped_read_streak_ = 0U;
       if (stop_requested_) {
-        run_state_ = RunState::STOPPING;
+        run_state_ = run_state_ == RunState::STOP_UNCONFIRMED ? RunState::STOP_UNCONFIRMED : RunState::STOPPING;
       } else if ((run_state_ == RunState::START_REQUESTED || run_state_ == RunState::WAIT_MODE ||
                   run_state_ == RunState::WAIT_COMPRESSOR) &&
                  !observation.mode_matches_request) {
@@ -183,10 +190,14 @@ class HpIncidentEngine {
       compressor_running_confirmed_ = false;
       stop_requested_ = false;
       stop_request_initialized_ = false;
+      stop_confirmation_pending_ = false;
       stopped_read_streak_ = 0U;
       wrong_mode_compressor_active_ = false;
     } else {
-      run_state_ = RunState::STOPPING;
+      // A real stop-confirmation timeout remains active until the complete
+      // two-read confirmation succeeds. A single stopped observation must not
+      // prematurely clear the fault incident.
+      run_state_ = run_state_ == RunState::STOP_UNCONFIRMED ? RunState::STOP_UNCONFIRMED : RunState::STOPPING;
     }
     refresh_derived();
   }
@@ -383,6 +394,7 @@ class HpIncidentEngine {
         elapsed_at_least(now_ms, stop_requested_at_ms_, tuning_.stop_confirm_timeout_ms)) {
       run_state_ = RunState::STOP_UNCONFIRMED;
       compressor_running_confirmed_ = false;
+      stop_confirmation_pending_ = false;
     }
   }
 
@@ -455,7 +467,13 @@ class HpIncidentEngine {
   }
 
   void invalidate_stop_confirmation_() {
-    run_state_ = RunState::STOP_UNCONFIRMED;
+    // A hard fault or confirmed link loss makes the old stop observation
+    // stale. This is a neutral revalidation phase; only the stop timeout may
+    // promote it to STOP_UNCONFIRMED and incident 1003.
+    if (run_state_ != RunState::STOP_UNCONFIRMED) {
+      run_state_ = RunState::STOPPING;
+      stop_confirmation_pending_ = true;
+    }
     compressor_running_confirmed_ = false;
     stop_requested_ = false;
     stop_request_initialized_ = false;
@@ -564,6 +582,7 @@ class HpIncidentEngine {
     outputs_.run_state = run_state_;
     outputs_.running_confirmed = compressor_running_confirmed_;
     outputs_.stop_confirmed = run_state_ == RunState::STOPPED;
+    outputs_.stop_confirmation_pending = stop_confirmation_pending_;
     outputs_.stop_unconfirmed = run_state_ == RunState::STOP_UNCONFIRMED;
     outputs_.start_mode_ack_timed_out = start_mode_ack_timed_out_;
     outputs_.start_timed_out = start_timed_out_;
@@ -612,11 +631,13 @@ class HpIncidentEngine {
     }
 
     const bool link_recovery_after_loss = link_state_ == LinkState::RECOVERING && recovering_from_loss_;
-    outputs_.must_stop = hard_fault || start_timed_out_ || link_state_ == LinkState::LOST || link_recovery_after_loss;
+    outputs_.must_stop = hard_fault || start_timed_out_ || outputs_.stop_confirmation_pending ||
+                         outputs_.stop_unconfirmed || link_state_ == LinkState::LOST || link_recovery_after_loss;
     outputs_.available_for_start = link_state_ == LinkState::HEALTHY &&
                                    (outputs_.protection_state == ProtectionState::CLEAR ||
                                     outputs_.protection_state == ProtectionState::LIMITED) &&
-                                   run_state_ != RunState::STOP_UNCONFIRMED && !start_timed_out_;
+                                   !outputs_.stop_confirmation_pending && run_state_ != RunState::STOP_UNCONFIRMED &&
+                                   !start_timed_out_;
     outputs_.fallback_cause_present = fallback_fault || fault_recovery_active_ || start_timed_out_ ||
                                       link_state_ == LinkState::LOST || link_recovery_after_loss;
     outputs_.fallback_eligible = outputs_.fallback_cause_present && !outputs_.available_for_start &&
@@ -660,6 +681,7 @@ class HpIncidentEngine {
   bool compressor_running_confirmed_ = false;
   bool stop_requested_ = false;
   bool stop_request_initialized_ = false;
+  bool stop_confirmation_pending_ = false;
   uint32_t stop_requested_at_ms_ = 0U;
   uint8_t stopped_read_streak_ = 0U;
 

--- a/openquatt/includes/incidents/oq_hp_incident_types.h
+++ b/openquatt/includes/incidents/oq_hp_incident_types.h
@@ -200,6 +200,7 @@ struct DerivedOutputs {
   bool protection_active = false;
   bool running_confirmed = false;
   bool stop_confirmed = false;
+  bool stop_confirmation_pending = false;
   bool stop_unconfirmed = false;
   bool start_mode_ack_timed_out = false;
   bool start_timed_out = false;

--- a/openquatt/oq_thermal_actuator.yaml
+++ b/openquatt/oq_thermal_actuator.yaml
@@ -520,9 +520,11 @@ interval:
               const bool initial_stop_registration_required =
                   prev_applied > 0 || incident_stop_registration_required;
               const bool stop_notification_required =
-                  initial_stop_registration_required ||
-                  (incident_outputs.must_stop &&
-                   !incident_outputs.stop_confirmed);
+                  oq_incident_actuator::requires_stop_notification(
+                      initial_stop_registration_required,
+                      incident_outputs.must_stop,
+                      incident_outputs.stop_confirmed,
+                      incident_outputs.stop_confirmation_pending);
               oq_incident_actuator::apply_stop_notification_before_safe_write(
                   stop_notification_required,
                   [&]() {

--- a/openquatt/web/js/mock-incident-scenarios.js
+++ b/openquatt/web/js/mock-incident-scenarios.js
@@ -39,6 +39,7 @@
       protection_active: false,
       running_confirmed: running,
       stop_confirmed: !running,
+      stop_confirmation_pending: false,
       stop_unconfirmed: false,
       fallback_cause_present: false,
       fallback_eligible: false,
@@ -315,22 +316,18 @@
           action: "fallback_blocked",
           fallback_block_reason: 10,
         },
-        heatPumps: [stoppedFaulted(1, 1001, [
-          INCIDENTS.linkLoss(),
-          INCIDENTS.stopUnconfirmed(),
-        ], {
+        heatPumps: [stoppedFaulted(1, 1001, [INCIDENTS.linkLoss()], {
           link_state: "lost",
           protection_state: "clear",
-          run_state: "stop_unconfirmed",
+          run_state: "stopping",
           stop_confirmed: false,
-          stop_unconfirmed: true,
+          stop_confirmation_pending: true,
           fault_active: false,
           fallback_eligible: false,
         })],
         events: [
           event(30, "incident_start", "HP1", "hp_link_loss", "fault", 1, "standby", "active", 1001),
           event(30, "hp_availability_change", "HP1", "hp_link_loss", "fault", 1, "available", "offline", 1001, 2),
-          event(30, "incident_start", "HP1", "hp_stop_unconfirmed", "fault", 1, "standby", "active", 1003),
         ],
       }),
       phase("fallback", "Stop bevestigd, CM4 actief", "De stopstatus is vers bevestigd; de ketel neemt veilig over.", 36, {
@@ -348,7 +345,6 @@
         })],
         events: [
           event(34, "hp_stop_confirmed", "HP1", "hp_link_loss", "normal", 1, "active", "standby"),
-          event(34, "incident_clear", "HP1", "hp_stop_unconfirmed", "normal", 1, "active", "standby", 1003),
           event(36, "control_mode_change", "SYSTEM", "boiler_fallback", "attention", 4, "standby", "active", 1, 4),
           event(36, "boiler_fallback_start", "CV", "boiler_fallback", "attention", 4, "standby", "active", 350, 0),
         ],

--- a/openquatt/web/js/mock-incident-scenarios.js
+++ b/openquatt/web/js/mock-incident-scenarios.js
@@ -351,6 +351,79 @@
       }),
     ], { boilerTransport: "R1" }),
 
+    scenario("duo-link-loss-recovery", "Duo: communicatie-uitval HP1 → herstel", "Communicatie", "duo", [
+      phase("healthy", "Beide verbindingen gezond", "HP1 en HP2 draaien met geldige communicatie.", 0, {
+        heatPumps: [hp1Running(), heatPump(2, { run_state: "running" })],
+      }),
+      phase("suspect", "Uitval wordt gefilterd", "De verbinding met HP1 is verdacht; beide warmtepompen blijven voorlopig draaien.", 20, {
+        heatPumps: [
+          heatPump(1, {
+            link_state: "suspect",
+            run_state: "running",
+            availability: "unknown",
+            available_for_start: false,
+            running_confirmed: true,
+            stop_confirmed: false,
+          }),
+          heatPump(2, { run_state: "running" }),
+        ],
+      }),
+      phase("lost", "Uitval HP1 bevestigd", "De verbinding met HP1 is weg. HP2 blijft verwarmen terwijl HP1 opnieuw veilig wordt gestopt.", 30, {
+        heatPumps: [
+          stoppedFaulted(1, 1001, [INCIDENTS.linkLoss()], {
+            link_state: "lost",
+            protection_state: "clear",
+            run_state: "stopping",
+            stop_confirmed: false,
+            stop_confirmation_pending: true,
+            fault_active: false,
+            fallback_eligible: false,
+          }),
+          heatPump(2, { run_state: "running" }),
+        ],
+        events: [
+          event(30, "incident_start", "HP1", "hp_link_loss", "fault", 2, "standby", "active", 1001),
+          event(30, "hp_availability_change", "HP1", "hp_link_loss", "fault", 2, "available", "offline", 1001, 2),
+        ],
+      }),
+      phase("revalidating", "Verbinding herstelt", "Nieuwe telemetrie is binnen; de stop van HP1 moet nog met verse feedback worden bevestigd.", 34, {
+        heatPumps: [
+          stoppedFaulted(1, 1001, [INCIDENTS.linkLoss()], {
+            link_state: "recovering",
+            protection_state: "clear",
+            run_state: "stopping",
+            availability: "recovering",
+            stop_confirmed: false,
+            stop_confirmation_pending: true,
+            fault_active: false,
+            fallback_eligible: false,
+          }),
+          heatPump(2, { run_state: "running" }),
+        ],
+      }),
+      phase("stop-confirmed", "Stop HP1 opnieuw bevestigd", "Verse feedback bevestigt dat HP1 stilstaat; HP2 blijft de warmtevraag leveren.", 38, {
+        heatPumps: [
+          stoppedFaulted(1, 1001, [INCIDENTS.linkLoss()], {
+            link_state: "recovering",
+            protection_state: "clear",
+            availability: "recovering",
+            fault_active: false,
+          }),
+          heatPump(2, { run_state: "running" }),
+        ],
+        events: [
+          event(38, "hp_stop_confirmed", "HP1", "hp_link_loss", "normal", 2, "active", "standby"),
+        ],
+      }),
+      phase("recovered", "HP1 weer beschikbaar", "De communicatie is stabiel en HP1 is weer beschikbaar; HP2 is zonder onderbreking blijven draaien.", 68, {
+        heatPumps: [heatPump(1), heatPump(2, { run_state: "running" })],
+        events: [
+          event(68, "incident_clear", "HP1", "hp_link_loss", "normal", 2, "active", "standby", 1001),
+          event(68, "hp_availability_change", "HP1", "hp_recovered", "normal", 2, "recovering", "available", 1001),
+        ],
+      }),
+    ]),
+
     scenario("status-only", "Statusmelding: olie-retour", "Incidentmodel", "any", [
       phase("active", "Status actief", "De melding is zichtbaar, maar begrenst of stopt de warmtepomp niet.", 5, {
         heatPumps: [heatPump(1, {

--- a/openquatt/web/js/src/core/incident-monitoring.js
+++ b/openquatt/web/js/src/core/incident-monitoring.js
@@ -270,7 +270,10 @@ export function getHeatPumpStatusPresentation(heatPump = {}) {
     stopping: "Stop aangevraagd",
     stop_unconfirmed: "Stop nog niet bevestigd",
   };
-  const note = `${links[heatPump.linkState] || links.unknown} · ${runs[heatPump.runState] || runs.unknown}`;
+  const runStatus = heatPump.stopConfirmationPending
+    ? "Stopstatus wordt opnieuw bevestigd"
+    : runs[heatPump.runState] || runs.unknown;
+  const note = `${links[heatPump.linkState] || links.unknown} · ${runStatus}`;
   if (heatPump.faultActive || heatPump.protectionState === "fault_active") {
     return { label: "Storing actief", note, tone: "fault" };
   }
@@ -374,6 +377,7 @@ function normalizeHeatPump(raw) {
     availableForStart,
     mustStop,
     faultActive: normalizeBoolean(raw.fault_active),
+    stopConfirmationPending: normalizeBoolean(raw.stop_confirmation_pending),
     lastActionResult,
     actionResults,
     incidents: Array.isArray(raw.incidents)

--- a/openquatt/web/tests/incident-monitoring.test.mjs
+++ b/openquatt/web/tests/incident-monitoring.test.mjs
@@ -94,6 +94,7 @@ test("incident snapshot normalizes HP state, lifecycle and stable machine fields
   assert.equal(normalized.heatPumps[0].linkState, "lost");
   assert.equal(normalized.heatPumps[0].runState, "stop_unconfirmed");
   assert.equal(normalized.heatPumps[0].mustStop, true);
+  assert.equal(normalized.heatPumps[0].stopConfirmationPending, false);
   assert.deepEqual(
     normalized.heatPumps[0].incidents[0].effects,
     ["stop_compressor", "mark_hp_unavailable", "allow_cm4"],
@@ -362,6 +363,25 @@ test("a suspect HP link is shown as confirmation in progress instead of an outag
   assert.equal(presentation.label, "Status wordt bepaald");
   assert.equal(presentation.tone, "clear");
   assert.match(presentation.note, /eerst bevestigd/);
+});
+
+test("stop revalidation is presented as a neutral pending status", () => {
+  const normalized = normalizeIncidentMonitoringSnapshot(snapshot({
+    heat_pumps: [{
+      index: 1,
+      link_state: "healthy",
+      protection_state: "clear",
+      run_state: "stopping",
+      stop_confirmation_pending: true,
+    }],
+  }));
+  const heatPump = normalized.heatPumps[0];
+  const presentation = getHeatPumpStatusPresentation(heatPump);
+
+  assert.equal(heatPump.stopConfirmationPending, true);
+  assert.equal(presentation.label, "Status wordt bepaald");
+  assert.equal(presentation.note, "Verbinding gezond · Stopstatus wordt opnieuw bevestigd");
+  assert.equal(presentation.tone, "warning");
 });
 
 test("incident polling keeps last-good data through transient failures and cleanly handles 404", () => {

--- a/openquatt/web/tests/mock-incident-scenarios.test.mjs
+++ b/openquatt/web/tests/mock-incident-scenarios.test.mjs
@@ -71,7 +71,10 @@ test("confirmed link loss waits for stop confirmation before CM4", () => {
   assert.equal(lost.elapsed_s, 30);
   assert.equal(lost.system.action, "fallback_blocked");
   assert.equal(lost.system.fallback_block_reason, 10);
-  assert.equal(lost.heat_pumps[0].stop_unconfirmed, true);
+  assert.equal(lost.heat_pumps[0].stop_confirmation_pending, true);
+  assert.equal(lost.heat_pumps[0].stop_unconfirmed, false);
+  assert.equal(lost.heat_pumps[0].incidents.some((incident) => incident.definition.id === 1003), false);
+  assert.equal(lost.events.some((event) => event.reason === "hp_stop_unconfirmed"), false);
   assert.equal(lost.heat_pumps[0].protection_state, "clear");
   assert.equal(lost.heat_pumps[0].fault_active, false);
   assert.equal(fallback.system.control_mode, 4);

--- a/openquatt/web/tests/mock-incident-scenarios.test.mjs
+++ b/openquatt/web/tests/mock-incident-scenarios.test.mjs
@@ -87,6 +87,38 @@ test("confirmed link loss waits for stop confirmation before CM4", () => {
   );
 });
 
+test("Duo link loss revalidates HP1 while HP2 remains available", () => {
+  const scenario = catalog.getScenario("duo-link-loss-recovery");
+  assert.equal(scenario.topology, "duo");
+
+  const lost = scenario.phases.find((phase) => phase.id === "lost");
+  const revalidating = scenario.phases.find((phase) => phase.id === "revalidating");
+  const confirmed = scenario.phases.find((phase) => phase.id === "stop-confirmed");
+  const recovered = scenario.phases.find((phase) => phase.id === "recovered");
+
+  for (const phase of scenario.phases) {
+    assert.equal(phase.system.control_mode, 2);
+    assert.equal(phase.system.boiler_command_active, false);
+    assert.equal(phase.heat_pumps[1].link_state, "healthy");
+    assert.equal(phase.heat_pumps[1].availability, "available");
+    assert.equal(phase.heat_pumps[1].run_state, "running");
+  }
+
+  assert.equal(lost.heat_pumps[0].link_state, "lost");
+  assert.equal(lost.heat_pumps[0].stop_confirmation_pending, true);
+  assert.equal(revalidating.heat_pumps[0].link_state, "recovering");
+  assert.equal(revalidating.heat_pumps[0].stop_confirmation_pending, true);
+  assert.equal(revalidating.heat_pumps[0].stop_unconfirmed, false);
+  assert.equal(confirmed.heat_pumps[0].stop_confirmed, true);
+  assert.equal(confirmed.heat_pumps[0].stop_confirmation_pending, false);
+  assert.equal(recovered.heat_pumps[0].link_state, "healthy");
+  assert.equal(recovered.heat_pumps[0].availability, "available");
+  assert.ok(
+    catalog.collectEvents(scenario.id, scenario.phases.indexOf(confirmed))
+      .some((event) => event.event_type === "hp_stop_confirmed" && event.subject === "HP1"),
+  );
+});
+
 test("CM3 to CM4 R1 and OpenTherm fixtures preserve the active boiler command", () => {
   for (const [id, transport] of [
     ["cm3-cm4-r1", "R1"],

--- a/tests/host/incident_actuator_logic_test.cpp
+++ b/tests/host/incident_actuator_logic_test.cpp
@@ -8,6 +8,7 @@ int main() {
   using oq_incident_actuator::apply_stop_notification_before_safe_write;
   using oq_incident_actuator::decide;
   using oq_incident_actuator::Inputs;
+  using oq_incident_actuator::requires_stop_notification;
   using oq_incident_actuator::safe_stop_write_retry_due;
 
   auto decision = decide(Inputs{5, 0, true, false});
@@ -62,5 +63,10 @@ int main() {
   assert(!safe_stop_write_retry_due(true, 19999U, 10000U, 10000U));
   assert(safe_stop_write_retry_due(true, 20000U, 10000U, 10000U));
   assert(safe_stop_write_retry_due(true, 5U, UINT32_MAX - 10U, 10U));
+
+  assert(!requires_stop_notification(false, false, true, false));
+  assert(requires_stop_notification(true, false, true, false));
+  assert(requires_stop_notification(false, true, false, false));
+  assert(requires_stop_notification(false, false, false, true));
   return 0;
 }

--- a/tests/host/openquatt_incident_runtime_policy_test.cpp
+++ b/tests/host/openquatt_incident_runtime_policy_test.cpp
@@ -70,12 +70,16 @@ void test_confirmation_audit_policy() {
                                         std::numeric_limits<uint32_t>::max()));
 
   // Passive boot observations may establish that an already-idle HP is
-  // stopped. A commanded stop still requires feedback newer than its write.
-  assert(run_observation_is_fresh(false, true, false, false));
-  assert(!run_observation_is_fresh(false, true, true, false));
-  assert(run_observation_is_fresh(false, true, true, true));
-  assert(!run_observation_is_fresh(true, false, false, false));
-  assert(run_observation_is_fresh(true, false, false, true));
+  // stopped. A commanded stop or revalidation must be armed and use feedback
+  // newer than its write.
+  assert(run_observation_is_fresh(false, true, false, false, false));
+  assert(!run_observation_is_fresh(false, true, true, false, false));
+  assert(!run_observation_is_fresh(false, true, true, true, false));
+  assert(run_observation_is_fresh(false, true, true, true, true));
+  assert(!run_observation_is_fresh(false, true, false, true, false));
+  assert(run_observation_is_fresh(false, true, false, true, true));
+  assert(!run_observation_is_fresh(true, false, false, false, false));
+  assert(run_observation_is_fresh(true, false, false, false, true));
 }
 
 void test_start_failure_retry_production_policy() {

--- a/tests/host/oq_hp_incident_engine_test.cpp
+++ b/tests/host/oq_hp_incident_engine_test.cpp
@@ -96,7 +96,9 @@ void test_short_link_dip_and_confirmed_loss() {
   engine.observe_link_round(142100U, false);
   assert(engine.outputs().link_state == LinkState::LOST);
   assert(engine.outputs().must_stop);
-  assert(engine.outputs().run_state == RunState::STOP_UNCONFIRMED);
+  assert(engine.outputs().run_state == RunState::STOPPING);
+  assert(engine.outputs().stop_confirmation_pending);
+  assert(!engine.outputs().stop_unconfirmed);
 
   engine.observe_link_round(152100U, true);
   assert(engine.outputs().link_state == LinkState::RECOVERING);
@@ -122,7 +124,8 @@ void test_link_loss_invalidates_old_stop_confirmation() {
   engine.observe_link_round(121100U, false);
   engine.observe_link_round(122100U, false);
   assert(engine.outputs().link_state == LinkState::LOST);
-  assert(engine.outputs().stop_unconfirmed);
+  assert(engine.outputs().stop_confirmation_pending);
+  assert(!engine.outputs().stop_unconfirmed);
   assert(!engine.outputs().stop_confirmed);
   assert(engine.outputs().fallback_cause_present);
   assert(!engine.outputs().fallback_eligible);
@@ -133,6 +136,7 @@ void test_link_loss_invalidates_old_stop_confirmation() {
   assert(!engine.outputs().fallback_eligible);
   engine.observe_run(frequency(124100U, 0.0F));
   assert(engine.outputs().stop_confirmed);
+  assert(!engine.outputs().stop_confirmation_pending);
   assert(engine.outputs().fallback_eligible);
 }
 
@@ -150,7 +154,9 @@ void test_link_loss_rearms_an_inflight_stop() {
   engine.observe_link_round(131100U, false);
   engine.observe_link_round(132100U, false);
   assert(engine.outputs().link_state == LinkState::LOST);
-  assert(engine.outputs().run_state == RunState::STOP_UNCONFIRMED);
+  assert(engine.outputs().run_state == RunState::STOPPING);
+  assert(engine.outputs().stop_confirmation_pending);
+  assert(!engine.outputs().stop_unconfirmed);
 
   // The next actuator pass must register a new stop and generation baseline.
   assert(engine.request_stop(132101U));
@@ -171,16 +177,24 @@ void test_new_hard_fault_invalidates_old_stop_confirmation() {
   assert(engine.outputs().stop_confirmed);
   engine.observe_fault_words(words(90101U, kHardFault));
   assert(engine.outputs().fallback_cause_present);
-  assert(engine.outputs().run_state == RunState::STOP_UNCONFIRMED);
+  assert(engine.outputs().run_state == RunState::STOPPING);
+  assert(engine.outputs().stop_confirmation_pending);
+  assert(!engine.outputs().stop_unconfirmed);
   assert(!engine.outputs().stop_confirmed);
   assert(!engine.outputs().fallback_eligible);
 
-  assert(engine.request_stop(90102U));
+  engine.observe_run(frequency(90102U, 0.0F));
+  engine.observe_run(frequency(90103U, 0.0F));
+  assert(engine.outputs().stop_confirmation_pending);
+  assert(!engine.outputs().stop_confirmed);
+
+  assert(engine.request_stop(90104U));
   engine.observe_run(frequency(100102U, 0.0F));
   assert(!engine.outputs().stop_confirmed);
   assert(!engine.request_stop(100103U));
   engine.observe_run(frequency(110102U, 0.0F));
   assert(engine.outputs().stop_confirmed);
+  assert(!engine.outputs().stop_confirmation_pending);
   assert(engine.outputs().fallback_eligible);
 }
 
@@ -197,7 +211,9 @@ void test_new_hard_fault_discards_partial_stop_confirmation() {
   constexpr uint16_t kHardFault = 1U << 0U;
   engine.observe_fault_words(words(100101U, kHardFault));
   engine.observe_fault_words(words(110101U, kHardFault));
-  assert(engine.outputs().run_state == RunState::STOP_UNCONFIRMED);
+  assert(engine.outputs().run_state == RunState::STOPPING);
+  assert(engine.outputs().stop_confirmation_pending);
+  assert(!engine.outputs().stop_unconfirmed);
   assert(!engine.outputs().stop_confirmed);
   assert(!engine.outputs().fallback_eligible);
 
@@ -463,6 +479,34 @@ void test_repeated_stop_request_does_not_restart_timeout() {
   assert(!engine.request_stop(140101U));
   engine.tick(150102U);
   assert(engine.outputs().run_state == RunState::STOP_UNCONFIRMED);
+  assert(!engine.outputs().stop_confirmation_pending);
+}
+
+void test_revalidation_only_becomes_unconfirmed_after_timeout() {
+  EngineTuning tuning;
+  tuning.stop_confirm_timeout_ms = 60000U;
+  HpIncidentEngine engine(tuning);
+  establish_healthy_link(engine, 100U);
+  confirm_stopped(engine, 60101U);
+
+  constexpr uint16_t kHardFault = 1U << 0U;
+  engine.observe_fault_words(words(80101U, kHardFault));
+  engine.observe_fault_words(words(90101U, kHardFault));
+  assert(engine.outputs().stop_confirmation_pending);
+  assert(!engine.outputs().stop_unconfirmed);
+  assert(!engine.outputs().available_for_start);
+  assert(engine.outputs().must_stop);
+  assert(!engine.outputs().fallback_eligible);
+
+  assert(engine.request_stop(90102U));
+  engine.tick(150101U);
+  assert(engine.outputs().stop_confirmation_pending);
+  assert(!engine.outputs().stop_unconfirmed);
+  engine.tick(150102U);
+  assert(!engine.outputs().stop_confirmation_pending);
+  assert(engine.outputs().stop_unconfirmed);
+  assert(engine.outputs().must_stop);
+  assert(!engine.outputs().fallback_eligible);
 }
 
 void test_preheat_pauses_start_watchdog() {
@@ -555,8 +599,19 @@ void test_stop_unconfirmed_blocks_fallback() {
   engine.request_stop(90101U);
   engine.tick(150102U);
   assert(engine.outputs().stop_unconfirmed);
+  assert(engine.outputs().must_stop);
   assert(!engine.outputs().fallback_eligible);
   assert(engine.outputs().primary_incident_id == kStopUnconfirmedIncidentId);
+
+  engine.observe_run(frequency(150103U, 12.0F));
+  assert(engine.outputs().stop_unconfirmed);
+  assert(!engine.outputs().stop_confirmed);
+  engine.observe_run(frequency(150104U, 0.0F));
+  assert(engine.outputs().stop_unconfirmed);
+  assert(!engine.outputs().stop_confirmed);
+  engine.observe_run(frequency(150105U, 0.0F));
+  assert(!engine.outputs().stop_unconfirmed);
+  assert(engine.outputs().stop_confirmed);
 }
 
 void test_power_cycle_latch_requires_explicit_confirmation() {
@@ -613,6 +668,7 @@ int main() {
   test_persistent_wrong_mode_requires_safe_stop_and_retry();
   test_stop_requires_post_command_mode_confirmation();
   test_repeated_stop_request_does_not_restart_timeout();
+  test_revalidation_only_becomes_unconfirmed_after_timeout();
   test_preheat_pauses_start_watchdog();
   test_start_timeout_requires_safe_stop_and_explicit_recovery();
   test_start_failure_retry_waits_for_fault_recovery();


### PR DESCRIPTION
# Wat verandert deze PR?

- Toont een opnieuw te bevestigen stopstatus als tijdelijke status, niet als storing.
- Maakt incident `Warmtepompstop niet bevestigd` pas actief na de bestaande timeout van 60 seconden.
- Houdt starten en CM4 geblokkeerd totdat verse stopfeedback is bevestigd.
- Voegt een Duo-mockscenario toe voor communicatie-uitval en herstel van HP1 terwijl HP2 blijft draaien.

Closes #462.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Een oude stopbevestiging wordt na een harde storing of linkuitval nog steeds ongeldig. OpenQuatt registreert eerst een nieuwe stopopdracht en accepteert alleen feedback van daarna. Een echte timeout blijft actief totdat twee verse stopmetingen de stop bevestigen.

## Achtergrond

De tijdelijke herbevestiging en een echte stop-timeout gebruikten dezelfde toestand. Daardoor ontstond direct incident 1003, inclusief tijdlijn-entry en latch. De nieuwe tijdelijke status veroorzaakt geen incident of historie. De Duo- en CM4-controles blijven fail-closed.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit corrigeert incidentclassificatie en statuscopy; er verandert geen instelling of gebruikersworkflow.

## Validatie

- `npm run check:cpp-format`
- `./scripts/run_host_regression_tests.sh` — 25 hosttests
- `npm run check:web` — 193 webtests en webkwaliteitscontrole
- `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml` — config en volledige firmwarecompile met ESPHome 2026.8.0

De audit controleerde ook feedback van vóór de nieuwe stopopdracht, gedeeltelijke bevestiging, de grens van 60 seconden, herhaalde stopaanvragen, bootstrap, herstel, Duo/CM4 en communicatie-uitval van één Duo-warmtepomp.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen dynamische allocaties, buffers of taken toegevoegd; alleen één booleaanse toestand in de bestaande incidentstatus.
