### PR TITLE
Scheid de instellingen voor de aanvullende warmtebron

### DIFF
--- a/docs/q-edition.md
+++ b/docs/q-edition.md
@@ -156,7 +156,7 @@ Volg de route die de web-app voor jouw installatie toont. De basisstappen zijn:
 2. **Kies je Quatt Hybrid:** V1, V1.5 of V2.
 3. **Flowmeting configureren:** controleer en activeer de juiste flowbron.
 4. **Thermostaatgegevens configureren:** kies waar kamertemperatuur en kamer-setpoint vandaan komen.
-5. **CV-ketel of boiler:** geef aan of OpenQuatt deze als ondersteuning mag gebruiken.
+5. **Aanvullende warmtebron:** leg vast of een warmtebron is aangesloten en of OpenQuatt deze als bij- of reserveverwarming mag gebruiken.
 6. **Kies de verwarmingsstrategie:** kies hoe OpenQuatt de verwarming regelt.
 7. **Werk de regeling uit:** stel Power House of de stooklijn verder in.
 8. **Flowregeling en afstelling:** leg vast hoe de pomp geregeld moet worden en welke waarden daarbij horen.

--- a/docs/q-edition.md
+++ b/docs/q-edition.md
@@ -156,7 +156,7 @@ Volg de route die de web-app voor jouw installatie toont. De basisstappen zijn:
 2. **Kies je Quatt Hybrid:** V1, V1.5 of V2.
 3. **Flowmeting configureren:** controleer en activeer de juiste flowbron.
 4. **Thermostaatgegevens configureren:** kies waar kamertemperatuur en kamer-setpoint vandaan komen.
-5. **Aanvullende warmtebron:** leg vast of een warmtebron is aangesloten en of OpenQuatt deze als bij- of reserveverwarming mag gebruiken.
+5. **Aanvullende warmtebron:** leg vast of een warmtebron is aangesloten, of deze hybride mag meeverwarmen bij een vermogenstekort en of deze mag overnemen wanneer geen warmtepomp beschikbaar is.
 6. **Kies de verwarmingsstrategie:** kies hoe OpenQuatt de verwarming regelt.
 7. **Werk de regeling uit:** stel Power House of de stooklijn verder in.
 8. **Flowregeling en afstelling:** leg vast hoe de pomp geregeld moet worden en welke waarden daarbij horen.

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -84,7 +84,7 @@ Quick Start begint op de Heatpump Controller Q met de configuratiekeuze en softw
 | `Kies je Quatt Hybrid` | V1, V1.5 of V2 | Selecteert de juiste basislogica voor jouw warmtepompgeneratie. |
 | `Flowmeting configureren` | De juiste flowbron | Zorgt dat de regeling de juiste meting gebruikt. |
 | `Thermostaatgegevens configureren` | Eén bron voor kamertemperatuur en setpoint | Voorkomt dat OpenQuatt waarden uit verschillende bronnen combineert. |
-| `CV-ketel of boiler` | Ondersteuning en fysieke aansluiting (`R1` of `OTB`) | Bepaalt of OpenQuatt aanvullende warmte mag inzetten. Op Q-hardware controleert OpenQuatt bij een R1-keuze tijdens het opstarten kort of toch een OpenTherm-ketel antwoordt. Tijdens Quick Start wordt een gedetecteerde OT-ketel automatisch als `OpenTherm (OTB)` ingesteld en wordt die keuze toegelicht. Na afgeronde onboarding blijft een onverwachte OT-ketel geblokkeerd totdat de aansluiting handmatig is gecorrigeerd. |
+| `Aanvullende warmtebron` | Aansluiting (`R1` of `OTB`), bijverwarming en reserveverwarming | Legt afzonderlijk vast of een warmtebron is aangesloten en wanneer OpenQuatt deze mag inzetten. Op Q-hardware controleert OpenQuatt bij een R1-keuze tijdens het opstarten kort of toch een OpenTherm-ketel antwoordt. Tijdens Quick Start wordt een gedetecteerde OT-ketel automatisch als `OpenTherm (OTB)` ingesteld en wordt die keuze toegelicht. Na afgeronde onboarding blijft een onverwachte OT-ketel geblokkeerd totdat de aansluiting handmatig is gecorrigeerd. |
 | `Kies de verwarmingsstrategie` | `Power House` of `Water Temperature Control` | Bepaalt hoe OpenQuatt warmtevraag maakt en vervangt daarbij automatisch de warmtetoestemming (`Niet gebruiken` voor Power House; de eerder gekozen actieve thermostaatbron voor stooklijn). |
 | `Werk de regeling uit` | Strategie-instellingen | Toont alleen de instellingen die bij de gekozen strategie horen. |
 | `Flowregeling en afstelling` | Automatische flow of vaste pompstand | Bepaalt hoe OpenQuatt de waterdoorstroming regelt. |
@@ -170,9 +170,9 @@ Onder `Instellingen` staan de onderdelen bewust gescheiden. Het idee is: eerst d
 
 ### Installatie
 
-Hier staan basiskeuzes zoals Quatt Hybrid-versie, flowregeling, boiler- of CV-ondersteuning, stille uren, watergrenzen en compressorinstellingen.
+Hier staan basiskeuzes zoals Quatt Hybrid-versie, flowregeling, een aanvullende warmtebron, stille uren, watergrenzen en compressorinstellingen.
 
-`Automatische ketelovername bij warmtepompstoring` is een aparte installatiekeuze en staat standaard uit. Als je deze inschakelt, mag OpenQuatt bij een bevestigde storing van alle geconfigureerde warmtepompen overschakelen naar CM4 en de cv-ketel de verwarmingsopdracht geven. OpenQuatt doet dit alleen nadat de warmtepompen veilig zijn gestopt en flow, aanvoertemperatuur en ketelaansturing geldig zijn. Een korte communicatiedip telt niet als bevestigde storing en vraagt geen actie of bevestiging van de gebruiker.
+Bij `Aanvullende warmtebron` leg je eerst vast of OpenQuatt een warmtebron fysiek kan aansturen. Daarna kies je afzonderlijk of die bron als `Bijverwarming` naast de warmtepomp mag werken en of `Reserveverwarming` is toegestaan wanneer geen warmtepomp veilig beschikbaar is. Reserveverwarming staat standaard uit. OpenQuatt schakelt pas over nadat de warmtepompen veilig zijn gestopt en flow, aanvoertemperatuur en aansturing geldig zijn. Een korte communicatiedip telt niet als uitval.
 
 Gebruik dit deel vooral tijdens de eerste inrichting of als je installatie later verandert.
 

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -84,7 +84,7 @@ Quick Start begint op de Heatpump Controller Q met de configuratiekeuze en softw
 | `Kies je Quatt Hybrid` | V1, V1.5 of V2 | Selecteert de juiste basislogica voor jouw warmtepompgeneratie. |
 | `Flowmeting configureren` | De juiste flowbron | Zorgt dat de regeling de juiste meting gebruikt. |
 | `Thermostaatgegevens configureren` | Eén bron voor kamertemperatuur en setpoint | Voorkomt dat OpenQuatt waarden uit verschillende bronnen combineert. |
