### PR TITLE
Voorkom stooklijnrestart bij actuele kamerovertemperatuur

### DIFF
--- a/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
+++ b/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
@@ -1,4 +1,5 @@
 #include "OpenQuattOTSlave.h"
+#include "room_signal_freshness.h"
 #include "esphome/core/log.h"
 #include "esp_timer.h"
 #include <cstdio>
@@ -145,11 +146,29 @@ void OpenQuattOTSlave::stop_opentherm_() {
   m_runtimeGraceUntilMs = 0;
   m_linkProblemGraceUntilMs = 0;
   m_lastSuccessfulFrameMs = 0;
+  m_lastMasterRoomTemperatureMs = 0;
+  m_lastMasterRoomSetpointMs = 0;
   if (m_ot_thermostat_ == NULL || !m_otStarted) {
     return;
   }
   m_ot_thermostat_->end();
   m_otStarted = false;
+}
+
+bool OpenQuattOTSlave::master_room_temperature_fresh() const {
+  const unsigned long now_ms = now_millis();
+  const bool link_fresh =
+      m_lastSuccessfulFrameMs != 0 && (now_ms - m_lastSuccessfulFrameMs) <= OT_LINK_PROBLEM_TIMEOUT_MS;
+  return link_fresh && oq_ot_slave::room_signal_fresh(m_enabled, m_otStarted, m_otaActive || m_updatePrepareActive,
+                                                      m_lastMasterRoomTemperatureMs, now_ms);
+}
+
+bool OpenQuattOTSlave::master_room_setpoint_fresh() const {
+  const unsigned long now_ms = now_millis();
+  const bool link_fresh =
+      m_lastSuccessfulFrameMs != 0 && (now_ms - m_lastSuccessfulFrameMs) <= OT_LINK_PROBLEM_TIMEOUT_MS;
+  return link_fresh && oq_ot_slave::room_signal_fresh(m_enabled, m_otStarted, m_otaActive || m_updatePrepareActive,
+                                                      m_lastMasterRoomSetpointMs, now_ms);
 }
 
 void OpenQuattOTSlave::try_start_opentherm_() {
@@ -342,10 +361,12 @@ void OpenQuattOTSlave::parseRequest(OpenThermMessageType type, OpenThermMessageI
 
     case OpenThermMessageID::TrSet:
       m_master_state.t_room_set = message_data::parse_f88(data);
+      m_lastMasterRoomSetpointMs = now_millis();
       break;
 
     case OpenThermMessageID::Tr:
       m_master_state.t_room = message_data::parse_f88(data);
+      m_lastMasterRoomTemperatureMs = now_millis();
       break;
 
     case OpenThermMessageID::MConfigMMemberIDcode:

--- a/components/openquatt_ot_slave/OpenQuattOTSlave.h
+++ b/components/openquatt_ot_slave/OpenQuattOTSlave.h
@@ -80,6 +80,8 @@ class OpenQuattOTSlave : public PollingComponent
   }
   void set_slave_t_dhw_set(float value) { m_slave_state.t_dhw_set = value; }
   void prepare_for_firmware_update();
+  bool master_room_temperature_fresh() const;
+  bool master_room_setpoint_fresh() const;
 
 #define OPENQUATT_OT_SLAVE_SET_SENSOR(entity) \
   void set_##entity(sensor::Sensor* sensor) { this->entity = sensor; }
@@ -165,6 +167,8 @@ class OpenQuattOTSlave : public PollingComponent
   bool m_updatePrepareActive = false;
   unsigned long m_lastMasterStatusMs = 0;
   unsigned long m_lastSuccessfulFrameMs = 0;
+  unsigned long m_lastMasterRoomTemperatureMs = 0;
+  unsigned long m_lastMasterRoomSetpointMs = 0;
   unsigned long m_linkProblemGraceUntilMs = 0;
   unsigned long m_t6CompatUntilMs = 0;
   unsigned long m_otStartNotBeforeMs = 0;

--- a/components/openquatt_ot_slave/room_signal_freshness.h
+++ b/components/openquatt_ot_slave/room_signal_freshness.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace oq_ot_slave {
+
+// Room values are expected cyclically, but allow slow masters the same ten-minute
+// freshness window used by the external room-temperature ingress contracts.
+constexpr uint32_t ROOM_SIGNAL_TIMEOUT_MS = 600000UL;
+
+inline bool room_signal_fresh(bool enabled, bool runtime_started, bool runtime_paused, uint32_t last_update_ms,
+                              uint32_t now_ms, uint32_t timeout_ms = ROOM_SIGNAL_TIMEOUT_MS) {
+  if (!enabled || !runtime_started || runtime_paused || last_update_ms == 0 || timeout_ms == 0) return false;
+  return static_cast<uint32_t>(now_ms - last_update_ms) <= timeout_ms;
+}
+
+}  // namespace oq_ot_slave

--- a/openquatt/includes/control/oq_heating_curve_logic.h
+++ b/openquatt/includes/control/oq_heating_curve_logic.h
@@ -34,6 +34,19 @@ struct ControlProfileTuning {
   float dual_disable_temp_err_max_c = 0.50f;
 };
 
+enum RestartReason : uint8_t {
+  RESTART_NONE = 0,
+  RESTART_WATER_BAND = 1,
+  RESTART_ROOM_DEMAND = 2,
+};
+
+struct RestartDecision {
+  bool restart = false;
+  bool blocked_by_room = false;
+  bool blocked_by_off_lock = false;
+  RestartReason reason = RESTART_NONE;
+};
+
 struct DispatchCandidate {
   bool valid = false;
   int hp1_level = 0;
@@ -96,9 +109,39 @@ inline ControlProfileTuning control_profile(const std::string& profile_option) {
   return tuning;
 }
 
+inline RestartDecision evaluate_restart(bool below_restart_band, bool deep_undershoot_restart, bool off_lock_active,
+                                        bool room_data_fresh, float room_c, float room_sp_c, float room_overheat_off_c,
+                                        float room_resume_heat_c) {
+  RestartDecision decision;
+  const bool room_values_valid = room_data_fresh && !isnan(room_c) && !isnan(room_sp_c);
+  const bool room_requests_heat = room_values_valid && room_c <= (room_sp_c - room_resume_heat_c);
+  if (room_requests_heat) {
+    decision.restart = true;
+    decision.reason = RESTART_ROOM_DEMAND;
+    return decision;
+  }
+
+  if (!below_restart_band) return decision;
+
+  const bool room_blocks_water_restart = room_values_valid && room_c >= (room_sp_c + room_overheat_off_c);
+  if (room_blocks_water_restart) {
+    decision.blocked_by_room = true;
+    return decision;
+  }
+
+  if (off_lock_active && !deep_undershoot_restart) {
+    decision.blocked_by_off_lock = true;
+    return decision;
+  }
+
+  decision.restart = true;
+  decision.reason = RESTART_WATER_BAND;
+  return decision;
+}
+
 inline void reset_control_state(float& demand_continuous, int& demand_curve, int& demand_pre_guardrail,
                                 bool& heat_request_active, uint32_t& stop_arm_ms, uint32_t& off_since_ms,
-                                bool& restart_inhibit_active, int& regime_code) {
+                                bool& restart_inhibit_active, bool& restart_blocked_by_room, int& regime_code) {
   demand_continuous = NAN;
   demand_curve = 0;
   demand_pre_guardrail = 0;
@@ -106,6 +149,7 @@ inline void reset_control_state(float& demand_continuous, int& demand_curve, int
   stop_arm_ms = 0;
   off_since_ms = 0;
   restart_inhibit_active = false;
+  restart_blocked_by_room = false;
   regime_code = 0;
 }
 

--- a/openquatt/includes/control/oq_hp_supervisory_logic.h
+++ b/openquatt/includes/control/oq_hp_supervisory_logic.h
@@ -6,6 +6,17 @@
 
 namespace oq_hp_supervisory {
 
+inline bool apply_heating_enable_gate(bool heating_request, bool heating_enable_valid, bool heating_enable_selected) {
+  return heating_request && heating_enable_valid && heating_enable_selected;
+}
+
+inline int base_control_mode(bool cooling_request, bool heating_request, bool frost_request) {
+  if (cooling_request) return 5;
+  if (heating_request) return 2;
+  if (frost_request) return 98;
+  return 0;
+}
+
 inline bool fallback_availability_is_confirmed(bool raw_availability_complete,
                                                bool every_unavailable_hp_has_fallback_cause, bool all_hp_outputs_safe) {
   // Link-loss recovery is intentionally not "available" yet. It may still

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -63,6 +63,12 @@ globals:
     restore_value: false
     initial_value: 'false'
 
+  # Diagnostic flag: a fresh, clearly warm room blocks a water-only restart.
+  - id: oq_curve_restart_blocked_by_room
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+
   # Curve outside-temperature EMA state.
   - id: oq_curve_outside_ema_c
     type: float
@@ -138,6 +144,7 @@ select:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
+              id(oq_curve_restart_blocked_by_room),
               id(oq_curve_regime_code));
             id(oq_curve_oil_return_hold_until_ms) = 0;
             oq_curve::reset_outside_ema_state(
@@ -367,6 +374,7 @@ output:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
+              id(oq_curve_restart_blocked_by_room),
               id(oq_curve_regime_code));
             return;
           }
@@ -381,6 +389,7 @@ output:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
+              id(oq_curve_restart_blocked_by_room),
               id(oq_curve_regime_code));
             return;
           }
@@ -405,6 +414,7 @@ output:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
+              id(oq_curve_restart_blocked_by_room),
               id(oq_curve_regime_code));
             return;
           }
