### PR TITLE
YAML naar C++: CiC – registercontracten

### DIFF
--- a/openquatt/includes/protocol/oq_cic_compatibility_runtime.h
+++ b/openquatt/includes/protocol/oq_cic_compatibility_runtime.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "oq_cic_register_logic.h"
+
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+namespace oq_cic {
+
+inline uint16_t read(uint16_t value) {
+  id(cic_compatibility_last_request_ms) = millis();
+  return gated(id(cic_compatibility_enable).state, value);
+}
+
+inline uint16_t constant(uint16_t value) {
+  id(cic_compatibility_last_request_ms) = millis();
+  return value;
+}
+
+inline uint16_t read_hp1_status_flags() {
+  return read(status_flags(id(hp1_fan_low_speed_mode).state, id(hp1_bottom_plate_heater).state,
+                           id(hp1_crankcase_heater).state, id(hp1_fan_defrost_mode).state,
+                           id(hp1_fan_high_speed_mode).state, id(hp1_4_way_valve).state, id(hp1_pump_relay).state));
+}
+
+#if OQ_TOPOLOGY_DUO
+inline uint16_t read_hp2_status_flags() {
+  return read(status_flags(id(hp2_fan_low_speed_mode).state, id(hp2_bottom_plate_heater).state,
+                           id(hp2_crankcase_heater).state, id(hp2_fan_defrost_mode).state,
+                           id(hp2_fan_high_speed_mode).state, id(hp2_4_way_valve).state, id(hp2_pump_relay).state));
+}
+#endif
+
+}  // namespace oq_cic
+#endif

--- a/openquatt/includes/protocol/oq_cic_register_logic.h
+++ b/openquatt/includes/protocol/oq_cic_register_logic.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+namespace oq_cic {
+
+inline constexpr uint16_t UNAVAILABLE = 0xFFFFu;
+inline constexpr uint16_t FIRMWARE_FALLBACK = 0x011Eu;
+
+constexpr uint16_t gated(bool enabled, uint16_t value) { return enabled ? value : 0u; }
+
+inline uint16_t scaled(float value, float factor = 1.0f, uint16_t nan_value = 0u) {
+  return isnan(value) ? nan_value : static_cast<uint16_t>(lroundf(value * factor));
+}
+
+inline uint16_t temperature(float value) {
+  return isnan(value) ? 0u : static_cast<uint16_t>(lroundf((value * 100.0f) + 3000.0f));
+}
+
+inline uint16_t flow(float value) { return isnan(value) ? 0u : static_cast<uint16_t>(lroundf(value / 0.618f)); }
+
+inline uint16_t on_option(const char* option, uint16_t on_value = 1u) {
+  return option != nullptr && strcmp(option, "On") == 0 ? on_value : 0u;
+}
+
+constexpr uint16_t boolean(bool value, uint16_t true_value = 1u) { return value ? true_value : 0u; }
+
+inline uint16_t working_mode(const char* option) {
+  if (option != nullptr && strcmp(option, "Cooling") == 0) return 1u;
+  if (option != nullptr && strcmp(option, "Heating") == 0) return 2u;
+  return 0u;
+}
+
+inline uint16_t compressor_level(const char* option) {
+  return option == nullptr || option[0] == '\0' ? 0u : static_cast<uint16_t>(atoi(option));
+}
+
+constexpr uint16_t status_flags(bool fan_low, bool bottom_plate, bool crankcase, bool fan_defrost, bool fan_high,
+                                bool four_way, bool pump_relay) {
+  return (fan_low ? 0x0001u : 0u) | (bottom_plate ? 0x0004u : 0u) | (crankcase ? 0x0008u : 0u) |
+         (fan_defrost ? 0x0010u : 0u) | (fan_high ? 0x0020u : 0u) | (four_way ? 0x0040u : 0u) |
+         (pump_relay ? 0x0800u : 0u);
+}
+
+}  // namespace oq_cic

