### PR TITLE
Decode OpenTherm slave input with edge-phase tracking

### DIFF
--- a/components/openquatt_ot_slave/OpenTherm.cpp
+++ b/components/openquatt_ot_slave/OpenTherm.cpp
@@ -4,6 +4,7 @@ Copyright 2018, Ihor Melnyk
 */
 
 #include "OpenTherm.h"
+#include "OpenThermRmtDecoder.h"
 #include "esphome/core/log.h"
 #include "esp_err.h"
 #include "esp_private/esp_clk.h"
@@ -22,11 +23,6 @@ static constexpr uint32_t OT_TX_RESOLUTION_HZ = 1000000;
 static constexpr uint32_t OT_RX_RESOLUTION_HZ = 1000000;
 static constexpr uint16_t OT_HALF_BIT_US = 500;
 static constexpr uint32_t OT_RMT_CLK_FREQ_HZ = 80000000;
-static constexpr uint32_t OT_RMT_GLITCH_REJECT_US = 180;
-static constexpr uint32_t OT_RMT_HALF_BIT_MIN_US = 380;
-static constexpr uint32_t OT_RMT_HALF_BIT_MAX_US = 620;
-static constexpr uint32_t OT_RMT_FULL_BIT_MIN_US = 880;
-static constexpr uint32_t OT_RMT_FULL_BIT_MAX_US = 1120;
 static constexpr uint32_t OT_RX_SIGNAL_MAX_US = 2500;
 #endif
 static constexpr uint32_t OT_FRAME_DELAY_US = 100000;