@@ -433,9 +443,69 @@ output:
           const float room_c = id(room_temp_selected).state;
           const float room_sp_c = id(room_setpoint_selected).state;
           const bool room_valid = !isnan(room_c) && !isnan(room_sp_c);
-          const bool room_warm_for_off = room_valid && (room_c >= (room_sp_c + room_overheat_off_c));
-          const bool room_requests_heat = room_valid && (room_c <= (room_sp_c - room_resume_heat_c));
-          const bool room_allows_off = (!room_valid) || room_warm_for_off;
+
+          auto room_temperature_source_fresh = [&]() -> bool {
+            if (!id(room_temp_source).has_state()) return false;
+            const auto source = id(room_temp_source).current_option();
+            if (source == "HA input") {
+              return id(room_temp_valid_ha).state && id(thermostat_room_temp_ha).has_state() &&
+                     !isnan(id(thermostat_room_temp_ha).state) && !id(oq_room_temp_selected_hold_active);
+            }
+            if (source == "OT thermostat") {
+              return (${oq_ot_room_temperature_fresh_expr}) &&
+                     id(ot_thermostat_room_temp).has_state() && !isnan(id(ot_thermostat_room_temp).state);
+            }
+            if (source == "CIC") {
+              return id(feed_ok).has_state() && id(feed_ok).state &&
+                     id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
+                     id(cic_room_temp).has_state() && !isnan(id(cic_room_temp).state);
+            }
+            if (source == "API input") {
+              return id(api_input_room_temperature_valid).has_state() &&
+                     id(api_input_room_temperature_valid).state &&
+                     id(api_input_room_temperature).has_state() && !isnan(id(api_input_room_temperature).state);
+            }
+            if (source == "MQTT") {
+              return id(mqtt_room_temperature_valid).has_state() && id(mqtt_room_temperature_valid).state &&
+                     id(mqtt_room_temperature).has_state() && !isnan(id(mqtt_room_temperature).state);
+            }
+            return false;
+          };
+
+          auto room_setpoint_source_fresh = [&]() -> bool {
+            if (!id(room_setpoint_source).has_state()) return false;
+            const auto source = id(room_setpoint_source).current_option();
+            if (source == "HA input") {
+              return id(room_setpoint_valid_ha).state && id(thermostat_setpoint_ha).has_state() &&
+                     !isnan(id(thermostat_setpoint_ha).state) && !id(oq_room_setpoint_selected_hold_active);
+            }
+            if (source == "OT thermostat") {
+              return (${oq_ot_room_setpoint_fresh_expr}) &&
+                     id(ot_thermostat_room_setpoint).has_state() && !isnan(id(ot_thermostat_room_setpoint).state);
+            }
+            if (source == "CIC") {
+              return id(feed_ok).has_state() && id(feed_ok).state &&
+                     id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
+                     id(cic_room_setpoint).has_state() && !isnan(id(cic_room_setpoint).state);
+            }
+            if (source == "API input") {
+              return id(api_input_room_setpoint_valid).has_state() && id(api_input_room_setpoint_valid).state &&
+                     id(api_input_room_setpoint).has_state() && !isnan(id(api_input_room_setpoint).state);
+            }
+            if (source == "MQTT") {
+              return id(mqtt_room_setpoint_valid).has_state() && id(mqtt_room_setpoint_valid).state &&
+                     id(mqtt_room_setpoint).has_state() && !isnan(id(mqtt_room_setpoint).state);
+            }
+            return false;
+          };
+
+          const bool room_data_fresh =
+              room_valid && room_temperature_source_fresh() && room_setpoint_source_fresh();
+          const bool room_warm_for_off =
+              room_data_fresh && (room_c >= (room_sp_c + room_overheat_off_c));
+          const bool room_requests_heat =
+              room_data_fresh && (room_c <= (room_sp_c - room_resume_heat_c));
+          const bool room_allows_off = (!room_data_fresh) || room_warm_for_off;
 
           const uint32_t now_ms = (uint32_t) millis();
           constexpr uint32_t oil_return_hold_ms = 180000UL;