--- a/openquatt/oq_cic_compatibility_server.yaml
+++ b/openquatt/oq_cic_compatibility_server.yaml
@@ -24,445 +24,228 @@ modbus_server:
     registers:
       - address: 1999
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          const auto compressor_level = id(${cic_compat_hp_id}_compressor_level).current_option();
-          if (!id(cic_compatibility_enable).state || compressor_level.empty()) return 0;
-          return static_cast<uint16_t>(atoi(compressor_level.c_str()));
-        write_lambda: |-
-          return true;
+        read_lambda: return oq_cic::read(oq_cic::compressor_level(id(${cic_compat_hp_id}_compressor_level).current_option().c_str()));
+        write_lambda: return true;
       - address: 2006
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          return id(${cic_compat_hp_id}_low_noise_mode).current_option() == "On" ? 1 : 0;
-        write_lambda: |-
-          return true;
+        read_lambda: return oq_cic::read(oq_cic::on_option(id(${cic_compat_hp_id}_low_noise_mode).current_option().c_str()));
+        write_lambda: return true;
       - address: 2010
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          return id(${cic_compat_hp_id}_set_pump_mode).current_option() == "On" ? 4096 : 0;
-        write_lambda: |-
-          return true;
+        read_lambda: return oq_cic::read(oq_cic::on_option(id(${cic_compat_hp_id}_set_pump_mode).current_option().c_str(), 4096u));
+        write_lambda: return true;
       - address: 2015
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_pump_speed).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
-        write_lambda: |-
-          return true;
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_pump_speed).state));
+        write_lambda: return true;
       - address: 3999
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          const auto working_mode = id(${cic_compat_hp_id}_set_working_mode).current_option();
-          if (!id(cic_compatibility_enable).state) return 0;
-          if (working_mode == "Cooling") return 1;
-          if (working_mode == "Heating") return 2;
-          return 0;
-        write_lambda: |-
-          return true;
+        read_lambda: return oq_cic::read(oq_cic::working_mode(id(${cic_compat_hp_id}_set_working_mode).current_option().c_str()));
+        write_lambda: return true;
       - address: 2099
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_working_mode).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_working_mode).state));
       - address: 2100
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_voltage).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_voltage).state));
       - address: 2101
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_current).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_current).state, 10.0f));
       - address: 2102
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_compressor_frequency_demand).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_compressor_frequency_demand).state));
       - address: 2103
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_compressor_frequency).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_compressor_frequency).state));
       - address: 2104
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_fan_speed_max).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_fan_speed_max).state));
       - address: 2105
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_fan_speed).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_fan_speed).state));
       - address: 2106
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0;
+        read_lambda: return oq_cic::constant(0u);
       - address: 2107
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_eev_steps).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_eev_steps).state));
       - address: 2108
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          uint16_t bits = 0;
-          if (id(${cic_compat_hp_id}_fan_low_speed_mode).state) bits |= 0x0001u;
-          if (id(${cic_compat_hp_id}_bottom_plate_heater).state) bits |= 0x0004u;
-          if (id(${cic_compat_hp_id}_crankcase_heater).state) bits |= 0x0008u;
-          if (id(${cic_compat_hp_id}_fan_defrost_mode).state) bits |= 0x0010u;
-          if (id(${cic_compat_hp_id}_fan_high_speed_mode).state) bits |= 0x0020u;
-          if (id(${cic_compat_hp_id}_4_way_valve).state) bits |= 0x0040u;
-          if (id(${cic_compat_hp_id}_pump_relay).state) bits |= 0x0800u;
-          return bits;
+        read_lambda: return oq_cic::read_${cic_compat_hp_id}_status_flags();
       - address: 2109
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0;
+        read_lambda: return oq_cic::constant(0u);
       - address: 2110
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_outside_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_outside_temp).state));
       - address: 2111
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_evaporator_coil_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_evaporator_coil_temp).state));
       - address: 2112
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_gas_discharge_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_gas_discharge_temp).state));
       - address: 2113
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_gas_return_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_gas_return_temp).state));
       - address: 2114
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0;
+        read_lambda: return oq_cic::constant(0u);
       - address: 2116
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_evaporator_pressure).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_evaporator_pressure).state, 10.0f));
       - address: 2117
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_condenser_pressure).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v * 10.0f));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_condenser_pressure).state, 10.0f));
       - address: 2118
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          return id(${cic_compat_hp_id}_defrost).state ? 1 : 0;
+        read_lambda: return oq_cic::read(oq_cic::boolean(id(${cic_compat_hp_id}_defrost).state));
       - address: 2122
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_pcb_firmware_raw).state;
-          return isnan(v) ? 0x011Eu : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_pcb_firmware_raw).state, 1.0f, oq_cic::FIRMWARE_FALLBACK));
       - address: 2131
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_condensing_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_condensing_temp).state));
       - address: 2132
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_evaporating_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_evaporating_temp).state));
       - address: 2133
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_water_in_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_water_in_temp).state));
       - address: 2134
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_water_out_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_water_out_temp).state));
       - address: 2135
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_inner_coil_temp).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf((v * 100.0f) + 3000.0f));
+        read_lambda: return oq_cic::read(oq_cic::temperature(id(${cic_compat_hp_id}_inner_coil_temp).state));
       - address: 2136
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0;
+        read_lambda: return oq_cic::constant(0u);
       - address: 2137
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_pump_ipwm_feedback_raw).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v));
+        read_lambda: return oq_cic::read(oq_cic::scaled(id(${cic_compat_hp_id}_pump_ipwm_feedback_raw).state));
       - address: 2138
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          if (!id(cic_compatibility_enable).state) return 0;
-          const float v = id(${cic_compat_hp_id}_flow).state;
-          return isnan(v) ? 0 : static_cast<uint16_t>(lroundf(v / 0.618f));
+        read_lambda: return oq_cic::read(oq_cic::flow(id(${cic_compat_hp_id}_flow).state));
       - address: 11006
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0;
+        read_lambda: return oq_cic::constant(0u);
       - address: 11160
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11161
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11162
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11163
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11164
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11165
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11166
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11167
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11168
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11169
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11170
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11171
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11172
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11173
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11174
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11175
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11176
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11177
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11178
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11179
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11219
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11220
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11221
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11222
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11223
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11224
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11225
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11226
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11227
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11228
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11229
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11230
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11231
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11232
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11233
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11234
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11235
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11236
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11237
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);
       - address: 11238
         value_type: U_WORD