-| `Aanvullende warmtebron` | Aansluiting (`R1` of `OTB`), bijverwarming en reserveverwarming | Legt afzonderlijk vast of een warmtebron is aangesloten en wanneer OpenQuatt deze mag inzetten. Op Q-hardware controleert OpenQuatt bij een R1-keuze tijdens het opstarten kort of toch een OpenTherm-ketel antwoordt. Tijdens Quick Start wordt een gedetecteerde OT-ketel automatisch als `OpenTherm (OTB)` ingesteld en wordt die keuze toegelicht. Na afgeronde onboarding blijft een onverwachte OT-ketel geblokkeerd totdat de aansluiting handmatig is gecorrigeerd. |
+| `Aanvullende warmtebron` | Aansluiting (`R1` of `OTB`), hybride verwarmen en overname | Legt afzonderlijk vast of een warmtebron is aangesloten, of deze bij een vermogenstekort hybride mag meeverwarmen en of deze mag overnemen wanneer geen warmtepomp beschikbaar is. Op Q-hardware controleert OpenQuatt bij een R1-keuze tijdens het opstarten kort of toch een OpenTherm-ketel antwoordt. Tijdens Quick Start wordt een gedetecteerde OT-ketel automatisch als `OpenTherm (OTB)` ingesteld en wordt die keuze toegelicht. Na afgeronde onboarding blijft een onverwachte OT-ketel geblokkeerd totdat de aansluiting handmatig is gecorrigeerd. |
 | `Kies de verwarmingsstrategie` | `Power House` of `Water Temperature Control` | Bepaalt hoe OpenQuatt warmtevraag maakt en vervangt daarbij automatisch de warmtetoestemming (`Niet gebruiken` voor Power House; de eerder gekozen actieve thermostaatbron voor stooklijn). |
 | `Werk de regeling uit` | Strategie-instellingen | Toont alleen de instellingen die bij de gekozen strategie horen. |
 | `Flowregeling en afstelling` | Automatische flow of vaste pompstand | Bepaalt hoe OpenQuatt de waterdoorstroming regelt. |
@@ -172,7 +172,7 @@ Onder `Instellingen` staan de onderdelen bewust gescheiden. Het idee is: eerst d
 
 Hier staan basiskeuzes zoals Quatt Hybrid-versie, flowregeling, een aanvullende warmtebron, stille uren, watergrenzen en compressorinstellingen.
 
-Bij `Aanvullende warmtebron` leg je eerst vast of OpenQuatt een warmtebron fysiek kan aansturen. Daarna kies je afzonderlijk of die bron als `Bijverwarming` naast de warmtepomp mag werken en of `Reserveverwarming` is toegestaan wanneer geen warmtepomp veilig beschikbaar is. Reserveverwarming staat standaard uit. OpenQuatt schakelt pas over nadat de warmtepompen veilig zijn gestopt en flow, aanvoertemperatuur en aansturing geldig zijn. Een korte communicatiedip telt niet als uitval.
+Bij `Aanvullende warmtebron` leg je eerst vast of OpenQuatt een warmtebron fysiek kan aansturen. Daarna kies je afzonderlijk voor `Hybride verwarmen bij vermogenstekort` en `Overnemen wanneer de warmtepomp niet beschikbaar is`. Overname staat standaard uit. OpenQuatt schakelt pas over nadat de warmtepompen veilig zijn gestopt en flow, aanvoertemperatuur en aansturing geldig zijn. Een korte communicatiedip telt niet als uitval.
 
 Gebruik dit deel vooral tijdens de eerste inrichting of als je installatie later verandert.
 