@@ -463,12 +533,14 @@ output:
               heat_request_active &&
               (id(oq_curve_regime_code) == 2) &&
               (id(oq_curve_demand_pre_guardrail) <= 0) &&
-              ((!room_valid) || (room_c >= (room_sp_c - room_resume_heat_c))) &&
+              ((!room_data_fresh) || (room_c >= (room_sp_c - room_resume_heat_c))) &&
               (pv >= (spw + 0.25f));
           const bool normal_stop_condition =
               !oil_return_mask_active && above_stop_band && low_pid_for_off && room_allows_off;
           const float restart_bypass_delta_c = restart_delta_c + restart_bypass_extra_c;
           bool restart_inhibit_active = false;
+          const bool was_restart_blocked_by_room = id(oq_curve_restart_blocked_by_room);
+          bool restart_blocked_by_room = false;
           uint32_t off_since_ms = id(oq_curve_off_since_ms);
           const bool was_heat_request_active = heat_request_active;
           if (heat_request_active) {
@@ -498,8 +570,12 @@ output:
             if (off_reentry_min_ms > 0 && now_ms > off_since_ms) {
               off_lock_active = (now_ms - off_since_ms) < off_reentry_min_ms;
             }
-            restart_inhibit_active = off_lock_active && !deep_undershoot_restart && !room_requests_heat;
-            if ((below_restart_band || room_requests_heat) && !restart_inhibit_active) {
+            const auto restart_decision = oq_curve::evaluate_restart(
+                below_restart_band, deep_undershoot_restart, off_lock_active, room_data_fresh, room_c, room_sp_c,
+                room_overheat_off_c, room_resume_heat_c);
+            restart_inhibit_active = restart_decision.blocked_by_off_lock;
+            restart_blocked_by_room = restart_decision.blocked_by_room;
+            if (restart_decision.restart) {
               heat_request_active = true;
               off_since_ms = 0;
             }
@@ -519,7 +595,17 @@ output:
           }
           if (heat_request_active) {
             restart_inhibit_active = false;
+            restart_blocked_by_room = false;
             off_since_ms = 0;
+          }
+
+          if (restart_blocked_by_room != was_restart_blocked_by_room) {
+            if (restart_blocked_by_room) {
+              ESP_LOGI("quatt.heatcurve", "Restart blocked: fresh room %.2f C is above %.2f C setpoint",
+                       room_c, room_sp_c);
+            } else {
+              ESP_LOGI("quatt.heatcurve", "Warm-room restart block cleared");
+            }
           }
 
           static bool last_heat_request_active = false;
@@ -557,7 +643,7 @@ output:
               regime = (supply_error_c >= recovery_enter_c) ? 1 : 2;
             }
             const bool room_allows_recovery =
