### PR TITLE
Add confirmed dev-to-main firmware downgrade

### DIFF
--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -308,6 +308,8 @@ De web-app toont update-informatie via de firmware-updatefunctie. Normaal volg j
 
 Gebruik een dev-kanaal alleen als je bewust test en weet dat de firmware nog kan veranderen. Voor releasegebruik is het stabiele kanaal de route.
 
+Draait het device op een nieuwere dev-versie dan de laatste main-release, dan biedt de OTA-modal na het kiezen van `main` een expliciete downgrade aan. Controleer de getoonde doelversie en bevestig bewust dat je teruggaat naar oudere firmware. Maak zo nodig eerst een instellingenbackup: instellingen blijven lokaal opgeslagen, maar functies en instellingen die alleen in de dev-build bestaan, zijn na de downgrade mogelijk niet meer beschikbaar.
+
 Bij de Heatpump Controller Q kan Quick Start vóór de verdere configuratie direct wisselen tussen `Single Wi-Fi`, `Single Ethernet`, `Duo Wi-Fi` en `Duo Ethernet`. De OTA-modal kan later nog steeds de verbinding of opstelling afzonderlijk wisselen. Dit zijn geen gewone updates: de web-app installeert de firmware voor de gekozen setup. Controleer bij Ethernet eerst of de netwerkkabel is aangesloten en bij Duo of de tweede warmtepomp bij deze controller hoort.
 
 Als de verbinding voor de firmwaredownload niet kan worden geopend, probeert OpenQuatt dit eenmaal automatisch opnieuw. Mislukt ook die poging of wordt de installatie afgebroken, dan stopt de voortgang en kun je de setupwissel opnieuw starten.

--- a/openquatt/web/css/src/03-modals.css
+++ b/openquatt/web/css/src/03-modals.css
@@ -280,6 +280,10 @@
   line-height: 1.5;
 }
 
