### PR TITLE
Refresh web app cache after firmware updates

### DIFF
--- a/openquatt/web/js/src/core/app-cache.js
+++ b/openquatt/web/js/src/core/app-cache.js
@@ -1,0 +1,30 @@
+import { fetchWithTimeout } from "./browser-utils.js";
+
+export const WEB_APP_CACHE_REFRESH_TIMEOUT_MS = 10000;
+export const WEB_APP_STATIC_ASSET_URLS = Object.freeze(["/0.css", "/0.js"]);
+
+export function getWebAppCacheRefreshUrls() {
+  const currentDocumentUrl = typeof window.location?.href === "string" && window.location.href
+    ? window.location.href
+    : "/";
+  return [...new Set([currentDocumentUrl, ...WEB_APP_STATIC_ASSET_URLS])];
+}
+
+async function refreshWebAppResource(url) {
+  // `reload` replaces a stale HTTP-cache entry; consuming the full body completes that refresh before navigation.
+  const response = await fetchWithTimeout(
+    url,
+    { cache: "reload", credentials: "same-origin" },
+    WEB_APP_CACHE_REFRESH_TIMEOUT_MS,
+    `${url} cache refresh timed out after ${WEB_APP_CACHE_REFRESH_TIMEOUT_MS}ms`,
+  );
+  if (!response.ok) {
+    throw new Error(`${url} cache refresh HTTP ${response.status}`);
+  }
+  await response.arrayBuffer();
+}
+
+export async function refreshWebAppCache() {
+  const results = await Promise.allSettled(getWebAppCacheRefreshUrls().map(refreshWebAppResource));
+  return results.every((result) => result.status === "fulfilled");
+}

