### PR TITLE
Decode OpenTherm RMT input with edge-phase tracking

### DIFF
--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -688,7 +688,10 @@ void OpenTherm::process_esp32_rmt_() {
   }
 
   this->stop_timer_();
-  const rmt_decoder::DecodeResult result = rmt_decoder::decode(pulses, pulse_count);
+  // The OpenQuatt boiler input front-end maps an active OpenTherm level to a
+  // high GPIO level. Keep that hardware polarity outside the protocol decoder.
+  const rmt_decoder::DecodeResult result =
+      rmt_decoder::decode(pulses, pulse_count, rmt_decoder::InputPolarity::ACTIVE_HIGH);
   if (result.error != rmt_decoder::DecodeError::NONE) {
     const char* decode_error = "unknown";
     switch (result.error) {

--- a/components/opentherm/opentherm_rmt_decoder.h
+++ b/components/opentherm/opentherm_rmt_decoder.h
@@ -6,11 +6,14 @@
 namespace esphome::opentherm::rmt_decoder {
 
 static constexpr size_t FRAME_BITS = 34;
-static constexpr size_t HALF_BITS = FRAME_BITS * 2;
-static constexpr uint16_t HALF_BIT_MIN_US = 380;
-static constexpr uint16_t HALF_BIT_MAX_US = 620;
-static constexpr uint16_t FULL_BIT_MIN_US = 880;
-static constexpr uint16_t FULL_BIT_MAX_US = 1120;
+
+// A boundary transition divides the 900-1150 us interval between two
+// mandatory mid-bit transitions. Keep the proven short-pulse capture window,
+// but validate the complete mid-bit interval separately below.
+static constexpr uint16_t BOUNDARY_INTERVAL_MIN_US = 380;
+static constexpr uint16_t BOUNDARY_INTERVAL_MAX_US = 620;
+static constexpr uint16_t MID_BIT_INTERVAL_MIN_US = 900;
+static constexpr uint16_t MID_BIT_INTERVAL_MAX_US = 1150;
 
 inline bool completion_is_within_deadline(uint32_t completed_us, uint32_t deadline_us) {
   return static_cast<int32_t>(completed_us - deadline_us) <= 0;
@@ -18,7 +21,12 @@ inline bool completion_is_within_deadline(uint32_t completed_us, uint32_t deadli
 
 struct Pulse {
   uint16_t duration_us;
-  bool level;
+  bool level;  // GPIO level held during this interval, before its ending edge.
+};
+
+enum class InputPolarity : uint8_t {
+  ACTIVE_LOW = 0,
+  ACTIVE_HIGH,
 };
 
 enum class DecodeError : uint8_t {
@@ -58,109 +66,138 @@ inline bool has_even_parity(uint32_t value) {
   return (~value) & 1U;
 }
 
-inline DecodeResult decode(const Pulse* pulses, size_t pulse_count) {
+inline bool is_active(bool input_level, InputPolarity polarity) {
+  return input_level == (polarity == InputPolarity::ACTIVE_HIGH);
+}
+
+inline DecodeResult decode(const Pulse* pulses, size_t pulse_count, InputPolarity polarity) {
   DecodeResult result{};
   result.pulse_count = pulse_count;
-  uint8_t half_bits[HALF_BITS]{};
-  uint8_t decoded_half_bits[HALF_BITS]{};
-  size_t half_bit_count = 0;
+  bool have_pulse = false;
+  bool previous_level = false;
+  bool boundary_seen = false;
+  bool frame_complete = false;
+  uint16_t time_since_mid_bit_us = 0;
+  size_t bit_count = 0;
+
+  if (pulses == nullptr && pulse_count != 0U) {
+    result.error = DecodeError::TIMING;
+    result.capture_failure = CaptureFailure::HALF_BIT_COUNT;
+    return result;
+  }
 
   for (size_t pulse_index = 0; pulse_index < pulse_count; pulse_index++) {
     const Pulse& pulse = pulses[pulse_index];
-    if (pulse.duration_us == 0) {
+    if (pulse.duration_us == 0U) {
       continue;
     }
 
-    uint8_t repeats = 0;
-    if (pulse.duration_us >= HALF_BIT_MIN_US && pulse.duration_us <= HALF_BIT_MAX_US) {
-      repeats = 1;
-    } else if (pulse.duration_us >= FULL_BIT_MIN_US && pulse.duration_us <= FULL_BIT_MAX_US) {
-      repeats = 2;
-    } else {
-      result.error = pulse.duration_us < HALF_BIT_MIN_US ? DecodeError::GLITCH : DecodeError::TIMING;
+    if (frame_complete) {
+      result.error = DecodeError::TIMING;
       result.failure_pulse_index = pulse_index;
       result.failure_pulse_duration_us = pulse.duration_us;
-      result.half_bit_count = half_bit_count;
+      result.capture_failure = CaptureFailure::HALF_BIT_OVERFLOW;
+      return result;
+    }
+
+    const bool short_interval =
+        pulse.duration_us >= BOUNDARY_INTERVAL_MIN_US && pulse.duration_us <= BOUNDARY_INTERVAL_MAX_US;
+    const bool full_interval =
+        pulse.duration_us >= MID_BIT_INTERVAL_MIN_US && pulse.duration_us <= MID_BIT_INTERVAL_MAX_US;
+    if (!short_interval && !full_interval) {
+      result.error = pulse.duration_us < BOUNDARY_INTERVAL_MIN_US ? DecodeError::GLITCH : DecodeError::TIMING;
+      result.failure_pulse_index = pulse_index;
+      result.failure_pulse_duration_us = pulse.duration_us;
       result.capture_failure = CaptureFailure::PULSE_DURATION;
       return result;
     }
 
-    if (half_bit_count + repeats > HALF_BITS) {
-      result.error = DecodeError::TIMING;
+    if (have_pulse && pulse.level == previous_level) {
+      result.error = DecodeError::MANCHESTER;
       result.failure_pulse_index = pulse_index;
       result.failure_pulse_duration_us = pulse.duration_us;
-      result.half_bit_count = half_bit_count;
-      result.capture_failure = CaptureFailure::HALF_BIT_OVERFLOW;
       return result;
     }
-    for (uint8_t repeat = 0; repeat < repeats; repeat++) {
-      half_bits[half_bit_count++] = pulse.level ? 1U : 0U;
-    }
-  }
+    previous_level = pulse.level;
 
-  // RMT starts at the first transition and may therefore omit the leading low
-  // half of the start bit. It may likewise omit the final high half when the
-  // frame is terminated by the idle-range threshold. Only salvage those two
-  // exact 67-half-bit boundary cases.
-  if (half_bit_count == HALF_BITS - 1U && half_bit_count > 0) {
-    if (half_bits[0] == 1U) {
-      for (size_t index = half_bit_count; index > 0; index--) {
-        half_bits[index] = half_bits[index - 1U];
+    bool is_mid_bit = false;
+    if (!have_pulse) {
+      // RMT starts after the idle-to-active frame-start transition. The first
+      // captured run is therefore the active first half of the start bit and
+      // must end at its mandatory mid-bit transition.
+      have_pulse = true;
+      if (!short_interval) {
+        result.error = DecodeError::TIMING;
+        result.failure_pulse_index = pulse_index;
+        result.failure_pulse_duration_us = pulse.duration_us;
+        result.capture_failure = CaptureFailure::PULSE_DURATION;
+        return result;
       }
-      half_bits[0] = 0U;
-      half_bit_count++;
-    } else if (half_bits[half_bit_count - 1U] == 0U) {
-      half_bits[half_bit_count++] = 1U;
-    }
-  }
-
-  if (half_bit_count != HALF_BITS) {
-    result.error = DecodeError::TIMING;
-    result.failure_pulse_index = pulse_count;
-    result.half_bit_count = half_bit_count;
-    result.capture_failure = CaptureFailure::HALF_BIT_COUNT;
-    return result;
-  }
-  result.half_bit_count = half_bit_count;
-
-  // The OpenQuatt OT input front-end presents an inverted signal, and RMT
-  // starts capturing at the first edge rather than at the logical frame
-  // boundary. The existing OpenQuatt OT-slave receiver has established this
-  // single one-half-bit-forward, inverted interpretation in long-running HIL.
-  for (size_t index = 0; index < HALF_BITS - 1U; index++) {
-    decoded_half_bits[index] = half_bits[index + 1U] ^ 0x1U;
-  }
-  decoded_half_bits[HALF_BITS - 1U] = decoded_half_bits[HALF_BITS - 2U] ^ 0x1U;
-
-  for (size_t bit_index = 0; bit_index < FRAME_BITS; bit_index++) {
-    result.bit_position = static_cast<uint8_t>(bit_index);
-    const uint8_t first = decoded_half_bits[bit_index * 2U];
-    const uint8_t second = decoded_half_bits[(bit_index * 2U) + 1U];
-    bool bit_value = false;
-    if (first == 0U && second == 1U) {
-      bit_value = true;
-    } else if (first == 1U && second == 0U) {
-      bit_value = false;
+      if (!is_active(pulse.level, polarity)) {
+        result.error = DecodeError::START_BIT;
+        result.failure_pulse_index = pulse_index;
+        result.failure_pulse_duration_us = pulse.duration_us;
+        return result;
+      }
+      is_mid_bit = true;
+    } else if (boundary_seen) {
+      if (!short_interval) {
+        result.error = DecodeError::MANCHESTER;
+        result.failure_pulse_index = pulse_index;
+        result.failure_pulse_duration_us = pulse.duration_us;
+        return result;
+      }
+      time_since_mid_bit_us = static_cast<uint16_t>(time_since_mid_bit_us + pulse.duration_us);
+      if (time_since_mid_bit_us < MID_BIT_INTERVAL_MIN_US || time_since_mid_bit_us > MID_BIT_INTERVAL_MAX_US) {
+        result.error = DecodeError::TIMING;
+        result.failure_pulse_index = pulse_index;
+        result.failure_pulse_duration_us = pulse.duration_us;
+        result.capture_failure = CaptureFailure::PULSE_DURATION;
+        return result;
+      }
+      boundary_seen = false;
+      is_mid_bit = true;
+    } else if (short_interval) {
+      boundary_seen = true;
+      time_since_mid_bit_us = pulse.duration_us;
     } else {
-      result.error = bit_index == 0 ? DecodeError::START_BIT : DecodeError::MANCHESTER;
-      return result;
+      is_mid_bit = true;
     }
 
-    if (bit_index == 0) {
+    const size_t elapsed_half_bits = short_interval ? 1U : 2U;
+    result.half_bit_count += elapsed_half_bits;
+
+    if (!is_mid_bit) {
+      continue;
+    }
+
+    time_since_mid_bit_us = 0;
+    result.bit_position = static_cast<uint8_t>(bit_count);
+    // At a mid-bit edge, an active-to-idle transition is one and an
+    // idle-to-active transition is zero. The pulse level is the pre-edge level.
+    const bool bit_value = is_active(pulse.level, polarity);
+    if (bit_count == 0U) {
       if (!bit_value) {
         result.error = DecodeError::START_BIT;
         return result;
       }
-      continue;
-    }
-    if (bit_index == FRAME_BITS - 1U) {
+    } else if (bit_count == FRAME_BITS - 1U) {
       if (!bit_value) {
         result.error = DecodeError::STOP_BIT;
         return result;
       }
-      break;
+      frame_complete = true;
+    } else {
+      result.data = (result.data << 1U) | static_cast<uint32_t>(bit_value);
     }
-    result.data = (result.data << 1U) | static_cast<uint32_t>(bit_value);
+    bit_count++;
+  }
+
+  if (!frame_complete || boundary_seen || bit_count != FRAME_BITS) {
+    result.error = DecodeError::TIMING;
+    result.failure_pulse_index = pulse_count;
+    result.capture_failure = CaptureFailure::HALF_BIT_COUNT;
+    return result;
   }
 
   if (!has_even_parity(result.data)) {

--- a/tests/host/opentherm_rmt_decoder_test.cpp
+++ b/tests/host/opentherm_rmt_decoder_test.cpp
@@ -8,6 +8,7 @@ namespace {
 
 using esphome::opentherm::rmt_decoder::CaptureFailure;
 using esphome::opentherm::rmt_decoder::DecodeError;
+using esphome::opentherm::rmt_decoder::InputPolarity;
 using esphome::opentherm::rmt_decoder::Pulse;
 
 uint32_t with_even_parity(uint32_t value_without_parity) {
@@ -18,61 +19,91 @@ uint32_t with_even_parity(uint32_t value_without_parity) {
   return value_without_parity;
 }
 
+bool input_level(bool active, InputPolarity polarity) {
+  return polarity == InputPolarity::ACTIVE_HIGH ? active : !active;
+}
+
 struct EncodedFrame {
-  Pulse pulses[68]{};
+  Pulse pulses[72]{};
   size_t size{0};
 
-  void erase_first() {
-    for (size_t index = 1; index < size; index++) {
-      pulses[index - 1U] = pulses[index];
+  void erase(size_t index) {
+    assert(index < size);
+    for (size_t next = index + 1U; next < size; next++) {
+      pulses[next - 1U] = pulses[next];
     }
     size--;
   }
 
-  void erase_last() { size--; }
+  size_t find_duration(uint16_t duration_us, size_t begin = 0U) const {
+    for (size_t index = begin; index < size; index++) {
+      if (pulses[index].duration_us == duration_us) {
+        return index;
+      }
+    }
+    assert(false);
+    return size;
+  }
+
+  size_t find_short_pair() const {
+    for (size_t index = 1U; index + 1U < size; index++) {
+      if (pulses[index].duration_us == 500U && pulses[index + 1U].duration_us == 500U) {
+        return index;
+      }
+    }
+    assert(false);
+    return size;
+  }
 };
 
-EncodedFrame encode(uint32_t data, int jitter_us = 0) {
-  uint8_t logical_half_bits[68]{};
-  uint8_t captured_half_bits[68]{};
+// Build the protocol waveform directly from Bi-phase-L: one is active-to-idle
+// and zero is idle-to-active at the mandatory mid-bit transition. Compress the
+// resulting levels into the runs that RMT returns after the frame-start edge.
+EncodedFrame encode(uint32_t data, InputPolarity polarity = InputPolarity::ACTIVE_HIGH, bool stop_bit = true,
+                    uint16_t short_duration_us = 500U, uint16_t full_duration_us = 1000U, int jitter_us = 0) {
+  bool half_bits[68]{};
   size_t half_bit_count = 0;
   const auto append_bit = [&](bool value) {
-    logical_half_bits[half_bit_count++] = value ? 0U : 1U;
-    logical_half_bits[half_bit_count++] = value ? 1U : 0U;
+    half_bits[half_bit_count++] = value;
+    half_bits[half_bit_count++] = !value;
   };
 
   append_bit(true);
   for (int bit = 31; bit >= 0; bit--) {
-    append_bit(((data >> bit) & 1U) != 0);
+    append_bit(((data >> bit) & 1U) != 0U);
   }
-  append_bit(true);
-
-  // Inverse of the single RMT interpretation used by the decoder: the first
-  // captured half-bit is ignored, and every following half-bit is inverted.
-  captured_half_bits[0] = 0U;
-  for (size_t index = 0; index < 67U; index++) {
-    captured_half_bits[index + 1U] = logical_half_bits[index] ^ 0x1U;
-  }
+  append_bit(stop_bit);
+  assert(half_bit_count == 68U);
 
   EncodedFrame encoded;
-  size_t run_start = 0;
-  while (run_start < 68U) {
-    size_t run_end = run_start + 1U;
-    while (run_end < 68U && captured_half_bits[run_end] == captured_half_bits[run_start]) {
-      run_end++;
+  bool run_level = half_bits[0];
+  size_t run_half_bits = 1U;
+  for (size_t index = 1U; index < half_bit_count; index++) {
+    if (half_bits[index] == run_level) {
+      run_half_bits++;
+      continue;
     }
-    const int base_duration = static_cast<int>((run_end - run_start) * 500U);
+
+    assert(run_half_bits == 1U || run_half_bits == 2U);
+    const int base_duration = run_half_bits == 1U ? short_duration_us : full_duration_us;
     const int signed_jitter = encoded.size % 2U == 0U ? jitter_us : -jitter_us;
     encoded.pulses[encoded.size++] =
-        Pulse{static_cast<uint16_t>(base_duration + signed_jitter), captured_half_bits[run_start] != 0U};
-    run_start = run_end;
+        Pulse{static_cast<uint16_t>(base_duration + signed_jitter), input_level(run_level, polarity)};
+    run_level = half_bits[index];
+    run_half_bits = 1U;
   }
+
+  // The final stop-bit half is idle and has no terminating edge. RMT ends the
+  // capture on its idle threshold, so it is intentionally not a decoder pulse.
+  assert(!run_level || !stop_bit);
   return encoded;
 }
 
 }  // namespace
 
 int main() {
+  using esphome::opentherm::rmt_decoder::decode;
+
   assert(esphome::opentherm::rmt_decoder::completion_is_within_deadline(1000U, 1000U));
   assert(esphome::opentherm::rmt_decoder::completion_is_within_deadline(999U, 1000U));
   assert(!esphome::opentherm::rmt_decoder::completion_is_within_deadline(1001U, 1000U));
@@ -80,81 +111,153 @@ int main() {
   assert(!esphome::opentherm::rmt_decoder::completion_is_within_deadline(20U, 5U));
 
   const uint32_t data = with_even_parity(0x40001234U);
-
   const auto nominal = encode(data);
-  auto decoded = esphome::opentherm::rmt_decoder::decode(nominal.pulses, nominal.size);
+  auto decoded = decode(nominal.pulses, nominal.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == data);
+  assert(decoded.half_bit_count == 67U);
+
+  const auto active_low = encode(data, InputPolarity::ACTIVE_LOW);
+  decoded = decode(active_low.pulses, active_low.size, InputPolarity::ACTIVE_LOW);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == data);
+  decoded = decode(nominal.pulses, nominal.size, InputPolarity::ACTIVE_LOW);
+  assert(decoded.error == DecodeError::START_BIT);
+
+  const auto all_ones = encode(0xFFFFFFFFU);
+  decoded = decode(all_ones.pulses, all_ones.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == 0xFFFFFFFFU);
+  assert(all_ones.size == 67U);
+  for (size_t index = 0; index < all_ones.size; index++) {
+    assert(all_ones.pulses[index].duration_us == 500U);
+  }
+
+  const auto alternating = encode(0xAAAAAAAAU);
+  decoded = decode(alternating.pulses, alternating.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == 0xAAAAAAAAU);
+  assert(alternating.find_duration(1000U) < alternating.size);
+
+  uint32_t random_data = 0x12345678U;
+  for (size_t iteration = 0; iteration < 4096U; iteration++) {
+    random_data = random_data * 1664525U + 1013904223U;
+    const uint32_t frame_data = with_even_parity(random_data);
+    const auto frame = encode(frame_data);
+    decoded = decode(frame.pulses, frame.size, InputPolarity::ACTIVE_HIGH);
+    assert(decoded.error == DecodeError::NONE);
+    assert(decoded.data == frame_data);
+  }
+
+  const auto jittered = encode(data, InputPolarity::ACTIVE_HIGH, true, 500U, 1000U, 19);
+  decoded = decode(jittered.pulses, jittered.size, InputPolarity::ACTIVE_HIGH);
   assert(decoded.error == DecodeError::NONE);
   assert(decoded.data == data);
 
-  const auto jittered = encode(data, 19);
-  decoded = esphome::opentherm::rmt_decoder::decode(jittered.pulses, jittered.size);
+  const auto lower_timing = encode(data, InputPolarity::ACTIVE_HIGH, true, 450U, 900U);
+  decoded = decode(lower_timing.pulses, lower_timing.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  const auto upper_timing = encode(data, InputPolarity::ACTIVE_HIGH, true, 575U, 1150U);
+  decoded = decode(upper_timing.pulses, upper_timing.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+
+  auto asymmetric_boundary = nominal;
+  const size_t short_pair = asymmetric_boundary.find_short_pair();
+  asymmetric_boundary.pulses[short_pair].duration_us = 380U;
+  asymmetric_boundary.pulses[short_pair + 1U].duration_us = 620U;
+  decoded = decode(asymmetric_boundary.pulses, asymmetric_boundary.size, InputPolarity::ACTIVE_HIGH);
   assert(decoded.error == DecodeError::NONE);
   assert(decoded.data == data);
 
-  decoded = esphome::opentherm::rmt_decoder::decode(nullptr, 0);
+  decoded = decode(nullptr, 0U, InputPolarity::ACTIVE_HIGH);
   assert(decoded.error == DecodeError::TIMING);
   assert(decoded.capture_failure == CaptureFailure::HALF_BIT_COUNT);
-  assert(decoded.pulse_count == 0U);
-  assert(decoded.half_bit_count == 0U);
 
-  auto missing_leading_half = nominal;
-  assert(missing_leading_half.pulses[0].duration_us == 500);
-  missing_leading_half.erase_first();
-  decoded = esphome::opentherm::rmt_decoder::decode(missing_leading_half.pulses, missing_leading_half.size);
-  assert(decoded.error == DecodeError::NONE);
-  assert(decoded.data == data);
+  auto missing_start = all_ones;
+  missing_start.erase(0U);
+  decoded = decode(missing_start.pulses, missing_start.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::START_BIT);
 
-  const uint32_t trailing_data = with_even_parity(0x40001235U);
-  auto missing_trailing_half = encode(trailing_data);
-  assert(missing_trailing_half.pulses[missing_trailing_half.size - 1U].duration_us == 500);
-  missing_trailing_half.erase_last();
-  decoded = esphome::opentherm::rmt_decoder::decode(missing_trailing_half.pulses, missing_trailing_half.size);
-  assert(decoded.error == DecodeError::NONE);
-  assert(decoded.data == trailing_data);
+  auto missing_end = nominal;
+  missing_end.erase(missing_end.size - 1U);
+  decoded = decode(missing_end.pulses, missing_end.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+  assert(decoded.capture_failure == CaptureFailure::HALF_BIT_COUNT);
+
+  auto wrong_start_level = nominal;
+  wrong_start_level.pulses[0].level = input_level(false, InputPolarity::ACTIVE_HIGH);
+  decoded = decode(wrong_start_level.pulses, wrong_start_level.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::START_BIT);
+
+  auto wrong_start_timing = nominal;
+  wrong_start_timing.pulses[0].duration_us = 1000U;
+  decoded = decode(wrong_start_timing.pulses, wrong_start_timing.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+  assert(decoded.capture_failure == CaptureFailure::PULSE_DURATION);
+
+  const auto invalid_stop = encode(data, InputPolarity::ACTIVE_HIGH, false);
+  decoded = decode(invalid_stop.pulses, invalid_stop.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::STOP_BIT);
+
+  const auto invalid_parity = encode(data ^ 0x1U);
+  decoded = decode(invalid_parity.pulses, invalid_parity.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::PARITY);
 
   auto glitch = nominal;
-  glitch.pulses[1].duration_us = 200;
-  decoded = esphome::opentherm::rmt_decoder::decode(glitch.pulses, glitch.size);
+  glitch.pulses[1].duration_us = 200U;
+  decoded = decode(glitch.pulses, glitch.size, InputPolarity::ACTIVE_HIGH);
   assert(decoded.error == DecodeError::GLITCH);
   assert(decoded.capture_failure == CaptureFailure::PULSE_DURATION);
   assert(decoded.failure_pulse_index == 1U);
-  assert(decoded.failure_pulse_duration_us == 200U);
+
+  auto below_short_window = nominal;
+  below_short_window.pulses[below_short_window.find_duration(500U)].duration_us = 379U;
+  decoded = decode(below_short_window.pulses, below_short_window.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::GLITCH);
+
+  auto above_short_window = nominal;
+  above_short_window.pulses[above_short_window.find_duration(500U)].duration_us = 621U;
+  decoded = decode(above_short_window.pulses, above_short_window.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
 
   auto invalid_timing = nominal;
-  invalid_timing.pulses[1].duration_us = 750;
-  decoded = esphome::opentherm::rmt_decoder::decode(invalid_timing.pulses, invalid_timing.size);
+  invalid_timing.pulses[invalid_timing.find_duration(1000U)].duration_us = 899U;
+  decoded = decode(invalid_timing.pulses, invalid_timing.size, InputPolarity::ACTIVE_HIGH);
   assert(decoded.error == DecodeError::TIMING);
   assert(decoded.capture_failure == CaptureFailure::PULSE_DURATION);
-  assert(decoded.failure_pulse_index == 1U);
-  assert(decoded.failure_pulse_duration_us == 750U);
 
-  auto too_many_half_bits = nominal;
-  too_many_half_bits.pulses[too_many_half_bits.size++] = Pulse{1000U, false};
-  decoded = esphome::opentherm::rmt_decoder::decode(too_many_half_bits.pulses, too_many_half_bits.size);
+  invalid_timing = nominal;
+  invalid_timing.pulses[invalid_timing.find_duration(1000U)].duration_us = 1151U;
+  decoded = decode(invalid_timing.pulses, invalid_timing.size, InputPolarity::ACTIVE_HIGH);
   assert(decoded.error == DecodeError::TIMING);
-  assert(decoded.capture_failure == CaptureFailure::HALF_BIT_OVERFLOW);
-  assert(decoded.failure_pulse_index == too_many_half_bits.size - 1U);
-  assert(decoded.failure_pulse_duration_us == 1000U);
-  assert(decoded.half_bit_count == 68U);
 
-  auto too_few_half_bits = nominal;
-  too_few_half_bits.erase_last();
-  too_few_half_bits.erase_last();
-  decoded = esphome::opentherm::rmt_decoder::decode(too_few_half_bits.pulses, too_few_half_bits.size);
+  auto invalid_mid_bit_period = nominal;
+  const size_t invalid_pair = invalid_mid_bit_period.find_short_pair();
+  invalid_mid_bit_period.pulses[invalid_pair].duration_us = 380U;
+  invalid_mid_bit_period.pulses[invalid_pair + 1U].duration_us = 380U;
+  decoded = decode(invalid_mid_bit_period.pulses, invalid_mid_bit_period.size, InputPolarity::ACTIVE_HIGH);
   assert(decoded.error == DecodeError::TIMING);
-  assert(decoded.capture_failure == CaptureFailure::HALF_BIT_COUNT);
-  assert(decoded.failure_pulse_index == too_few_half_bits.size);
-  assert(decoded.failure_pulse_duration_us == 0U);
-  assert(decoded.half_bit_count < 67U);
 
   auto invalid_manchester = nominal;
   invalid_manchester.pulses[1].level = invalid_manchester.pulses[0].level;
-  decoded = esphome::opentherm::rmt_decoder::decode(invalid_manchester.pulses, invalid_manchester.size);
-  assert(decoded.error != DecodeError::NONE);
+  decoded = decode(invalid_manchester.pulses, invalid_manchester.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::MANCHESTER);
 
-  const auto invalid_parity = encode(data ^ 0x1U);
-  decoded = esphome::opentherm::rmt_decoder::decode(invalid_parity.pulses, invalid_parity.size);
-  assert(decoded.error == DecodeError::PARITY);
+  auto missing_mid_bit = nominal;
+  missing_mid_bit.erase(missing_mid_bit.find_short_pair() + 1U);
+  decoded = decode(missing_mid_bit.pulses, missing_mid_bit.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::MANCHESTER);
+
+  auto missing_final_mid_bit = all_ones;
+  missing_final_mid_bit.pulses[missing_final_mid_bit.size - 1U].duration_us = 1000U;
+  decoded = decode(missing_final_mid_bit.pulses, missing_final_mid_bit.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::MANCHESTER);
+
+  auto trailing_pulse = nominal;
+  trailing_pulse.pulses[trailing_pulse.size++] = Pulse{500U, false};
+  decoded = decode(trailing_pulse.pulses, trailing_pulse.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+  assert(decoded.capture_failure == CaptureFailure::HALF_BIT_OVERFLOW);
 
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Vervangt half-bitreconstructie, vaste shift/inversie en 67-half-bit-salvage door een allocation-free edge/fase-decoder.
- Maakt de hardwaremapping expliciet: GPIO high is OpenTherm active.
- Decodeert alleen mid-bit-edges als databits en gebruikt boundary-edges voor fase- en timingcontrole.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de ESP32 OpenTherm-master RMT RX-decoder verandert. Driver, lifecycle, conversation timing, slave-component en configuratie blijven ongewijzigd. De branch bevat na het mergen van #509 ook de nieuwe wire-level timing en TX/RX-handover uit `dev`.

## Achtergrond

Closes #481.

Korte edge-intervallen blijven 380–620 µs. De afstand tussen opeenvolgende mid-bit-edges moet 900–1150 µs zijn, direct of als som van twee korte intervallen rond een boundary-edge. Startbit, stopbit en parity blijven afzonderlijk gevalideerd.

De host-encoder bouwt het Bi-phase-L-signaal rechtstreeks vanuit protocolbits en comprimeert daarna gelijke levels tot RMT-runs; hij is niet langer de inverse van de productie-decoder.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen gebruikersconfiguratie of entities wijzigen; de protocolmapping staat bij de decoder en aanroep gedocumenteerd.

## Validatie

- [x] `./scripts/run_host_regression_tests.sh` — 27 hosttests geslaagd op de decoderbranch
- [x] Gefocuste decoderregressie opnieuw gebouwd/uitgevoerd na integratie van #509
- [x] Decoderregressie met 4096 gegenereerde geldige frames, beide polariteiten, jitter, timinggrenzen en foutgevallen
- [x] `npm run check:cpp-format`
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- [x] `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — ESP-IDF 5.5.5; image 2.072.059 bytes; DIRAM 201.079/341.760 bytes
- [x] OTA naar de Q-edition Duo WiFi-installatie via `openquatt.local`
- [x] Volledige koude diff-audit na integratie van #509; geen bevindingen
- [ ] Replay van opgeslagen raw RMT-captures
- [x] Live ketelsimulator-HIL/soak

HIL-resultaat:

- simulatorresponses ingeschakeld; echte boilerlink bleef de volledige test beschikbaar
- 20 ms response delay: 279 request/capture-cycli, geen nieuwe invalid/decode/glitch/start/timing/queue/TX-fouten
- 700 ms response delay: 517 request/capture-cycli, geen nieuwe invalid/decode/glitch/start/timing/queue/TX-fouten
- geen linkdrop-samples en geen relevante OpenTherm/RMT-waarschuwingen
- de live captures bevestigen de production capturevorm en `ACTIVE_HIGH`-polariteit

De actuele brede host-her-run op deze Mac stopte buiten deze wijziging in `cooling_limiter_logic_test`, omdat de lokale Apple toolchain standaardheader `<algorithm>` niet vindt. De gewijzigde decoder-test is daarna afzonderlijk opnieuw gebouwd en groen uitgevoerd; GitHub CI blijft de actuele volledige suite-gate.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

- geen persistent state of dynamische allocaties toegevoegd
- de twee oude 68-byte half-bitarrays zijn verwijderd; de decoder gebruikt alleen vaste scalars
- de firmware is op representatieve hardware geboot en gedurende beide HIL-runs stabiel gebleven
