### PR TITLE
Herstel onbedoelde merges van #550 en #551 op main

### DIFF
--- a/docs/q-edition.md
+++ b/docs/q-edition.md
@@ -156,7 +156,7 @@ Volg de route die de web-app voor jouw installatie toont. De basisstappen zijn:
 2. **Kies je Quatt Hybrid:** V1, V1.5 of V2.
 3. **Flowmeting configureren:** controleer en activeer de juiste flowbron.
 4. **Thermostaatgegevens configureren:** kies waar kamertemperatuur en kamer-setpoint vandaan komen.
-5. **Aanvullende warmtebron:** leg vast of een warmtebron is aangesloten, of deze hybride mag meeverwarmen bij een vermogenstekort en of deze mag overnemen wanneer geen warmtepomp beschikbaar is.
+5. **CV-ketel of boiler:** geef aan of OpenQuatt deze als ondersteuning mag gebruiken.
 6. **Kies de verwarmingsstrategie:** kies hoe OpenQuatt de verwarming regelt.
 7. **Werk de regeling uit:** stel Power House of de stooklijn verder in.
 8. **Flowregeling en afstelling:** leg vast hoe de pomp geregeld moet worden en welke waarden daarbij horen.

--- a/docs/q-edition.md
+++ b/docs/q-edition.md
@@ -165,8 +165,6 @@ Volg de route die de web-app voor jouw installatie toont. De basisstappen zijn:
 11. **Gebruiksstatistieken:** controleer of OpenQuatt beperkte technische systeemstatus, aan/uit-statussen van functies en configuratiekeuzes zoals Quatt Hybrid-versie, verwarmingsstrategie, flowbron en regelbronnen mag delen; tijdens een nieuwe Quick Start staat dit standaard aan en kan het hier worden uitgezet. Gemeten of ingestelde temperaturen, wifi-gegevens, gebruikersnamen en wachtwoorden worden nooit meegestuurd.
 12. **Bevestigen en afronden:** controleer je keuzes en markeer Quick Start als voltooid.
 
-Bij een koude verwarmingsstart circuleert OpenQuatt eerst water en controleert daarna de uitgaande temperatuur van iedere aangesloten ODU. Onder `5 °C` blijven de compressoren uit; met `Overnemen wanneer de warmtepomp niet beschikbaar is` kan de aanvullende warmtebron voorverwarmen. Tussen `5 en 12 °C` starten de warmtepompen zelfstandig; met `Hybride verwarmen bij vermogenstekort` helpt de aanvullende warmtebron tijdelijk mee. Vanaf `12 °C` geldt de normale warmteregeling. Een algemene startgrens van `18 °C` wordt niet toegepast.
-
 ## Je installatie is klaar wanneer
 
 - `openquatt.local` stabiel bereikbaar is;

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -83,7 +83,7 @@ Quick Start begint op de Heatpump Controller Q met een controle van de firmware-
 | `Kies je Quatt Hybrid` | V1, V1.5 of V2 | Selecteert de juiste basislogica voor jouw warmtepompgeneratie. |
 | `Flowmeting configureren` | De juiste flowbron | Zorgt dat de regeling de juiste meting gebruikt. |
 | `Thermostaatgegevens configureren` | Eén bron voor kamertemperatuur en setpoint | Voorkomt dat OpenQuatt waarden uit verschillende bronnen combineert. |
-| `Aanvullende warmtebron` | Aansluiting (`R1` of `OTB`), hybride verwarmen en overname | Legt afzonderlijk vast of een warmtebron is aangesloten, of deze bij een vermogenstekort hybride mag meeverwarmen en of deze mag overnemen wanneer geen warmtepomp beschikbaar is. Op Q-hardware controleert OpenQuatt bij een R1-keuze tijdens het opstarten kort of toch een OpenTherm-ketel antwoordt. Tijdens Quick Start wordt een gedetecteerde OT-ketel automatisch als `OpenTherm (OTB)` ingesteld en wordt die keuze toegelicht. Na afgeronde onboarding blijft een onverwachte OT-ketel geblokkeerd totdat de aansluiting handmatig is gecorrigeerd. |
+| `CV-ketel of boiler` | Ondersteuning en fysieke aansluiting (`R1` of `OTB`) | Bepaalt of OpenQuatt aanvullende warmte mag inzetten. Op Q-hardware controleert OpenQuatt bij een R1-keuze tijdens het opstarten kort of toch een OpenTherm-ketel antwoordt. Tijdens Quick Start wordt een gedetecteerde OT-ketel automatisch als `OpenTherm (OTB)` ingesteld en wordt die keuze toegelicht. Na afgeronde onboarding blijft een onverwachte OT-ketel geblokkeerd totdat de aansluiting handmatig is gecorrigeerd. |
 | `Kies de verwarmingsstrategie` | `Power House` of `Water Temperature Control` | Bepaalt hoe OpenQuatt warmtevraag maakt en vervangt daarbij automatisch de warmtetoestemming (`Niet gebruiken` voor Power House; de eerder gekozen actieve thermostaatbron voor stooklijn). |
 | `Werk de regeling uit` | Strategie-instellingen | Toont alleen de instellingen die bij de gekozen strategie horen. |
 | `Flowregeling en afstelling` | Automatische flow of vaste pompstand | Bepaalt hoe OpenQuatt de waterdoorstroming regelt. |
@@ -169,9 +169,9 @@ Onder `Instellingen` staan de onderdelen bewust gescheiden. Het idee is: eerst d
 
 ### Installatie
 
-Hier staan basiskeuzes zoals Quatt Hybrid-versie, flowregeling, een aanvullende warmtebron, stille uren, watergrenzen en compressorinstellingen.
+Hier staan basiskeuzes zoals Quatt Hybrid-versie, flowregeling, boiler- of CV-ondersteuning, stille uren, watergrenzen en compressorinstellingen.
 
-Bij `Aanvullende warmtebron` leg je eerst vast of OpenQuatt een warmtebron fysiek kan aansturen. Daarna kies je afzonderlijk voor `Hybride verwarmen bij vermogenstekort` en `Overnemen wanneer de warmtepomp niet beschikbaar is`. Overname staat standaard uit. OpenQuatt schakelt pas over nadat de warmtepompen veilig zijn gestopt en flow, aanvoertemperatuur en aansturing geldig zijn. Een korte communicatiedip telt niet als uitval.
+`Automatische ketelovername bij warmtepompstoring` is een aparte installatiekeuze en staat standaard uit. Als je deze inschakelt, mag OpenQuatt bij een bevestigde storing van alle geconfigureerde warmtepompen overschakelen naar CM4 en de cv-ketel de verwarmingsopdracht geven. OpenQuatt doet dit alleen nadat de warmtepompen veilig zijn gestopt en flow, aanvoertemperatuur en ketelaansturing geldig zijn. Een korte communicatiedip telt niet als bevestigde storing en vraagt geen actie of bevestiging van de gebruiker.
 
 Gebruik dit deel vooral tijdens de eerste inrichting of als je installatie later verandert.
 

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -173,8 +173,6 @@ Hier staan basiskeuzes zoals Quatt Hybrid-versie, flowregeling, een aanvullende 
 
 Bij `Aanvullende warmtebron` leg je eerst vast of OpenQuatt een warmtebron fysiek kan aansturen. Daarna kies je afzonderlijk voor `Hybride verwarmen bij vermogenstekort` en `Overnemen wanneer de warmtepomp niet beschikbaar is`. Overname staat standaard uit. OpenQuatt schakelt pas over nadat de warmtepompen veilig zijn gestopt en flow, aanvoertemperatuur en aansturing geldig zijn. Een korte communicatiedip telt niet als uitval.
 
-Bij een nieuwe warmtevraag controleert OpenQuatt na het starten van de circulatie de uitgaande watertemperatuur van iedere aangesloten warmtepomp. Onder `5 °C` blijven de compressoren uit; met `Overnemen wanneer de warmtepomp niet beschikbaar is` kan de aanvullende warmtebron het circuit eerst opwarmen. Vanaf `5 °C` mogen de warmtepompen starten. Met `Hybride verwarmen bij vermogenstekort` helpt de aanvullende warmtebron tot alle uitgaande temperaturen minimaal `12 °C` zijn. Zonder aangesloten of toegestane aanvullende warmtebron start de warmtepomp vanaf `5 °C` zelfstandig. De oude algemene startgrens van `18 °C` wordt niet gebruikt.
-
 Gebruik dit deel vooral tijdens de eerste inrichting of als je installatie later verandert.
 
 ### Verwarmen

