### PR TITLE
Maak de elektrische ingangsgrens instelbaar

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -53,11 +53,14 @@ Deze groep bepaalt hoeveel ruimte OpenQuatt krijgt:
 - `Silent Mode Override`
 - `Day max level`
 - `Silent max level`
+- `Electrical current limit`
 - `Silent start time`
 - `Silent end time`
 - `CM Override`
 
 Gebruik deze groep vooral om gedrag te begrenzen of te verklaren, niet om fijn te tunen.
+
+`Electrical current limit` begrenst het gezamenlijke elektrische ingangsvermogen. Standaard blijft de bestaande grens actief: 16 A voor Single en voor Duo V1/V1.5, 20 A voor Duo V2. Power House gebruikt de grens voorspellend én via gemeten feedback; stooklijn en koelen alleen via gemeten feedback. Het is een regelgrens en geen vervanging voor zekeringen, aardlekbeveiliging of load balancing.
 
 ### 2. Verwarmingsstrategie
 

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -172,6 +172,8 @@ Onder `Instellingen` staan de onderdelen bewust gescheiden. Het idee is: eerst d
 
 Hier staan basiskeuzes zoals Quatt Hybrid-versie, flowregeling, boiler- of CV-ondersteuning, stille uren, watergrenzen en compressorinstellingen.
 
+Bij `Elektrische ingangsgrens` kun je de gezamenlijke stroomgrens van de warmtepompinstallatie verlagen. De standaard blijft 16 A voor Single en Duo V1/V1.5 en 20 A voor Duo V2. Power House houdt er vooraf en via gemeten vermogen rekening mee; stooklijn en koelen alleen via gemeten vermogen. Deze instelling is een regelgrens, geen elektrische beveiliging.
+
 `Automatische ketelovername bij warmtepompstoring` is een aparte installatiekeuze en staat standaard uit. Als je deze inschakelt, mag OpenQuatt bij een bevestigde storing van alle geconfigureerde warmtepompen overschakelen naar CM4 en de cv-ketel de verwarmingsopdracht geven. OpenQuatt doet dit alleen nadat de warmtepompen veilig zijn gestopt en flow, aanvoertemperatuur en ketelaansturing geldig zijn. Een korte communicatiedip telt niet als bevestigde storing en vraagt geen actie of bevestiging van de gebruiker.
 
 Gebruik dit deel vooral tijdens de eerste inrichting of als je installatie later verandert.

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -119,6 +119,16 @@ globals:
     restore_value: false
     initial_value: '0'
 
+  - id: ${hp_id}_voltage_last_update_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+  - id: ${hp_id}_current_last_update_ms
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
   # Modbus controller online/offline
   - id: ${hp_id}_is_online
     type: bool
@@ -466,6 +476,10 @@ sensor:
           max_value: 300
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
+    on_value:
+      then:
+        - lambda: |-
+            id(${hp_id}_voltage_last_update_ms) = millis();
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
@@ -486,6 +500,10 @@ sensor:
           max_value: 16
           ignore_out_of_range: true
     skip_updates: ${oq_modbus_telemetry_skip}
+    on_value:
+      then:
+        - lambda: |-
+            id(${hp_id}_current_last_update_ms) = millis();
 
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -774,15 +774,10 @@ interval:
             if (P_target > cap_total) P_target = cap_total;
             if (P_target < 0.0f) P_target = 0.0f;
 
