### PR TITLE
Beperk OpenTherm-statusmelding tot toestemmingsbronnen

### DIFF
--- a/openquatt/web/js/src/core/installation-monitoring.js
+++ b/openquatt/web/js/src/core/installation-monitoring.js
@@ -4,13 +4,6 @@ import { formatFailures, formatWarningFailures } from "./failure-format.js";
 import { combineInstallationMonitoringModel } from "./incident-monitoring.js";
 import { state } from "./state.js";
 
-const OT_THERMOSTAT_SOURCE_KEYS = [
-  "roomTempSource",
-  "roomSetpointSource",
-  "heatingEnableSource",
-  "coolingEnableSource",
-];
-
 export function isInstallationMonitoringBinaryActive(key) {
   return hasEntity(key) && isEntityActive(key);
 }
@@ -50,10 +43,12 @@ export function getInstallationMonitoringModel() {
   const cyclingAlertLatched = isInstallationMonitoringBinaryActive("compressorCyclingAlertLatched");
   const cicPollingEnabled = isInstallationMonitoringIntegrationEnabled("cicPollingEnabled");
   const otEnabled = isInstallationMonitoringIntegrationEnabled("otEnabled");
-  const otThermostatSourceSelected = OT_THERMOSTAT_SOURCE_KEYS.some(
-    (key) => hasEntity(key) && String(getEntityValue(key) || "").trim() === "OT thermostat",
+  const isOtThermostatSource = (key) => (
+    hasEntity(key) && String(getEntityValue(key) || "").trim() === "OT thermostat"
   );
-  const otThermostatStatusInvalid = otThermostatSourceSelected
+  const heatingEnableFromOt = isOtThermostatSource("heatingEnableSource");
+  const coolingEnableFromOt = isOtThermostatSource("coolingEnableSource");
+  const otThermostatStatusInvalid = (heatingEnableFromOt || coolingEnableFromOt)
     && hasEntity("otThermostatStatusValid")
     && !isEntityActive("otThermostatStatusValid");
   const addBinaryProblem = (key, label) => {
@@ -71,16 +66,18 @@ export function getInstallationMonitoringModel() {
   if (cicPollingEnabled) {
     addBinaryProblem("cicDataStale", "CIC-data is verouderd");
   }
-  if (otThermostatStatusInvalid) {
+  if (otEnabled && isInstallationMonitoringBinaryActive("otLinkProblem")) {
     problems.push({
-      key: "otThermostatStatusInvalid",
-      label: "Geen actuele OpenTherm-thermostaatstatus",
+      key: "otLinkProblem",
+      label: "OpenTherm-verbinding meldt een probleem",
     });
-  }
-  if (otEnabled) {
-    if (!otThermostatStatusInvalid) {
-      addBinaryProblem("otLinkProblem", "OpenTherm-verbinding meldt een probleem");
-    }
+  } else if (otThermostatStatusInvalid) {
+    const label = heatingEnableFromOt && coolingEnableFromOt
+      ? "Geen actuele verwarmings- en koeltoestemming van OpenTherm-thermostaat"
+      : heatingEnableFromOt
+        ? "Geen actuele warmtetoestemming van OpenTherm-thermostaat"
+        : "Geen actuele koeltoestemming van OpenTherm-thermostaat";
+    problems.push({ key: "otThermostatStatusInvalid", label });
   }
   if (!structuredIncidentMonitoringAvailable && isInstallationMonitoringFailureActive("hp1Failures")) {
     problems.push({ key: "hp1Failures", label: `Warmtepomp 1: ${getInstallationMonitoringWarningFailureText("hp1Failures")}` });

--- a/openquatt/web/js/src/settings/integrations.js
+++ b/openquatt/web/js/src/settings/integrations.js
@@ -95,7 +95,7 @@ import { escapeHtml } from "../core/html.js";
           : isInstallationMonitoringBinaryActive("otLinkProblem") ? "Probleem" : "OK",
         active: otEnabled && isInstallationMonitoringBinaryActive("otLinkProblem"),
       }) : "",
-      renderBinaryDiagnosticItem("otThermostatStatusValid", "Status geldig", "Ja", "Nee"),
+      renderBinaryDiagnosticItem("otThermostatStatusValid", "Statusbericht (ID 0) actueel", "Ja", "Nee"),
       renderBinaryDiagnosticItem("otThermostatChEnable", "Thermostaat CH", "Actief", "Normaal"),
       renderBinaryDiagnosticItem("otThermostatCoolingEnable", "Thermostaat koeling", "Actief", "Normaal"),
       renderValueDiagnosticItem("otControlSetpoint", "Control setpoint"),

--- a/openquatt/web/tests/boiler-view.test.mjs
+++ b/openquatt/web/tests/boiler-view.test.mjs
@@ -322,6 +322,7 @@ test("integration diagnostics separates thermostat, boiler control, OTB and CiC"
   try {
     const html = renderSettingsOpenThermCicSection();
     assert.match(html, /OpenTherm thermostaat \(OTT\)/);
+    assert.match(html, /Statusbericht \(ID 0\) actueel/);
     assert.match(html, /Ketelregeling/);
     assert.match(html, /OpenTherm ketel \(OTB\)/);
     assert.match(html, /CiC-feed/);

--- a/openquatt/web/tests/installation-monitoring.test.mjs
+++ b/openquatt/web/tests/installation-monitoring.test.mjs
@@ -39,7 +39,7 @@ test("actieve aanvoertemperatuurfallback verschijnt in de installatiebewaking", 
   }]);
 });
 
-test("ongeldige OTT-status verschijnt wanneer de thermostaat als bron is geselecteerd", () => {
+test("ongeldige OTT-status geeft geen melding wanneer alleen de kamertemperatuur via OTT komt", () => {
   state.entities = {
     otEnabled: { value: true, state: "ON" },
     otThermostatStatusValid: { value: false, state: "OFF" },
@@ -49,11 +49,104 @@ test("ongeldige OTT-status verschijnt wanneer de thermostaat als bron is geselec
 
   const monitoring = getInstallationMonitoringModel();
 
+  assert.equal(monitoring.active, false);
+  assert.deepEqual(monitoring.problems, []);
+});
+
+test("ongeldige OTT-status geeft geen melding wanneer alleen het kamer-setpoint via OTT komt", () => {
+  state.entities = {
+    otEnabled: { value: true, state: "ON" },
+    otThermostatStatusValid: { value: false, state: "OFF" },
+    otLinkProblem: { value: false, state: "OFF" },
+    roomSetpointSource: { value: "OT thermostat", state: "OT thermostat" },
+  };
+
+  const monitoring = getInstallationMonitoringModel();
+
+  assert.equal(monitoring.active, false);
+  assert.deepEqual(monitoring.problems, []);
+});
+
+test("ongeldige OTT-status geeft geen melding wanneer beide kamerwaarden via OTT komen", () => {
+  state.entities = {
+    otEnabled: { value: true, state: "ON" },
+    otThermostatStatusValid: { value: false, state: "OFF" },
+    otLinkProblem: { value: false, state: "OFF" },
+    roomTempSource: { value: "OT thermostat", state: "OT thermostat" },
+    roomSetpointSource: { value: "OT thermostat", state: "OT thermostat" },
+  };
+
+  const monitoring = getInstallationMonitoringModel();
+
+  assert.equal(monitoring.active, false);
+  assert.deepEqual(monitoring.problems, []);
+});
+
+test("ongeldige OTT-status meldt ontbrekende warmtetoestemming", () => {
+  state.entities = {
+    otEnabled: { value: true, state: "ON" },
+    otThermostatStatusValid: { value: false, state: "OFF" },
+    otLinkProblem: { value: false, state: "OFF" },
+    heatingEnableSource: { value: "OT thermostat", state: "OT thermostat" },
+  };
+
+  const monitoring = getInstallationMonitoringModel();
+
   assert.equal(monitoring.active, true);
   assert.deepEqual(monitoring.problems, [{
     key: "otThermostatStatusInvalid",
-    label: "Geen actuele OpenTherm-thermostaatstatus",
+    label: "Geen actuele warmtetoestemming van OpenTherm-thermostaat",
   }]);
+});
+
+test("ongeldige OTT-status meldt ontbrekende koeltoestemming", () => {
+  state.entities = {
+    otEnabled: { value: true, state: "ON" },
+    otThermostatStatusValid: { value: false, state: "OFF" },
+    otLinkProblem: { value: false, state: "OFF" },
+    coolingEnableSource: { value: "OT thermostat", state: "OT thermostat" },
+  };
+
+  const monitoring = getInstallationMonitoringModel();
+
+  assert.equal(monitoring.active, true);
+  assert.deepEqual(monitoring.problems, [{
+    key: "otThermostatStatusInvalid",
+    label: "Geen actuele koeltoestemming van OpenTherm-thermostaat",
+  }]);
+});
+
+test("ongeldige OTT-status combineert ontbrekende verwarmings- en koeltoestemming", () => {
+  state.entities = {
+    otEnabled: { value: true, state: "ON" },
+    otThermostatStatusValid: { value: false, state: "OFF" },
+    otLinkProblem: { value: false, state: "OFF" },
+    heatingEnableSource: { value: "OT thermostat", state: "OT thermostat" },
+    coolingEnableSource: { value: "OT thermostat", state: "OT thermostat" },
+  };
+
+  const monitoring = getInstallationMonitoringModel();
+
+  assert.equal(monitoring.active, true);
+  assert.deepEqual(monitoring.problems, [{
+    key: "otThermostatStatusInvalid",
+    label: "Geen actuele verwarmings- en koeltoestemming van OpenTherm-thermostaat",
+  }]);
+});
+
+test("actuele OTT-status geeft geen melding voor toestemming via OTT", () => {
+  state.entities = {
+    otEnabled: { value: true, state: "ON" },
+    otThermostatStatusValid: { value: true, state: "ON" },
+    otLinkProblem: { value: false, state: "OFF" },
+    heatingEnableSource: { value: "OT thermostat", state: "OT thermostat" },
+    coolingEnableSource: { value: "OT thermostat", state: "OT thermostat" },
+  };
+
+  const monitoring = getInstallationMonitoringModel();
+
+  assert.equal(monitoring.active, false);
+  assert.deepEqual(monitoring.problems, []);
 });
 
 test("ongeldige OTT-status geeft geen melding wanneer OTT niet als bron is geselecteerd", () => {
@@ -73,12 +166,31 @@ test("ongeldige OTT-status geeft geen melding wanneer OTT niet als bron is gesel
   assert.deepEqual(monitoring.problems, []);
 });
 
-test("OTT-linkprobleem blijft apart zichtbaar wanneer OTT niet als bron is geselecteerd", () => {
+test("OTT-linkprobleem blijft zichtbaar wanneer alleen de kamerwaarden via OTT komen", () => {
   state.entities = {
     otEnabled: { value: true, state: "ON" },
     otThermostatStatusValid: { value: false, state: "OFF" },
     otLinkProblem: { value: true, state: "ON" },
-    roomTempSource: { value: "HA input", state: "HA input" },
+    roomTempSource: { value: "OT thermostat", state: "OT thermostat" },
+    roomSetpointSource: { value: "OT thermostat", state: "OT thermostat" },
+  };
+
+  const monitoring = getInstallationMonitoringModel();
+
+  assert.equal(monitoring.active, true);
+  assert.deepEqual(monitoring.problems, [{
+    key: "otLinkProblem",
+    label: "OpenTherm-verbinding meldt een probleem",
+  }]);
+});
+
+test("OTT-linkprobleem heeft voorrang op een ongeldige toestemmingsstatus", () => {
+  state.entities = {
+    otEnabled: { value: true, state: "ON" },
+    otThermostatStatusValid: { value: false, state: "OFF" },
+    otLinkProblem: { value: true, state: "ON" },
+    heatingEnableSource: { value: "OT thermostat", state: "OT thermostat" },
+    coolingEnableSource: { value: "OT thermostat", state: "OT thermostat" },
   };
 
   const monitoring = getInstallationMonitoringModel();


### PR DESCRIPTION
# Wat verandert deze PR?

- Bewaak OpenTherm Status / Data-ID 0 alleen wanneer verwarmings- en/of koeltoestemming uit de OT-thermostaat wordt gebruikt.
- Geef een algemene OpenTherm-linkfout voorrang en toon anders een contextuele melding voor warmte-, koel- of beide toestemmingen.
- Verduidelijk de diagnostiekregel en dek de bron-/statuscombinaties af met gerichte regressietests.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Dit is een web-only correctie van installatiebewaking en diagnostische tekst. OpenTherm-time-outs, firmwarematige fail-closed verwerking en regellogica blijven ongewijzigd.

## Achtergrond

Fixes #472.

Data-ID 0 bevat de CH- en cooling-enablebits, maar is niet nodig voor de afzonderlijke OT-kamerwaarden uit Data-ID 16 en 24. Daarom veroorzaken alleen geselecteerde toestemmingsbronnen nog een ID0-waarschuwing. Bij een werkelijk linkprobleem blijft uitsluitend de algemene OpenTherm-linkmelding zichtbaar.

Buiten scope blijft afzonderlijke ouderdoms-/geldigheidsbewaking voor `TrSet` en `Tr`; dat is een apart vervolgpunt.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De wijziging corrigeert bestaande runtimecopy en verduidelijkt de diagnostiekregel zonder configuratiecontract, gebruikersworkflow of publieke interface te wijzigen.

## Validatie

- `node --test openquatt/web/tests/installation-monitoring.test.mjs openquatt/web/tests/boiler-view.test.mjs` — 37/37 tests geslaagd.
- `npm run check:web` — webbuild, 191/191 tests en webkwaliteitscontrole geslaagd.
- Lokale preview van Instellingen → Bronnen / integraties → Diagnostiek visueel gecontroleerd.
- Volledige diff tegen actuele `origin/dev` gecontroleerd op correctheid, bronwaarden/UI-copy, linkprioriteit, ontbrekende entities, compatibiliteit en fresh-install/upgradegedrag; aparte adversariële herreview zonder bevindingen.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Web-only wijziging; firmware, heap, PSRAM en task-stacks worden niet geraakt.