--- a/openquatt/includes/boiler/oq_boiler_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_logic.h
@@ -12,7 +12,6 @@ enum CommandSource : uint8_t {
   COMMAND_SOURCE_COMMISSIONING = 2,
   COMMAND_SOURCE_HEATING_CURVE = 3,
   COMMAND_SOURCE_FALLBACK = 4,
-  COMMAND_SOURCE_COLD_START = 5,
 };
 
 enum BlockReason : uint8_t {
@@ -230,8 +229,7 @@ inline ControllerDecision evaluate(const BoilerCommand& command, const Controlle
   } else if (command.source == COMMAND_SOURCE_FALLBACK && !input.fallback_enabled) {
     decision.force_off = true;
     decision.block_reason = BLOCK_FALLBACK_DISABLED;
-  } else if ((command.source == COMMAND_SOURCE_POWER_HOUSE || command.source == COMMAND_SOURCE_HEATING_CURVE ||
-              command.source == COMMAND_SOURCE_COLD_START) &&
+  } else if ((command.source == COMMAND_SOURCE_POWER_HOUSE || command.source == COMMAND_SOURCE_HEATING_CURVE) &&
              !input.assist_enabled) {
     decision.force_off = true;
     decision.block_reason = BLOCK_ASSIST_DISABLED;

--- a/openquatt/includes/boiler/oq_boiler_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_logic.h
@@ -35,7 +35,6 @@ enum BlockReason : uint8_t {
   BLOCK_FLOW_UNAVAILABLE = 17,
   BLOCK_FLOW_INSUFFICIENT = 18,
   BLOCK_HP_STOP_UNCONFIRMED = 19,
-  BLOCK_SOURCE_NOT_CONNECTED = 20,
 };
 
 struct BoilerCommand {
@@ -49,7 +48,6 @@ struct BoilerCommand {
 };
 
 struct ControllerInput {
-  bool source_present;
   bool assist_enabled;
   bool fallback_enabled;
   bool supply_temperature_valid;
@@ -223,14 +221,13 @@ inline ControllerDecision evaluate(const BoilerCommand& command, const Controlle
   } else if (input.boiler_inhibit_active) {
     decision.force_off = true;
     decision.block_reason = BLOCK_WATER_TEMP_INHIBIT;
-  } else if (!input.source_present) {
+  } else if (command.source == COMMAND_SOURCE_FALLBACK && !input.assist_enabled) {
     decision.force_off = true;
-    decision.block_reason = BLOCK_SOURCE_NOT_CONNECTED;
+    decision.block_reason = BLOCK_ASSIST_DISABLED;
   } else if (command.source == COMMAND_SOURCE_FALLBACK && !input.fallback_enabled) {
     decision.force_off = true;
     decision.block_reason = BLOCK_FALLBACK_DISABLED;
-  } else if ((command.source == COMMAND_SOURCE_POWER_HOUSE || command.source == COMMAND_SOURCE_HEATING_CURVE) &&
-             !input.assist_enabled) {
+  } else if (command.source != COMMAND_SOURCE_FALLBACK && !input.assist_enabled) {
     decision.force_off = true;
     decision.block_reason = BLOCK_ASSIST_DISABLED;
   } else if (!command.valid) {
@@ -338,8 +335,6 @@ inline const char* block_reason_text(uint8_t reason) {
       return "flow too low";
     case BLOCK_HP_STOP_UNCONFIRMED:
       return "heat-pump stop is not confirmed";
-    case BLOCK_SOURCE_NOT_CONNECTED:
-      return "auxiliary heat source not connected";
     default:
       return "";
   }

--- a/openquatt/includes/control/oq_boiler_control_logic.h
+++ b/openquatt/includes/control/oq_boiler_control_logic.h
@@ -150,7 +150,6 @@ inline BoilerLogDecision classify_boiler_controller_log(const BoilerControllerLo
       reason = BoilerLogReason::SENSOR_FALLBACK;
       break;
     case BLOCK_ASSIST_DISABLED:
-    case BLOCK_SOURCE_NOT_CONNECTED:
       reason = BoilerLogReason::NO_CANDIDATE;
       break;
     case BLOCK_FALLBACK_DISABLED:

--- a/openquatt/includes/control/oq_boiler_control_logic.h
+++ b/openquatt/includes/control/oq_boiler_control_logic.h
@@ -11,7 +11,6 @@ inline BoilerRole boiler_role_for_source(uint8_t source) {
   switch (source) {
     case COMMAND_SOURCE_POWER_HOUSE:
     case COMMAND_SOURCE_HEATING_CURVE:
-    case COMMAND_SOURCE_COLD_START:
       return BoilerRole::ASSIST_CM3;
     case COMMAND_SOURCE_FALLBACK:
       return BoilerRole::FALLBACK_CM4;

--- a/openquatt/includes/control/oq_hp_supervisory_logic.h
+++ b/openquatt/includes/control/oq_hp_supervisory_logic.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <math.h>
 #include <stdint.h>
 
 #include "oq_hp_fallback_logic.h"
@@ -16,48 +15,6 @@ inline int base_control_mode(bool cooling_request, bool heating_request, bool fr
   if (heating_request) return 2;
   if (frost_request) return 98;
   return 0;
-}
-
-struct ColdStartWaterSample {
-  bool required = false;
-  float temperature_c = NAN;
-  uint32_t updated_at_ms = 0;
-};
-
-struct ColdStartDecision {
-  bool samples_ready = false;
-  bool hp_start_allowed = false;
-  bool auxiliary_assist_recommended = false;
-  bool released = false;
-  float minimum_temperature_c = NAN;
-};
-
-inline bool cold_start_sample_is_new(const ColdStartWaterSample& sample, uint32_t sample_after_ms) {
-  if (!sample.required) return true;
-  if (sample_after_ms == 0 || sample.updated_at_ms == 0 || isnan(sample.temperature_c)) return false;
-  return static_cast<int32_t>(sample.updated_at_ms - sample_after_ms) > 0;
-}
-
-inline ColdStartDecision evaluate_cold_start(uint32_t sample_after_ms, const ColdStartWaterSample& hp1,
-                                             const ColdStartWaterSample& hp2, float minimum_start_c,
-                                             float assist_release_c) {
-  ColdStartDecision decision;
-  if (isnan(minimum_start_c) || isnan(assist_release_c) || assist_release_c <= minimum_start_c ||
-      !cold_start_sample_is_new(hp1, sample_after_ms) || !cold_start_sample_is_new(hp2, sample_after_ms)) {
-    return decision;
-  }
-
-  float minimum_c = NAN;
-  if (hp1.required) minimum_c = hp1.temperature_c;
-  if (hp2.required) minimum_c = isnan(minimum_c) ? hp2.temperature_c : fminf(minimum_c, hp2.temperature_c);
-  if (isnan(minimum_c)) return decision;
-
-  decision.samples_ready = true;
-  decision.minimum_temperature_c = minimum_c;
-  decision.hp_start_allowed = minimum_c >= minimum_start_c;
-  decision.auxiliary_assist_recommended = decision.hp_start_allowed && minimum_c < assist_release_c;
-  decision.released = minimum_c >= assist_release_c;
-  return decision;
 }
 
 inline bool fallback_availability_is_confirmed(bool raw_availability_complete,
@@ -112,7 +69,6 @@ struct FallbackEvaluationInputs {
   bool raw_availability_complete = false;
   bool every_unavailable_hp_has_fallback_cause = false;
   bool all_hp_outputs_safe = false;
-  bool cold_start_blocked = false;
   bool flow_valid = false;
   bool flow_sufficient = false;
   bool supply_temperature_valid = false;
@@ -133,24 +89,19 @@ struct FallbackEvaluation {
 
 inline FallbackEvaluation evaluate_fallback(const FallbackEvaluationInputs& inputs) {
   FallbackEvaluation evaluation;
-  const uint8_t effective_available_hp_count = inputs.cold_start_blocked ? 0 : inputs.available_hp_count;
-  const bool effective_fallback_cause = inputs.cold_start_blocked || inputs.every_unavailable_hp_has_fallback_cause;
-  evaluation.availability_complete =
-      inputs.cold_start_blocked ? inputs.all_hp_outputs_safe
-                                : fallback_availability_is_confirmed(inputs.raw_availability_complete,
-                                                                     inputs.every_unavailable_hp_has_fallback_cause,
-                                                                     inputs.all_hp_outputs_safe);
-  evaluation.no_hp_available_confirmed = effective_available_hp_count == 0 && evaluation.availability_complete;
+  evaluation.availability_complete = fallback_availability_is_confirmed(
+      inputs.raw_availability_complete, inputs.every_unavailable_hp_has_fallback_cause, inputs.all_hp_outputs_safe);
+  evaluation.no_hp_available_confirmed = inputs.available_hp_count == 0 && evaluation.availability_complete;
   evaluation.fallback_requested =
-      inputs.heating_demand && effective_available_hp_count == 0 && effective_fallback_cause;
+      inputs.heating_demand && inputs.available_hp_count == 0 && inputs.every_unavailable_hp_has_fallback_cause;
 
   oq_hp_fallback::FallbackInputs fallback_inputs;
   fallback_inputs.current_mode = static_cast<oq_hp_fallback::ControlMode>(inputs.current_mode);
   fallback_inputs.heating_demand = inputs.heating_demand;
   fallback_inputs.fallback_enabled = inputs.fallback_enabled;
-  fallback_inputs.available_hp_count = effective_available_hp_count;
+  fallback_inputs.available_hp_count = inputs.available_hp_count;
   fallback_inputs.hp_availability_complete = evaluation.availability_complete;
-  fallback_inputs.confirmed_fallback_cause = effective_fallback_cause;
+  fallback_inputs.confirmed_fallback_cause = inputs.every_unavailable_hp_has_fallback_cause;
   fallback_inputs.hp_output_state_safe = inputs.all_hp_outputs_safe;
   fallback_inputs.flow_valid = inputs.flow_valid;
   fallback_inputs.flow_sufficient = inputs.flow_sufficient;

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -64,8 +64,8 @@ class BoilerPowerTestRuntime {
   void start(const RuntimeConfig& cfg, uint32_t now_ms) {
     const int cm_code = id(oq_control_mode_code);
     const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != TASK_NONE;
-    if (!id(oq_aux_heat_source_present).state) {
-      oq_service_status::set_boiler_power_test("REFUSED: auxiliary heat source not connected");
+    if (!id(oq_boiler_assist_enabled).state) {
+      oq_service_status::set_boiler_power_test("REFUSED: boiler/CV assist disabled");
       return;
     }
     if (task_running || id(oq_commissioning_request_pending)) {
@@ -416,9 +416,9 @@ class BoilerPowerTestRuntime {
       finish_task("FAILED: boiler inhibit active", STATE_FAILED, false, true);
       return false;
     }
-    if (!id(oq_aux_heat_source_present).state) {
-      ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: auxiliary heat source not connected");
-      finish_task("FAILED: auxiliary heat source not connected", STATE_FAILED, false, true);
+    if (!id(oq_boiler_assist_enabled).state) {
+      ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: boiler/CV assist disabled");
+      finish_task("FAILED: boiler/CV assist disabled", STATE_FAILED, false, true);
       return false;
     }
     return true;

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -420,7 +420,6 @@ interval:
             id(oq_boiler_rearm_required) = false;
           }
           const oq_boiler::ControllerInput input{
-              id(oq_aux_heat_source_present).state,
               id(oq_boiler_assist_enabled).state,
               id(oq_boiler_fault_fallback_enabled).state,
               has_valid_supply_temp,

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -330,8 +330,6 @@ text_sensor:
           return {"Commissioning"};
         case oq_boiler::COMMAND_SOURCE_FALLBACK:
           return {"Fallback"};
-        case oq_boiler::COMMAND_SOURCE_COLD_START:
-          return {"Cold start"};
         default:
           return {"None"};
       }

--- a/openquatt/oq_boiler_dispatch.yaml
+++ b/openquatt/oq_boiler_dispatch.yaml
@@ -5,8 +5,7 @@
 # Owns the transport-neutral command contract consumed by `oq_boiler_control`.
 # CM3 commands are derived from the active heating strategy. Power House asks
 # for the remaining thermal power after the selected heat-pump levels; Heating
-# Curve forwards its supply target. A cold start can temporarily own CM3 with a
-# bounded preheat target. CM4 emits a dedicated boiler-only fallback
+# Curve forwards its supply target. CM4 emits a dedicated boiler-only fallback
 # command after supervisory has confirmed heat-pump unavailability. CM100
 # remains an explicit commissioning command. The selected transport is not
 # considered here.
@@ -75,16 +74,7 @@ interval:
               now_ms,
           };
 
-          if (cm_code == 3 && id(oq_cold_start_assist_active)) {
-            command.demand_present = true;
-            command.heat_request = id(oq_strategy_heat_request_active);
-            command.requested_power_w = id(oq_boiler_rated_heat_power).state;
-            float cold_start_target_c = ${oq_hp_cold_start_boiler_target_c};
-            const float maximum_c = id(max_water_temp_limit_c).state;
-            if (!isnan(maximum_c)) cold_start_target_c = fminf(cold_start_target_c, maximum_c);
-            command.target_temperature_c = cold_start_target_c;
-            command.source = oq_boiler::COMMAND_SOURCE_COLD_START;
-          } else if (cm_code == 3) {
+          if (cm_code == 3) {
             command.demand_present = true;
             const int strategy_code = id(oq_strategy_active_code);
             const uint32_t strategy_updated_ms = id(oq_strategy_output_updated_ms);

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -149,9 +149,6 @@ oq_cm3_min_run_s: "300"                               # Minimum dwell time in CM
 oq_cm2_min_run_s: "120"                               # Minimum dwell time in CM2 before promotion [s].
 oq_cm3_curve_on_delta_c: "3.0"                        # Heating Curve target-minus-supply margin for CM2 -> CM3 [°C].
 oq_cm3_curve_off_delta_c: "1.0"                       # Heating Curve target-minus-supply margin for CM3 -> CM2 [°C].
-oq_hp_cold_start_min_c: "5.0"                         # Absolute minimum ODU outlet temperature for compressor start [°C].
-oq_hp_cold_start_assist_release_c: "12.0"              # End auxiliary cold-start assist at this ODU outlet temperature [°C].
-oq_hp_cold_start_boiler_target_c: "25.0"               # Conservative OpenTherm target while cold-start assist is active [°C].
 oq_cm0_sticky_wait_s: "86400"                         # Wait time in CM0 before sticky-pump run starts [s].
 oq_cm0_sticky_run_s: "60"                             # Duration of sticky-pump run in CM0 [s].
 oq_cm0_pump_stop_ipwm: "1000.0"                       # iPWM setpoint that forces pump off in CM0.

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -127,29 +127,6 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # One cold-start session per continuous heating request. Only a fresh ODU
-  # outlet sample taken after circulation starts may release the compressor.
-  - id: oq_cold_start_session_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-  - id: oq_cold_start_pending
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-  - id: oq_cold_start_sample_after_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_cold_start_hp_blocked
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-  - id: oq_cold_start_assist_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
   # Sticky Pump Protection (CM0-only)
   - id: oq_cm0_since_ms
     type: uint32_t
@@ -830,8 +807,6 @@ interval:
           const bool hp1_active_guard = hp1_heating || hp1_cooling || hp1_target_heating || hp1_target_cooling || (hp1_lvl > 0);
           const bool hp2_active_guard = hp2_heating || hp2_cooling || hp2_target_heating || hp2_target_cooling || (hp2_lvl > 0);
           const bool any_hp_active_guard = hp1_active_guard || hp2_active_guard;
-          const bool any_hp_compressor_active =
-              hp1_lvl > 0 || hp2_lvl > 0 || hp1_cmd_lvl > 0 || hp2_cmd_lvl > 0;
           #else
           const int hp2_lvl = 0;
           const int hp2_cmd_lvl = -1;
@@ -848,8 +823,6 @@ interval:
           const bool hp1_active_guard = hp1_heating || hp1_cooling || hp1_target_heating || hp1_target_cooling || (hp1_lvl > 0);
           const bool hp2_active_guard = false;
           const bool any_hp_active_guard = hp1_active_guard;
-          const bool any_hp_compressor_active =
-              hp1_lvl > 0 || hp1_cmd_lvl > 0;
           #endif
           auto defrost_stop_hold_level = [&](bool is_hp1)->int {
             const bool defrost_active = is_hp1 ? id(hp1_defrost).state : id(${secondary_defrost_id}).state;
@@ -1125,79 +1098,6 @@ interval:
             }
             #endif
           }
-
-          // -------------------------------------------------
-          // 2b) Cold water start
-          //    - below 5°C: keep compressors stopped; CM4 may preheat only
-          //      when reserve heating is explicitly allowed
-          //    - 5..12°C: HP start is allowed; configured auxiliary assist
-          //      remains active until every ODU outlet reaches 12°C
-          //    - >=12°C: normal heating logic owns the session
-          // -------------------------------------------------
-          bool cold_start_blocked = false;
-          bool cold_start_below_minimum = false;
-          bool cold_start_assist_requested = false;
-          bool cold_start_released_now = false;
-          if (!heating_req) {
-            id(oq_cold_start_session_active) = false;
-            id(oq_cold_start_pending) = false;
-            id(oq_cold_start_sample_after_ms) = 0;
-            id(oq_cold_start_hp_blocked) = false;
-            id(oq_cold_start_assist_active) = false;
-          } else {
-            if (!id(oq_cold_start_session_active)) {
-              id(oq_cold_start_session_active) = true;
-              id(oq_cold_start_pending) = !any_hp_compressor_active;
-              id(oq_cold_start_sample_after_ms) = 0;
-              id(oq_cold_start_assist_active) = false;
-            }
-
-            if (id(oq_cold_start_pending)) {
-              if (flow_ok && id(oq_cold_start_sample_after_ms) == 0) {
-                id(oq_cold_start_sample_after_ms) = now_ms;
-              }
-
-              const float hp1_raw_c = id(hp1_water_out_temp_raw).state;
-              const float hp1_offset_c = id(hp1_water_out_temp_offset).state;
-              const float hp1_out_c =
-                  isnan(hp1_raw_c) || isnan(hp1_offset_c) ? NAN : hp1_raw_c + hp1_offset_c;
-              #if OQ_TOPOLOGY_DUO
-              const float hp2_raw_c = id(${secondary_hp_id}_water_out_temp_raw).state;
-              const float hp2_offset_c = id(${secondary_hp_id}_water_out_temp_offset).state;
-              const float hp2_out_c =
-                  isnan(hp2_raw_c) || isnan(hp2_offset_c) ? NAN : hp2_raw_c + hp2_offset_c;
-              const oq_hp_supervisory::ColdStartWaterSample hp2_cold_start_sample{
-                  true, hp2_out_c, id(${secondary_water_out_last_update_ms_id})};
-              #else
-              const float hp2_out_c = NAN;
-              const oq_hp_supervisory::ColdStartWaterSample hp2_cold_start_sample{
-                  false, hp2_out_c, 0};
-              #endif
-              const auto cold_start = oq_hp_supervisory::evaluate_cold_start(
-                  id(oq_cold_start_sample_after_ms),
-                  oq_hp_supervisory::ColdStartWaterSample{
-                      true, hp1_out_c, id(hp1_water_out_temp_last_update_ms)},
-                  hp2_cold_start_sample,
-                  ${oq_hp_cold_start_min_c},
-                  ${oq_hp_cold_start_assist_release_c});
-
-              if (cold_start.released) {
-                id(oq_cold_start_pending) = false;
-                cold_start_released_now = true;
-              } else {
-                cold_start_blocked =
-                    !any_hp_compressor_active && !cold_start.hp_start_allowed;
-                cold_start_below_minimum =
-                    !any_hp_compressor_active && cold_start.samples_ready &&
-                    !cold_start.hp_start_allowed;
-                cold_start_assist_requested =
-                    cold_start.auxiliary_assist_recommended &&
-                    id(oq_aux_heat_source_present).state &&
-                    id(oq_boiler_assist_enabled).state;
-              }
-            }
-            id(oq_cold_start_hp_blocked) = cold_start_blocked;
-          }
           // -------------------------------------------------
           // 3) Frost condition (hysteresis + fail-safe) [CM98]
           //    Relevant only when there is no heat demand.
@@ -1254,10 +1154,6 @@ interval:
 
             // Determine base target (without CM1 timer)
             int base_target = oq_hp_supervisory::base_control_mode(cooling_req, heating_req, frost);
-
-            if (heating_req && cold_start_blocked) {
-              base_target = 1;
-            }
 
             // Apply flow interlock: if thermal output is requested but low-flow fault => hold in CM1.
             if (thermal_req && (id(oq_lowflow_fault_active) || flow_low)) {
@@ -1338,7 +1234,6 @@ interval:
             fallback_inputs.every_unavailable_hp_has_fallback_cause =
                 every_unavailable_hp_allows_fallback;
             fallback_inputs.all_hp_outputs_safe = fallback_outputs_safe;
-            fallback_inputs.cold_start_blocked = cold_start_below_minimum;
             fallback_inputs.flow_valid = flow_valid;
             fallback_inputs.flow_sufficient =
                 flow_ok && !id(oq_lowflow_fault_active);
@@ -1563,8 +1458,7 @@ interval:
               const bool boiler_assist_available =
                   boiler_assist_enabled &&
                   boiler_transport_available &&
-                  (cold_start_assist_requested ||
-                   boiler_strategy_command_available);
+                  boiler_strategy_command_available;
               if (heating_strategy_active && boiler_assist_available &&
                   !fallback_requested && !no_hp_available_confirmed) {
                 bool need_on = false;
@@ -1572,12 +1466,7 @@ interval:
                 const char *promote_reason = "boiler assist promoted to CM3";
                 const char *demote_reason = "boiler assist cleared, demoting to CM2";
 
-                if (cold_start_assist_requested) {
-                  need_on = true;
-                  ok_off = false;
-                  promote_reason = "cold water start promoted to CM3";
-                  demote_reason = "cold water start released, demoting to CM2";
-                } else if (power_house_active) {
+                if (power_house_active) {
                   const auto assist = oq_boiler::power_house_assist(
                       id(oq_P_deficit_w),
                       id(oq_cm3_deficit_on_w).state,
@@ -1605,14 +1494,7 @@ interval:
                 const uint32_t MIN_CM3_MS = (uint32_t)(${oq_cm3_min_run_s}UL * 1000UL);
                 const uint32_t MIN_CM2_MS = (uint32_t)(${oq_cm2_min_run_s}UL * 1000UL);
 
-                if (cold_start_assist_requested &&
-                    (desired_local == 2 || cm_now == 2 || cm_now == 3 || cm_now == 4)) {
-                  desired_local = 3;
-                  id(oq_cold_start_assist_active) = true;
-                  id(oq_cm3_need_since_ms) = 0;
-                  id(oq_cm3_demote_since_ms) = 0;
-                  cm_transition_reason = promote_reason;
-                } else if (cm_now == 2) {
+                if (cm_now == 2) {
                   if (now_ms - id(oq_cm_last_change_ms) >= MIN_CM2_MS) {
                     if (need_on) {
                       if (id(oq_cm3_need_since_ms) == 0) id(oq_cm3_need_since_ms) = now_ms;
@@ -1670,18 +1552,6 @@ interval:
                     cm_transition_reason = "heating strategy unavailable for boiler assist, returning to CM2";
                   }
                 }
-              }
-
-              if (cold_start_released_now &&
-                  id(oq_cold_start_assist_active) &&
-                  cm_now == 3) {
-                desired_local = 2;
-                id(oq_cm3_need_since_ms) = 0;
-                id(oq_cm3_demote_since_ms) = 0;
-                cm_transition_reason = "cold water start reached release temperature";
-              }
-              if (!cold_start_assist_requested || desired_local != 3) {
-                id(oq_cold_start_assist_active) = false;
               }
               }
             }

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -51,33 +51,10 @@ time:
     id: oq_time
     timezone: Europe/Amsterdam
 
-esphome:
-  on_boot:
-    - priority: -100
-      then:
-        - lambda: |-
-            if (!id(oq_aux_heat_source_policy_migrated)) {
-              const bool legacy_source_present = id(oq_boiler_assist_enabled).state;
-              if (legacy_source_present) {
-                id(oq_aux_heat_source_present).turn_on();
-              } else {
-                id(oq_aux_heat_source_present).turn_off();
-              }
-              id(oq_aux_heat_source_policy_migrated) = true;
-            }
-
 # ----------------------------
 # INTERNAL STATE
 # ----------------------------
 globals:
-  # One-time split of the legacy combined boiler-present/assist switch. The
-  # existing assist state seeds physical presence; assist and fallback retain
-  # their own restored values.
-  - id: oq_aux_heat_source_policy_migrated
-    type: bool
-    restore_value: true
-    initial_value: 'false'
-
   # Frost hysteresis state for CM98 selection
   - id: oq_cm_frost_prev
     type: bool
@@ -255,32 +232,16 @@ select:
 
 switch:
   - platform: template
-    id: oq_aux_heat_source_present
-    name: "Auxiliary heat source connected"
-    icon: mdi:heating-coil
-    restore_mode: RESTORE_DEFAULT_ON
-    optimistic: true
-    entity_category: config
-    on_turn_off:
-      # Physical absence is the top-level fail-closed gate. Also clear both
-      # permissions so a later reconnect requires an explicit choice.
-      - switch.turn_off: oq_boiler_assist_enabled
-      - switch.turn_off: oq_boiler_fault_fallback_enabled
-
-  - platform: template
     id: oq_boiler_assist_enabled
     name: "Boiler assist enabled"
     icon: mdi:water-boiler
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
     entity_category: config
-    on_turn_on:
-      - if:
-          condition:
-            lambda: |-
-              return !id(oq_aux_heat_source_present).state;
-          then:
-            - switch.turn_off: oq_boiler_assist_enabled
+    on_turn_off:
+      # This switch is the installation-level boiler-present permission in
+      # the web app. Turning it off must also revoke the hidden CM4 opt-in.
+      - switch.turn_off: oq_boiler_fault_fallback_enabled
 
   - platform: template
     id: oq_boiler_fault_fallback_enabled
@@ -291,13 +252,6 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: config
-    on_turn_on:
-      - if:
-          condition:
-            lambda: |-
-              return !id(oq_aux_heat_source_present).state;
-          then:
-            - switch.turn_off: oq_boiler_fault_fallback_enabled
 
   - platform: template
     id: oq_enabled
@@ -1226,7 +1180,7 @@ interval:
             fallback_inputs.current_mode = current_cm_code;
             fallback_inputs.heating_demand = heating_req;
             fallback_inputs.fallback_enabled =
-                id(oq_aux_heat_source_present).state &&
+                id(oq_boiler_assist_enabled).state &&
                 id(oq_boiler_fault_fallback_enabled).state;
             fallback_inputs.available_hp_count = available_hp_count;
             fallback_inputs.raw_availability_complete =
@@ -1389,8 +1343,7 @@ interval:
                           cm4_resume_tracker.resume_mode(),
                           available_hp_count > 0,
                           power_house_active,
-                          id(oq_aux_heat_source_present).state &&
-                              id(oq_boiler_assist_enabled).state,
+                          id(oq_boiler_assist_enabled).state,
                       });
                   if (heating_mode.start_cm1_for_mode >= 0) {
                     start_cm1(heating_mode.start_cm1_for_mode);
@@ -1432,9 +1385,7 @@ interval:
                   (strcmp(cur_cm, "CM5") == 0) ? 5 :
                   (strcmp(cur_cm, "CM1") == 0) ? 1 :
                   (strcmp(cur_cm, "CM98") == 0) ? 98 : 0;
-              const bool boiler_assist_enabled =
-                  id(oq_aux_heat_source_present).state &&
-                  id(oq_boiler_assist_enabled).state;
+              const bool boiler_assist_enabled = id(oq_boiler_assist_enabled).state;
               const bool opentherm_selected =
                   id(oq_boiler_connection).has_state() &&
                   id(oq_boiler_connection).current_option() == "OpenTherm";

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -1402,13 +1402,11 @@ interval:
           }
 
           // =========================
-          // 5) Absolute water-temperature/low-flow/cold-start hard stop
+          // 5) Absolute water-temperature/low-flow hard stop
           // These safety stops have higher priority than compressor minimum runtime.
           // =========================
           const bool hard_request_stop_active =
-              id(oq_water_temp_hard_trip_active) ||
-              id(oq_lowflow_fault_active) ||
-              (!is_cooling_mode && id(oq_cold_start_hp_blocked));
+              id(oq_water_temp_hard_trip_active) || id(oq_lowflow_fault_active);
           if (hard_request_stop_active) {
             hp1_req = 0;
             #if OQ_TOPOLOGY_DUO

--- a/openquatt/web/js/src/core/config.js
+++ b/openquatt/web/js/src/core/config.js
@@ -14,7 +14,7 @@
     ["generation", "Kies je Quatt Hybrid", "Geef hier aan welke Quatt Hybrid je hebt. Dan zet OpenQuatt de juiste regeling klaar."],
     ["flow-source", "Flowmeting configureren", "Controleer en activeer de flowbron die bij jouw Quatt-versie en controller hoort."],
     ["thermostat-source", "Thermostaatgegevens configureren", "Leg vast waar OpenQuatt de kamertemperatuur en het kamer-setpoint samen vandaan haalt."],
-    ["boiler", "Aanvullende warmtebron", "Leg vast of een aanvullende warmtebron is aangesloten en wanneer OpenQuatt die mag gebruiken.", "auxHeatSourcePresent"],
+    ["boiler", "CV-ketel of boiler", "Leg vast of er een ketel is en hoe die fysiek is aangesloten.", "boilerCvAssistEnabled"],
     ["strategy", "Kies de verwarmingsstrategie", "Kies hier hoe OpenQuatt je verwarming regelt. Daarna lopen we samen de belangrijkste instellingen langs."],
     ["heating", "Werk de regeling uit", "Stel nu de gekozen regeling verder in. De inhoud hieronder past zich aan aan je keuze."],
     ["flow", "Flowregeling en afstelling", "Leg daarna vast hoe de pomp geregeld moet worden en welke waarden daarbij horen. De autotune staat later onder Instellingen → Installatie → Service & commissioning."],
@@ -118,7 +118,6 @@
     hpGeneration: { domain: "select", name: "Quatt Hybrid version" },
     strategy: { domain: "select", name: "Heating Control Mode" },
     openquattEnabled: { domain: "switch", name: "OpenQuatt Enabled", optional: true },
-    auxHeatSourcePresent: { domain: "switch", name: "Auxiliary heat source connected", optional: true },
     boilerCvAssistEnabled: { domain: "switch", name: "Boiler assist enabled", optional: true },
     boilerFaultFallbackEnabled: { domain: "switch", name: "Boiler fallback on heat-pump fault", optional: true },
     boilerConnection: { domain: "select", name: "Boiler connection", optional: true },
@@ -1019,7 +1018,6 @@
   export const CIC_COMPATIBILITY_KEYS = ["cicCompatibilityMode"];
   export const OPENTHERM_SETTING_KEYS = ["otEnabled", "otLinkProblem"];
   export const BOILER_SETTING_KEYS = [
-    "auxHeatSourcePresent",
     "boilerConnection",
     "boilerFaultFallbackEnabled",
   ];
@@ -1512,7 +1510,6 @@
     "openquattEnabled",
     "usageTelemetryEnabled",
     "usageTelemetryChoiceConfigured",
-    "auxHeatSourcePresent",
     "boilerCvAssistEnabled",
     "boilerConnection",
     "openquattResumeAt",
@@ -1610,7 +1607,6 @@
     "openquattEnabled",
     "usageTelemetryEnabled",
     "usageTelemetryChoiceConfigured",
-    "auxHeatSourcePresent",
     "boilerCvAssistEnabled",
     "boilerRatedHeatPower",
     "boilerConnection",

--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -192,7 +192,6 @@ import { fetchWithTimeout } from "./browser-utils.js";
       "minRuntime",
     ],
     service: [
-      "auxHeatSourcePresent",
       "compressorStarts2hWarningLimit",
       "compressorStarts72hWarningLimit",
       "compressorCyclingWarning2h",
@@ -238,7 +237,6 @@ import { fetchWithTimeout } from "./browser-utils.js";
       ...COMMISSIONING_STATE_KEYS,
       ...SENSOR_CALIBRATION_KEYS,
       ...SENSOR_CALIBRATION_STATE_KEYS,
-      "auxHeatSourcePresent",
       "boilerCvAssistEnabled",
       "boilerRatedHeatPower",
       "flowSelected",

--- a/openquatt/web/js/src/features/quickstart-actions.js
+++ b/openquatt/web/js/src/features/quickstart-actions.js
@@ -35,7 +35,6 @@ import { render } from "../core/render-scheduler.js";
     if (stepId === "boiler") {
       return [...new Set([
         ...base,
-        "auxHeatSourcePresent",
         "boilerCvAssistEnabled",
         "boilerFaultFallbackEnabled",
         "boilerConnection",
@@ -73,7 +72,6 @@ import { render } from "../core/render-scheduler.js";
         "hpGeneration",
         ...ODU_GENERATION_KEYS,
         ...ODU_GENERATION_DETECT_KEYS,
-        "auxHeatSourcePresent",
         "boilerCvAssistEnabled",
         "boilerFaultFallbackEnabled",
         "boilerConnection",

--- a/openquatt/web/js/src/features/quickstart.js
+++ b/openquatt/web/js/src/features/quickstart.js
@@ -656,8 +656,8 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
     return `
       <section class="oq-helper-panel">
         <p class="oq-helper-label">${escapeHtml(getQuickStepKicker("boiler"))}</p>
-        <h2 class="oq-helper-section-title">Aanvullende warmtebron</h2>
-        <p class="oq-helper-section-copy">Dit kan bijvoorbeeld een cv-ketel, elektrische cv-ketel (e-cv) of doorstroomverwarmer zijn. Kies of de warmtebron hybride meeverwarmt bij een vermogenstekort en of deze mag overnemen wanneer geen warmtepomp beschikbaar is.</p>
+        <h2 class="oq-helper-section-title">CV-ketel of boiler</h2>
+        <p class="oq-helper-section-copy">Geef aan of er een ketel aanwezig is, hoe die is aangesloten en of deze automatisch mag overnemen wanneer alle warmtepompen door een storing uitvallen.</p>
         ${renderBoilerCvFields("oq-settings-grid oq-settings-grid--quickstart oq-settings-boiler-simple-grid", true)}
         ${renderQuickStartStepNav({
           nextDisabled: boilerConnectionMismatch,
@@ -983,23 +983,17 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
         : ["Gewenste flow", formatValue("flowSetpoint")],
     ];
 
-    const sourcePresent = hasEntity("auxHeatSourcePresent")
-      ? isEntityActive("auxHeatSourcePresent")
-      : isEntityActive("boilerCvAssistEnabled");
-    const boilerLines = hasEntity("auxHeatSourcePresent") || hasEntity("boilerCvAssistEnabled")
+    const boilerLines = hasEntity("boilerCvAssistEnabled")
       ? [
-          ["Warmtebron aangesloten", sourcePresent ? "Ja" : "Nee"],
-          ...(sourcePresent
+          ["CV-ketel/boiler aanwezig", isEntityActive("boilerCvAssistEnabled") ? "Ja" : "Nee"],
+          ...(isEntityActive("boilerCvAssistEnabled")
             ? [
                 ...(hasEntity("boilerConnection")
-                  ? [["Aansturing warmtebron", String(getEntityValue("boilerConnection") || "R1") === "OpenTherm" ? "OpenTherm (OTB)" : "Aan/uit (R1)"]]
+                  ? [["Ketelaansluiting", String(getEntityValue("boilerConnection") || "R1") === "OpenTherm" ? "OpenTherm (OTB)" : "Aan/uit (R1)"]]
                   : []),
-                ["Beschikbaar verwarmingsvermogen", formatValue("boilerRatedHeatPower")],
-                ...(hasEntity("boilerCvAssistEnabled")
-                  ? [["Hybride verwarmen bij vermogenstekort", isEntityActive("boilerCvAssistEnabled") ? "Aan" : "Uit"]]
-                  : []),
+                ["Ingesteld ketelvermogen", formatValue("boilerRatedHeatPower")],
                 ...(hasEntity("boilerFaultFallbackEnabled")
-                  ? [["Overnemen wanneer de warmtepomp niet beschikbaar is", isEntityActive("boilerFaultFallbackEnabled") ? "Aan" : "Uit"]]
+                  ? [["Automatische ketelovername bij warmtepompstoring", isEntityActive("boilerFaultFallbackEnabled") ? "Aan" : "Uit"]]
                   : []),
               ]
             : []),

--- a/openquatt/web/js/src/settings/installation.js
+++ b/openquatt/web/js/src/settings/installation.js
@@ -19,9 +19,8 @@ import { getSelectEntityOptions, renderNamedActionButton, renderSettingsAdvanced
 import { renderSettingsHeatPumpLimiterCard } from "./heating.js";
 import { escapeHtml } from "../core/html.js";
 
-const AUX_HEAT_ASSIST_TITLE = "Hybride verwarmen bij vermogenstekort";
-const AUX_HEAT_BACKUP_TITLE = "Overnemen wanneer de warmtepomp niet beschikbaar is";
-const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer geen warmtepomp veilig beschikbaar is. Dit gebeurt pas na een veilige stop en geldige flow, temperatuur en aansturing. Een korte communicatiedip telt niet als uitval.";
+const BOILER_FAULT_FALLBACK_TITLE = "Automatische ketelovername bij warmtepompstoring";
+const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepompen door een storing uitvallen. Dit gebeurt pas na veilige stop en geldige flow, temperatuur en ketelaansturing. OpenQuatt stelt dit zelf vast; je hoeft niets te bevestigen. Een korte communicatiedip telt niet als storing.";
 
   export function getOduRuntimeFrequencyHpIndexes() {
     return ODU_RUNTIME_FREQUENCY_HP_IDS.filter((hpIndex) => (
@@ -880,24 +879,15 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
     className = "oq-settings-grid oq-settings-boiler-simple-grid",
     includeFaultFallback = false,
   ) {
-    if (!hasEntity("auxHeatSourcePresent") && !hasEntity("boilerCvAssistEnabled")) {
+    if (!hasEntity("boilerCvAssistEnabled")) {
       return "";
     }
 
-    const separateSourcePolicyAvailable = hasEntity("auxHeatSourcePresent");
-    const sourcePresenceKey = separateSourcePolicyAvailable
-      ? "auxHeatSourcePresent"
-      : "boilerCvAssistEnabled";
-    const sourcePresent = separateSourcePolicyAvailable
-      ? isEntityActive("auxHeatSourcePresent")
-      : isEntityActive("boilerCvAssistEnabled");
-    const sourcePresentBusy = state.loadingEntities || state.busyAction === `switch-${sourcePresenceKey}`;
-    const assistSettingAvailable = hasEntity("boilerCvAssistEnabled");
-    const assistEnabled = assistSettingAvailable && isEntityActive("boilerCvAssistEnabled");
-    const assistBusy = state.loadingEntities || state.busyAction === "switch-boilerCvAssistEnabled";
+    const boilerPresent = isEntityActive("boilerCvAssistEnabled");
     const boilerPowerEntityAvailable = hasEntity("boilerRatedHeatPower");
     const boilerMeta = getNumberMeta("boilerRatedHeatPower");
     const boilerValue = getInputDraftValue("boilerRatedHeatPower");
+    const boilerBusy = state.loadingEntities || state.busyAction === "switch-boilerCvAssistEnabled";
     const fallbackSettingAvailable = hasEntity("boilerFaultFallbackEnabled");
     const fallbackEnabled = fallbackSettingAvailable && isEntityActive("boilerFaultFallbackEnabled");
     const fallbackBusy = state.loadingEntities || state.busyAction === "switch-boilerFaultFallbackEnabled";
@@ -940,7 +930,7 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
         <p>De aansluitingskeuze is tijdelijk geblokkeerd.</p>
       </div>
     ` : "";
-    const boilerPowerMissingHint = "Deze firmware levert nog geen bewerkbare vermogensinstelling voor de warmtebron.";
+    const boilerPowerMissingHint = "Deze firmware levert nog geen bewerkbare boilervermogensinstelling.";
     const boilerPowerControl = boilerPowerEntityAvailable
       ? renderNumberInputControl({
           key: "boilerRatedHeatPower",
@@ -955,7 +945,7 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
           <p>${escapeHtml(boilerPowerMissingHint)}</p>
         </div>
       `;
-    const boilerPowerFooter = sourcePresent && boilerPowerEntityAvailable
+    const boilerPowerFooter = boilerPresent && boilerPowerEntityAvailable
       ? `<p class="oq-settings-boiler-power-note">Je kunt deze waarde altijd handmatig aanpassen.</p>`
       : "";
     const boilerConnectionFooter = boilerConnectionAutoSelected
@@ -977,91 +967,75 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
           <p class="oq-settings-boiler-connection-note">OT-controle bij opstart actief.</p>
         `
         : "";
-    const supportSwitchingFields = !isCurveMode() && sourcePresent && assistEnabled
+    const supportSwitchingFields = !isCurveMode() && boilerPresent
       ? [
           renderSettingsNumberField(
             "boilerSupportStartThreshold",
             "Ondersteuning starten vanaf",
-            "Standaard 1000 W. Power House moet eerst minimaal 2 minuten zonder aanvullende warmtebron draaien; daarna moet het warmtetekort 5 minuten onafgebroken boven deze grens blijven.",
+            "Standaard 1000 W. Power House moet eerst minimaal 2 minuten zonder ketelondersteuning draaien; daarna moet het warmtetekort 5 minuten onafgebroken boven deze grens blijven.",
           ),
           renderSettingsNumberField(
             "boilerSupportStopThreshold",
             "Ondersteuning stoppen onder",
-            "Standaard 400 W. De aanvullende warmtebron blijft minimaal 5 minuten actief en stopt pas wanneer het warmtetekort daarna 2 minuten onder deze grens blijft.",
+            "Standaard 400 W. Ketelondersteuning blijft minimaal 5 minuten actief en stopt pas wanneer het warmtetekort daarna 2 minuten onder deze grens blijft.",
           ),
         ].filter(Boolean).join("")
       : "";
     const supportSwitchingMarkup = renderSettingsAdvancedDisclosure(
       "boiler-support",
-      "Wanneer hybride ondersteuning start en stopt",
-      "Alleen voor Power House. Het warmtetekort is het gevraagde woningvermogen min het maximaal beschikbare warmtepompvermogen, met minimaal 0 W. Tussen beide grenzen blijft de huidige toestand behouden. Deze waarden veranderen het beschikbare verwarmingsvermogen en de aansturing niet.",
+      "Wanneer ketelondersteuning start en stopt",
+      "Alleen voor Power House. Het warmtetekort is het gevraagde woningvermogen min het maximaal beschikbare warmtepompvermogen, met minimaal 0 W. Tussen beide grenzen blijft de huidige toestand behouden. Deze waarden veranderen het ketelvermogen en de OpenTherm-aansturing niet.",
       supportSwitchingFields ? `<div class="oq-settings-grid">${supportSwitchingFields}</div>` : "",
     );
 
     return `
         <div class="${escapeHtml(className)}">
           ${renderSettingsFieldCard(
-            sourcePresenceKey,
-            "Warmtebron aangesloten",
-            "Zet dit aan als OpenQuatt een aanvullende warmtebron kan aansturen, zoals een cv-ketel, elektrische cv-ketel (e-cv) of doorstroomverwarmer.",
+            "boilerCvAssistEnabled",
+            "CV-ketel / boiler aanwezig",
+            "Geef aan of OpenQuatt deze installatie als ondersteuning mag gebruiken.",
             `
               <div class="oq-settings-compact-switch-field">
-                ${renderSettingsCompactSwitchControl(sourcePresenceKey, "Warmtebron aangesloten", sourcePresent, sourcePresentBusy)}
+                ${renderSettingsCompactSwitchControl("boilerCvAssistEnabled", "CV-ketel / boiler aanwezig", boilerPresent, boilerBusy)}
               </div>
             `,
             "oq-settings-field--compact",
           )}
 
-          ${(sourcePresent || boilerConnectionMismatch || boilerConnectionAutoSelected) && boilerConnectionAvailable ? renderSettingsFieldCard(
+          ${(boilerPresent || boilerConnectionMismatch || boilerConnectionAutoSelected) && boilerConnectionAvailable ? renderSettingsFieldCard(
             "boilerConnection",
-            "Aansturing warmtebron",
+            "Ketelaansluiting",
             !openthermBoilerCapabilityKnown
-              ? "OpenQuatt controleert welke aansturingen deze hardware ondersteunt."
+              ? "OpenQuatt controleert welke ketelaansluitingen deze hardware ondersteunt."
               : openthermBoilerSupported
-              ? "Kies de route waarmee de warmtebron fysiek is verbonden. OpenQuatt gebruikt nooit beide routes tegelijk."
+              ? "Kies de aansluiting die fysiek met de ketel is verbonden. OpenQuatt gebruikt nooit beide routes tegelijk."
               : "Deze hardware ondersteunt alleen de aan/uit-aansluiting via R1.",
             boilerConnectionControl,
             "oq-settings-field--compact",
             boilerConnectionFooter,
           ) : ""}
 
-          ${sourcePresent ? renderSettingsFieldCard(
+          ${boilerPresent ? renderSettingsFieldCard(
             "boilerRatedHeatPower",
-            "Beschikbaar verwarmingsvermogen",
+            "Ingesteld boilervermogen",
             "Vul hier het vermogen in dat OpenQuatt mag meerekenen.",
             `
               <div class="oq-settings-boiler-power-inline">
                 ${boilerPowerControl}
               </div>
             `,
-            sourcePresent && boilerPowerEntityAvailable ? "oq-settings-field--compact" : "oq-settings-field--compact is-disabled",
+            boilerPresent && boilerPowerEntityAvailable ? "oq-settings-field--compact" : "oq-settings-field--compact is-disabled",
             boilerPowerFooter,
           ) : ""}
-          ${sourcePresent && separateSourcePolicyAvailable && assistSettingAvailable ? renderSettingsFieldCard(
-            "boilerCvAssistEnabled",
-            AUX_HEAT_ASSIST_TITLE,
-            "Laat de aanvullende warmtebron meeverwarmen wanneer het beschikbare warmtepompvermogen niet genoeg is voor de warmtevraag.",
-            `
-              <div class="oq-settings-compact-switch-field">
-                ${renderSettingsCompactSwitchControl(
-                  "boilerCvAssistEnabled",
-                  AUX_HEAT_ASSIST_TITLE,
-                  assistEnabled,
-                  assistBusy,
-                )}
-              </div>
-            `,
-            "oq-settings-field--compact",
-          ) : ""}
-          ${sourcePresent && includeFaultFallback && fallbackSettingAvailable ? renderSettingsFieldCard(
+          ${boilerPresent && includeFaultFallback && fallbackSettingAvailable ? renderSettingsFieldCard(
             "boilerFaultFallbackEnabled",
-            AUX_HEAT_BACKUP_TITLE,
-            AUX_HEAT_BACKUP_COPY,
+            BOILER_FAULT_FALLBACK_TITLE,
+            BOILER_FAULT_FALLBACK_COPY,
             `
               <div class="oq-settings-compact-switch-field">
                 ${renderSettingsCompactSwitchControl(
                   "boilerFaultFallbackEnabled",
-                  AUX_HEAT_BACKUP_TITLE,
+                  BOILER_FAULT_FALLBACK_TITLE,
                   fallbackEnabled,
                   fallbackBusy,
                 )}
@@ -1076,19 +1050,17 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
   }
 
   export function renderSettingsBoilerCvSection() {
-    if (!hasEntity("auxHeatSourcePresent") && !hasEntity("boilerCvAssistEnabled")) {
+    if (!hasEntity("boilerCvAssistEnabled")) {
       return "";
     }
 
-    const sourcePresent = hasEntity("auxHeatSourcePresent")
-      ? isEntityActive("auxHeatSourcePresent")
-      : isEntityActive("boilerCvAssistEnabled");
+    const boilerPresent = isEntityActive("boilerCvAssistEnabled");
     return renderSettingsSection(
       "Basis",
-      "Aanvullende warmtebron",
-      sourcePresent
-        ? "Bijvoorbeeld een cv-ketel, elektrische cv-ketel (e-cv) of doorstroomverwarmer. Kies wanneer OpenQuatt deze mag gebruiken."
-        : "Geef aan of OpenQuatt een aanvullende warmtebron kan aansturen, zoals een cv-ketel, elektrische cv-ketel (e-cv) of doorstroomverwarmer.",
+      "CV-ketel of boiler",
+      boilerPresent
+        ? "Kies hoe de ketel is aangesloten en hoeveel effectief vermogen OpenQuatt als ondersteuning mag gebruiken."
+        : "Geef aan of OpenQuatt een CV-ketel of boiler als ondersteuning mag gebruiken.",
       renderBoilerCvFields("oq-settings-grid oq-settings-boiler-simple-grid", true),
     );
   }

--- a/openquatt/web/js/src/settings/installation.js
+++ b/openquatt/web/js/src/settings/installation.js
@@ -21,7 +21,7 @@ import { escapeHtml } from "../core/html.js";
 
 const AUX_HEAT_ASSIST_TITLE = "Hybride verwarmen bij vermogenstekort";
 const AUX_HEAT_BACKUP_TITLE = "Overnemen wanneer de warmtepomp niet beschikbaar is";
-const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer geen warmtepomp veilig beschikbaar is, ook bij een koude opstart onder 5 °C. Dit gebeurt pas na een veilige stop en geldige flow, temperatuur en aansturing. Een korte communicatiedip telt niet als uitval.";
+const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer geen warmtepomp veilig beschikbaar is. Dit gebeurt pas na een veilige stop en geldige flow, temperatuur en aansturing. Een korte communicatiedip telt niet als uitval.";
 
   export function getOduRuntimeFrequencyHpIndexes() {
     return ODU_RUNTIME_FREQUENCY_HP_IDS.filter((hpIndex) => (
@@ -1040,7 +1040,7 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
           ${sourcePresent && separateSourcePolicyAvailable && assistSettingAvailable ? renderSettingsFieldCard(
             "boilerCvAssistEnabled",
             AUX_HEAT_ASSIST_TITLE,
-            "Laat de aanvullende warmtebron meeverwarmen wanneer het beschikbare warmtepompvermogen niet genoeg is voor de warmtevraag en tijdens een koude opstart van 5 tot 12 °C.",
+            "Laat de aanvullende warmtebron meeverwarmen wanneer het beschikbare warmtepompvermogen niet genoeg is voor de warmtevraag.",
             `
               <div class="oq-settings-compact-switch-field">
                 ${renderSettingsCompactSwitchControl(

--- a/openquatt/web/js/src/settings/service.js
+++ b/openquatt/web/js/src/settings/service.js
@@ -449,9 +449,7 @@ import { renderModalShell } from "../core/modal-shell.js";
   }
 
   export function getSettingsServiceModel() {
-    const hasBoilerAssist = hasEntity("auxHeatSourcePresent")
-      ? isEntityActive("auxHeatSourcePresent")
-      : hasEntity("boilerCvAssistEnabled") && isEntityActive("boilerCvAssistEnabled");
+    const hasBoilerAssist = hasEntity("boilerCvAssistEnabled") && isEntityActive("boilerCvAssistEnabled");
     const cm100Status = getCommissioningStatusValue();
     const cm100Active = isEntityActive("cm100Active");
     const cm100StatusUpper = String(cm100Status || "").trim().toUpperCase();
@@ -837,7 +835,7 @@ import { renderModalShell } from "../core/modal-shell.js";
           taskKey: "boiler",
           title: "Boiler power test",
           copy: "Meet het effectieve boilervermogen bij stabiele flow en schrijf daarna een afgerond voorstel weg naar de boilerinstelling. Boilertest duurt meestal ongeveer 5 tot 10 minuten.",
-          subcopy: `Beschikbaar verwarmingsvermogen: ${escapeHtml(boilerRatedPower)}`,
+          subcopy: `Ingesteld boilervermogen: ${escapeHtml(boilerRatedPower)}`,
           status: boilerStatusDisplay,
           statusCopy: boilerTaskWaitingForCm100
             ? "Wacht totdat CM100 actief is voordat je de boiler-test start."

--- a/openquatt/web/js/src/views/heatpump.js
+++ b/openquatt/web/js/src/views/heatpump.js
@@ -756,10 +756,7 @@ import { replaceOuterHtmlIfSignatureChanged, setInnerHtmlIfChanged } from "./vie
   }
 
   export function shouldRenderBoilerPanel() {
-    const sourcePresent = hasEntity("auxHeatSourcePresent")
-      ? isEntityActive("auxHeatSourcePresent")
-      : isEntityActive("boilerCvAssistEnabled");
-    return sourcePresent && hasEntity("boilerHeatPower");
+    return isEntityActive("boilerCvAssistEnabled") && hasEntity("boilerHeatPower");
   }
 
   export function getBoilerReturnTemperatureKey() {

--- a/openquatt/web/tests/boiler-view.test.mjs
+++ b/openquatt/web/tests/boiler-view.test.mjs
@@ -28,7 +28,6 @@ const heatPumpCss = await readFile(new URL("../css/src/40-heatpump.css", import.
 const boilerOpenThermYaml = await readFile(new URL("../../oq_boiler_opentherm.yaml", import.meta.url), "utf8");
 const heatPumpQProfileYaml = await readFile(new URL("../../profiles/heatpump_controller_q.yaml", import.meta.url), "utf8");
 const otSlaveYaml = await readFile(new URL("../../oq_ot_slave.yaml", import.meta.url), "utf8");
-const commonSubstitutionsYaml = await readFile(new URL("../../oq_substitutions_common.yaml", import.meta.url), "utf8");
 const quickStartSource = await readFile(new URL("../js/src/features/quickstart.js", import.meta.url), "utf8");
 const quickStartActionsSource = await readFile(new URL("../js/src/features/quickstart-actions.js", import.meta.url), "utf8");
 const installationSource = await readFile(new URL("../js/src/settings/installation.js", import.meta.url), "utf8");
@@ -390,10 +389,6 @@ test("auxiliary heat source setting remains editable on legacy firmware", () => 
 test("fallback heating setting explains its guarded scope", () => {
   assert.match(installationSource, /Overnemen wanneer de warmtepomp niet beschikbaar is/);
   assert.match(installationSource, /wanneer geen warmtepomp veilig beschikbaar is/);
-  assert.match(installationSource, /koude opstart onder 5 °C/);
-  assert.match(installationSource, /koude opstart van 5 tot 12 °C/);
-  assert.match(commonSubstitutionsYaml, /oq_hp_cold_start_min_c: "5\.0"/);
-  assert.match(commonSubstitutionsYaml, /oq_hp_cold_start_assist_release_c: "12\.0"/);
   assert.match(installationSource, /na een veilige stop/);
   assert.match(installationSource, /Een korte communicatiedip telt niet als uitval/);
 });

--- a/openquatt/web/tests/boiler-view.test.mjs
+++ b/openquatt/web/tests/boiler-view.test.mjs
@@ -336,13 +336,11 @@ test("integration diagnostics separates thermostat, boiler control, OTB and CiC"
 });
 
 test("settings hydration loads boiler setup and diagnostics before rendering", () => {
-  assert.ok(FAST_OVERVIEW_KEYS.includes("auxHeatSourcePresent"));
   assert.ok(FAST_OVERVIEW_KEYS.includes("boilerCvAssistEnabled"));
   assert.ok(FAST_OVERVIEW_KEYS.includes("boilerRatedHeatPower"));
   assert.ok(FAST_OVERVIEW_KEYS.includes("boilerConnection"));
   assert.ok(FAST_OVERVIEW_KEYS.includes("boilerFaultFallbackEnabled"));
   assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("boilerConnection"));
-  assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("auxHeatSourcePresent"));
   assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("boilerRatedHeatPower"));
   assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("boilerFaultFallbackEnabled"));
   assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("otbLinkAvailable"));
@@ -371,32 +369,11 @@ test("settings hydration loads boiler setup and diagnostics before rendering", (
   );
 });
 
-test("auxiliary heat source setting remains editable on legacy firmware", () => {
-  assert.match(
-    installationSource,
-    /const sourcePresenceKey = separateSourcePolicyAvailable[\s\S]*?"auxHeatSourcePresent"[\s\S]*?: "boilerCvAssistEnabled"/,
-  );
-  assert.match(
-    installationSource,
-    /renderSettingsCompactSwitchControl\(sourcePresenceKey, "Warmtebron aangesloten"/,
-  );
-  assert.match(
-    installationSource,
-    /sourcePresent && separateSourcePolicyAvailable && assistSettingAvailable/,
-  );
-});
-
-test("fallback heating setting explains its guarded scope", () => {
-  assert.match(installationSource, /Overnemen wanneer de warmtepomp niet beschikbaar is/);
-  assert.match(installationSource, /wanneer geen warmtepomp veilig beschikbaar is/);
-  assert.match(installationSource, /na een veilige stop/);
-  assert.match(installationSource, /Een korte communicatiedip telt niet als uitval/);
-});
-
-test("auxiliary heat source copy names common examples and explains hybrid heating", () => {
-  assert.match(installationSource, /cv-ketel, elektrische cv-ketel \(e-cv\) of doorstroomverwarmer/);
-  assert.match(installationSource, /Hybride verwarmen bij vermogenstekort/);
-  assert.match(installationSource, /het beschikbare warmtepompvermogen niet genoeg is/);
+test("fault fallback setting explains the consequence of both switch states", () => {
+  assert.match(installationSource, /Automatische ketelovername bij warmtepompstoring/);
+  assert.match(installationSource, /OpenQuatt stelt dit zelf vast/);
+  assert.match(installationSource, /je hoeft niets te bevestigen/);
+  assert.match(installationSource, /Een korte communicatiedip telt niet als storing/);
 });
 
 test("fault fallback is editable in Installation and the shared Quick Start boiler fields", () => {
@@ -417,7 +394,7 @@ test("fault fallback is editable in Installation and the shared Quick Start boil
   );
   assert.match(
     quickStartSource,
-    /\["Overnemen wanneer de warmtepomp niet beschikbaar is", isEntityActive\("boilerFaultFallbackEnabled"\) \? "Aan" : "Uit"\]/,
+    /\["Automatische ketelovername bij warmtepompstoring", isEntityActive\("boilerFaultFallbackEnabled"\) \? "Aan" : "Uit"\]/,
   );
   assert.match(servicePanelSource, /renderInstallationMonitoringStatusRow/);
   assert.doesNotMatch(servicePanelSource, /boilerFaultFallbackEnabled/);
@@ -443,7 +420,7 @@ test("onboarding auto-selects a detected OpenTherm boiler and explains the choic
   assert.match(installationSource, /automatisch als ketelaansluiting geselecteerd/);
   assert.match(
     installationSource,
-    /sourcePresent \|\| boilerConnectionMismatch \|\| boilerConnectionAutoSelected/,
+    /boilerPresent \|\| boilerConnectionMismatch \|\| boilerConnectionAutoSelected/,
   );
 });
 
@@ -462,10 +439,10 @@ test("firmware publishes boiler connection mismatch transitions immediately", ()
   );
 });
 
-test("Quick Start keeps the mismatch remedy visible when the source is disconnected", () => {
+test("Quick Start keeps the mismatch remedy visible when boiler assist is off", () => {
   assert.match(
     installationSource,
-    /\(sourcePresent \|\| boilerConnectionMismatch \|\| boilerConnectionAutoSelected\) && boilerConnectionAvailable \? renderSettingsFieldCard/,
+    /\(boilerPresent \|\| boilerConnectionMismatch \|\| boilerConnectionAutoSelected\) && boilerConnectionAvailable \? renderSettingsFieldCard/,
   );
   assert.match(installationSource, /OpenTherm-ketel gevonden/);
 });

--- a/tests/host/hp_fallback_logic_test.cpp
+++ b/tests/host/hp_fallback_logic_test.cpp
@@ -208,7 +208,6 @@ void test_boiler_role_and_log_classification() {
   const auto codes = boiler_log_codes();
   assert(boiler_role_for_source(oq_boiler::COMMAND_SOURCE_POWER_HOUSE) == BoilerRole::ASSIST_CM3);
   assert(boiler_role_for_source(oq_boiler::COMMAND_SOURCE_HEATING_CURVE) == BoilerRole::ASSIST_CM3);
-  assert(boiler_role_for_source(oq_boiler::COMMAND_SOURCE_COLD_START) == BoilerRole::ASSIST_CM3);
   assert(boiler_role_for_source(oq_boiler::COMMAND_SOURCE_FALLBACK) == BoilerRole::FALLBACK_CM4);
   assert(boiler_role_for_source(oq_boiler::COMMAND_SOURCE_COMMISSIONING) == BoilerRole::COMMISSIONING_CM100);
   assert(boiler_role_for_source(oq_boiler::COMMAND_SOURCE_NONE) == BoilerRole::OFF);

--- a/tests/host/hp_supervisory_logic_test.cpp
+++ b/tests/host/hp_supervisory_logic_test.cpp
@@ -23,49 +23,6 @@ void test_frost_control_mode_remains_independent_of_heating_request() {
   assert(base_control_mode(false, false, false) == 0);
 }
 
-void test_cold_start_temperature_bands() {
-  using oq_hp_supervisory::ColdStartWaterSample;
-  using oq_hp_supervisory::evaluate_cold_start;
-
-  const uint32_t sample_after_ms = 1000;
-  ColdStartWaterSample hp1{true, 4.9f, 1001};
-  ColdStartWaterSample hp2{false, NAN, 0};
-
-  auto decision = evaluate_cold_start(sample_after_ms, hp1, hp2, 5.0f, 12.0f);
-  assert(decision.samples_ready);
-  assert(!decision.hp_start_allowed);
-  assert(!decision.auxiliary_assist_recommended);
-  assert(!decision.released);
-
-  hp1.temperature_c = 5.0f;
-  decision = evaluate_cold_start(sample_after_ms, hp1, hp2, 5.0f, 12.0f);
-  assert(decision.hp_start_allowed);
-  assert(decision.auxiliary_assist_recommended);
-  assert(!decision.released);
-
-  hp1.temperature_c = 12.0f;
-  decision = evaluate_cold_start(sample_after_ms, hp1, hp2, 5.0f, 12.0f);
-  assert(decision.hp_start_allowed);
-  assert(!decision.auxiliary_assist_recommended);
-  assert(decision.released);
-
-  hp1.updated_at_ms = sample_after_ms;
-  decision = evaluate_cold_start(sample_after_ms, hp1, hp2, 5.0f, 12.0f);
-  assert(!decision.samples_ready);
-  assert(!decision.hp_start_allowed);
-
-  hp1 = ColdStartWaterSample{true, 10.0f, 1002};
-  hp2 = ColdStartWaterSample{true, 4.0f, 1003};
-  decision = evaluate_cold_start(sample_after_ms, hp1, hp2, 5.0f, 12.0f);
-  assert(decision.samples_ready);
-  assert(decision.minimum_temperature_c == 4.0f);
-  assert(!decision.hp_start_allowed);
-
-  hp2.temperature_c = NAN;
-  decision = evaluate_cold_start(sample_after_ms, hp1, hp2, 5.0f, 12.0f);
-  assert(!decision.samples_ready);
-}
-
 oq_hp_supervisory::FallbackEvaluationInputs eligible_fallback_evaluation_inputs() {
   oq_hp_supervisory::FallbackEvaluationInputs inputs;
   inputs.current_mode = 3;
@@ -158,23 +115,6 @@ void test_fallback_evaluation_and_recovering_handover() {
   evaluation = evaluate_fallback(inputs);
   assert(!evaluation.fallback_requested);
   assert(!evaluation.cm3_handover_wait);
-
-  // A confirmed sub-5°C cold start is a temporary HP-unavailable cause.
-  // It may enter CM4 only when the normal output and boiler guards pass.
-  inputs = eligible_fallback_evaluation_inputs();
-  inputs.available_hp_count = 2;
-  inputs.every_unavailable_hp_has_fallback_cause = false;
-  inputs.cold_start_blocked = true;
-  evaluation = evaluate_fallback(inputs);
-  assert(evaluation.no_hp_available_confirmed);
-  assert(evaluation.fallback_requested);
-  assert(evaluation.decision.cm4_allowed);
-
-  inputs.all_hp_outputs_safe = false;
-  evaluation = evaluate_fallback(inputs);
-  assert(!evaluation.no_hp_available_confirmed);
-  assert(evaluation.fallback_requested);
-  assert(!evaluation.decision.cm4_allowed);
 }
 
 void test_heating_mode_decisions() {
@@ -283,7 +223,6 @@ void test_control_mode_log_classification() {
 int main() {
   test_heating_enable_gate();
   test_frost_control_mode_remains_independent_of_heating_request();
-  test_cold_start_temperature_bands();
   using oq_hp_supervisory::Cm4ResumeTracker;
   using oq_hp_supervisory::fallback_availability_is_confirmed;
   using oq_hp_supervisory::recovered_heating_mode;

--- a/tests/host/ot_boiler_safety_interlocks_test.cpp
+++ b/tests/host/ot_boiler_safety_interlocks_test.cpp
@@ -15,7 +15,7 @@ oq_boiler::BoilerCommand active_command(uint32_t updated_at_ms) {
 
 oq_boiler::ControllerInput safe_input(uint32_t now_ms) {
   return oq_boiler::ControllerInput{
-      true, true, true, true, true,  true,   true,  false, false, false,  true,
+      true, true, true, true, true,  true,   false, false, false, true,
       true, true, true, true, false, now_ms, 15000, 0,     30000, 120000,
   };
 }
@@ -144,11 +144,6 @@ void test_fail_safe_priority() {
   assert_decision(decision, false, true, oq_boiler::BLOCK_WATER_TEMP_INHIBIT);
 
   input = safe_input(1500);
-  input.source_present = false;
-  decision = oq_boiler::evaluate(command, input);
-  assert_decision(decision, false, true, oq_boiler::BLOCK_SOURCE_NOT_CONNECTED);
-
-  input = safe_input(1500);
   input.assist_enabled = false;
   decision = oq_boiler::evaluate(command, input);
   assert_decision(decision, false, true, oq_boiler::BLOCK_ASSIST_DISABLED);
@@ -225,7 +220,7 @@ void test_fallback_and_flow_guards() {
   auto input = safe_input(1500);
   input.assist_enabled = false;
   auto decision = oq_boiler::evaluate(command, input);
-  assert_decision(decision, true, false, oq_boiler::BLOCK_NONE);
+  assert_decision(decision, false, true, oq_boiler::BLOCK_ASSIST_DISABLED);
 
   input = safe_input(1500);
   input.fallback_enabled = false;
@@ -321,7 +316,6 @@ void test_commissioning_wait_state() {
   command.heat_request = false;
 
   auto input = safe_input(1500);
-  input.assist_enabled = false;
   auto decision = oq_boiler::evaluate(command, input);
   assert_decision(decision, false, false, oq_boiler::BLOCK_COMMISSIONING_WAITING);
   assert(decision.blocked);
@@ -330,12 +324,6 @@ void test_commissioning_wait_state() {
   input.output_last_change_ms = 1400;
   decision = oq_boiler::evaluate(command, input);
   assert_decision(decision, true, false, oq_boiler::BLOCK_MIN_ON_TIME);
-
-  command.heat_request = true;
-  input = safe_input(1500);
-  input.assist_enabled = false;
-  decision = oq_boiler::evaluate(command, input);
-  assert_decision(decision, true, false, oq_boiler::BLOCK_NONE);
 }
 
 void test_commissioning_start_failure_reason() {

--- a/tests/host/ot_boiler_safety_interlocks_test.cpp
+++ b/tests/host/ot_boiler_safety_interlocks_test.cpp
@@ -248,19 +248,6 @@ void test_fallback_and_flow_guards() {
   assert_decision(decision, false, true, oq_boiler::BLOCK_HP_STOP_UNCONFIRMED);
 }
 
-void test_cold_start_requires_assist_permission() {
-  auto command = active_command(1500);
-  command.source = oq_boiler::COMMAND_SOURCE_COLD_START;
-  auto input = safe_input(1500);
-
-  auto decision = oq_boiler::evaluate(command, input);
-  assert_decision(decision, true, false, oq_boiler::BLOCK_NONE);
-
-  input.assist_enabled = false;
-  decision = oq_boiler::evaluate(command, input);
-  assert_decision(decision, false, true, oq_boiler::BLOCK_ASSIST_DISABLED);
-}
-
 void test_minimum_times_and_ownership_loss() {
   const auto command = active_command(1000);
   auto no_heat_command = command;
@@ -375,7 +362,6 @@ int main() {
   test_fail_safe_priority();
   test_transport_selection_guard();
   test_fallback_and_flow_guards();
-  test_cold_start_requires_assist_permission();
   test_minimum_times_and_ownership_loss();
   test_commissioning_wait_state();
   test_commissioning_start_failure_reason();


### PR DESCRIPTION
# Wat verandert deze PR?

- Revert uitsluitend de mergecommits van #551 en #550 op `main`, in omgekeerde volgorde.
- Herstelt de volledige repository-inhoud exact naar commit `252e9ea9`, de toestand van `main` vóór beide merges.
- Dezelfde functionele wijzigingen worden afzonderlijk en in dezelfde volgorde naar `dev` gebracht.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen nieuw runtime/control gedrag bedoeld
- [x] Runtime/control gedrag van de onbedoelde merges wordt verwijderd
- [x] User-facing wijzigingen van #550/#551 worden uit `main` verwijderd
- [x] Hardware/boiler/flow-logica keert terug naar de eerdere `main`-toestand
- [x] Geen runtime-geheugenimpact

## Achtergrond

#550 en #551 hadden naar `dev` gemoeten, maar zijn per ongeluk naar `main` gemerged. Een force-push of geschiedenisherschrijving wordt vermeden; deze PR herstelt `main` met twee traceerbare revertcommits.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De documentatiewijzigingen uit #550/#551 worden samen met de code teruggedraaid en volgen opnieuw via `dev`.

## Validatie

- [x] De tree van de herstelbranch is byte-for-byte gelijk aan `252e9ea97ca938b6b0705677e8c42a9d32a84f5a`
- [x] `git diff --check origin/main...HEAD` — geslaagd
- [x] Volledige revert-diff gecontroleerd: geen wijzigingen buiten #550 en #551
- [ ] GitHub CI — wordt op deze PR uitgevoerd

## PR-audit

Beide mergecommits zijn in omgekeerde volgorde met mainline-parent 1 teruggedraaid. Er zijn sinds #551 geen andere commits op `main` geland. De resulterende tree is exact de pre-merge tree; er zijn geen conflicten of handmatige inhoudswijzigingen.