--- a/openquatt/includes/boiler/oq_boiler_logic.h
+++ b/openquatt/includes/boiler/oq_boiler_logic.h
@@ -35,6 +35,7 @@ enum BlockReason : uint8_t {
   BLOCK_FLOW_UNAVAILABLE = 17,
   BLOCK_FLOW_INSUFFICIENT = 18,
   BLOCK_HP_STOP_UNCONFIRMED = 19,
+  BLOCK_SOURCE_NOT_CONNECTED = 20,
 };
 
 struct BoilerCommand {
@@ -48,6 +49,7 @@ struct BoilerCommand {
 };
 
 struct ControllerInput {
+  bool source_present;
   bool assist_enabled;
   bool fallback_enabled;
   bool supply_temperature_valid;
@@ -221,13 +223,14 @@ inline ControllerDecision evaluate(const BoilerCommand& command, const Controlle
   } else if (input.boiler_inhibit_active) {
     decision.force_off = true;
     decision.block_reason = BLOCK_WATER_TEMP_INHIBIT;
-  } else if (command.source == COMMAND_SOURCE_FALLBACK && !input.assist_enabled) {
+  } else if (!input.source_present) {
     decision.force_off = true;
-    decision.block_reason = BLOCK_ASSIST_DISABLED;
+    decision.block_reason = BLOCK_SOURCE_NOT_CONNECTED;
   } else if (command.source == COMMAND_SOURCE_FALLBACK && !input.fallback_enabled) {
     decision.force_off = true;
     decision.block_reason = BLOCK_FALLBACK_DISABLED;
-  } else if (command.source != COMMAND_SOURCE_FALLBACK && !input.assist_enabled) {
+  } else if ((command.source == COMMAND_SOURCE_POWER_HOUSE || command.source == COMMAND_SOURCE_HEATING_CURVE) &&
+             !input.assist_enabled) {
     decision.force_off = true;
     decision.block_reason = BLOCK_ASSIST_DISABLED;
   } else if (!command.valid) {
@@ -335,6 +338,8 @@ inline const char* block_reason_text(uint8_t reason) {
       return "flow too low";
     case BLOCK_HP_STOP_UNCONFIRMED:
       return "heat-pump stop is not confirmed";
+    case BLOCK_SOURCE_NOT_CONNECTED:
+      return "auxiliary heat source not connected";
     default:
       return "";
   }

--- a/openquatt/includes/control/oq_boiler_control_logic.h
+++ b/openquatt/includes/control/oq_boiler_control_logic.h
@@ -150,6 +150,7 @@ inline BoilerLogDecision classify_boiler_controller_log(const BoilerControllerLo
       reason = BoilerLogReason::SENSOR_FALLBACK;
       break;
     case BLOCK_ASSIST_DISABLED:
+    case BLOCK_SOURCE_NOT_CONNECTED:
       reason = BoilerLogReason::NO_CANDIDATE;
       break;
     case BLOCK_FALLBACK_DISABLED:

--- a/openquatt/includes/service/tasks/oq_boiler_task_logic.h
+++ b/openquatt/includes/service/tasks/oq_boiler_task_logic.h
@@ -64,8 +64,8 @@ class BoilerPowerTestRuntime {
   void start(const RuntimeConfig& cfg, uint32_t now_ms) {
     const int cm_code = id(oq_control_mode_code);
     const bool task_running = id(oq_commissioning_active) && id(oq_commissioning_task_code) != TASK_NONE;
-    if (!id(oq_boiler_assist_enabled).state) {
-      oq_service_status::set_boiler_power_test("REFUSED: boiler/CV assist disabled");
+    if (!id(oq_aux_heat_source_present).state) {
+      oq_service_status::set_boiler_power_test("REFUSED: auxiliary heat source not connected");
       return;
     }
     if (task_running || id(oq_commissioning_request_pending)) {
@@ -416,9 +416,9 @@ class BoilerPowerTestRuntime {
       finish_task("FAILED: boiler inhibit active", STATE_FAILED, false, true);
       return false;
     }
-    if (!id(oq_boiler_assist_enabled).state) {
-      ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: boiler/CV assist disabled");
-      finish_task("FAILED: boiler/CV assist disabled", STATE_FAILED, false, true);
+    if (!id(oq_aux_heat_source_present).state) {
+      ESP_LOGW("quatt.cm100.boiler", "Boiler test failed: auxiliary heat source not connected");
+      finish_task("FAILED: auxiliary heat source not connected", STATE_FAILED, false, true);
       return false;
     }
     return true;

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -420,6 +420,7 @@ interval:
             id(oq_boiler_rearm_required) = false;
           }
           const oq_boiler::ControllerInput input{
+              id(oq_aux_heat_source_present).state,
               id(oq_boiler_assist_enabled).state,
               id(oq_boiler_fault_fallback_enabled).state,
               has_valid_supply_temp,

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -51,10 +51,33 @@ time:
     id: oq_time
     timezone: Europe/Amsterdam
 
+esphome:
+  on_boot:
+    - priority: -100
+      then:
+        - lambda: |-
+            if (!id(oq_aux_heat_source_policy_migrated)) {
+              const bool legacy_source_present = id(oq_boiler_assist_enabled).state;
+              if (legacy_source_present) {
+                id(oq_aux_heat_source_present).turn_on();
+              } else {
+                id(oq_aux_heat_source_present).turn_off();
+              }
+              id(oq_aux_heat_source_policy_migrated) = true;
+            }
+
 # ----------------------------
 # INTERNAL STATE
 # ----------------------------
 globals:
+  # One-time split of the legacy combined boiler-present/assist switch. The
+  # existing assist state seeds physical presence; assist and fallback retain
+  # their own restored values.
+  - id: oq_aux_heat_source_policy_migrated
+    type: bool
+    restore_value: true
+    initial_value: 'false'
+
   # Frost hysteresis state for CM98 selection
   - id: oq_cm_frost_prev
     type: bool
@@ -232,16 +255,32 @@ select:
 
 switch:
   - platform: template
+    id: oq_aux_heat_source_present
+    name: "Auxiliary heat source connected"
+    icon: mdi:heating-coil
+    restore_mode: RESTORE_DEFAULT_ON
+    optimistic: true
+    entity_category: config
+    on_turn_off:
+      # Physical absence is the top-level fail-closed gate. Also clear both
+      # permissions so a later reconnect requires an explicit choice.
+      - switch.turn_off: oq_boiler_assist_enabled
+      - switch.turn_off: oq_boiler_fault_fallback_enabled
+
+  - platform: template
     id: oq_boiler_assist_enabled
     name: "Boiler assist enabled"
     icon: mdi:water-boiler
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
     entity_category: config
-    on_turn_off:
-      # This switch is the installation-level boiler-present permission in
-      # the web app. Turning it off must also revoke the hidden CM4 opt-in.
-      - switch.turn_off: oq_boiler_fault_fallback_enabled
+    on_turn_on:
+      - if:
+          condition:
+            lambda: |-
+              return !id(oq_aux_heat_source_present).state;
+          then:
+            - switch.turn_off: oq_boiler_assist_enabled
 
   - platform: template
     id: oq_boiler_fault_fallback_enabled
@@ -252,6 +291,13 @@ switch:
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
     entity_category: config
+    on_turn_on:
+      - if:
+          condition:
+            lambda: |-
+              return !id(oq_aux_heat_source_present).state;
+          then:
+            - switch.turn_off: oq_boiler_fault_fallback_enabled
 
   - platform: template
     id: oq_enabled
@@ -1180,7 +1226,7 @@ interval:
             fallback_inputs.current_mode = current_cm_code;
             fallback_inputs.heating_demand = heating_req;
             fallback_inputs.fallback_enabled =
-                id(oq_boiler_assist_enabled).state &&
+                id(oq_aux_heat_source_present).state &&
                 id(oq_boiler_fault_fallback_enabled).state;
             fallback_inputs.available_hp_count = available_hp_count;
             fallback_inputs.raw_availability_complete =
@@ -1343,7 +1389,8 @@ interval:
                           cm4_resume_tracker.resume_mode(),
                           available_hp_count > 0,
                           power_house_active,
-                          id(oq_boiler_assist_enabled).state,
+                          id(oq_aux_heat_source_present).state &&
+                              id(oq_boiler_assist_enabled).state,
                       });
                   if (heating_mode.start_cm1_for_mode >= 0) {
                     start_cm1(heating_mode.start_cm1_for_mode);
@@ -1385,7 +1432,9 @@ interval:
                   (strcmp(cur_cm, "CM5") == 0) ? 5 :
                   (strcmp(cur_cm, "CM1") == 0) ? 1 :
                   (strcmp(cur_cm, "CM98") == 0) ? 98 : 0;
-              const bool boiler_assist_enabled = id(oq_boiler_assist_enabled).state;
+              const bool boiler_assist_enabled =
+                  id(oq_aux_heat_source_present).state &&
+                  id(oq_boiler_assist_enabled).state;
               const bool opentherm_selected =
                   id(oq_boiler_connection).has_state() &&
                   id(oq_boiler_connection).current_option() == "OpenTherm";

--- a/openquatt/web/js/src/core/config.js
+++ b/openquatt/web/js/src/core/config.js
@@ -14,7 +14,7 @@
     ["generation", "Kies je Quatt Hybrid", "Geef hier aan welke Quatt Hybrid je hebt. Dan zet OpenQuatt de juiste regeling klaar."],
     ["flow-source", "Flowmeting configureren", "Controleer en activeer de flowbron die bij jouw Quatt-versie en controller hoort."],
     ["thermostat-source", "Thermostaatgegevens configureren", "Leg vast waar OpenQuatt de kamertemperatuur en het kamer-setpoint samen vandaan haalt."],
-    ["boiler", "CV-ketel of boiler", "Leg vast of er een ketel is en hoe die fysiek is aangesloten.", "boilerCvAssistEnabled"],
+    ["boiler", "Aanvullende warmtebron", "Leg vast of een aanvullende warmtebron is aangesloten en wanneer OpenQuatt die mag gebruiken.", "auxHeatSourcePresent"],
     ["strategy", "Kies de verwarmingsstrategie", "Kies hier hoe OpenQuatt je verwarming regelt. Daarna lopen we samen de belangrijkste instellingen langs."],
     ["heating", "Werk de regeling uit", "Stel nu de gekozen regeling verder in. De inhoud hieronder past zich aan aan je keuze."],
     ["flow", "Flowregeling en afstelling", "Leg daarna vast hoe de pomp geregeld moet worden en welke waarden daarbij horen. De autotune staat later onder Instellingen → Installatie → Service & commissioning."],
@@ -118,6 +118,7 @@
     hpGeneration: { domain: "select", name: "Quatt Hybrid version" },
     strategy: { domain: "select", name: "Heating Control Mode" },
     openquattEnabled: { domain: "switch", name: "OpenQuatt Enabled", optional: true },
+    auxHeatSourcePresent: { domain: "switch", name: "Auxiliary heat source connected", optional: true },
     boilerCvAssistEnabled: { domain: "switch", name: "Boiler assist enabled", optional: true },
     boilerFaultFallbackEnabled: { domain: "switch", name: "Boiler fallback on heat-pump fault", optional: true },
     boilerConnection: { domain: "select", name: "Boiler connection", optional: true },
@@ -1018,6 +1019,7 @@
   export const CIC_COMPATIBILITY_KEYS = ["cicCompatibilityMode"];
   export const OPENTHERM_SETTING_KEYS = ["otEnabled", "otLinkProblem"];
   export const BOILER_SETTING_KEYS = [
+    "auxHeatSourcePresent",
     "boilerConnection",
     "boilerFaultFallbackEnabled",
   ];
@@ -1510,6 +1512,7 @@
     "openquattEnabled",
     "usageTelemetryEnabled",
     "usageTelemetryChoiceConfigured",
+    "auxHeatSourcePresent",
     "boilerCvAssistEnabled",
     "boilerConnection",
     "openquattResumeAt",
@@ -1607,6 +1610,7 @@
     "openquattEnabled",
     "usageTelemetryEnabled",
     "usageTelemetryChoiceConfigured",
+    "auxHeatSourcePresent",
     "boilerCvAssistEnabled",
     "boilerRatedHeatPower",
     "boilerConnection",

--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -192,6 +192,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
       "minRuntime",
     ],
     service: [
+      "auxHeatSourcePresent",
       "compressorStarts2hWarningLimit",
       "compressorStarts72hWarningLimit",
       "compressorCyclingWarning2h",
@@ -237,6 +238,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
       ...COMMISSIONING_STATE_KEYS,
       ...SENSOR_CALIBRATION_KEYS,
       ...SENSOR_CALIBRATION_STATE_KEYS,
+      "auxHeatSourcePresent",
       "boilerCvAssistEnabled",
       "boilerRatedHeatPower",
       "flowSelected",

--- a/openquatt/web/js/src/features/quickstart-actions.js
+++ b/openquatt/web/js/src/features/quickstart-actions.js
@@ -35,6 +35,7 @@ import { render } from "../core/render-scheduler.js";
     if (stepId === "boiler") {
       return [...new Set([
         ...base,
+        "auxHeatSourcePresent",
         "boilerCvAssistEnabled",
         "boilerFaultFallbackEnabled",
         "boilerConnection",
@@ -72,6 +73,7 @@ import { render } from "../core/render-scheduler.js";
         "hpGeneration",
         ...ODU_GENERATION_KEYS,
         ...ODU_GENERATION_DETECT_KEYS,
+        "auxHeatSourcePresent",
         "boilerCvAssistEnabled",
         "boilerFaultFallbackEnabled",
         "boilerConnection",

--- a/openquatt/web/js/src/features/quickstart.js
+++ b/openquatt/web/js/src/features/quickstart.js
@@ -669,7 +669,7 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
       <section class="oq-helper-panel">
         <p class="oq-helper-label">${escapeHtml(getQuickStepKicker("boiler"))}</p>
         <h2 class="oq-helper-section-title">Aanvullende warmtebron</h2>
-        <p class="oq-helper-section-copy">Geef aan of een aanvullende warmtebron is aangesloten en kies afzonderlijk of OpenQuatt die als bij- of reserveverwarming mag gebruiken.</p>
+        <p class="oq-helper-section-copy">Dit kan bijvoorbeeld een cv-ketel, elektrische cv-ketel (e-cv) of doorstroomverwarmer zijn. Kies of de warmtebron hybride meeverwarmt bij een vermogenstekort en of deze mag overnemen wanneer geen warmtepomp beschikbaar is.</p>
         ${renderBoilerCvFields("oq-settings-grid oq-settings-grid--quickstart oq-settings-boiler-simple-grid", true)}
         ${renderQuickStartStepNav({
           nextDisabled: boilerConnectionMismatch,
@@ -1024,10 +1024,10 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
                   : []),
                 ["Beschikbaar verwarmingsvermogen", formatValue("boilerRatedHeatPower")],
                 ...(hasEntity("boilerCvAssistEnabled")
-                  ? [["Gebruiken als bijverwarming", isEntityActive("boilerCvAssistEnabled") ? "Aan" : "Uit"]]
+                  ? [["Hybride verwarmen bij vermogenstekort", isEntityActive("boilerCvAssistEnabled") ? "Aan" : "Uit"]]
                   : []),
                 ...(hasEntity("boilerFaultFallbackEnabled")
-                  ? [["Gebruiken als reserveverwarming", isEntityActive("boilerFaultFallbackEnabled") ? "Aan" : "Uit"]]
+                  ? [["Overnemen wanneer de warmtepomp niet beschikbaar is", isEntityActive("boilerFaultFallbackEnabled") ? "Aan" : "Uit"]]
                   : []),
               ]
             : []),

--- a/openquatt/web/js/src/features/quickstart.js
+++ b/openquatt/web/js/src/features/quickstart.js
@@ -668,8 +668,8 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
     return `
       <section class="oq-helper-panel">
         <p class="oq-helper-label">${escapeHtml(getQuickStepKicker("boiler"))}</p>
-        <h2 class="oq-helper-section-title">CV-ketel of boiler</h2>
-        <p class="oq-helper-section-copy">Geef aan of er een ketel aanwezig is, hoe die is aangesloten en of deze automatisch mag overnemen wanneer alle warmtepompen door een storing uitvallen.</p>
+        <h2 class="oq-helper-section-title">Aanvullende warmtebron</h2>
+        <p class="oq-helper-section-copy">Geef aan of een aanvullende warmtebron is aangesloten en kies afzonderlijk of OpenQuatt die als bij- of reserveverwarming mag gebruiken.</p>
         ${renderBoilerCvFields("oq-settings-grid oq-settings-grid--quickstart oq-settings-boiler-simple-grid", true)}
         ${renderQuickStartStepNav({
           nextDisabled: boilerConnectionMismatch,
@@ -1011,17 +1011,23 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
         : ["Gewenste flow", formatValue("flowSetpoint")],
     ];
 
-    const boilerLines = hasEntity("boilerCvAssistEnabled")
+    const sourcePresent = hasEntity("auxHeatSourcePresent")
+      ? isEntityActive("auxHeatSourcePresent")
+      : isEntityActive("boilerCvAssistEnabled");
+    const boilerLines = hasEntity("auxHeatSourcePresent") || hasEntity("boilerCvAssistEnabled")
       ? [
-          ["CV-ketel/boiler aanwezig", isEntityActive("boilerCvAssistEnabled") ? "Ja" : "Nee"],
-          ...(isEntityActive("boilerCvAssistEnabled")
+          ["Warmtebron aangesloten", sourcePresent ? "Ja" : "Nee"],
+          ...(sourcePresent
             ? [
                 ...(hasEntity("boilerConnection")
-                  ? [["Ketelaansluiting", String(getEntityValue("boilerConnection") || "R1") === "OpenTherm" ? "OpenTherm (OTB)" : "Aan/uit (R1)"]]
+                  ? [["Aansturing warmtebron", String(getEntityValue("boilerConnection") || "R1") === "OpenTherm" ? "OpenTherm (OTB)" : "Aan/uit (R1)"]]
                   : []),
-                ["Ingesteld ketelvermogen", formatValue("boilerRatedHeatPower")],
+                ["Beschikbaar verwarmingsvermogen", formatValue("boilerRatedHeatPower")],
+                ...(hasEntity("boilerCvAssistEnabled")
+                  ? [["Gebruiken als bijverwarming", isEntityActive("boilerCvAssistEnabled") ? "Aan" : "Uit"]]
+                  : []),
                 ...(hasEntity("boilerFaultFallbackEnabled")
-                  ? [["Automatische ketelovername bij warmtepompstoring", isEntityActive("boilerFaultFallbackEnabled") ? "Aan" : "Uit"]]
+                  ? [["Gebruiken als reserveverwarming", isEntityActive("boilerFaultFallbackEnabled") ? "Aan" : "Uit"]]
                   : []),
               ]
             : []),

--- a/openquatt/web/js/src/settings/installation.js
+++ b/openquatt/web/js/src/settings/installation.js
@@ -19,7 +19,8 @@ import { getSelectEntityOptions, renderNamedActionButton, renderSettingsAdvanced
 import { renderSettingsHeatPumpLimiterCard } from "./heating.js";
 import { escapeHtml } from "../core/html.js";
 
-const AUX_HEAT_BACKUP_TITLE = "Gebruiken als reserveverwarming";
+const AUX_HEAT_ASSIST_TITLE = "Hybride verwarmen bij vermogenstekort";
+const AUX_HEAT_BACKUP_TITLE = "Overnemen wanneer de warmtepomp niet beschikbaar is";
 const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer geen warmtepomp veilig beschikbaar is. Dit gebeurt pas na een veilige stop en geldige flow, temperatuur en aansturing. Een korte communicatiedip telt niet als uitval.";
 
   export function getOduRuntimeFrequencyHpIndexes() {
@@ -981,18 +982,18 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
           renderSettingsNumberField(
             "boilerSupportStartThreshold",
             "Ondersteuning starten vanaf",
-            "Standaard 1000 W. Power House moet eerst minimaal 2 minuten zonder bijverwarming draaien; daarna moet het warmtetekort 5 minuten onafgebroken boven deze grens blijven.",
+            "Standaard 1000 W. Power House moet eerst minimaal 2 minuten zonder aanvullende warmtebron draaien; daarna moet het warmtetekort 5 minuten onafgebroken boven deze grens blijven.",
           ),
           renderSettingsNumberField(
             "boilerSupportStopThreshold",
             "Ondersteuning stoppen onder",
-            "Standaard 400 W. Bijverwarming blijft minimaal 5 minuten actief en stopt pas wanneer het warmtetekort daarna 2 minuten onder deze grens blijft.",
+            "Standaard 400 W. De aanvullende warmtebron blijft minimaal 5 minuten actief en stopt pas wanneer het warmtetekort daarna 2 minuten onder deze grens blijft.",
           ),
         ].filter(Boolean).join("")
       : "";
     const supportSwitchingMarkup = renderSettingsAdvancedDisclosure(
       "boiler-support",
-      "Wanneer bijverwarming start en stopt",
+      "Wanneer hybride ondersteuning start en stopt",
       "Alleen voor Power House. Het warmtetekort is het gevraagde woningvermogen min het maximaal beschikbare warmtepompvermogen, met minimaal 0 W. Tussen beide grenzen blijft de huidige toestand behouden. Deze waarden veranderen het beschikbare verwarmingsvermogen en de aansturing niet.",
       supportSwitchingFields ? `<div class="oq-settings-grid">${supportSwitchingFields}</div>` : "",
     );
@@ -1002,7 +1003,7 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
           ${renderSettingsFieldCard(
             sourcePresenceKey,
             "Warmtebron aangesloten",
-            "Zet dit aan als OpenQuatt een aanvullende warmtebron fysiek kan aansturen.",
+            "Zet dit aan als OpenQuatt een aanvullende warmtebron kan aansturen, zoals een cv-ketel, elektrische cv-ketel (e-cv) of doorstroomverwarmer.",
             `
               <div class="oq-settings-compact-switch-field">
                 ${renderSettingsCompactSwitchControl(sourcePresenceKey, "Warmtebron aangesloten", sourcePresent, sourcePresentBusy)}
@@ -1038,13 +1039,13 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
           ) : ""}
           ${sourcePresent && separateSourcePolicyAvailable && assistSettingAvailable ? renderSettingsFieldCard(
             "boilerCvAssistEnabled",
-            "Gebruiken als bijverwarming",
-            "Laat de warmtebron naast de warmtepomp meeverwarmen bij extra warmtevraag.",
+            AUX_HEAT_ASSIST_TITLE,
+            "Laat de aanvullende warmtebron meeverwarmen wanneer het beschikbare warmtepompvermogen niet genoeg is voor de warmtevraag.",
             `
               <div class="oq-settings-compact-switch-field">
                 ${renderSettingsCompactSwitchControl(
                   "boilerCvAssistEnabled",
-                  "Gebruiken als bijverwarming",
+                  AUX_HEAT_ASSIST_TITLE,
                   assistEnabled,
                   assistBusy,
                 )}
@@ -1086,8 +1087,8 @@ const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer gee
       "Basis",
       "Aanvullende warmtebron",
       sourcePresent
-        ? "Kies hoe de warmtebron is aangesloten en wanneer OpenQuatt deze mag gebruiken."
-        : "Geef aan of OpenQuatt een aanvullende warmtebron kan aansturen.",
+        ? "Bijvoorbeeld een cv-ketel, elektrische cv-ketel (e-cv) of doorstroomverwarmer. Kies wanneer OpenQuatt deze mag gebruiken."
+        : "Geef aan of OpenQuatt een aanvullende warmtebron kan aansturen, zoals een cv-ketel, elektrische cv-ketel (e-cv) of doorstroomverwarmer.",
       renderBoilerCvFields("oq-settings-grid oq-settings-boiler-simple-grid", true),
     );
   }

--- a/openquatt/web/js/src/settings/installation.js
+++ b/openquatt/web/js/src/settings/installation.js
@@ -19,8 +19,8 @@ import { getSelectEntityOptions, renderNamedActionButton, renderSettingsAdvanced
 import { renderSettingsHeatPumpLimiterCard } from "./heating.js";
 import { escapeHtml } from "../core/html.js";
 
-const BOILER_FAULT_FALLBACK_TITLE = "Automatische ketelovername bij warmtepompstoring";
-const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepompen door een storing uitvallen. Dit gebeurt pas na veilige stop en geldige flow, temperatuur en ketelaansturing. OpenQuatt stelt dit zelf vast; je hoeft niets te bevestigen. Een korte communicatiedip telt niet als storing.";
+const AUX_HEAT_BACKUP_TITLE = "Gebruiken als reserveverwarming";
+const AUX_HEAT_BACKUP_COPY = "Laat de warmtebron tijdelijk overnemen wanneer geen warmtepomp veilig beschikbaar is. Dit gebeurt pas na een veilige stop en geldige flow, temperatuur en aansturing. Een korte communicatiedip telt niet als uitval.";
 
   export function getOduRuntimeFrequencyHpIndexes() {
     return ODU_RUNTIME_FREQUENCY_HP_IDS.filter((hpIndex) => (
@@ -879,15 +879,24 @@ const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepo
     className = "oq-settings-grid oq-settings-boiler-simple-grid",
     includeFaultFallback = false,
   ) {
-    if (!hasEntity("boilerCvAssistEnabled")) {
+    if (!hasEntity("auxHeatSourcePresent") && !hasEntity("boilerCvAssistEnabled")) {
       return "";
     }
 
-    const boilerPresent = isEntityActive("boilerCvAssistEnabled");
+    const separateSourcePolicyAvailable = hasEntity("auxHeatSourcePresent");
+    const sourcePresenceKey = separateSourcePolicyAvailable
+      ? "auxHeatSourcePresent"
+      : "boilerCvAssistEnabled";
+    const sourcePresent = separateSourcePolicyAvailable
+      ? isEntityActive("auxHeatSourcePresent")
+      : isEntityActive("boilerCvAssistEnabled");
+    const sourcePresentBusy = state.loadingEntities || state.busyAction === `switch-${sourcePresenceKey}`;
+    const assistSettingAvailable = hasEntity("boilerCvAssistEnabled");
+    const assistEnabled = assistSettingAvailable && isEntityActive("boilerCvAssistEnabled");
+    const assistBusy = state.loadingEntities || state.busyAction === "switch-boilerCvAssistEnabled";
     const boilerPowerEntityAvailable = hasEntity("boilerRatedHeatPower");
     const boilerMeta = getNumberMeta("boilerRatedHeatPower");
     const boilerValue = getInputDraftValue("boilerRatedHeatPower");
-    const boilerBusy = state.loadingEntities || state.busyAction === "switch-boilerCvAssistEnabled";
     const fallbackSettingAvailable = hasEntity("boilerFaultFallbackEnabled");
     const fallbackEnabled = fallbackSettingAvailable && isEntityActive("boilerFaultFallbackEnabled");
     const fallbackBusy = state.loadingEntities || state.busyAction === "switch-boilerFaultFallbackEnabled";
@@ -930,7 +939,7 @@ const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepo
         <p>De aansluitingskeuze is tijdelijk geblokkeerd.</p>
       </div>
     ` : "";
-    const boilerPowerMissingHint = "Deze firmware levert nog geen bewerkbare boilervermogensinstelling.";
+    const boilerPowerMissingHint = "Deze firmware levert nog geen bewerkbare vermogensinstelling voor de warmtebron.";
     const boilerPowerControl = boilerPowerEntityAvailable
       ? renderNumberInputControl({
           key: "boilerRatedHeatPower",
@@ -945,7 +954,7 @@ const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepo
           <p>${escapeHtml(boilerPowerMissingHint)}</p>
         </div>
       `;
-    const boilerPowerFooter = boilerPresent && boilerPowerEntityAvailable
+    const boilerPowerFooter = sourcePresent && boilerPowerEntityAvailable
       ? `<p class="oq-settings-boiler-power-note">Je kunt deze waarde altijd handmatig aanpassen.</p>`
       : "";
     const boilerConnectionFooter = boilerConnectionAutoSelected
@@ -967,75 +976,91 @@ const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepo
           <p class="oq-settings-boiler-connection-note">OT-controle bij opstart actief.</p>
         `
         : "";
-    const supportSwitchingFields = !isCurveMode() && boilerPresent
+    const supportSwitchingFields = !isCurveMode() && sourcePresent && assistEnabled
       ? [
           renderSettingsNumberField(
             "boilerSupportStartThreshold",
             "Ondersteuning starten vanaf",
-            "Standaard 1000 W. Power House moet eerst minimaal 2 minuten zonder ketelondersteuning draaien; daarna moet het warmtetekort 5 minuten onafgebroken boven deze grens blijven.",
+            "Standaard 1000 W. Power House moet eerst minimaal 2 minuten zonder bijverwarming draaien; daarna moet het warmtetekort 5 minuten onafgebroken boven deze grens blijven.",
           ),
           renderSettingsNumberField(
             "boilerSupportStopThreshold",
             "Ondersteuning stoppen onder",
-            "Standaard 400 W. Ketelondersteuning blijft minimaal 5 minuten actief en stopt pas wanneer het warmtetekort daarna 2 minuten onder deze grens blijft.",
+            "Standaard 400 W. Bijverwarming blijft minimaal 5 minuten actief en stopt pas wanneer het warmtetekort daarna 2 minuten onder deze grens blijft.",
           ),
         ].filter(Boolean).join("")
       : "";
     const supportSwitchingMarkup = renderSettingsAdvancedDisclosure(
       "boiler-support",
-      "Wanneer ketelondersteuning start en stopt",
-      "Alleen voor Power House. Het warmtetekort is het gevraagde woningvermogen min het maximaal beschikbare warmtepompvermogen, met minimaal 0 W. Tussen beide grenzen blijft de huidige toestand behouden. Deze waarden veranderen het ketelvermogen en de OpenTherm-aansturing niet.",
+      "Wanneer bijverwarming start en stopt",
+      "Alleen voor Power House. Het warmtetekort is het gevraagde woningvermogen min het maximaal beschikbare warmtepompvermogen, met minimaal 0 W. Tussen beide grenzen blijft de huidige toestand behouden. Deze waarden veranderen het beschikbare verwarmingsvermogen en de aansturing niet.",
       supportSwitchingFields ? `<div class="oq-settings-grid">${supportSwitchingFields}</div>` : "",
     );
 
     return `
         <div class="${escapeHtml(className)}">
           ${renderSettingsFieldCard(
-            "boilerCvAssistEnabled",
-            "CV-ketel / boiler aanwezig",
-            "Geef aan of OpenQuatt deze installatie als ondersteuning mag gebruiken.",
+            sourcePresenceKey,
+            "Warmtebron aangesloten",
+            "Zet dit aan als OpenQuatt een aanvullende warmtebron fysiek kan aansturen.",
             `
               <div class="oq-settings-compact-switch-field">
-                ${renderSettingsCompactSwitchControl("boilerCvAssistEnabled", "CV-ketel / boiler aanwezig", boilerPresent, boilerBusy)}
+                ${renderSettingsCompactSwitchControl(sourcePresenceKey, "Warmtebron aangesloten", sourcePresent, sourcePresentBusy)}
               </div>
             `,
             "oq-settings-field--compact",
           )}
 
-          ${(boilerPresent || boilerConnectionMismatch || boilerConnectionAutoSelected) && boilerConnectionAvailable ? renderSettingsFieldCard(
+          ${(sourcePresent || boilerConnectionMismatch || boilerConnectionAutoSelected) && boilerConnectionAvailable ? renderSettingsFieldCard(
             "boilerConnection",
-            "Ketelaansluiting",
+            "Aansturing warmtebron",
             !openthermBoilerCapabilityKnown
-              ? "OpenQuatt controleert welke ketelaansluitingen deze hardware ondersteunt."
+              ? "OpenQuatt controleert welke aansturingen deze hardware ondersteunt."
               : openthermBoilerSupported
-              ? "Kies de aansluiting die fysiek met de ketel is verbonden. OpenQuatt gebruikt nooit beide routes tegelijk."
+              ? "Kies de route waarmee de warmtebron fysiek is verbonden. OpenQuatt gebruikt nooit beide routes tegelijk."
               : "Deze hardware ondersteunt alleen de aan/uit-aansluiting via R1.",
             boilerConnectionControl,
             "oq-settings-field--compact",
             boilerConnectionFooter,
           ) : ""}
 
-          ${boilerPresent ? renderSettingsFieldCard(
+          ${sourcePresent ? renderSettingsFieldCard(
             "boilerRatedHeatPower",
-            "Ingesteld boilervermogen",
+            "Beschikbaar verwarmingsvermogen",
             "Vul hier het vermogen in dat OpenQuatt mag meerekenen.",
             `
               <div class="oq-settings-boiler-power-inline">
                 ${boilerPowerControl}
               </div>
             `,
-            boilerPresent && boilerPowerEntityAvailable ? "oq-settings-field--compact" : "oq-settings-field--compact is-disabled",
+            sourcePresent && boilerPowerEntityAvailable ? "oq-settings-field--compact" : "oq-settings-field--compact is-disabled",
             boilerPowerFooter,
           ) : ""}
-          ${boilerPresent && includeFaultFallback && fallbackSettingAvailable ? renderSettingsFieldCard(
+          ${sourcePresent && separateSourcePolicyAvailable && assistSettingAvailable ? renderSettingsFieldCard(
+            "boilerCvAssistEnabled",
+            "Gebruiken als bijverwarming",
+            "Laat de warmtebron naast de warmtepomp meeverwarmen bij extra warmtevraag.",
+            `
+              <div class="oq-settings-compact-switch-field">
+                ${renderSettingsCompactSwitchControl(
+                  "boilerCvAssistEnabled",
+                  "Gebruiken als bijverwarming",
+                  assistEnabled,
+                  assistBusy,
+                )}
+              </div>
+            `,
+            "oq-settings-field--compact",
+          ) : ""}
+          ${sourcePresent && includeFaultFallback && fallbackSettingAvailable ? renderSettingsFieldCard(
             "boilerFaultFallbackEnabled",
-            BOILER_FAULT_FALLBACK_TITLE,
-            BOILER_FAULT_FALLBACK_COPY,
+            AUX_HEAT_BACKUP_TITLE,
+            AUX_HEAT_BACKUP_COPY,
             `
               <div class="oq-settings-compact-switch-field">
                 ${renderSettingsCompactSwitchControl(
                   "boilerFaultFallbackEnabled",
-                  BOILER_FAULT_FALLBACK_TITLE,
+                  AUX_HEAT_BACKUP_TITLE,
                   fallbackEnabled,
                   fallbackBusy,
                 )}
@@ -1050,17 +1075,19 @@ const BOILER_FAULT_FALLBACK_COPY = "Laat de cv-ketel overnemen als alle warmtepo
   }
 
   export function renderSettingsBoilerCvSection() {
-    if (!hasEntity("boilerCvAssistEnabled")) {
+    if (!hasEntity("auxHeatSourcePresent") && !hasEntity("boilerCvAssistEnabled")) {
       return "";
     }
 
-    const boilerPresent = isEntityActive("boilerCvAssistEnabled");
+    const sourcePresent = hasEntity("auxHeatSourcePresent")
+      ? isEntityActive("auxHeatSourcePresent")
+      : isEntityActive("boilerCvAssistEnabled");
     return renderSettingsSection(
       "Basis",
-      "CV-ketel of boiler",
-      boilerPresent
-        ? "Kies hoe de ketel is aangesloten en hoeveel effectief vermogen OpenQuatt als ondersteuning mag gebruiken."
-        : "Geef aan of OpenQuatt een CV-ketel of boiler als ondersteuning mag gebruiken.",
+      "Aanvullende warmtebron",
+      sourcePresent
+        ? "Kies hoe de warmtebron is aangesloten en wanneer OpenQuatt deze mag gebruiken."
+        : "Geef aan of OpenQuatt een aanvullende warmtebron kan aansturen.",
       renderBoilerCvFields("oq-settings-grid oq-settings-boiler-simple-grid", true),
     );
   }

--- a/openquatt/web/js/src/settings/service.js
+++ b/openquatt/web/js/src/settings/service.js
@@ -449,7 +449,9 @@ import { renderModalShell } from "../core/modal-shell.js";
   }
 
   export function getSettingsServiceModel() {
-    const hasBoilerAssist = hasEntity("boilerCvAssistEnabled") && isEntityActive("boilerCvAssistEnabled");
+    const hasBoilerAssist = hasEntity("auxHeatSourcePresent")
+      ? isEntityActive("auxHeatSourcePresent")
+      : hasEntity("boilerCvAssistEnabled") && isEntityActive("boilerCvAssistEnabled");
     const cm100Status = getCommissioningStatusValue();
     const cm100Active = isEntityActive("cm100Active");
     const cm100StatusUpper = String(cm100Status || "").trim().toUpperCase();
@@ -835,7 +837,7 @@ import { renderModalShell } from "../core/modal-shell.js";
           taskKey: "boiler",
           title: "Boiler power test",
           copy: "Meet het effectieve boilervermogen bij stabiele flow en schrijf daarna een afgerond voorstel weg naar de boilerinstelling. Boilertest duurt meestal ongeveer 5 tot 10 minuten.",
-          subcopy: `Ingesteld boilervermogen: ${escapeHtml(boilerRatedPower)}`,
+          subcopy: `Beschikbaar verwarmingsvermogen: ${escapeHtml(boilerRatedPower)}`,
           status: boilerStatusDisplay,
           statusCopy: boilerTaskWaitingForCm100
             ? "Wacht totdat CM100 actief is voordat je de boiler-test start."

--- a/openquatt/web/js/src/views/heatpump.js
+++ b/openquatt/web/js/src/views/heatpump.js
@@ -756,7 +756,10 @@ import { replaceOuterHtmlIfSignatureChanged, setInnerHtmlIfChanged } from "./vie
   }
 
   export function shouldRenderBoilerPanel() {
-    return isEntityActive("boilerCvAssistEnabled") && hasEntity("boilerHeatPower");
+    const sourcePresent = hasEntity("auxHeatSourcePresent")
+      ? isEntityActive("auxHeatSourcePresent")
+      : isEntityActive("boilerCvAssistEnabled");
+    return sourcePresent && hasEntity("boilerHeatPower");
   }
 
   export function getBoilerReturnTemperatureKey() {

--- a/openquatt/web/tests/boiler-view.test.mjs
+++ b/openquatt/web/tests/boiler-view.test.mjs
@@ -336,11 +336,13 @@ test("integration diagnostics separates thermostat, boiler control, OTB and CiC"
 });
 
 test("settings hydration loads boiler setup and diagnostics before rendering", () => {
+  assert.ok(FAST_OVERVIEW_KEYS.includes("auxHeatSourcePresent"));
   assert.ok(FAST_OVERVIEW_KEYS.includes("boilerCvAssistEnabled"));
   assert.ok(FAST_OVERVIEW_KEYS.includes("boilerRatedHeatPower"));
   assert.ok(FAST_OVERVIEW_KEYS.includes("boilerConnection"));
   assert.ok(FAST_OVERVIEW_KEYS.includes("boilerFaultFallbackEnabled"));
   assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("boilerConnection"));
+  assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("auxHeatSourcePresent"));
   assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("boilerRatedHeatPower"));
   assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("boilerFaultFallbackEnabled"));
   assert.ok(INITIAL_SETTINGS_READY_KEY_MAP.installation.includes("otbLinkAvailable"));
@@ -369,11 +371,26 @@ test("settings hydration loads boiler setup and diagnostics before rendering", (
   );
 });
 
-test("fault fallback setting explains the consequence of both switch states", () => {
-  assert.match(installationSource, /Automatische ketelovername bij warmtepompstoring/);
-  assert.match(installationSource, /OpenQuatt stelt dit zelf vast/);
-  assert.match(installationSource, /je hoeft niets te bevestigen/);
-  assert.match(installationSource, /Een korte communicatiedip telt niet als storing/);
+test("auxiliary heat source setting remains editable on legacy firmware", () => {
+  assert.match(
+    installationSource,
+    /const sourcePresenceKey = separateSourcePolicyAvailable[\s\S]*?"auxHeatSourcePresent"[\s\S]*?: "boilerCvAssistEnabled"/,
+  );
+  assert.match(
+    installationSource,
+    /renderSettingsCompactSwitchControl\(sourcePresenceKey, "Warmtebron aangesloten"/,
+  );
+  assert.match(
+    installationSource,
+    /sourcePresent && separateSourcePolicyAvailable && assistSettingAvailable/,
+  );
+});
+
+test("reserve heating setting explains its guarded scope", () => {
+  assert.match(installationSource, /Gebruiken als reserveverwarming/);
+  assert.match(installationSource, /wanneer geen warmtepomp veilig beschikbaar is/);
+  assert.match(installationSource, /na een veilige stop/);
+  assert.match(installationSource, /Een korte communicatiedip telt niet als uitval/);
 });
 
 test("fault fallback is editable in Installation and the shared Quick Start boiler fields", () => {
@@ -394,7 +411,7 @@ test("fault fallback is editable in Installation and the shared Quick Start boil
   );
   assert.match(
     quickStartSource,
-    /\["Automatische ketelovername bij warmtepompstoring", isEntityActive\("boilerFaultFallbackEnabled"\) \? "Aan" : "Uit"\]/,
+    /\["Gebruiken als reserveverwarming", isEntityActive\("boilerFaultFallbackEnabled"\) \? "Aan" : "Uit"\]/,
   );
   assert.match(servicePanelSource, /renderInstallationMonitoringStatusRow/);
   assert.doesNotMatch(servicePanelSource, /boilerFaultFallbackEnabled/);
@@ -420,7 +437,7 @@ test("onboarding auto-selects a detected OpenTherm boiler and explains the choic
   assert.match(installationSource, /automatisch als ketelaansluiting geselecteerd/);
   assert.match(
     installationSource,
-    /boilerPresent \|\| boilerConnectionMismatch \|\| boilerConnectionAutoSelected/,
+    /sourcePresent \|\| boilerConnectionMismatch \|\| boilerConnectionAutoSelected/,
   );
 });
 
@@ -439,10 +456,10 @@ test("firmware publishes boiler connection mismatch transitions immediately", ()
   );
 });
 
-test("Quick Start keeps the mismatch remedy visible when boiler assist is off", () => {
+test("Quick Start keeps the mismatch remedy visible when the source is disconnected", () => {
   assert.match(
     installationSource,
-    /\(boilerPresent \|\| boilerConnectionMismatch \|\| boilerConnectionAutoSelected\) && boilerConnectionAvailable \? renderSettingsFieldCard/,
+    /\(sourcePresent \|\| boilerConnectionMismatch \|\| boilerConnectionAutoSelected\) && boilerConnectionAvailable \? renderSettingsFieldCard/,
   );
   assert.match(installationSource, /OpenTherm-ketel gevonden/);
 });

--- a/openquatt/web/tests/boiler-view.test.mjs
+++ b/openquatt/web/tests/boiler-view.test.mjs
@@ -386,11 +386,17 @@ test("auxiliary heat source setting remains editable on legacy firmware", () => 
   );
 });
 
-test("reserve heating setting explains its guarded scope", () => {
-  assert.match(installationSource, /Gebruiken als reserveverwarming/);
+test("fallback heating setting explains its guarded scope", () => {
+  assert.match(installationSource, /Overnemen wanneer de warmtepomp niet beschikbaar is/);
   assert.match(installationSource, /wanneer geen warmtepomp veilig beschikbaar is/);
   assert.match(installationSource, /na een veilige stop/);
   assert.match(installationSource, /Een korte communicatiedip telt niet als uitval/);
+});
+
+test("auxiliary heat source copy names common examples and explains hybrid heating", () => {
+  assert.match(installationSource, /cv-ketel, elektrische cv-ketel \(e-cv\) of doorstroomverwarmer/);
+  assert.match(installationSource, /Hybride verwarmen bij vermogenstekort/);
+  assert.match(installationSource, /het beschikbare warmtepompvermogen niet genoeg is/);
 });
 
 test("fault fallback is editable in Installation and the shared Quick Start boiler fields", () => {
@@ -411,7 +417,7 @@ test("fault fallback is editable in Installation and the shared Quick Start boil
   );
   assert.match(
     quickStartSource,
-    /\["Gebruiken als reserveverwarming", isEntityActive\("boilerFaultFallbackEnabled"\) \? "Aan" : "Uit"\]/,
+    /\["Overnemen wanneer de warmtepomp niet beschikbaar is", isEntityActive\("boilerFaultFallbackEnabled"\) \? "Aan" : "Uit"\]/,
   );
   assert.match(servicePanelSource, /renderInstallationMonitoringStatusRow/);
   assert.doesNotMatch(servicePanelSource, /boilerFaultFallbackEnabled/);

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -14,8 +14,9 @@ export const WEB_BUNDLE_BUDGETS = [
     // selectable cooling restart by water temperature or minimum off-time,
     // toelichting lokale historie in Quick Start, plus fase-2 flash-I/O observability,
     // strategie-afhankelijke warmtetoestemming-advies (Power House vs stooklijn, OT-voorkeur, centrale modal, auto-set in Quick Start),
-    // plus hervatbare, fail-closed Quick Start-OTA met main-/doelcontrole en duurzaam post-bootbewijs.
-    raw: 956_000,
+    // plus hervatbare, fail-closed Quick Start-OTA met main-/doelcontrole en duurzaam post-bootbewijs,
+    // en afzonderlijke rollen voor een aangesloten aanvullende warmtebron, hybride verwarmen en overname.
+    raw: 957_000,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.

--- a/tests/host/ot_boiler_safety_interlocks_test.cpp
+++ b/tests/host/ot_boiler_safety_interlocks_test.cpp
@@ -15,7 +15,7 @@ oq_boiler::BoilerCommand active_command(uint32_t updated_at_ms) {
 
 oq_boiler::ControllerInput safe_input(uint32_t now_ms) {
   return oq_boiler::ControllerInput{
-      true, true, true, true, true,  true,   false, false, false, true,
+      true, true, true, true, true,  true,   true,  false, false, false,  true,
       true, true, true, true, false, now_ms, 15000, 0,     30000, 120000,
   };
 }
@@ -144,6 +144,11 @@ void test_fail_safe_priority() {
   assert_decision(decision, false, true, oq_boiler::BLOCK_WATER_TEMP_INHIBIT);
 
   input = safe_input(1500);
+  input.source_present = false;
+  decision = oq_boiler::evaluate(command, input);
+  assert_decision(decision, false, true, oq_boiler::BLOCK_SOURCE_NOT_CONNECTED);
+
+  input = safe_input(1500);
   input.assist_enabled = false;
   decision = oq_boiler::evaluate(command, input);
   assert_decision(decision, false, true, oq_boiler::BLOCK_ASSIST_DISABLED);
@@ -220,7 +225,7 @@ void test_fallback_and_flow_guards() {
   auto input = safe_input(1500);
   input.assist_enabled = false;
   auto decision = oq_boiler::evaluate(command, input);
-  assert_decision(decision, false, true, oq_boiler::BLOCK_ASSIST_DISABLED);
+  assert_decision(decision, true, false, oq_boiler::BLOCK_NONE);
 
   input = safe_input(1500);
   input.fallback_enabled = false;
@@ -316,6 +321,7 @@ void test_commissioning_wait_state() {
   command.heat_request = false;
 
   auto input = safe_input(1500);
+  input.assist_enabled = false;
   auto decision = oq_boiler::evaluate(command, input);
   assert_decision(decision, false, false, oq_boiler::BLOCK_COMMISSIONING_WAITING);
   assert(decision.blocked);
@@ -324,6 +330,12 @@ void test_commissioning_wait_state() {
   input.output_last_change_ms = 1400;
   decision = oq_boiler::evaluate(command, input);
   assert_decision(decision, true, false, oq_boiler::BLOCK_MIN_ON_TIME);
+
+  command.heat_request = true;
+  input = safe_input(1500);
+  input.assist_enabled = false;
+  decision = oq_boiler::evaluate(command, input);
+  assert_decision(decision, true, false, oq_boiler::BLOCK_NONE);
 }
 
 void test_commissioning_start_failure_reason() {


### PR DESCRIPTION
# Wat verandert deze PR?

- Brengt de wijzigingen van #550 naar de juiste doelbranch `dev`.
- Splitst fysieke aanwezigheid, hybride verwarmen bij vermogenstekort en overname wanneer de warmtepomp niet beschikbaar is in drie onafhankelijke instellingen.
- Laat overname werken zonder dat hybride meeverwarmen aan hoeft te staan; fysieke afwezigheid blijft een harde fail-closed blokkade.
- Noemt herkenbare voorbeelden, zoals een cv-ketel, elektrische cv-ketel (e-cv) en doorstroomverwarmer, en werkt Quick Start, installatie-UI, servicefuncties en documentatie bij.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [x] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De nieuwe fysieke broninstelling is de bovenliggende veiligheidsgrens. Bij uitschakelen worden beide gebruikstoestemmingen gewist. Een eenmalige migratie leidt bronaanwezigheid af uit de bestaande ondersteuningsinstelling; bestaande entity-id's voor hybride ondersteuning en overname blijven behouden voor restore- en downgradecompatibiliteit.

Het JS raw-budget is voor de nieuwere `dev`-basis minimaal verhoogd van 956,5 naar 958 kB; de gecombineerde bundle met #547 is 957791 bytes.

## Achtergrond

#550 is per ongeluk naar `main` gemerged. Deze vervangende PR bevat dezelfde twee oorspronkelijke featurecommits, opnieuw toegepast op de actuele `dev`-branch. De koude-opstartregeling volgt als afzonderlijke, gestapelde PR.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

`docs/q-edition.md` en `docs/web-app.md` beschrijven de drie onafhankelijke keuzes, herkenbare voorbeelden en hun veiligheidsgrenzen.

## Validatie

- [x] `npm run check:web` — 264 webtests en kwaliteitscontrole geslaagd
- [x] `npm run check:cpp-format` — geslaagd
- [x] `./scripts/run_host_regression_tests.sh` — 37 hosttests geslaagd
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single_wifi.yaml` — geslaagd
- [x] Toestemmingsgedrag eerder HIL-getest op Q-edition Duo WiFi-controller met de gestapelde koude-opstartfirmware
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

### HIL/simulatortest

| Toestemming en situatie | Waargenomen resultaat |
| --- | --- |
| Hybride verwarmen aan, overname uit, koudste ODU 10,34 °C | Warmtepompen en aanvullende bron samen actief; CM3; OpenTherm TSet 25 °C |
| Hybride verwarmen uit, overname uit, beide ODU-uitlaten 5,54–5,57 °C | Alleen warmtepompen actief; CM2; aanvullende bron uit |
| Overname uit, beide ODU-uitlaten onder 5 °C | Geen compressor en geen aanvullende bron; CM1 |
| Overname aan, beide ODU-uitlaten onder 5 °C | Aanvullende bron neemt over; CM4; OpenTherm TSet 50 °C |

De test met synthetische sensordata bewijst het regelgedrag en de OpenTherm-opdrachten. De eenmalige migratie/restore is niet afzonderlijk op hardware getest.

Heap/stack-impact:

Alleen enkele booleans en bestaande control/UI-paden; geen nieuwe buffers, tasks of netwerkallocaties.

## PR-audit

De twee oorspronkelijke #550-commits zijn afzonderlijk gecherry-pickt op de actuele `dev`. `git range-diff` toont uitsluitend verwachte contextverschillen in documentatie door nieuwere `dev`-inhoud. De volledige diff is opnieuw beoordeeld op fysieke bron-gate, onafhankelijke toestemmingen, veilige fallback-interlocks, migratie/restore, legacy webcompatibiliteit en docs/UI/testconsistentie. De gelijktijdig gemergede #547 wijzigde hetzelfde `esphome.on_boot`-blok; beide bootacties zijn daarom expliciet samengevoegd en opnieuw voor Single en Duo gevalideerd. Geen resterende bevindingen.
