### PR TITLE
Voeg documentatie toe voor de Homey-app

### DIFF
--- a/docs/api-input.md
+++ b/docs/api-input.md
@@ -107,6 +107,7 @@ Bij `Warmtetoestemming` en `Koeltoestemming` telt API-invoer alleen mee als de w
 ## Verder lezen
 
 - [MQTT inputbronnen](mqtt.md)
+- [OpenQuatt in Homey](homey.md)
 - [Web-app gebruiken](web-app.md)
 - [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)
 - [Verwarmen en koelen uitgelegd](verwarmen-en-koelen.md)

--- a/docs/homey.md
+++ b/docs/homey.md
@@ -1,0 +1,105 @@
+# OpenQuatt in Homey
+
+De Homey-app verbindt Homey Pro rechtstreeks met OpenQuatt op je eigen netwerk. De controller wordt automatisch gevonden en stuurt zijn waarden live door over de lokale verbinding. Er is geen cloudaccount voor nodig en de Quatt-app blijft er buiten.
+
+Homey is optioneel voor OpenQuatt zelf, net als Home Assistant. Gebruik het als je vanuit Homey wilt meekijken, wilt automatiseren, of OpenQuatt wilt voeden met sensoren die je al in Homey hebt.
+
+De app is open source en heeft een eigen repository: [OpenQuatt/homey-openquatt](https://github.com/OpenQuatt/homey-openquatt).
+
+## Wat je nodig hebt
+
+- Homey Pro met firmware `12.3.0` of nieuwer. De app draait lokaal op Homey Pro en is niet beschikbaar voor Homey Cloud.
+- OpenQuatt online op hetzelfde netwerk, met Quick Start afgerond.
+
+## Installeren en koppelen
+
+1. Installeer [OpenQuatt](https://homey.app/a/nl.openquatt/) uit de Homey App Store.
+2. Voeg in Homey een apparaat toe en kies OpenQuatt. Homey vindt de controller via mDNS, dezelfde route waarmee `openquatt.local` werkt.
+3. Blijft de lijst leeg, vul dan het adres van de controller in bij de apparaatinstellingen onder `Host / IP-adres (handmatig)`. Dat is ook de oplossing als mDNS in je netwerk niet doorkomt, bijvoorbeeld over een gast-VLAN of tussen twee subnetten.
+
+Verandert het IP-adres later, dan volgt de app dat vanzelf zolang je het veld leeg laat.
+
+## Wat je in Homey ziet
+
+| Waarde | Toelichting |
+|---|---|
+| Aanvoer-, buiten- en kamertemperatuur | De waarden zoals de controller ze zelf geselecteerd heeft. |
+| Kamer-setpoint en koelingsdauwpunt | Idem, dus inclusief de gekozen bron. |
+| Vermogen, warmteafgifte en koelvermogen | Live uit de regeling. |
+| COP en EER | Live rendement. |
+| Flow | Waterdebiet in liter per uur. |
+| Regelmodus | Als leesbaar label en als getal, zodat Homey er een grafiek van kan maken. |
+| Warmte- en koeltoestemming | Of de regeling verwarmen en koelen op dit moment toestaat. |
+| Hulprelais (R2) | Functie en status. |
+
+Homey logt elke waarde in Inzichten, dus je kunt ze zonder verdere configuratie over de tijd terugkijken. Luchtvochtigheid ontbreekt, want OpenQuatt rekent met het dauwpunt en heeft zelf geen kamervochtigheid. Zet daarvoor je eigen vochtsensor in de grafiek.
+
+Naast de losse waarden heeft de app een dashboardwidget met de status van de installatie in één oogopslag.
+
+## Wat je kunt schakelen
+
+Direct vanaf de apparaatpagina schakel je de OpenQuatt-regeling, de handmatige koelvrijgave en het hulprelais (R2). De functie van R2 kies je uit dezelfde vijf standen die de firmware kent.
+
+## Flow-kaarten
+
+Triggers voor het volgen van de installatie: de regelmodus is veranderd, verwarmen of koelen gestart en gestopt, ontdooien gestart en gestopt per warmtepomp, de CV-ketel in- en uitgeschakeld, stille modus aan en uit, een storing gedetecteerd of opgelost, en het dauwpunt beschikbaar gekomen of weggevallen.
+
+Condities om een flow te laten afhangen van wat OpenQuatt doet: is aan het verwarmen, koelen of ontdooien, is er een storing actief, draait de CV-ketel, staat stille modus aan, is er een dauwpunt beschikbaar, is koelen toegestaan, en staat het hulprelais op een bepaalde functie.
+
+Acties om bij te sturen: regelmodus forceren, stille-modus-override zetten, CV-ketel-assist aan of uit, de OpenQuatt-regeling aan of uit, handmatige koelvrijgave, en het hulprelais schakelen of van functie wisselen.
+
+Daarnaast zijn er acties om de controller te voeden. Die staan hieronder.
+
+## OpenQuatt voeden vanuit Homey
+
+Sensoren die je al in Homey hebt, kun je als bron aan OpenQuatt doorgeven. Elk signaal heeft een eigen flow-kaart en gaat rechtstreeks naar de [API-invoer](api-input.md) van de controller, met [MQTT](mqtt.md) als terugvaloptie.
+
+| Flow-kaart | Bereik | Blijft geldig |
+|---|---|---|
+| Stuur dauwpunt naar de controller | `-20..35` graden | tot je flow stopt met verversen |
+| Stuur buitentemperatuur naar de controller | `-40..60` graden | tot je flow stopt met verversen |
+| Stuur kamertemperatuur naar de controller | `0..50` graden | tot je flow stopt met verversen |
+| Stuur kamer-setpoint naar de controller | `5..35` graden | tot je een nieuwe waarde stuurt |
+| Zet warmtetoestemming | aan of uit | tot je een nieuwe waarde stuurt |
+| Zet koeltoestemming | aan of uit | tot je een nieuwe waarde stuurt |
+
+De app stuurt alles wat hij voedt elke minuut opnieuw, zodat de geldigheidsduur van de controller niet onder je flow vandaan verloopt. Blijft een meetwaarde langer weg dan `Maximale leeftijd sensorwaarde` (standaard 60 minuten), dan stopt de app met versturen en valt de controller terug op zijn eigen bron. Dat is met opzet: liever de eigen meting dan een kamertemperatuur van vanochtend.
+
+Het setpoint en de twee toestemmingen zijn commando's in plaats van metingen. Die blijven staan tot je ze vervangt, en de app stuurt ze opnieuw na een herstart.
+
+Zet aan de kant van de controller wel de juiste bron. Ga naar **Instellingen -> Bronnen / integraties -> Sensorselectie** in de web-app en sta `API input` toe voor het signaal dat je voedt. `Auto` dekt de meeste gevallen al.
+
+> [!NOTE]
+> `Zet koeltoestemming` is het normale toestemmingssignaal en weegt dus mee in de bronselectie. `Zet handmatige koelvrijgave` is iets anders: dat is de override, die koelen toestaat ongeacht de gekozen bron.
+
+## Dauwpunt uit je eigen kamersensoren
+
+OpenQuatt koelt alleen als het het dauwpunt binnen kent. Heb je een temperatuur- en vochtsensor per kamer, dan kan Homey het dauwpunt uitrekenen en doorgeven, met dezelfde Magnus-formule en hoogste-kamer-wint-logica als het dynamische koelpakket voor Home Assistant.
+
+Maak per gekoelde kamer een flow: *als* de temperatuur of luchtvochtigheid verandert, *dan* `Werk het dauwpunt van [kamer] bij met temperatuur en luchtvochtigheid`, met de tags van je sensor. De app aggregeert de kamers, laat oude waarden vervallen en stuurt de hoogste elke minuut opnieuw.
+
+Heb je al een berekend dauwpunt, gebruik dan de kaart `Stuur dauwpunt naar de controller`.
+
+## MQTT als terugvaloptie
+
+Draait er nog firmware zonder API-invoer, dan werkt MQTT. Zet **MQTT inputbronnen** aan onder **Instellingen -> Bronnen / integraties**, wijs een broker op je netwerk aan en vul dezelfde broker in bij de apparaatinstellingen in Homey, onder `Externe waarden - MQTT-fallback`.
+
+Heb je geen broker, dan kan Homey Pro er zelf een zijn met de app [MQTT Server](https://homey.app/a/net.weejewel.mqttserver/). Die accepteert geen anonieme verbindingen, dus vul aan beide kanten de gebruikersnaam en het wachtwoord uit de app-instellingen in.
+
+De app probeert altijd eerst de API-invoer en gebruikt MQTT alleen als dat niet lukt. Je hoeft dus niets om te zetten als je later naar nieuwere firmware gaat.
+
+## Als het niet werkt
+
+- Het apparaat is niet beschikbaar in Homey: controleer of `http://openquatt.local` nog opent. Lukt dat wel en Homey niet, vul dan het IP-adres handmatig in bij de apparaatinstellingen.
+- Een gevoede waarde komt niet aan: kijk in de web-app onder **Instellingen -> Bronnen / integraties -> Sensorselectie** of het signaal `API input` als bron mag gebruiken.
+- De hulprelais-functie blijft leeg: die bestaat alleen op firmware met R2-ondersteuning.
+
+Blijft het onduidelijk, kijk dan verder bij [Problemen oplossen](problemen-oplossen.md).
+
+## Verder lezen
+
+- [API inputbronnen](api-input.md)
+- [MQTT inputbronnen](mqtt.md)
+- [Verwarmen en koelen uitgelegd](verwarmen-en-koelen.md)
+- [Web-app gebruiken](web-app.md)
+- [Problemen oplossen](problemen-oplossen.md)

--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -150,6 +150,7 @@ mosquitto_pub -h mqtt.local -t openquatt/openquatt/input/thermostat/heating_enab
 
 - [Web-app gebruiken](web-app.md)
 - [API inputbronnen](api-input.md)
+- [OpenQuatt in Homey](homey.md)
 - [Instellingen en meetwaarden](instellingen-en-meetwaarden.md)
 - [Problemen oplossen](problemen-oplossen.md)
 - [Verwarmen en koelen uitgelegd](verwarmen-en-koelen.md)

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -50,6 +50,7 @@ De oude OpenQuatt-preference wordt bij deze firmwareversie niet gewist, maar ook
 | Installer | Een bestaande Waveshare- of Heatpump Listener-module flashen, Wi-Fi op een nieuwe HCQ instellen of een HCQ herstellen. |
 | Web-app | Quick Start, installatiekeuzes, instellingen, updates, backup en beveiliging. |
 | Optioneel: Home Assistant | Dagelijks meekijken, dashboards, bronselectie en dynamische bronnen. |
+| Optioneel: Homey | Dagelijks meekijken, flows en OpenQuatt voeden vanuit Homey-sensoren. |
 
 Kies bij een eerste installatie eerst de passende route in het [projectoverzicht](../README.md#kies-je-route). Beide installatieroutes komen uit bij de web-app; Home Assistant is geen onderdeel van de basisinstallatie.
 
@@ -337,4 +338,4 @@ Als de web-app niet opent:
 
 Als Quick Start niet verschijnt terwijl je nog niet klaar bent, open `Instellingen -> Systeem -> Quick Start` en reset de setupstatus.
 
-Wil je OpenQuatt ook aan Home Assistant toevoegen? Ga dan optioneel verder met [Dashboard installeren](dashboard/README.md) en [Dashboard gebruiken](dashboardoverzicht.md).
+Wil je OpenQuatt ook aan Home Assistant toevoegen? Ga dan optioneel verder met [Dashboard installeren](dashboard/README.md) en [Dashboard gebruiken](dashboardoverzicht.md). Gebruik je Homey Pro, kijk dan bij [OpenQuatt in Homey](homey.md).

--- a/scripts/build_pages_docs.py
+++ b/scripts/build_pages_docs.py
@@ -46,6 +46,7 @@ PAGES = [
     Page(PurePosixPath("docs/web-app.md"), PurePosixPath("web-app.html"), "Web-app gebruiken", "Handleiding", "Quick Start, instellingen, updates, backup en beveiliging via openquatt.local."),
     Page(PurePosixPath("docs/dashboard/README.md"), PurePosixPath("dashboard/index.html"), "OpenQuatt Home Assistant", "Doorverwijzing", "Dashboards, packages en handleidingen staan in de Home Assistant companion-repository."),
     Page(PurePosixPath("docs/dashboardoverzicht.md"), PurePosixPath("dashboardoverzicht.html"), "Dashboard gebruiken", "Doorverwijzing", "Actuele dashboardhandleiding in de Home Assistant companion-repository."),
+    Page(PurePosixPath("docs/homey.md"), PurePosixPath("homey.html"), "OpenQuatt in Homey", "Handleiding", "Homey Pro koppelen, meekijken, automatiseren en OpenQuatt voeden met je eigen sensoren."),
     Page(PurePosixPath("docs/verwarmen-en-koelen.md"), PurePosixPath("verwarmen-en-koelen.html"), "Verwarmen en koelen uitgelegd", "Uitleg", "Heldere uitleg van Power House, stooklijnregeling, koeling, Single en Duo."),
     Page(PurePosixPath("docs/mqtt.md"), PurePosixPath("mqtt.html"), "MQTT inputbronnen", "Docs", "Beperkte MQTT inputbronnen voor externe meetwaarden zoals koelingsdauwpunt."),
     Page(PurePosixPath("docs/api-input.md"), PurePosixPath("api-input.html"), "API inputbronnen", "Docs", "Lokale HTTP-endpoints voor externe bronwaarden en toestemmingssignalen."),
@@ -84,6 +85,13 @@ SIDEBAR_GROUPS = [
         [
             PurePosixPath("docs/dashboard/README.md"),
             PurePosixPath("docs/dashboardoverzicht.md"),
+        ],
+    ),
+    (
+        "Optioneel: Homey",
+        "Homey Pro koppelen nadat OpenQuatt lokaal werkt.",
+        [
+            PurePosixPath("docs/homey.md"),
         ],
     ),
     (


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt `docs/homey.md` toe: koppelen aan Homey Pro, wat je in Homey ziet, de flow-kaarten, en het voeden van de controller met sensoren die je al in Homey hebt.
- Zet Homey als eigen zijbalkgroep `Optioneel: Homey` in `scripts/build_pages_docs.py`, direct onder `Optioneel: Home Assistant`.
- Linkt de pagina vanuit `docs/api-input.md`, `docs/mqtt.md` en de routetabel in `docs/web-app.md`.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen documentatie en de paginalijst van de docs-site. Geen firmware, ESPHome-configuratie of web-app geraakt.

## Achtergrond

De Homey-app staat als [OpenQuatt](https://homey.app/a/nl.openquatt/) in de Homey App Store en is open source in [OpenQuatt/homey-openquatt](https://github.com/OpenQuatt/homey-openquatt), maar de docs verwezen er nergens naar.

Homey is op dezelfde manier optioneel als Home Assistant: pas nuttig nadat OpenQuatt lokaal werkt. Daarom een eigen groep naast Home Assistant in plaats van een pagina ergens onder Naslag.

Inhoudelijk raakt de pagina vooral aan `api-input.md`. De app stuurt dauwpunt, buitentemperatuur, kamertemperatuur, kamer-setpoint en de warmte- en koeltoestemming via de `api_input_*` entiteiten, met MQTT als terugvaloptie. Het onderscheid tussen `Zet koeltoestemming` en de handmatige koelvrijgave staat expliciet in de pagina, omdat dat in de app zelf verwarring opleverde ([homey-openquatt#1](https://github.com/OpenQuatt/homey-openquatt/issues/1)).

De App Store-link is gecontroleerd en werkt.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

n.v.t.

## Validatie

Lokaal uitgevoerd:

- `python3 scripts/build_pages_docs.py <site-dir>` en de gerenderde `homey.html` gecontroleerd: zijbalkgroep staat op de juiste plek, de `NOTE`-callout rendert, en alle relatieve links naar andere pagina's resolven.
- `python3 scripts/check_docs_consistency.py`
- `node scripts/check_web_docs_sync.mjs`
- `python3 scripts/check_style_consistency.py`
- `python3 -m unittest discover -s scripts/tests -p "test_*.py"` (85 tests)

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen. Documentatie en een paginalijst voor de docs-site.
