### PR TITLE
Toon ODU-detectie als lopende actie

### DIFF
--- a/openquatt/web/js/src/core/entity-write-actions.js
+++ b/openquatt/web/js/src/core/entity-write-actions.js
@@ -836,6 +836,19 @@ export async function triggerNamedButtonGroup(keys, options = {}) {
     }
     if (failed) throw failed.reason;
 
+    const refreshUntil = typeof options.refreshUntil === "function" ? options.refreshUntil : null;
+    const refreshIntervalMs = Math.max(0, Number(options.refreshIntervalMs || 0));
+    const refreshTimeoutMs = Math.max(0, Number(options.refreshTimeoutMs || 0));
+    const refreshStartedAt = Date.now();
+    while (refreshUntil && !refreshUntil()) {
+      if (state.busyAction !== busyAction) return;
+      if (Date.now() - refreshStartedAt >= refreshTimeoutMs) {
+        throw new Error(options.refreshTimeoutMessage || "Resultaat niet binnen de verwachte tijd ontvangen");
+      }
+      await new Promise((resolve) => window.setTimeout(resolve, refreshIntervalMs));
+      await refreshEntities(options.refreshKeys, "state");
+    }
+
     if (state.busyAction === busyAction) {
       state.controlNotice = options.successNotice || "Acties gestart.";
     }

--- a/openquatt/web/js/src/core/named-button-actions.js
+++ b/openquatt/web/js/src/core/named-button-actions.js
@@ -1,7 +1,7 @@
 import { getOduRuntimeFrequencyButtonHp, getOduRuntimeFrequencyHpKeys, INSTALLATION_MONITORING_STATE_KEYS, ODU_RUNTIME_FREQUENCY_BUTTON_KEYS } from "./config.js";
-import { hasEntity } from "./entity-store.js";
+import { getEntityValue, hasEntity } from "./entity-store.js";
 import { triggerIncidentAction, triggerNamedButton, triggerNamedButtonGroup } from "./entity-write-actions.js";