--- a/openquatt/web/js/src/core/app-cache.js
+++ b/openquatt/web/js/src/core/app-cache.js
@@ -12,16 +12,18 @@ export function getWebAppCacheRefreshUrls() {
 
 async function refreshWebAppResource(url) {
   // `reload` replaces a stale HTTP-cache entry; consuming the full body completes that refresh before navigation.
-  const response = await fetchWithTimeout(
+  return fetchWithTimeout(
     url,
     { cache: "reload", credentials: "same-origin" },
     WEB_APP_CACHE_REFRESH_TIMEOUT_MS,
     `${url} cache refresh timed out after ${WEB_APP_CACHE_REFRESH_TIMEOUT_MS}ms`,
+    async (response) => {
+      if (!response.ok) {
+        throw new Error(`${url} cache refresh HTTP ${response.status}`);
+      }
+      await response.arrayBuffer();
+    },
   );
-  if (!response.ok) {
-    throw new Error(`${url} cache refresh HTTP ${response.status}`);
-  }
-  await response.arrayBuffer();
 }
 
 export async function refreshWebAppCache() {

--- a/openquatt/web/js/src/core/browser-utils.js
+++ b/openquatt/web/js/src/core/browser-utils.js
@@ -1,12 +1,14 @@
-export async function fetchWithTimeout(input, options = {}, timeoutMs = 0, timeoutMessage = "") {
+export async function fetchWithTimeout(input, options = {}, timeoutMs = 0, timeoutMessage = "", consumeResponse = null) {
   if (typeof AbortController !== "function" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return fetch(input, options);
+    const response = await fetch(input, options);
+    return typeof consumeResponse === "function" ? consumeResponse(response) : response;
   }
 
   const controller = new AbortController();
   const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(input, { ...options, signal: controller.signal });
+    const response = await fetch(input, { ...options, signal: controller.signal });
+    return typeof consumeResponse === "function" ? await consumeResponse(response) : response;
   } catch (error) {
     if (controller.signal.aborted) {
       throw new Error(timeoutMessage || `request timed out after ${timeoutMs}ms`);

--- a/openquatt/web/js/src/core/device-reconnect.js
+++ b/openquatt/web/js/src/core/device-reconnect.js
@@ -1,6 +1,7 @@
 import { state } from "./state.js";
 import { render } from "./render-scheduler.js";
 import { updateFirmwareState } from "./feature-state.js";
+import { refreshWebAppCache } from "./app-cache.js";
 
 export const DEVICE_RECONNECT_RECOVERY_CLEAR_DELAY_MS = 1500;
 export const OTA_REFRESH_DELAY_MS = 1500;
@@ -62,7 +63,7 @@ function hasRebootEvidence(refresh, acceptVersionChange = false) {
     || (acceptVersionChange && refresh.base[1] && evidence[1] && evidence[1] !== refresh.base[1]);
 }
 
-function scheduleBrowserRefresh(refresh, clearRefresh, delayMs) {
+function scheduleBrowserRefresh(refresh, clearRefresh, delayMs, refreshAppCache = false) {
   if (!refresh.on || (refresh.id && !refresh.wait)) {
     return;
   }
@@ -71,9 +72,15 @@ function scheduleBrowserRefresh(refresh, clearRefresh, delayMs) {
     window.clearTimeout(refresh.id);
   }
   refresh.wait = false;
-  refresh.id = window.setTimeout(() => {
+  refresh.id = window.setTimeout(async () => {
     if (!refresh.on) {
       return;
+    }
+    if (refreshAppCache) {
+      await refreshWebAppCache();
+      if (!refresh.on) {
+        return;
+      }
     }
     clearRefresh();
     window.location.reload();
@@ -99,7 +106,7 @@ export function reconcileOtaEvidence() {
 }
 
 export function scheduleOtaRefresh(delayMs = OTA_REFRESH_DELAY_MS) {
-  scheduleBrowserRefresh(state.ota, clearOtaRefresh, delayMs);
+  scheduleBrowserRefresh(state.ota, clearOtaRefresh, delayMs, true);
 }
 
 export function armRestartRefresh() {

--- a/openquatt/web/tests/app-cache.test.mjs
+++ b/openquatt/web/tests/app-cache.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const originalFetch = globalThis.fetch;
+
+globalThis.window = {
+  clearTimeout,
+  location: { href: "http://openquatt.local/?view=settings" },
+  setTimeout,
+};
+
+const {
+  WEB_APP_CACHE_REFRESH_TIMEOUT_MS,
+  getWebAppCacheRefreshUrls,
+  refreshWebAppCache,
+} = await import("../js/src/core/app-cache.js");
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+  window.clearTimeout = clearTimeout;
+  window.setTimeout = setTimeout;
+});
+
+test("OTA cache refresh fully reloads the document and embedded app assets", async () => {
+  const requests = [];
+  const consumed = [];
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options });
+    return {
+      ok: true,
+      async arrayBuffer() {
+        consumed.push(url);
+        return new ArrayBuffer(0);
+      },
+    };
+  };
+
+  assert.deepEqual(getWebAppCacheRefreshUrls(), [
+    "http://openquatt.local/?view=settings",
+    "/0.css",
+    "/0.js",
+  ]);
+  assert.equal(await refreshWebAppCache(), true);
+  assert.deepEqual(requests.map(({ url }) => url), getWebAppCacheRefreshUrls());
+  requests.forEach(({ options }) => {
+    assert.equal(options.cache, "reload");
+    assert.equal(options.credentials, "same-origin");
+    assert.ok(options.signal instanceof AbortSignal);
+  });
+  assert.deepEqual(consumed, getWebAppCacheRefreshUrls());
+});
+
+test("OTA cache refresh reports a failed asset request without throwing", async () => {
+  globalThis.fetch = async (url) => ({
+    ok: url !== "/0.js",
+    status: url === "/0.js" ? 503 : 200,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  });
+
+  assert.equal(await refreshWebAppCache(), false);
+});
+
+test("OTA cache refresh aborts stalled app-shell requests after a bounded timeout", async () => {
+  const timers = [];
+  window.clearTimeout = (timer) => {
+    timer.cancelled = true;
+  };
+  window.setTimeout = (callback, delay) => {
+    const timer = { callback, cancelled: false, delay };
+    timers.push(timer);
+    return timer;
+  };
+  globalThis.fetch = (_url, options) => new Promise((_resolve, reject) => {
+    options.signal.addEventListener("abort", () => reject(new Error("aborted")));
+  });
+
+  const refreshPromise = refreshWebAppCache();
+  assert.equal(timers.length, getWebAppCacheRefreshUrls().length);
+  assert.ok(timers.every((timer) => timer.delay === WEB_APP_CACHE_REFRESH_TIMEOUT_MS));
+  timers.forEach((timer) => timer.callback());
+
+  assert.equal(await refreshPromise, false);
+  assert.ok(timers.every((timer) => timer.cancelled));
+});

--- a/openquatt/web/tests/app-cache.test.mjs
+++ b/openquatt/web/tests/app-cache.test.mjs
@@ -82,3 +82,33 @@ test("OTA cache refresh aborts stalled app-shell requests after a bounded timeou
   assert.equal(await refreshPromise, false);
   assert.ok(timers.every((timer) => timer.cancelled));
 });
+
+test("OTA cache refresh also bounds a stalled response body", async () => {
+  const timers = [];
+  window.clearTimeout = (timer) => {
+    timer.cancelled = true;
+  };
+  window.setTimeout = (callback, delay) => {
+    const timer = { callback, cancelled: false, delay };
+    timers.push(timer);
+    return timer;
+  };
+  globalThis.fetch = async (_url, options) => ({
+    ok: true,
+    arrayBuffer: () => new Promise((_resolve, reject) => {
+      if (options.signal.aborted) {
+        reject(new Error("aborted"));
+        return;
+      }
+      options.signal.addEventListener("abort", () => reject(new Error("aborted")));
+    }),
+  });
+
+  const refreshPromise = refreshWebAppCache();
+  await Promise.resolve();
+  assert.equal(timers.length, getWebAppCacheRefreshUrls().length);
+  timers.forEach((timer) => timer.callback());
+
+  assert.equal(await refreshPromise, false);
+  assert.ok(timers.every((timer) => timer.cancelled));
+});

--- a/openquatt/web/tests/device-reconnect.test.mjs
+++ b/openquatt/web/tests/device-reconnect.test.mjs
@@ -11,6 +11,7 @@ globalThis.window = {
     timer.cancelled = true;
   },
   location: {
+    href: "http://openquatt.local/?view=settings",
     reload() {
       reloadCount += 1;
     },
@@ -70,7 +71,7 @@ test("a reboot unit change overrides stale uptime metadata", async () => {
 
   const refreshTimer = timers.find((timer) => timer.delay === OTA_REFRESH_DELAY_MS && !timer.cancelled);
   assert.ok(refreshTimer);
-  refreshTimer.callback();
+  await refreshTimer.callback();
 
   assert.equal(reloadCount, 1);
   assert.equal(state.ota.on, false);
@@ -310,16 +311,55 @@ test("an explicit restart rejection cancels its pending page reload", async () =
   assert.equal(reloadCount, 0);
 });
 
-test("a rejected OTA cancels its pending page reload", () => {
+test("a rejected OTA cancels its pending page reload", async () => {
   armOtaRefresh();
 
   scheduleOtaRefresh();
   const refreshTimer = timers[0];
   clearOtaRefresh();
-  refreshTimer.callback();
+  await refreshTimer.callback();
 
   assert.equal(refreshTimer.cancelled, true);
   assert.equal(reloadCount, 0);
+});
+
+test("an OTA refresh reloads even when explicit cache refresh fails", async () => {
+  const requestedUrls = [];
+  globalThis.fetch = async (url) => {
+    requestedUrls.push(url);
+    throw new TypeError("Failed to fetch");
+  };
+
+  armOtaRefresh();
+  scheduleOtaRefresh();
+  const refreshTimer = timers[0];
+  await refreshTimer.callback();
+
+  assert.deepEqual(requestedUrls, [
+    "http://openquatt.local/?view=settings",
+    "/0.css",
+    "/0.js",
+  ]);
+  assert.equal(reloadCount, 1);
+  assert.equal(state.ota.on, false);
+});
+
+test("cancelling OTA during cache refresh prevents a stale scheduled reload", async () => {
+  const fetchResolvers = [];
+  globalThis.fetch = () => new Promise((resolve) => {
+    fetchResolvers.push(resolve);
+  });
+
+  armOtaRefresh();
+  scheduleOtaRefresh();
+  const refreshTimer = timers[0];
+  const refreshPromise = refreshTimer.callback();
+  clearOtaRefresh();
+  fetchResolvers.forEach((resolve) => resolve({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) }));
+  await refreshPromise;
+
+  assert.equal(reloadCount, 0);
+  assert.equal(state.ota.on, false);
 });
 
 test("a lost OTA acknowledgement enters reconnect recovery", async () => {

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -9,8 +9,9 @@ export const WEB_BUNDLE_BUDGETS = [
     // its read-only sensor-correction summary, calibration backup/restore,
     // the read-only ODU EEPROM service export, API ingress source controls,
     // concise CM100 boiler test phase copy (FLOW_SETTLING/BOILER_SETTLING/MEASURING/COOLDOWN),
-    // and advisory per-ODU generation detection with single bulk-detect button for onboarding and installation settings.
-    raw: 912_000,
+    // advisory per-ODU generation detection with single bulk-detect button for onboarding and installation settings,
+    // and bounded OTA app-shell cache refresh before reloading into newly installed firmware.
+    raw: 912_100,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -11,7 +11,7 @@ export const WEB_BUNDLE_BUDGETS = [
     // concise CM100 boiler test phase copy (FLOW_SETTLING/BOILER_SETTLING/MEASURING/COOLDOWN),
     // advisory per-ODU generation detection with single bulk-detect button for onboarding and installation settings,
     // and bounded OTA app-shell cache refresh before reloading into newly installed firmware.
-    raw: 912_100,
+    raw: 912_200,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.


### PR DESCRIPTION
# Wat verandert deze PR?

- Ververs de huidige documentresponse, `/0.css` en `/0.js` met Fetch-cachemodus `reload` voordat de browser na OTA herlaadt.
- Wacht op de volledige responses zodat de HTTP-cache is bijgewerkt; de timeout blijft actief totdat ook de responsebody volledig is gelezen.
- Bij een HTTP-fout, transportfout of timeout blijft de bestaande normale reload de fallback.
- Dek succes, gedeeltelijke fout, vastgelopen request, vastgelopen responsebody en annuleren-tijdens-refresh af met regressietests.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alle nieuwe logica draait in de browser en alleen nadat de bestaande OTA-flow de installatie/herstart voldoende heeft bevestigd. Een gewone device-herstart gebruikt de bestaande directe reload zonder cache-prefetch.

De refresh geldt voor de tab die de OTA start. Andere reeds geopende tabs worden niet automatisch herladen. Bij de eerste OTA vanaf firmware die deze code nog niet bevat, voert de reeds geladen oude webapp nog de oude reloadlogica uit; zodra de nieuwe webapp eenmaal is geladen, geldt de expliciete cache-refresh voor volgende OTA's.

## Achtergrond

Closes #522.

De ESPHome-webapp wordt onder vaste URL's `/0.js` en `/0.css` aangeboden. Een gewone reload alleen maakte het resultaat afhankelijk van de bestaande browsercache. Fetch-cachemodus `reload` slaat de bestaande cache over en werkt de HTTP-cache bij met de nieuwe response; de body wordt volledig gelezen voordat de navigatie start.

Volledige diff-audit tegen de actuele `dev` uitgevoerd op correctheid, security/privacy, same-origin authenticatie, OTA-bevestigingspoorten, timeout/fallback, annuleren en normale restart-/fresh-installpaden. Daarna apart adversarieel beoordeeld op gedeeltelijke responses, verloren OTA-acknowledgements, tijdelijke onbereikbaarheid, callbacks die met annuleren racen en een response die na ontvangst van de headers vastloopt. Die laatste review vond dat de oorspronkelijke timeout alleen tot de headers liep; dit is vóór merge hersteld en met een regressietest afgedekt. Geen open bevindingen.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt intern cachegedrag na OTA; de updateworkflow en gebruikersbediening veranderen niet.

## Validatie

- `npm run check:web` — geslaagd: 221 tests, bundelbouw en kwaliteitsbudgetten.
- `npm run smoke:web` — geslaagd.
- Lokale Chrome A→B-cachetest — geslaagd met lang cachebare, onveranderde asset-URL's; document, CSS en JavaScript eindigden alle drie op B en de drie expliciete refreshrequests gingen met `no-cache` over het netwerk.
- `esphome config configs/heatpump_controller_q/duo_wifi.yaml` — geldige configuratie; alleen de bestaande GPIO45-strappingwaarschuwing.
- `git diff --check origin/dev...HEAD` — geslaagd.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — stopt vóór ESPHome op een bestaande, ongewijzigde stijlmelding in `openquatt/oq_HP_io.yaml:1121`; de directe ESPHome-configvalidatie hierboven slaagt.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Browserzijdige wijziging zonder nieuwe firmwaretaken of runtime-allocaties. De embedded JS-bundel blijft binnen het bewaakte raw/gzip-budget.