-        read_lambda: |-
-          id(cic_compatibility_last_request_ms) = millis();
-          return 0xFFFFu;
+        read_lambda: return oq_cic::constant(oq_cic::UNAVAILABLE);

--- a/scripts/tests/test_cic_compatibility_contract.py
+++ b/scripts/tests/test_cic_compatibility_contract.py
@@ -1,0 +1,63 @@
+import hashlib
+import re
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVER = ROOT / "openquatt" / "oq_cic_compatibility_server.yaml"
+MODE = ROOT / "openquatt" / "oq_cic_compatibility.yaml"
+RUNTIME = ROOT / "openquatt" / "includes" / "protocol" / "oq_cic_compatibility_runtime.h"
+MODULE_FILES = (
+    SERVER,
+    ROOT / "openquatt" / "includes" / "protocol" / "oq_cic_register_logic.h",
+    RUNTIME,
+    ROOT / "tests" / "host" / "cic_register_logic_test.cpp",
+    Path(__file__),
+)
+ORIGINAL_YAML_LINES = 468
+REGISTER_CONTRACT_SHA256 = "08bb09cd60102bad0b79c3e94b95606c5d3e15abecf365983dd85019dfff9a58"
+FIXED_ADDRESSES = (
+    1999, 2006, 2010, 2015, 3999, 2099, 2100, 2101, 2102, 2103, 2104, 2105,
+    2106, 2107, 2108, 2109, 2110, 2111, 2112, 2113, 2114, 2116, 2117, 2118,
+    2122, 2131, 2132, 2133, 2134, 2135, 2136, 2137, 2138, 11006,
+)
+EXPECTED_ADDRESSES = FIXED_ADDRESSES + tuple(range(11160, 11180)) + tuple(range(11219, 11239))
+
+
+class CicCompatibilityContractTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.server = SERVER.read_text(encoding="utf-8")
+
+    def test_register_map_and_lambda_shape_are_stable(self) -> None:
+        addresses = tuple(int(value) for value in re.findall(r"^\s+- address: (\d+)$", self.server, re.MULTILINE))
+        self.assertEqual(addresses, EXPECTED_ADDRESSES)
+        self.assertEqual(len(addresses), len(set(addresses)))
+        self.assertEqual(self.server.count("value_type: U_WORD"), 74)
+        self.assertEqual(self.server.count("read_lambda: return "), 74)
+        self.assertEqual(self.server.count("write_lambda: return true;"), 5)
+        self.assertEqual(self.server.count("read_lambda: return oq_cic::read("), 28)
+        self.assertEqual(self.server.count("read_lambda: return oq_cic::read_${cic_compat_hp_id}_status_flags();"), 1)
+        self.assertEqual(self.server.count("read_lambda: return oq_cic::constant("), 45)
+
+    def test_register_contract_hash_is_stable(self) -> None:
+        contract_keys = ("- address:", "value_type:", "read_lambda:", "write_lambda:")
+        contract = "\n".join(
+            line.strip() for line in self.server.splitlines() if line.strip().startswith(contract_keys)
+        )
+        self.assertEqual(hashlib.sha256(contract.encode()).hexdigest(), REGISTER_CONTRACT_SHA256)
+
+    def test_runtime_preserves_current_dev_sources_and_timestamp(self) -> None:
+        self.assertIn("id: cic_compatibility_last_request_ms", MODE.read_text(encoding="utf-8"))
+        self.assertIn("id(${cic_compat_hp_id}_pump_ipwm_feedback_raw).state", self.server)
+        self.assertEqual(
+            RUNTIME.read_text(encoding="utf-8").count("id(cic_compatibility_last_request_ms) = millis();"), 2
+        )
+
+    def test_module_including_regression_tests_is_smaller_than_original_yaml(self) -> None:
+        line_count = sum(len(path.read_text(encoding="utf-8").splitlines()) for path in MODULE_FILES)
+        self.assertLess(line_count, ORIGINAL_YAML_LINES)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host/cic_register_logic_test.cpp
+++ b/tests/host/cic_register_logic_test.cpp
@@ -1,0 +1,51 @@
+#include <assert.h>
+#include <math.h>
+#include <stddef.h>
+
+#include "../../openquatt/includes/protocol/oq_cic_register_logic.h"
+
+int main() {
+  assert(oq_cic::gated(false, 42u) == 0u);
+  assert(oq_cic::gated(true, 42u) == 42u);
+  assert(oq_cic::FIRMWARE_FALLBACK == 0x011Eu);
+  assert(oq_cic::scaled(NAN) == 0u);
+  assert(oq_cic::scaled(NAN, 1.0f, oq_cic::FIRMWARE_FALLBACK) == 0x011Eu);
+  assert(oq_cic::scaled(12.49f) == 12u);
+  assert(oq_cic::scaled(12.5f) == 13u);
+  assert(oq_cic::scaled(-0.5f) == oq_cic::UNAVAILABLE);
+  assert(oq_cic::scaled(4.25f, 10.0f) == 43u);
+  assert(oq_cic::temperature(NAN) == 0u);
+  assert(oq_cic::temperature(-30.0f) == 0u);
+  assert(oq_cic::temperature(0.0f) == 3000u);
+  assert(oq_cic::temperature(21.25f) == 5125u);
+  assert(oq_cic::flow(NAN) == 0u);
+  assert(oq_cic::flow(0.618f) == 1u);
+  assert(oq_cic::flow(0.926f) == 1u);
+  assert(oq_cic::flow(0.927f) == 2u);
+  assert(oq_cic::flow(12.36f) == 20u);
+
+  assert(oq_cic::on_option("Off") == 0u);
+  assert(oq_cic::on_option("On") == 1u);
+  assert(oq_cic::on_option(nullptr) == 0u);
+  assert(oq_cic::on_option("On", 0x1000u) == 0x1000u);
+  assert(oq_cic::boolean(false) == 0u);
+  assert(oq_cic::boolean(true) == 1u);
+  assert(oq_cic::working_mode("Cooling") == 1u);
+  assert(oq_cic::working_mode("Heating") == 2u);
+  assert(oq_cic::working_mode("Standby") == 0u);
+  assert(oq_cic::working_mode(nullptr) == 0u);
+  assert(oq_cic::compressor_level("") == 0u);
+  assert(oq_cic::compressor_level(nullptr) == 0u);
+  assert(oq_cic::compressor_level("3") == 3u);
+  assert(oq_cic::compressor_level("invalid") == 0u);
+  assert(oq_cic::compressor_level("-1") == oq_cic::UNAVAILABLE);
+
+  constexpr uint16_t masks[] = {0x0001u, 0x0004u, 0x0008u, 0x0010u, 0x0020u, 0x0040u, 0x0800u};
+  for (size_t active = 0; active < 7; ++active) {
+    bool flags[7] = {};
+    flags[active] = true;
+    assert(oq_cic::status_flags(flags[0], flags[1], flags[2], flags[3], flags[4], flags[5], flags[6]) == masks[active]);
+  }
+  assert(oq_cic::status_flags(true, true, true, true, true, true, true) == 0x087Du);
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst CiC-registerconversies, statusbits en enable-gating naar kleine C++-helpers.
- Houdt de YAML als compact registercontract met dezelfde 74 adressen en vijf schrijfcallbacks.
- Voegt host- en contracttests toe en verkleint de totale diff inclusief tests met 22 regels.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De CiC Modbus-registerwaarden, fallbackwaarden, requesttimestamp en enable-gating blijven semantisch gelijk. De write-callbacks blijven no-op acknowledgements.

## Achtergrond

Dit is de eerste onafhankelijke splitsing uit de YAML-naar-C++ refactor. De volledige diff is koud beoordeeld op registervolgorde, adresuniciteit, schaalfactoren, NaN/fallbackgedrag, enable-gating, statusbits, Single/Duo-preprocessing en callbacklifecycle. Er zijn geen open auditbevindingen.

Netto diff inclusief tests: +274/-296 (−22 regels).

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen gebruikersgerichte configuratie, entity of Modbus-contractwijziging.

## Validatie

- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe persistente state, heapallocaties, taken of netwerkbuffers. Alleen inline conversiehelpers; de firmwarebuilds tonen ongewijzigde statische DIRAM-secties binnen de geteste splitbuilds.

Uitgevoerd:

- `npm run check:python-contracts` — 134 tests geslaagd
- `CPLUS_INCLUDE_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 ./scripts/run_host_regression_tests.sh` — 44 tests geslaagd
- `npm run check:cpp-format` — geslaagd
- `python3 scripts/dev.py validate --config-only` — alle 6 configuraties geslaagd
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd
- `esphome compile configs/heatpump_controller_q/single_wifi.yaml` — geslaagd

De volledige `scripts/dev.py validate`-wrapper compileerde beide firmwares succesvol, maar de afsluitende artefactcontrole zoekt op de oude paden `.esphome/build/duo_wifi` en `.esphome/build/single_wifi`; ESPHome 2026.8.0 gebruikt hier `heatpump_controller_q_duo` en `heatpump_controller_q_single`. Rechtstreekse ESPHome-compiles bevestigen beide artefacten.