-import { ODU_CUSTOMER_MODEL_CODE_KEYS, ODU_GENERATION_DETECT_KEYS, ODU_GENERATION_KEYS, ODU_GENERATION_VARIANT_KEYS } from "./odu-generation.js";
+import { normalizeDetectedOduGeneration, ODU_CUSTOMER_MODEL_CODE_KEYS, ODU_GENERATION_DETECT_KEYS, ODU_GENERATION_KEYS, ODU_GENERATION_VARIANT_KEYS } from "./odu-generation.js";
 import { state } from "./state.js";
 
 const commissioningRefreshGroups = [
@@ -157,17 +157,6 @@ function getRefreshOptions(buttonKey) {
     return { refreshIncidentMonitoring: true };
   }
 
-  const generationDetectIndex = ODU_GENERATION_DETECT_KEYS.indexOf(buttonKey);
-  if (generationDetectIndex !== -1) {
-    const hpIndex = generationDetectIndex + 1;
-    return {
-      refreshKeys: [ODU_GENERATION_KEYS[generationDetectIndex]],
-      refreshDelayMs: 1800,
-      successNotice: `HP${hpIndex} ODU-detectie opnieuw aangevraagd.`,
-      errorPrefix: `ODU-detectie mislukt voor HP${hpIndex}`,
-    };
-  }
-
   const group = commissioningRefreshGroups.find(({ actions }) => actions.includes(buttonKey));
   if (group) {
     return { refreshKeys: [...group.keys] };
@@ -191,6 +180,33 @@ function getRefreshOptions(buttonKey) {
   return {};
 }
 
+function triggerOduGenerationDetection(detectKeys) {
+  const detectIndexes = detectKeys.map((key) => ODU_GENERATION_DETECT_KEYS.indexOf(key));
+  const generationKeys = detectIndexes.map((index) => ODU_GENERATION_KEYS[index]);
+  const refreshKeys = detectIndexes.flatMap((index) => [
+    ODU_GENERATION_KEYS[index],
+    ODU_GENERATION_VARIANT_KEYS[index],
+    ODU_CUSTOMER_MODEL_CODE_KEYS[index],
+  ]);
+
+  generationKeys.forEach((key) => {
+    const current = state.entities[key];
+    if (current) state.entities[key] = { ...current, state: "Unknown", value: "Unknown" };
+  });
+
+  return triggerNamedButtonGroup(detectKeys, {
+    busyAction: "odu-generation-detect-all",
+    refreshKeys,
+    refreshDelayMs: 800,
+    refreshIntervalMs: 1200,
+    refreshTimeoutMs: 33000,
+    refreshUntil: () => generationKeys.every((key) => normalizeDetectedOduGeneration(getEntityValue(key)) !== "Unknown"),
+    refreshTimeoutMessage: "ODU-detectie niet binnen 33 seconden voltooid",
+    successNotice: "ODU-detectie voltooid.",
+    errorPrefix: "ODU-detectie niet volledig uitgevoerd",
+  });
+}
+
   export function handleNamedButtonAction(action, button) {
   if (action === "retry-hp-start" || action === "confirm-hp-power-cycle") {
     const hpIndex = Number(button.dataset.oqHpIndex || 0);
@@ -210,19 +226,7 @@ function getRefreshOptions(buttonKey) {
   if (action === "press-odu-generation-detect-all") {
     const detectKeys = ODU_GENERATION_DETECT_KEYS.filter((key) => hasEntity(key));
     if (detectKeys.length === 0) return true;
-    const detectIndexes = detectKeys.map((key) => ODU_GENERATION_DETECT_KEYS.indexOf(key));
-    const refreshKeys = detectIndexes.flatMap((index) => [
-      ODU_GENERATION_KEYS[index],
-      ODU_GENERATION_VARIANT_KEYS[index],
-      ODU_CUSTOMER_MODEL_CODE_KEYS[index],
-    ]);
-    void triggerNamedButtonGroup(detectKeys, {
-      busyAction: "odu-generation-detect-all",
-      refreshKeys,
-      refreshDelayMs: 3200,
-      successNotice: "ODU-detectie opnieuw aangevraagd.",
-      errorPrefix: "ODU-detectie niet volledig uitgevoerd",
-    });
+    void triggerOduGenerationDetection(detectKeys);
     return true;
   }
   if (action !== "press-named-button") {
@@ -232,6 +236,10 @@ function getRefreshOptions(buttonKey) {
   const buttonKey = String(button.dataset.oqButtonKey || button.dataset.buttonKey || button.getAttribute("data-oq-button-key") || "").trim();
   if (buttonKey) {
     prepareCommissioningState(buttonKey);
+    if (ODU_GENERATION_DETECT_KEYS.includes(buttonKey)) {
+      void triggerOduGenerationDetection([buttonKey]);
+      return true;
+    }
     void triggerNamedButton(buttonKey, getRefreshOptions(buttonKey));
   }
   return true;

--- a/openquatt/web/js/src/features/odu-generation-ui.js
+++ b/openquatt/web/js/src/features/odu-generation-ui.js
@@ -70,20 +70,31 @@ export function renderOduGenerationDetectionStatus({ embedded = false } = {}) {
     return "";
   }
 
-  const advice = getOduGenerationDetectionAdvice(model);
-  const match = model.status === "match";
-  const title = !model.complete ? "Detectie onvolledig" : model.mixed ? "Gemengde Duo" : "Automatisch gevonden";
-  const badge = match ? "Komt overeen" : model.recommendation ? `Advies ${model.recommendation}` : "Geen advies";
-  const badgeTone = match ? " is-success" : model.recommendation ? "" : " is-neutral";
   const busy = state.loadingEntities || Boolean(state.busyAction);
   const detectKeys = model.heatPumps.filter((heatPump) => heatPump.detectAvailable).map((heatPump) => heatPump.detectKey);
   const isDetecting = detectKeys.some((key) => state.busyAction === key) || state.busyAction === "odu-generation-detect-all";
+  const advice = isDetecting
+    ? {
+        warning: false,
+        copy: model.heatPumps.length > 1
+          ? "OpenQuatt leest de buitenunits opnieuw uit. Dit kan enkele seconden duren."
+          : "OpenQuatt leest de buitenunit opnieuw uit. Dit kan enkele seconden duren.",
+      }
+    : getOduGenerationDetectionAdvice(model);
+  const match = !isDetecting && model.status === "match";
+  const title = isDetecting
+    ? "Detectie bezig"
+    : !model.complete ? "Detectie onvolledig" : model.mixed ? "Gemengde Duo" : "Automatisch gevonden";
+  const badge = isDetecting
+    ? "Even geduld"
+    : match ? "Komt overeen" : model.recommendation ? `Advies ${model.recommendation}` : "Geen advies";
+  const badgeTone = match ? " is-success" : model.recommendation || isDetecting ? "" : " is-neutral";
   const detectButton = canDetect
     ? `<button class="oq-gen-reset" type="button" data-oq-action="press-odu-generation-detect-all" aria-label="ODU-generatie opnieuw detecteren" ${busy ? "disabled" : ""} aria-busy="${isDetecting ? "true" : "false"}">${escapeHtml(isDetecting ? "Detecteren…" : "Opnieuw detecteren")}</button>`
     : "";
   const rows = model.heatPumps.map((heatPump) => {
-    const value = heatPump.known ? `Quatt ODU ${heatPump.generation}` : "Unknown";
-    return `<div class="oq-settings-source-row oq-gen-unit${heatPump.known ? "" : " is-warning"}" data-oq-odu-generation="hp${heatPump.index}"><span class="oq-settings-source-row-label">HP${heatPump.index}</span><strong>${escapeHtml(value)}</strong></div>`;
+    const value = isDetecting ? "Detecteren…" : heatPump.known ? `Quatt ODU ${heatPump.generation}` : "Unknown";
+    return `<div class="oq-settings-source-row oq-gen-unit${heatPump.known || isDetecting ? "" : " is-warning"}" data-oq-odu-generation="hp${heatPump.index}"><span class="oq-settings-source-row-label">HP${heatPump.index}</span><strong>${escapeHtml(value)}</strong></div>`;
   }).join("");
 
   return `<section class="oq-gen-detection oq-settings-field--span-2${embedded ? " is-embedded" : " oq-helper-surface oq-settings-field"}" data-oq-settings-field="oduGenerationDetection" aria-label="ODU-detectie"><div class="oq-gen-hd"><strong>${escapeHtml(title)}</strong><div class="oq-gen-hd-actions"><span class="oq-settings-section-badge oq-gen-badge${badgeTone}">${escapeHtml(badge)}</span>${detectButton}</div></div><div class="oq-gen-units${model.heatPumps.length > 1 ? " is-duo" : ""}" role="group" aria-label="Gedetecteerde buitenunits">${rows}</div>${match ? "" : `<p class="oq-settings-action-note${advice.warning ? " oq-settings-action-note--warning" : ""}" aria-live="polite">${escapeHtml(advice.copy)}</p>`}</section>`;

--- a/openquatt/web/tests/odu-generation-actions.test.mjs
+++ b/openquatt/web/tests/odu-generation-actions.test.mjs
@@ -146,6 +146,62 @@ test("late afronding van detectie overschrijft geen nieuwere actie", async () =>
   assert.equal(state.controlError, "");
 });
 
+test("detectie blijft bezig en ververst totdat de generatie bekend is", async () => {
+  resetState();
+  let refreshCount = 0;
+  globalThis.fetch = async (url, options = {}) => {
+    if (String(url) !== "/openquatt/entities") return { ok: true, status: 200 };
+    refreshCount += 1;
+    const response = entityRefreshResponse(options);
+    const payload = await response.json();
+    if (refreshCount === 1) {
+      payload.entities.hp1Generation = textEntity("Unknown");
+    }
+    return { ...response, json: async () => payload };
+  };
+
+  const pending = triggerNamedButtonGroup(["hp1GenerationDetect"], {
+    busyAction: "odu-generation-detect-all",
+    refreshKeys: refreshKeys.slice(0, 3),
+    refreshIntervalMs: 1,
+    refreshTimeoutMs: 100,
+    refreshUntil: () => state.entities.hp1Generation.value === "V2",
+    successNotice: "ODU-detectie voltooid.",
+  });
+
+  assert.equal(state.busyAction, "odu-generation-detect-all");
+  await pending;
+  assert.equal(refreshCount, 2);
+  assert.equal(state.entities.hp1Generation.value, "V2");
+  assert.equal(state.controlNotice, "ODU-detectie voltooid.");
+  assert.equal(state.busyAction, "");
+});
+
+test("detectie toont pas na de wachttijd een timeout", async () => {
+  resetState();
+  globalThis.fetch = async (url, options = {}) => {
+    if (String(url) !== "/openquatt/entities") return { ok: true, status: 200 };
+    const response = entityRefreshResponse(options);
+    const payload = await response.json();
+    payload.entities.hp1Generation = textEntity("Unknown");
+    return { ...response, json: async () => payload };
+  };
+
+  await triggerNamedButtonGroup(["hp1GenerationDetect"], {
+    busyAction: "odu-generation-detect-all",
+    refreshKeys: refreshKeys.slice(0, 3),
+    refreshIntervalMs: 2,
+    refreshTimeoutMs: 1,
+    refreshUntil: () => state.entities.hp1Generation.value === "V2",
+    refreshTimeoutMessage: "ODU-detectie niet binnen de testtijd voltooid",
+    errorPrefix: "ODU-detectie niet volledig uitgevoerd",
+  });
+
+  assert.match(state.controlError, /ODU-detectie niet binnen de testtijd voltooid/);
+  assert.equal(state.controlNotice, "");
+  assert.equal(state.busyAction, "");
+});
+
 test("nieuwe webapp blijft compatibel wanneer oude firmware fingerprintdiagnostiek mist", async () => {
   resetState();
   delete state.entities.hp1GenerationVariant;

--- a/openquatt/web/tests/odu-generation-onboarding.test.mjs
+++ b/openquatt/web/tests/odu-generation-onboarding.test.mjs
@@ -162,9 +162,15 @@ test("onboarding toont Duo per HP en onderscheidt geselecteerd van aanbevolen zo
   assert.deepEqual(state.drafts, {});
 
   state.busyAction = "hp1GenerationDetect";
-  assert.match(renderOduGenerationDetectionStatus(), /Detecteren…/);
+  const singlePendingMarkup = renderOduGenerationDetectionStatus();
+  assert.match(singlePendingMarkup, /Detectie bezig/);
+  assert.match(singlePendingMarkup, /Even geduld/);
+  assert.match(singlePendingMarkup, /Detecteren…/);
+  assert.doesNotMatch(singlePendingMarkup, /Detectie onvolledig/);
   state.busyAction = "odu-generation-detect-all";
-  assert.match(renderOduGenerationDetectionStatus(), /Detecteren…/);
+  const groupPendingMarkup = renderOduGenerationDetectionStatus();
+  assert.match(groupPendingMarkup, /OpenQuatt leest de buitenunits opnieuw uit/);
+  assert.doesNotMatch(groupPendingMarkup, />Unknown</);
 });
 
 test("Unknown blijft zichtbaar, toont geen aanbevolen badge en behoudt handmatige fallback", () => {
@@ -208,9 +214,10 @@ test("onboarding en installatiehydratie laden status en optionele detectieknoppe
   assert.match(entitySyncSource, /installation:\s*\[[\s\S]*\.\.\.ODU_GENERATION_KEYS[\s\S]*\.\.\.ODU_GENERATION_DETECT_KEYS/);
   assert.match(entitySyncSource, /state\.currentStep === "generation" \|\| state\.currentStep === "confirm"/);
   assert.match(entitySyncSource, /\.\.\.quickStartGenerationKeys/);
-  assert.match(namedButtonActionsSource, /ODU_GENERATION_DETECT_KEYS\.indexOf\(buttonKey\)/);
-  assert.match(namedButtonActionsSource, /refreshKeys: \[ODU_GENERATION_KEYS\[generationDetectIndex\]\]/);
+  assert.match(namedButtonActionsSource, /ODU_GENERATION_DETECT_KEYS\.includes\(buttonKey\)/);
   assert.match(namedButtonActionsSource, /triggerNamedButtonGroup\(detectKeys/);
+  assert.match(namedButtonActionsSource, /refreshUntil:/);
+  assert.match(namedButtonActionsSource, /refreshTimeoutMs: 33000/);
   assert.match(namedButtonActionsSource, /ODU_GENERATION_VARIANT_KEYS\[index\]/);
   assert.match(namedButtonActionsSource, /ODU_CUSTOMER_MODEL_CODE_KEYS\[index\]/);
   assert.match(namedButtonActionsSource, /busyAction: "odu-generation-detect-all"/);


### PR DESCRIPTION
# Wat verandert deze PR?

- Houdt **Opnieuw detecteren** actief totdat alle aangevraagde ODU-generaties bekend zijn of de begrensde detectietijd verloopt.
- Toont tijdens die tussenfase **Detectie bezig**, **Even geduld** en **Detecteren…** in plaats van de tijdelijke foutindruk **Detectie onvolledig / Unknown**.
- Voegt regressietests toe voor succes na meerdere polls, timeout, partial failure, oudere firmware en de gebruikerscopy.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de web-app wijzigt. De firmware blijft de generatie tijdens een herdetectie intern fail-closed op `Unknown` zetten. De browser ververst de bestaande fingerprintvelden begrensd totdat de firmware klaar is; er worden geen nieuwe entities of ODU-writes toegevoegd.

## Achtergrond

Een echte V2-new-test liet zien dat de firmware binnen circa tien seconden correct terugkeerde van `Unknown` naar `V2 new model`. De web-app beëindigde de bezigaanduiding echter al na het accepteren van de knopactie en één vroege refresh. Daardoor leek een geldige ODU tijdelijk niet meer herkend.

De polling stopt bij een bekende generatie, na 33 seconden, bij een mislukte knopactie of wanneer een nieuwere browseractie de lock overneemt. Partial failures en onbekende hardware blijven zichtbaar en fail-closed. Relates to #475.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit corrigeert uitsluitend een kortstondige statusweergave tijdens een bestaande actie; de bediening en configuratie veranderen niet.

## Validatie

- `node --test openquatt/web/tests/odu-generation-actions.test.mjs openquatt/web/tests/odu-generation-onboarding.test.mjs`
- `npm run check:web` — 295 tests, webbuild en kwaliteitscontrole geslaagd.
- `dev.html?view=settings&preview=odu-detection` via de Chrome-extensie: de volledige klikflow toont eerst **Detectie bezig / Detecteren…** en daarna **ODU-detectie voltooid** met de herkende ODU-generaties; geen browserwaarschuwingen of -fouten.
- Volledige diff tegen `dev` apart beoordeeld op lifecycle, timeout/retry, partial failure, concurrerende acties, compatibiliteit met oudere firmware en fail-closed gedrag.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen firmware-, embedded runtime- of geheugentoewijzingswijziging.