-                (!room_valid) || (room_c <= (room_sp_c + tuning.trim_start_c));
+                (!room_data_fresh) || (room_c <= (room_sp_c + tuning.trim_start_c));
             constexpr int recovery_reenter_min_f = 8;
             if (regime == 1) {
               if (supply_error_c <= recovery_exit_c) regime = 2;
@@ -603,6 +689,7 @@ output:
           id(oq_curve_heat_request_active) = heat_request_active;
           id(oq_curve_off_since_ms) = off_since_ms;
           id(oq_curve_restart_inhibit_active) = restart_inhibit_active;
+          id(oq_curve_restart_blocked_by_room) = restart_blocked_by_room;
           id(oq_demand_curve) = d;
 
 sensor:
@@ -804,6 +891,18 @@ sensor:
     lambda: |-
       return id(oq_curve_restart_inhibit_active) ? 1.0f : 0.0f;
 
+  - platform: template
+    id: oq_curve_restart_blocked_by_room_sensor
+    name: "Curve restart blocked by room"
+    internal: true
+    disabled_by_default: true
+    icon: mdi:home-thermometer-outline
+    accuracy_decimals: 0
+    update_interval: 5s
+    entity_category: diagnostic
+    lambda: |-
+      return id(oq_curve_restart_blocked_by_room) ? 1.0f : 0.0f;
+
 text_sensor:
   - platform: template
     id: oq_curve_phase_sensor
@@ -873,6 +972,7 @@ interval:
                 id(oq_curve_stop_arm_ms),
                 id(oq_curve_off_since_ms),
                 id(oq_curve_restart_inhibit_active),
+                id(oq_curve_restart_blocked_by_room),
                 id(oq_curve_regime_code));
             } else {
               const float cur2 = id(oq_heating_curve_pid).target_temperature;
@@ -933,6 +1033,7 @@ interval:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
+              id(oq_curve_restart_blocked_by_room),
               id(oq_curve_regime_code));
           }
       - if:

--- a/openquatt/oq_sensor_source_selects_no_opentherm.yaml
+++ b/openquatt/oq_sensor_source_selects_no_opentherm.yaml
@@ -6,6 +6,10 @@
 #   Source selectors for hardware profiles without a supported OT thermostat bus.
 # ==============================================================================
 
+substitutions:
+  oq_ot_room_temperature_fresh_expr: "false"
+  oq_ot_room_setpoint_fresh_expr: "false"
+
 select:
   - platform: template
     name: "Room Temperature Source"

--- a/openquatt/oq_sensor_source_selects_opentherm.yaml
+++ b/openquatt/oq_sensor_source_selects_opentherm.yaml
@@ -7,6 +7,10 @@
 #   Include only on hardware profiles that actually provide the OT slave bridge.
 # ==============================================================================
 
+substitutions:
+  oq_ot_room_temperature_fresh_expr: "id(oq_ot_slave_hub).master_room_temperature_fresh()"
+  oq_ot_room_setpoint_fresh_expr: "id(oq_ot_slave_hub).master_room_setpoint_fresh()"
+
 select:
   - platform: template
     name: "Room Temperature Source"

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -142,6 +142,7 @@ select:
               id(oq_curve_stop_arm_ms),
               id(oq_curve_off_since_ms),
               id(oq_curve_restart_inhibit_active),
+              id(oq_curve_restart_blocked_by_room),
               id(oq_curve_regime_code));
             oq_curve::reset_outside_ema_state(
               id(oq_curve_outside_ema_c),

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -911,12 +911,12 @@ interval:
             }
           }
 