@@ -350,117 +346,47 @@ bool OpenTherm::pop_rx_frame_(RxFrame& frame) {
 }
 
 bool OpenTherm::decode_rmt_frame_(const RxFrame& frame, unsigned long& decoded_frame, OpenThermDriverError& error) {
-  static constexpr size_t OT_FRAME_BITS = 34;
-  static constexpr size_t OT_HALF_BITS = OT_FRAME_BITS * 2;
-  uint8_t half_bits[OT_HALF_BITS]{};
-  uint8_t inverted_shifted_forward[OT_HALF_BITS]{};
-  size_t half_bit_count = 0;
+  using openquatt_ot_slave::rmt_decoder::DecodeError;
+  using openquatt_ot_slave::rmt_decoder::Decoder;
+  using openquatt_ot_slave::rmt_decoder::InputPolarity;
+  using openquatt_ot_slave::rmt_decoder::Pulse;
+
+  // The thermostat input front-end maps an active OpenTherm level to GPIO
+  // high. Keep this hardware mapping explicit and outside the protocol state
+  // machine.
+  Decoder decoder(InputPolarity::ACTIVE_HIGH);
+  bool accepting_pulses = true;
 
   for (size_t i = 0; i < frame.symbol_count; ++i) {
     const uint32_t durations[2] = {frame.symbols[i].duration0, frame.symbols[i].duration1};
-    const uint8_t levels[2] = {static_cast<uint8_t>(frame.symbols[i].level0),
-                               static_cast<uint8_t>(frame.symbols[i].level1)};
+    const bool levels[2] = {frame.symbols[i].level0 != 0, frame.symbols[i].level1 != 0};
     for (int part = 0; part < 2; ++part) {
       const uint32_t duration = durations[part];
       if (duration == 0) {
         continue;
       }
-
-      uint8_t repeats = 0;
-      if (duration >= OT_RMT_HALF_BIT_MIN_US && duration <= OT_RMT_HALF_BIT_MAX_US) {
-        repeats = 1;
-      } else if (duration >= OT_RMT_FULL_BIT_MIN_US && duration <= OT_RMT_FULL_BIT_MAX_US) {
-        repeats = 2;
-      } else if (duration < OT_RMT_HALF_BIT_MIN_US) {
-        error = OpenThermDriverError::DRIVER_ERROR_GLITCH_REJECT;
-        return false;
-      } else {
-        error = OpenThermDriverError::DRIVER_ERROR_TIMING_INVALID;
-        return false;
-      }
-
-      if (half_bit_count + repeats > OT_HALF_BITS) {
-        error = OpenThermDriverError::DRIVER_ERROR_TIMING_INVALID;
-        return false;
-      }
-
-      for (uint8_t repeat = 0; repeat < repeats; ++repeat) {
-        half_bits[half_bit_count++] = levels[part];
+      if (accepting_pulses) {
+        accepting_pulses = decoder.consume(Pulse{static_cast<uint16_t>(duration), levels[part]});
       }
     }
   }
 
-  // RMT captures can be short by exactly one half-bit at the frame boundary.
-  // In practice we see either the leading low half of the start bit or the
-  // trailing high half of the stop bit dropped when the receiver arms/tears
-  // down around the idle gap. Salvage those two specific 67-half-bit cases.
-  if (half_bit_count == (OT_HALF_BITS - 1U) && half_bit_count > 0) {
-    if (half_bits[0] == 1) {
-      for (size_t i = half_bit_count; i > 0; --i) {
-        half_bits[i] = half_bits[i - 1U];
-      }
-      half_bits[0] = 0;
-      half_bit_count++;
-    } else if (half_bits[half_bit_count - 1U] == 0) {
-      half_bits[half_bit_count++] = 1;
-    }
+  const auto result = decoder.finish();
+  decoded_frame = result.data;
+  if (result.error == DecodeError::NONE || result.error == DecodeError::PARITY) {
+    // Preserve the existing callback contract: parity is classified later as
+    // INVALID_PARITY instead of collapsing into a generic decoder failure.
+    error = OpenThermDriverError::DRIVER_ERROR_NONE;
+    return true;
   }
 
-  if (half_bit_count != OT_HALF_BITS) {
+  if (result.error == DecodeError::GLITCH) {
+    error = OpenThermDriverError::DRIVER_ERROR_GLITCH_REJECT;
+  } else if (result.error == DecodeError::START_BIT) {
+    error = OpenThermDriverError::DRIVER_ERROR_START_BIT_INVALID;
+  } else {
     error = OpenThermDriverError::DRIVER_ERROR_TIMING_INVALID;
-    return false;
   }
-
-  auto try_decode_pairs = [&](const uint8_t* bits, unsigned long& frame_out, OpenThermDriverError& err) -> bool {
-    frame_out = 0;
-    for (size_t bit_index = 0; bit_index < OT_FRAME_BITS; ++bit_index) {
-      const uint8_t first = bits[bit_index * 2U];
-      const uint8_t second = bits[(bit_index * 2U) + 1U];
-      bool bit_value = false;
-      if (first == 0 && second == 1) {
-        bit_value = true;
-      } else if (first == 1 && second == 0) {
-        bit_value = false;
-      } else {
-        err = (bit_index == 0) ? OpenThermDriverError::DRIVER_ERROR_START_BIT_INVALID
-                               : OpenThermDriverError::DRIVER_ERROR_TIMING_INVALID;
-        return false;
-      }
-
-      if (bit_index == 0 || bit_index == (OT_FRAME_BITS - 1U)) {
-        if (!bit_value) {
-          err = (bit_index == 0) ? OpenThermDriverError::DRIVER_ERROR_START_BIT_INVALID
-                                 : OpenThermDriverError::DRIVER_ERROR_TIMING_INVALID;
-          return false;
-        }
-        continue;
-      }
-
-      frame_out = (frame_out << 1U) | static_cast<unsigned long>(bit_value);
-    }
-    err = OpenThermDriverError::DRIVER_ERROR_NONE;
-    return true;
-  };
-
-  uint8_t shifted_forward[OT_HALF_BITS]{};
-  for (size_t i = 0; i < (OT_HALF_BITS - 1U); ++i) {
-    shifted_forward[i] = half_bits[i + 1U];
-  }
-  shifted_forward[OT_HALF_BITS - 1U] = shifted_forward[OT_HALF_BITS - 2U] ^ 0x1U;
-  for (size_t i = 0; i < OT_HALF_BITS; ++i) {
-    inverted_shifted_forward[i] = shifted_forward[i] ^ 0x1U;
-  }
-
-  // Long-run telemetry showed that all successful RMT frames consistently decode
-  // through the inverted, one-half-bit-forward interpretation. Keep only that
-  // explicit path now that the search phase is complete.
-  OpenThermDriverError candidate_error = OpenThermDriverError::DRIVER_ERROR_NONE;
-  if (try_decode_pairs(inverted_shifted_forward, decoded_frame, candidate_error)) {
-    error = candidate_error;
-    return true;
-  }
-
-  error = candidate_error;
   return false;
 }
 
@@ -471,9 +397,15 @@ void OpenTherm::process_rmt_frame_(const RxFrame& frame) {
   unsigned long decoded_frame = 0;
   OpenThermDriverError error = OpenThermDriverError::DRIVER_ERROR_NONE;
   if (!decode_rmt_frame_(frame, decoded_frame, error)) {
+    // The RX channel remains armed while the slave transmits. Ignore any
+    // rejected self-capture without disturbing TX completion state.
+    if (status == OpenThermStatus::REQUEST_SENDING) {
+      return;
+    }
     response = 0;
     responseTimestamp = frame.done_ts_cycles;
     responseStatus = OpenThermResponseStatus::INVALID;
+    status = OpenThermStatus::RESPONSE_INVALID;
     return;
   }
 

--- a/components/openquatt_ot_slave/OpenThermRmtDecoder.h
+++ b/components/openquatt_ot_slave/OpenThermRmtDecoder.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace openquatt_ot_slave::rmt_decoder {
+
+static constexpr size_t FRAME_BITS = 34;
+
+// Boundary transitions split the 900-1150 us interval between mandatory
+// mid-bit transitions. Validate the complete interval rather than treating
+// every individual RMT run as a complete OpenTherm bit.
+static constexpr uint16_t BOUNDARY_INTERVAL_MIN_US = 380;
+static constexpr uint16_t BOUNDARY_INTERVAL_MAX_US = 620;
+static constexpr uint16_t MID_BIT_INTERVAL_MIN_US = 900;
+static constexpr uint16_t MID_BIT_INTERVAL_MAX_US = 1150;
+
+struct Pulse {
+  uint16_t duration_us;
+  bool level;  // GPIO level held during this interval, before its ending edge.
+};
+
+enum class InputPolarity : uint8_t {
+  ACTIVE_LOW = 0,
+  ACTIVE_HIGH,
+};
+
+enum class DecodeError : uint8_t {
+  NONE = 0,
+  GLITCH,
+  TIMING,
+  START_BIT,
+  MANCHESTER,
+  STOP_BIT,
+  PARITY,
+};
+
+struct DecodeResult {
+  uint32_t data{0};
+  DecodeError error{DecodeError::NONE};
+  uint8_t bit_position{0};
+  size_t pulse_count{0};
+  size_t failure_pulse_index{0};
+  uint16_t failure_pulse_duration_us{0};
+};
+
+inline bool has_even_parity(uint32_t value) {
+  value ^= value >> 16;
+  value ^= value >> 8;
+  value ^= value >> 4;
+  value ^= value >> 2;
+  value ^= value >> 1;
+  return (~value) & 1U;
+}
+
+inline bool is_active(bool input_level, InputPolarity polarity) {
+  return input_level == (polarity == InputPolarity::ACTIVE_HIGH);
+}
+
+class Decoder {
+ public:
+  explicit Decoder(InputPolarity polarity) : polarity_(polarity) {}
+
+  bool consume(Pulse pulse) {
+    const size_t pulse_index = result_.pulse_count++;
+    if (pulse.duration_us == 0U) {
+      return true;
+    }
+    if (result_.error != DecodeError::NONE) {
+      return false;
+    }
+    if (frame_complete_) {
+      return this->fail_(DecodeError::TIMING, pulse_index, pulse.duration_us);
+    }
+
+    const bool short_interval =
+        pulse.duration_us >= BOUNDARY_INTERVAL_MIN_US && pulse.duration_us <= BOUNDARY_INTERVAL_MAX_US;
+    const bool full_interval =
+        pulse.duration_us >= MID_BIT_INTERVAL_MIN_US && pulse.duration_us <= MID_BIT_INTERVAL_MAX_US;
+    if (!short_interval && !full_interval) {
+      return this->fail_(pulse.duration_us < BOUNDARY_INTERVAL_MIN_US ? DecodeError::GLITCH : DecodeError::TIMING,
+                         pulse_index, pulse.duration_us);
+    }
+
+    if (have_pulse_ && pulse.level == previous_level_) {
+      return this->fail_(DecodeError::MANCHESTER, pulse_index, pulse.duration_us);
+    }
+    previous_level_ = pulse.level;
+
+    bool is_mid_bit = false;
+    if (!have_pulse_) {
+      // RMT starts after the idle-to-active frame-start transition. The first
+      // captured run is the active first half of the start bit and ends at its
+      // mandatory mid-bit transition.
+      have_pulse_ = true;
+      if (!short_interval) {
+        return this->fail_(DecodeError::TIMING, pulse_index, pulse.duration_us);
+      }
+      if (!is_active(pulse.level, polarity_)) {
+        return this->fail_(DecodeError::START_BIT, pulse_index, pulse.duration_us);
+      }
+      is_mid_bit = true;
+    } else if (boundary_seen_) {
+      if (!short_interval) {
+        return this->fail_(DecodeError::MANCHESTER, pulse_index, pulse.duration_us);
+      }
+      time_since_mid_bit_us_ = static_cast<uint16_t>(time_since_mid_bit_us_ + pulse.duration_us);
+      if (time_since_mid_bit_us_ < MID_BIT_INTERVAL_MIN_US || time_since_mid_bit_us_ > MID_BIT_INTERVAL_MAX_US) {
+        return this->fail_(DecodeError::TIMING, pulse_index, pulse.duration_us);
+      }
+      boundary_seen_ = false;
+      is_mid_bit = true;
+    } else if (short_interval) {
+      boundary_seen_ = true;
+      time_since_mid_bit_us_ = pulse.duration_us;
+    } else {
+      is_mid_bit = true;
+    }
+
+    if (!is_mid_bit) {
+      return true;
+    }
+
+    time_since_mid_bit_us_ = 0;
+    result_.bit_position = static_cast<uint8_t>(bit_count_);
+    // At a mid-bit edge, active-to-idle is one and idle-to-active is zero.
+    // The RMT pulse level is the level immediately before that edge.
+    const bool bit_value = is_active(pulse.level, polarity_);
+    if (bit_count_ == 0U) {
+      if (!bit_value) {
+        return this->fail_(DecodeError::START_BIT, pulse_index, pulse.duration_us);
+      }
+    } else if (bit_count_ == FRAME_BITS - 1U) {
+      if (!bit_value) {
+        return this->fail_(DecodeError::STOP_BIT, pulse_index, pulse.duration_us);
+      }
+      frame_complete_ = true;
+    } else {
+      result_.data = (result_.data << 1U) | static_cast<uint32_t>(bit_value);
+    }
+    bit_count_++;
+    return true;
+  }
+
+  DecodeResult finish() {
+    if (result_.error != DecodeError::NONE) {
+      return result_;
+    }
+    if (!frame_complete_ || boundary_seen_ || bit_count_ != FRAME_BITS) {
+      result_.error = DecodeError::TIMING;
+      result_.failure_pulse_index = result_.pulse_count;
+      return result_;
+    }
+    if (!has_even_parity(result_.data)) {
+      result_.error = DecodeError::PARITY;
+    }
+    return result_;
+  }
+
+ private:
+  bool fail_(DecodeError error, size_t pulse_index, uint16_t pulse_duration_us) {
+    result_.error = error;
+    result_.failure_pulse_index = pulse_index;
+    result_.failure_pulse_duration_us = pulse_duration_us;
+    return false;
+  }
+
+  const InputPolarity polarity_;
+  DecodeResult result_{};
+  bool have_pulse_{false};
+  bool previous_level_{false};
+  bool boundary_seen_{false};
+  bool frame_complete_{false};
+  uint16_t time_since_mid_bit_us_{0};
+  size_t bit_count_{0};
+};
+
+inline DecodeResult decode(const Pulse* pulses, size_t pulse_count, InputPolarity polarity) {
+  Decoder decoder(polarity);
+  if (pulses == nullptr && pulse_count != 0U) {
+    DecodeResult result{};
+    result.error = DecodeError::TIMING;
+    return result;
+  }
+  for (size_t pulse_index = 0; pulse_index < pulse_count; pulse_index++) {
+    if (!decoder.consume(pulses[pulse_index])) {
+      break;
+    }
+  }
+  return decoder.finish();
+}
+
+}  // namespace openquatt_ot_slave::rmt_decoder

--- a/tests/host/openquatt_ot_slave_rmt_decoder_test.cpp
+++ b/tests/host/openquatt_ot_slave_rmt_decoder_test.cpp
@@ -191,6 +191,16 @@ int main() {
   assert(decoded.error == DecodeError::GLITCH);
   assert(decoded.failure_pulse_index == 1U);
 
+  auto below_short_window = nominal;
+  below_short_window.pulses[below_short_window.find_duration(500U)].duration_us = 379U;
+  decoded = decode(below_short_window.pulses, below_short_window.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::GLITCH);
+
+  auto above_short_window = nominal;
+  above_short_window.pulses[above_short_window.find_duration(500U)].duration_us = 621U;
+  decoded = decode(above_short_window.pulses, above_short_window.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+
   auto invalid_timing = nominal;
   invalid_timing.pulses[invalid_timing.find_duration(1000U)].duration_us = 899U;
   decoded = decode(invalid_timing.pulses, invalid_timing.size, InputPolarity::ACTIVE_HIGH);

--- a/tests/host/openquatt_ot_slave_rmt_decoder_test.cpp
+++ b/tests/host/openquatt_ot_slave_rmt_decoder_test.cpp
@@ -1,0 +1,226 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "../../components/openquatt_ot_slave/OpenThermRmtDecoder.h"
+
+namespace {
+
+using openquatt_ot_slave::rmt_decoder::DecodeError;
+using openquatt_ot_slave::rmt_decoder::InputPolarity;
+using openquatt_ot_slave::rmt_decoder::Pulse;
+
+uint32_t with_even_parity(uint32_t value_without_parity) {
+  value_without_parity &= 0x7FFFFFFFU;
+  if (!openquatt_ot_slave::rmt_decoder::has_even_parity(value_without_parity)) {
+    value_without_parity |= 0x80000000U;
+  }
+  return value_without_parity;
+}
+
+bool input_level(bool active, InputPolarity polarity) {
+  return polarity == InputPolarity::ACTIVE_HIGH ? active : !active;
+}
+
+struct EncodedFrame {
+  Pulse pulses[72]{};
+  size_t size{0};
+
+  void erase(size_t index) {
+    assert(index < size);
+    for (size_t next = index + 1U; next < size; next++) {
+      pulses[next - 1U] = pulses[next];
+    }
+    size--;
+  }
+
+  size_t find_duration(uint16_t duration_us, size_t begin = 0U) const {
+    for (size_t index = begin; index < size; index++) {
+      if (pulses[index].duration_us == duration_us) {
+        return index;
+      }
+    }
+    assert(false);
+    return size;
+  }
+
+  size_t find_short_pair() const {
+    for (size_t index = 1U; index + 1U < size; index++) {
+      if (pulses[index].duration_us == 500U && pulses[index + 1U].duration_us == 500U) {
+        return index;
+      }
+    }
+    assert(false);
+    return size;
+  }
+};
+
+// Build the Bi-phase-L waveform independently from the decoder and compress
+// equal half-bit levels into the runs returned by RMT after the frame-start
+// edge. The final idle half has no terminating edge and is not emitted.
+EncodedFrame encode(uint32_t data, InputPolarity polarity = InputPolarity::ACTIVE_HIGH, bool stop_bit = true,
+                    uint16_t short_duration_us = 500U, uint16_t full_duration_us = 1000U, int jitter_us = 0) {
+  bool half_bits[68]{};
+  size_t half_bit_count = 0;
+  const auto append_bit = [&](bool value) {
+    half_bits[half_bit_count++] = value;
+    half_bits[half_bit_count++] = !value;
+  };
+
+  append_bit(true);
+  for (int bit = 31; bit >= 0; bit--) {
+    append_bit(((data >> bit) & 1U) != 0U);
+  }
+  append_bit(stop_bit);
+  assert(half_bit_count == 68U);
+
+  EncodedFrame encoded;
+  bool run_level = half_bits[0];
+  size_t run_half_bits = 1U;
+  for (size_t index = 1U; index < half_bit_count; index++) {
+    if (half_bits[index] == run_level) {
+      run_half_bits++;
+      continue;
+    }
+
+    assert(run_half_bits == 1U || run_half_bits == 2U);
+    const int base_duration = run_half_bits == 1U ? short_duration_us : full_duration_us;
+    const int signed_jitter = encoded.size % 2U == 0U ? jitter_us : -jitter_us;
+    encoded.pulses[encoded.size++] =
+        Pulse{static_cast<uint16_t>(base_duration + signed_jitter), input_level(run_level, polarity)};
+    run_level = half_bits[index];
+    run_half_bits = 1U;
+  }
+  return encoded;
+}
+
+}  // namespace
+
+int main() {
+  using openquatt_ot_slave::rmt_decoder::decode;
+
+  const uint32_t data = with_even_parity(0x00001234U);
+  const auto nominal = encode(data);
+  auto decoded = decode(nominal.pulses, nominal.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == data);
+
+  const auto active_low = encode(data, InputPolarity::ACTIVE_LOW);
+  decoded = decode(active_low.pulses, active_low.size, InputPolarity::ACTIVE_LOW);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == data);
+  decoded = decode(nominal.pulses, nominal.size, InputPolarity::ACTIVE_LOW);
+  assert(decoded.error == DecodeError::START_BIT);
+
+  const auto all_ones = encode(0xFFFFFFFFU);
+  decoded = decode(all_ones.pulses, all_ones.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == 0xFFFFFFFFU);
+
+  const auto alternating = encode(0xAAAAAAAAU);
+  decoded = decode(alternating.pulses, alternating.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == 0xAAAAAAAAU);
+  assert(alternating.find_duration(1000U) < alternating.size);
+
+  // Cover master request payloads, including the valid all-zero ID 0 request
+  // that previously exposed a separate slave request-processing bug.
+  uint32_t random_data = 0x12345678U;
+  for (size_t iteration = 0; iteration < 4096U; iteration++) {
+    random_data = random_data * 1664525U + 1013904223U;
+    const uint32_t frame_data = with_even_parity(random_data & 0x3FFFFFFFU);
+    const auto frame = encode(frame_data);
+    decoded = decode(frame.pulses, frame.size, InputPolarity::ACTIVE_HIGH);
+    assert(decoded.error == DecodeError::NONE);
+    assert(decoded.data == frame_data);
+  }
+  const auto id_zero = encode(0U);
+  decoded = decode(id_zero.pulses, id_zero.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == 0U);
+
+  const auto jittered = encode(data, InputPolarity::ACTIVE_HIGH, true, 500U, 1000U, 19);
+  decoded = decode(jittered.pulses, jittered.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+
+  const auto lower_timing = encode(data, InputPolarity::ACTIVE_HIGH, true, 450U, 900U);
+  decoded = decode(lower_timing.pulses, lower_timing.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  const auto upper_timing = encode(data, InputPolarity::ACTIVE_HIGH, true, 575U, 1150U);
+  decoded = decode(upper_timing.pulses, upper_timing.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+
+  auto asymmetric_boundary = nominal;
+  const size_t short_pair = asymmetric_boundary.find_short_pair();
+  asymmetric_boundary.pulses[short_pair].duration_us = 380U;
+  asymmetric_boundary.pulses[short_pair + 1U].duration_us = 620U;
+  decoded = decode(asymmetric_boundary.pulses, asymmetric_boundary.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::NONE);
+  assert(decoded.data == data);
+
+  decoded = decode(nullptr, 0U, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+
+  auto missing_start = all_ones;
+  missing_start.erase(0U);
+  decoded = decode(missing_start.pulses, missing_start.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::START_BIT);
+
+  auto missing_end = nominal;
+  missing_end.erase(missing_end.size - 1U);
+  decoded = decode(missing_end.pulses, missing_end.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+
+  auto wrong_start_level = nominal;
+  wrong_start_level.pulses[0].level = input_level(false, InputPolarity::ACTIVE_HIGH);
+  decoded = decode(wrong_start_level.pulses, wrong_start_level.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::START_BIT);
+
+  const auto invalid_stop = encode(data, InputPolarity::ACTIVE_HIGH, false);
+  decoded = decode(invalid_stop.pulses, invalid_stop.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::STOP_BIT);
+
+  const auto invalid_parity = encode(data ^ 0x1U);
+  decoded = decode(invalid_parity.pulses, invalid_parity.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::PARITY);
+  assert(decoded.data == (data ^ 0x1U));
+
+  auto glitch = nominal;
+  glitch.pulses[1].duration_us = 200U;
+  decoded = decode(glitch.pulses, glitch.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::GLITCH);
+  assert(decoded.failure_pulse_index == 1U);
+
+  auto invalid_timing = nominal;
+  invalid_timing.pulses[invalid_timing.find_duration(1000U)].duration_us = 899U;
+  decoded = decode(invalid_timing.pulses, invalid_timing.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+  invalid_timing = nominal;
+  invalid_timing.pulses[invalid_timing.find_duration(1000U)].duration_us = 1151U;
+  decoded = decode(invalid_timing.pulses, invalid_timing.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+
+  auto invalid_mid_bit_period = nominal;
+  const size_t invalid_pair = invalid_mid_bit_period.find_short_pair();
+  invalid_mid_bit_period.pulses[invalid_pair].duration_us = 380U;
+  invalid_mid_bit_period.pulses[invalid_pair + 1U].duration_us = 380U;
+  decoded = decode(invalid_mid_bit_period.pulses, invalid_mid_bit_period.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+
+  auto invalid_manchester = nominal;
+  invalid_manchester.pulses[1].level = invalid_manchester.pulses[0].level;
+  decoded = decode(invalid_manchester.pulses, invalid_manchester.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::MANCHESTER);
+
+  auto missing_mid_bit = nominal;
+  missing_mid_bit.erase(missing_mid_bit.find_short_pair() + 1U);
+  decoded = decode(missing_mid_bit.pulses, missing_mid_bit.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::MANCHESTER);
+
+  auto trailing_pulse = nominal;
+  trailing_pulse.pulses[trailing_pulse.size++] = Pulse{500U, false};
+  decoded = decode(trailing_pulse.pulses, trailing_pulse.size, InputPolarity::ACTIVE_HIGH);
+  assert(decoded.error == DecodeError::TIMING);
+
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Vervangt de slave-RMT half-bitreconstructie, vaste shift/inversie en 67-half-bit-salvage door een streaming edge/fase-decoder.
- Maakt de thermostat-inputmapping expliciet: GPIO high is OpenTherm active.
- Behoudt de bestaande parity-callbackstatus en behandelt decodefouten expliciet zonder TX/self-capturestate te verstoren.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de OpenTherm thermostat/slave RX-decoder verandert. TX-codering, configuratie, entities en de OpenTherm boiler/master blijven ongewijzigd. Een decoderreject wordt voortaan als `INVALID` afgehandeld; rejects tijdens een lopende slave-response worden genegeerd om TX-completionstate intact te houden.

## Achtergrond

Dit is bewust een aparte vervolg-PR op #510: het protocolmodel is gelijk, maar de thermostat-ingang en fysieke HIL-opstelling zijn een afzonderlijke richting. De decoder verwerkt RMT-runs direct als mid-bit- en boundary-transitions en gebruikt geen intermediate pulse- of half-bitbuffer.

De bestaande simulator op `192.168.2.63` emuleert uitsluitend een boiler/slave en kan deze RX-richting niet testen. De aangesloten echte thermostaat is daarom als masterbron voor de HIL gebruikt.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen gebruikersconfiguratie of entities wijzigen; protocolmapping en hardwarepolariteit zijn bij de decoder en aanroep gedocumenteerd.

## Validatie

- [x] Gefocuste slave-decoderhosttest: 4096 geldige masterrequests, ID 0, beide polariteiten, jitter, timinggrenzen, start/stop/parity en foutgevallen
- [x] `npm run check:cpp-format`
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- [x] `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — ESP-IDF 5.5.5; image 2.072.111 bytes; DIRAM 201.079/341.760 bytes
- [x] OTA naar de Q-edition Duo WiFi-installatie via `openquatt.local`
- [x] Slave-HIL met de aangesloten echte thermostaat
- [x] GitHub CI — hosttests, formatting, contracts en volledige firmwareprofielmatrix groen
- [x] Volledige koude diff-audit en lifecycle/interleaving-review; geen bevindingen

HIL-resultaat:

- kandidaat bootte en bleef stabiel
- `OT - Thermostat Status Valid = ON` en `OT - Link Problem = OFF` na de kandidaat-reboot
- actuele masterrequests leverden kamertemperatuur 21,25 °C en setpoint 20,00 °C
- dit bevestigt de production capturevorm en `ACTIVE_HIGH`-polariteit op de thermostat-ingang
- TX-codering bleef ongewijzigd; rejected captures tijdens TX kunnen de response-lifecycle niet meer onderbreken

De brede `./scripts/run_host_regression_tests.sh` stopt lokaal buiten deze wijziging in `cooling_limiter_logic_test`, omdat de Apple toolchain standaardheader `<algorithm>` niet vindt. De nieuwe test is afzonderlijk met dezelfde flags gebouwd en groen uitgevoerd.

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- geen persistent state, dynamische allocaties of nieuwe tasks
- de drie oude 68-byte half-bitarrays vervallen; de streaming decoder gebruikt alleen vaste scalars
- static DIRAM blijft 201.079 bytes
- kandidaat na OTA/HIL: current internal heap 117.903 B; minimum-since-boot 40.844 B; largest block 63.488 B; fragmentatie 46,2%; vrij PSRAM 6.861.576 B