-            const float duo_current_limit_a =
-                (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2")
-                    ? ${oq_duo_current_limit_v2_a}
-                    : ${oq_duo_current_limit_v1_a};
-            const float mains_voltage_v = ${oq_mains_voltage_v};
             const int last1 = id(hp1_last_applied_level);
             const int last2 = id(${secondary_last_applied_level_id});
-            const float P_EL_SOFT_W = duo_current_limit_a * mains_voltage_v * (3400.0f / (16.0f * 230.0f));
-            const float P_EL_PEAK_W = duo_current_limit_a * mains_voltage_v * (3650.0f / (16.0f * 230.0f));
+            const float P_EL_SOFT_W = id(oq_power_limit_soft_w);
+            const float P_EL_PEAK_W = id(oq_power_limit_peak_w);
             const float thermal_tie_band_w = fmaxf(150.0f, 0.05f * fmaxf(P_target, 1000.0f));
             const float thermal_keep_margin_w = fminf(90.0f, thermal_tie_band_w * 0.5f);
             float topology_power_margin_w = ${oq_optimizer_topology_power_margin_w};
@@ -1100,9 +1095,8 @@ interval:
             float best_cost = 1e12f;
             int best_l1 = 0;
             const float W_change_penalty_per_step = 50.0f;
-            const float mains_voltage_v = ${oq_mains_voltage_v};
-            const float P_EL_SOFT_W = ${oq_duo_current_limit_v1_a} * mains_voltage_v * (3400.0f / (16.0f * 230.0f));
-            const float P_EL_PEAK_W = ${oq_duo_current_limit_v1_a} * mains_voltage_v * (3650.0f / (16.0f * 230.0f));
+            const float P_EL_SOFT_W = id(oq_power_limit_soft_w);
+            const float P_EL_PEAK_W = id(oq_power_limit_peak_w);
             const float W_el_over_soft_penalty_per_W = ${oq_optimizer_penalty_per_w};
 
             for (int l1 = 0; l1 <= level_cap; l1++) {

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -126,9 +126,11 @@ oq_power_peak_trip_s: "15"                            # Time above peak required
 oq_power_soft_trip_s: "300"                           # Time above soft required for a mild cap step [s].
 oq_power_recover_s: "60"                              # Time below recover required for cap recovery [s].
 oq_power_cap_max_f: "20"                              # Upper limit of demand-cap factor f.
-oq_power_cap_nan_f: "16"                              # Fail-safe cap factor for invalid power measurement.
+oq_power_cap_nan_f: "16"                              # Duo fail-safe demand cap for invalid power measurement; Single uses half.
 oq_duo_current_limit_v1_a: "16.0"                     # Duo current limit for V1/V1.5 hardware [A].
 oq_duo_current_limit_v2_a: "20.0"                     # Duo current limit for V2 hardware [A].
+oq_electrical_current_limit_min_a: "10.0"             # Lowest configurable installation current limit [A].
+oq_power_measurement_stale_s: "60"                    # Maximum age of voltage/current measurements used by the limiter [s].
 oq_mains_voltage_v: "230.0"                           # Nominal mains voltage used to convert current limits to power thresholds [V].
 oq_cm_prepost_s: "30"                                 # Duration of CM1 pre/postflow window [s].
 oq_cm_min_flow_lph: "250.0"                           # Minimum valid flow for compressor operation [L/h].

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -43,6 +43,19 @@
 #
 # ==============================================================================
 
+esphome:
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          float max_current_a = ${oq_duo_current_limit_v1_a};
+          #if OQ_TOPOLOGY_DUO
+          if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2") {
+            max_current_a = ${oq_duo_current_limit_v2_a};
+          }
+          #endif
+          id(oq_electrical_current_limit_a).traits.set_max_value(max_current_a);
+
 # ----------------------------
 # TIME
 # ----------------------------
@@ -331,6 +344,7 @@ number:
         max_current_a = ${oq_duo_current_limit_v2_a};
       }
       #endif
+      id(oq_electrical_current_limit_a).traits.set_max_value(max_current_a);
       const float configured_a = id(oq_electrical_current_limit_configured_a);
       if (isnan(configured_a)) return max_current_a;
       return fminf(max_current_a, fmaxf(${oq_electrical_current_limit_min_a}, configured_a));
@@ -343,6 +357,7 @@ number:
               max_current_a = ${oq_duo_current_limit_v2_a};
             }
             #endif
+            id(oq_electrical_current_limit_a).traits.set_max_value(max_current_a);
             const float configured_a = fminf(max_current_a, fmaxf(${oq_electrical_current_limit_min_a}, x));
             id(oq_electrical_current_limit_configured_a) = configured_a;
             id(oq_electrical_current_limit_a).publish_state(configured_a);
@@ -663,10 +678,12 @@ interval:
 
             // Fail-safe: unavailable or stale power -> conservative demand cap.
             if (!measurement_valid) {
+              const float fallback_scale =
+                  fminf(current_limit_a, ${oq_duo_current_limit_v1_a}) / ${oq_duo_current_limit_v1_a};
               #if OQ_TOPOLOGY_DUO
-              id(oq_power_cap_f) = ${oq_power_cap_nan_f};
+              id(oq_power_cap_f) = (int) floorf(${oq_power_cap_nan_f} * fallback_scale);
               #else
-              id(oq_power_cap_f) = ${oq_power_cap_nan_f} / 2;
+              id(oq_power_cap_f) = (int) floorf((${oq_power_cap_nan_f} / 2.0f) * fallback_scale);
               #endif
               id(oq_power_over_soft_s) = 0;
               id(oq_power_over_peak_s) = 0;

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -152,12 +152,32 @@ globals:
     initial_value: 'false'
 
   # ----------------------------
-  # Power limiter (duo current guard) - total demand cap
+  # Electrical input limiter - total demand cap
   # Cap is applied to total filtered demand f (0..20) before HP split.
   - id: oq_power_cap_f
     type: int
     restore_value: false
     initial_value: '20'
+
+  # NaN means that the user has not overridden the generation-dependent default.
+  - id: oq_electrical_current_limit_configured_a
+    type: float
+    restore_value: true
+    initial_value: 'NAN'
+
+  # One calculated threshold set is shared by supervisory feedback and Power House.
+  - id: oq_power_limit_soft_w
+    type: float
+    restore_value: false
+    initial_value: '3400.0'
+  - id: oq_power_limit_peak_w
+    type: float
+    restore_value: false
+    initial_value: '3650.0'
+  - id: oq_power_limit_recover_w
+    type: float
+    restore_value: false
+    initial_value: '3300.0'
 
   - id: oq_power_over_soft_s
     type: int
@@ -293,6 +313,39 @@ number:
     restore_value: true
     initial_value: 10
     entity_category: config
+
+  - platform: template
+    id: oq_electrical_current_limit_a
+    name: "Electrical current limit"
+    icon: mdi:current-ac
+    unit_of_measurement: "A"
+    min_value: ${oq_electrical_current_limit_min_a}
+    max_value: ${oq_duo_current_limit_v2_a}
+    step: 0.5
+    update_interval: ${oq_supervisory_loop_s}s
+    entity_category: config
+    lambda: |-
+      float max_current_a = ${oq_duo_current_limit_v1_a};
+      #if OQ_TOPOLOGY_DUO
+      if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2") {
+        max_current_a = ${oq_duo_current_limit_v2_a};
+      }
+      #endif
+      const float configured_a = id(oq_electrical_current_limit_configured_a);
+      if (isnan(configured_a)) return max_current_a;
+      return fminf(max_current_a, fmaxf(${oq_electrical_current_limit_min_a}, configured_a));
+    set_action:
+      then:
+        - lambda: |-
+            float max_current_a = ${oq_duo_current_limit_v1_a};
+            #if OQ_TOPOLOGY_DUO
+            if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2") {
+              max_current_a = ${oq_duo_current_limit_v2_a};
+            }
+            #endif
+            const float configured_a = fminf(max_current_a, fmaxf(${oq_electrical_current_limit_min_a}, x));
+            id(oq_electrical_current_limit_configured_a) = configured_a;
+            id(oq_electrical_current_limit_a).publish_state(configured_a);
 
   - platform: template
     id: oq_cm3_deficit_on_w
