### PR TITLE
Restore boot automations overwritten by HP package

### DIFF
--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -28,14 +28,14 @@
 
 esphome:
   on_boot:
-    - priority: -90
-      then:
-        - lambda: |-
-            // Runtime identity is deliberately not restored across boots.
-            id(${hp_id}_odu_generation_detection_complete) = false;
-            id(${hp_id}_odu_generation_request_pending) = false;
-            id(${hp_id}_odu_generation_request_token) = 0U;
-            id(${hp_id}_generation).publish_state("Unknown");
+    priority: -100
+    then:
+      - lambda: |-
+          // Runtime identity is deliberately not restored across boots.
+          id(${hp_id}_odu_generation_detection_complete) = false;
+          id(${hp_id}_odu_generation_request_pending) = false;
+          id(${hp_id}_odu_generation_request_token) = 0U;
+          id(${hp_id}_generation).publish_state("Unknown");
 
 # ----------------------------
 # MODBUS CONTROLLER

--- a/scripts/tests/test_otb_polling_lifecycle_contract.py
+++ b/scripts/tests/test_otb_polling_lifecycle_contract.py
@@ -6,12 +6,19 @@ ROOT = Path(__file__).resolve().parents[2]
 HUB_HEADER = (ROOT / "components" / "opentherm" / "hub.h").read_text()
 HUB_CPP = (ROOT / "components" / "opentherm" / "hub.cpp").read_text()
 OTB_PACKAGE = (ROOT / "openquatt" / "oq_boiler_opentherm.yaml").read_text()
+COMMON_PACKAGE = (ROOT / "openquatt" / "oq_common.yaml").read_text()
 Q_PROFILE = (
     ROOT / "openquatt" / "profiles" / "heatpump_controller_q.yaml"
 ).read_text()
+HP_IO_PACKAGE = (ROOT / "openquatt" / "oq_HP_io.yaml").read_text()
 
 
 class OtbPollingLifecycleContractTest(unittest.TestCase):
+    def test_boot_packages_keep_the_same_merge_shape(self) -> None:
+        for package in (COMMON_PACKAGE, OTB_PACKAGE, HP_IO_PACKAGE):
+            self.assertIn("on_boot:\n    priority: -100\n    then:", package)
+            self.assertNotIn("on_boot:\n    - priority:", package)
+
     def test_hub_owns_a_hard_polling_gate(self) -> None:
         self.assertIn("bool polling_enabled_ = false;", HUB_HEADER)
         self.assertIn("void suspend_polling();", HUB_HEADER)


### PR DESCRIPTION
# Wat verandert deze PR?

- Zet de HP I/O-`on_boot` terug naar dezelfde merge-compatibele mappingvorm en prioriteit als de bestaande OpenQuatt-bootpackages.
- Voorkomt dat de HP1/HP2-package de OTB-ownerboot en build-identiteitspublicatie overschrijft.
- Voegt een contracttest toe voor de gezamenlijke mergevorm van common, OTB en HP I/O.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Deze wijziging herstelt de al bedoelde bootacties: veilige lokale OTB-initialisatie, hervatten van OTB-polling bij een herstelde OpenTherm-selectie, publicatie van versie/releasekanaal en HP1/HP2-generatie-initialisatie. Er worden geen nieuwe controleregels, buffers, taken of dynamische allocaties toegevoegd.

## Achtergrond

PR #511 introduceerde in `openquatt/oq_HP_io.yaml` een list-form `esphome.on_boot`, terwijl de bestaande packages mapping-form gebruiken. ESPHome vervangt bij deze typebotsing de eerdere mapping volledig. Daardoor bleef de OTB-hub standaard op `polling_enabled=false` en werden ook Version/Release Channel niet gepubliceerd.

HIL met de OTB-simulator bevestigde de volledige keten:

- pre-PR-#517 build `32d50b7`: ruim 180 s `hub_ready=false`, `polling=false`, nul controller- en simulatorrequests;
- dezelfde minimale mappingfix op `505b151`: ownerboot en polling binnen circa 1,3 s, link beschikbaar, CH uit en TSet 0;
- boot en runtime zonder simulatorresponses: requests en timeouts lopen door, CH/TSet blijven veilig;
- na herstel van responses en na normale reboot komt de link terug zonder oude warmtevraag;
- Version en Release Channel worden weer gevuld.

Fixes #523
Fixes #524
Related to #516 (alleen de latere no-poll-waarneming; niet het oorspronkelijke CM100-probleem).

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt bestaand, gedocumenteerd bootgedrag. De afwijking en HIL-bewijzen staan in #523 en #524; er worden geen gebruikersopties of configuraties toegevoegd.

## Validatie

- `python3 -m unittest discover -s scripts/tests` — 74 tests geslaagd.
- `esphome config configs/heatpump_controller_q/single_wifi.yaml` — configuratie geldig.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd, config hash `0x6be7471a`.
- Gegenereerde Duo-C++ gecontroleerd: één `StartupTrigger(-100)` bevat OTB-init/resume, versiepublicatie en HP1/HP2-initialisatie.
- OTB-simulator-HIL zoals hierboven beschreven; simulator eindigde met responses aan, CH uit, TSet 0 en vlam uit.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- static RAM-delta op identieke Q/Duo/Wi-Fi compiles: DIRAM `203143 -> 203319` bytes (`+176`);
- image-delta: `2091359 -> 2093855` bytes (`+2496`);
- de delta herstelt de eerder weggecompileerde bootactions; geen nieuwe buffers, taken of dynamische allocaties;
- runtime heap-/stackwatermarks zijn niet apart opnieuw gemeten; de instrumented candidate doorliep wel boot, polling, responseverlies en herstel op representatieve hardware.
