### PR TITLE
Add crash timestamps and stop retained publishing

### DIFF
--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
@@ -59,13 +59,6 @@ bool OpenQuattCrashTelemetry::copy_text_(char* destination, size_t destination_s
   return true;
 }
 
-bool OpenQuattCrashTelemetry::valid_record_(const CrashRecord& record) {
-  return record.magic == CRASH_RECORD_MAGIC && record.version == CRASH_RECORD_VERSION && record.pending <= 1U &&
-         record.truncated <= 1U && record.captured_by_reporting_build <= 1U && record.sequence != 0U &&
-         record.report_length < CRASH_REPORT_CAPACITY && record.report[record.report_length] == '\0' &&
-         record.checksum == checksum_(&record, offsetof(CrashRecord, checksum));
-}
-
 void OpenQuattCrashTelemetry::random_uuid_(char* destination, size_t destination_size) {
   if (destination == nullptr || destination_size < 37U) return;
   std::array<uint8_t, 16U> bytes{};
@@ -98,7 +91,7 @@ bool OpenQuattCrashTelemetry::load_record_() {
     const size_t offset = openquatt_common::OpenQuattFlashLayout::CRASH_TELEMETRY_OFFSET +
                           (static_cast<size_t>(slot) * openquatt_common::OpenQuattFlashLayout::SECTOR_SIZE);
     if (esp_partition_read(this->flash_partition_, offset, this->record_.data(), sizeof(CrashRecord)) != ESP_OK ||
-        !valid_record_(*this->record_.data())) {
+        !detail::valid_stored_crash_record(*this->record_.data())) {
       continue;
     }
     if (!found || flash_sequence_is_newer(this->record_.data()->sequence, newest_sequence)) {
@@ -115,7 +108,7 @@ bool OpenQuattCrashTelemetry::load_record_() {
   const size_t newest_offset = openquatt_common::OpenQuattFlashLayout::CRASH_TELEMETRY_OFFSET +
                                (static_cast<size_t>(newest_slot) * openquatt_common::OpenQuattFlashLayout::SECTOR_SIZE);
   if (esp_partition_read(this->flash_partition_, newest_offset, this->record_.data(), sizeof(CrashRecord)) != ESP_OK ||
-      !valid_record_(*this->record_.data())) {
+      !detail::migrate_crash_record(this->record_.data())) {
     std::memset(this->record_.data(), 0, sizeof(CrashRecord));
     this->active_record_slot_ = -1;
     return false;
@@ -131,8 +124,8 @@ bool OpenQuattCrashTelemetry::save_record_() {
   const uint32_t previous_sequence = record->sequence;
   record->sequence++;
   if (record->sequence == 0U) record->sequence = 1U;
-  record->magic = CRASH_RECORD_MAGIC;
-  record->version = CRASH_RECORD_VERSION;
+  record->magic = detail::CRASH_RECORD_MAGIC;
+  record->version = detail::CRASH_RECORD_VERSION;
   record->checksum = 0U;
   record->checksum = checksum_(record, offsetof(CrashRecord, checksum));
   const int8_t previous_slot = this->active_record_slot_;
@@ -294,7 +287,14 @@ void OpenQuattCrashTelemetry::setup() {
 
 void OpenQuattCrashTelemetry::capture_pending_crash_() {
 #ifdef USE_ESP32_CRASH_HANDLER
-  if (!esp32::crash_handler_has_data() || logger::global_logger == nullptr || !this->record_) return;
+  if (!esp32::crash_handler_has_data()) {
+    openquatt_log_history::invalidate_crash_time_breadcrumb();
+    return;
+  }
+  if (logger::global_logger == nullptr || !this->record_) return;
+
+  openquatt_log_history::CrashTimeBreadcrumbSnapshot crash_time{};
+  const bool crash_time_valid = openquatt_log_history::read_crash_time_breadcrumb(&crash_time);
 
   CrashRecord* record = this->record_.data();
   const uint32_t previous_sequence = record->sequence;
@@ -302,6 +302,9 @@ void OpenQuattCrashTelemetry::capture_pending_crash_() {
   record->sequence = previous_sequence;
   record->pending = 1U;
   record->captured_by_reporting_build = 1U;
+  record->crash_time_valid = crash_time_valid ? 1U : 0U;
+  record->crash_timestamp = crash_time_valid ? crash_time.epoch_s : 0U;
+  record->crash_uptime_s = crash_time_valid ? crash_time.uptime_s : 0U;
   record->build_epoch = static_cast<uint32_t>(ESPHOME_BUILD_TIME);
   record->config_hash = static_cast<uint32_t>(ESPHOME_CONFIG_HASH);
   record->reset_reason = static_cast<uint32_t>(esp_reset_reason());
@@ -335,7 +338,7 @@ void OpenQuattCrashTelemetry::capture_pending_crash_() {
   // OpenQuattLogHistory can still replay this record during the current boot:
   // ESPHome intentionally keeps its in-RAM valid flag after clearing the NOINIT marker.
   esp32::crash_handler_clear();
-  ESP_LOGI(TAG, "Stored crash %s for retained publication", record->crash_id);
+  ESP_LOGI(TAG, "Stored crash %s for publication", record->crash_id);
 #endif
 }
 

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
@@ -294,7 +294,7 @@ void OpenQuattCrashTelemetry::capture_pending_crash_() {
   if (logger::global_logger == nullptr || !this->record_) return;
 
   openquatt_log_history::CrashTimeBreadcrumbSnapshot crash_time{};
-  const bool crash_time_valid = openquatt_log_history::read_crash_time_breadcrumb(&crash_time);
+  const bool crash_time_valid = openquatt_log_history::consume_crash_time_breadcrumb(&crash_time);
 
   CrashRecord* record = this->record_.data();
   const uint32_t previous_sequence = record->sequence;

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
@@ -9,11 +9,13 @@
 #include <freertos/semphr.h>
 
 #include "OpenQuattCrashTelemetryPolicy.h"
+#include "OpenQuattCrashTelemetryRecord.h"
 #include "OpenQuattFlashLayout.h"
 #include "PsramBuffer.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/time/real_time_clock.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esp_partition.h"
@@ -32,6 +34,7 @@ class OpenQuattCrashTelemetry : public Component {
   void set_usage_switch(switch_::Switch* value) { this->usage_switch_ = value; }
   void set_installation_id_sensor(text_sensor::TextSensor* value) { this->installation_id_sensor_ = value; }
   void set_setup_complete_sensor(binary_sensor::BinarySensor* value) { this->setup_complete_sensor_ = value; }
+  void set_clock(time::RealTimeClock* value) { this->clock_ = value; }
   void set_source_repository(const std::string& value) { this->source_repository_ = value; }
   void set_source_commit(const std::string& value) { this->source_commit_ = value; }
   void set_build_target(const std::string& value) { this->build_target_ = value; }
@@ -54,45 +57,16 @@ class OpenQuattCrashTelemetry : public Component {
   bool is_persisted_consent_enabled() const { return this->state_ && this->state_.data()->consent_enabled != 0U; }
 
  protected:
-  static constexpr uint32_t CRASH_RECORD_MAGIC = 0x4F514352UL;  // OQCR
-  static constexpr uint16_t CRASH_RECORD_VERSION = 1U;
   static constexpr uint32_t STATE_MAGIC = 0x4F514353UL;  // OQCS
   static constexpr uint16_t STATE_VERSION = 1U;
-  static constexpr size_t CRASH_REPORT_CAPACITY = 2048U;
+  static constexpr size_t CRASH_REPORT_CAPACITY = detail::CRASH_REPORT_CAPACITY;
   static constexpr size_t CRASH_PAYLOAD_CAPACITY = 4096U;
   static constexpr uint32_t SESSION_TIMEOUT_MS = 30000UL;
   static constexpr uint32_t INITIAL_RETRY_MS = 5UL * 60UL * 1000UL;
   static constexpr uint32_t INITIAL_PUBLISH_DELAY_MS = 15000UL;
   static constexpr int MQTT_TASK_STACK_SIZE = 12288;
 
-  struct CrashRecord {
-    uint32_t magic;
-    uint16_t version;
-    uint8_t pending;
-    uint8_t truncated;
-    uint8_t captured_by_reporting_build;
-    uint8_t reserved[3];
-    uint16_t report_length;
-    uint16_t reserved2;
-    uint32_t sequence;
-    uint32_t build_epoch;
-    uint32_t config_hash;
-    uint32_t reset_reason;
-    char crash_id[37];
-    char build_id[65];
-    char source_repository[98];
-    char source_commit[41];
-    char build_target[97];
-    char release_manifest_url[257];
-    char firmware_version[33];
-    char release_channel[17];
-    char esphome_version[17];
-    char hardware_profile[33];
-    char topology[17];
-    char connection[17];
-    char report[CRASH_REPORT_CAPACITY];
-    uint32_t checksum;
-  };
+  using CrashRecord = detail::CrashRecord;
 
   struct StateStorage {
     uint32_t magic;
@@ -105,7 +79,6 @@ class OpenQuattCrashTelemetry : public Component {
     uint32_t checksum;
   };
 
-  static_assert(sizeof(CrashRecord) < 3072U, "Crash record should remain a small bounded blob");
   static_assert(sizeof(StateStorage) < 64U, "Crash telemetry state should remain small");
 
   void capture_pending_crash_();
@@ -133,7 +106,6 @@ class OpenQuattCrashTelemetry : public Component {
   static uint32_t checksum_(const void* data, size_t length);
   static bool copy_text_(char* destination, size_t destination_size, const std::string& source);
   static bool copy_text_(char* destination, size_t destination_size, const char* source);
-  static bool valid_record_(const CrashRecord& record);
   static void random_uuid_(char* destination, size_t destination_size);
   static const char* extract_message_body_(const char* message);
   static void mqtt_event_handler_(void* handler_args, esp_event_base_t base, int32_t event_id, void* event_data);
@@ -158,6 +130,7 @@ class OpenQuattCrashTelemetry : public Component {
   switch_::Switch* usage_switch_{nullptr};
   text_sensor::TextSensor* installation_id_sensor_{nullptr};
   binary_sensor::BinarySensor* setup_complete_sensor_{nullptr};
+  time::RealTimeClock* clock_{nullptr};
 
   StaticSemaphore_t gate_mutex_storage_{};
   SemaphoreHandle_t gate_mutex_{nullptr};

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
@@ -39,6 +39,15 @@ bool OpenQuattCrashTelemetry::build_crash_payload_() {
   if (!this->payload_buffer_.allocate_external(CRASH_PAYLOAD_CAPACITY + 1U)) return false;
 
   const CrashRecord& record = *this->record_.data();
+  uint32_t reported_at = 0U;
+  if (this->clock_ != nullptr) {
+    const auto now = this->clock_->now();
+    const int64_t timestamp = static_cast<int64_t>(now.timestamp);
+    if (now.is_valid() && timestamp >= static_cast<int64_t>(openquatt_log_history::MIN_VALID_CRASH_EPOCH_S) &&
+        timestamp < static_cast<int64_t>(openquatt_log_history::MAX_VALID_CRASH_EPOCH_S)) {
+      reported_at = static_cast<uint32_t>(timestamp);
+    }
+  }
   FixedWriter writer(this->payload_buffer_.data(), this->payload_buffer_.size());
   writer.append("{\"schema_version\":1,\"message_id\":");
   writer.append_json_string(record.crash_id);
@@ -46,6 +55,24 @@ bool OpenQuattCrashTelemetry::build_crash_payload_() {
   writer.append_json_string(this->state_.data()->installation_id);
   append_json_key(writer, "event");
   writer.append_json_string("crash");
+  append_json_key(writer, "crash_timestamp");
+  if (record.crash_time_valid != 0U) {
+    writer.append_uint(record.crash_timestamp);
+  } else {
+    writer.append("null");
+  }
+  append_json_key(writer, "crash_uptime_s");
+  if (record.crash_time_valid != 0U) {
+    writer.append_uint(record.crash_uptime_s);
+  } else {
+    writer.append("null");
+  }
+  append_json_key(writer, "reported_at");
+  if (reported_at != 0U) {
+    writer.append_uint(reported_at);
+  } else {
+    writer.append("null");
+  }
   append_json_key(writer, "reset_reason");
   writer.append_json_string(reset_reason_name(static_cast<esp_reset_reason_t>(record.reset_reason)));
   append_json_key(writer, "reporting_build_id");
@@ -145,7 +172,7 @@ bool OpenQuattCrashTelemetry::start_session_(CrashPublishKind kind) {
     return false;
   }
   this->mqtt_client_started_ = true;
-  ESP_LOGD(TAG, "Started %s publication", kind == CrashPublishKind::CRASH ? "retained crash" : "retained tombstone");
+  ESP_LOGD(TAG, "Started %s publication", kind == CrashPublishKind::CRASH ? "crash" : "retained tombstone");
   return true;
 }
 
@@ -175,7 +202,7 @@ void OpenQuattCrashTelemetry::complete_session_(bool succeeded) {
   if (succeeded && kind == CrashPublishKind::CRASH) {
     if (!this->clear_record_()) {
       succeeded = false;
-      ESP_LOGW(TAG, "Retained crash was acknowledged, but local record clearing failed; retrying is harmless");
+      ESP_LOGW(TAG, "Crash was acknowledged, but local record clearing failed; retrying is harmless");
     }
   } else if (succeeded && kind == CrashPublishKind::TOMBSTONE) {
     this->state_.data()->tombstone_pending = 0U;
@@ -197,7 +224,7 @@ void OpenQuattCrashTelemetry::complete_session_(bool succeeded) {
 
   if (succeeded) {
     this->next_attempt_ms_ = 0U;
-    ESP_LOGI(TAG, "%s published successfully", kind == CrashPublishKind::CRASH ? "Retained crash" : "Crash tombstone");
+    ESP_LOGI(TAG, "%s published successfully", kind == CrashPublishKind::CRASH ? "Crash" : "Crash tombstone");
   } else {
     this->schedule_retry_();
   }
@@ -233,7 +260,7 @@ void OpenQuattCrashTelemetry::loop() {
 }
 
 void OpenQuattCrashTelemetry::dump_config() {
-  ESP_LOGCONFIG(TAG, "OpenQuatt retained crash telemetry:");
+  ESP_LOGCONFIG(TAG, "OpenQuatt crash telemetry:");
   ESP_LOGCONFIG(TAG, "  Broker configured: %s", YESNO(this->is_configured()));
   ESP_LOGCONFIG(TAG, "  Pending crash: %s", YESNO(this->record_ && this->record_.data()->pending != 0U));
   ESP_LOGCONFIG(TAG, "  Tombstone pending: %s", YESNO(this->state_ && this->state_.data()->tombstone_pending != 0U));
@@ -260,8 +287,9 @@ void OpenQuattCrashTelemetry::mqtt_event_handler_(void* handler_args, esp_event_
         static const char EMPTY_PAYLOAD[] = "";
         const char* payload = kind == CrashPublishKind::TOMBSTONE ? EMPTY_PAYLOAD : self->payload_buffer_.data();
         const size_t payload_size = kind == CrashPublishKind::TOMBSTONE ? 0U : self->payload_size_;
+        const int retain = crash_publication_is_retained(kind) ? 1 : 0;
         message_id = esp_mqtt_client_enqueue(event->client, self->topic_buffer_.data(), payload,
-                                             static_cast<int>(payload_size), 1, 1, true);
+                                             static_cast<int>(payload_size), 1, retain, true);
       }
       self->unlock_gate_();
       if (message_id < 0) {

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
@@ -41,4 +41,8 @@ inline constexpr bool crash_data_may_be_published(CrashPublishKind kind, bool co
   return kind == CrashPublishKind::CRASH && consent_enabled && setup_complete;
 }
 
+inline constexpr bool crash_publication_is_retained(CrashPublishKind kind) {
+  return kind == CrashPublishKind::TOMBSTONE;
+}
+
 }  // namespace esphome::openquatt_crash_telemetry

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryRecord.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryRecord.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "../openquatt_log_history/OpenQuattCrashTimeBreadcrumb.h"
+
+namespace esphome::openquatt_crash_telemetry::detail {
+
+static constexpr uint32_t CRASH_RECORD_MAGIC = 0x4F514352UL;  // OQCR
+static constexpr uint16_t CRASH_RECORD_VERSION = 1U;
+static constexpr size_t LEGACY_CRASH_REPORT_CAPACITY = 2048U;
+static constexpr size_t CRASH_REPORT_CAPACITY = 2040U;
+
+struct CrashRecord {
+  uint32_t magic;
+  uint16_t version;
+  uint8_t pending;
+  uint8_t truncated;
+  uint8_t captured_by_reporting_build;
+  uint8_t crash_time_valid;
+  uint8_t reserved[2];
+  uint16_t report_length;
+  uint16_t reserved2;
+  uint32_t sequence;
+  uint32_t build_epoch;
+  uint32_t config_hash;
+  uint32_t reset_reason;
+  char crash_id[37];
+  char build_id[65];
+  char source_repository[98];
+  char source_commit[41];
+  char build_target[97];
+  char release_manifest_url[257];
+  char firmware_version[33];
+  char release_channel[17];
+  char esphome_version[17];
+  char hardware_profile[33];
+  char topology[17];
+  char connection[17];
+  char report[CRASH_REPORT_CAPACITY];
+  uint8_t reserved_report_tail[3];
+  uint32_t crash_timestamp;
+  uint32_t crash_uptime_s;
+  uint32_t checksum;
+};
+
+static_assert(offsetof(CrashRecord, checksum) ==
+                  ((offsetof(CrashRecord, report) + LEGACY_CRASH_REPORT_CAPACITY + alignof(uint32_t) - 1U) &
+                   ~(alignof(uint32_t) - 1U)),
+              "Crash timestamp fields must preserve the original checksum and flash layout");
+static_assert(sizeof(CrashRecord) < 3072U, "Crash record should remain a small bounded blob");
+
+inline uint32_t crash_record_checksum(const void* data, size_t length) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  uint32_t hash = 2166136261UL;
+  for (size_t index = 0U; index < length; ++index) {
+    hash ^= bytes[index];
+    hash *= 16777619UL;
+  }
+  return hash;
+}
+
+inline bool valid_stored_crash_record(const CrashRecord& record) {
+  if (record.magic != CRASH_RECORD_MAGIC || record.version != CRASH_RECORD_VERSION || record.pending > 1U ||
+      record.truncated > 1U || record.captured_by_reporting_build > 1U || record.crash_time_valid > 1U ||
+      record.sequence == 0U) {
+    return false;
+  }
+  const size_t report_capacity = record.crash_time_valid != 0U ? CRASH_REPORT_CAPACITY : LEGACY_CRASH_REPORT_CAPACITY;
+  if (record.report_length >= report_capacity) return false;
+  const auto* record_bytes = reinterpret_cast<const uint8_t*>(&record);
+  if (record_bytes[offsetof(CrashRecord, report) + record.report_length] != '\0' ||
+      record.checksum != crash_record_checksum(&record, offsetof(CrashRecord, checksum))) {
+    return false;
+  }
+  if (record.crash_time_valid != 0U &&
+      (record.reserved_report_tail[0] != 0U || record.reserved_report_tail[1] != 0U ||
+       record.reserved_report_tail[2] != 0U || !openquatt_log_history::crash_epoch_is_sane(record.crash_timestamp))) {
+    return false;
+  }
+  return true;
+}
+
+inline bool migrate_crash_record(CrashRecord* record) {
+  if (record == nullptr || !valid_stored_crash_record(*record)) return false;
+  if (record->crash_time_valid != 0U) return true;
+  if (record->report_length >= CRASH_REPORT_CAPACITY) {
+    record->report_length = CRASH_REPORT_CAPACITY - 1U;
+    record->report[record->report_length] = '\0';
+    record->truncated = 1U;
+  }
+  record->crash_time_valid = 0U;
+  record->reserved_report_tail[0] = 0U;
+  record->reserved_report_tail[1] = 0U;
+  record->reserved_report_tail[2] = 0U;
+  record->crash_timestamp = 0U;
+  record->crash_uptime_s = 0U;
+  record->checksum = 0U;
+  record->checksum = crash_record_checksum(record, offsetof(CrashRecord, checksum));
+  return true;
+}
+
+}  // namespace esphome::openquatt_crash_telemetry::detail

--- a/components/openquatt_crash_telemetry/__init__.py
+++ b/components/openquatt_crash_telemetry/__init__.py
@@ -1,10 +1,15 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, socket, switch, text_sensor
+from esphome.components import binary_sensor, socket, switch, text_sensor, time
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.const import CONF_ID
 
-DEPENDENCIES = ["logger", "psram", "openquatt_usage_telemetry"]
+DEPENDENCIES = [
+    "logger",
+    "psram",
+    "openquatt_usage_telemetry",
+    "openquatt_log_history",
+]
 
 CONF_BROKER = "broker"
 CONF_PORT = "port"
@@ -15,6 +20,7 @@ CONF_TOPIC = "topic"
 CONF_USAGE_SWITCH = "usage_switch"
 CONF_INSTALLATION_ID_SENSOR = "installation_id_sensor"
 CONF_SETUP_COMPLETE_SENSOR = "setup_complete_sensor"
+CONF_CLOCK = "clock"
 CONF_SOURCE_REPOSITORY = "source_repository"
 CONF_SOURCE_COMMIT = "source_commit"
 CONF_BUILD_TARGET = "build_target"
@@ -54,6 +60,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_USAGE_SWITCH): cv.use_id(switch.Switch),
             cv.Required(CONF_INSTALLATION_ID_SENSOR): cv.use_id(text_sensor.TextSensor),
             cv.Required(CONF_SETUP_COMPLETE_SENSOR): cv.use_id(binary_sensor.BinarySensor),
+            cv.Required(CONF_CLOCK): cv.use_id(time.RealTimeClock),
             cv.Required(CONF_SOURCE_REPOSITORY): cv.All(
                 cv.string_strict, cv.Length(min=1, max=97)
             ),
@@ -107,6 +114,8 @@ async def to_code(config):
     cg.add(var.set_installation_id_sensor(installation_id_sensor))
     setup_complete_sensor = await cg.get_variable(config[CONF_SETUP_COMPLETE_SENSOR])
     cg.add(var.set_setup_complete_sensor(setup_complete_sensor))
+    clock = await cg.get_variable(config[CONF_CLOCK])
+    cg.add(var.set_clock(clock))
     cg.add(var.set_source_repository(config[CONF_SOURCE_REPOSITORY]))
     cg.add(var.set_source_commit(config[CONF_SOURCE_COMMIT]))
     cg.add(var.set_build_target(config[CONF_BUILD_TARGET]))

--- a/components/openquatt_log_history/OpenQuattCrashTimeBreadcrumb.h
+++ b/components/openquatt_log_history/OpenQuattCrashTimeBreadcrumb.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace esphome::openquatt_log_history {
+
+static constexpr uint32_t CRASH_TIME_BREADCRUMB_MAGIC = 0x4F514348UL;  // OQCH
+static constexpr uint16_t CRASH_TIME_BREADCRUMB_VERSION = 1U;
+static constexpr uint32_t MIN_VALID_CRASH_EPOCH_S = 1704067200UL;  // 2024-01-01 00:00:00 UTC
+static constexpr uint32_t MAX_VALID_CRASH_EPOCH_S = 2082758400UL;  // 2036-01-01 00:00:00 UTC
+
+struct CrashTimeBreadcrumb {
+  uint32_t magic;
+  uint16_t version;
+  uint16_t reserved;
+  uint32_t epoch_s;
+  uint32_t uptime_s;
+  uint32_t sequence;
+  uint32_t crc;
+};
+
+struct CrashTimeBreadcrumbSnapshot {
+  uint32_t epoch_s;
+  uint32_t uptime_s;
+  uint32_t sequence;
+};
+
+inline bool crash_epoch_is_sane(uint32_t epoch_s) {
+  return epoch_s >= MIN_VALID_CRASH_EPOCH_S && epoch_s < MAX_VALID_CRASH_EPOCH_S;
+}
+
+inline uint32_t crash_time_breadcrumb_checksum(const CrashTimeBreadcrumb& breadcrumb) {
+  CrashTimeBreadcrumb copy = breadcrumb;
+  copy.crc = 0U;
+  const auto* bytes = reinterpret_cast<const uint8_t*>(&copy);
+  uint32_t hash = 2166136261UL;
+  for (size_t index = 0U; index < sizeof(copy); ++index) {
+    hash ^= bytes[index];
+    hash *= 16777619UL;
+  }
+  return hash;
+}
+
+inline bool crash_time_breadcrumb_is_valid(const CrashTimeBreadcrumb& breadcrumb) {
+  return breadcrumb.magic == CRASH_TIME_BREADCRUMB_MAGIC && breadcrumb.version == CRASH_TIME_BREADCRUMB_VERSION &&
+         crash_epoch_is_sane(breadcrumb.epoch_s) && breadcrumb.crc == crash_time_breadcrumb_checksum(breadcrumb);
+}
+
+bool read_crash_time_breadcrumb(CrashTimeBreadcrumbSnapshot* snapshot);
+void invalidate_crash_time_breadcrumb();
+
+}  // namespace esphome::openquatt_log_history

--- a/components/openquatt_log_history/OpenQuattCrashTimeBreadcrumb.h
+++ b/components/openquatt_log_history/OpenQuattCrashTimeBreadcrumb.h
@@ -26,6 +26,11 @@ struct CrashTimeBreadcrumbSnapshot {
   uint32_t sequence;
 };
 
+struct CrashTimeBreadcrumbBootCache {
+  bool valid;
+  CrashTimeBreadcrumbSnapshot snapshot;
+};
+
 inline bool crash_epoch_is_sane(uint32_t epoch_s) {
   return epoch_s >= MIN_VALID_CRASH_EPOCH_S && epoch_s < MAX_VALID_CRASH_EPOCH_S;
 }
@@ -47,7 +52,36 @@ inline bool crash_time_breadcrumb_is_valid(const CrashTimeBreadcrumb& breadcrumb
          crash_epoch_is_sane(breadcrumb.epoch_s) && breadcrumb.crc == crash_time_breadcrumb_checksum(breadcrumb);
 }
 
-bool read_crash_time_breadcrumb(CrashTimeBreadcrumbSnapshot* snapshot);
+inline uint32_t crash_uptime_seconds_from_microseconds(uint64_t uptime_us) {
+  return static_cast<uint32_t>(uptime_us / 1000000ULL);
+}
+
+inline bool consume_crash_time_breadcrumb_state(CrashTimeBreadcrumb* breadcrumb,
+                                                CrashTimeBreadcrumbBootCache* boot_cache,
+                                                CrashTimeBreadcrumbSnapshot* snapshot) {
+  if (breadcrumb == nullptr || boot_cache == nullptr || snapshot == nullptr) return false;
+  if (!boot_cache->valid) {
+    const CrashTimeBreadcrumb copy = *breadcrumb;
+    if (!crash_time_breadcrumb_is_valid(copy)) return false;
+    // Invalidate first so a reset during the handoff fails closed instead of
+    // exposing the previous boot's timestamp to another crash.
+    breadcrumb->magic = 0U;
+    boot_cache->snapshot.epoch_s = copy.epoch_s;
+    boot_cache->snapshot.uptime_s = copy.uptime_s;
+    boot_cache->snapshot.sequence = copy.sequence;
+    boot_cache->valid = true;
+  }
+  *snapshot = boot_cache->snapshot;
+  return true;
+}
+
+inline void invalidate_crash_time_breadcrumb_state(CrashTimeBreadcrumb* breadcrumb,
+                                                   CrashTimeBreadcrumbBootCache* boot_cache) {
+  if (breadcrumb != nullptr) breadcrumb->magic = 0U;
+  if (boot_cache != nullptr) *boot_cache = {};
+}
+
+bool consume_crash_time_breadcrumb(CrashTimeBreadcrumbSnapshot* snapshot);
 void invalidate_crash_time_breadcrumb();
 
 }  // namespace esphome::openquatt_log_history

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -1,4 +1,5 @@
 #include "OpenQuattLogHistory.h"
+#include "OpenQuattCrashTimeBreadcrumb.h"
 
 #include <algorithm>
 #include <array>
@@ -25,10 +26,7 @@ static const char* const TAG = "openquatt.log_history";
 
 namespace {
 
-static constexpr uint32_t MIN_VALID_EPOCH_S = 1704067200UL;  // 2024-01-01 00:00:00 UTC
-static constexpr uint32_t MAX_VALID_EPOCH_S = 2082758400UL;  // 2036-01-01 00:00:00 UTC
-
-static bool epoch_is_sane(uint32_t epoch_s) { return epoch_s >= MIN_VALID_EPOCH_S && epoch_s < MAX_VALID_EPOCH_S; }
+static bool epoch_is_sane(uint32_t epoch_s) { return crash_epoch_is_sane(epoch_s); }
 
 static std::string base64_encode_bytes_(const uint8_t* data, size_t length) {
   static constexpr char TABLE[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -79,43 +77,10 @@ static bool header_matches_host_(const std::string& header_value, const std::str
 }
 
 #ifdef USE_ESP32_CRASH_HANDLER
-static constexpr uint32_t CRASH_TIME_BREADCRUMB_MAGIC = 0x4F514348UL;  // OQCH
-static constexpr uint16_t CRASH_TIME_BREADCRUMB_VERSION = 1;
 static constexpr uint32_t CRASH_TIME_BREADCRUMB_UPDATE_INTERVAL_MS = 15000UL;
 static constexpr uint32_t CRASH_REPORT_WAIT_TIMEOUT_MS = 120000UL;
 
-struct CrashTimeBreadcrumb {
-  uint32_t magic;
-  uint16_t version;
-  uint16_t reserved;
-  uint32_t epoch_s;
-  uint32_t uptime_s;
-  uint32_t sequence;
-  uint32_t crc;
-};
-
 RTC_NOINIT_ATTR static CrashTimeBreadcrumb crash_time_breadcrumb;
-
-static uint32_t fnv1a32(const void* data, size_t len) {
-  const auto* bytes = static_cast<const uint8_t*>(data);
-  uint32_t hash = 2166136261UL;
-  for (size_t index = 0; index < len; ++index) {
-    hash ^= bytes[index];
-    hash *= 16777619UL;
-  }
-  return hash;
-}
-
-static uint32_t crash_time_breadcrumb_crc(const CrashTimeBreadcrumb& breadcrumb) {
-  CrashTimeBreadcrumb copy = breadcrumb;
-  copy.crc = 0;
-  return fnv1a32(&copy, sizeof(copy));
-}
-
-static bool crash_time_breadcrumb_is_valid(const CrashTimeBreadcrumb& breadcrumb) {
-  return breadcrumb.magic == CRASH_TIME_BREADCRUMB_MAGIC && breadcrumb.version == CRASH_TIME_BREADCRUMB_VERSION &&
-         epoch_is_sane(breadcrumb.epoch_s) && breadcrumb.crc == crash_time_breadcrumb_crc(breadcrumb);
-}
 
 static const char* reset_reason_to_string(esp_reset_reason_t reason) {
   switch (reason) {
@@ -353,6 +318,24 @@ class OpenQuattLogHistoryRequestHandler : public AsyncWebHandler {
 
 }  // namespace
 
+#ifdef USE_ESP32_CRASH_HANDLER
+bool read_crash_time_breadcrumb(CrashTimeBreadcrumbSnapshot* snapshot) {
+  if (snapshot == nullptr) return false;
+  const CrashTimeBreadcrumb copy = crash_time_breadcrumb;
+  if (!crash_time_breadcrumb_is_valid(copy)) return false;
+  snapshot->epoch_s = copy.epoch_s;
+  snapshot->uptime_s = copy.uptime_s;
+  snapshot->sequence = copy.sequence;
+  return true;
+}
+
+void invalidate_crash_time_breadcrumb() {
+  // Invalidate the aligned marker so a reset during cleanup fails closed instead
+  // of exposing a stale timestamp from an earlier normal boot.
+  crash_time_breadcrumb.magic = 0U;
+}
+#endif
+
 float OpenQuattLogHistory::get_setup_priority() const { return setup_priority::WIFI; }
 
 bool OpenQuattLogHistory::capture_enabled_() const { return this->enabled_ && this->entries_; }
@@ -562,14 +545,13 @@ void OpenQuattLogHistory::load_crash_time_breadcrumb_() {
   this->pending_crash_uptime_s_ = 0;
   this->pending_crash_breadcrumb_sequence_ = 0;
 
-  if (!crash_time_breadcrumb_is_valid(crash_time_breadcrumb)) {
-    return;
-  }
+  CrashTimeBreadcrumbSnapshot snapshot{};
+  if (!read_crash_time_breadcrumb(&snapshot)) return;
 
   this->pending_crash_breadcrumb_valid_ = true;
-  this->pending_crash_epoch_s_ = crash_time_breadcrumb.epoch_s;
-  this->pending_crash_uptime_s_ = crash_time_breadcrumb.uptime_s;
-  this->pending_crash_breadcrumb_sequence_ = crash_time_breadcrumb.sequence;
+  this->pending_crash_epoch_s_ = snapshot.epoch_s;
+  this->pending_crash_uptime_s_ = snapshot.uptime_s;
+  this->pending_crash_breadcrumb_sequence_ = snapshot.sequence;
 }
 
 void OpenQuattLogHistory::update_crash_time_breadcrumb_() {
@@ -591,7 +573,7 @@ void OpenQuattLogHistory::update_crash_time_breadcrumb_() {
   next.epoch_s = static_cast<uint32_t>(now.timestamp);
   next.uptime_s = now_ms / 1000UL;
   next.sequence = crash_time_breadcrumb_is_valid(crash_time_breadcrumb) ? (crash_time_breadcrumb.sequence + 1) : 1;
-  next.crc = crash_time_breadcrumb_crc(next);
+  next.crc = crash_time_breadcrumb_checksum(next);
   crash_time_breadcrumb = next;
   this->last_crash_breadcrumb_update_ms_ = now_ms;
 }
@@ -700,6 +682,16 @@ bool OpenQuattLogHistory::lock_history_() const {
 void OpenQuattLogHistory::unlock_history_() const { xSemaphoreGive(this->history_mutex_); }
 
 void OpenQuattLogHistory::setup() {
+#ifdef USE_ESP32_CRASH_HANDLER
+  this->load_crash_time_breadcrumb_();
+  this->pending_crash_report_ = esp32::crash_handler_has_data();
+  this->pending_crash_report_since_ms_ = millis();
+  if (!this->pending_crash_report_) {
+    invalidate_crash_time_breadcrumb();
+    this->pending_crash_breadcrumb_valid_ = false;
+  }
+#endif
+
   if (logger::global_logger == nullptr) {
     ESP_LOGE(TAG, "global_logger is unavailable");
     return;
@@ -727,12 +719,6 @@ void OpenQuattLogHistory::setup() {
       this, [](void* self, uint8_t level, const char* tag, const char* message, size_t message_len) {
         static_cast<OpenQuattLogHistory*>(self)->on_log_(level, tag, message, message_len);
       });
-
-#ifdef USE_ESP32_CRASH_HANDLER
-  this->load_crash_time_breadcrumb_();
-  this->pending_crash_report_ = esp32::crash_handler_has_data();
-  this->pending_crash_report_since_ms_ = millis();
-#endif
 
   web_server_base::global_web_server_base->add_handler(new OpenQuattLogHistoryRequestHandler(this));
   this->sync_time_state_();

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -12,6 +12,7 @@
 #ifdef USE_ESP32_CRASH_HANDLER
 #include <esp_attr.h>
 #include <esp_system.h>
+#include <esp_timer.h>
 
 #include "esphome/components/esp32/crash_handler.h"
 #endif
@@ -81,6 +82,7 @@ static constexpr uint32_t CRASH_TIME_BREADCRUMB_UPDATE_INTERVAL_MS = 15000UL;
 static constexpr uint32_t CRASH_REPORT_WAIT_TIMEOUT_MS = 120000UL;
 
 RTC_NOINIT_ATTR static CrashTimeBreadcrumb crash_time_breadcrumb;
+static CrashTimeBreadcrumbBootCache crash_time_breadcrumb_boot_cache;
 
 static const char* reset_reason_to_string(esp_reset_reason_t reason) {
   switch (reason) {
@@ -319,20 +321,14 @@ class OpenQuattLogHistoryRequestHandler : public AsyncWebHandler {
 }  // namespace
 
 #ifdef USE_ESP32_CRASH_HANDLER
-bool read_crash_time_breadcrumb(CrashTimeBreadcrumbSnapshot* snapshot) {
-  if (snapshot == nullptr) return false;
-  const CrashTimeBreadcrumb copy = crash_time_breadcrumb;
-  if (!crash_time_breadcrumb_is_valid(copy)) return false;
-  snapshot->epoch_s = copy.epoch_s;
-  snapshot->uptime_s = copy.uptime_s;
-  snapshot->sequence = copy.sequence;
-  return true;
+bool consume_crash_time_breadcrumb(CrashTimeBreadcrumbSnapshot* snapshot) {
+  return consume_crash_time_breadcrumb_state(&crash_time_breadcrumb, &crash_time_breadcrumb_boot_cache, snapshot);
 }
 
 void invalidate_crash_time_breadcrumb() {
   // Invalidate the aligned marker so a reset during cleanup fails closed instead
   // of exposing a stale timestamp from an earlier normal boot.
-  crash_time_breadcrumb.magic = 0U;
+  invalidate_crash_time_breadcrumb_state(&crash_time_breadcrumb, &crash_time_breadcrumb_boot_cache);
 }
 #endif
 
@@ -546,7 +542,7 @@ void OpenQuattLogHistory::load_crash_time_breadcrumb_() {
   this->pending_crash_breadcrumb_sequence_ = 0;
 
   CrashTimeBreadcrumbSnapshot snapshot{};
-  if (!read_crash_time_breadcrumb(&snapshot)) return;
+  if (!consume_crash_time_breadcrumb(&snapshot)) return;
 
   this->pending_crash_breadcrumb_valid_ = true;
   this->pending_crash_epoch_s_ = snapshot.epoch_s;
@@ -571,7 +567,7 @@ void OpenQuattLogHistory::update_crash_time_breadcrumb_() {
   next.version = CRASH_TIME_BREADCRUMB_VERSION;
   next.reserved = 0;
   next.epoch_s = static_cast<uint32_t>(now.timestamp);
-  next.uptime_s = now_ms / 1000UL;
+  next.uptime_s = crash_uptime_seconds_from_microseconds(static_cast<uint64_t>(esp_timer_get_time()));
   next.sequence = crash_time_breadcrumb_is_valid(crash_time_breadcrumb) ? (crash_time_breadcrumb.sequence + 1) : 1;
   next.crc = crash_time_breadcrumb_checksum(next);
   crash_time_breadcrumb = next;

--- a/docs/crash-telemetry.md
+++ b/docs/crash-telemetry.md
@@ -1,15 +1,17 @@
-# Retained crashtelemetrie
+# Crashtelemetrie
 
 Wanneer gebruiksstatistieken zijn ingeschakeld, bewaart OpenQuatt na een echte
 ESP32/ESPHome-crash één begrensd technisch crashrapport. Dit rapport wordt na de
-herstart met QoS 1 en retain gepubliceerd op:
+herstart met QoS 1 en zonder retain gepubliceerd op:
 
 ```text
 <usage_telemetry_topic>/<installation-id>/crash
 ```
 
-Het topic representeert bewust alleen de laatste crash. Een volgende crash
-vervangt de vorige retained waarde. Er is geen crashqueue.
+Na een MQTT PUBACK wordt de lokale crashkopie gewist. Tot dat moment blijft het
+begrensde record in flash beschikbaar voor een retry. MQTT QoS 1 kan dezelfde
+crash opnieuw afleveren wanneer een acknowledgement verloren gaat. Een ontvanger
+moet daarom dedupliceren op de combinatie van `installation_id` en `message_id`.
 
 De payload bevat geen gewone runtime-logs, metingen of regelwaarden. Wel bevat
 hij de regels uit het ESPHome-crashrapport, het resettype, firmwareversie,
@@ -17,6 +19,22 @@ releasekanaal, ESPHome-versie, bronrepository, volledige commit-SHA, exact
 buildtarget, release-manifest-URL indien van toepassing, hardwareprofiel,
 topologie, verbinding, buildtijd en de volledige ELF-SHA256 van de firmware die
 het rapport verstuurt.
+
+De tijdvelden hebben bewust verschillende betekenissen:
+
+- `crash_timestamp` is de laatste geldige UTC Unix-tijd die vóór de reset in een
+  RTC-breadcrumb is vastgelegd. Deze wordt normaal iedere 15 seconden vernieuwd,
+  maar kan bij een vastgelopen controllerloop ouder zijn. Het veld is `null`
+  wanneer geen geldige breadcrumb beschikbaar is.
+- `crash_uptime_s` is de uptime die bij dezelfde breadcrumb hoorde en is eveneens
+  `null` wanneer de breadcrumb ontbreekt.
+- `reported_at` is de geldige UTC Unix-tijd waarop de MQTT-payload na de herstart
+  is opgebouwd. Dit veld is `null` wanneer de controllerklok nog niet geldig is.
+- `reporting_build_epoch` is uitsluitend de compileertijd van de rapporterende
+  firmware en mag niet als crash- of ontvangsttijd worden gebruikt.
+
+Een server-`received_at` kan bij retries of een opnieuw afgeleverde MQTT-message
+veranderen en is daarom evenmin het crashmoment.
 
 ESPHome geeft in zijn replay aan wanneer de adressen bij een andere firmwarebuild
 horen. In dat geval staat `captured_by_reporting_build` op `false` en mogen de
@@ -29,15 +47,17 @@ Gebruik dit ELF uitsluitend wanneer zijn SHA256 exact gelijk is aan
 `reporting_build_id`. De firmware bewaart of publiceert niet standaard bij
 iedere build een ELF-bestand.
 
-Na een MQTT PUBACK wordt de lokale crashkopie gewist. Tot dat moment blijft het
-begrensde record in flash beschikbaar voor een retry. Bij opt-out bewaart
-OpenQuatt alleen een kleine pending-tombstone status en publiceert het een lege
-retained payload zodra de broker bereikbaar is.
+Bij opt-out bewaart OpenQuatt alleen een kleine pending-tombstone status en
+publiceert het een lege retained payload zodra de broker bereikbaar is. Deze
+tombstone verwijdert ook crashwaarden die door oudere firmware retained zijn
+gepubliceerd; gewone crashberichten zijn niet retained. Alleen een firmware-
+upgrade verstuurt geen opruimtombstone; bestaande retained waarden worden
+server-side afgehandeld.
 
 ## Bewuste begrenzingen van deze eerste versie
 
-- Er wordt één crash bewaard; een nieuwere crash vervangt een nog niet
-  verwerkte oudere crash.
+- Er wordt lokaal één crash bewaard; een nieuwere crash vervangt een nog niet
+  gepubliceerde oudere crash.
 - Een pending tombstone gebruikt de op dat moment geconfigureerde broker en
   topicbasis. Migratie over meerdere oude endpoints valt buiten deze versie.
 - De opgenomen buildvelden maken een gerichte rebuild en SHA-controle mogelijk,

--- a/openquatt/oq_usage_telemetry.yaml
+++ b/openquatt/oq_usage_telemetry.yaml
@@ -76,6 +76,7 @@ openquatt_crash_telemetry:
   usage_switch: oq_usage_telemetry
   installation_id_sensor: oq_usage_telemetry_installation_id
   setup_complete_sensor: oq_setup_complete_sensor
+  clock: oq_time
   source_repository: "${build_source_repository}"
   source_commit: "${build_source_commit}"
   build_target: "${build_target}"

--- a/tests/host/openquatt_crash_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_crash_telemetry_policy_test.cpp
@@ -3,6 +3,7 @@
 #include "components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h"
 
 using esphome::openquatt_crash_telemetry::crash_data_may_be_published;
+using esphome::openquatt_crash_telemetry::crash_publication_is_retained;
 using esphome::openquatt_crash_telemetry::CrashPublishKind;
 using esphome::openquatt_crash_telemetry::flash_sequence_is_newer;
 using esphome::openquatt_crash_telemetry::persisted_consent_blocks_crash;
@@ -38,5 +39,10 @@ int main() {
   assert(!crash_data_may_be_published(CrashPublishKind::CRASH, true, false));
   assert(crash_data_may_be_published(CrashPublishKind::TOMBSTONE, false, false));
   assert(!crash_data_may_be_published(CrashPublishKind::NONE, true, true));
+
+  assert(!crash_publication_is_retained(CrashPublishKind::CRASH));
+  assert(crash_publication_is_retained(CrashPublishKind::TOMBSTONE));
+  assert(!crash_publication_is_retained(CrashPublishKind::NONE));
+
   return 0;
 }

--- a/tests/host/openquatt_crash_telemetry_record_test.cpp
+++ b/tests/host/openquatt_crash_telemetry_record_test.cpp
@@ -1,0 +1,133 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "components/openquatt_crash_telemetry/OpenQuattCrashTelemetryRecord.h"
+#include "components/openquatt_log_history/OpenQuattCrashTimeBreadcrumb.h"
+
+using esphome::openquatt_crash_telemetry::detail::crash_record_checksum;
+using esphome::openquatt_crash_telemetry::detail::CRASH_RECORD_MAGIC;
+using esphome::openquatt_crash_telemetry::detail::CRASH_RECORD_VERSION;
+using esphome::openquatt_crash_telemetry::detail::CRASH_REPORT_CAPACITY;
+using esphome::openquatt_crash_telemetry::detail::CrashRecord;
+using esphome::openquatt_crash_telemetry::detail::LEGACY_CRASH_REPORT_CAPACITY;
+using esphome::openquatt_crash_telemetry::detail::migrate_crash_record;
+using esphome::openquatt_crash_telemetry::detail::valid_stored_crash_record;
+using esphome::openquatt_log_history::crash_time_breadcrumb_checksum;
+using esphome::openquatt_log_history::crash_time_breadcrumb_is_valid;
+using esphome::openquatt_log_history::CRASH_TIME_BREADCRUMB_MAGIC;
+using esphome::openquatt_log_history::CRASH_TIME_BREADCRUMB_VERSION;
+using esphome::openquatt_log_history::CrashTimeBreadcrumb;
+using esphome::openquatt_log_history::MAX_VALID_CRASH_EPOCH_S;
+using esphome::openquatt_log_history::MIN_VALID_CRASH_EPOCH_S;
+
+namespace {
+
+struct LegacyCrashRecord {
+  uint32_t magic;
+  uint16_t version;
+  uint8_t pending;
+  uint8_t truncated;
+  uint8_t captured_by_reporting_build;
+  uint8_t reserved[3];
+  uint16_t report_length;
+  uint16_t reserved2;
+  uint32_t sequence;
+  uint32_t build_epoch;
+  uint32_t config_hash;
+  uint32_t reset_reason;
+  char crash_id[37];
+  char build_id[65];
+  char source_repository[98];
+  char source_commit[41];
+  char build_target[97];
+  char release_manifest_url[257];
+  char firmware_version[33];
+  char release_channel[17];
+  char esphome_version[17];
+  char hardware_profile[33];
+  char topology[17];
+  char connection[17];
+  char report[LEGACY_CRASH_REPORT_CAPACITY];
+  uint32_t checksum;
+};
+
+static_assert(sizeof(LegacyCrashRecord) == sizeof(CrashRecord));
+static_assert(offsetof(LegacyCrashRecord, report) == offsetof(CrashRecord, report));
+static_assert(offsetof(LegacyCrashRecord, checksum) == offsetof(CrashRecord, checksum));
+
+void finalize_record(CrashRecord* record) {
+  record->checksum = 0U;
+  record->checksum = crash_record_checksum(record, offsetof(CrashRecord, checksum));
+}
+
+CrashTimeBreadcrumb make_breadcrumb(uint32_t epoch_s) {
+  CrashTimeBreadcrumb breadcrumb{};
+  breadcrumb.magic = CRASH_TIME_BREADCRUMB_MAGIC;
+  breadcrumb.version = CRASH_TIME_BREADCRUMB_VERSION;
+  breadcrumb.epoch_s = epoch_s;
+  breadcrumb.uptime_s = 123U;
+  breadcrumb.sequence = 7U;
+  breadcrumb.crc = crash_time_breadcrumb_checksum(breadcrumb);
+  return breadcrumb;
+}
+
+}  // namespace
+
+int main() {
+  CrashTimeBreadcrumb breadcrumb = make_breadcrumb(MIN_VALID_CRASH_EPOCH_S);
+  assert(crash_time_breadcrumb_is_valid(breadcrumb));
+  breadcrumb.uptime_s++;
+  assert(!crash_time_breadcrumb_is_valid(breadcrumb));
+  assert(!crash_time_breadcrumb_is_valid(make_breadcrumb(MIN_VALID_CRASH_EPOCH_S - 1U)));
+  assert(!crash_time_breadcrumb_is_valid(make_breadcrumb(MAX_VALID_CRASH_EPOCH_S)));
+
+  CrashRecord current{};
+  current.magic = CRASH_RECORD_MAGIC;
+  current.version = CRASH_RECORD_VERSION;
+  current.pending = 1U;
+  current.captured_by_reporting_build = 1U;
+  current.crash_time_valid = 1U;
+  current.report_length = 4U;
+  current.sequence = 5U;
+  current.crash_timestamp = MIN_VALID_CRASH_EPOCH_S;
+  current.crash_uptime_s = 16U;
+  std::memcpy(current.report, "test", 5U);
+  finalize_record(&current);
+  assert(valid_stored_crash_record(current));
+  assert(migrate_crash_record(&current));
+  assert(current.crash_timestamp == MIN_VALID_CRASH_EPOCH_S);
+  LegacyCrashRecord rollback_record{};
+  std::memcpy(&rollback_record, &current, sizeof(current));
+  assert(rollback_record.version == CRASH_RECORD_VERSION);
+  assert(rollback_record.report_length < LEGACY_CRASH_REPORT_CAPACITY);
+  assert(rollback_record.report[rollback_record.report_length] == '\0');
+  assert(rollback_record.checksum == crash_record_checksum(&rollback_record, offsetof(LegacyCrashRecord, checksum)));
+
+  CrashRecord legacy{};
+  legacy.magic = CRASH_RECORD_MAGIC;
+  legacy.version = CRASH_RECORD_VERSION;
+  legacy.pending = 1U;
+  legacy.captured_by_reporting_build = 1U;
+  legacy.report_length = LEGACY_CRASH_REPORT_CAPACITY - 1U;
+  legacy.sequence = 9U;
+  auto* legacy_bytes = reinterpret_cast<uint8_t*>(&legacy);
+  std::memset(legacy_bytes + offsetof(CrashRecord, report), 'x', LEGACY_CRASH_REPORT_CAPACITY);
+  legacy_bytes[offsetof(CrashRecord, report) + legacy.report_length] = '\0';
+  finalize_record(&legacy);
+  assert(valid_stored_crash_record(legacy));
+  assert(migrate_crash_record(&legacy));
+  assert(legacy.version == CRASH_RECORD_VERSION);
+  assert(legacy.report_length == CRASH_REPORT_CAPACITY - 1U);
+  assert(legacy.report[legacy.report_length] == '\0');
+  assert(legacy.truncated == 1U);
+  assert(legacy.crash_time_valid == 0U);
+  assert(legacy.crash_timestamp == 0U);
+  assert(legacy.crash_uptime_s == 0U);
+  assert(valid_stored_crash_record(legacy));
+
+  legacy.checksum++;
+  assert(!valid_stored_crash_record(legacy));
+  return 0;
+}

--- a/tests/host/openquatt_crash_telemetry_record_test.cpp
+++ b/tests/host/openquatt_crash_telemetry_record_test.cpp
@@ -14,11 +14,15 @@ using esphome::openquatt_crash_telemetry::detail::CrashRecord;
 using esphome::openquatt_crash_telemetry::detail::LEGACY_CRASH_REPORT_CAPACITY;
 using esphome::openquatt_crash_telemetry::detail::migrate_crash_record;
 using esphome::openquatt_crash_telemetry::detail::valid_stored_crash_record;
+using esphome::openquatt_log_history::consume_crash_time_breadcrumb_state;
 using esphome::openquatt_log_history::crash_time_breadcrumb_checksum;
 using esphome::openquatt_log_history::crash_time_breadcrumb_is_valid;
 using esphome::openquatt_log_history::CRASH_TIME_BREADCRUMB_MAGIC;
 using esphome::openquatt_log_history::CRASH_TIME_BREADCRUMB_VERSION;
+using esphome::openquatt_log_history::crash_uptime_seconds_from_microseconds;
 using esphome::openquatt_log_history::CrashTimeBreadcrumb;
+using esphome::openquatt_log_history::CrashTimeBreadcrumbBootCache;
+using esphome::openquatt_log_history::CrashTimeBreadcrumbSnapshot;
 using esphome::openquatt_log_history::MAX_VALID_CRASH_EPOCH_S;
 using esphome::openquatt_log_history::MIN_VALID_CRASH_EPOCH_S;
 
@@ -82,6 +86,19 @@ int main() {
   assert(!crash_time_breadcrumb_is_valid(breadcrumb));
   assert(!crash_time_breadcrumb_is_valid(make_breadcrumb(MIN_VALID_CRASH_EPOCH_S - 1U)));
   assert(!crash_time_breadcrumb_is_valid(make_breadcrumb(MAX_VALID_CRASH_EPOCH_S)));
+  assert(crash_uptime_seconds_from_microseconds(4294967296000ULL) == 4294967U);
+
+  CrashTimeBreadcrumb retained = make_breadcrumb(MIN_VALID_CRASH_EPOCH_S);
+  CrashTimeBreadcrumbBootCache boot_cache{};
+  CrashTimeBreadcrumbSnapshot first_consumer{};
+  CrashTimeBreadcrumbSnapshot second_consumer{};
+  assert(consume_crash_time_breadcrumb_state(&retained, &boot_cache, &first_consumer));
+  assert(retained.magic == 0U);
+  assert(consume_crash_time_breadcrumb_state(&retained, &boot_cache, &second_consumer));
+  assert(std::memcmp(&first_consumer, &second_consumer, sizeof(first_consumer)) == 0);
+  CrashTimeBreadcrumbBootCache next_boot_cache{};
+  CrashTimeBreadcrumbSnapshot next_boot_consumer{};
+  assert(!consume_crash_time_breadcrumb_state(&retained, &next_boot_cache, &next_boot_consumer));
 
   CrashRecord current{};
   current.magic = CRASH_RECORD_MAGIC;


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt `crash_timestamp`, `crash_uptime_s` en `reported_at` toe aan crashtelemetrie.
- Publiceert nieuwe crashberichten met QoS 1 en `retain=false`; de bestaande retained opt-out-tombstone blijft ongewijzigd.
- Behoudt flash-layout en recordversie, zodat pending records uit PR #517 én OTA-rollback naar die firmware leesbaar blijven.
- Gebruikt `esp_timer_get_time()` voor niet-wrappende bootuptime en consumeert de RTC-breadcrumb één keer per boot, met een gewone-RAM kopie voor crashtelemetrie en logboek.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen crashtelemetrie verandert. `crash_timestamp` en `crash_uptime_s` komen uit de laatste geldige RTC-breadcrumb vóór de reset; `reported_at` wordt na reboot uit de controllerklok bepaald. Ontbrekende of ongeldige tijden worden `null`. Gewone crashberichten zijn niet meer retained. Een firmware-upgrade verstuurt bewust geen automatische tombstone; bestaande retained waarden worden server-side afgehandeld.

## Achtergrond

Follow-up op #488 en PR #517. Ontvangsttijd is geen betrouwbare crashtijd en QoS 1 kan hetzelfde `message_id` opnieuw afleveren. Ontvangers moeten daarom dedupliceren op `(installation_id, message_id)`.

De complete diff is gecontroleerd op consent, retries/PUBACK-verlies, herstarts, stale/ongeldige RTC-breadcrumbs, vroege crashlussen, `millis()`-wrap, flash-write failures, bestaande pending records, fresh install, upgrade en OTA-rollback. De timestamp-uitbreiding gebruikt gereserveerde bytes in hetzelfde flash-record; lange legacyrapporten worden begrensd gemigreerd. De reviewfix consumeert eerst de RTC-marker zodat een reset tijdens de handoff fail-closed is, terwijl beide consumers in dezelfde boot dezelfde boot-lokale snapshot ontvangen.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/crash-telemetry.md` beschrijft de drie tijdsemantieken, nullable waarden, QoS 1-deduplicatie, `retain=false` en server-side afhandeling van bestaande retained waarden.

## Validatie

- [x] `npm run check:cpp-format`
- [x] `npm run check:python-contracts` — 79 tests
- [x] `./scripts/run_host_regression_tests.sh` — 37 tests, inclusief breadcrumb single-consumption en uptime voorbij de `millis()`-wrap
- [x] `esphome config configs/heatpump_controller_q/duo_wifi.yaml`
- [x] `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`
- [ ] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — wordt vóór targetvalidatie geblokkeerd door de bestaande, ongewijzigde style-fout in `openquatt/oq_HP_io.yaml:1121`.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe buffers of taken. De boot-lokale breadcrumbkopie gebruikt 16 bytes statische DRAM; het flashrecord houdt exact dezelfde omvang en checksum-offset. De Q Duo WiFi-build gebruikt 203663 / 341760 bytes DIRAM (59,59%) en de app-partitie houdt 60% vrij.