-          const bool heating_enable_permitted =
-              id(heating_enable_valid).has_state() && id(heating_enable_valid).state &&
+          const bool heating_enable_valid_now =
+              id(heating_enable_valid).has_state() && id(heating_enable_valid).state;
+          const bool heating_enable_selected_now =
               id(heating_enable_selected).has_state() && id(heating_enable_selected).state;
-          if (heating_req && !heating_enable_permitted) {
-            heating_req = false;
-          }
+          heating_req = oq_hp_supervisory::apply_heating_enable_gate(
+              heating_req, heating_enable_valid_now, heating_enable_selected_now);
 
           const uint32_t cm2_idle_exit_ms = (uint32_t)(${oq_cm2_idle_exit_s}UL * 1000UL);
           const bool curve_mode_active = (strategy_active_code == 2);
@@ -1107,11 +1107,7 @@ interval:
             };
 
             // Determine base target (without CM1 timer)
-            int base_target = 0; // CM0
-            if (cooling_req) base_target = 5;     // CM5 desired
-            else if (heating_req) base_target = 2; // CM2 desired
-            else if (frost)  base_target = 98;     // CM98 desired
-            else             base_target = 0;      // CM0
+            int base_target = oq_hp_supervisory::base_control_mode(cooling_req, heating_req, frost);
 
             // Apply flow interlock: if thermal output is requested but low-flow fault => hold in CM1.
             if (thermal_req && (id(oq_lowflow_fault_active) || flow_low)) {

--- a/openquatt/web/js/src/core/config.js
+++ b/openquatt/web/js/src/core/config.js
@@ -493,6 +493,7 @@
     curveTargetHp1Level: { domain: "sensor", name: "Curve target HP1 level", optional: true },
     curveTargetHp2Level: { domain: "sensor", name: "Curve target HP2 level", optional: true },
     curveRestartInhibit: { domain: "sensor", name: "Curve restart inhibit", optional: true },
+    curveRestartBlockedByRoom: { domain: "sensor", name: "Curve restart blocked by room", optional: true },
     curvePhase: { domain: "text_sensor", name: "Curve Phase", optional: true },
     curveOperatingRegime: { domain: "text_sensor", name: "Curve operating regime", optional: true },
     curveCapacityMode: { domain: "text_sensor", name: "Curve capacity mode", optional: true },
@@ -1424,6 +1425,14 @@
     "otbResponseCount",
     "otbTransportErrorCount",
     "otbResponseTimeoutCount",
+    "otbMaxCapacity",
+    "otbMinModulation",
+    "curveRestartBlockedByRoom",
+    "heatingEnableSource",
+    "heatingEnableValid",
+    "heatingEnableSelected",
+    "otThermostatStatusValid",
+    "otThermostatChEnable",
   ];
   export const FIRMWARE_ENTITY_KEYS = ["firmwareUpdate", "firmwareUpdateChannel", "firmwareUpdateTarget", "firmwareUpdateProgress", "firmwareUpdateStatus"];
   export const FIRMWARE_TEST_ENTITY_KEYS = ["firmwareTestOtaUrl", "firmwareTestOtaMd5Url", "installFirmwareTestOta"];

--- a/openquatt/web/js/src/core/feature-state.js
+++ b/openquatt/web/js/src/core/feature-state.js
@@ -1,12 +1,4 @@
-import { DEBUG_RECORDING_KEYS } from "./config.js";
 import { state } from "./state.js";