@@ -520,11 +573,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
-      #if OQ_TOPOLOGY_DUO
       return (float) id(oq_power_cap_f);
-      #else
-      return (float) ${oq_power_cap_max_f};
-      #endif
 
 # ----------------------------
 # MAIN LOOP
@@ -557,37 +606,68 @@ interval:
           }
           // -------------------------------------------------
           // -------------------------------------------------
-          // Power Limiter (duo current guard) - simplified safety net
+          // Electrical input limiter - measured safety net for Single and Duo
           // - Uses oq_total_power_input (W) = HP1+HP2 electrical
-          // - Primary limiting happens in heat-control optimizer (COP-based).
-          // - Supervisory is only a safety net for measured overshoot.
+          // - Power House also applies the same thresholds predictively.
+          // - Heating Curve and cooling only use this measured demand cap.
           //
-          // Targets scale from the active duo current limit at 230V:
+          // Targets scale from the configured current limit at 230V:
           //   V1/V1.5 = 16A -> 3400W / 3650W / 3300W
           //   V2      = 20A -> 4250W / 4562.5W / 4125W
           // -------------------------------------------------
-          #if OQ_TOPOLOGY_DUO
           {
             const int dt_s = ${oq_supervisory_loop_s};
-            const float duo_current_limit_a =
-                (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2")
-                    ? ${oq_duo_current_limit_v2_a}
-                    : ${oq_duo_current_limit_v1_a};
+            float max_current_a = ${oq_duo_current_limit_v1_a};
+            #if OQ_TOPOLOGY_DUO
+            if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2") {
+              max_current_a = ${oq_duo_current_limit_v2_a};
+            }
+            #endif
+            const float configured_a = id(oq_electrical_current_limit_configured_a);
+            const float current_limit_a = isnan(configured_a)
+                ? max_current_a
+                : fminf(max_current_a, fmaxf(${oq_electrical_current_limit_min_a}, configured_a));
             const float mains_voltage_v = ${oq_mains_voltage_v};
-            const float P_SOFT = duo_current_limit_a * mains_voltage_v * (3400.0f / (16.0f * 230.0f));
-            const float P_PEAK = duo_current_limit_a * mains_voltage_v * (3650.0f / (16.0f * 230.0f));
-            const float P_RECOVER = duo_current_limit_a * mains_voltage_v * (3300.0f / (16.0f * 230.0f));
+            const float P_SOFT = current_limit_a * mains_voltage_v * (3400.0f / (16.0f * 230.0f));
+            const float P_PEAK = current_limit_a * mains_voltage_v * (3650.0f / (16.0f * 230.0f));
+            const float P_RECOVER = current_limit_a * mains_voltage_v * (3300.0f / (16.0f * 230.0f));
+            id(oq_power_limit_soft_w) = P_SOFT;
+            id(oq_power_limit_peak_w) = P_PEAK;
+            id(oq_power_limit_recover_w) = P_RECOVER;
 
             // behavior
             const int PEAK_TRIP_S = ${oq_power_peak_trip_s};
             const int SOFT_TRIP_S = ${oq_power_soft_trip_s};
             const int RECOVER_S = ${oq_power_recover_s};
 
-            float p = id(oq_total_power_input).state;
+            const uint32_t measurement_stale_ms = (uint32_t)(${oq_power_measurement_stale_s}UL * 1000UL);
+            auto measurement_fresh = [&](uint32_t updated_ms) -> bool {
+              return updated_ms != 0 && (uint32_t)(now_ms - updated_ms) <= measurement_stale_ms;
+            };
+            bool measurement_valid =
+                id(hp1_is_online) &&
+                id(hp1_voltage).has_state() && !isnan(id(hp1_voltage).state) &&
+                id(hp1_current).has_state() && !isnan(id(hp1_current).state) &&
+                measurement_fresh(id(hp1_voltage_last_update_ms)) &&
+                measurement_fresh(id(hp1_current_last_update_ms));
+            #if OQ_TOPOLOGY_DUO
+            measurement_valid = measurement_valid &&
+                id(${secondary_hp_id}_is_online) &&
+                id(${secondary_hp_id}_voltage).has_state() && !isnan(id(${secondary_hp_id}_voltage).state) &&
+                id(${secondary_hp_id}_current).has_state() && !isnan(id(${secondary_hp_id}_current).state) &&
+                measurement_fresh(id(${secondary_hp_id}_voltage_last_update_ms)) &&
+                measurement_fresh(id(${secondary_hp_id}_current_last_update_ms));
+            #endif
+            const float p = id(oq_total_power_input).state;
+            measurement_valid = measurement_valid && id(oq_total_power_input).has_state() && !isnan(p);
 
-            // Fail-safe: power not available -> cap total demand to conservative fallback
-            if (isnan(p)) {
+            // Fail-safe: unavailable or stale power -> conservative demand cap.
+            if (!measurement_valid) {
+              #if OQ_TOPOLOGY_DUO
               id(oq_power_cap_f) = ${oq_power_cap_nan_f};
+              #else
+              id(oq_power_cap_f) = ${oq_power_cap_nan_f} / 2;
+              #endif
               id(oq_power_over_soft_s) = 0;
               id(oq_power_over_peak_s) = 0;
               id(oq_power_under_ok_s)  = 0;
@@ -627,12 +707,6 @@ interval:
               if (id(oq_power_cap_f) > ${oq_power_cap_max_f}) id(oq_power_cap_f) = ${oq_power_cap_max_f};
             }
           }
-          #else
-          id(oq_power_cap_f) = (int) ${oq_power_cap_max_f};
-          id(oq_power_over_soft_s) = 0;
-          id(oq_power_over_peak_s) = 0;
-          id(oq_power_under_ok_s) = 0;
-          #endif
 
           const uint32_t prepost_ms = (uint32_t)(${oq_cm_prepost_s}UL * 1000UL);
           const uint32_t frost_nan_grace_ms = (uint32_t)(${oq_cm_frost_nan_grace_s}UL * 1000UL);

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -2177,6 +2177,7 @@
       ["Boiler rated heat power", 1800, 500, 10000, 100, "W"],
       ["CM3 deficit ON threshold", 1000, 0, 10000, 50, "W"],
       ["CM3 deficit OFF threshold", 400, 0, 10000, 50, "W"],
+      ["Electrical current limit", 16, 10, 20, 0.5, "A"],
       ["Day max level", 10, 0, 10, 1, ""],
       ["Silent max level", 6, 0, 10, 1, ""],
       ["Maximum water temperature", 56, 25, 75, 1, "°C"],

--- a/openquatt/web/js/src/core/config.js
+++ b/openquatt/web/js/src/core/config.js
@@ -116,6 +116,7 @@
     usageTelemetryChoiceConfigured: { domain: "binary_sensor", name: "Usage statistics choice configured", optional: true },
     usageTelemetryInstallationId: { domain: "text_sensor", name: "Usage statistics installation ID", optional: true },
     hpGeneration: { domain: "select", name: "Quatt Hybrid version" },
+    electricalCurrentLimit: { domain: "number", name: "Electrical current limit", optional: true },
     strategy: { domain: "select", name: "Heating Control Mode" },
     openquattEnabled: { domain: "switch", name: "OpenQuatt Enabled", optional: true },
     boilerCvAssistEnabled: { domain: "switch", name: "Boiler assist enabled", optional: true },
@@ -1790,6 +1791,7 @@
     "strategy",
     "installationTopology",
     "hpGeneration",
+    "electricalCurrentLimit",
     "openquattEnabled",
     "boilerCvAssistEnabled",
     "boilerRatedHeatPower",
@@ -1868,6 +1870,7 @@
       keys: [
         "setupComplete",
         "hpGeneration",
+        "electricalCurrentLimit",
         "boilerCvAssistEnabled",
         "boilerRatedHeatPower",
         ...BOILER_SETTING_KEYS,

--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -176,6 +176,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
   export const INITIAL_SETTINGS_READY_KEY_MAP = {
     installation: [
       "hpGeneration",
+      "electricalCurrentLimit",
       "boilerCvAssistEnabled",
       "boilerRatedHeatPower",
       ...BOILER_SETTING_KEYS,
@@ -212,6 +213,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
       "setupComplete",
       "installationTopology",
       "hpGeneration",
+      "electricalCurrentLimit",
       ...ODU_GENERATION_KEYS,
       ...ODU_GENERATION_DETECT_KEYS,
       "boilerCvAssistEnabled",

--- a/openquatt/web/js/src/settings/core.js
+++ b/openquatt/web/js/src/settings/core.js
@@ -12,6 +12,7 @@ import { getWebAuthStatusDetail, getWebAuthStatusLabel } from "../features/secur
 import { getCommissioningStatusValue, getSelectEntityOptions, renderSettingsSection } from "./controls.js";
 import { renderSettingsCoolingSection } from "./cooling.js";
 import { renderSettingsFlowSection, renderSettingsHeatingSection } from "./heating.js";
+import { renderSettingsElectricalCurrentLimitSection } from "./electrical-limit.js";
 import { renderSettingsAuxRelaySection, renderSettingsBoilerCvSection, renderSettingsCompressorSection, renderSettingsDiagnosticsSection, renderSettingsGenerationSection, renderSettingsInstallationMonitoringSection, renderSettingsOduRuntimeFrequencySection, renderSettingsQuickStartSection } from "./installation.js";
 import { renderSettingsMqttSection, renderSettingsOpenThermCicSection, renderSettingsSensorSelectionSection } from "./integrations.js";
 import { renderSettingsPrivacySection } from "./privacy.js";
@@ -49,6 +50,7 @@ import { escapeHtml } from "../core/html.js";
     const sections = activeGroup === "installation"
       ? [
           renderSettingsGenerationSection(),
+          renderSettingsElectricalCurrentLimitSection(),
           renderSettingsBoilerCvSection(),
           renderSettingsAuxRelaySection(),
           renderSettingsFlowSection(),

--- a/openquatt/web/js/src/settings/core.js
+++ b/openquatt/web/js/src/settings/core.js
@@ -50,13 +50,13 @@ import { escapeHtml } from "../core/html.js";
     const sections = activeGroup === "installation"
       ? [
           renderSettingsGenerationSection(),
-          renderSettingsElectricalCurrentLimitSection(),
           renderSettingsBoilerCvSection(),
           renderSettingsAuxRelaySection(),
           renderSettingsFlowSection(),
           renderSettingsSilentSection(),
           renderSettingsWaterSection(),
           renderSettingsCompressorSection(),
+          renderSettingsElectricalCurrentLimitSection(),
           renderSettingsOduRuntimeFrequencySection(),
         ]
       : activeGroup === "service"

--- a/openquatt/web/js/src/settings/electrical-limit.js
+++ b/openquatt/web/js/src/settings/electrical-limit.js
@@ -1,0 +1,46 @@
+import { getEntityStateText, hasEntity } from "../core/app-shared.js";
+import { getInputDraftValue } from "../core/control-drafts.js";
+import { getEntityValue, getNumberMeta, parseLooseNumber } from "../core/entity-store.js";
+import { renderNumberInputControl } from "../core/number-controls.js";
+import { renderSettingsFieldCard, renderSettingsSection } from "./controls.js";
+
+export function renderSettingsElectricalCurrentLimitSection() {
+  if (!hasEntity("electricalCurrentLimit")) {
+    return "";
+  }
+
+  const topology = String(getEntityStateText("installationTopology") || "").trim().toLowerCase();
+  const generation = String(getEntityValue("hpGeneration") || "").trim();
+  const maxCurrentA = topology === "duo" && generation === "V2" ? 20 : 16;
+  const entityMeta = getNumberMeta("electricalCurrentLimit");
+  const currentDraft = parseLooseNumber(getInputDraftValue("electricalCurrentLimit"));
+  const currentA = Number.isFinite(currentDraft)
+    ? Math.min(maxCurrentA, Math.max(entityMeta.min, currentDraft))
+    : maxCurrentA;
+  const peakLimitW = Math.round(currentA * (3650 / 16));
+  const meta = {
+    ...entityMeta,
+    max: maxCurrentA,
+  };
+  const control = renderNumberInputControl({
+    key: "electricalCurrentLimit",
+    value: currentA,
+    meta,
+    controlClass: "oq-helper-control oq-helper-control--suffix",
+    unitMarkup: '<span class="oq-helper-unit-chip">A</span>',
+  });
+
+  return renderSettingsSection(
+    "Elektrische installatie",
+    "Elektrische ingangsgrens",
+    "Begrenst het gezamenlijke elektrische ingangsvermogen van de warmtepompinstallatie.",
+    renderSettingsFieldCard(
+      "electricalCurrentLimit",
+      "Maximale stroom",
+      "Een lagere waarde beperkt de warmtepomp(en) eerder. De maximale waarde volgt de gekozen installatie en Quatt Hybrid-versie.",
+      control,
+      "",
+      `<div class="oq-settings-field-note"><p>Actieve piekgrens: circa ${peakLimitW} W bij 230 V.</p><p>Power House gebruikt deze grens vooraf en via gemeten feedback. Stooklijn en koelen gebruiken alleen de gemeten feedback. Dit is een regelgrens, geen elektrische beveiliging.</p></div>`,
+    ),
+  );
+}

--- a/openquatt/web/tests/settings-regulation.test.mjs
+++ b/openquatt/web/tests/settings-regulation.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 globalThis.__OQ_PREVIEW__ = false;
@@ -27,6 +28,7 @@ const {
   renderSettingsCounterServiceSection,
 } = await import("../js/src/settings/service.js");
 const { renderSettingsElectricalCurrentLimitSection } = await import("../js/src/settings/electrical-limit.js");
+const settingsCoreSource = await readFile(new URL("../js/src/settings/core.js", import.meta.url), "utf8");
 
 function numberEntity(value, uom = "", extra = {}) {
   return {
@@ -151,6 +153,17 @@ test("elektrische ingangsgrens respecteert Single en Duo maxima", () => {
   });
   markup = renderSettingsElectricalCurrentLimitSection();
   assert.match(markup, /value="10"/);
+});
+
+test("elektrische ingangsgrens staat voor ODU runtime", () => {
+  const installationStart = settingsCoreSource.indexOf('activeGroup === "installation"');
+  const installationEnd = settingsCoreSource.indexOf(': activeGroup === "service"', installationStart);
+  const installationOrder = settingsCoreSource.slice(installationStart, installationEnd);
+  const electricalLimitIndex = installationOrder.indexOf("renderSettingsElectricalCurrentLimitSection()");
+  const oduRuntimeIndex = installationOrder.indexOf("renderSettingsOduRuntimeFrequencySection()");
+
+  assert.ok(electricalLimitIndex >= 0);
+  assert.ok(oduRuntimeIndex > electricalLimitIndex);
 });
 
 test("koelsterkte licht de lagere limiet tijdens stille modus toe", () => {

--- a/openquatt/web/tests/settings-regulation.test.mjs
+++ b/openquatt/web/tests/settings-regulation.test.mjs
@@ -26,6 +26,7 @@ const {
   renderSettingsControlModeOverridePanel,
   renderSettingsCounterServiceSection,
 } = await import("../js/src/settings/service.js");
+const { renderSettingsElectricalCurrentLimitSection } = await import("../js/src/settings/electrical-limit.js");
 
 function numberEntity(value, uom = "", extra = {}) {
   return {
@@ -110,12 +111,46 @@ test("start- en stopgrens kunnen elkaar niet passeren", () => {
 });
 
 test("nieuwe installatie- en service-entiteiten worden bij het juiste scherm geladen", () => {
+  assert.ok(SETTINGS_GROUP_KEY_MAP.installation.includes("electricalCurrentLimit"));
   assert.ok(SETTINGS_GROUP_KEY_MAP.installation.includes("boilerSupportStartThreshold"));
   assert.ok(SETTINGS_GROUP_KEY_MAP.installation.includes("boilerSupportStopThreshold"));
   assert.ok(SETTINGS_GROUP_KEY_MAP.service.includes("controlModeOverride"));
   assert.ok(SETTINGS_GROUP_KEY_MAP.service.includes("hp1RuntimeHours"));
   assert.ok(SETTINGS_GROUP_KEY_MAP.service.includes("resetRuntimeCountersHp1Hp2"));
   assert.ok(!SETTINGS_GROUP_KEY_MAP.service.includes("resetCumulativeEnergyCounters"));
+});
+
+test("elektrische ingangsgrens respecteert Single en Duo maxima", () => {
+  const limit = numberEntity(20, "A", { min_value: 10, max_value: 20, step: 0.5 });
+  resetSettingsState({
+    installationTopology: { value: "single", state: "single" },
+    hpGeneration: { value: "V2", state: "V2" },
+    electricalCurrentLimit: limit,
+  });
+
+  let markup = renderSettingsElectricalCurrentLimitSection();
+  assert.match(markup, /Elektrische ingangsgrens/);
+  assert.match(markup, /max="16"/);
+  assert.match(markup, /circa 3650 W/);
+  assert.match(markup, /Stooklijn en koelen gebruiken alleen de gemeten feedback/);
+  assert.match(markup, /geen elektrische beveiliging/);
+
+  resetSettingsState({
+    installationTopology: { value: "duo", state: "duo" },
+    hpGeneration: { value: "V2", state: "V2" },
+    electricalCurrentLimit: limit,
+  });
+  markup = renderSettingsElectricalCurrentLimitSection();
+  assert.match(markup, /max="20"/);
+  assert.match(markup, /circa 4563 W/);
+
+  resetSettingsState({
+    installationTopology: { value: "duo", state: "duo" },
+    hpGeneration: { value: "V2", state: "V2" },
+    electricalCurrentLimit: { ...limit, value: 5, state: "5" },
+  });
+  markup = renderSettingsElectricalCurrentLimitSection();
+  assert.match(markup, /value="10"/);
 });
 
 test("koelsterkte licht de lagere limiet tijdens stille modus toe", () => {

--- a/openquatt/web/tests/storage-history.test.mjs
+++ b/openquatt/web/tests/storage-history.test.mjs
@@ -62,6 +62,11 @@ test("calibration records are restored before the supply source selection", () =
   assert.ok(keys.indexOf("waterSupplyHaInputCalibrationIdentity") < keys.indexOf("waterSupplyHaInputCalibrationOffset"));
 });
 
+test("installation backup includes the electrical current limit", () => {
+  const keys = SETTINGS_BACKUP_SECTIONS.find(({ id }) => id === "installation").keys;
+  assert.ok(keys.includes("electricalCurrentLimit"));
+});
+
 test("completed backup restore disables telemetry only for incomplete setup", () => {
   assert.equal(shouldDisableUsageTelemetryForSetupRestore(true, false), true);
   assert.equal(shouldDisableUsageTelemetryForSetupRestore(true, true), false);

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -12,10 +12,11 @@ export const WEB_BUNDLE_BUDGETS = [
     // advisory per-ODU generation detection with single bulk-detect button for onboarding and installation settings,
     // the explicitly confirmed dev-to-main firmware downgrade flow,
     // selectable cooling restart by water temperature or minimum off-time,
+    // instelbare elektrische ingangsgrens met topologie- en ODU-afhankelijk maximum,
     // toelichting lokale historie in Quick Start, plus fase-2 flash-I/O observability,
     // strategie-afhankelijke warmtetoestemming-advies (Power House vs stooklijn, OT-voorkeur, centrale modal, auto-set in Quick Start),
     // plus hervatbare, fail-closed Quick Start-OTA met main-/doelcontrole en duurzaam post-bootbewijs.
-    raw: 956_000,
+    raw: 956_500,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.

--- a/scripts/tests/test_electrical_input_limit_contract.py
+++ b/scripts/tests/test_electrical_input_limit_contract.py
@@ -18,6 +18,12 @@ class ElectricalInputLimitContractTest(unittest.TestCase):
         self.assertIn("id(hp_generation).current_option() == \"V2\"", SUPERVISOR)
         self.assertIn("max_current_a = ${oq_duo_current_limit_v2_a}", SUPERVISOR)
         self.assertIn("fmaxf(${oq_electrical_current_limit_min_a}, x)", SUPERVISOR)
+        self.assertGreaterEqual(
+            SUPERVISOR.count(
+                "id(oq_electrical_current_limit_a).traits.set_max_value(max_current_a)"
+            ),
+            3,
+        )
 
     def test_single_and_duo_share_measured_feedback_limiter(self) -> None:
         limiter = SUPERVISOR.split(
@@ -33,8 +39,14 @@ class ElectricalInputLimitContractTest(unittest.TestCase):
         self.assertIn("${hp_id}_voltage_last_update_ms", HP_IO)
         self.assertIn("${hp_id}_current_last_update_ms", HP_IO)
         self.assertIn("${oq_power_measurement_stale_s}", SUPERVISOR)
-        self.assertIn("id(oq_power_cap_f) = ${oq_power_cap_nan_f}", SUPERVISOR)
-        self.assertIn("id(oq_power_cap_f) = ${oq_power_cap_nan_f} / 2", SUPERVISOR)
+        self.assertIn("fminf(current_limit_a, ${oq_duo_current_limit_v1_a})", SUPERVISOR)
+        self.assertIn(
+            "floorf(${oq_power_cap_nan_f} * fallback_scale)", SUPERVISOR
+        )
+        self.assertIn(
+            "floorf((${oq_power_cap_nan_f} / 2.0f) * fallback_scale)",
+            SUPERVISOR,
+        )
 
     def test_power_house_alone_uses_predictive_thresholds(self) -> None:
         self.assertEqual(POWER_HOUSE.count("const float P_EL_SOFT_W = id(oq_power_limit_soft_w);"), 2)

--- a/scripts/tests/test_electrical_input_limit_contract.py
+++ b/scripts/tests/test_electrical_input_limit_contract.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SUPERVISOR = (ROOT / "openquatt" / "oq_supervisory_controlmode.yaml").read_text()
+POWER_HOUSE = (ROOT / "openquatt" / "oq_power_house_strategy.yaml").read_text()
+HEATING_CURVE = (ROOT / "openquatt" / "oq_heating_curve_strategy.yaml").read_text()
+COOLING = (ROOT / "openquatt" / "oq_cooling_strategy.yaml").read_text()
+HP_IO = (ROOT / "openquatt" / "oq_HP_io.yaml").read_text()
+
+
+class ElectricalInputLimitContractTest(unittest.TestCase):
+    def test_setting_is_persistent_and_keeps_generation_defaults(self) -> None:
+        self.assertIn("id: oq_electrical_current_limit_configured_a", SUPERVISOR)
+        self.assertIn("restore_value: true\n    initial_value: 'NAN'", SUPERVISOR)
+        self.assertIn("id: oq_electrical_current_limit_a", SUPERVISOR)
+        self.assertIn("id(hp_generation).current_option() == \"V2\"", SUPERVISOR)
+        self.assertIn("max_current_a = ${oq_duo_current_limit_v2_a}", SUPERVISOR)
+        self.assertIn("fmaxf(${oq_electrical_current_limit_min_a}, x)", SUPERVISOR)
+
+    def test_single_and_duo_share_measured_feedback_limiter(self) -> None:
+        limiter = SUPERVISOR.split(
+            "// Electrical input limiter - measured safety net for Single and Duo",
+            maxsplit=1,
+        )[1].split("const uint32_t prepost_ms", maxsplit=1)[0]
+        self.assertIn("id(hp1_is_online)", limiter)
+        self.assertIn("id(${secondary_hp_id}_is_online)", limiter)
+        self.assertIn("if (!measurement_valid)", limiter)
+        self.assertNotIn("id(oq_power_cap_f) = (int) ${oq_power_cap_max_f}", limiter)
+
+    def test_missing_or_stale_measurements_fail_conservatively(self) -> None:
+        self.assertIn("${hp_id}_voltage_last_update_ms", HP_IO)
+        self.assertIn("${hp_id}_current_last_update_ms", HP_IO)
+        self.assertIn("${oq_power_measurement_stale_s}", SUPERVISOR)
+        self.assertIn("id(oq_power_cap_f) = ${oq_power_cap_nan_f}", SUPERVISOR)
+        self.assertIn("id(oq_power_cap_f) = ${oq_power_cap_nan_f} / 2", SUPERVISOR)
+
+    def test_power_house_alone_uses_predictive_thresholds(self) -> None:
+        self.assertEqual(POWER_HOUSE.count("const float P_EL_SOFT_W = id(oq_power_limit_soft_w);"), 2)
+        self.assertEqual(POWER_HOUSE.count("const float P_EL_PEAK_W = id(oq_power_limit_peak_w);"), 2)
+        self.assertIn("id(oq_power_cap_f)", HEATING_CURVE)
+        self.assertIn("id(oq_power_cap_f)", COOLING)
+        self.assertNotIn("oq_power_limit_peak_w", HEATING_CURVE)
+        self.assertNotIn("oq_power_limit_peak_w", COOLING)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Maakt de elektrische ingangsgrens instelbaar van 10 A tot 16 A (Single en Duo V1/V1.5) of 20 A (Duo V2), met behoud van de huidige standaardwaarden.
- Past gemeten vermogensfeedback toe op Single en Duo. Power House gebruikt de grens daarnaast voorspellend; stooklijn en koelen blijven uitsluitend op gemeten feedback begrenzen.
- Neemt de instelling mee in backup/restore en documenteert dat dit een regelgrens is, geen elektrische beveiliging.
<img width="1366" height="386" alt="image" src="https://github.com/user-attachments/assets/1a0314ec-7eeb-4760-8fce-ae97886ed547" />

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De bestaande defaults blijven gelijk: 16 A voor Single en Duo V1/V1.5, 20 A voor Duo V2. Bij ontbrekende, verouderde of offline vermogensmetingen valt de regeling terug op een conservatieve demand-cap. Een waarde boven het actieve topologie-/generatiemaximum wordt door firmware en webinterface begrensd.

## Achtergrond

Closes #544.

De gekozen oplossingsrichting houdt één centrale stroominstelling aan en leidt daar de bestaande soft-, peak- en recover-vermogensgrenzen uit af. Daardoor delen gemeten feedback en de Power House-optimalisatie dezelfde grens, zonder een nieuw voorspellend vermogensmodel voor stooklijn of koelen.

De volledige diff is apart gecontroleerd op fresh install/upgrade, persistentie en backup/restore, Single/Duo en V1/V2-wissels, ontbrekende/verouderde metingen, offline warmtepompen, opstartvolgorde en `millis()`-rollover. Na de rebase op de actuele `dev` is daarnaast een koude adversarial review uitgevoerd; daarbij zijn geen nieuwe bevindingen gevonden.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De nieuwe instelling, defaults, strategiewerking en veiligheidsafbakening zijn toegevoegd aan de instellingen- en webappdocumentatie.

## Validatie

- [x] `npm run check:web` — 262 tests en webkwaliteit geslaagd
- [x] `npm run check:python-contracts` — 89 tests geslaagd
- [x] `npm run check:cpp-format` — geslaagd
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — na rebase geslaagd
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml` — na rebase geslaagd
- [x] Volledige Duo- en Single-firmwarecompile — geslaagd
- [x] Webinterface visueel gecontroleerd in de demo: 16 A, circa 3650 W en toelichting correct weergegeven
- [x] Simulator/HIL: exacte voltage/current-telemetrie, peak/soft/recovery-timing, stale/offline fallback, Single/Duo en V1/V1.5/V2-maxima gecontroleerd
- [x] Simulator/HIL: Power House gebruikte de gedeelde voorspellende drempels; stooklijn gebruikte uitsluitend de gemeten feedback
- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe taken of dynamische buffers. Alleen vaste globals voor de ingestelde grens, afgeleide drempels en twee meettimestamps per warmtepomp; heap/stack is niet op hardware gemeten.
