### PR TITLE
Kleine tekstverduidelijkingen web UI

### DIFF
--- a/openquatt/web/js/src/features/header-status.js
+++ b/openquatt/web/js/src/features/header-status.js
@@ -672,7 +672,7 @@ import { render } from "../core/render-scheduler.js";
         closeLabel: "Sluit regeling-popup",
         bodyMarkup: `
           <p class="oq-helper-modal-copy">${enabled
-              ? "Kies hoe lang de regeling uit moet blijven. Verwarmen en koelen stoppen dan, maar beveiligingen blijven actief."
+              ? "Kies hoe lang de regeling uit moet blijven. Verwarmen en koelen stoppen dan, maar beveiligingen (inclusief vorstbeveiliging) blijven actief."
               : "De regeling staat nu tijdelijk uit. Je kunt meteen weer inschakelen of een nieuw hervatmoment plannen."
           }</p>
           ${resumeScheduled

--- a/openquatt/web/js/src/settings/cooling.js
+++ b/openquatt/web/js/src/settings/cooling.js
@@ -19,7 +19,7 @@ import { escapeHtml } from "../core/html.js";
     }
 
     const labels = {
-      Ready: "Gereed",
+      Ready: "Gereed om te koelen",
       "Waiting for room request": "Koeling toegestaan, wacht op kamertemperatuur boven koel-setpoint",
       "Cooling enabled, waiting for room temperature above cooling setpoint": "Koeling toegestaan, wacht op kamertemperatuur boven koel-setpoint",
       "No dew point source": "Geen dauwpuntbron",

--- a/openquatt/web/js/src/settings/installation.js
+++ b/openquatt/web/js/src/settings/installation.js
@@ -85,7 +85,7 @@ const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepo
       return "Nog geen readback of apply-status ontvangen.";
     }
     if (normalized.includes("APPLIED")) {
-      return "Runtime registers zijn geschreven en via readback bevestigd. Een ODU powercycle zet de originele tabel terug.";
+      return "Runtime registers zijn geschreven en via readback bevestigd. Een power-cycle / stroomloos maken van de buitenunit zet de originele tabel terug.";
     }
     if (normalized.includes("GUARD_READ_REQUESTED")) {
       return "Firmware leest actuele ODU mode en compressorfrequentie voordat er geschreven wordt.";
@@ -230,7 +230,7 @@ const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepo
               </div>
             </div>
             <h3>ODU runtime frequentietabel</h3>
-            <p>Lees en schrijf de ODU frequentietabel alleen runtime; waarden worden niet opgeslagen in EEPROM.</p>
+            <p>Lees en schrijf de ODU frequentietabel alleen runtime; waarden worden niet opgeslagen in EEPROM. Een power-cycle / stroomloos maken van de buitenunit reset de frequentietabel weer naar de originele tabel.</p>
           </div>
           <span class="oq-settings-section-summary-toggle" aria-hidden="true"></span>
         </summary>
@@ -239,6 +239,7 @@ const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepo
             <strong>Schrijft direct naar ODU runtime registers.</strong>
             <p>Gebruik dit alleen voor gecontroleerde tests. Apply werkt alleen wanneer de HP in standby staat, de compressor uit is en de enable-schakelaar bewust aan staat.</p>
             <p>Verlaag koel-frequenties onder de OEM-ondergrens rond 30 Hz alleen met superheat-bewaking. Bij te lage suction superheat kan natte zuigretour richting compressor ontstaan.</p>
+            <p>Een power-cycle / stroomloos maken van de buitenunit reset de frequentietabel weer naar de originele tabel.</p>
           </div>
           <div class="oq-settings-odu-runtime-panels">
             ${hpIndexes.map((hpIndex) => renderOduRuntimeFrequencyHpPanel(hpIndex)).join("")}

--- a/openquatt/web/js/src/views/overview.js
+++ b/openquatt/web/js/src/views/overview.js
@@ -621,15 +621,19 @@ import { isSystemInStandby, replaceOuterHtmlIfSignatureChanged, setInnerHtmlIfCh
       : coolingConfiguredSource && coolingConfiguredSource !== "geen bron"
       ? `Koeltoestemming is niet gegeven: ${coolingConfiguredSource} geeft geen toestemming en handmatig staat uit.`
       : "Koeltoestemming is niet gegeven.";
+    const coolingIsReady = String(coolingBlockReasonRaw).trim().toLowerCase() === "ready" || String(coolingBlockReasonRaw).trim().toLowerCase() === "gereed" || String(coolingBlockReasonRaw).trim().toLowerCase() === "gereed om te koelen";
     if (coolingEnabled && coolingModeActive) {
       coolingStatus = "Actief";
       coolingCopy = appendCoolingPermissionSource("Koeling draait nu.", coolingEffectiveSource);
     } else if (coolingEnabled && coolingWaitingForRoomRequest) {
       coolingStatus = "Aan";
       coolingCopy = appendCoolingPermissionSource("Koeling is toegestaan en wacht op kamertemperatuur boven het koel-setpoint.", coolingEffectiveSource);
-    } else if (coolingEnabled && coolingBlocked) {
+    } else if (coolingEnabled && coolingBlocked && !coolingIsReady) {
       coolingStatus = "Geblokkeerd";
       coolingCopy = appendCoolingPermissionSource(formatCoolingBlockReason(coolingBlockReasonRaw || "Koeling wacht nog op veilige condities."), coolingEffectiveSource);
+    } else if (coolingEnabled && coolingBlocked && coolingIsReady) {
+      coolingStatus = "Aan";
+      coolingCopy = appendCoolingPermissionSource("Koeltoestemming is gegeven en wacht op koelvraag.", coolingEffectiveSource);
     } else if (coolingEnabled && coolingRequestActive) {
       coolingStatus = "Start bijna";
       coolingCopy = appendCoolingPermissionSource("Er is koelvraag. Koeling start zodra dat kan.", coolingEffectiveSource);

--- a/openquatt/web/js/src/views/overview.js
+++ b/openquatt/web/js/src/views/overview.js
@@ -617,10 +617,10 @@ import { isSystemInStandby, replaceOuterHtmlIfSignatureChanged, setInnerHtmlIfCh
 
     let coolingStatus = "Uit";
     let coolingCopy = coolingConfiguredSourceRaw === "Disabled"
-      ? "Koeling is niet toegestaan: handmatig staat uit."
+      ? "Koeltoestemming is niet gegeven: handmatig staat uit."
       : coolingConfiguredSource && coolingConfiguredSource !== "geen bron"
-      ? `Koeling is niet toegestaan: ${coolingConfiguredSource} geeft geen toestemming en handmatig staat uit.`
-      : "Koeling is niet toegestaan.";
+      ? `Koeltoestemming is niet gegeven: ${coolingConfiguredSource} geeft geen toestemming en handmatig staat uit.`
+      : "Koeltoestemming is niet gegeven.";
     if (coolingEnabled && coolingModeActive) {
       coolingStatus = "Actief";
       coolingCopy = appendCoolingPermissionSource("Koeling draait nu.", coolingEffectiveSource);
@@ -656,8 +656,8 @@ import { isSystemInStandby, replaceOuterHtmlIfSignatureChanged, setInnerHtmlIfCh
     }
 
     return [
-      { key: "openquattEnabled", label: "Openquatt regeling", status: openquattEnabled ? "Actief" : "Tijdelijk uit", copy: openquattEnabled ? "Verwarmen en koelen worden automatisch geregeld." : openquattResumeScheduled ? "Verwarming en koeling zijn tijdelijk uitgeschakeld. Beveiligingen blijven actief." : "Verwarming en koeling zijn uitgeschakeld. Beveiligingen blijven actief.", tone: openquattEnabled ? "green" : "orange", kind: "openquatt-control", meta: openquattEnabled ? [] : [openquattResumeLoading ? { label: "Hervatten", value: "Laden…", tone: "neutral", loading: true } : { label: openquattResumeScheduled ? "Hervat automatisch" : "Hervatten", value: openquattResumeScheduled ? formatOpenQuattResumeDateTime(openquattResumeAt, true) : "Handmatig", tone: openquattResumeScheduled ? "orange" : "neutral" }] },
-      { key: "manualCoolingEnable", label: "Koeling", status: coolingStatus, copy: coolingCopy, buttonLabel: manualCoolingEnabled ? "Handmatig uit" : "Handmatig aan", nextState: manualCoolingEnabled ? "off" : "on", tone: coolingEnabled ? (coolingModeActive ? "blue" : "sky") : "neutral" },
+      { key: "openquattEnabled", label: "Openquatt regeling", status: openquattEnabled ? "Actief" : "Tijdelijk uit", copy: openquattEnabled ? "Verwarmen en koelen worden automatisch geregeld." : openquattResumeScheduled ? "Verwarming en koeling zijn tijdelijk uitgeschakeld. Beveiligingen (inclusief vorstbeveiliging) blijven actief." : "Verwarming en koeling zijn uitgeschakeld. Beveiligingen (inclusief vorstbeveiliging) blijven actief.", tone: openquattEnabled ? "green" : "orange", kind: "openquatt-control", meta: openquattEnabled ? [] : [openquattResumeLoading ? { label: "Hervatten", value: "Laden…", tone: "neutral", loading: true } : { label: openquattResumeScheduled ? "Hervat automatisch" : "Hervatten", value: openquattResumeScheduled ? formatOpenQuattResumeDateTime(openquattResumeAt, true) : "Handmatig", tone: openquattResumeScheduled ? "orange" : "neutral" }] },
+      { key: "manualCoolingEnable", label: "Koeltoestemming", status: coolingStatus, copy: coolingCopy, buttonLabel: manualCoolingEnabled ? "Toestemming uit" : "Toestemming aan", nextState: manualCoolingEnabled ? "off" : "on", tone: coolingEnabled ? (coolingModeActive ? "blue" : "sky") : "neutral" },
       { key: "silentModeOverride", label: "Stille modus", status: silentStatus, copy: silentCopy, tone: silentTone, kind: "select", selectedOption: silentModeOverride, settingsAction: true, options: [{ value: "Off", label: "Uit" }, { value: "On", label: "Aan" }, { value: "Schedule", label: "Schema" }] },
     ].filter((card) => hasEntity(card.key));
   }

--- a/openquatt/web/js/src/views/overview.js
+++ b/openquatt/web/js/src/views/overview.js
@@ -82,7 +82,7 @@ import { isSystemInStandby, replaceOuterHtmlIfSignatureChanged, setInnerHtmlIfCh
     if (!sourceLabel || sourceLabel === "geen bron") {
       return copy;
     }
-    return `${copy} Toestemming: ${sourceLabel}.`;
+    return `${copy} Toestemming via ${sourceLabel}.`;
   }
 
   export function getHeatPumpPanelStatusLabel(mode, running) {


### PR DESCRIPTION
# Wat verandert deze PR?

- Regeling pauze: tekst aangevuld naar “beveiligingen (inclusief vorstbeveiliging) blijven actief”.
- ODU runtime frequentietabel: toegevoegd dat een power-cycle / stroomloos maken van de buitenunit de tabel weer naar origineel reset.
- Koelkaart op overview heet nu **Koeltoestemming** i.p.v. Koeling — het gaat om toestemming, niet direct koelen (koelvraag via kamerthermostaat blijft leidend). Knop is nu “Toestemming aan/uit”. Ook gefixt: als kamervraag uit staat verscheen ten onrechte “Geblokkeerd Gereed”; dat is nu “Aan, wacht op koelvraag”.

## Type

- [x] UI/config
- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting: alleen teksten in de web UI aangepast.

## Achtergrond

Kleine verduidelijkingen op verzoek.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie: alleen copy verduidelijkt in web UI, geen gebruikersdocumentatie geraakt.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact: n.v.t. — geen firmware-build, `npm run build:web` en `build:web:preview` ok, `node openquatt/web/run-web-tests.mjs` 242 pass, live gecontroleerd op `dev.html` preview.