-
-const REQUIRED_DEBUG_RECORDING_KEYS = ["otbMaxCapacity", "otbMinModulation"];
-for (const key of REQUIRED_DEBUG_RECORDING_KEYS) {
-  if (!DEBUG_RECORDING_KEYS.includes(key)) {
-    DEBUG_RECORDING_KEYS.push(key);
-  }
-}
 
 const stateDomains = {
   debugRecording: (key) => key.startsWith("debugRecording"),

--- a/openquatt/web/tests/debug-recording-observability.test.mjs
+++ b/openquatt/web/tests/debug-recording-observability.test.mjs
@@ -12,6 +12,10 @@ const FIRMWARE_ENTITY_PACKAGES = [
   "../../oq_installation_monitoring.yaml",
   "../../oq_boiler_control.yaml",
   "../../oq_boiler_opentherm.yaml",
+  "../../oq_heating_curve_strategy.yaml",
+  "../../oq_sensor_sources.yaml",
+  "../../oq_sensor_source_selects_opentherm.yaml",
+  "../../oq_ot_slave.yaml",
 ];
 
 const OBSERVABILITY_KEYS = [
@@ -44,17 +48,32 @@ const OBSERVABILITY_KEYS = [
   "otbMinModulation",
 ];
 
+const ISSUE_473_OBSERVABILITY_KEYS = [
+  "curveRestartBlockedByRoom",
+  "heatingEnableSource",
+  "heatingEnableValid",
+  "heatingEnableSelected",
+  "otThermostatStatusValid",
+  "otThermostatChEnable",
+];
+
+const ADDED_OBSERVABILITY_KEYS = [...OBSERVABILITY_KEYS, ...ISSUE_473_OBSERVABILITY_KEYS];
+
 test("debugobservability wordt additief achter het bestaande opnamecontract geplaatst", () => {
   const legacyTailIndex = DEBUG_RECORDING_KEYS.indexOf("otLinkProblem");
 
   assert.equal(legacyTailIndex, 134);
-  assert.deepEqual(DEBUG_RECORDING_KEYS.slice(legacyTailIndex + 1), OBSERVABILITY_KEYS);
+  assert.deepEqual(
+    DEBUG_RECORDING_KEYS.slice(legacyTailIndex + 1, legacyTailIndex + 1 + OBSERVABILITY_KEYS.length),
+    OBSERVABILITY_KEYS,
+  );
+  assert.deepEqual(DEBUG_RECORDING_KEYS.slice(legacyTailIndex + 1 + OBSERVABILITY_KEYS.length), ISSUE_473_OBSERVABILITY_KEYS);
   assert.equal(new Set(DEBUG_RECORDING_KEYS).size, DEBUG_RECORDING_KEYS.length);
   assert.ok(DEBUG_RECORDING_KEYS.length <= 188, "debugrecorder heeft maximaal 188 entityvelden naast 4 systeemvelden");
 });
 
 test("elk nieuw debugveld heeft een opneembare entitydefinitie", () => {
-  for (const key of OBSERVABILITY_KEYS) {
+  for (const key of ADDED_OBSERVABILITY_KEYS) {
     assert.ok(ENTITY_DEFS[key], `entitydefinitie ontbreekt voor ${key}`);
     assert.match(ENTITY_DEFS[key].domain, /^(binary_sensor|number|select|sensor|switch|text_sensor)$/);
     assert.ok(key.length < 40, `debugsleutel past niet in DebugField.key: ${key}`);
@@ -68,7 +87,7 @@ test("elk nieuw debugveld verwijst naar een echte firmware-entity", async () => 
   );
   const firmwareSource = packages.join("\n");
 
-  for (const key of OBSERVABILITY_KEYS) {
+  for (const key of ADDED_OBSERVABILITY_KEYS) {
     assert.ok(firmwareSource.includes(`name: "${ENTITY_DEFS[key].name}"`), `firmware-entity ontbreekt voor ${key}`);
   }
 });

--- a/tests/host/heating_curve_restart_logic_test.cpp
+++ b/tests/host/heating_curve_restart_logic_test.cpp
@@ -1,0 +1,131 @@
+#include <assert.h>
+#include <math.h>
+
+#include "../../openquatt/includes/control/oq_heating_curve_logic.h"
+
+namespace {
+
+using oq_curve::evaluate_restart;
+using oq_curve::reset_control_state;
+using oq_curve::RESTART_NONE;
+using oq_curve::RESTART_ROOM_DEMAND;
+using oq_curve::RESTART_WATER_BAND;
+
+constexpr float ROOM_SETPOINT_C = 20.5f;
+constexpr float ROOM_OVERHEAT_OFF_C = 0.3f;
+constexpr float ROOM_RESUME_HEAT_C = 0.05f;
+
+void test_fresh_warm_room_blocks_water_restart() {
+  const auto decision =
+      evaluate_restart(true, false, false, true, 23.4f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
+
+  assert(!decision.restart);
+  assert(decision.blocked_by_room);
+  assert(!decision.blocked_by_off_lock);
+  assert(decision.reason == RESTART_NONE);
+}
+
+void test_fresh_warm_room_also_blocks_deep_undershoot() {
+  const auto decision =
+      evaluate_restart(true, true, true, true, 23.4f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
+
+  assert(!decision.restart);
+  assert(decision.blocked_by_room);
+  assert(!decision.blocked_by_off_lock);
+}
+
+void test_fresh_room_demand_has_highest_priority() {
+  const auto decision =
+      evaluate_restart(false, false, true, true, 20.0f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
+
+  assert(decision.restart);
+  assert(!decision.blocked_by_room);
+  assert(!decision.blocked_by_off_lock);
+  assert(decision.reason == RESTART_ROOM_DEMAND);
+}
+
+void test_stale_warm_room_fails_open_to_water_restart() {
+  const auto decision =
+      evaluate_restart(true, false, false, false, 23.4f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
+
+  assert(decision.restart);
+  assert(!decision.blocked_by_room);
+  assert(decision.reason == RESTART_WATER_BAND);
+}
+
+void test_stale_room_does_not_bypass_off_lock() {
+  const auto decision =
+      evaluate_restart(true, false, true, false, 19.0f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
+
+  assert(!decision.restart);
+  assert(!decision.blocked_by_room);
+  assert(decision.blocked_by_off_lock);
+}
+
+void test_deep_undershoot_keeps_existing_off_lock_bypass_without_room_veto() {
+  const auto decision =
+      evaluate_restart(true, true, true, true, 20.5f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
+
+  assert(decision.restart);
+  assert(!decision.blocked_by_room);
+  assert(!decision.blocked_by_off_lock);
+  assert(decision.reason == RESTART_WATER_BAND);
+}
+
+void test_no_water_restart_does_not_report_a_room_block() {
+  const auto decision =
+      evaluate_restart(false, false, false, true, 23.4f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
+
+  assert(!decision.restart);
+  assert(!decision.blocked_by_room);
+  assert(!decision.blocked_by_off_lock);
+}
+
+void test_non_finite_room_values_cannot_block_restart() {
+  const auto decision =
+      evaluate_restart(true, false, false, true, NAN, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
+
+  assert(decision.restart);
+  assert(!decision.blocked_by_room);
+  assert(decision.reason == RESTART_WATER_BAND);
+}
+
+void test_control_reset_clears_restart_diagnostics() {
+  float demand_continuous = 12.0f;
+  int demand_curve = 8;
+  int demand_pre_guardrail = 7;
+  bool heat_request_active = true;
+  uint32_t stop_arm_ms = 100U;
+  uint32_t off_since_ms = 200U;
+  bool restart_inhibit_active = true;
+  bool restart_blocked_by_room = true;
+  int regime_code = 2;
+
+  reset_control_state(demand_continuous, demand_curve, demand_pre_guardrail, heat_request_active, stop_arm_ms,
+                      off_since_ms, restart_inhibit_active, restart_blocked_by_room, regime_code);
+
+  assert(isnan(demand_continuous));
+  assert(demand_curve == 0);
+  assert(demand_pre_guardrail == 0);
+  assert(!heat_request_active);
+  assert(stop_arm_ms == 0U);
+  assert(off_since_ms == 0U);
+  assert(!restart_inhibit_active);
+  assert(!restart_blocked_by_room);
+  assert(regime_code == 0);
+}
+
+}  // namespace
+
+int main() {
+  test_fresh_warm_room_blocks_water_restart();
+  test_fresh_warm_room_also_blocks_deep_undershoot();
+  test_fresh_room_demand_has_highest_priority();
+  test_stale_warm_room_fails_open_to_water_restart();
+  test_stale_room_does_not_bypass_off_lock();
+  test_deep_undershoot_keeps_existing_off_lock_bypass_without_room_veto();
+  test_no_water_restart_does_not_report_a_room_block();
+  test_non_finite_room_values_cannot_block_restart();
+  test_control_reset_clears_restart_diagnostics();
+  return 0;
+}

--- a/tests/host/hp_supervisory_logic_test.cpp
+++ b/tests/host/hp_supervisory_logic_test.cpp
@@ -5,6 +5,24 @@
 
 namespace {
 
+void test_heating_enable_gate() {
+  using oq_hp_supervisory::apply_heating_enable_gate;
+
+  assert(apply_heating_enable_gate(true, true, true));
+  assert(!apply_heating_enable_gate(true, true, false));
+  assert(!apply_heating_enable_gate(true, false, false));
+  assert(!apply_heating_enable_gate(false, true, true));
+}
+
+void test_frost_control_mode_remains_independent_of_heating_request() {
+  using oq_hp_supervisory::base_control_mode;
+
+  assert(base_control_mode(false, false, true) == 98);
+  assert(base_control_mode(false, true, true) == 2);
+  assert(base_control_mode(true, true, true) == 5);
+  assert(base_control_mode(false, false, false) == 0);
+}
+
 oq_hp_supervisory::FallbackEvaluationInputs eligible_fallback_evaluation_inputs() {
   oq_hp_supervisory::FallbackEvaluationInputs inputs;
   inputs.current_mode = 3;
@@ -203,6 +221,8 @@ void test_control_mode_log_classification() {
 }  // namespace
 
 int main() {
+  test_heating_enable_gate();
+  test_frost_control_mode_remains_independent_of_heating_request();
   using oq_hp_supervisory::Cm4ResumeTracker;
   using oq_hp_supervisory::fallback_availability_is_confirmed;
   using oq_hp_supervisory::recovered_heating_mode;

--- a/tests/host/opentherm_room_freshness_test.cpp
+++ b/tests/host/opentherm_room_freshness_test.cpp
@@ -1,0 +1,44 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "../../components/openquatt_ot_slave/room_signal_freshness.h"
+
+namespace {
+
+using oq_ot_slave::room_signal_fresh;
+using oq_ot_slave::ROOM_SIGNAL_TIMEOUT_MS;
+
+void test_requires_an_active_runtime_and_received_value() {
+  assert(!room_signal_fresh(false, true, false, 100U, 101U));
+  assert(!room_signal_fresh(true, false, false, 100U, 101U));
+  assert(!room_signal_fresh(true, true, true, 100U, 101U));
+  assert(!room_signal_fresh(true, true, false, 0U, 101U));
+}
+
+void test_value_is_fresh_through_timeout_boundary() {
+  constexpr uint32_t last_update_ms = 1000U;
+
+  assert(room_signal_fresh(true, true, false, last_update_ms, last_update_ms));
+  assert(room_signal_fresh(true, true, false, last_update_ms, last_update_ms + ROOM_SIGNAL_TIMEOUT_MS));
+  assert(!room_signal_fresh(true, true, false, last_update_ms, last_update_ms + ROOM_SIGNAL_TIMEOUT_MS + 1U));
+}
+
+void test_zero_timeout_fails_closed() { assert(!room_signal_fresh(true, true, false, 100U, 100U, 0U)); }
+
+void test_millis_wrap_preserves_elapsed_age() {
+  constexpr uint32_t last_update_ms = UINT32_MAX - 100U;
+  constexpr uint32_t now_ms = 50U;
+
+  assert(room_signal_fresh(true, true, false, last_update_ms, now_ms, 151U));
+  assert(!room_signal_fresh(true, true, false, last_update_ms, now_ms, 150U));
+}
+
+}  // namespace
+
+int main() {
+  test_requires_an_active_runtime_and_received_value();
+  test_value_is_fresh_through_timeout_boundary();
+  test_zero_timeout_fails_closed();
+  test_millis_wrap_preserves_elapsed_age();
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Blokkeert een waterzijdige stooklijnrestart wanneer de geselecteerde, verse kamerdata duidelijk boven het setpoint liggen.
- Laat expliciete kamervraag voorgaan en valt bij ongeldige of verouderde kamerdata terug op het bestaande waterzijdige gedrag.
- Voegt brongebonden OpenTherm-freshness, de diagnose `Curve restart blocked by room`, debugvelden en hostregressies voor restart, OT-warmtetoestemming en CM98 toe.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De OFF→heating-overgang van de stooklijn krijgt een versheidsgekwalificeerd kamerveto. Een verse kamervraag blijft de hoogste prioriteit en omzeilt, zoals voorheen, de minimale uit-tijd. Een verse warme kamer blokkeert zowel de normale als diepe wateronderschrijdingsrestart. Stale/ongeldige data blokkeren nooit.

Voor OpenTherm worden ontvangsttijden van `Tr` en `TrSet` afzonderlijk gevolgd. Freshness vereist daarnaast een actuele werkende OT-link en wordt bij disable, OTA/update-pauze en shutdown gewist. ID0-status wordt bewust niet als proxy voor kamerfreshness gebruikt.

De bestaande warmtetoestemmingsgate en de onafhankelijke CM98-route zijn zonder gedragswijziging via pure helpers testbaar gemaakt.

## Achtergrond

Fixes #473.

De regelaar gebruikte `room_warm_for_off` wel om een actieve warmtevraag te stoppen, maar niet als veto bij een restart door koud systeemwater. Alleen de kamertrim vergroten lost dat niet structureel op.

Quick Start-selectie van OpenTherm-warmtetoestemming en een versnelde stop bij grote kamerovertemperatuur blijven buiten scope; daarvoor zijn afzonderlijke ontwerpkeuzes en pendeltests nodig.

De complete diff is gecontroleerd op bronwissels, boot/reset, OTA/disable, stale/NaN-data, minimale uit-tijd, diepe onderschrijding, OT zonder ID0, no-OpenTherm-profielen, CM98-prioriteit en debugrecorder-compatibiliteit. Een aparte koude review vond en corrigeerde de resetbaarheid van de overgangsdiagnose; er staan geen open auditbevindingen meer.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een interne correctie van bestaand stooklijngedrag en voegt geen gebruikersinstelling of publiek Home Assistant-entitycontract toe. Diagnose en bronstatus worden in de bestaande debugopname vastgelegd.

## Validatie

- [x] `npm run check:cpp-format`
- [x] `./scripts/run_host_regression_tests.sh` — 27 suites
- [x] `npm run check:web` — 196 tests en bundlebudget
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml`
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_listener/single_wifi.yaml`
- [x] `python3 scripts/dev.py validate --config configs/heatpump_controller_q/single_wifi.yaml`
- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- Identieke `dev`-baseline/candidate-build: static RAM 186.499 → 186.595 bytes (+96); image 2.027.495 → 2.028.839 bytes (+1.344).
- Geen nieuwe taken, netwerkbuffers, heap/PSRAM-allocaties of allocatiefallbacks.
- Current/minimum internal heap, largest block, fragmentatie, PSRAM en task-stack-watermarks zijn niet op HIL gemeten; de resterende impact is de vaste 96-byte vermindering van de interne RAM-marge.


Risicoacceptatie:

- De maintainer accepteert bewust dat de volledige baseline/candidate-HIL-geheugenmatrix voor deze PR wordt overgeslagen.
- De gemeten vaste impact is +96 bytes static RAM, met 155.165 bytes resterende DIRAM in de candidate-build.
- De wijziging voegt geen taken, netwerkbuffers, heap/PSRAM-allocaties of allocatiefallbacks toe; ESPHome `current_option()` gebruikt hier een `StringRef` naar statische opslag.
- Verwachte runtime-impact: een vaste vermindering van 96 bytes, zonder belastingsafhankelijke geheugengroei. Het restrisico van ontbrekende minimum-heap/largest-block/stack-watermark-HIL is expliciet geaccepteerd.
