### PR TITLE
Test Q flowmeter filters side-by-side

### DIFF
--- a/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.cpp
+++ b/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.cpp
@@ -6,31 +6,38 @@
 
 namespace esphome::openquatt_flow_filter_probe {
 
-static const char *const TAG = "oq.flow_probe";
+static const char* const TAG = "oq.flow_probe";
 static constexpr uint32_t EDGE_FILTER_US = 100;
-static constexpr uint32_t PULSE_100_FILTER_US = 100;
+static constexpr uint32_t PULSE_13_FILTER_US = 13;
 static constexpr uint32_t PULSE_20_FILTER_US = 20;
+static constexpr uint32_t PULSE_50_FILTER_US = 50;
+static constexpr uint32_t PULSE_100_FILTER_US = 100;
 static constexpr uint32_t TIMEOUT_US = 5000000UL;
+static constexpr uint32_t DIAGNOSTICS_WINDOW_US = 10000000UL;
 
 void OpenQuattFlowFilterProbe::setup() {
   this->pin_->setup();
   this->isr_pin_ = this->pin_->to_isr();
   this->last_pin_val_ = this->pin_->digital_read();
-  this->pulse_100_filter_.latched = this->last_pin_val_;
+  this->pulse_13_filter_.latched = this->last_pin_val_;
   this->pulse_20_filter_.latched = this->last_pin_val_;
+  this->pulse_50_filter_.latched = this->last_pin_val_;
+  this->pulse_100_filter_.latched = this->last_pin_val_;
 
   const uint32_t now = micros();
   this->edge_100_runtime_.last_processed_edge_us = now;
-  this->pulse_100_runtime_.last_processed_edge_us = now;
+  this->pulse_13_runtime_.last_processed_edge_us = now;
   this->pulse_20_runtime_.last_processed_edge_us = now;
+  this->pulse_50_runtime_.last_processed_edge_us = now;
+  this->pulse_100_runtime_.last_processed_edge_us = now;
+  this->diagnostics_window_started_us_ = now;
 
   this->pin_->attach_interrupt(OpenQuattFlowFilterProbe::gpio_intr, this, gpio::INTERRUPT_ANY_EDGE);
 }
 
-void IRAM_ATTR OpenQuattFlowFilterProbe::apply_pulse_filter_(volatile ChannelState &channel,
-                                                             volatile PulseFilterState &filter,
-                                                             uint32_t filter_us, uint32_t now_us, bool pin_val,
-                                                             bool previous_pin_val) {
+void IRAM_ATTR OpenQuattFlowFilterProbe::apply_pulse_filter_(volatile ChannelState& channel,
+                                                             volatile PulseFilterState& filter, uint32_t filter_us,
+                                                             uint32_t now_us, bool pin_val, bool previous_pin_val) {
   const bool length = now_us - filter.last_intr_us >= filter_us;
 
   if (length && filter.latched && !previous_pin_val) {
@@ -45,21 +52,45 @@ void IRAM_ATTR OpenQuattFlowFilterProbe::apply_pulse_filter_(volatile ChannelSta
   filter.last_intr_us = now_us;
 }
 
-void IRAM_ATTR OpenQuattFlowFilterProbe::gpio_intr(OpenQuattFlowFilterProbe *probe) {
+void IRAM_ATTR OpenQuattFlowFilterProbe::gpio_intr(OpenQuattFlowFilterProbe* probe) {
   const uint32_t now = micros();
   const bool pin_val = probe->isr_pin_.digital_read();
   const bool previous_pin_val = probe->last_pin_val_;
 
-  if (pin_val && !previous_pin_val && (now - probe->edge_100_last_sent_us_) >= EDGE_FILTER_US) {
-    probe->edge_100_last_sent_us_ = now;
-    probe->edge_100_state_.last_detected_edge_us = now;
-    probe->edge_100_state_.last_rising_edge_us = now;
-    probe->edge_100_state_.count += 1;
+  if (pin_val && !previous_pin_val) {
+    probe->raw_rising_count_window_ += 1;
+    probe->raw_high_started_us_ = now;
+    if ((now - probe->edge_100_last_sent_us_) >= EDGE_FILTER_US) {
+      probe->edge_100_last_sent_us_ = now;
+      probe->edge_100_state_.last_detected_edge_us = now;
+      probe->edge_100_state_.last_rising_edge_us = now;
+      probe->edge_100_state_.count += 1;
+    }
+  } else if (!pin_val && previous_pin_val && probe->raw_high_started_us_ != 0) {
+    const uint32_t width_us = now - probe->raw_high_started_us_;
+    probe->raw_high_started_us_ = 0;
+    probe->width_stats_.count += 1;
+    probe->width_stats_.sum_us += width_us;
+    if (width_us < probe->width_stats_.min_us) probe->width_stats_.min_us = width_us;
+    if (width_us > probe->width_stats_.max_us) probe->width_stats_.max_us = width_us;
+    if (width_us < 20) {
+      probe->width_stats_.lt20 += 1;
+    } else if (width_us < 50) {
+      probe->width_stats_.from20_to50 += 1;
+    } else if (width_us < 100) {
+      probe->width_stats_.from50_to100 += 1;
+    } else {
+      probe->width_stats_.ge100 += 1;
+    }
   }
 
-  apply_pulse_filter_(probe->pulse_100_state_, probe->pulse_100_filter_, PULSE_100_FILTER_US, now, pin_val,
+  apply_pulse_filter_(probe->pulse_13_state_, probe->pulse_13_filter_, PULSE_13_FILTER_US, now, pin_val,
                       previous_pin_val);
   apply_pulse_filter_(probe->pulse_20_state_, probe->pulse_20_filter_, PULSE_20_FILTER_US, now, pin_val,
+                      previous_pin_val);
+  apply_pulse_filter_(probe->pulse_50_state_, probe->pulse_50_filter_, PULSE_50_FILTER_US, now, pin_val,
+                      previous_pin_val);
+  apply_pulse_filter_(probe->pulse_100_state_, probe->pulse_100_filter_, PULSE_100_FILTER_US, now, pin_val,
                       previous_pin_val);
 
   probe->last_pin_val_ = pin_val;
@@ -73,7 +104,7 @@ float OpenQuattFlowFilterProbe::pulses_per_minute_to_lph_(float ppm) const {
   return lph > 0.0f ? lph : 0.0f;
 }
 
-void OpenQuattFlowFilterProbe::process_channel_(sensor::Sensor *sensor, ChannelState state, RuntimeState &runtime,
+void OpenQuattFlowFilterProbe::process_channel_(sensor::Sensor* sensor, ChannelState state, RuntimeState& runtime,
                                                 uint32_t filter_us, bool pulse_mode, uint32_t now_us) {
   if (runtime.peeked_edge && state.count > 0) {
     runtime.peeked_edge = false;
@@ -108,46 +139,112 @@ void OpenQuattFlowFilterProbe::process_channel_(sensor::Sensor *sensor, ChannelS
   }
 }
 
+void OpenQuattFlowFilterProbe::publish_raw_diagnostics_(uint32_t now_us) {
+  if (now_us - this->diagnostics_window_started_us_ < DIAGNOSTICS_WINDOW_US) return;
+
+  uint32_t raw_count = 0;
+  WidthStats stats{};
+  {
+    InterruptLock lock;
+    raw_count = this->raw_rising_count_window_;
+    this->raw_rising_count_window_ = 0;
+
+    stats.count = this->width_stats_.count;
+    stats.sum_us = this->width_stats_.sum_us;
+    stats.min_us = this->width_stats_.min_us;
+    stats.max_us = this->width_stats_.max_us;
+    stats.lt20 = this->width_stats_.lt20;
+    stats.from20_to50 = this->width_stats_.from20_to50;
+    stats.from50_to100 = this->width_stats_.from50_to100;
+    stats.ge100 = this->width_stats_.ge100;
+    this->width_stats_ = WidthStats{};
+  }
+
+  const uint32_t elapsed_us = now_us - this->diagnostics_window_started_us_;
+  this->diagnostics_window_started_us_ = now_us;
+  const float elapsed_s = elapsed_us / 1000000.0f;
+  const float raw_hz = elapsed_s > 0.0f ? raw_count / elapsed_s : 0.0f;
+
+  if (this->raw_rising_hz_sensor_ != nullptr) this->raw_rising_hz_sensor_->publish_state(raw_hz);
+  if (this->raw_rising_count_sensor_ != nullptr) this->raw_rising_count_sensor_->publish_state(raw_count);
+
+  if (stats.count == 0) {
+    if (this->pulse_width_min_sensor_ != nullptr) this->pulse_width_min_sensor_->publish_state(NAN);
+    if (this->pulse_width_avg_sensor_ != nullptr) this->pulse_width_avg_sensor_->publish_state(NAN);
+    if (this->pulse_width_max_sensor_ != nullptr) this->pulse_width_max_sensor_->publish_state(NAN);
+    if (this->pulse_width_lt20_sensor_ != nullptr) this->pulse_width_lt20_sensor_->publish_state(0.0f);
+    if (this->pulse_width_20_50_sensor_ != nullptr) this->pulse_width_20_50_sensor_->publish_state(0.0f);
+    if (this->pulse_width_50_100_sensor_ != nullptr) this->pulse_width_50_100_sensor_->publish_state(0.0f);
+    if (this->pulse_width_ge100_sensor_ != nullptr) this->pulse_width_ge100_sensor_->publish_state(0.0f);
+    return;
+  }
+
+  const float count = static_cast<float>(stats.count);
+  if (this->pulse_width_min_sensor_ != nullptr) this->pulse_width_min_sensor_->publish_state(stats.min_us);
+  if (this->pulse_width_avg_sensor_ != nullptr)
+    this->pulse_width_avg_sensor_->publish_state(static_cast<float>(stats.sum_us) / count);
+  if (this->pulse_width_max_sensor_ != nullptr) this->pulse_width_max_sensor_->publish_state(stats.max_us);
+  if (this->pulse_width_lt20_sensor_ != nullptr) this->pulse_width_lt20_sensor_->publish_state(100.0f * stats.lt20 / count);
+  if (this->pulse_width_20_50_sensor_ != nullptr)
+    this->pulse_width_20_50_sensor_->publish_state(100.0f * stats.from20_to50 / count);
+  if (this->pulse_width_50_100_sensor_ != nullptr)
+    this->pulse_width_50_100_sensor_->publish_state(100.0f * stats.from50_to100 / count);
+  if (this->pulse_width_ge100_sensor_ != nullptr) this->pulse_width_ge100_sensor_->publish_state(100.0f * stats.ge100 / count);
+}
+
 void OpenQuattFlowFilterProbe::loop() {
   ChannelState edge_100{};
-  ChannelState pulse_100{};
+  ChannelState pulse_13{};
   ChannelState pulse_20{};
+  ChannelState pulse_50{};
+  ChannelState pulse_100{};
 
   {
     InterruptLock lock;
     const bool current = this->pin_->digital_read();
-    if (current != this->last_pin_val_) {
-      gpio_intr(this);
-    }
+    if (current != this->last_pin_val_) gpio_intr(this);
 
     edge_100.last_detected_edge_us = this->edge_100_state_.last_detected_edge_us;
     edge_100.last_rising_edge_us = this->edge_100_state_.last_rising_edge_us;
     edge_100.count = this->edge_100_state_.count;
     this->edge_100_state_.count = 0;
 
-    pulse_100.last_detected_edge_us = this->pulse_100_state_.last_detected_edge_us;
-    pulse_100.last_rising_edge_us = this->pulse_100_state_.last_rising_edge_us;
-    pulse_100.count = this->pulse_100_state_.count;
-    this->pulse_100_state_.count = 0;
+    pulse_13.last_detected_edge_us = this->pulse_13_state_.last_detected_edge_us;
+    pulse_13.last_rising_edge_us = this->pulse_13_state_.last_rising_edge_us;
+    pulse_13.count = this->pulse_13_state_.count;
+    this->pulse_13_state_.count = 0;
 
     pulse_20.last_detected_edge_us = this->pulse_20_state_.last_detected_edge_us;
     pulse_20.last_rising_edge_us = this->pulse_20_state_.last_rising_edge_us;
     pulse_20.count = this->pulse_20_state_.count;
     this->pulse_20_state_.count = 0;
+
+    pulse_50.last_detected_edge_us = this->pulse_50_state_.last_detected_edge_us;
+    pulse_50.last_rising_edge_us = this->pulse_50_state_.last_rising_edge_us;
+    pulse_50.count = this->pulse_50_state_.count;
+    this->pulse_50_state_.count = 0;
+
+    pulse_100.last_detected_edge_us = this->pulse_100_state_.last_detected_edge_us;
+    pulse_100.last_rising_edge_us = this->pulse_100_state_.last_rising_edge_us;
+    pulse_100.count = this->pulse_100_state_.count;
+    this->pulse_100_state_.count = 0;
   }
 
   const uint32_t now = micros();
   this->process_channel_(this->edge_100_sensor_, edge_100, this->edge_100_runtime_, EDGE_FILTER_US, false, now);
-  this->process_channel_(this, pulse_100, this->pulse_100_runtime_, PULSE_100_FILTER_US, true, now);
+  this->process_channel_(this->pulse_13_sensor_, pulse_13, this->pulse_13_runtime_, PULSE_13_FILTER_US, true, now);
   this->process_channel_(this->pulse_20_sensor_, pulse_20, this->pulse_20_runtime_, PULSE_20_FILTER_US, true, now);
+  this->process_channel_(this->pulse_50_sensor_, pulse_50, this->pulse_50_runtime_, PULSE_50_FILTER_US, true, now);
+  this->process_channel_(this, pulse_100, this->pulse_100_runtime_, PULSE_100_FILTER_US, true, now);
+  this->publish_raw_diagnostics_(now);
 }
 
 void OpenQuattFlowFilterProbe::dump_config() {
   ESP_LOGCONFIG(TAG, "Q flow filter comparison probe");
   LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG, "  Primary/control: PULSE 100us");
-  ESP_LOGCONFIG(TAG, "  Comparison 1: EDGE 100us");
-  ESP_LOGCONFIG(TAG, "  Comparison 2: PULSE 20us");
+  ESP_LOGCONFIG(TAG, "  Comparison: PULSE 13us / 20us / 50us and EDGE 100us");
+  ESP_LOGCONFIG(TAG, "  Raw diagnostics: rising-edge Hz/count and pulse-width distribution");
 }
 
 }  // namespace esphome::openquatt_flow_filter_probe

--- a/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.cpp
+++ b/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.cpp
@@ -1,0 +1,153 @@
+#include "OpenQuattFlowFilterProbe.h"
+
+#include <cmath>
+
+#include "esphome/core/log.h"
+
+namespace esphome::openquatt_flow_filter_probe {
+
+static const char *const TAG = "oq.flow_probe";
+static constexpr uint32_t EDGE_FILTER_US = 100;
+static constexpr uint32_t PULSE_100_FILTER_US = 100;
+static constexpr uint32_t PULSE_20_FILTER_US = 20;
+static constexpr uint32_t TIMEOUT_US = 5000000UL;
+
+void OpenQuattFlowFilterProbe::setup() {
+  this->pin_->setup();
+  this->isr_pin_ = this->pin_->to_isr();
+  this->last_pin_val_ = this->pin_->digital_read();
+  this->pulse_100_filter_.latched = this->last_pin_val_;
+  this->pulse_20_filter_.latched = this->last_pin_val_;
+
+  const uint32_t now = micros();
+  this->edge_100_runtime_.last_processed_edge_us = now;
+  this->pulse_100_runtime_.last_processed_edge_us = now;
+  this->pulse_20_runtime_.last_processed_edge_us = now;
+
+  this->pin_->attach_interrupt(OpenQuattFlowFilterProbe::gpio_intr, this, gpio::INTERRUPT_ANY_EDGE);
+}
+
+void IRAM_ATTR OpenQuattFlowFilterProbe::apply_pulse_filter_(volatile ChannelState &channel,
+                                                             volatile PulseFilterState &filter,
+                                                             uint32_t filter_us, uint32_t now_us, bool pin_val,
+                                                             bool previous_pin_val) {
+  const bool length = now_us - filter.last_intr_us >= filter_us;
+
+  if (length && filter.latched && !previous_pin_val) {
+    filter.latched = false;
+  } else if (length && !filter.latched && previous_pin_val) {
+    filter.latched = true;
+    channel.last_detected_edge_us = filter.last_intr_us;
+    channel.count += 1;
+  }
+
+  channel.last_rising_edge_us = !filter.latched && pin_val ? now_us : channel.last_detected_edge_us;
+  filter.last_intr_us = now_us;
+}
+
+void IRAM_ATTR OpenQuattFlowFilterProbe::gpio_intr(OpenQuattFlowFilterProbe *probe) {
+  const uint32_t now = micros();
+  const bool pin_val = probe->isr_pin_.digital_read();
+  const bool previous_pin_val = probe->last_pin_val_;
+
+  if (pin_val && !previous_pin_val && (now - probe->edge_100_last_sent_us_) >= EDGE_FILTER_US) {
+    probe->edge_100_last_sent_us_ = now;
+    probe->edge_100_state_.last_detected_edge_us = now;
+    probe->edge_100_state_.last_rising_edge_us = now;
+    probe->edge_100_state_.count += 1;
+  }
+
+  apply_pulse_filter_(probe->pulse_100_state_, probe->pulse_100_filter_, PULSE_100_FILTER_US, now, pin_val,
+                      previous_pin_val);
+  apply_pulse_filter_(probe->pulse_20_state_, probe->pulse_20_filter_, PULSE_20_FILTER_US, now, pin_val,
+                      previous_pin_val);
+
+  probe->last_pin_val_ = pin_val;
+}
+
+float OpenQuattFlowFilterProbe::pulses_per_minute_to_lph_(float ppm) const {
+  const float hz = ppm / 60.0f;
+  const float lpm = this->kf_lpm_per_hz_ * hz + this->q0_lpm_;
+  if (std::isnan(lpm)) return NAN;
+  const float lph = lpm * 60.0f;
+  return lph > 0.0f ? lph : 0.0f;
+}
+
+void OpenQuattFlowFilterProbe::process_channel_(sensor::Sensor *sensor, ChannelState state, RuntimeState &runtime,
+                                                uint32_t filter_us, bool pulse_mode, uint32_t now_us) {
+  if (runtime.peeked_edge && state.count > 0) {
+    runtime.peeked_edge = false;
+    state.count--;
+  }
+
+  if (pulse_mode && !runtime.peeked_edge && state.last_rising_edge_us != state.last_detected_edge_us &&
+      now_us - state.last_rising_edge_us >= filter_us) {
+    runtime.peeked_edge = true;
+    state.last_detected_edge_us = state.last_rising_edge_us;
+    state.count++;
+  }
+
+  if (state.count > 0) {
+    if (runtime.meter_state != 1) {
+      runtime.meter_state = 1;
+    } else {
+      const uint32_t delta_us = state.last_detected_edge_us - runtime.last_processed_edge_us;
+      const float pulse_width_us = delta_us / static_cast<float>(state.count);
+      if (pulse_width_us > 0.0f) {
+        const float ppm = (60.0f * 1000000.0f) / pulse_width_us;
+        sensor->publish_state(this->pulses_per_minute_to_lph_(ppm));
+      }
+    }
+    runtime.last_processed_edge_us = state.last_detected_edge_us;
+    return;
+  }
+
+  if (now_us - runtime.last_processed_edge_us > TIMEOUT_US && runtime.meter_state != 2) {
+    runtime.meter_state = 2;
+    sensor->publish_state(0.0f);
+  }
+}
+
+void OpenQuattFlowFilterProbe::loop() {
+  ChannelState edge_100{};
+  ChannelState pulse_100{};
+  ChannelState pulse_20{};
+
+  {
+    InterruptLock lock;
+    const bool current = this->pin_->digital_read();
+    if (current != this->last_pin_val_) {
+      gpio_intr(this);
+    }
+
+    edge_100.last_detected_edge_us = this->edge_100_state_.last_detected_edge_us;
+    edge_100.last_rising_edge_us = this->edge_100_state_.last_rising_edge_us;
+    edge_100.count = this->edge_100_state_.count;
+    this->edge_100_state_.count = 0;
+
+    pulse_100.last_detected_edge_us = this->pulse_100_state_.last_detected_edge_us;
+    pulse_100.last_rising_edge_us = this->pulse_100_state_.last_rising_edge_us;
+    pulse_100.count = this->pulse_100_state_.count;
+    this->pulse_100_state_.count = 0;
+
+    pulse_20.last_detected_edge_us = this->pulse_20_state_.last_detected_edge_us;
+    pulse_20.last_rising_edge_us = this->pulse_20_state_.last_rising_edge_us;
+    pulse_20.count = this->pulse_20_state_.count;
+    this->pulse_20_state_.count = 0;
+  }
+
+  const uint32_t now = micros();
+  this->process_channel_(this->edge_100_sensor_, edge_100, this->edge_100_runtime_, EDGE_FILTER_US, false, now);
+  this->process_channel_(this, pulse_100, this->pulse_100_runtime_, PULSE_100_FILTER_US, true, now);
+  this->process_channel_(this->pulse_20_sensor_, pulse_20, this->pulse_20_runtime_, PULSE_20_FILTER_US, true, now);
+}
+
+void OpenQuattFlowFilterProbe::dump_config() {
+  ESP_LOGCONFIG(TAG, "Q flow filter comparison probe");
+  LOG_PIN("  Pin: ", this->pin_);
+  ESP_LOGCONFIG(TAG, "  Primary/control: PULSE 100us");
+  ESP_LOGCONFIG(TAG, "  Comparison 1: EDGE 100us");
+  ESP_LOGCONFIG(TAG, "  Comparison 2: PULSE 20us");
+}
+
+}  // namespace esphome::openquatt_flow_filter_probe

--- a/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.cpp
+++ b/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.cpp
@@ -157,7 +157,15 @@ void OpenQuattFlowFilterProbe::publish_raw_diagnostics_(uint32_t now_us) {
     stats.from20_to50 = this->width_stats_.from20_to50;
     stats.from50_to100 = this->width_stats_.from50_to100;
     stats.ge100 = this->width_stats_.ge100;
-    this->width_stats_ = WidthStats{};
+
+    this->width_stats_.count = 0;
+    this->width_stats_.sum_us = 0;
+    this->width_stats_.min_us = UINT32_MAX;
+    this->width_stats_.max_us = 0;
+    this->width_stats_.lt20 = 0;
+    this->width_stats_.from20_to50 = 0;
+    this->width_stats_.from50_to100 = 0;
+    this->width_stats_.ge100 = 0;
   }
 
   const uint32_t elapsed_us = now_us - this->diagnostics_window_started_us_;
@@ -184,12 +192,14 @@ void OpenQuattFlowFilterProbe::publish_raw_diagnostics_(uint32_t now_us) {
   if (this->pulse_width_avg_sensor_ != nullptr)
     this->pulse_width_avg_sensor_->publish_state(static_cast<float>(stats.sum_us) / count);
   if (this->pulse_width_max_sensor_ != nullptr) this->pulse_width_max_sensor_->publish_state(stats.max_us);
-  if (this->pulse_width_lt20_sensor_ != nullptr) this->pulse_width_lt20_sensor_->publish_state(100.0f * stats.lt20 / count);
+  if (this->pulse_width_lt20_sensor_ != nullptr)
+    this->pulse_width_lt20_sensor_->publish_state(100.0f * stats.lt20 / count);
   if (this->pulse_width_20_50_sensor_ != nullptr)
     this->pulse_width_20_50_sensor_->publish_state(100.0f * stats.from20_to50 / count);
   if (this->pulse_width_50_100_sensor_ != nullptr)
     this->pulse_width_50_100_sensor_->publish_state(100.0f * stats.from50_to100 / count);
-  if (this->pulse_width_ge100_sensor_ != nullptr) this->pulse_width_ge100_sensor_->publish_state(100.0f * stats.ge100 / count);
+  if (this->pulse_width_ge100_sensor_ != nullptr)
+    this->pulse_width_ge100_sensor_->publish_state(100.0f * stats.ge100 / count);
 }
 
 void OpenQuattFlowFilterProbe::loop() {

--- a/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.h
+++ b/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.h
@@ -51,7 +51,7 @@ class OpenQuattFlowFilterProbe : public sensor::Sensor, public Component {
 
   struct WidthStats {
     uint32_t count{0};
-    uint64_t sum_us{0};
+    uint32_t sum_us{0};
     uint32_t min_us{UINT32_MAX};
     uint32_t max_us{0};
     uint32_t lt20{0};

--- a/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.h
+++ b/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.h
@@ -33,12 +33,12 @@ class OpenQuattFlowFilterProbe : public sensor::Sensor, public Component {
   };
 
   struct RuntimeState {
-    bool running{false};
+    uint8_t meter_state{0};  // 0=initial, 1=running, 2=timed out
     bool peeked_edge{false};
     uint32_t last_processed_edge_us{0};
   };
 
-  static void gpio_intr(OpenQuattFlowFilterProbe *probe);
+  static void IRAM_ATTR gpio_intr(OpenQuattFlowFilterProbe *probe);
   static void IRAM_ATTR apply_pulse_filter_(volatile ChannelState &channel, volatile PulseFilterState &filter,
                                             uint32_t filter_us, uint32_t now_us, bool pin_val, bool previous_pin_val);
   void process_channel_(sensor::Sensor *sensor, ChannelState state, RuntimeState &runtime, uint32_t filter_us,

--- a/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.h
+++ b/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.h
@@ -10,9 +10,20 @@ namespace esphome::openquatt_flow_filter_probe {
 
 class OpenQuattFlowFilterProbe : public sensor::Sensor, public Component {
  public:
-  void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
-  void set_edge_100_sensor(sensor::Sensor *sensor) { this->edge_100_sensor_ = sensor; }
-  void set_pulse_20_sensor(sensor::Sensor *sensor) { this->pulse_20_sensor_ = sensor; }
+  void set_pin(InternalGPIOPin* pin) { this->pin_ = pin; }
+  void set_edge_100_sensor(sensor::Sensor* sensor) { this->edge_100_sensor_ = sensor; }
+  void set_pulse_13_sensor(sensor::Sensor* sensor) { this->pulse_13_sensor_ = sensor; }
+  void set_pulse_20_sensor(sensor::Sensor* sensor) { this->pulse_20_sensor_ = sensor; }
+  void set_pulse_50_sensor(sensor::Sensor* sensor) { this->pulse_50_sensor_ = sensor; }
+  void set_raw_rising_hz_sensor(sensor::Sensor* sensor) { this->raw_rising_hz_sensor_ = sensor; }
+  void set_raw_rising_count_sensor(sensor::Sensor* sensor) { this->raw_rising_count_sensor_ = sensor; }
+  void set_pulse_width_min_sensor(sensor::Sensor* sensor) { this->pulse_width_min_sensor_ = sensor; }
+  void set_pulse_width_avg_sensor(sensor::Sensor* sensor) { this->pulse_width_avg_sensor_ = sensor; }
+  void set_pulse_width_max_sensor(sensor::Sensor* sensor) { this->pulse_width_max_sensor_ = sensor; }
+  void set_pulse_width_lt20_sensor(sensor::Sensor* sensor) { this->pulse_width_lt20_sensor_ = sensor; }
+  void set_pulse_width_20_50_sensor(sensor::Sensor* sensor) { this->pulse_width_20_50_sensor_ = sensor; }
+  void set_pulse_width_50_100_sensor(sensor::Sensor* sensor) { this->pulse_width_50_100_sensor_ = sensor; }
+  void set_pulse_width_ge100_sensor(sensor::Sensor* sensor) { this->pulse_width_ge100_sensor_ = sensor; }
   void set_kf_lpm_per_hz(float value) { this->kf_lpm_per_hz_ = value; }
   void set_q0_lpm(float value) { this->q0_lpm_ = value; }
 
@@ -38,32 +49,66 @@ class OpenQuattFlowFilterProbe : public sensor::Sensor, public Component {
     uint32_t last_processed_edge_us{0};
   };
 
-  static void IRAM_ATTR gpio_intr(OpenQuattFlowFilterProbe *probe);
-  static void IRAM_ATTR apply_pulse_filter_(volatile ChannelState &channel, volatile PulseFilterState &filter,
+  struct WidthStats {
+    uint32_t count{0};
+    uint64_t sum_us{0};
+    uint32_t min_us{UINT32_MAX};
+    uint32_t max_us{0};
+    uint32_t lt20{0};
+    uint32_t from20_to50{0};
+    uint32_t from50_to100{0};
+    uint32_t ge100{0};
+  };
+
+  static void IRAM_ATTR gpio_intr(OpenQuattFlowFilterProbe* probe);
+  static void IRAM_ATTR apply_pulse_filter_(volatile ChannelState& channel, volatile PulseFilterState& filter,
                                             uint32_t filter_us, uint32_t now_us, bool pin_val, bool previous_pin_val);
-  void process_channel_(sensor::Sensor *sensor, ChannelState state, RuntimeState &runtime, uint32_t filter_us,
+  void process_channel_(sensor::Sensor* sensor, ChannelState state, RuntimeState& runtime, uint32_t filter_us,
                         bool pulse_mode, uint32_t now_us);
+  void publish_raw_diagnostics_(uint32_t now_us);
   float pulses_per_minute_to_lph_(float ppm) const;
 
-  InternalGPIOPin *pin_{nullptr};
+  InternalGPIOPin* pin_{nullptr};
   ISRInternalGPIOPin isr_pin_;
-  sensor::Sensor *edge_100_sensor_{nullptr};
-  sensor::Sensor *pulse_20_sensor_{nullptr};
+  sensor::Sensor* edge_100_sensor_{nullptr};
+  sensor::Sensor* pulse_13_sensor_{nullptr};
+  sensor::Sensor* pulse_20_sensor_{nullptr};
+  sensor::Sensor* pulse_50_sensor_{nullptr};
+  sensor::Sensor* raw_rising_hz_sensor_{nullptr};
+  sensor::Sensor* raw_rising_count_sensor_{nullptr};
+  sensor::Sensor* pulse_width_min_sensor_{nullptr};
+  sensor::Sensor* pulse_width_avg_sensor_{nullptr};
+  sensor::Sensor* pulse_width_max_sensor_{nullptr};
+  sensor::Sensor* pulse_width_lt20_sensor_{nullptr};
+  sensor::Sensor* pulse_width_20_50_sensor_{nullptr};
+  sensor::Sensor* pulse_width_50_100_sensor_{nullptr};
+  sensor::Sensor* pulse_width_ge100_sensor_{nullptr};
 
   float kf_lpm_per_hz_{0.05f};
   float q0_lpm_{0.0f};
   bool last_pin_val_{false};
 
   volatile ChannelState edge_100_state_{};
-  volatile ChannelState pulse_100_state_{};
+  volatile ChannelState pulse_13_state_{};
   volatile ChannelState pulse_20_state_{};
-  volatile PulseFilterState pulse_100_filter_{};
+  volatile ChannelState pulse_50_state_{};
+  volatile ChannelState pulse_100_state_{};
+  volatile PulseFilterState pulse_13_filter_{};
   volatile PulseFilterState pulse_20_filter_{};
+  volatile PulseFilterState pulse_50_filter_{};
+  volatile PulseFilterState pulse_100_filter_{};
   volatile uint32_t edge_100_last_sent_us_{0};
 
+  volatile uint32_t raw_rising_count_window_{0};
+  volatile uint32_t raw_high_started_us_{0};
+  volatile WidthStats width_stats_{};
+  uint32_t diagnostics_window_started_us_{0};
+
   RuntimeState edge_100_runtime_{};
-  RuntimeState pulse_100_runtime_{};
+  RuntimeState pulse_13_runtime_{};
   RuntimeState pulse_20_runtime_{};
+  RuntimeState pulse_50_runtime_{};
+  RuntimeState pulse_100_runtime_{};
 };
 
 }  // namespace esphome::openquatt_flow_filter_probe

--- a/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.h
+++ b/components/openquatt_flow_filter_probe/OpenQuattFlowFilterProbe.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+
+namespace esphome::openquatt_flow_filter_probe {
+
+class OpenQuattFlowFilterProbe : public sensor::Sensor, public Component {
+ public:
+  void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
+  void set_edge_100_sensor(sensor::Sensor *sensor) { this->edge_100_sensor_ = sensor; }
+  void set_pulse_20_sensor(sensor::Sensor *sensor) { this->pulse_20_sensor_ = sensor; }
+  void set_kf_lpm_per_hz(float value) { this->kf_lpm_per_hz_ = value; }
+  void set_q0_lpm(float value) { this->q0_lpm_ = value; }
+
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+ protected:
+  struct ChannelState {
+    uint32_t last_detected_edge_us{0};
+    uint32_t last_rising_edge_us{0};
+    uint32_t count{0};
+  };
+
+  struct PulseFilterState {
+    uint32_t last_intr_us{0};
+    bool latched{false};
+  };
+
+  struct RuntimeState {
+    bool running{false};
+    bool peeked_edge{false};
+    uint32_t last_processed_edge_us{0};
+  };
+
+  static void gpio_intr(OpenQuattFlowFilterProbe *probe);
+  static void IRAM_ATTR apply_pulse_filter_(volatile ChannelState &channel, volatile PulseFilterState &filter,
+                                            uint32_t filter_us, uint32_t now_us, bool pin_val, bool previous_pin_val);
+  void process_channel_(sensor::Sensor *sensor, ChannelState state, RuntimeState &runtime, uint32_t filter_us,
+                        bool pulse_mode, uint32_t now_us);
+  float pulses_per_minute_to_lph_(float ppm) const;
+
+  InternalGPIOPin *pin_{nullptr};
+  ISRInternalGPIOPin isr_pin_;
+  sensor::Sensor *edge_100_sensor_{nullptr};
+  sensor::Sensor *pulse_20_sensor_{nullptr};
+
+  float kf_lpm_per_hz_{0.05f};
+  float q0_lpm_{0.0f};
+  bool last_pin_val_{false};
+
+  volatile ChannelState edge_100_state_{};
+  volatile ChannelState pulse_100_state_{};
+  volatile ChannelState pulse_20_state_{};
+  volatile PulseFilterState pulse_100_filter_{};
+  volatile PulseFilterState pulse_20_filter_{};
+  volatile uint32_t edge_100_last_sent_us_{0};
+
+  RuntimeState edge_100_runtime_{};
+  RuntimeState pulse_100_runtime_{};
+  RuntimeState pulse_20_runtime_{};
+};
+
+}  // namespace esphome::openquatt_flow_filter_probe

--- a/components/openquatt_flow_filter_probe/__init__.py
+++ b/components/openquatt_flow_filter_probe/__init__.py
@@ -1,0 +1,55 @@
+from esphome import pins
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_PIN, STATE_CLASS_MEASUREMENT
+
+CODEOWNERS = ["@jeroen85"]
+
+CONF_EDGE_100 = "edge_100"
+CONF_PULSE_20 = "pulse_20"
+CONF_KF_LPM_PER_HZ = "kf_lpm_per_hz"
+CONF_Q0_LPM = "q0_lpm"
+
+openquatt_flow_filter_probe_ns = cg.esphome_ns.namespace("openquatt_flow_filter_probe")
+OpenQuattFlowFilterProbe = openquatt_flow_filter_probe_ns.class_(
+    "OpenQuattFlowFilterProbe", sensor.Sensor, cg.Component
+)
+
+CONFIG_SCHEMA = sensor.sensor_schema(
+    OpenQuattFlowFilterProbe,
+    unit_of_measurement="L/h",
+    accuracy_decimals=1,
+    state_class=STATE_CLASS_MEASUREMENT,
+).extend(
+    {
+        cv.Required(CONF_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Required(CONF_EDGE_100): sensor.sensor_schema(
+            unit_of_measurement="L/h",
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_PULSE_20): sensor.sensor_schema(
+            unit_of_measurement="L/h",
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_KF_LPM_PER_HZ): cv.positive_float,
+        cv.Optional(CONF_Q0_LPM, default=0.0): cv.float_,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    await cg.register_component(var, config)
+
+    pin = await cg.gpio_pin_expression(config[CONF_PIN])
+    cg.add(var.set_pin(pin))
+
+    edge_100 = await sensor.new_sensor(config[CONF_EDGE_100])
+    pulse_20 = await sensor.new_sensor(config[CONF_PULSE_20])
+    cg.add(var.set_edge_100_sensor(edge_100))
+    cg.add(var.set_pulse_20_sensor(pulse_20))
+    cg.add(var.set_kf_lpm_per_hz(config[CONF_KF_LPM_PER_HZ]))
+    cg.add(var.set_q0_lpm(config[CONF_Q0_LPM]))

--- a/components/openquatt_flow_filter_probe/__init__.py
+++ b/components/openquatt_flow_filter_probe/__init__.py
@@ -7,13 +7,30 @@ from esphome.const import CONF_PIN, STATE_CLASS_MEASUREMENT
 CODEOWNERS = ["@jeroen85"]
 
 CONF_EDGE_100 = "edge_100"
+CONF_PULSE_13 = "pulse_13"
 CONF_PULSE_20 = "pulse_20"
+CONF_PULSE_50 = "pulse_50"
+CONF_RAW_RISING_HZ = "raw_rising_hz"
+CONF_RAW_RISING_COUNT = "raw_rising_count"
+CONF_PULSE_WIDTH_MIN = "pulse_width_min"
+CONF_PULSE_WIDTH_AVG = "pulse_width_avg"
+CONF_PULSE_WIDTH_MAX = "pulse_width_max"
+CONF_PULSE_WIDTH_LT20 = "pulse_width_lt20"
+CONF_PULSE_WIDTH_20_50 = "pulse_width_20_50"
+CONF_PULSE_WIDTH_50_100 = "pulse_width_50_100"
+CONF_PULSE_WIDTH_GE100 = "pulse_width_ge100"
 CONF_KF_LPM_PER_HZ = "kf_lpm_per_hz"
 CONF_Q0_LPM = "q0_lpm"
 
 openquatt_flow_filter_probe_ns = cg.esphome_ns.namespace("openquatt_flow_filter_probe")
 OpenQuattFlowFilterProbe = openquatt_flow_filter_probe_ns.class_(
     "OpenQuattFlowFilterProbe", sensor.Sensor, cg.Component
+)
+
+FLOW_SENSOR_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement="L/h",
+    accuracy_decimals=1,
+    state_class=STATE_CLASS_MEASUREMENT,
 )
 
 CONFIG_SCHEMA = sensor.sensor_schema(
@@ -24,13 +41,51 @@ CONFIG_SCHEMA = sensor.sensor_schema(
 ).extend(
     {
         cv.Required(CONF_PIN): pins.internal_gpio_input_pin_schema,
-        cv.Required(CONF_EDGE_100): sensor.sensor_schema(
-            unit_of_measurement="L/h",
+        cv.Required(CONF_EDGE_100): FLOW_SENSOR_SCHEMA,
+        cv.Required(CONF_PULSE_13): FLOW_SENSOR_SCHEMA,
+        cv.Required(CONF_PULSE_20): FLOW_SENSOR_SCHEMA,
+        cv.Required(CONF_PULSE_50): FLOW_SENSOR_SCHEMA,
+        cv.Required(CONF_RAW_RISING_HZ): sensor.sensor_schema(
+            unit_of_measurement="Hz",
+            accuracy_decimals=2,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_RAW_RISING_COUNT): sensor.sensor_schema(
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_PULSE_WIDTH_MIN): sensor.sensor_schema(
+            unit_of_measurement="us",
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_PULSE_WIDTH_AVG): sensor.sensor_schema(
+            unit_of_measurement="us",
             accuracy_decimals=1,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Required(CONF_PULSE_20): sensor.sensor_schema(
-            unit_of_measurement="L/h",
+        cv.Required(CONF_PULSE_WIDTH_MAX): sensor.sensor_schema(
+            unit_of_measurement="us",
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_PULSE_WIDTH_LT20): sensor.sensor_schema(
+            unit_of_measurement="%",
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_PULSE_WIDTH_20_50): sensor.sensor_schema(
+            unit_of_measurement="%",
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_PULSE_WIDTH_50_100): sensor.sensor_schema(
+            unit_of_measurement="%",
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Required(CONF_PULSE_WIDTH_GE100): sensor.sensor_schema(
+            unit_of_measurement="%",
             accuracy_decimals=1,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
@@ -47,9 +102,24 @@ async def to_code(config):
     pin = await cg.gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(pin))
 
-    edge_100 = await sensor.new_sensor(config[CONF_EDGE_100])
-    pulse_20 = await sensor.new_sensor(config[CONF_PULSE_20])
-    cg.add(var.set_edge_100_sensor(edge_100))
-    cg.add(var.set_pulse_20_sensor(pulse_20))
+    sensor_setters = [
+        (CONF_EDGE_100, var.set_edge_100_sensor),
+        (CONF_PULSE_13, var.set_pulse_13_sensor),
+        (CONF_PULSE_20, var.set_pulse_20_sensor),
+        (CONF_PULSE_50, var.set_pulse_50_sensor),
+        (CONF_RAW_RISING_HZ, var.set_raw_rising_hz_sensor),
+        (CONF_RAW_RISING_COUNT, var.set_raw_rising_count_sensor),
+        (CONF_PULSE_WIDTH_MIN, var.set_pulse_width_min_sensor),
+        (CONF_PULSE_WIDTH_AVG, var.set_pulse_width_avg_sensor),
+        (CONF_PULSE_WIDTH_MAX, var.set_pulse_width_max_sensor),
+        (CONF_PULSE_WIDTH_LT20, var.set_pulse_width_lt20_sensor),
+        (CONF_PULSE_WIDTH_20_50, var.set_pulse_width_20_50_sensor),
+        (CONF_PULSE_WIDTH_50_100, var.set_pulse_width_50_100_sensor),
+        (CONF_PULSE_WIDTH_GE100, var.set_pulse_width_ge100_sensor),
+    ]
+    for key, setter in sensor_setters:
+        child = await sensor.new_sensor(config[key])
+        cg.add(setter(child))
+
     cg.add(var.set_kf_lpm_per_hz(config[CONF_KF_LPM_PER_HZ]))
     cg.add(var.set_q0_lpm(config[CONF_Q0_LPM]))

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -71,6 +71,12 @@ substitutions:
   hpcq_status_led_red_pin: "GPIO2"                      # Red status LED output.
   hpcq_status_led_inverted: "false"                     # Set true when the board LED is active-low.
 
+external_components:
+  - source:
+      type: local
+      path: ${external_components_path}
+    components: [openquatt_flow_filter_probe]
+
 packages:
   oq_hardware_revision: !include heatpump_controller_q_hardware_revision.yaml
   oq_status_leds: !include heatpump_controller_q_status_leds.yaml
@@ -168,34 +174,33 @@ sensor:
           if (x < -10.0f || x > 100.0f) return NAN;
           return x;
 
-  - platform: pulse_meter
-    id: flow_rate_controller
-    name: "Controller Flow"
+openquatt_flow_filter_probe:
+  id: flow_rate_controller
+  name: "Controller Flow"
+  icon: mdi:waves
+  unit_of_measurement: "L/h"
+  device_class: volume_flow_rate
+  state_class: measurement
+  accuracy_decimals: 1
+  pin:
+    number: ${hpcq_flow_pin}
+    mode:
+      input: true
+      pullup: true
+  kf_lpm_per_hz: ${hpcq_flow_kf_lpm_per_hz}
+  q0_lpm: ${hpcq_flow_q0_lpm}
+  edge_100:
+    id: oq_flow_probe_edge_100
+    name: "Controller Flow test EDGE 100us"
     icon: mdi:waves
-    unit_of_measurement: "L/h"
     device_class: volume_flow_rate
-    state_class: measurement
-    accuracy_decimals: 1
-    timeout: 5s
-    internal_filter_mode: PULSE
-    internal_filter: 100us
-    pin:
-      number: ${hpcq_flow_pin}
-      mode:
-        input: true
-        pullup: true
-    filters:
-      - lambda: |-
-          // pulse_meter publishes pulses/minute. Convert to Hz first:
-          // Qv[l/min] = Kf * f[Hz] + Q0, then convert to l/h.
-          const float hz = x / 60.0f;
-          const float lpm =
-            (static_cast<float>(${hpcq_flow_kf_lpm_per_hz}) * hz)
-            + static_cast<float>(${hpcq_flow_q0_lpm});
-          if (isnan(lpm)) return NAN;
-          const float lph = lpm * 60.0f;
-          return lph > 0.0f ? lph : 0.0f;
-      - throttle_average: 10s
+    entity_category: diagnostic
+  pulse_20:
+    id: oq_flow_probe_pulse_20
+    name: "Controller Flow test PULSE 20us"
+    icon: mdi:waves
+    device_class: volume_flow_rate
+    entity_category: diagnostic
 
 interval:
   - interval: 5s

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -199,6 +199,14 @@ openquatt_flow_filter_probe:
     entity_category: diagnostic
     filters:
       - throttle_average: 10s
+  pulse_13:
+    id: oq_flow_probe_pulse_13
+    name: "Controller Flow test PULSE 13us"
+    icon: mdi:waves
+    device_class: volume_flow_rate
+    entity_category: diagnostic
+    filters:
+      - throttle_average: 10s
   pulse_20:
     id: oq_flow_probe_pulse_20
     name: "Controller Flow test PULSE 20us"
@@ -207,6 +215,50 @@ openquatt_flow_filter_probe:
     entity_category: diagnostic
     filters:
       - throttle_average: 10s
+  pulse_50:
+    id: oq_flow_probe_pulse_50
+    name: "Controller Flow test PULSE 50us"
+    icon: mdi:waves
+    device_class: volume_flow_rate
+    entity_category: diagnostic
+    filters:
+      - throttle_average: 10s
+  raw_rising_hz:
+    id: oq_flow_probe_raw_rising_hz
+    name: "Controller Flow test raw rising Hz"
+    entity_category: diagnostic
+  raw_rising_count:
+    id: oq_flow_probe_raw_rising_count
+    name: "Controller Flow test raw rising count 10s"
+    entity_category: diagnostic
+  pulse_width_min:
+    id: oq_flow_probe_width_min
+    name: "Controller Flow test pulse width min"
+    entity_category: diagnostic
+  pulse_width_avg:
+    id: oq_flow_probe_width_avg
+    name: "Controller Flow test pulse width avg"
+    entity_category: diagnostic
+  pulse_width_max:
+    id: oq_flow_probe_width_max
+    name: "Controller Flow test pulse width max"
+    entity_category: diagnostic
+  pulse_width_lt20:
+    id: oq_flow_probe_width_lt20
+    name: "Controller Flow test pulse width <20us"
+    entity_category: diagnostic
+  pulse_width_20_50:
+    id: oq_flow_probe_width_20_50
+    name: "Controller Flow test pulse width 20-50us"
+    entity_category: diagnostic
+  pulse_width_50_100:
+    id: oq_flow_probe_width_50_100
+    name: "Controller Flow test pulse width 50-100us"
+    entity_category: diagnostic
+  pulse_width_ge100:
+    id: oq_flow_probe_width_ge100
+    name: "Controller Flow test pulse width >=100us"
+    entity_category: diagnostic
 
 interval:
   - interval: 5s

--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -182,6 +182,8 @@ openquatt_flow_filter_probe:
   device_class: volume_flow_rate
   state_class: measurement
   accuracy_decimals: 1
+  filters:
+    - throttle_average: 10s
   pin:
     number: ${hpcq_flow_pin}
     mode:
@@ -195,12 +197,16 @@ openquatt_flow_filter_probe:
     icon: mdi:waves
     device_class: volume_flow_rate
     entity_category: diagnostic
+    filters:
+      - throttle_average: 10s
   pulse_20:
     id: oq_flow_probe_pulse_20
     name: "Controller Flow test PULSE 20us"
     icon: mdi:waves
     device_class: volume_flow_rate
     entity_category: diagnostic
+    filters:
+      - throttle_average: 10s
 
 interval:
   - interval: 5s

--- a/openquatt/web/js/src/core/feature-state.js
+++ b/openquatt/web/js/src/core/feature-state.js
@@ -17,15 +17,17 @@ const TEST_FLOW_ENTITIES = [
   ["PulseWidthGe100", "pulse width >=100us"],
 ];
 
+for (const key of ["otbMaxCapacity", "otbMinModulation", "flowSource", "qFlowSource", "controllerFlow"]) {
+  if (!DEBUG_RECORDING_KEYS.includes(key)) DEBUG_RECORDING_KEYS.push(key);
+}
+
 for (const [suffix, label] of TEST_FLOW_ENTITIES) {
   const key = `controllerFlow${suffix}`;
   ENTITY_DEFS[key] = { domain: "sensor", name: `Controller Flow test ${label}`, optional: true };
   if (!DEBUG_RECORDING_KEYS.includes(key)) DEBUG_RECORDING_KEYS.push(key);
 }
 
-for (const key of ["otbMaxCapacity", "otbMinModulation", "flowSource", "qFlowSource", "controllerFlow", "cicFlowrate"]) {
-  if (!DEBUG_RECORDING_KEYS.includes(key)) DEBUG_RECORDING_KEYS.push(key);
-}
+if (!DEBUG_RECORDING_KEYS.includes("cicFlowrate")) DEBUG_RECORDING_KEYS.push("cicFlowrate");
 
 const stateDomains = {
   debugRecording: (key) => key.startsWith("debugRecording"),

--- a/openquatt/web/js/src/core/feature-state.js
+++ b/openquatt/web/js/src/core/feature-state.js
@@ -1,25 +1,25 @@
 import { DEBUG_RECORDING_KEYS, ENTITY_DEFS } from "./config.js";
 import { state } from "./state.js";
 
-const TEST_FLOW_SUFFIXES = [
-  "Edge100",
-  "Pulse13",
-  "Pulse20",
-  "Pulse50",
-  "RawRisingHz",
-  "RawRisingCount",
-  "PulseWidthMin",
-  "PulseWidthAvg",
-  "PulseWidthMax",
-  "PulseWidthLt20",
-  "PulseWidth20To50",
-  "PulseWidth50To100",
-  "PulseWidthGe100",
+const TEST_FLOW_ENTITIES = [
+  ["Edge100", "EDGE 100us"],
+  ["Pulse13", "PULSE 13us"],
+  ["Pulse20", "PULSE 20us"],
+  ["Pulse50", "PULSE 50us"],
+  ["RawRisingHz", "raw rising Hz"],
+  ["RawRisingCount", "raw rising count 10s"],
+  ["PulseWidthMin", "pulse width min"],
+  ["PulseWidthAvg", "pulse width avg"],
+  ["PulseWidthMax", "pulse width max"],
+  ["PulseWidthLt20", "pulse width <20us"],
+  ["PulseWidth20To50", "pulse width 20-50us"],
+  ["PulseWidth50To100", "pulse width 50-100us"],
+  ["PulseWidthGe100", "pulse width >=100us"],
 ];
 
-for (const suffix of TEST_FLOW_SUFFIXES) {
+for (const [suffix, label] of TEST_FLOW_ENTITIES) {
   const key = `controllerFlow${suffix}`;
-  ENTITY_DEFS[key] = { domain: "sensor", name: `QFF ${suffix}`, optional: true };
+  ENTITY_DEFS[key] = { domain: "sensor", name: `Controller Flow test ${label}`, optional: true };
   if (!DEBUG_RECORDING_KEYS.includes(key)) DEBUG_RECORDING_KEYS.push(key);
 }
 

--- a/openquatt/web/js/src/core/feature-state.js
+++ b/openquatt/web/js/src/core/feature-state.js
@@ -1,19 +1,25 @@
 import { DEBUG_RECORDING_KEYS, ENTITY_DEFS } from "./config.js";
 import { state } from "./state.js";
 
-// Test-only Q flow-filter probes. Keep these out of the normal UI, but make
-// them resolvable by the device-side debug recorder so field testers do not
-// need Home Assistant to compare the three pulse-filter variants.
-ENTITY_DEFS.controllerFlowEdge100 = {
-  domain: "sensor",
-  name: "Controller Flow test EDGE 100us",
-  optional: true,
+const TEST_FLOW_ENTITIES = {
+  controllerFlowEdge100: "Controller Flow test EDGE 100us",
+  controllerFlowPulse13: "Controller Flow test PULSE 13us",
+  controllerFlowPulse20: "Controller Flow test PULSE 20us",
+  controllerFlowPulse50: "Controller Flow test PULSE 50us",
+  controllerFlowRawRisingHz: "Controller Flow test raw rising Hz",
+  controllerFlowRawRisingCount: "Controller Flow test raw rising count 10s",
+  controllerFlowPulseWidthMin: "Controller Flow test pulse width min",
+  controllerFlowPulseWidthAvg: "Controller Flow test pulse width avg",
+  controllerFlowPulseWidthMax: "Controller Flow test pulse width max",
+  controllerFlowPulseWidthLt20: "Controller Flow test pulse width <20us",
+  controllerFlowPulseWidth20To50: "Controller Flow test pulse width 20-50us",
+  controllerFlowPulseWidth50To100: "Controller Flow test pulse width 50-100us",
+  controllerFlowPulseWidthGe100: "Controller Flow test pulse width >=100us",
 };
-ENTITY_DEFS.controllerFlowPulse20 = {
-  domain: "sensor",
-  name: "Controller Flow test PULSE 20us",
-  optional: true,
-};
+
+for (const [key, name] of Object.entries(TEST_FLOW_ENTITIES)) {
+  ENTITY_DEFS[key] = { domain: "sensor", name, optional: true };
+}
 
 const REQUIRED_DEBUG_RECORDING_KEYS = [
   "otbMaxCapacity",
@@ -21,14 +27,11 @@ const REQUIRED_DEBUG_RECORDING_KEYS = [
   "flowSource",
   "qFlowSource",
   "controllerFlow",
-  "controllerFlowEdge100",
-  "controllerFlowPulse20",
+  ...Object.keys(TEST_FLOW_ENTITIES),
   "cicFlowrate",
 ];
 for (const key of REQUIRED_DEBUG_RECORDING_KEYS) {
-  if (!DEBUG_RECORDING_KEYS.includes(key)) {
-    DEBUG_RECORDING_KEYS.push(key);
-  }
+  if (!DEBUG_RECORDING_KEYS.includes(key)) DEBUG_RECORDING_KEYS.push(key);
 }
 
 const stateDomains = {
@@ -42,9 +45,7 @@ const stateDomains = {
 function updateFeatureState(domain, patch) {
   const ownsKey = stateDomains[domain];
   const foreignKey = Object.keys(patch).find((key) => !ownsKey(key));
-  if (foreignKey) {
-    throw new Error(`${domain} state beheert sleutel ${foreignKey} niet.`);
-  }
+  if (foreignKey) throw new Error(`${domain} state beheert sleutel ${foreignKey} niet.`);
   Object.assign(state, patch);
 }
 

--- a/openquatt/web/js/src/core/feature-state.js
+++ b/openquatt/web/js/src/core/feature-state.js
@@ -1,7 +1,30 @@
-import { DEBUG_RECORDING_KEYS } from "./config.js";
+import { DEBUG_RECORDING_KEYS, ENTITY_DEFS } from "./config.js";
 import { state } from "./state.js";
 
-const REQUIRED_DEBUG_RECORDING_KEYS = ["otbMaxCapacity", "otbMinModulation"];
+// Test-only Q flow-filter probes. Keep these out of the normal UI, but make
+// them resolvable by the device-side debug recorder so field testers do not
+// need Home Assistant to compare the three pulse-filter variants.
+ENTITY_DEFS.controllerFlowEdge100 = {
+  domain: "sensor",
+  name: "Controller Flow test EDGE 100us",
+  optional: true,
+};
+ENTITY_DEFS.controllerFlowPulse20 = {
+  domain: "sensor",
+  name: "Controller Flow test PULSE 20us",
+  optional: true,
+};
+
+const REQUIRED_DEBUG_RECORDING_KEYS = [
+  "otbMaxCapacity",
+  "otbMinModulation",
+  "flowSource",
+  "qFlowSource",
+  "controllerFlow",
+  "controllerFlowEdge100",
+  "controllerFlowPulse20",
+  "cicFlowrate",
+];
 for (const key of REQUIRED_DEBUG_RECORDING_KEYS) {
   if (!DEBUG_RECORDING_KEYS.includes(key)) {
     DEBUG_RECORDING_KEYS.push(key);

--- a/openquatt/web/js/src/core/feature-state.js
+++ b/openquatt/web/js/src/core/feature-state.js
@@ -1,36 +1,29 @@
 import { DEBUG_RECORDING_KEYS, ENTITY_DEFS } from "./config.js";
 import { state } from "./state.js";
 
-const TEST_FLOW_ENTITIES = {
-  controllerFlowEdge100: "Controller Flow test EDGE 100us",
-  controllerFlowPulse13: "Controller Flow test PULSE 13us",
-  controllerFlowPulse20: "Controller Flow test PULSE 20us",
-  controllerFlowPulse50: "Controller Flow test PULSE 50us",
-  controllerFlowRawRisingHz: "Controller Flow test raw rising Hz",
-  controllerFlowRawRisingCount: "Controller Flow test raw rising count 10s",
-  controllerFlowPulseWidthMin: "Controller Flow test pulse width min",
-  controllerFlowPulseWidthAvg: "Controller Flow test pulse width avg",
-  controllerFlowPulseWidthMax: "Controller Flow test pulse width max",
-  controllerFlowPulseWidthLt20: "Controller Flow test pulse width <20us",
-  controllerFlowPulseWidth20To50: "Controller Flow test pulse width 20-50us",
-  controllerFlowPulseWidth50To100: "Controller Flow test pulse width 50-100us",
-  controllerFlowPulseWidthGe100: "Controller Flow test pulse width >=100us",
-};
+const TEST_FLOW_SUFFIXES = [
+  "Edge100",
+  "Pulse13",
+  "Pulse20",
+  "Pulse50",
+  "RawRisingHz",
+  "RawRisingCount",
+  "PulseWidthMin",
+  "PulseWidthAvg",
+  "PulseWidthMax",
+  "PulseWidthLt20",
+  "PulseWidth20To50",
+  "PulseWidth50To100",
+  "PulseWidthGe100",
+];
 
-for (const [key, name] of Object.entries(TEST_FLOW_ENTITIES)) {
-  ENTITY_DEFS[key] = { domain: "sensor", name, optional: true };
+for (const suffix of TEST_FLOW_SUFFIXES) {
+  const key = `controllerFlow${suffix}`;
+  ENTITY_DEFS[key] = { domain: "sensor", name: `QFF ${suffix}`, optional: true };
+  if (!DEBUG_RECORDING_KEYS.includes(key)) DEBUG_RECORDING_KEYS.push(key);
 }
 
-const REQUIRED_DEBUG_RECORDING_KEYS = [
-  "otbMaxCapacity",
-  "otbMinModulation",
-  "flowSource",
-  "qFlowSource",
-  "controllerFlow",
-  ...Object.keys(TEST_FLOW_ENTITIES),
-  "cicFlowrate",
-];
-for (const key of REQUIRED_DEBUG_RECORDING_KEYS) {
+for (const key of ["otbMaxCapacity", "otbMinModulation", "flowSource", "qFlowSource", "controllerFlow", "cicFlowrate"]) {
   if (!DEBUG_RECORDING_KEYS.includes(key)) DEBUG_RECORDING_KEYS.push(key);
 }
 

--- a/openquatt/web/tests/debug-recording-observability.test.mjs
+++ b/openquatt/web/tests/debug-recording-observability.test.mjs
@@ -44,17 +44,40 @@ const OBSERVABILITY_KEYS = [
   "otbMinModulation",
 ];
 
+const FLOW_FILTER_TEST_KEYS = [
+  "flowSource",
+  "qFlowSource",
+  "controllerFlow",
+  "controllerFlowEdge100",
+  "controllerFlowPulse13",
+  "controllerFlowPulse20",
+  "controllerFlowPulse50",
+  "controllerFlowRawRisingHz",
+  "controllerFlowRawRisingCount",
+  "controllerFlowPulseWidthMin",
+  "controllerFlowPulseWidthAvg",
+  "controllerFlowPulseWidthMax",
+  "controllerFlowPulseWidthLt20",
+  "controllerFlowPulseWidth20To50",
+  "controllerFlowPulseWidth50To100",
+  "controllerFlowPulseWidthGe100",
+  "cicFlowrate",
+];
+
+const FLOW_FILTER_PROBE_ENTITY_KEYS = FLOW_FILTER_TEST_KEYS.filter((key) => key.startsWith("controllerFlow"));
+const ADDITIVE_KEYS = [...OBSERVABILITY_KEYS, ...FLOW_FILTER_TEST_KEYS];
+
 test("debugobservability wordt additief achter het bestaande opnamecontract geplaatst", () => {
   const legacyTailIndex = DEBUG_RECORDING_KEYS.indexOf("otLinkProblem");
 
   assert.equal(legacyTailIndex, 134);
-  assert.deepEqual(DEBUG_RECORDING_KEYS.slice(legacyTailIndex + 1), OBSERVABILITY_KEYS);
+  assert.deepEqual(DEBUG_RECORDING_KEYS.slice(legacyTailIndex + 1), ADDITIVE_KEYS);
   assert.equal(new Set(DEBUG_RECORDING_KEYS).size, DEBUG_RECORDING_KEYS.length);
   assert.ok(DEBUG_RECORDING_KEYS.length <= 188, "debugrecorder heeft maximaal 188 entityvelden naast 4 systeemvelden");
 });
 
 test("elk nieuw debugveld heeft een opneembare entitydefinitie", () => {
-  for (const key of OBSERVABILITY_KEYS) {
+  for (const key of ADDITIVE_KEYS) {
     assert.ok(ENTITY_DEFS[key], `entitydefinitie ontbreekt voor ${key}`);
     assert.match(ENTITY_DEFS[key].domain, /^(binary_sensor|number|select|sensor|switch|text_sensor)$/);
     assert.ok(key.length < 40, `debugsleutel past niet in DebugField.key: ${key}`);
@@ -62,7 +85,7 @@ test("elk nieuw debugveld heeft een opneembare entitydefinitie", () => {
   }
 });
 
-test("elk nieuw debugveld verwijst naar een echte firmware-entity", async () => {
+test("elk regulier observabilityveld verwijst naar een echte firmware-entity", async () => {
   const packages = await Promise.all(
     FIRMWARE_ENTITY_PACKAGES.map((path) => readFile(new URL(path, import.meta.url), "utf8")),
   );
@@ -70,6 +93,14 @@ test("elk nieuw debugveld verwijst naar een echte firmware-entity", async () => 
 
   for (const key of OBSERVABILITY_KEYS) {
     assert.ok(firmwareSource.includes(`name: "${ENTITY_DEFS[key].name}"`), `firmware-entity ontbreekt voor ${key}`);
+  }
+});
+
+test("Q flow-filter testvelden verwijzen naar de probe-entities", async () => {
+  const profile = await readFile(new URL("../../profiles/heatpump_controller_q.yaml", import.meta.url), "utf8");
+
+  for (const key of FLOW_FILTER_PROBE_ENTITY_KEYS) {
+    assert.ok(profile.includes(`name: "${ENTITY_DEFS[key].name}"`), `Q flow probe-entity ontbreekt voor ${key}`);
   }
 });
 

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -9,7 +9,9 @@ export const WEB_BUNDLE_BUDGETS = [
     // its read-only sensor-correction summary, calibration backup/restore,
     // the read-only ODU EEPROM service export, API ingress source controls,
     // and concise CM100 boiler test phase copy (FLOW_SETTLING/BOILER_SETTLING/MEASURING/COOLDOWN).
-    raw: 902_000,
+    // Temporary +1 kB allowance for PR #505 flow-filter field diagnostics.
+    // Revert to 902_000 when the field-test probe is removed.
+    raw: 903_000,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.


### PR DESCRIPTION
## Doel

Gerichte veldtest naar de mogelijke relatie tussen #463 (`PULSE 100 us`) en een Q-edition installatie die via de lokale controller-flowmeter uiteindelijk circa 700 L/h meet terwijl de originele CiC historisch circa 800 L/h rapporteerde.

## Testopzet

Eén GPIO interrupt/capture voert exact dezelfde flankstroom parallel door vijf varianten:

- **PULSE 100 us** – huidige productie-instelling uit #463; bleef tijdens de test `flow_rate_controller` en dus de regelbron.
- **PULSE 50 us**
- **PULSE 20 us**
- **PULSE 13 us** – ESPHome-defaultreferentie.
- **EDGE 100 us** – referentie voor gedrag vóór #463.

Daarnaast zijn per 10 s raw rising-edge Hz/count en de HIGH-pulsbreedteverdeling geregistreerd.

## Resultaten

### Referentie-installatie

Op een Q-edition met HCQ rev. 1.2 en V1.5-ODU's lag de stabiele flow rond 800 L/h:

- `controllerFlow` / PULSE100: circa **805 L/h**;
- EDGE100, PULSE13, PULSE20 en PULSE50: praktisch identiek;
- raw rising-edge frequentie omgerekend met `Kf = 0.05`: eveneens circa **805 L/h**;
- ODU-flowmeters: circa **797–800 L/h**.

Alle gemeten HIGH-pulsen lagen ruim boven 100 us; de minimumwaarden lagen rond 1.3 ms of hoger. `PULSE 100 us` verwerpt hier dus geen relevante geldige pulsen.

### Probleeminstallatie

Op de Single Q-edition met HCQ rev. 1.2 volgen tijdens de volledige flow-ramp alle meetmethoden elkaar eveneens vrijwel exact:

- `controllerFlow` / PULSE100 ≈ EDGE100 ≈ PULSE13 ≈ PULSE20 ≈ PULSE50;
- raw rising-edge frequentie omgerekend met dezelfde `Kf` komt overeen met de gemeten controllerflow;
- over het bruikbare deel van de opname lag PULSE100 gemiddeld circa **522 L/h** en raw omgerekend circa **521 L/h**;
- **100%** van de gemeten HIGH-pulsen lag `>=100 us`;
- de kortste waargenomen HIGH-puls was circa **842 us**, meestal lag het minimum rond 2.5–3.1 ms.

Er verdwijnen dus geen betekenisvolle pulsen door de 100-us-validatie.

De opname bevestigt daarnaast opnieuw de langzame flow-ramp: bij afnemende iPWM stijgt de flow slechts geleidelijk. In eerdere langere opnames liep de regeling uiteindelijk door tot iPWM 50 en stabiliseerde de lokale flow rond 700 L/h.

## Conclusie

**PR #463 / `PULSE 100 us` is niet de oorzaak van het gemeten verschil van circa 700 versus historisch circa 800 L/h.**

Op zowel de referentie-installatie als de probleeminstallatie geldt:

`raw rising edges ≈ EDGE100 ≈ PULSE13 ≈ PULSE20 ≈ PULSE50 ≈ PULSE100`

Daarmee is aangetoond dat OpenQuatt niet ongeveer 12.5% van de geldige pulsen wegfiltert. De lokale flowwaarde volgt rechtstreeks uit de daadwerkelijk op de ESP32-ingang ontvangen rising-edge frequentie.

Ook de schaalfactor is geen verklaring: CiC en OpenQuatt gebruiken voor de lokale flowmeter beide `Kf = 0.05 L/min/Hz` en `Q0 = 0` (`Q[L/h] = 3 × f[Hz]`). De filtering/averaging verandert de stationaire gain niet relevant.

De langzame stijging naar de flowsetpoint is een afzonderlijk regelgedragsvraagstuk en past bij de conservatieve flow-PI-instellingen. Het eventuele resterende verschil tussen de huidige maximale lokale flow en historische CiC-metingen moet daarom buiten de PULSE-filter worden gezocht, bijvoorbeeld in pompaansturing, hydraulische omstandigheden, de daadwerkelijk ontvangen pulstrein of de omstandigheden waaronder de historische CiC-waarde is gemeten.

## Afsluiting

De diagnostische vraag van deze test-PR is beantwoord. Er is **geen productiefix uit deze PR om te mergen**; de tijdelijke probe en het tijdelijke web-bundlebudget zijn uitsluitend voor de veldtest gebruikt.

PR wordt daarom gesloten zonder merge.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie: dit was een tijdelijke diagnostische test-PR zonder bedoelde gebruikersfunctionaliteit of installatieprocedure voor reguliere releases.