### PR TITLE
Wacht op tijdsync voor crashrapportage

### DIFF
--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
@@ -222,6 +222,12 @@ bool OpenQuattCrashTelemetry::save_state_() {
 }
 
 void OpenQuattCrashTelemetry::setup() {
+  this->time_sync_deadline_ms_ = millis() + TIME_SYNC_WAIT_MS;
+  if (this->clock_ != nullptr) {
+    // A sane epoch may be stale RTC state. Only a sync event proves that the
+    // reporting clock was refreshed during this boot.
+    this->clock_->add_on_time_sync_callback([this]() { this->on_time_synchronized_(); });
+  }
   this->gate_mutex_ = xSemaphoreCreateMutexStatic(&this->gate_mutex_storage_);
   if (this->gate_mutex_ == nullptr) {
     ESP_LOGE(TAG, "Could not initialize crash telemetry publish gate");
@@ -394,6 +400,12 @@ void OpenQuattCrashTelemetry::on_setup_complete_(bool complete) {
   if (complete && this->consent_enabled_.load() && this->record_ && this->record_.data()->pending != 0U) {
     this->next_attempt_ms_ = millis() + INITIAL_PUBLISH_DELAY_MS;
   }
+}
+
+void OpenQuattCrashTelemetry::on_time_synchronized_() {
+  // Keep the existing initial delay or transport retry backoff intact. Once its
+  // deadline passes, loop() observes this flag and can publish immediately.
+  this->time_synchronized_.store(true);
 }
 
 void OpenQuattCrashTelemetry::on_consent_state_(bool enabled) {

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
@@ -64,6 +64,7 @@ class OpenQuattCrashTelemetry : public Component {
   static constexpr uint32_t SESSION_TIMEOUT_MS = 30000UL;
   static constexpr uint32_t INITIAL_RETRY_MS = 5UL * 60UL * 1000UL;
   static constexpr uint32_t INITIAL_PUBLISH_DELAY_MS = 15000UL;
+  static constexpr uint32_t TIME_SYNC_WAIT_MS = 60000UL;
   static constexpr int MQTT_TASK_STACK_SIZE = 12288;
 
   using CrashRecord = detail::CrashRecord;
@@ -86,6 +87,7 @@ class OpenQuattCrashTelemetry : public Component {
   void on_consent_state_(bool enabled);
   void on_installation_id_(const std::string& installation_id);
   void on_setup_complete_(bool complete);
+  void on_time_synchronized_();
 
   bool load_record_();
   bool save_record_();
@@ -146,10 +148,12 @@ class OpenQuattCrashTelemetry : public Component {
   bool capture_active_{false};
   std::atomic<bool> setup_complete_{false};
   std::atomic<bool> consent_enabled_{false};
+  std::atomic<bool> time_synchronized_{false};
   bool consent_seen_{false};
   bool record_loaded_{false};
   bool state_loaded_{false};
   uint32_t next_attempt_ms_{0U};
+  uint32_t time_sync_deadline_ms_{0U};
   uint32_t session_started_ms_{0U};
   uint8_t cleanup_attempts_{0U};
 

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
@@ -43,9 +43,16 @@ bool OpenQuattCrashTelemetry::build_crash_payload_() {
   if (this->clock_ != nullptr) {
     const auto now = this->clock_->now();
     const int64_t timestamp = static_cast<int64_t>(now.timestamp);
-    if (now.is_valid() && timestamp >= static_cast<int64_t>(openquatt_log_history::MIN_VALID_CRASH_EPOCH_S) &&
-        timestamp < static_cast<int64_t>(openquatt_log_history::MAX_VALID_CRASH_EPOCH_S)) {
-      reported_at = static_cast<uint32_t>(timestamp);
+    const bool timestamp_is_sane = now.is_valid() &&
+                                   timestamp >= static_cast<int64_t>(openquatt_log_history::MIN_VALID_CRASH_EPOCH_S) &&
+                                   timestamp < static_cast<int64_t>(openquatt_log_history::MAX_VALID_CRASH_EPOCH_S);
+    const uint32_t candidate = timestamp_is_sane ? static_cast<uint32_t>(timestamp) : 0U;
+    if (reported_at_is_usable(this->time_synchronized_.load(), timestamp_is_sane, record.crash_time_valid != 0U,
+                              candidate, record.crash_timestamp)) {
+      reported_at = candidate;
+    } else if (this->time_synchronized_.load() && timestamp_is_sane && record.crash_time_valid != 0U &&
+               candidate < record.crash_timestamp) {
+      ESP_LOGW(TAG, "Synchronized reporting time predates crash breadcrumb; omitting reported_at");
     }
   }
   FixedWriter writer(this->payload_buffer_.data(), this->payload_buffer_.size());
@@ -256,6 +263,7 @@ void OpenQuattCrashTelemetry::loop() {
   if (kind == CrashPublishKind::NONE || !valid_installation_id(this->state_.data()->installation_id)) return;
   if (this->next_attempt_ms_ == 0U) this->next_attempt_ms_ = millis() + INITIAL_PUBLISH_DELAY_MS;
   if (static_cast<int32_t>(millis() - this->next_attempt_ms_) < 0) return;
+  if (should_wait_for_time_sync(kind, this->time_synchronized_.load(), millis(), this->time_sync_deadline_ms_)) return;
   if (!this->start_session_(kind)) this->schedule_retry_();
 }
 
@@ -265,6 +273,7 @@ void OpenQuattCrashTelemetry::dump_config() {
   ESP_LOGCONFIG(TAG, "  Pending crash: %s", YESNO(this->record_ && this->record_.data()->pending != 0U));
   ESP_LOGCONFIG(TAG, "  Tombstone pending: %s", YESNO(this->state_ && this->state_.data()->tombstone_pending != 0U));
   ESP_LOGCONFIG(TAG, "  Consent observed: %s", YESNO(this->consent_seen_));
+  ESP_LOGCONFIG(TAG, "  Time synchronized this boot: %s", YESNO(this->time_synchronized_.load()));
 }
 
 void OpenQuattCrashTelemetry::mqtt_event_handler_(void* handler_args, esp_event_base_t base, int32_t event_id,

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
@@ -45,4 +45,14 @@ inline constexpr bool crash_publication_is_retained(CrashPublishKind kind) {
   return kind == CrashPublishKind::TOMBSTONE;
 }
 
+inline constexpr bool should_wait_for_time_sync(CrashPublishKind kind, bool time_synchronized, uint32_t now_ms,
+                                                uint32_t deadline_ms) {
+  return kind == CrashPublishKind::CRASH && !time_synchronized && static_cast<int32_t>(now_ms - deadline_ms) < 0;
+}
+
+inline constexpr bool reported_at_is_usable(bool time_synchronized, bool timestamp_is_sane, bool crash_time_valid,
+                                            uint32_t reported_at, uint32_t crash_timestamp) {
+  return time_synchronized && timestamp_is_sane && (!crash_time_valid || reported_at >= crash_timestamp);
+}
+
 }  // namespace esphome::openquatt_crash_telemetry

--- a/docs/crash-telemetry.md
+++ b/docs/crash-telemetry.md
@@ -29,7 +29,9 @@ De tijdvelden hebben bewust verschillende betekenissen:
 - `crash_uptime_s` is de uptime die bij dezelfde breadcrumb hoorde en is eveneens
   `null` wanneer de breadcrumb ontbreekt.
 - `reported_at` is de geldige UTC Unix-tijd waarop de MQTT-payload na de herstart
-  is opgebouwd. Dit veld is `null` wanneer de controllerklok nog niet geldig is.
+  is opgebouwd. OpenQuatt wacht hiervoor maximaal 60 seconden op een tijdsync
+  tijdens de huidige boot. Het veld is `null` zonder zo'n sync of wanneer de
+  gesynchroniseerde tijd vóór `crash_timestamp` ligt.
 - `reporting_build_epoch` is uitsluitend de compileertijd van de rapporterende
   firmware en mag niet als crash- of ontvangsttijd worden gebruikt.
 

--- a/tests/host/openquatt_crash_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_crash_telemetry_policy_test.cpp
@@ -7,8 +7,10 @@ using esphome::openquatt_crash_telemetry::crash_publication_is_retained;
 using esphome::openquatt_crash_telemetry::CrashPublishKind;
 using esphome::openquatt_crash_telemetry::flash_sequence_is_newer;
 using esphome::openquatt_crash_telemetry::persisted_consent_blocks_crash;
+using esphome::openquatt_crash_telemetry::reported_at_is_usable;
 using esphome::openquatt_crash_telemetry::select_crash_publish_kind;
 using esphome::openquatt_crash_telemetry::should_request_tombstone;
+using esphome::openquatt_crash_telemetry::should_wait_for_time_sync;
 
 int main() {
   assert(select_crash_publish_kind(true, false, false, false) == CrashPublishKind::TOMBSTONE);
@@ -43,6 +45,20 @@ int main() {
   assert(!crash_publication_is_retained(CrashPublishKind::CRASH));
   assert(crash_publication_is_retained(CrashPublishKind::TOMBSTONE));
   assert(!crash_publication_is_retained(CrashPublishKind::NONE));
+
+  assert(should_wait_for_time_sync(CrashPublishKind::CRASH, false, 100U, 200U));
+  assert(!should_wait_for_time_sync(CrashPublishKind::CRASH, true, 100U, 200U));
+  assert(!should_wait_for_time_sync(CrashPublishKind::TOMBSTONE, false, 100U, 200U));
+  assert(!should_wait_for_time_sync(CrashPublishKind::CRASH, false, 200U, 200U));
+  assert(!should_wait_for_time_sync(CrashPublishKind::CRASH, false, 201U, 200U));
+  assert(should_wait_for_time_sync(CrashPublishKind::CRASH, false, UINT32_MAX - 10U, 20U));
+
+  assert(reported_at_is_usable(true, true, false, 200U, 0U));
+  assert(reported_at_is_usable(true, true, true, 200U, 200U));
+  assert(reported_at_is_usable(true, true, true, 201U, 200U));
+  assert(!reported_at_is_usable(false, true, true, 201U, 200U));
+  assert(!reported_at_is_usable(true, false, true, 201U, 200U));
+  assert(!reported_at_is_usable(true, true, true, 199U, 200U));
 
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Wacht bij een pending crash maximaal 60 seconden op een tijdsync tijdens de huidige boot.
- Publiceert daarna ook zonder sync, maar dan met `reported_at: null`; een `reported_at` vóór `crash_timestamp` wordt eveneens geweigerd.
- Laat de bestaande startupdelay, MQTT-retrybackoff, consentgates en tombstone-afhandeling intact.

Aanvulling op #533 en #488.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de timing en validatie van crashpublicatie wijzigen. Er komt één callback op de bestaande realtimeklok bij en enkele bytes componentstatus; er komen geen buffers, taken of sockets bij. Reguliere usage telemetry en de regeltechniek wijzigen niet.

## Achtergrond

Een geldige epoch direct na reboot kan nog oude RTC-tijd zijn. Daardoor kon `reported_at` vóór `crash_timestamp` liggen. Alleen een tijdsync-event uit de huidige boot maakt `reported_at` nu bruikbaar.

De wachttijd is begrensd: zonder sync wordt het flashrecord na 60 seconden alsnog gepubliceerd met `reported_at: null`. Een transportfout houdt de bestaande retrybackoff; een sync-event verkort die backoff niet.

De volledige diff is gecontroleerd op consent/privacy, timing, retries, restarts, ontbrekende of achterlopende tijd, upgrades en fresh installs. Er is geen opslagmigratie. Een aparte cold review vond dat een sync-event aanvankelijk de startupdelay/retrybackoff kon overschrijven; dat is vóór publicatie hersteld.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/crash-telemetry.md` beschrijft de 60-secondenlimiet en wanneer `reported_at` null blijft.

## Validatie

- `./scripts/run_host_regression_tests.sh` — 37 hosttests groen, inclusief nieuwe sync/deadline/volgorde-cases.
- `npm run check:cpp-format` — groen.
- `npm run check:docs:contracts` — groen.
- `esphome config configs/heatpump_controller_q/duo_wifi.yaml` met ESPHome 2026.8.0 — geldig.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` met ESPHome 2026.8.0 — groen; image 2.109.959 bytes, DIRAM 204.063/341.760 bytes.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` stopt op de bestaande, ongerelateerde style-finding in `openquatt/oq_HP_io.yaml:1121`; directe configvalidatie en volledige compile zijn wel groen.

- Q Duo WiFi HIL op PR-head `a3cbe5c`: lokale crashknopfirmware gecompileerd en OTA geladen.
- Gecontroleerde `abort`-crash: MQTT-rapport ontvangen met `crash_timestamp=1787732329`, `crash_uptime_s=121` en `reported_at=1787732348` (`+19s`); lokale pendingstatus daarna `0`.
- Cold adversarial review na HIL: geen aanvullende bevindingen; time-syncwait, consent, retries, tombstones, reboot- en null-paden blijven begrensd.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen HIL-heapmeting voor deze kleine follow-up. De wijziging voegt geen nieuwe MQTT-client, taak, stack of payloadbuffer toe; alleen één callbackregistratie en kleine componentstatus. De representatieve firmwarecompile blijft op 59,71% DIRAM.