### PR TITLE
Verwijder test-firmware-label na merge naar dev

### DIFF
--- a/.github/workflows/pr-test-firmware-publish.yml
+++ b/.github/workflows/pr-test-firmware-publish.yml
@@ -308,3 +308,34 @@ jobs:
             cat release-view.err >&2
             exit 1
           fi
+
+  remove-merged-pr-test-label:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name == 'pull_request_target' &&
+        github.event.action == 'closed' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.base.ref == 'dev' &&
+        contains(github.event.pull_request.labels.*.name, 'test-firmware')
+      }}
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove test-firmware label from merged PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api \
+            --method DELETE \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/test-firmware" \
+            --silent || true
+
+          PR_LABELS="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '.labels[].name')"
+          if grep -Fxq 'test-firmware' <<< "${PR_LABELS}"; then
+            echo "Failed to remove the test-firmware label from PR #${PR_NUMBER}." >&2
+            exit 1
+          fi

--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -79,6 +79,16 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
             PUBLISH_WORKFLOW,
         )
 
+    def test_test_firmware_label_is_removed_only_after_merge_to_dev(self) -> None:
+        self.assertIn("github.event.pull_request.merged == true", PUBLISH_WORKFLOW)
+        self.assertIn("github.event.pull_request.base.ref == 'dev'", PUBLISH_WORKFLOW)
+        self.assertIn("pull-requests: write", PUBLISH_WORKFLOW)
+        self.assertIn(
+            '"repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/test-firmware"',
+            PUBLISH_WORKFLOW,
+        )
+        self.assertIn("grep -Fxq 'test-firmware'", PUBLISH_WORKFLOW)
+
     def test_artifact_root_option_is_available(self) -> None:
         args = build_targets.create_parser().parse_args(
             [


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert automatisch het `test-firmware`-label wanneer een PR naar `dev` is gemergd.
- Laat gesloten, niet-gemergde PR's en merges naar andere doelbranches ongemoeid.
- Controleert na de delete opnieuw of het label daadwerkelijk verdwenen is.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de vertrouwde GitHub Actions-workflow voor PR-testfirmware verandert. De job krijgt uitsluitend `pull-requests: write` en voert geen code uit de PR uit.

## Achtergrond

De tijdelijke release en git-tag `pr-<nummer>` werden bij sluiten al verwijderd. Deze wijziging ruimt na een merge naar `dev` ook het activerende PR-label op. De operatie is idempotent: een gelijktijdig al verwijderd label geldt als succes, terwijl een label dat na de poging nog aanwezig is de job laat falen.

Pre-PR-audit: de volledige diff tegen `dev` is gecontroleerd op workflowrechten, onbetrouwbare input, merge- en branchvoorwaarden, racegedrag en foutafhandeling. Geen aanvullende bevindingen.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne repository-automatisering zonder gebruikersgerichte configuratie- of gedragswijziging.

## Validatie

- `python3 -m unittest scripts.tests.test_pr_test_firmware_workflows` — 9 tests geslaagd
- YAML-syntax van `.github/workflows/pr-test-firmware-publish.yml` gecontroleerd
- `git diff --check origin/dev...HEAD` — geslaagd
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; alleen GitHub Actions-automatisering verandert.
