### PR TITLE
Separate OpenTherm wire timing from main-loop latency

### DIFF
--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -1,4 +1,5 @@
 #include "hub.h"
+#include "opentherm_timing.h"
 #include "esphome/core/helpers.h"
 
 #include <string>
@@ -6,6 +7,9 @@
 namespace esphome::opentherm {
 
 static const char* const TAG = "opentherm";
+static constexpr uint32_t MIN_CONVERSATION_GAP_US = 100000;
+static constexpr uint32_t MAX_CONVERSATION_CADENCE_US = 1150000;
+static constexpr uint32_t SLOW_PHASE_US = 50000;
 namespace message_data {
 bool parse_flag8_lb_0(OpenthermData& data) { return read_bit(data.valueLB, 0); }
 bool parse_flag8_lb_1(OpenthermData& data) { return read_bit(data.valueLB, 1); }
@@ -205,8 +209,9 @@ void OpenthermHub::resume_polling() {
   this->priority_sequence_active_ = false;
   this->write_initial_messages_(this->messages_);
   this->message_iterator_ = this->messages_.begin();
-  this->last_conversation_start_ = 0;
-  this->last_conversation_end_ = 0;
+  this->has_last_conversation_start_ = false;
+  this->has_last_conversation_end_ = false;
+  this->has_last_wire_response_ = false;
   this->enable_loop();
 }
 
@@ -249,13 +254,15 @@ void OpenthermHub::loop() {
   if (!this->polling_enabled_) {
     return;
   }
+  const uint32_t transport_started_us = micros();
   this->opentherm_->process();
+  this->warn_if_slow_("RMT completion processing", transport_started_us);
   if (this->sync_mode_) {
     this->sync_loop_();
     return;
   }
 
-  auto cur_time = millis();
+  auto cur_time_us = micros();
   auto const cur_mode = this->opentherm_->get_mode();
 
   if (this->handle_error_(cur_mode)) {
@@ -268,8 +275,7 @@ void OpenthermHub::loop() {
     case OperationMode::LISTEN:
       break;
     case OperationMode::IDLE:
-      this->check_timings_(cur_time);
-      if (this->should_skip_loop_(cur_time)) {
+      if (this->should_skip_loop_(cur_time_us)) {
         break;
       }
       this->start_conversation_();
@@ -312,11 +318,9 @@ void OpenthermHub::sync_loop_() {
     return;
   }
 
-  auto cur_time = millis();
+  auto cur_time_us = micros();
 
-  this->check_timings_(cur_time);
-
-  if (this->should_skip_loop_(cur_time)) {
+  if (this->should_skip_loop_(cur_time_us)) {
     return;
   }
 
@@ -381,22 +385,60 @@ void OpenthermHub::sync_loop_() {
   this->read_response_();
 }
 
-void OpenthermHub::check_timings_(uint32_t cur_time) {
-  if (this->last_conversation_start_ > 0 && (cur_time - this->last_conversation_start_) > 1150) {
-    ESP_LOGW(TAG,
-             "%d ms elapsed since the start of the last convo, but 1150 ms are allowed at maximum. Look at other "
-             "components that might slow the loop down.",
-             (int)(cur_time - this->last_conversation_start_));
+void OpenthermHub::check_cadence_(uint32_t started_us) const {
+  if (!this->has_last_conversation_start_) {
+    return;
   }
+
+  const uint32_t cadence_us = timing::elapsed_us(started_us, this->last_conversation_start_us_);
+  if (cadence_us <= MAX_CONVERSATION_CADENCE_US) {
+    return;
+  }
+
+  if (this->has_last_wire_response_) {
+    ESP_LOGW(TAG,
+             "OpenTherm request cadence delayed to %u ms: previous wire response %u ms, main-loop processing "
+             "latency %u ms. Response timeouts are reported separately.",
+             static_cast<unsigned>(cadence_us / 1000U), static_cast<unsigned>(this->last_wire_response_us_ / 1000U),
+             static_cast<unsigned>(this->last_processing_latency_us_ / 1000U));
+  } else {
+    ESP_LOGW(TAG,
+             "OpenTherm request cadence delayed to %u ms; the previous conversation had no captured response. "
+             "Response timeouts are reported separately.",
+             static_cast<unsigned>(cadence_us / 1000U));
+  }
+  this->log_transport_diagnostics_();
 }
 
-bool OpenthermHub::should_skip_loop_(uint32_t cur_time) const {
-  if (this->last_conversation_end_ > 0 && (cur_time - this->last_conversation_end_) < 100) {
+bool OpenthermHub::should_skip_loop_(uint32_t cur_time_us) const {
+  if (this->has_last_conversation_end_ &&
+      !timing::delay_elapsed(cur_time_us, this->last_conversation_end_us_, MIN_CONVERSATION_GAP_US)) {
     ESP_LOGV(TAG, "Less than 100 ms elapsed since last convo, skipping this iteration");
     return true;
   }
 
   return false;
+}
+
+void OpenthermHub::warn_if_slow_(const char* phase, uint32_t started_us) const {
+  const uint32_t elapsed = timing::elapsed_us(micros(), started_us);
+  if (elapsed >= SLOW_PHASE_US) {
+    ESP_LOGW(TAG, "%s took %u ms in the main loop; this is not OpenTherm wire wait time", phase,
+             static_cast<unsigned>(elapsed / 1000U));
+  }
+}
+
+void OpenthermHub::log_transport_diagnostics_() const {
+  ESP_LOGD(TAG,
+           "OpenTherm transport: requests=%u tx_completed=%u rx_captured=%u rx_accepted=%u rx_rejected=%u "
+           "tx_timeouts=%u response_timeouts=%u late_timeouts=%u max_wire_response=%u ms "
+           "max_processing_latency=%u ms",
+           static_cast<unsigned>(this->requests_started_), static_cast<unsigned>(this->tx_completed_),
+           static_cast<unsigned>(this->rx_captured_), static_cast<unsigned>(this->rx_accepted_),
+           static_cast<unsigned>(this->rx_rejected_), static_cast<unsigned>(this->tx_timeouts_),
+           static_cast<unsigned>(this->response_timeouts_), static_cast<unsigned>(this->late_response_timeouts_),
+           static_cast<unsigned>(this->max_wire_response_us_ / 1000U),
+           static_cast<unsigned>(this->max_processing_latency_us_ / 1000U));
 }
 
 void OpenthermHub::activate_priority_sequence_(MessageId first, MessageId second) {
@@ -446,17 +488,44 @@ void OpenthermHub::start_conversation_() {
 
   auto request = this->build_request_(*this->message_iterator_);
 
+  const uint32_t request_processing_started_us = micros();
   this->before_send_callback_.call(request);
 
   ESP_LOGD(TAG, "Sending request with id %d (%s)", request.id,
            this->opentherm_->message_id_to_str((MessageId)request.id));
   this->opentherm_->debug_data(request);
+  uint32_t fallback_started_us = micros();
+#ifndef USE_ESP32
+  // Avoid diagnostics while the timer-driven Manchester transmission is active.
+  this->check_cadence_(fallback_started_us);
+  this->warn_if_slow_("request preparation", request_processing_started_us);
+  fallback_started_us = micros();
+  this->last_conversation_start_us_ = fallback_started_us;
+  this->has_last_conversation_start_ = true;
+#endif
   // Send the request
-  this->last_conversation_start_ = millis();
   this->opentherm_->send(request);
+
+#ifdef USE_ESP32
+  ConversationTiming conversation_timing;
+  const bool has_wire_timing = this->opentherm_->get_conversation_timing(conversation_timing);
+  if (has_wire_timing) {
+    this->requests_started_++;
+  }
+  const uint32_t started_us = has_wire_timing ? conversation_timing.request_started_us : fallback_started_us;
+  this->check_cadence_(started_us);
+  this->last_conversation_start_us_ = started_us;
+  this->has_last_conversation_start_ = true;
+  this->warn_if_slow_("request preparation and send", request_processing_started_us);
+#else
+  if (!this->opentherm_->is_error()) {
+    this->requests_started_++;
+  }
+#endif
 }
 
 void OpenthermHub::read_response_() {
+  const uint32_t response_processing_started_us = micros();
   OpenthermData response;
   if (!this->opentherm_->get_message(response)) {
     ESP_LOGW(TAG, "Couldn't get the response, but flags indicated success. This is a bug.");
@@ -468,13 +537,74 @@ void OpenthermHub::read_response_() {
 
   this->before_process_response_callback_.call(response);
   this->process_response(response);
+  this->warn_if_slow_("response callbacks and entity updates", response_processing_started_us);
 
   this->message_iterator_++;
 }
 
 void OpenthermHub::stop_opentherm_() {
-  this->opentherm_->stop();
-  this->last_conversation_end_ = millis();
+  const OperationMode completed_mode = this->opentherm_->get_mode();
+  ConversationTiming conversation_timing;
+  const bool has_wire_timing = this->opentherm_->stop(conversation_timing);
+  const uint32_t processed_us = micros();
+
+  this->has_last_wire_response_ = has_wire_timing && conversation_timing.response_captured;
+  const bool receive_timed_out = completed_mode == OperationMode::ERROR_TIMEOUT && has_wire_timing &&
+                                 conversation_timing.request_completed && !conversation_timing.response_captured;
+  this->last_conversation_end_us_ =
+      timing::conversation_end_us(this->has_last_wire_response_, conversation_timing.response_captured_us,
+                                  receive_timed_out, conversation_timing.response_deadline_us, processed_us);
+  if (this->has_last_wire_response_) {
+    this->last_processing_latency_us_ = timing::elapsed_us(processed_us, conversation_timing.response_captured_us);
+    if (conversation_timing.request_completed) {
+      this->last_wire_response_us_ =
+          timing::elapsed_us(conversation_timing.response_captured_us, conversation_timing.request_completed_us);
+    } else {
+      this->last_wire_response_us_ =
+          timing::elapsed_us(conversation_timing.response_captured_us, conversation_timing.request_started_us);
+    }
+  } else if (receive_timed_out) {
+    // No response occupied the wire. Use the existing receive deadline as the
+    // protocol end so scheduler latency does not extend the 100 ms gap.
+    this->last_processing_latency_us_ = 0;
+    this->last_wire_response_us_ = 0;
+  } else {
+    this->last_processing_latency_us_ = 0;
+    this->last_wire_response_us_ = 0;
+  }
+  this->has_last_conversation_end_ = true;
+
+  if (has_wire_timing && conversation_timing.request_completed) {
+    this->tx_completed_++;
+  }
+  if (this->has_last_wire_response_) {
+    this->rx_captured_++;
+    if (this->last_wire_response_us_ > this->max_wire_response_us_) {
+      this->max_wire_response_us_ = this->last_wire_response_us_;
+    }
+    if (this->last_processing_latency_us_ > this->max_processing_latency_us_) {
+      this->max_processing_latency_us_ = this->last_processing_latency_us_;
+    }
+  }
+  if (completed_mode == OperationMode::RECEIVED) {
+    this->rx_accepted_++;
+  } else if (completed_mode == OperationMode::ERROR_PROTOCOL) {
+    this->rx_rejected_++;
+  } else if (completed_mode == OperationMode::ERROR_TIMEOUT) {
+    if (has_wire_timing && !conversation_timing.request_completed) {
+      this->tx_timeouts_++;
+    } else {
+      this->response_timeouts_++;
+      if (this->has_last_wire_response_) {
+        this->late_response_timeouts_++;
+      }
+    }
+  }
+
+  // Keep the counter summary useful for soak tests without logging every conversation.
+  if (this->requests_started_ > 0 && (this->requests_started_ % 128U) == 0U) {
+    this->log_transport_diagnostics_();
+  }
 }
 
 void OpenthermHub::handle_protocol_error_() {
@@ -487,7 +617,17 @@ void OpenthermHub::handle_protocol_error_() {
 }
 
 void OpenthermHub::handle_timeout_error_() {
-  ESP_LOGW(TAG, "Timeout while waiting for response from device");
+  ConversationTiming conversation_timing;
+  const bool has_wire_timing = this->opentherm_->get_conversation_timing(conversation_timing);
+  if (has_wire_timing && !conversation_timing.request_completed) {
+    ESP_LOGW(TAG, "Timeout while waiting for response from device: RMT TX did not complete");
+  } else if (has_wire_timing && conversation_timing.response_captured) {
+    ESP_LOGW(TAG, "Timeout while waiting for response from device: frame was captured after the receive deadline");
+  } else if (has_wire_timing) {
+    ESP_LOGW(TAG, "Timeout while waiting for response from device: no frame captured before the receive deadline");
+  } else {
+    ESP_LOGW(TAG, "Timeout while waiting for response from device");
+  }
   this->stop_opentherm_();
 }
 

--- a/components/opentherm/hub.h
+++ b/components/opentherm/hub.h
@@ -76,8 +76,23 @@ class OpenthermHub final : public Component {
   std::vector<MessageId> messages_;
   std::vector<MessageId>::const_iterator message_iterator_;
 
-  uint32_t last_conversation_start_ = 0;
-  uint32_t last_conversation_end_ = 0;
+  bool has_last_conversation_start_ = false;
+  bool has_last_conversation_end_ = false;
+  bool has_last_wire_response_ = false;
+  uint32_t last_conversation_start_us_ = 0;
+  uint32_t last_conversation_end_us_ = 0;
+  uint32_t last_wire_response_us_ = 0;
+  uint32_t last_processing_latency_us_ = 0;
+  uint32_t requests_started_ = 0;
+  uint32_t tx_completed_ = 0;
+  uint32_t rx_captured_ = 0;
+  uint32_t rx_accepted_ = 0;
+  uint32_t rx_rejected_ = 0;
+  uint32_t tx_timeouts_ = 0;
+  uint32_t response_timeouts_ = 0;
+  uint32_t late_response_timeouts_ = 0;
+  uint32_t max_wire_response_us_ = 0;
+  uint32_t max_processing_latency_us_ = 0;
   OperationMode last_mode_ = IDLE;
   OpenthermData last_request_;
 
@@ -101,8 +116,10 @@ class OpenthermHub final : public Component {
   void apply_deferred_priority_();
   void start_conversation_();
   void read_response_();
-  void check_timings_(uint32_t cur_time);
-  bool should_skip_loop_(uint32_t cur_time) const;
+  void check_cadence_(uint32_t started_us) const;
+  bool should_skip_loop_(uint32_t cur_time_us) const;
+  void warn_if_slow_(const char* phase, uint32_t started_us) const;
+  void log_transport_diagnostics_() const;
   void sync_loop_();
 
   void write_initial_messages_(std::vector<MessageId>& target);

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -72,7 +72,9 @@ void OpenTherm::listen() {
   this->bit_pos_ = 0;
 
 #ifdef USE_ESP32
+  portENTER_CRITICAL(&this->rmt_mux_);
   this->receive_deadline_us_ = micros() + static_cast<uint32_t>(this->device_timeout_) * 1000U;
+  portEXIT_CRITICAL(&this->rmt_mux_);
   if (!this->arm_esp32_rmt_()) {
     this->timer_error_ = ESP_FAIL;
     this->timer_error_type_ = TimerErrorType::TIMER_START_ERROR;
@@ -132,22 +134,57 @@ bool OpenTherm::get_protocol_error(OpenThermError& error) {
   return true;
 }
 
+bool OpenTherm::get_conversation_timing(ConversationTiming& timing) {
+#ifdef USE_ESP32
+  portENTER_CRITICAL(&this->rmt_mux_);
+  timing.request_started = this->rmt_request_started_;
+  timing.request_completed = this->rmt_request_completed_;
+  timing.response_captured = this->rmt_response_captured_;
+  timing.request_started_us = this->rmt_request_started_us_;
+  timing.request_completed_us = this->rmt_request_completed_us_;
+  timing.response_captured_us = this->rmt_response_captured_us_;
+  timing.response_deadline_us = this->receive_deadline_us_;
+  portEXIT_CRITICAL(&this->rmt_mux_);
+  return timing.request_started;
+#else
+  timing = {};
+  return false;
+#endif
+}
+
 void OpenTherm::stop() {
+  ConversationTiming timing;
+  this->stop(timing);
+}
+
+bool OpenTherm::stop(ConversationTiming& timing) {
   this->stop_timer_();
+  bool has_timing = false;
 #ifdef USE_ESP32
   // Invalidate both RMT callbacks before cancelling either channel. Without
   // this claim, a TX-complete ISR could arm RX between the two cancellations.
   portENTER_CRITICAL(&this->rmt_mux_);
   this->mode_ = OperationMode::IDLE;
+  timing.request_started = this->rmt_request_started_;
+  timing.request_completed = this->rmt_request_completed_;
+  timing.response_captured = this->rmt_response_captured_;
+  timing.request_started_us = this->rmt_request_started_us_;
+  timing.request_completed_us = this->rmt_request_completed_us_;
+  timing.response_captured_us = this->rmt_response_captured_us_;
+  timing.response_deadline_us = this->receive_deadline_us_;
+  has_timing = timing.request_started;
   portEXIT_CRITICAL(&this->rmt_mux_);
   this->cancel_esp32_rmt_();
   this->cancel_esp32_rmt_tx_();
+#else
+  timing = {};
 #endif
   // A runtime transport change can stop an in-flight request. Always restore
   // the master output to its initialized idle level instead of leaving the
   // final Manchester half-bit asserted on the physical interface.
   this->out_pin_->digital_write(true);
   this->mode_ = OperationMode::IDLE;
+  return has_timing;
 }
 
 void OpenTherm::process() {
@@ -455,6 +492,12 @@ bool OpenTherm::restore_esp32_rmt_tx_idle_() {
 }
 
 bool OpenTherm::start_esp32_rmt_tx_() {
+  portENTER_CRITICAL(&this->rmt_mux_);
+  this->rmt_request_started_ = false;
+  this->rmt_request_completed_ = false;
+  this->rmt_response_captured_ = false;
+  portEXIT_CRITICAL(&this->rmt_mux_);
+
   if (this->rmt_tx_channel_ == nullptr || this->rmt_tx_encoder_ == nullptr) {
     ESP_LOGE(TAG, "RMT TX is not initialized");
     return false;
@@ -472,6 +515,12 @@ bool OpenTherm::start_esp32_rmt_tx_() {
   portENTER_CRITICAL(&this->rmt_mux_);
   this->rmt_tx_active_ = true;
   const uint32_t tx_started_us = micros();
+  this->rmt_request_started_ = true;
+  this->rmt_request_completed_ = false;
+  this->rmt_response_captured_ = false;
+  this->rmt_request_started_us_ = tx_started_us;
+  this->rmt_request_completed_us_ = 0;
+  this->rmt_response_captured_us_ = 0;
   this->rmt_tx_deadline_us_ = tx_started_us + RMT_TX_TIMEOUT_US;
   this->receive_deadline_us_ = tx_started_us +
                                static_cast<uint32_t>(RMT_TX_SYMBOLS * 2U * rmt_encoder::HALF_BIT_DURATION_US) +
@@ -486,6 +535,7 @@ bool OpenTherm::start_esp32_rmt_tx_() {
   if (result != ESP_OK) {
     portENTER_CRITICAL(&this->rmt_mux_);
     this->rmt_tx_active_ = false;
+    this->rmt_request_started_ = false;
     portEXIT_CRITICAL(&this->rmt_mux_);
     ESP_LOGE(TAG, "Failed to start RMT TX: %s", esp_err_to_name(result));
     this->timer_error_ = result;
@@ -586,7 +636,10 @@ bool IRAM_ATTR OpenTherm::rmt_rx_done_callback_(rmt_channel_handle_t, const rmt_
   if (instance->rmt_armed_ && instance->mode_ == OperationMode::LISTEN) {
     instance->rmt_symbol_count_ = event->num_symbols < RMT_CAPTURE_SYMBOLS ? event->num_symbols : RMT_CAPTURE_SYMBOLS;
     instance->rmt_armed_ = false;
-    instance->rmt_frame_completed_us_ = micros();
+    const uint32_t completed_us = micros();
+    instance->rmt_frame_completed_us_ = completed_us;
+    instance->rmt_response_captured_us_ = completed_us;
+    instance->rmt_response_captured_ = true;
     instance->rmt_frame_ready_ = true;
     // Claim the completed frame immediately while keeping the bounded
     // Manchester decode in the main loop.
@@ -605,6 +658,8 @@ bool IRAM_ATTR OpenTherm::rmt_tx_done_callback_(rmt_channel_handle_t, const rmt_
   portENTER_CRITICAL_ISR(&instance->rmt_mux_);
   if (instance->rmt_tx_active_ && instance->mode_ == OperationMode::WRITE) {
     instance->rmt_tx_active_ = false;
+    instance->rmt_request_completed_us_ = micros();
+    instance->rmt_request_completed_ = true;
     instance->rmt_symbol_count_ = 0;
     instance->rmt_frame_ready_ = false;
     instance->rmt_frame_completed_us_ = 0;

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -244,6 +244,16 @@ struct OpenThermError {
   uint8_t bit_pos;
 };
 
+struct ConversationTiming {
+  bool request_started{false};
+  bool request_completed{false};
+  bool response_captured{false};
+  uint32_t request_started_us{0};
+  uint32_t request_completed_us{0};
+  uint32_t response_captured_us{0};
+  uint32_t response_deadline_us{0};
+};
+
 /**
  * Opentherm static class that supports either listening or sending Opentherm data packets in the same time
  */
@@ -302,11 +312,23 @@ class OpenTherm {
   void stop();
 
   /**
+   * Atomically claim the final ESP32 RMT timing snapshot while stopping the conversation.
+   * Returns false on platforms without RMT timing data.
+   */
+  bool stop(ConversationTiming& timing);
+
+  /**
    * Get protocol error details in case a protocol error occured.
    * @param error reference to data structure to which fill the error details
    * @return true if protocol error occured during last conversation, false otherwise.
    */
   bool get_protocol_error(OpenThermError& error);
+
+  /**
+   * Return wire-level timestamps for the current or most recently completed ESP32 RMT conversation.
+   * Returns false on platforms without RMT timing data.
+   */
+  bool get_conversation_timing(ConversationTiming& timing);
 
   /**
    * Use this function to check whether send() function already finished sending data packed to line.
@@ -407,6 +429,12 @@ class OpenTherm {
   volatile bool rmt_frame_ready_{false};
   volatile uint32_t rmt_frame_completed_us_{0};
   volatile bool rmt_tx_active_{false};
+  volatile bool rmt_request_started_{false};
+  volatile bool rmt_request_completed_{false};
+  volatile bool rmt_response_captured_{false};
+  volatile uint32_t rmt_request_started_us_{0};
+  volatile uint32_t rmt_request_completed_us_{0};
+  volatile uint32_t rmt_response_captured_us_{0};
   uint32_t rmt_tx_deadline_us_{0};
   uint32_t receive_deadline_us_{0};
 #endif

--- a/components/opentherm/opentherm_timing.h
+++ b/components/opentherm/opentherm_timing.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace esphome::opentherm::timing {
+
+inline uint32_t elapsed_us(uint32_t now_us, uint32_t started_us) { return now_us - started_us; }
+
+inline bool delay_elapsed(uint32_t now_us, uint32_t started_us, uint32_t delay_us) {
+  return elapsed_us(now_us, started_us) >= delay_us;
+}
+
+inline uint32_t conversation_end_us(bool response_captured, uint32_t response_captured_us, bool receive_timed_out,
+                                    uint32_t response_deadline_us, uint32_t processed_us) {
+  if (response_captured) {
+    return response_captured_us;
+  }
+  if (receive_timed_out) {
+    return response_deadline_us;
+  }
+  return processed_us;
+}
+
+}  // namespace esphome::opentherm::timing

--- a/tests/host/opentherm_timing_test.cpp
+++ b/tests/host/opentherm_timing_test.cpp
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "../../components/opentherm/opentherm_timing.h"
+
+int main() {
+  using esphome::opentherm::timing::conversation_end_us;
+  using esphome::opentherm::timing::delay_elapsed;
+  using esphome::opentherm::timing::elapsed_us;
+
+  assert(elapsed_us(25U, UINT32_MAX - 24U) == 50U);
+  assert(!delay_elapsed(99U, 0U, 100U));
+  assert(delay_elapsed(100U, 0U, 100U));
+  assert(delay_elapsed(25U, UINT32_MAX - 24U, 50U));
+  assert(!delay_elapsed(49999U, UINT32_MAX - 49999U, 100000U));
+  assert(delay_elapsed(50000U, UINT32_MAX - 49999U, 100000U));
+
+  constexpr uint32_t response_captured_us = 735000U;
+  constexpr uint32_t response_deadline_us = 834000U;
+  constexpr uint32_t processed_us = 1250000U;
+  assert(conversation_end_us(true, response_captured_us, false, response_deadline_us, processed_us) ==
+         response_captured_us);
+  assert(conversation_end_us(true, response_captured_us, true, response_deadline_us, processed_us) ==
+         response_captured_us);
+  assert(conversation_end_us(false, 0U, true, response_deadline_us, processed_us) == response_deadline_us);
+  assert(conversation_end_us(false, 0U, false, response_deadline_us, processed_us) == processed_us);
+  assert(delay_elapsed(processed_us,
+                       conversation_end_us(true, response_captured_us, false, response_deadline_us, processed_us),
+                       100000U));
+
+  return 0;
+}

--- a/tests/host/ot_boiler_telemetry_test.cpp
+++ b/tests/host/ot_boiler_telemetry_test.cpp
@@ -98,7 +98,9 @@ int main() {
   state.record_log_message(1020, "opentherm", "Protocol error occured while receiving response: NO_CHANGE_TOO_LONG");
   state.record_log_message(1030, "opentherm", "Protocol error occured while receiving response: INVALID_STOP_BIT");
   state.record_log_message(1040, "opentherm", "Protocol error occured while receiving response: PARITY_ERROR");
-  state.record_log_message(1050, "opentherm", "Timeout while waiting for response from device");
+  state.record_log_message(1050, "opentherm",
+                           "Timeout while waiting for response from device: no frame captured before the receive "
+                           "deadline");
   state.record_log_message(1060, "opentherm", "Hub timeout triggered during send");
   state.record_log_message(1070, "opentherm", "Hub timeout triggered during receive");
   state.record_log_message(1080, "opentherm", "Error occured while manipulating timer (TIMER_START_ERROR): ESP_FAIL");


### PR DESCRIPTION
# Wat verandert deze PR?

- Legt RMT TX-start, TX-completion en RX-capture als afzonderlijke wire-timestamps vast.
- Baseert conversation-end en de minimale 100 ms-pauze op RX-capture of receive-deadline, niet op latere main-loopverwerking.
- Splitst cadence-, processing- en timeoutdiagnostiek en voegt compacte soak-counters toe.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Een volgende request mag na main-loopvertraging starten zodra de fysieke RX-capture of timeoutdeadline plus 100 ms is verstreken. De bestaande receive-deadline en decoder blijven ongewijzigd. De extra toestand bestaat uitsluitend uit vaste timestamps/counters; er komen geen dynamische allocaties of nieuwe tasks bij.

## Achtergrond

Closes #480.

De terminale timing-snapshot en het stoppen van RMT worden onder dezelfde critical section geclaimd. Daardoor kan een late RX/TX-callback niet na de snapshot alsnog timingstate van de afgesloten conversatie wijzigen.

De volledige diff is gecontroleerd op TX→RX-handover, response vóór/na deadline, main-loopstalls, timeout zonder response, TX-timeout, timer-wraparound, suspend/stop en callback/stop-interleavings. Ook is de bestaande timeout-logprefix behouden omdat OTB-telemetrie die als contract gebruikt.

De historische melding `opentherm took ... 555 ms` is zonder reproduceerbare trace niet retrospectief toe te wijzen. Nieuwe fasewarnings onderscheiden RMT-afhandeling, requestvoorbereiding en responsecallbacks/entity-updates.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Alle wijzigingen zijn interne transporttiming en diagnostiek; entities en configuratie blijven gelijk.

## Validatie

- [x] `./scripts/run_host_regression_tests.sh` — 28 hosttests geslaagd
- [x] `npm run check:cpp-format`
- [x] `python3 scripts/dev.py validate --config configs/heatpump_controller_q/duo_wifi.yaml --jobs 1`
- [x] `git diff --check origin/dev...HEAD`
- [x] Volledige koude diff-audit en failure/interleaving-analyse
- [x] HIL op Heatpump Controller Q / Duo / Wi-Fi met simulatorresponse van 700 ms
  - Schone kandidaat: 384 requests, TX-completions, RX-captures en geaccepteerde responses; 0 rejects en 0 TX/response/late timeouts.
  - Maximum wire-response 768 ms; maximum normale processing latency 95 ms.
  - Tijdelijke, niet-gecommitte HIL-overlay: 8 × 650 ms main-loopstall binnen startup-inhibit en CM0.
  - Tijdens zichtbare worst-case overlaps: cadence 1197–1255 ms, wire-response 739–747 ms en processing latency 397–430 ms; responses bleven geaccepteerd zonder timeout.
  - Simulator-decodecounter steeg alleen met 2 op iedere OTA/rebootgrens en bleef daarna stabiel; de schone kandidaat is na de test teruggezet.

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- static DIRAM: 200995 → 201079 bytes (+84 bytes)
- kandidaat na 700 ms HIL-soak: current internal heap 117495 B; minimum-since-boot 40340 B; largest block 63488 B; fragmentatie 46.0%
- geen heapallocaties, PSRAM-wijzigingen of nieuwe task-stacks
- geteste overlap: Duo Modbus/Wi-Fi/web/API actief, 700 ms OpenTherm-response en 650 ms main-loopstall