+.oq-firmware-downgrade-callout {
+  margin-top: 12px;
+}
+
 .oq-helper-modal-auth-stack {
   display: grid;
   gap: 12px;

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -3875,7 +3875,6 @@
       applyPreset(value);
     } else if (name === "Firmware Update Channel") {
       clearOtaSimulation();
-      setText("text_sensor", "OpenQuatt Release Channel", value);
       setText("text_sensor", "Firmware Update Status", "Idle");
       setNumber("Firmware Update Progress", 0, "%");
       const updateEntity = getEntity("update", "Firmware Update");
@@ -3885,14 +3884,16 @@
         updateEntity.current_version = currentVersion;
         updateEntity.latest_version = latestVersion;
         updateEntity.release_url = getMockReleaseUrl(value);
-        if (value === "main" || currentVersion === latestVersion) {
+        if (currentVersion === latestVersion) {
           updateEntity.state = "up_to_date";
           updateEntity.value = "up_to_date";
-          updateEntity.summary = "Je preview gebruikt nu het stabiele kanaal. Er staat op dit moment geen nieuwere stable release klaar.";
+          updateEntity.summary = `De preview draait al op de nieuwste ${value}-firmware.`;
         } else {
           updateEntity.state = "available";
           updateEntity.value = "available";
-          updateEntity.summary = "Het dev-kanaal heeft een nieuwere OTA-build beschikbaar voor deze preview.";
+          updateEntity.summary = value === "main"
+            ? "De stabiele main-release is beschikbaar als bewuste downgrade voor deze preview."
+            : "Het dev-kanaal heeft een nieuwere OTA-build beschikbaar voor deze preview.";
         }
       }
     } else if (name === "Firmware Update Target") {
@@ -3901,6 +3902,8 @@
       setNumber("Firmware Update Progress", 0, "%");
       const updateEntity = getEntity("update", "Firmware Update");
       const currentVersion = String(getEntity("text_sensor", "OpenQuatt Version")?.value || MOCK_STABLE_VERSION);
+      const channel = String(getEntity("select", "Firmware Update Channel")?.value || "dev");
+      const latestVersion = channel === "main" ? MOCK_STABLE_VERSION : MOCK_DEV_VERSION;
       const alternateBuild = value !== "current build";
       const targetConnection = value === "alternate connection" || value === "alternate topology and connection"
         ? state.connection === "wifi" ? "eth" : "wifi"
@@ -3911,9 +3914,9 @@
       const targetLabel = `Heatpump Controller Q ${targetTopology === "duo" ? "Duo" : "Single"} ${targetConnection === "eth" ? "Ethernet" : "Wi-Fi"}`;
       if (updateEntity) {
         updateEntity.current_version = currentVersion;
-        updateEntity.latest_version = alternateBuild ? currentVersion : MOCK_DEV_VERSION;
-        updateEntity.release_url = getMockReleaseUrl(String(getEntity("select", "Firmware Update Channel")?.value || "dev"));
-        updateEntity.state = alternateBuild ? "up_to_date" : "available";
+        updateEntity.latest_version = latestVersion;
+        updateEntity.release_url = getMockReleaseUrl(channel);
+        updateEntity.state = currentVersion === latestVersion ? "up_to_date" : "available";
         updateEntity.value = updateEntity.state;
         updateEntity.summary = alternateBuild
           ? `${targetLabel} is als alternatieve target-build geselecteerd voor deze preview.`
@@ -4843,6 +4846,9 @@
         ? "De preview draait nu op testfirmware."
         : "De preview draait nu op de nieuwste firmware.";
       setText("text_sensor", "OpenQuatt Version", targetVersion);
+      if (!testFirmware) {
+        setText("text_sensor", "OpenQuatt Release Channel", String(getEntity("select", "Firmware Update Channel")?.value || "main"));
+      }
       setInstallationMode(targetTopology);
       state.connection = targetConnection;
       setText("text_sensor", "OpenQuatt Connection", state.connection);

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -1869,7 +1869,7 @@
     syncMockOduIdentityEntities(1);
     setEntity("text_sensor", "OpenQuatt Hardware Profile", { state: state.hardware, value: state.hardware });
     setEntity("text_sensor", "OpenQuatt Connection", { state: state.connection, value: state.connection });
-    setEntity("text_sensor", "OpenQuatt Version", { state: MOCK_STABLE_VERSION, value: MOCK_STABLE_VERSION });
+    setEntity("text_sensor", "OpenQuatt Version", { state: MOCK_DEV_VERSION, value: MOCK_DEV_VERSION });
     setEntity("text_sensor", "OpenQuatt Release Channel", { state: "dev", value: "dev" });
     setEntity("sensor", "Uptime", { value: 0, uom: "h" });
     syncUptimeEntity();
@@ -1902,12 +1902,12 @@
     setEntity("sensor", "Lifetime energiehistorie grootte", { value: state.energyHistoryStoredKiB, uom: "kB" });
     setEntity("sensor", "Lifetime energiehistorie schrijfacties", { value: state.energyHistoryWrites });
     setEntity("update", "Firmware Update", {
-      state: "available",
-      value: "available",
-      current_version: MOCK_STABLE_VERSION,
+      state: "up_to_date",
+      value: "up_to_date",
+      current_version: MOCK_DEV_VERSION,
       latest_version: MOCK_DEV_VERSION,
       title: "OpenQuatt firmware",
-      summary: "Nieuwe firmware met verdere UI- en regelingverbeteringen staat klaar voor deze preview.",
+      summary: "De preview draait op de nieuwste dev-firmware.",
       release_url: getMockReleaseUrl("dev"),
     });
     setEntity("binary_sensor", "Setup Complete", { value: state.complete, state: state.complete });

--- a/openquatt/web/js/src/core/entity-actions.js
+++ b/openquatt/web/js/src/core/entity-actions.js
@@ -12,7 +12,7 @@ import { handleDebugRecordingAction } from "../features/debug-recording.js";
 import { handleControlReplayAction } from "../features/control-replay-actions.js";
 import { handleFirmwareAction } from "../features/firmware-actions.js";
 import { updateFirmwareState, updateEnergyHistoryState } from "./feature-state.js";
-import { getFirmwareTestAssetUrls, getFirmwareTestPrNumber, getFirmwareTestTargetModel, resetFirmwareManualUploadSelection, resetFirmwareTestSelection } from "../features/firmware-update.js";
+import { getFirmwareLatestVersion, getFirmwareTestAssetUrls, getFirmwareTestPrNumber, getFirmwareTestTargetModel, resetFirmwareManualUploadSelection, resetFirmwareTestSelection } from "../features/firmware-update.js";
 import { handleMqttAction, syncMqttDraftFromInput } from "../features/mqtt-actions.js";
 import { handleOduEepromDumpAction } from "../features/odu-eeprom-dump.js";
 import { handleQuickStartAction } from "../features/quickstart-ui-actions.js";
@@ -86,6 +86,14 @@ const actionDelegates = [
   export function handleInput(event) {
     if (event.target.dataset.oqQuickstartSetupConfirm) {
       state.quickStartSetupConfirmed = Boolean(event.target.checked);
+      render();
+      return;
+    }
+
+    if (event.target.dataset.oqFirmwareDowngradeConfirm) {
+      updateFirmwareState({
+        firmwareDowngradeConfirmedVersion: event.target.checked ? getFirmwareLatestVersion() : "",
+      });
       render();
       return;
     }
@@ -328,6 +336,9 @@ const actionDelegates = [
     }
 
     if (entity.domain === "select") {
+      if (field === "firmwareUpdateChannel") {
+        updateFirmwareState({ firmwareDowngradeConfirmedVersion: "" });
+      }
       commitSelect(field, String(event.target.value));
       return;
     }
@@ -422,6 +433,7 @@ const actionDelegates = [
             updateTestFirmwareOpen: false,
             firmwareConnectionSwitchConfirmed: false,
             firmwareTopologySwitchConfirmed: false,
+            firmwareDowngradeConfirmedVersion: "",
           });
           resetFirmwareManualUploadSelection();
           resetFirmwareTestSelection();

--- a/openquatt/web/js/src/core/state-slices.js
+++ b/openquatt/web/js/src/core/state-slices.js
@@ -225,6 +225,7 @@ export function createFirmwareState() {
     updateInstallMode: "",
     updateInstallTargetConnection: "",
     updateInstallTargetTopology: "",
+    firmwareDowngradeConfirmedVersion: "",
     firmwareAdvancedOpen: false,
     firmwareConnectionSwitchOpen: false,
     firmwareConnectionSwitchConfirmed: false,

--- a/openquatt/web/js/src/features/firmware-actions.js
+++ b/openquatt/web/js/src/features/firmware-actions.js
@@ -568,6 +568,7 @@ import { render } from "../core/render-scheduler.js";
 
   const firmwareActionHandlers = {
     "open-update-modal": () => {
+      state.interfacePanelOpen = false;
       state.updateModalOpen = true;
       state.firmwareDowngradeConfirmedVersion = "";
       render();

--- a/openquatt/web/js/src/features/firmware-actions.js
+++ b/openquatt/web/js/src/features/firmware-actions.js
@@ -8,7 +8,7 @@ import { isLikelyDeviceConnectionError, refreshEntities } from "../core/entity-s
 import { armOtaRefresh, awaitOtaEvidence, beginDeviceReconnect, clearOtaRefresh } from "../core/device-reconnect.js";
 import { state } from "../core/state.js";
 import { getFirmwareConnectionLabel, getFirmwareTopologyLabel, getInstallationTopology } from "./device-context.js";
-import { beginFirmwareOtaQuietWindow, getFirmwareBuildSwitchModel, getFirmwareConnectionSwitchModel, getFirmwareCurrentVersion, getFirmwareLatestVersion, getFirmwareTestAssetUrls, getFirmwareTestPrNumber, getFirmwareTestTargetModel, getFirmwareTopologySwitchModel, getFirmwareUpdateEntity, hasKnownFirmwareTargetVersion, isFirmwareEntityAlignedWithChannel, isFirmwareUpdateEntityForBuild, pollFirmwareInstallState, pollFirmwareUpdateState, primeFirmwareInstallProgressHints, primeFirmwareUpdateState, resetFirmwareInstallUiState, resetFirmwareManualUploadSelection, resetFirmwareTestSelection } from "./firmware-update.js";
+import { beginFirmwareOtaQuietWindow, getFirmwareBuildSwitchModel, getFirmwareConnectionSwitchModel, getFirmwareCurrentVersion, getFirmwareLatestVersion, getFirmwareTestAssetUrls, getFirmwareTestPrNumber, getFirmwareTestTargetModel, getFirmwareTopologySwitchModel, getFirmwareUpdateEntity, hasKnownFirmwareTargetVersion, isFirmwareDowngradeAvailable, isFirmwareEntityAlignedWithChannel, isFirmwareUpdateEntityForBuild, pollFirmwareInstallState, pollFirmwareUpdateState, primeFirmwareInstallProgressHints, primeFirmwareUpdateState, resetFirmwareInstallUiState, resetFirmwareManualUploadSelection, resetFirmwareTestSelection } from "./firmware-update.js";
 import { render } from "../core/render-scheduler.js";
 
   export async function requestFirmwareOta(path, options) {
@@ -122,6 +122,14 @@ import { render } from "../core/render-scheduler.js";
       return;
     }
 
+    const targetVersion = getFirmwareLatestVersion(entity);
+    const downgrade = isFirmwareDowngradeAvailable(entity);
+    if (downgrade && state.firmwareDowngradeConfirmedVersion !== targetVersion) {
+      state.controlError = "Bevestig opnieuw dat je naar de oudere main-firmware wilt teruggaan.";
+      render();
+      return;
+    }
+
     state.firmwareAdvancedOpen = false;
     state.updateManualUploadOpen = false;
     state.firmwareConnectionSwitchOpen = false;
@@ -134,9 +142,9 @@ import { render } from "../core/render-scheduler.js";
     state.updateInstallCompleted = false;
     state.updateInstallCompletedVersion = "";
     state.updateInstallBusy = true;
-    state.updateInstallTargetVersion = getFirmwareLatestVersion(entity);
+    state.updateInstallTargetVersion = targetVersion;
     primeFirmwareInstallProgressHints();
-    state.updateInstallMode = "normal";
+    state.updateInstallMode = downgrade ? "downgrade" : "normal";
     state.updateInstallTargetConnection = "";
     state.updateInstallTargetTopology = "";
     state.controlError = "";
@@ -144,8 +152,22 @@ import { render } from "../core/render-scheduler.js";
     render();
 
     try {
-      await setFirmwareUpdateTarget("current build", { poll: false, force: true });
-      state.updateInstallTargetVersion = getFirmwareLatestVersion(getFirmwareUpdateEntity() || {}) || state.updateInstallTargetVersion;
+      if (downgrade) {
+        const targetReady = await setFirmwareUpdateTarget("current build", { force: true });
+        const refreshedEntity = getFirmwareUpdateEntity() || {};
+        const refreshedTargetVersion = getFirmwareLatestVersion(refreshedEntity);
+        if (
+          !targetReady
+          || !isFirmwareDowngradeAvailable(refreshedEntity)
+          || state.firmwareDowngradeConfirmedVersion !== refreshedTargetVersion
+        ) {
+          throw new Error("De main-doelversie is gewijzigd of niet meer beschikbaar. Controleer en bevestig de getoonde versie opnieuw.");
+        }
+        state.updateInstallTargetVersion = refreshedTargetVersion;
+      } else {
+        await setFirmwareUpdateTarget("current build", { poll: false, force: true });
+        state.updateInstallTargetVersion = getFirmwareLatestVersion(getFirmwareUpdateEntity() || {}) || state.updateInstallTargetVersion;
+      }
       beginFirmwareOtaQuietWindow();
       const installButtonEntity = ENTITY_DEFS.installFirmwareUpdateTarget;
       const installPath = installButtonEntity && hasEntity("installFirmwareUpdateTarget")
@@ -547,6 +569,7 @@ import { render } from "../core/render-scheduler.js";
   const firmwareActionHandlers = {
     "open-update-modal": () => {
       state.updateModalOpen = true;
+      state.firmwareDowngradeConfirmedVersion = "";
       render();
       return hydrateFirmwareUpdateModal();
     },
@@ -561,6 +584,7 @@ import { render } from "../core/render-scheduler.js";
       state.updateTestFirmwareOpen = false;
       state.firmwareConnectionSwitchConfirmed = false;
       state.firmwareTopologySwitchConfirmed = false;
+      state.firmwareDowngradeConfirmedVersion = "";
       resetFirmwareManualUploadSelection();
       resetFirmwareTestSelection();
       render();

--- a/openquatt/web/js/src/features/firmware-update.js
+++ b/openquatt/web/js/src/features/firmware-update.js
@@ -1339,7 +1339,7 @@ import { render } from "../core/render-scheduler.js";
             </label>
           ` : ""}
           ${downgradeAvailable && !installing && !progress ? `
-            <div class="oq-helper-modal-callout">
+            <div class="oq-helper-modal-callout oq-firmware-downgrade-callout">
               <strong>Bewuste downgrade</strong>
               <span>Main ${escapeHtml(latest)} vervangt de nieuwere dev-build ${escapeHtml(current)}. Functies en instellingen die alleen in dev bestaan, zijn daarna mogelijk niet meer beschikbaar.</span>
               <label class="oq-helper-modal-check">

--- a/openquatt/web/js/src/features/firmware-update.js
+++ b/openquatt/web/js/src/features/firmware-update.js
@@ -306,7 +306,7 @@ import { render } from "../core/render-scheduler.js";
   }
 
   export function isFirmwareUpdateJustCompleted() {
-    return (state.updateInstallCompleted || isFirmwareInstallSettled())
+    return state.updateInstallCompleted
       && !isFirmwareUpdateChecking()
       && !getFirmwareProgressModel()
       && !isFirmwareUpdateAvailable();

--- a/openquatt/web/js/src/features/firmware-update.js
+++ b/openquatt/web/js/src/features/firmware-update.js
@@ -202,6 +202,9 @@ import { render } from "../core/render-scheduler.js";
     if (isFirmwareUpdateInstalling()) {
       return "Bezig";
     }
+    if (isFirmwareDowngradeAvailable()) {
+      return "Downgrade beschikbaar";
+    }
     if (isFirmwareUpdateAvailable()) {
       return "Beschikbaar";
     }
@@ -267,16 +270,20 @@ import { render } from "../core/render-scheduler.js";
   export function hasInstalledFirmwareTargetVersion() {
     const target = String(state.updateInstallTargetVersion || "").trim();
     const current = getFirmwareCurrentVersion();
-    if (!target || !current) {
+    if (!target || !current || !parseFirmwareVersion(target) || !parseFirmwareVersion(current)) {
       return false;
     }
-    return compareFirmwareVersions(current, target) >= 0;
+    const relation = compareFirmwareVersions(current, target);
+    return state.updateInstallMode === "downgrade" ? relation === 0 : relation >= 0;
   }
 
   export function hasInstalledFirmwareLatestVersion(entity = getFirmwareUpdateEntity() || {}) {
     const latest = getFirmwareLatestVersion(entity);
     const current = getFirmwareCurrentVersion(entity);
     if (!latest || !current) {
+      return false;
+    }
+    if (isFirmwareDowngradeAvailable(entity)) {
       return false;
     }
     return compareFirmwareVersions(current, latest) >= 0;
@@ -315,6 +322,7 @@ import { render } from "../core/render-scheduler.js";
       updateInstallMode: "",
       updateInstallTargetConnection: "",
       updateInstallTargetTopology: "",
+      firmwareDowngradeConfirmedVersion: "",
     });
     clearFirmwareOtaQuietWindow();
   }
@@ -417,6 +425,8 @@ import { render } from "../core/render-scheduler.js";
         percent: Math.max(basePercent, 100),
         copy: state.updateInstallMode === "test-firmware"
           ? "Testfirmware is geplaatst. Het device start opnieuw op en komt daarna vanzelf terug."
+          : state.updateInstallMode === "downgrade"
+          ? "De stabiele main-firmware is geplaatst. Het device start opnieuw op en komt daarna vanzelf terug."
           : state.updateInstallMode === "connection-switch"
           ? "Firmware is geplaatst. Het device start opnieuw op en komt daarna via de gekozen verbinding terug."
           : state.updateInstallMode === "topology-switch" || state.updateInstallMode === "build-switch"
@@ -429,7 +439,9 @@ import { render } from "../core/render-scheduler.js";
       return {
         phaseLabel: "Opnieuw proberen",
         percent: 0,
-        copy: "De eerste verbinding voor de firmwaredownload mislukte. OpenQuatt probeert het automatisch nog één keer.",
+        copy: state.updateInstallMode === "downgrade"
+          ? "De eerste verbinding voor de main-firmwaredownload mislukte. OpenQuatt probeert het automatisch nog één keer."
+          : "De eerste verbinding voor de firmwaredownload mislukte. OpenQuatt probeert het automatisch nog één keer.",
       };
     }
 
@@ -439,6 +451,8 @@ import { render } from "../core/render-scheduler.js";
         percent: basePercent,
         copy: state.updateInstallMode === "test-firmware"
           ? `Testfirmware wordt nu door ${getFirmwareDeviceLabel()} gedownload en geïnstalleerd.`
+          : state.updateInstallMode === "downgrade"
+          ? `De stabiele main-firmware wordt nu naar ${getFirmwareDeviceLabel()} verzonden.`
           : state.updateInstallMode === "connection-switch"
           ? `De ${getFirmwareConnectionLabel(state.updateInstallTargetConnection)}-build wordt nu naar ${getFirmwareDeviceLabel()} verzonden.`
           : state.updateInstallMode === "topology-switch" || state.updateInstallMode === "build-switch"
@@ -452,6 +466,8 @@ import { render } from "../core/render-scheduler.js";
       percent: basePercent,
       copy: state.updateInstallMode === "test-firmware"
         ? `Testfirmware-installatie is gestart voor ${getFirmwareDeviceLabel()}.`
+        : state.updateInstallMode === "downgrade"
+        ? `Downgrade naar de stabiele main-firmware is gestart voor ${getFirmwareDeviceLabel()}.`
         : state.updateInstallMode === "connection-switch"
         ? `Verbindingswissel naar ${getFirmwareConnectionLabel(state.updateInstallTargetConnection)} is gestart.`
         : state.updateInstallMode === "topology-switch" || state.updateInstallMode === "build-switch"
@@ -638,8 +654,8 @@ import { render } from "../core/render-scheduler.js";
     const entity = getFirmwareUpdateEntity() || {};
     const current = getFirmwareCurrentVersion(entity) || "—";
     let latest = isFirmwareEntityAlignedWithChannel(entity) ? getFirmwareLatestVersion(entity) : "";
-    const relation = latest ? compareFirmwareVersions(latest, current) : null;
-    if (!isFirmwareUpdateChecking() && relation !== null && relation <= 0) {
+    const relation = getFirmwareVersionRelation(entity);
+    if (!isFirmwareUpdateChecking() && relation !== null && relation <= 0 && !isFirmwareDowngradeAvailable(entity)) {
       latest = "";
     }
     return {
@@ -648,9 +664,10 @@ import { render } from "../core/render-scheduler.js";
     };
   }
 
-  export function getFirmwareVersionRelation() {
-    const { current, latest } = getFirmwareUpdateVersions();
-    if (current === "—" || latest === "—") {
+  export function getFirmwareVersionRelation(entity = getFirmwareUpdateEntity() || {}) {
+    const current = getFirmwareCurrentVersion(entity);
+    const latest = isFirmwareEntityAlignedWithChannel(entity) ? getFirmwareLatestVersion(entity) : "";
+    if (!current || !latest || !parseFirmwareVersion(current) || !parseFirmwareVersion(latest)) {
       return null;
     }
     return compareFirmwareVersions(latest, current);
@@ -689,6 +706,29 @@ import { render } from "../core/render-scheduler.js";
       || state.entities.releaseChannelText?.value
       || "—"
     ).trim() || "—";
+  }
+
+  export function getFirmwareRunningChannelLabel() {
+    return String(
+      state.entities.releaseChannelText?.state
+      || state.entities.releaseChannelText?.value
+      || "—"
+    ).trim() || "—";
+  }
+
+  export function isFirmwareDowngradeAvailable(entity = getFirmwareUpdateEntity() || {}) {
+    const selectedChannel = getFirmwareChannelLabel().toLowerCase();
+    const runningChannel = getFirmwareRunningChannelLabel().toLowerCase();
+    if (
+      selectedChannel !== "main"
+      || runningChannel !== "dev"
+      || !hasEntity("installFirmwareUpdateTarget")
+      || !isFirmwareEntityAlignedWithChannel(entity, selectedChannel)
+    ) {
+      return false;
+    }
+    const relation = getFirmwareVersionRelation(entity);
+    return relation !== null && relation < 0;
   }
 
   export function hasKnownFirmwareTargetVersion() {
@@ -909,6 +949,10 @@ import { render } from "../core/render-scheduler.js";
     }
     if (isFirmwareUpdateChecking()) {
       return `We controleren of er op kanaal ${channel} een nieuwe firmware beschikbaar is.`;
+    }
+    if (isFirmwareDowngradeAvailable()) {
+      const { current, latest } = getFirmwareUpdateVersions();
+      return `De stabiele main-release ${latest} is ouder dan de draaiende dev-build ${current}. Je kunt bewust teruggaan naar main.`;
     }
     if (isFirmwareUpdateAvailable()) {
       return "Er staat een nieuwere firmware klaar.";
@@ -1212,6 +1256,9 @@ import { render } from "../core/render-scheduler.js";
     const checking = isFirmwareUpdateChecking();
     const installing = isFirmwareUpdateInstalling();
     const available = isFirmwareUpdateAvailable();
+    const downgradeAvailable = isFirmwareDowngradeAvailable(entity);
+    const downgradeConfirmed = downgradeAvailable
+      && state.firmwareDowngradeConfirmedVersion === latest;
     const summary = getFirmwareModalCopy();
     const progress = getFirmwareProgressModel();
     const justCompleted = isFirmwareUpdateJustCompleted();
@@ -1224,6 +1271,8 @@ import { render } from "../core/render-scheduler.js";
       ? "Firmware-update bezig"
       : checking
         ? "Controleren op firmware-update"
+        : downgradeAvailable
+          ? "Terug naar main"
         : getFirmwareTitle();
     const channelOptions = channelEntity
       ? (Array.isArray(channelEntity.option) ? channelEntity.option : Array.isArray(channelEntity.options) ? channelEntity.options : [])
@@ -1289,15 +1338,27 @@ import { render } from "../core/render-scheduler.js";
               </select>
             </label>
           ` : ""}
-          <p class="oq-helper-modal-note">Laat deze pagina open tijdens de OTA-update. Het device kan na installatie kort herstarten en daarna vanzelf weer terugkomen. Bestaande OpenQuatt-instellingen blijven behouden.</p>
+          ${downgradeAvailable && !installing && !progress ? `
+            <div class="oq-helper-modal-callout">
+              <strong>Bewuste downgrade</strong>
+              <span>Main ${escapeHtml(latest)} vervangt de nieuwere dev-build ${escapeHtml(current)}. Functies en instellingen die alleen in dev bestaan, zijn daarna mogelijk niet meer beschikbaar.</span>
+              <label class="oq-helper-modal-check">
+                <input type="checkbox" data-oq-firmware-downgrade-confirm="true" ${downgradeConfirmed ? "checked" : ""} ${checking ? "disabled" : ""}>
+                <span>Ik begrijp dat ik terugga naar een oudere stabiele firmwareversie.</span>
+              </label>
+            </div>
+          ` : ""}
+          <p class="oq-helper-modal-note">${downgradeAvailable
+            ? "Maak zo nodig eerst een instellingenbackup. Laat deze pagina open; het device herstart na de downgrade en komt daarna vanzelf weer terug."
+            : "Laat deze pagina open tijdens de OTA-update. Het device kan na installatie kort herstarten en daarna vanzelf weer terugkomen. Bestaande OpenQuatt-instellingen blijven behouden."}</p>
           <div class="oq-helper-modal-actions oq-firmware-modal-actions">
             <button class="oq-helper-button oq-helper-button--ghost" type="button" data-oq-action="run-firmware-check" ${checking || installing || progress ? "disabled" : ""}>
               ${checking ? "Controleren..." : "Controleer opnieuw"}
             </button>
             ${justCompleted
               ? '<button class="oq-helper-button oq-helper-button--primary" type="button" data-oq-action="close-update-modal">Gereed</button>'
-              : `<button class="oq-helper-button" type="button" data-oq-action="install-firmware-update" ${!available || installing || checking || progress || !entity ? "disabled" : ""}>
-              ${installing ? "Bijwerken..." : "Nu bijwerken"}
+              : `<button class="oq-helper-button${downgradeAvailable ? " oq-helper-button--warning" : ""}" type="button" data-oq-action="install-firmware-update" ${(!available && !downgradeAvailable) || (downgradeAvailable && !downgradeConfirmed) || installing || checking || progress || !entity ? "disabled" : ""}>
+              ${installing ? (state.updateInstallMode === "downgrade" ? "Downgraden..." : "Bijwerken...") : downgradeAvailable ? `Terug naar main ${escapeHtml(latest)}` : "Nu bijwerken"}
             </button>`}
             ${releaseUrl ? `<a class="oq-helper-button oq-helper-button--ghost oq-helper-modal-link" href="${escapeHtml(releaseUrl)}" target="_blank" rel="noreferrer">Release notes</a>` : ""}
             ${isFirmwareAdvancedOpen() ? "" : `

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -11,11 +11,45 @@ globalThis.window = {
 
 const { state } = await import("../js/src/core/state.js");
 const {
+  getFirmwareModalCopy,
   getFirmwareProgressModel,
   getFirmwareTestAssetUrls,
+  getFirmwareUpdateVersions,
+  getUpdateStatus,
+  isFirmwareDowngradeAvailable,
   isFirmwareInstallCompletionConfirmed,
+  isFirmwareUpdateAvailable,
   primeFirmwareInstallProgressHints,
+  renderUpdateModal,
 } = await import("../js/src/features/firmware-update.js");
+
+function setDevToMainDowngradeState() {
+  state.drafts = {};
+  state.entities = {
+    firmwareUpdate: {
+      state: "UPDATE AVAILABLE",
+      value: "v0.47.0",
+      current_version: "v0.48.0-dev.696+86f5997",
+      latest_version: "v0.47.0",
+      release_url: "https://github.com/OpenQuatt/OpenQuatt/releases/tag/v0.47.0",
+    },
+    firmwareUpdateChannel: { state: "main", value: "main", option: ["main", "dev"] },
+    installFirmwareUpdateTarget: { state: "" },
+    projectVersionText: { state: "v0.48.0-dev.696+86f5997", value: "v0.48.0-dev.696+86f5997" },
+    releaseChannelText: { state: "dev", value: "dev" },
+  };
+  state.updateCheckBusy = false;
+  state.updateInstallBusy = false;
+  state.updateInstallCompleted = false;
+  state.updateInstallCompletedVersion = "";
+  state.updateInstallMode = "";
+  state.updateInstallTargetVersion = "";
+  state.updateInstallPhaseHint = "";
+  state.updateInstallProgressHint = Number.NaN;
+  state.updateInstallStatusPollObserved = false;
+  state.firmwareDowngradeConfirmedVersion = "";
+  state.updateModalOpen = true;
+}
 
 test("PR firmware uses deterministic release URLs without the GitHub REST API", () => {
   const target = {
@@ -30,6 +64,76 @@ test("PR firmware uses deterministic release URLs without the GitHub REST API", 
     label: "PR 395 · Heatpump Controller Q Duo Wi-Fi",
   });
   assert.equal(getFirmwareTestAssetUrls("395/../../dev-latest", target), null);
+});
+
+test("dev firmware exposes an explicit confirmed downgrade to the older main release", () => {
+  setDevToMainDowngradeState();
+
+  assert.equal(isFirmwareDowngradeAvailable(), true);
+  assert.equal(isFirmwareUpdateAvailable(), false);
+  assert.deepEqual(getFirmwareUpdateVersions(), {
+    current: "v0.48.0-dev.696+86f5997",
+    latest: "v0.47.0",
+  });
+  assert.equal(getUpdateStatus(), "Downgrade beschikbaar");
+  assert.match(getFirmwareModalCopy(), /bewust teruggaan naar main/);
+
+  let modal = renderUpdateModal();
+  let installButton = modal.match(/<button class="oq-helper-button[^"]*" type="button" data-oq-action="install-firmware-update"[^>]*>/)?.[0] || "";
+  assert.match(modal, /data-oq-firmware-downgrade-confirm="true"/);
+  assert.match(modal, /Main v0\.47\.0 vervangt de nieuwere dev-build v0\.48\.0-dev\.696\+86f5997/);
+  assert.match(installButton, /oq-helper-button--warning/);
+  assert.match(installButton, /disabled/);
+
+  state.firmwareDowngradeConfirmedVersion = "v0.47.0";
+  modal = renderUpdateModal();
+  installButton = modal.match(/<button class="oq-helper-button[^"]*" type="button" data-oq-action="install-firmware-update"[^>]*>/)?.[0] || "";
+  assert.doesNotMatch(installButton, /disabled/);
+  assert.match(modal, /Terug naar main v0\.47\.0/);
+});
+
+test("downgrade remains unavailable outside the validated dev-to-main path", () => {
+  setDevToMainDowngradeState();
+
+  delete state.entities.installFirmwareUpdateTarget;
+  assert.equal(isFirmwareDowngradeAvailable(), false);
+
+  state.entities.installFirmwareUpdateTarget = { state: "" };
+  state.entities.releaseChannelText = { state: "main", value: "main" };
+  assert.equal(isFirmwareDowngradeAvailable(), false);
+
+  state.entities.releaseChannelText = { state: "dev", value: "dev" };
+  state.entities.firmwareUpdateChannel = { state: "dev", value: "dev", option: ["main", "dev"] };
+  assert.equal(isFirmwareDowngradeAvailable(), false);
+
+  state.entities.firmwareUpdateChannel = { state: "main", value: "main", option: ["main", "dev"] };
+  state.entities.firmwareUpdate.latest_version = "onbekend";
+  assert.equal(isFirmwareDowngradeAvailable(), false);
+});
+
+test("downgrade completion requires the device to boot the exact lower target", () => {
+  setDevToMainDowngradeState();
+  state.updateInstallBusy = true;
+  state.updateInstallMode = "downgrade";
+  state.updateInstallTargetVersion = "v0.47.0";
+
+  assert.equal(isFirmwareInstallCompletionConfirmed(), false);
+
+  state.entities.projectVersionText = { state: "onbekend", value: "onbekend" };
+  assert.equal(isFirmwareInstallCompletionConfirmed(), false);
+
+  state.entities.projectVersionText = { state: "v0.47.0", value: "v0.47.0" };
+  state.entities.releaseChannelText = { state: "main", value: "main" };
+  state.entities.firmwareUpdate = {
+    ...state.entities.firmwareUpdate,
+    state: "NO UPDATE",
+    value: "v0.47.0",
+    current_version: "v0.47.0",
+    latest_version: "v0.47.0",
+  };
+  state.entities.firmwareUpdateStatus = { state: "Idle", value: "Idle" };
+
+  assert.equal(isFirmwareInstallCompletionConfirmed(), true);
 });
 
 test("a new OTA attempt ignores cached reboot progress until a post-start poll", () => {

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -82,6 +82,7 @@ test("dev firmware exposes an explicit confirmed downgrade to the older main rel
 
   let modal = renderUpdateModal();
   let installButton = modal.match(/<button class="oq-helper-button[^"]*" type="button" data-oq-action="install-firmware-update"[^>]*>/)?.[0] || "";
+  assert.match(modal, /oq-firmware-downgrade-callout/);
   assert.match(modal, /data-oq-firmware-downgrade-confirm="true"/);
   assert.match(modal, /Main v0\.47\.0 vervangt de nieuwere dev-build v0\.48\.0-dev\.696\+86f5997/);
   assert.match(installButton, /oq-helper-button--warning/);

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 globalThis.__OQ_PREVIEW__ = false;
@@ -19,6 +20,7 @@ const {
   isFirmwareDowngradeAvailable,
   isFirmwareInstallCompletionConfirmed,
   isFirmwareUpdateAvailable,
+  isFirmwareUpdateJustCompleted,
   primeFirmwareInstallProgressHints,
   renderUpdateModal,
 } = await import("../js/src/features/firmware-update.js");
@@ -92,6 +94,19 @@ test("dev firmware exposes an explicit confirmed downgrade to the older main rel
   assert.match(modal, /Terug naar main v0\.47\.0/);
 });
 
+test("firmware preview starts from a consistent running dev build", async () => {
+  const mockSource = await readFile(new URL("../js/mock-device.js", import.meta.url), "utf8");
+
+  assert.match(
+    mockSource,
+    /setEntity\("text_sensor", "OpenQuatt Version", \{ state: MOCK_DEV_VERSION, value: MOCK_DEV_VERSION \}\);/
+  );
+  assert.match(
+    mockSource,
+    /current_version: MOCK_DEV_VERSION,\s+latest_version: MOCK_DEV_VERSION,/
+  );
+});
+
 test("downgrade remains unavailable outside the validated dev-to-main path", () => {
   setDevToMainDowngradeState();
 
@@ -134,6 +149,28 @@ test("downgrade completion requires the device to boot the exact lower target", 
   state.entities.firmwareUpdateStatus = { state: "Idle", value: "Idle" };
 
   assert.equal(isFirmwareInstallCompletionConfirmed(), true);
+});
+
+test("up-to-date firmware is only presented as completed after an install attempt", () => {
+  setDevToMainDowngradeState();
+  state.entities.projectVersionText = { state: "v0.47.0", value: "v0.47.0" };
+  state.entities.releaseChannelText = { state: "main", value: "main" };
+  state.entities.firmwareUpdate = {
+    ...state.entities.firmwareUpdate,
+    state: "up_to_date",
+    value: "up_to_date",
+    current_version: "v0.47.0",
+    latest_version: "v0.47.0",
+  };
+
+  assert.equal(isFirmwareUpdateJustCompleted(), false);
+  assert.doesNotMatch(renderUpdateModal(), /Firmware-update afgerond/);
+
+  state.updateInstallCompleted = true;
+  state.updateInstallCompletedVersion = "v0.47.0";
+
+  assert.equal(isFirmwareUpdateJustCompleted(), true);
+  assert.match(renderUpdateModal(), /Firmware-update afgerond/);
 });
 
 test("a new OTA attempt ignores cached reboot progress until a post-start poll", () => {

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -108,6 +108,18 @@ test("firmware preview starts from a consistent running dev build", async () => 
   );
 });
 
+test("opening the firmware modal closes the interface panel before rendering", async () => {
+  const actionsSource = await readFile(new URL("../js/src/features/firmware-actions.js", import.meta.url), "utf8");
+  const handlerStart = actionsSource.indexOf('    "open-update-modal": () => {');
+  const handlerEnd = actionsSource.indexOf('\n    "close-update-modal":', handlerStart);
+  const handlerSource = actionsSource.slice(handlerStart, handlerEnd);
+
+  assert.notEqual(handlerStart, -1);
+  assert.notEqual(handlerEnd, -1);
+  assert.match(handlerSource, /state\.interfacePanelOpen = false;/);
+  assert.ok(handlerSource.indexOf("state.interfacePanelOpen = false;") < handlerSource.indexOf("render();"));
+});
+
 test("downgrade remains unavailable outside the validated dev-to-main path", () => {
   setDevToMainDowngradeState();
 

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -9,8 +9,9 @@ export const WEB_BUNDLE_BUDGETS = [
     // its read-only sensor-correction summary, calibration backup/restore,
     // the read-only ODU EEPROM service export, API ingress source controls,
     // concise CM100 boiler test phase copy (FLOW_SETTLING/BOILER_SETTLING/MEASURING/COOLDOWN),
-    // and advisory per-ODU generation detection with single bulk-detect button for onboarding and installation settings.
-    raw: 912_000,
+    // advisory per-ODU generation detection with single bulk-detect button for onboarding and installation settings,
+    // and the explicitly confirmed dev-to-main firmware downgrade flow.
+    raw: 915_000,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -11,7 +11,7 @@ export const WEB_BUNDLE_BUDGETS = [
     // concise CM100 boiler test phase copy (FLOW_SETTLING/BOILER_SETTLING/MEASURING/COOLDOWN),
     // advisory per-ODU generation detection with single bulk-detect button for onboarding and installation settings,
     // and the explicitly confirmed dev-to-main firmware downgrade flow.
-    raw: 915_000,
+    raw: 915_200,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.

--- a/scripts/tests/test_firmware_downgrade_contract.py
+++ b/scripts/tests/test_firmware_downgrade_contract.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMON_PACKAGE = (ROOT / "openquatt" / "oq_common.yaml").read_text()
+
+
+class FirmwareDowngradeContractTest(unittest.TestCase):
+    def test_forced_install_rechecks_and_validates_the_selected_manifest(self) -> None:
+        start = COMMON_PACKAGE.index(
+            "  - id: oq_install_firmware_update_target_deferred\n"
+        )
+        end = COMMON_PACKAGE.index("\n  - id:", start + 1)
+        install_script = COMMON_PACKAGE[start:end]
+
+        self.assertIn("- update.check:\n          id: oq_firmware_update", install_script)
+        self.assertIn("&& id(oq_fw_check_target_ready)", install_script)
+        self.assertIn("- update.perform:\n                id: oq_firmware_update", install_script)
+        self.assertIn("force_update: true", install_script)
+        self.assertLess(
+            install_script.index("- update.check:"),
+            install_script.index("- update.perform:"),
+        )
+
+    def test_internal_install_button_uses_the_forced_install_script(self) -> None:
+        self.assertIn(
+            "id: oq_install_firmware_update_target\n"
+            "    name: Install Firmware Update Target",
+            COMMON_PACKAGE,
+        )
+        self.assertIn(
+            "- script.execute: oq_install_firmware_update_target_deferred",
+            COMMON_PACKAGE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Bied in de OpenQuatt OTA-modal een expliciete downgrade van een nieuwere `dev`-build naar de oudere actuele `main`-release aan.
- Vereis bevestiging van de getoonde doelversie, controleer het main-manifest opnieuw vóór installatie en gebruik de bestaande firmwarematige manifest-/buildvalidatie met geforceerde OTA.
- Houd de previewstatus consistent, toon “Firmware-update afgerond” alleen na een werkelijk bevestigde installatie en geef de downgradewaarschuwing duidelijke visuele ruimte; documenteer en test de volledige flow.
- Sluit het achterliggende interfacepaneel voordat de OTA-modal rendert, zodat de releasekanaalselector direct bij de eerste klik opent.

<img width="842" height="664" alt="image" src="https://github.com/user-attachments/assets/428ffad9-974a-4a7f-97ce-6c086b7d7908" />


## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de web-OTA-bediening, previewmock en documentatie wijzigen. De bestaande interne installatieroute en firmwarematige manifest-/hardwarevalidatie worden hergebruikt; regelgedrag en firmware-entiteiten wijzigen niet.

## Achtergrond

Gerelateerd aan #524. Een lager main-versienummer wordt door de normale updatepresentatie niet als update aangeboden, terwijl de firmware al een gevalideerde forced-installroute heeft. Deze PR maakt die route uitsluitend zichtbaar voor de begrensde overgang `dev` → `main`, met fail-closed kanaal- en versiecontrole.

De bevestiging wordt aan de getoonde doelversie gebonden en vlak vóór de aanvraag opnieuw gecontroleerd. De firmware controleert daarna zelf nogmaals het actuele main-manifest en de artifact/buildmatch. In het zeer kleine tijdvenster tussen beide controles kan een nieuw gepubliceerde main-release het manifest vervangen; het firmwareprotocol heeft geen parameter om een exacte verwachte versie mee te geven, maar blijft wel op main en valideert de build.

De preview start voortaan daadwerkelijk op de mock-dev-versie. Een gewone `up_to_date`-status wordt niet langer als een zojuist afgeronde OTA gepresenteerd; daarvoor is nu expliciet installatiesucces nodig.

Een reeds problematische oudere dev-build krijgt deze UI-wijziging niet retroactief; dit ondersteunt toekomstige dev-builds waarin deze PR is opgenomen.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De web-appdocumentatie beschrijft de bewuste downgrade, versiebevestiging, backupadvies en het mogelijk verdwijnen van dev-only functies/instellingen.

## Validatie

- `npm run check:web` — 227/227 tests geslaagd; JS-bundel 915135 B raw / 248984 B gzip, binnen het bijgewerkte featurebudget.
- `npm run check:docs` — docsconsistentie en web/docs-contract geslaagd.
- `npm run check:python-contracts` — 76/76 tests geslaagd, inclusief de forced-install/manifestvalidatie.
- `npm run smoke:web` — previewbuild en websmoke geslaagd.
- Volledige diff-audit en aparte adversarial review uitgevoerd op correctheid, kanaal-/versiefouten, stale bevestiging, onterechte completion-state, mislukte manifestchecks, OTA/reconnect/afronding, compatibiliteit, fresh install en upgradepaden.
- Handmatige in-app browser-QA kon lokaal niet worden uitgevoerd door een code-signaturefout in de browserplugin; de DOM-renderregressietests en preview-smoke zijn wel geslaagd.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen firmwarecode, allocaties, taken of controlpaden gewijzigd; alleen webbroncode, tests, mock en documentatie.