### PR TITLE
YAML naar C++: gedeelde HP-runtime – frequentie en energie

### DIFF
--- a/openquatt/includes/control/oq_compressor_frequency_runtime.h
+++ b/openquatt/includes/control/oq_compressor_frequency_runtime.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <math.h>
+
+#include "oq_compressor_frequency_policy.h"
+
+namespace oq_frequency_runtime {
+
+struct Context {
+  bool configured_v2{false};
+  oq_odu::RuntimeFrequencySnapshot hp1_snapshot{};
+  oq_odu::RuntimeFrequencySnapshot hp2_snapshot{};
+  int cap_hz{-1};
+  oq_frequency_policy::FrequencyRange hp1_excluded{};
+  oq_frequency_policy::FrequencyRange hp2_excluded{};
+
+  const oq_odu::RuntimeFrequencySnapshot& snapshot(bool is_hp1) const { return is_hp1 ? hp1_snapshot : hp2_snapshot; }
+
+  const oq_frequency_policy::FrequencyRange& excluded_range(bool is_hp1) const {
+    return is_hp1 ? hp1_excluded : hp2_excluded;
+  }
+
+  int automatic_frequency_hz(bool is_hp1, int mode_code, int level) const {
+    return oq_frequency_policy::automatic_frequency_hz(configured_v2, snapshot(is_hp1), mode_code, level);
+  }
+
+  bool frequency_allowed(bool is_hp1, int mode_code, int level) const {
+    return oq_frequency_policy::frequency_allowed(automatic_frequency_hz(is_hp1, mode_code, level), cap_hz,
+                                                  excluded_range(is_hp1));
+  }
+
+  int pick_allowed_level(bool is_hp1, int mode_code, int requested_level, int min_level, int max_level) const {
+    return oq_frequency_policy::pick_allowed_level(configured_v2, snapshot(is_hp1), mode_code, requested_level,
+                                                   min_level, max_level, cap_hz, excluded_range(is_hp1));
+  }
+};
+
+#if defined(OQ_TOPOLOGY_DUO)
+template <typename Number>
+inline int read_hz(const Number& number) {
+  return number.has_state() && !isnan(number.state) ? static_cast<int>(lroundf(number.state)) : -1;
+}
+
+inline Context capture() {
+  const bool configured_v2 = id(hp_generation).has_state() && id(hp_generation).current_option() == "V2";
+  const auto hp1_snapshot = oq_odu::decode_runtime_frequency_snapshot(id(hp1_runtime_frequency_snapshot_storage));
+#if OQ_TOPOLOGY_DUO
+  const auto hp2_snapshot = oq_odu::decode_runtime_frequency_snapshot(id(hp2_runtime_frequency_snapshot_storage));
+  const oq_frequency_policy::FrequencyRange hp2_excluded = {
+      read_hz(id(hp2_excluded_frequency_min_hz)),
+      read_hz(id(hp2_excluded_frequency_max_hz)),
+  };
+#else
+  const auto hp2_snapshot = hp1_snapshot;
+  const oq_frequency_policy::FrequencyRange hp2_excluded{};
+#endif
+  const auto& cap = id(oq_silent_active).state ? id(oq_silent_max_frequency_hz) : id(oq_day_max_frequency_hz);
+  return {
+      configured_v2,
+      hp1_snapshot,
+      hp2_snapshot,
+      read_hz(cap),
+      {read_hz(id(hp1_excluded_frequency_min_hz)), read_hz(id(hp1_excluded_frequency_max_hz))},
+      hp2_excluded,
+  };
+}
+#endif
+
+}  // namespace oq_frequency_runtime

--- a/openquatt/includes/performance/oq_energy_logic.h
+++ b/openquatt/includes/performance/oq_energy_logic.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <math.h>
+
+namespace oq_energy {
+
+struct HpElectricalInputs {
+  float voltage_v;
+  float current_a;
+  float fan_speed;
+  bool pump_relay_known;
+  bool pump_relay_running;
+  float pump_power_w;
+  bool bottom_plate_heater;
+  bool crankcase_heater;
+};
+
+inline float value_or_zero(float value) { return isnan(value) ? 0.0f : value; }
+
+inline float nonnegative(float value) { return value < 0.0f ? 0.0f : value; }
+
+inline float hp_input_power(const HpElectricalInputs& in) {
+  const float power_w = 5.150232354845286f +
+                        (value_or_zero(in.voltage_v) * value_or_zero(in.current_a) * 1.1240096401010435f) +
+                        (value_or_zero(in.fan_speed) * -0.04858859969715763f) +
+                        (in.pump_relay_known && in.pump_relay_running ? value_or_zero(in.pump_power_w) : 0.0f) +
+                        (in.bottom_plate_heater ? 150.06430841218332f : 0.0f) + (in.crankcase_heater ? 40.0f : 0.0f);
+  return nonnegative(power_w);
+}
+
+inline float hp_heating_power(float mode, float inlet_c, float outlet_c, float flow_lph, float cp_j_per_kgk) {
+  if (mode != 2.0f || isnan(inlet_c) || isnan(outlet_c) || isnan(flow_lph)) return 0.0f;
+  return (flow_lph / 3600.0f) * cp_j_per_kgk * (outlet_c - inlet_c);
+}
+
+inline float hp_cooling_power(float mode, float inlet_c, float outlet_c, float flow_lph, float cp_j_per_kgk) {
+  if (mode != 1.0f || isnan(inlet_c) || isnan(outlet_c) || isnan(flow_lph)) return 0.0f;
+  return nonnegative((flow_lph / 3600.0f) * cp_j_per_kgk * (inlet_c - outlet_c));
+}
+
+inline float sum_or_zero(float first, float second = NAN) { return value_or_zero(first) + value_or_zero(second); }
+
+inline float nonnegative_sum(float first, float second = NAN) { return nonnegative(sum_or_zero(first, second)); }
+
+inline float sum_available(float first, float second = NAN) {
+  return isnan(first) && isnan(second) ? NAN : sum_or_zero(first, second);
+}
+
+inline float heating_input_power(bool cooling_session, float hp1_mode, float hp1_power, float hp2_mode = NAN,
+                                 float hp2_power = NAN) {
+  if (cooling_session) return 0.0f;
+  return (hp1_mode == 2.0f ? value_or_zero(hp1_power) : 0.0f) + (hp2_mode == 2.0f ? value_or_zero(hp2_power) : 0.0f);
+}
+
+inline float cooling_input_power(bool cooling_session, float hp1_power, float hp2_power = NAN) {
+  return cooling_session ? sum_or_zero(hp1_power, hp2_power) : 0.0f;
+}
+
+inline float ratio_or_nan(float output, float input, float minimum_input) {
+  if (isnan(output) || isnan(input) || input < minimum_input) return NAN;
+  return output / input;
+}
+
+inline float instant_ratio_or_nan(float output, float input, float minimum_abs_input) {
+  if (isnan(output) || isnan(input) || fabsf(input) < minimum_abs_input) return NAN;
+  return output / input;
+}
+
+}  // namespace oq_energy

--- a/openquatt/includes/performance/oq_energy_runtime.h
+++ b/openquatt/includes/performance/oq_energy_runtime.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "oq_energy_logic.h"
+
+#if defined(OQ_TOPOLOGY_DUO)
+namespace oq_energy_runtime {
+
+inline float total_power_input() {
+#if OQ_TOPOLOGY_DUO
+  return oq_energy::nonnegative_sum(id(hp1_power_input).state, id(hp2_power_input).state);
+#else
+  return oq_energy::nonnegative_sum(id(hp1_power_input).state);
+#endif
+}
+
+inline float heating_power_input() {
+#if OQ_TOPOLOGY_DUO
+  return oq_energy::heating_input_power(id(oq_cooling_energy_session_active), id(hp1_working_mode).state,
+                                        id(hp1_power_input).state, id(hp2_working_mode).state,
+                                        id(hp2_power_input).state);
+#else
+  return oq_energy::heating_input_power(id(oq_cooling_energy_session_active), id(hp1_working_mode).state,
+                                        id(hp1_power_input).state);
+#endif
+}
+
+inline float cooling_power_input() {
+#if OQ_TOPOLOGY_DUO
+  return oq_energy::cooling_input_power(id(oq_cooling_energy_session_active), id(hp1_power_input).state,
+                                        id(hp2_power_input).state);
+#else
+  return oq_energy::cooling_input_power(id(oq_cooling_energy_session_active), id(hp1_power_input).state);
+#endif
+}
+
+inline float total_heat_power() {
+#if OQ_TOPOLOGY_DUO
+  return oq_energy::sum_available(id(hp1_heat_power).state, id(hp2_heat_power).state);
+#else
+  return oq_energy::sum_available(id(hp1_heat_power).state);
+#endif
+}
+
+inline float total_cooling_power() {
+#if OQ_TOPOLOGY_DUO
+  return oq_energy::sum_available(id(hp1_cooling_power).state, id(hp2_cooling_power).state);
+#else
+  return oq_energy::sum_available(id(hp1_cooling_power).state);
+#endif
+}
+
+}  // namespace oq_energy_runtime
+#endif

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -1236,36 +1236,16 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      // Keep model coefficients exactly as before; only readability/safety is improved.
-      const float standby_power_w = 5.150232354845286f;
-      const float compressor_calibration = 1.1240096401010435f;
-      const float fan_calibration = -0.04858859969715763f;
-      const float bottom_plate_heater_w = 150.06430841218332f;
-      const float crankcase_heater_w = 40.0f;
-
-      auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
-
-      const float voltage_v = nz(id(${hp_id}_voltage).state);
-      const float current_a = nz(id(${hp_id}_current).state);
-      const float fan_speed = nz(id(${hp_id}_fan_speed).state);
-
-      float pump_power_w = 0.0f;
-      if (id(${hp_id}_pump_relay).has_state() && id(${hp_id}_pump_relay).state) {
-        pump_power_w = nz(id(${hp_id}_pump_power).state);
-      }
-
-      const float bottom_plate_w = id(${hp_id}_bottom_plate_heater).state ? bottom_plate_heater_w : 0.0f;
-      const float crankcase_w = id(${hp_id}_crankcase_heater).state ? crankcase_heater_w : 0.0f;
-
-      const float p_input_w = standby_power_w
-                            + (voltage_v * current_a * compressor_calibration)
-                            + (fan_speed * fan_calibration)
-                            + pump_power_w
-                            + bottom_plate_w
-                            + crankcase_w;
-
-      // Physical lower bound: electrical input power cannot be negative.
-      return (p_input_w < 0.0f) ? 0.0f : p_input_w;
+      return oq_energy::hp_input_power({
+          id(${hp_id}_voltage).state,
+          id(${hp_id}_current).state,
+          id(${hp_id}_fan_speed).state,
+          id(${hp_id}_pump_relay).has_state(),
+          id(${hp_id}_pump_relay).state,
+          id(${hp_id}_pump_power).state,
+          id(${hp_id}_bottom_plate_heater).state,
+          id(${hp_id}_crankcase_heater).state,
+      });
 
   - platform: template
     id: ${hp_id}_heat_power
@@ -1277,20 +1257,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 10s
     lambda: |-
-      // Heat power follows measured HP working mode (2 = Heating), not supervisory CM.
-      const float working_mode = id(${hp_id}_working_mode).state;
-      if (working_mode != 2.0f) return 0.0f;
-
-      const float t_in_c = id(${hp_id}_water_in_temp).state;
-      const float t_out_c = id(${hp_id}_water_out_temp).state;
-      const float flow_lph = id(flow_rate_selected).state;
-
-      if (isnan(t_in_c) || isnan(t_out_c) || isnan(flow_lph)) return 0.0f;
-
-      const float water_cp_j_per_kgk = ${oq_water_cp_j_per_kgk};  // J/(kg·K)
-      const float mass_flow_kgps = flow_lph / 3600.0f;  // kg/s (≈ L/h)
-      const float delta_t_k = t_out_c - t_in_c;         // K
-      return mass_flow_kgps * water_cp_j_per_kgk * delta_t_k;
+      return oq_energy::hp_heating_power(id(${hp_id}_working_mode).state, id(${hp_id}_water_in_temp).state, id(${hp_id}_water_out_temp).state, id(flow_rate_selected).state, ${oq_water_cp_j_per_kgk});
 
   - platform: template
     id: ${hp_id}_cooling_power
@@ -1302,24 +1269,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 10s
     lambda: |-
-      // Cooling power follows measured HP working mode (1 = Cooling), not supervisory CM.
-      const float working_mode = id(${hp_id}_working_mode).state;
-      if (working_mode != 1.0f) return 0.0f;
-
-      const float t_in_c = id(${hp_id}_water_in_temp).state;
-      const float t_out_c = id(${hp_id}_water_out_temp).state;
-      const float flow_lph = id(flow_rate_selected).state;
-
-      if (isnan(t_in_c) || isnan(t_out_c) || isnan(flow_lph)) return 0.0f;
-
-      const float water_cp_j_per_kgk = ${oq_water_cp_j_per_kgk};  // J/(kg·K)
-      const float mass_flow_kgps = flow_lph / 3600.0f;            // kg/s (≈ L/h)
-      const float delta_t_k = t_in_c - t_out_c;                   // K, positive while cooling
-      const float cooling_power_w = mass_flow_kgps * water_cp_j_per_kgk * delta_t_k;
-
-      // During startup the water outlet can briefly still be warmer than the inlet.
-      // That is not cooling output, so do not expose or integrate it as negative power.
-      return (cooling_power_w < 0.0f) ? 0.0f : cooling_power_w;
+      return oq_energy::hp_cooling_power(id(${hp_id}_working_mode).state, id(${hp_id}_water_in_temp).state, id(${hp_id}_water_out_temp).state, id(flow_rate_selected).state, ${oq_water_cp_j_per_kgk});
 
   - platform: template
     id: ${hp_id}_cop
@@ -1329,16 +1279,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const float p_el_w = id(${hp_id}_power_input).state;
-      const float p_th_w = id(${hp_id}_heat_power).state;
-      const float min_valid_input_w = 5.0f;
-
-      if (isnan(p_el_w) || isnan(p_th_w)) return NAN;
-
-      // Avoid extreme COP values at (near) 0 W electrical input.
-      if (fabsf(p_el_w) < min_valid_input_w) return NAN;
-
-      return p_th_w / p_el_w;
+      return oq_energy::instant_ratio_or_nan(id(${hp_id}_heat_power).state, id(${hp_id}_power_input).state, 5.0f);
 
   - platform: template
     id: ${hp_id}_eer
@@ -1348,16 +1289,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const float p_el_w = id(${hp_id}_power_input).state;
-      const float p_cool_w = id(${hp_id}_cooling_power).state;
-      const float min_valid_input_w = 5.0f;
-
-      if (isnan(p_el_w) || isnan(p_cool_w)) return NAN;
-
-      // Avoid extreme EER values at (near) 0 W electrical input.
-      if (fabsf(p_el_w) < min_valid_input_w) return NAN;
-
-      return p_cool_w / p_el_w;
+      return oq_energy::instant_ratio_or_nan(id(${hp_id}_cooling_power).state, id(${hp_id}_power_input).state, 5.0f);
 
   # Internal raw diagnostic words. We keep these hidden and derive the compact
   # diagnostics we actually use from them instead of exposing dozens of

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -1387,61 +1387,10 @@ interval:
           const int lead_code = lead_is_hp1 ? 1 : 2;
           if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
 
-          const bool configured_v2 =
-              id(hp_generation).has_state() &&
-              id(hp_generation).current_option() == "V2";
-          const auto hp1_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(hp1_runtime_frequency_snapshot_storage));
-          const auto secondary_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(${secondary_runtime_frequency_snapshot_storage_id}));
-          auto runtime_frequency_snapshot = [&](bool is_hp1)
-              -> const oq_odu::RuntimeFrequencySnapshot& {
-            return is_hp1 ? hp1_frequency_snapshot
-                          : secondary_frequency_snapshot;
-          };
-
-          auto excluded_frequency_range = [&](bool is_hp1)
-              -> oq_frequency_policy::FrequencyRange {
-            auto read_hz = [](auto* number)->int {
-              return number->has_state() && !isnan(number->state)
-                  ? (int) lroundf(number->state)
-                  : -1;
-            };
-            if (is_hp1) {
-              return {
-                  read_hz(id(hp1_excluded_frequency_min_hz)),
-                  read_hz(id(hp1_excluded_frequency_max_hz)),
-              };
-            }
-            #if OQ_TOPOLOGY_DUO
-            return {
-                read_hz(id(${secondary_excluded_frequency_min_hz_id})),
-                read_hz(id(${secondary_excluded_frequency_max_hz_id})),
-            };
-            #else
-            return {};
-            #endif
-          };
-
-          auto cooling_cap_hz = [&]()->int {
-            auto* cap = id(oq_silent_active).state
-                ? id(oq_silent_max_frequency_hz)
-                : id(oq_day_max_frequency_hz);
-            return cap->has_state() && !isnan(cap->state)
-                ? (int) lroundf(cap->state)
-                : -1;
-          };
+          const auto frequency_runtime = oq_frequency_runtime::capture();
 
           auto level_allowed = [&](bool is_hp1, int level)->bool {
-            const int frequency_hz =
-                oq_frequency_policy::automatic_frequency_hz(
-                    configured_v2, runtime_frequency_snapshot(is_hp1), 1,
-                    level);
-            return oq_frequency_policy::frequency_allowed(
-                frequency_hz, cooling_cap_hz(),
-                excluded_frequency_range(is_hp1));
+            return frequency_runtime.frequency_allowed(is_hp1, 1, level);
           };
 
           auto hp_has_any_allowed_level = [&](bool is_hp1)->bool {

--- a/openquatt/oq_energy.yaml
+++ b/openquatt/oq_energy.yaml
@@ -120,10 +120,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 10s
     lambda: |-
-      auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
-      const float hp_heat_w = nz(id(oq_total_heat_power).state);
-      const float boiler_w = nz(id(boiler_heat_power).state);
-      return hp_heat_w + boiler_w;
+      return oq_energy::sum_or_zero(id(oq_total_heat_power).state, id(boiler_heat_power).state);
 
   # HeatPump COP based on daily thermal/electrical energy (kWh/kWh).
   - platform: template
@@ -134,13 +131,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const float heat_kwh = id(oq_heatpump_thermal_energy_daily).state;
-      const float elec_kwh = id(oq_heating_electrical_energy_daily).state;
-
-      if (isnan(heat_kwh) || isnan(elec_kwh)) return NAN;
-      if (elec_kwh < 0.01f) return NAN;
-
-      return heat_kwh / elec_kwh;
+      return oq_energy::ratio_or_nan(id(oq_heatpump_thermal_energy_daily).state, id(oq_heating_electrical_energy_daily).state, 0.01f);
 
   # HeatPump thermal energy (daily, kWh).
   - platform: total_daily_energy
@@ -207,13 +198,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const float heat_kwh = id(oq_heatpump_thermal_energy_cumulative).state;
-      const float elec_kwh = id(oq_heating_electrical_energy_cumulative).state;
-
-      if (isnan(heat_kwh) || isnan(elec_kwh)) return NAN;
-      if (elec_kwh < 0.01f) return NAN;
-
-      return heat_kwh / elec_kwh;
+      return oq_energy::ratio_or_nan(id(oq_heatpump_thermal_energy_cumulative).state, id(oq_heating_electrical_energy_cumulative).state, 0.01f);
 
   # HeatPump EER based on daily cooling/electrical energy (kWh/kWh).
   - platform: template
@@ -224,13 +209,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const float cooling_kwh = id(oq_heatpump_cooling_energy_daily).state;
-      const float elec_kwh = id(oq_cooling_electrical_energy_daily).state;
-
-      if (isnan(cooling_kwh) || isnan(elec_kwh)) return NAN;
-      if (elec_kwh < 0.01f) return NAN;
-
-      return cooling_kwh / elec_kwh;
+      return oq_energy::ratio_or_nan(id(oq_heatpump_cooling_energy_daily).state, id(oq_cooling_electrical_energy_daily).state, 0.01f);
 
   # HeatPump EER based on cumulative cooling/electrical energy (kWh/kWh).
   - platform: template
@@ -241,13 +220,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const float cooling_kwh = id(oq_heatpump_cooling_energy_cumulative).state;
-      const float elec_kwh = id(oq_cooling_electrical_energy_cumulative).state;
-
-      if (isnan(cooling_kwh) || isnan(elec_kwh)) return NAN;
-      if (elec_kwh < 0.01f) return NAN;
-
-      return cooling_kwh / elec_kwh;
+      return oq_energy::ratio_or_nan(id(oq_heatpump_cooling_energy_cumulative).state, id(oq_cooling_electrical_energy_cumulative).state, 0.01f);
 
   # Boiler thermal energy (daily, kWh).
   - platform: total_daily_energy

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -1117,61 +1117,10 @@ interval:
           const int lead_code = lead_is_hp1 ? 1 : 2;
           if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
 
-          const bool configured_v2 =
-              id(hp_generation).has_state() &&
-              id(hp_generation).current_option() == "V2";
-          const auto hp1_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(hp1_runtime_frequency_snapshot_storage));
-          const auto secondary_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(${secondary_runtime_frequency_snapshot_storage_id}));
-          auto runtime_frequency_snapshot = [&](bool is_hp1)
-              -> const oq_odu::RuntimeFrequencySnapshot& {
-            return is_hp1 ? hp1_frequency_snapshot
-                          : secondary_frequency_snapshot;
-          };
-
-          auto excluded_frequency_range = [&](bool is_hp1)
-              -> oq_frequency_policy::FrequencyRange {
-            auto read_hz = [](auto* number)->int {
-              return number->has_state() && !isnan(number->state)
-                  ? (int) lroundf(number->state)
-                  : -1;
-            };
-            if (is_hp1) {
-              return {
-                  read_hz(id(hp1_excluded_frequency_min_hz)),
-                  read_hz(id(hp1_excluded_frequency_max_hz)),
-              };
-            }
-            #if OQ_TOPOLOGY_DUO
-            return {
-                read_hz(id(${secondary_excluded_frequency_min_hz_id})),
-                read_hz(id(${secondary_excluded_frequency_max_hz_id})),
-            };
-            #else
-            return {};
-            #endif
-          };
-
-          auto heating_cap_hz = [&]()->int {
-            auto* cap = id(oq_silent_active).state
-                ? id(oq_silent_max_frequency_hz)
-                : id(oq_day_max_frequency_hz);
-            return cap->has_state() && !isnan(cap->state)
-                ? (int) lroundf(cap->state)
-                : -1;
-          };
+          const auto frequency_runtime = oq_frequency_runtime::capture();
 
           auto level_allowed = [&](bool is_hp1, int level)->bool {
-            const int frequency_hz =
-                oq_frequency_policy::automatic_frequency_hz(
-                    configured_v2, runtime_frequency_snapshot(is_hp1), 2,
-                    level);
-            return oq_frequency_policy::frequency_allowed(
-                frequency_hz, heating_cap_hz(),
-                excluded_frequency_range(is_hp1));
+            return frequency_runtime.frequency_allowed(is_hp1, 2, level);
           };
 
           auto valve_defrost_active = [&](bool is_hp1)->bool {

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -534,20 +534,7 @@ interval:
           const int lead_code = lead_is_hp1 ? 1 : 2;
           if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
 
-          const bool configured_v2 =
-              id(hp_generation).has_state() &&
-              id(hp_generation).current_option() == "V2";
-          const auto hp1_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(hp1_runtime_frequency_snapshot_storage));
-          const auto secondary_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(${secondary_runtime_frequency_snapshot_storage_id}));
-          auto runtime_frequency_snapshot = [&](bool is_hp1)
-              -> const oq_odu::RuntimeFrequencySnapshot& {
-            return is_hp1 ? hp1_frequency_snapshot
-                          : secondary_frequency_snapshot;
-          };
+          const auto frequency_runtime = oq_frequency_runtime::capture();
 
           auto publish_optimizer_reason = [&](const char* reason)->void {
             #if OQ_TOPOLOGY_DUO
@@ -563,46 +550,8 @@ interval:
           };
 
           constexpr int max_level = 10;
-          auto excluded_frequency_range = [&](bool is_hp1)
-              -> oq_frequency_policy::FrequencyRange {
-            auto read_hz = [](auto* number)->int {
-              return number->has_state() && !isnan(number->state)
-                  ? (int) lroundf(number->state)
-                  : -1;
-            };
-            if (is_hp1) {
-              return {
-                  read_hz(id(hp1_excluded_frequency_min_hz)),
-                  read_hz(id(hp1_excluded_frequency_max_hz)),
-              };
-            }
-            #if OQ_TOPOLOGY_DUO
-            return {
-                read_hz(id(${secondary_excluded_frequency_min_hz_id})),
-                read_hz(id(${secondary_excluded_frequency_max_hz_id})),
-            };
-            #else
-            return {};
-            #endif
-          };
-
-          auto heating_cap_hz = [&]()->int {
-            auto* cap = id(oq_silent_active).state
-                ? id(oq_silent_max_frequency_hz)
-                : id(oq_day_max_frequency_hz);
-            return cap->has_state() && !isnan(cap->state)
-                ? (int) lroundf(cap->state)
-                : -1;
-          };
-
           auto level_allowed = [&](bool is_hp1, int level)->bool {
-            const int frequency_hz =
-                oq_frequency_policy::automatic_frequency_hz(
-                    configured_v2, runtime_frequency_snapshot(is_hp1), 2,
-                    level);
-            return oq_frequency_policy::frequency_allowed(
-                frequency_hz, heating_cap_hz(),
-                excluded_frequency_range(is_hp1));
+            return frequency_runtime.frequency_allowed(is_hp1, 2, level);
           };
 
           auto valve_defrost_active = [&](bool is_hp1)->bool {

--- a/openquatt/oq_thermal_actuator.yaml
+++ b/openquatt/oq_thermal_actuator.yaml
@@ -165,53 +165,7 @@ interval:
           const bool request_thermal_active = (request_mode_code == 1 || request_mode_code == 2);
           const bool manual_hp_service_active = oq_manual_hp::owns_control();
           const char* request_thermal_mode_opt = oq_request::request_mode_option(request_mode_code);
-          const bool configured_v2 =
-              id(hp_generation).has_state() &&
-              id(hp_generation).current_option() == "V2";
-
-          const auto hp1_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(hp1_runtime_frequency_snapshot_storage));
-          const auto secondary_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(${secondary_runtime_frequency_snapshot_storage_id}));
-          auto runtime_frequency_snapshot = [&](bool is_hp1)
-              -> const oq_odu::RuntimeFrequencySnapshot& {
-            return is_hp1 ? hp1_frequency_snapshot
-                          : secondary_frequency_snapshot;
-          };
-
-          auto frequency_cap_hz = [&]()->int {
-            auto* cap = id(oq_silent_active).state
-                ? id(oq_silent_max_frequency_hz)
-                : id(oq_day_max_frequency_hz);
-            return cap->has_state() && !isnan(cap->state)
-                ? (int) lroundf(cap->state)
-                : -1;
-          };
-
-          auto excluded_frequency_range = [&](bool is_hp1)
-              -> oq_frequency_policy::FrequencyRange {
-            auto read_hz = [](auto* number)->int {
-              return number->has_state() && !isnan(number->state)
-                  ? (int) lroundf(number->state)
-                  : -1;
-            };
-            if (is_hp1) {
-              return {
-                  read_hz(id(hp1_excluded_frequency_min_hz)),
-                  read_hz(id(hp1_excluded_frequency_max_hz)),
-              };
-            }
-            #if OQ_TOPOLOGY_DUO
-            return {
-                read_hz(id(${secondary_excluded_frequency_min_hz_id})),
-                read_hz(id(${secondary_excluded_frequency_max_hz_id})),
-            };
-            #else
-            return {};
-            #endif
-          };
+          const auto frequency_runtime = oq_frequency_runtime::capture();
 
           auto hp_hold_mode_opt = [&](bool is_hp1)->const char* {
             return oq_request::retained_mode_name(
@@ -314,8 +268,8 @@ interval:
                 selected_physical_level,
                 prev_applied,
                 prev_physical,
-                configured_v2,
-                runtime_frequency_snapshot(is_hp1));
+                frequency_runtime.configured_v2,
+                frequency_runtime.snapshot(is_hp1));
             return retained;
           };
 
@@ -468,8 +422,8 @@ interval:
           auto apply_level = [&](bool is_hp1, int req_level, bool was_cooling)->int {
             const int actuator_max_level = manual_hp_service_active
                 ? oq_odu::physical_level_limit(
-                      configured_v2,
-                      runtime_frequency_snapshot(is_hp1),
+                      frequency_runtime.configured_v2,
+                      frequency_runtime.snapshot(is_hp1),
                       request_mode_code)
                 : max_level;
             req_level = std::max(min_level, std::min(actuator_max_level, req_level));
@@ -640,29 +594,22 @@ interval:
             int cap_hz = -1;
             const bool use_frequency_policy = !manual_hp_service_active;
             if (applied > 0 && use_frequency_policy) {
-              cap_hz = frequency_cap_hz();
-              applied = oq_frequency_policy::pick_allowed_level(
-                  configured_v2,
-                  runtime_frequency_snapshot(is_hp1),
-                  expected_mode,
-                  applied,
-                  1,
-                  max_level,
-                  cap_hz,
-                  excluded_frequency_range(is_hp1));
+              cap_hz = frequency_runtime.cap_hz;
+              applied = frequency_runtime.pick_allowed_level(
+                  is_hp1, expected_mode, applied, 1, max_level);
             }
 
             oq_odu::LevelCommand level_command{};
             if (applied > 0) {
               level_command = manual_hp_service_active
                   ? oq_odu::resolve_manual_level(
-                        configured_v2,
-                        runtime_frequency_snapshot(is_hp1),
+                        frequency_runtime.configured_v2,
+                        frequency_runtime.snapshot(is_hp1),
                         expected_mode,
                         applied)
                   : oq_odu::resolve_automatic_level(
-                        configured_v2,
-                        runtime_frequency_snapshot(is_hp1),
+                        frequency_runtime.configured_v2,
+                        frequency_runtime.snapshot(is_hp1),
                         expected_mode,
                         applied);
               if (level_command.control_level <= 0 ||

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -338,16 +338,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
-      const float hp1_power_w = nz(id(hp1_power_input).state);
-      #if OQ_TOPOLOGY_DUO
-      const float hp2_power_w = nz(id(${secondary_power_input_id}).state);
-      const float total_input_w = hp1_power_w + hp2_power_w;
-      #else
-      const float total_input_w = hp1_power_w;
-      #endif
-      // Safety clamp against tiny negative noise from upstream math/rounding.
-      return (total_input_w < 0.0f) ? 0.0f : total_input_w;
+      return oq_energy_runtime::total_power_input();
 
   - platform: template
     id: oq_heating_power_input
@@ -359,17 +350,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
-      if (id(oq_cooling_energy_session_active)) return 0.0f;
-      const float hp1_mode = id(hp1_working_mode).state;
-      const float hp1_power_w = (hp1_mode == 2.0f) ? nz(id(hp1_power_input).state) : 0.0f;
-      #if OQ_TOPOLOGY_DUO
-      const float hp2_mode = id(${secondary_working_mode_id}).state;
-      const float hp2_power_w = (hp2_mode == 2.0f) ? nz(id(${secondary_power_input_id}).state) : 0.0f;
-      return hp1_power_w + hp2_power_w;
-      #else
-      return hp1_power_w;
-      #endif
+      return oq_energy_runtime::heating_power_input();
 
   - platform: template
     id: oq_cooling_power_input
@@ -381,15 +362,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      auto nz = [](float value) -> float { return isnan(value) ? 0.0f : value; };
-      if (!id(oq_cooling_energy_session_active)) return 0.0f;
-      const float hp1_power_w = nz(id(hp1_power_input).state);
-      #if OQ_TOPOLOGY_DUO
-      const float hp2_power_w = nz(id(${secondary_power_input_id}).state);
-      return hp1_power_w + hp2_power_w;
-      #else
-      return hp1_power_w;
-      #endif
+      return oq_energy_runtime::cooling_power_input();
 
   - platform: template
     id: oq_total_heat_power
@@ -401,19 +374,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 10s
     lambda: |-
-      const float hp1_heat_w = id(hp1_heat_power).state;
-      #if OQ_TOPOLOGY_DUO
-      const float hp2_heat_w = id(${secondary_heat_power_id}).state;
-
-      if (isnan(hp1_heat_w) && isnan(hp2_heat_w)) return NAN;
-      if (isnan(hp1_heat_w)) return hp2_heat_w;
-      if (isnan(hp2_heat_w)) return hp1_heat_w;
-
-      return hp1_heat_w + hp2_heat_w;
-      #else
-      if (isnan(hp1_heat_w)) return NAN;
-      return hp1_heat_w;
-      #endif
+      return oq_energy_runtime::total_heat_power();
 
   - platform: template
     id: oq_total_cooling_power
@@ -425,19 +386,7 @@ sensor:
     accuracy_decimals: 0
     update_interval: 10s
     lambda: |-
-      const float hp1_cooling_w = id(hp1_cooling_power).state;
-      #if OQ_TOPOLOGY_DUO
-      const float hp2_cooling_w = id(${secondary_cooling_power_id}).state;
-
-      if (isnan(hp1_cooling_w) && isnan(hp2_cooling_w)) return NAN;
-      if (isnan(hp1_cooling_w)) return hp2_cooling_w;
-      if (isnan(hp2_cooling_w)) return hp1_cooling_w;
-
-      return hp1_cooling_w + hp2_cooling_w;
-      #else
-      if (isnan(hp1_cooling_w)) return NAN;
-      return hp1_cooling_w;
-      #endif
+      return oq_energy_runtime::total_cooling_power();
 
   - platform: template
     id: oq_total_cop
@@ -447,13 +396,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const float total_input_w = id(oq_total_power_input).state;
-      const float total_heat_w = id(oq_total_heat_power).state;
-
-      if (isnan(total_input_w) || isnan(total_heat_w)) return NAN;
-      if (fabsf(total_input_w) < ${oq_cop_min_input_w}) return NAN;
-
-      return total_heat_w / total_input_w;
+      return oq_energy::instant_ratio_or_nan(id(oq_total_heat_power).state, id(oq_total_power_input).state, ${oq_cop_min_input_w});
 
   - platform: template
     id: oq_total_eer
@@ -463,13 +406,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const float total_input_w = id(oq_cooling_power_input).state;
-      const float total_cooling_w = id(oq_total_cooling_power).state;
-
-      if (isnan(total_input_w) || isnan(total_cooling_w)) return NAN;
-      if (fabsf(total_input_w) < ${oq_cop_min_input_w}) return NAN;
-
-      return total_cooling_w / total_input_w;
+      return oq_energy::instant_ratio_or_nan(id(oq_total_cooling_power).state, id(oq_cooling_power_input).state, ${oq_cop_min_input_w});
 
   - platform: template
     id: oq_demand_raw_sensor

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -790,31 +790,18 @@ interval:
             #endif
           };
 
-          const bool configured_v2 =
-              id(hp_generation).has_state() &&
-              id(hp_generation).current_option() == "V2";
-          const auto hp1_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(hp1_runtime_frequency_snapshot_storage));
-          const auto secondary_frequency_snapshot =
-              oq_odu::decode_runtime_frequency_snapshot(
-                  id(${secondary_runtime_frequency_snapshot_storage_id}));
-          auto runtime_frequency_snapshot = [&](bool is_hp1)
-              -> const oq_odu::RuntimeFrequencySnapshot& {
-            return is_hp1 ? hp1_frequency_snapshot
-                          : secondary_frequency_snapshot;
-          };
+          const auto frequency_runtime = oq_frequency_runtime::capture();
 
           auto publish_request = [&](int mode_code, int req1, int req2, int strategy_code, int owner_hp, const char* reason)->void {
             (void) owner_hp;
             const bool manual_request = strategy_code == request_strategy_manual_hp;
             const int hp1_max_level = manual_request
                 ? oq_odu::physical_level_limit(
-                      configured_v2, runtime_frequency_snapshot(true), mode_code)
+                      frequency_runtime.configured_v2, frequency_runtime.snapshot(true), mode_code)
                 : oq_odu::MODEL_LEVEL_MAX;
             const int hp2_max_level = manual_request
                 ? oq_odu::physical_level_limit(
-                      configured_v2, runtime_frequency_snapshot(false), mode_code)
+                      frequency_runtime.configured_v2, frequency_runtime.snapshot(false), mode_code)
                 : oq_odu::MODEL_LEVEL_MAX;
             const auto published = oq_request::make_published_request(
                 mode_code, req1, req2, strategy_code,
@@ -1007,8 +994,8 @@ interval:
                        selected_physical_level,
                        prev_applied,
                        prev_physical,
-                       configured_v2,
-                       runtime_frequency_snapshot(is_hp1))
+                       frequency_runtime.configured_v2,
+                       frequency_runtime.snapshot(is_hp1))
                 .control_level;
           };
 
@@ -1047,16 +1034,16 @@ interval:
             int hp1_req = (hp1_mode_code > 0)
                 ? std::max(0, std::min(
                       oq_odu::physical_level_limit(
-                          configured_v2,
-                          runtime_frequency_snapshot(true),
+                          frequency_runtime.configured_v2,
+                          frequency_runtime.snapshot(true),
                           hp1_mode_code),
                       (int) roundf(id(oq_manual_hp1_level).state)))
                 : 0;
             int hp2_req = (hp2_mode_code > 0)
                 ? std::max(0, std::min(
                       oq_odu::physical_level_limit(
-                          configured_v2,
-                          runtime_frequency_snapshot(false),
+                          frequency_runtime.configured_v2,
+                          frequency_runtime.snapshot(false),
                           hp2_mode_code),
                       (int) roundf(id(oq_manual_hp2_level).state)))
                 : 0;
@@ -1224,38 +1211,6 @@ interval:
                               : (is_power_house ? "ph_idle" : "curve_idle");
           const int max_level = 10;
 
-          auto frequency_cap_hz = [&]()->int {
-            auto* cap = id(oq_silent_active).state
-                ? id(oq_silent_max_frequency_hz)
-                : id(oq_day_max_frequency_hz);
-            return cap->has_state() && !isnan(cap->state)
-                ? (int) lroundf(cap->state)
-                : -1;
-          };
-
-          auto excluded_frequency_range = [&](bool is_hp1)
-              -> oq_frequency_policy::FrequencyRange {
-            auto read_hz = [](auto* number)->int {
-              return number->has_state() && !isnan(number->state)
-                  ? (int) lroundf(number->state)
-                  : -1;
-            };
-            if (is_hp1) {
-              return {
-                  read_hz(id(hp1_excluded_frequency_min_hz)),
-                  read_hz(id(hp1_excluded_frequency_max_hz)),
-              };
-            }
-            #if OQ_TOPOLOGY_DUO
-            return {
-                read_hz(id(${secondary_excluded_frequency_min_hz_id})),
-                read_hz(id(${secondary_excluded_frequency_max_hz_id})),
-            };
-            #else
-            return {};
-            #endif
-          };
-
           const bool hp1_valve_def = valve_defrost_active(true);
           #if OQ_TOPOLOGY_DUO
           const bool hp2_valve_def = valve_defrost_active(false);
@@ -1361,15 +1316,8 @@ interval:
           //    range per HP are enforced directly against the runtime table.
           // =========================
           auto pick_allowed = [&](int req, bool is_hp1)->int {
-            return oq_frequency_policy::pick_allowed_level(
-                configured_v2,
-                runtime_frequency_snapshot(is_hp1),
-                active_thermal_mode_code,
-                req,
-                1,
-                max_level,
-                frequency_cap_hz(),
-                excluded_frequency_range(is_hp1));
+            return frequency_runtime.pick_allowed_level(
+                is_hp1, active_thermal_mode_code, req, 1, max_level);
           };
 
           hp1_req = pick_allowed(hp1_req, true);

--- a/scripts/tests/test_compressor_frequency_policy_contract.py
+++ b/scripts/tests/test_compressor_frequency_policy_contract.py
@@ -18,6 +18,9 @@ STRATEGIES = "\n".join(
 POLICY = (
     ROOT / "openquatt" / "includes" / "control" / "oq_compressor_frequency_policy.h"
 ).read_text()
+RUNTIME = (
+    ROOT / "openquatt" / "includes" / "control" / "oq_compressor_frequency_runtime.h"
+).read_text()
 WEB_CONFIG = (ROOT / "openquatt" / "web" / "js" / "src" / "core" / "config.js").read_text()
 
 
@@ -49,7 +52,8 @@ class CompressorFrequencyPolicyContractTest(unittest.TestCase):
 
     def test_request_and_actuator_enforce_the_policy_independently(self) -> None:
         for source in (REQUEST, ACTUATOR):
-            self.assertIn("oq_frequency_policy::pick_allowed_level(", source)
+            self.assertIn("frequency_runtime.pick_allowed_level(", source)
+            self.assertIn("oq_frequency_runtime::capture()", source)
         self.assertIn("const bool use_frequency_policy = !manual_hp_service_active", ACTUATOR)
         self.assertIn("Revalidate the final request", REQUEST)
 
@@ -64,21 +68,31 @@ class CompressorFrequencyPolicyContractTest(unittest.TestCase):
             "store_configured_frequency_hz",
             "shared_cap_frequency",
         ):
-            self.assertNotIn(removed, SUPERVISORY + HP_IO + REQUEST + ACTUATOR + POLICY)
+            self.assertNotIn(removed, SUPERVISORY + HP_IO + REQUEST + ACTUATOR + POLICY + RUNTIME)
         for removed in ("dayMax:", "silentMax:", "hp1ExcludedA:", "hp2ExcludedA:"):
             self.assertNotIn(removed, WEB_CONFIG)
         self.assertIn('export const FREQUENCY_CAP_KEYS = ["dayMaxHz", "silentMaxHz"]', WEB_CONFIG)
         self.assertIn('"hp1ExcludeMinHz", "hp1ExcludeMaxHz", "hp2ExcludeMinHz", "hp2ExcludeMaxHz"', WEB_CONFIG)
 
     def test_strategies_only_offer_allowed_runtime_frequencies(self) -> None:
-        self.assertEqual(
-            STRATEGIES.count("oq_frequency_policy::frequency_allowed("), 3
-        )
-        self.assertEqual(
-            STRATEGIES.count("oq_frequency_policy::automatic_frequency_hz("), 3
-        )
+        self.assertEqual(STRATEGIES.count("oq_frequency_runtime::capture()"), 3)
+        self.assertEqual(STRATEGIES.count("frequency_runtime.frequency_allowed("), 3)
         self.assertIn("boosted_allowed_level", STRATEGIES)
         self.assertIn("level_allowed(is_hp1, level)", STRATEGIES)
+
+    def test_runtime_inputs_are_captured_once_per_control_callback(self) -> None:
+        control_sources = STRATEGIES + REQUEST + ACTUATOR
+        self.assertEqual(control_sources.count("oq_frequency_runtime::capture()"), 5)
+        for inline_adapter in (
+            "auto runtime_frequency_snapshot",
+            "auto excluded_frequency_range",
+            "auto frequency_cap_hz",
+            "auto cooling_cap_hz",
+            "auto heating_cap_hz",
+        ):
+            self.assertNotIn(inline_adapter, control_sources)
+        self.assertIn("const auto hp1_snapshot =", RUNTIME)
+        self.assertIn("const oq_frequency_policy::FrequencyRange hp2_excluded", RUNTIME)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_energy_logic_contract.py
+++ b/scripts/tests/test_energy_logic_contract.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HP_IO = (ROOT / "openquatt" / "oq_HP_io.yaml").read_text()
+ENERGY = (ROOT / "openquatt" / "oq_energy.yaml").read_text()
+REQUEST = (ROOT / "openquatt" / "oq_thermal_request_control.yaml").read_text()
+LOGIC = (
+    ROOT / "openquatt" / "includes" / "performance" / "oq_energy_logic.h"
+).read_text()
+RUNTIME = (
+    ROOT / "openquatt" / "includes" / "performance" / "oq_energy_runtime.h"
+).read_text()
+
+
+class EnergyLogicContractTest(unittest.TestCase):
+    def test_per_hp_yaml_keeps_only_inputs_and_formula_contracts(self) -> None:
+        self.assertEqual(HP_IO.count("oq_energy::hp_input_power("), 1)
+        self.assertEqual(HP_IO.count("oq_energy::hp_heating_power("), 1)
+        self.assertEqual(HP_IO.count("oq_energy::hp_cooling_power("), 1)
+        self.assertEqual(HP_IO.count("oq_energy::instant_ratio_or_nan("), 2)
+        self.assertIn("id(${hp_id}_pump_relay).has_state(),", HP_IO)
+        self.assertIn("pump_relay_known && in.pump_relay_running", LOGIC)
+
+    def test_calibration_coefficients_have_one_owner(self) -> None:
+        for coefficient in (
+            "5.150232354845286f",
+            "1.1240096401010435f",
+            "-0.04858859969715763f",
+            "150.06430841218332f",
+        ):
+            self.assertIn(coefficient, LOGIC)
+            self.assertNotIn(coefficient, HP_IO)
+
+    def test_system_power_sensors_use_the_runtime_adapter(self) -> None:
+        for function in (
+            "total_power_input",
+            "heating_power_input",
+            "cooling_power_input",
+            "total_heat_power",
+            "total_cooling_power",
+        ):
+            self.assertEqual(REQUEST.count(f"oq_energy_runtime::{function}();"), 1)
+            self.assertIn(f"inline float {function}()", RUNTIME)
+        self.assertIn("#if OQ_TOPOLOGY_DUO", RUNTIME)
+        self.assertIn("id(hp2_power_input).state", RUNTIME)
+
+    def test_energy_ratios_share_the_tested_guards(self) -> None:
+        self.assertEqual(ENERGY.count("oq_energy::ratio_or_nan("), 4)
+        self.assertEqual(REQUEST.count("oq_energy::instant_ratio_or_nan("), 2)
+        self.assertIn("input < minimum_input", LOGIC)
+        self.assertIn("fabsf(input) < minimum_abs_input", LOGIC)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_v2_compressor_level_contract.py
+++ b/scripts/tests/test_v2_compressor_level_contract.py
@@ -55,8 +55,14 @@ class V2CompressorLevelContractTest(unittest.TestCase):
 
     def test_manual_request_surface_exposes_f20(self) -> None:
         self.assertEqual(MANUAL_HP.count("max_value: 20"), 2)
-        self.assertIn("configured_v2, runtime_frequency_snapshot(true)", REQUEST_CONTROL)
-        self.assertIn("configured_v2, runtime_frequency_snapshot(false)", REQUEST_CONTROL)
+        self.assertIn(
+            "frequency_runtime.configured_v2, frequency_runtime.snapshot(true)",
+            REQUEST_CONTROL,
+        )
+        self.assertIn(
+            "frequency_runtime.configured_v2, frequency_runtime.snapshot(false)",
+            REQUEST_CONTROL,
+        )
 
     def test_actuator_keeps_control_and_physical_domains_separate(self) -> None:
         self.assertIn("const char* lvl_opts[21]", ACTUATOR)
@@ -65,7 +71,7 @@ class V2CompressorLevelContractTest(unittest.TestCase):
         self.assertIn("return level_command.control_level;", ACTUATOR)
         self.assertIn("last_commanded_physical_level", ACTUATOR)
         self.assertLess(
-            ACTUATOR.index("applied = oq_frequency_policy::pick_allowed_level("),
+            ACTUATOR.index("applied = frequency_runtime.pick_allowed_level("),
             ACTUATOR.rindex("resolve_automatic_level("),
         )
         self.assertLess(

--- a/tests/host/energy_logic_test.cpp
+++ b/tests/host/energy_logic_test.cpp
@@ -1,0 +1,54 @@
+#include <assert.h>
+#include <math.h>
+
+#include "../../openquatt/includes/performance/oq_energy_logic.h"
+
+namespace {
+
+bool near(float actual, float expected, float tolerance = 0.01f) { return fabsf(actual - expected) < tolerance; }
+
+}  // namespace
+
+int main() {
+  assert(isnan(oq_energy::ratio_or_nan(NAN, 1.0f, 0.01f)));
+  assert(isnan(oq_energy::ratio_or_nan(1.0f, NAN, 0.01f)));
+  assert(isnan(oq_energy::ratio_or_nan(1.0f, 0.009f, 0.01f)));
+  assert(oq_energy::ratio_or_nan(1.0f, 0.01f, 0.01f) == 100.0f);
+  assert(oq_energy::ratio_or_nan(4.0f, 2.0f, 0.01f) == 2.0f);
+
+  const oq_energy::HpElectricalInputs idle{NAN, NAN, NAN, false, false, NAN, false, false};
+  const oq_energy::HpElectricalInputs nominal{230.0f, 2.0f, 50.0f, true, true, 60.0f, true, true};
+  assert(near(oq_energy::hp_input_power(idle), 5.150232f));
+  assert(near(oq_energy::hp_input_power(nominal), 769.8295f));
+  assert(oq_energy::hp_input_power({0.0f, 0.0f, 0.0f, false, true, 100.0f, false, false}) ==
+         oq_energy::hp_input_power({0.0f, 0.0f, 0.0f, false, false, NAN, false, false}));
+  assert(oq_energy::hp_input_power({0.0f, 0.0f, 0.0f, true, false, 100.0f, false, false}) ==
+         oq_energy::hp_input_power({0.0f, 0.0f, 0.0f, true, false, NAN, false, false}));
+  assert(oq_energy::hp_input_power({0.0f, 0.0f, 1000.0f, false, false, 0.0f, false, false}) == 0.0f);
+
+  assert(near(oq_energy::hp_heating_power(2.0f, 20.0f, 25.0f, 360.0f, 4186.0f), 2093.0f));
+  assert(near(oq_energy::hp_heating_power(2.0f, 25.0f, 20.0f, 360.0f, 4186.0f), -2093.0f));
+  assert(oq_energy::hp_heating_power(1.0f, 20.0f, 25.0f, 360.0f, 4186.0f) == 0.0f);
+  assert(oq_energy::hp_heating_power(2.0f, NAN, 25.0f, 360.0f, 4186.0f) == 0.0f);
+  assert(near(oq_energy::hp_cooling_power(1.0f, 25.0f, 20.0f, 360.0f, 4186.0f), 2093.0f));
+  assert(oq_energy::hp_cooling_power(1.0f, 20.0f, 25.0f, 360.0f, 4186.0f) == 0.0f);
+  assert(oq_energy::hp_cooling_power(2.0f, 25.0f, 20.0f, 360.0f, 4186.0f) == 0.0f);
+  assert(oq_energy::hp_cooling_power(1.0f, 25.0f, NAN, 360.0f, 4186.0f) == 0.0f);
+
+  assert(oq_energy::nonnegative_sum(-5.0f, NAN) == 0.0f);
+  assert(oq_energy::nonnegative_sum(100.0f, NAN) == 100.0f);
+  assert(isnan(oq_energy::sum_available(NAN, NAN)));
+  assert(oq_energy::sum_available(NAN, 200.0f) == 200.0f);
+  assert(oq_energy::sum_available(100.0f, 200.0f) == 300.0f);
+  assert(oq_energy::heating_input_power(true, 2.0f, 100.0f, 2.0f, 200.0f) == 0.0f);
+  assert(oq_energy::heating_input_power(false, 2.0f, 100.0f, 1.0f, 200.0f) == 100.0f);
+  assert(oq_energy::heating_input_power(false, 2.0f, NAN, 2.0f, 200.0f) == 200.0f);
+  assert(oq_energy::cooling_input_power(false, 100.0f, 200.0f) == 0.0f);
+  assert(oq_energy::cooling_input_power(true, NAN, 200.0f) == 200.0f);
+
+  assert(isnan(oq_energy::instant_ratio_or_nan(NAN, 5.0f, 5.0f)));
+  assert(isnan(oq_energy::instant_ratio_or_nan(10.0f, 4.999f, 5.0f)));
+  assert(oq_energy::instant_ratio_or_nan(10.0f, 5.0f, 5.0f) == 2.0f);
+  assert(oq_energy::instant_ratio_or_nan(10.0f, -5.0f, 5.0f) == -2.0f);
+  return 0;
+}

--- a/tests/host/oq_compressor_frequency_policy_test.cpp
+++ b/tests/host/oq_compressor_frequency_policy_test.cpp
@@ -2,7 +2,7 @@
 
 #include <array>
 
-#include "../../openquatt/includes/control/oq_compressor_frequency_policy.h"
+#include "../../openquatt/includes/control/oq_compressor_frequency_runtime.h"
 
 namespace {
 
@@ -79,6 +79,20 @@ int main() {
   assert(automatic_frequency_hz(false, runtime_edited, 2, 6) == 65);
   assert(automatic_frequency_hz(false, runtime_edited, 1, 6) == 54);
   assert(pick_allowed_level(false, runtime_edited, 2, 6, 1, 10, 64, {}) == 5);
+
+  auto hp2_source = runtime_edited;
+  const oq_frequency_runtime::Context runtime{
+      false, v1, hp2_source, 67, {}, {60, 68},
+  };
+  hp2_source.heating.hz[6] = 100;
+  assert(runtime.automatic_frequency_hz(true, 2, 6) == 67);
+  assert(runtime.automatic_frequency_hz(false, 2, 6) == 65);
+  assert(runtime.frequency_allowed(true, 2, 6));
+  assert(!runtime.frequency_allowed(false, 2, 6));
+  assert(runtime.pick_allowed_level(true, 2, 10, 1, 10) == 6);
+  auto invalid_runtime = runtime;
+  invalid_runtime.cap_hz = -1;
+  assert(invalid_runtime.pick_allowed_level(true, 2, 6, 1, 10) == 0);
 
   auto unknown = v1;
   unknown.heating.valid = false;


### PR DESCRIPTION
# Wat verandert deze PR?

- Centraliseert runtimefrequentietabellen, dag/stiltecaps en uitgesloten frequentiebereiken voor alle strategie- en actuatorpaden.
- Verplaatst elektrische, thermische en COP/EER-berekeningen naar herbruikbare C++-logica.
- Verkleint de totale diff inclusief regressietests met 80 regels.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Dezelfde frequentiepolicy wordt voortaan vanuit één onveranderlijke snapshot gebruikt door Cooling, Heating Curve, Power House, Thermal Request en Thermal Actuator. Handmatige service blijft de frequentiepolicy omzeilen terwijl technische actuatorguards actief blijven. Energiecoëfficiënten en update-intervallen blijven gelijk.

## Achtergrond

Dit is de tweede onafhankelijke splitsing uit de YAML-naar-C++ refactor. De volledige diff is koud beoordeeld op V1/V1.5/V2-mapping, ontbrekende runtime-tabellen, dag/stiltecaps, uitgesloten frequenties, Single/Duo-preprocessing, manual-service bypass, defrost-retain, NaN/stale energie-invoer en nul-/negatieve vermogensgrenzen. Er zijn geen open auditbevindingen.

Netto diff inclusief tests: +403/-483 (−80 regels).

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen gebruikersgerichte configuratie, entity of regelgedrag gewijzigd.

## Validatie

- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe persistente heap-, PSRAM-, task- of netwerkallocaties. De runtimecontext vervangt dezelfde lokale snapshots en policywaarden die eerder per YAML-lambda werden opgebouwd. Geteste statische DIRAM: Duo 211059 bytes, Single 193395 bytes.

Uitgevoerd:

- `npm run check:python-contracts` — oorspronkelijk 135 en bij hercontrole op actuele `dev` 139 tests geslaagd
- `CPLUS_INCLUDE_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 ./scripts/run_host_regression_tests.sh` — oorspronkelijk 44 en bij hercontrole 45 tests geslaagd
- `npm run check:cpp-format` — geslaagd
- `python3 scripts/dev.py validate --config-only` — alle 6 configuraties geslaagd
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd; 211059 bytes DIRAM en 2182007 bytes image
- `esphome compile configs/heatpump_controller_q/single_wifi.yaml` — geslaagd
- HIL op Q Duo met beide V1.5-ODU-simulatoradressen en OpenTherm: F5/F10, 61/90 Hz, energie/COP, defrost-retain, minimum runtime, communicatie-uitval en automatisch herstel geslaagd; Modbus- en OpenTherm-fouttellers bleven nul buiten de bewust geïnjecteerde drops

De volledige diff is vóór merge opnieuw conflictvrij op `dev` commit `7f65efe5` toegepast en apart adversarieel herbeoordeeld. De volledige `scripts/dev.py validate`-wrapper compileerde beide firmwares succesvol, maar de afsluitende artefactcontrole zoekt op de oude paden `.esphome/build/duo_wifi` en `.esphome/build/single_wifi`; ESPHome 2026.8.0 gebruikt hier `heatpump_controller_q_duo` en `heatpump_controller_q_single`. Rechtstreekse ESPHome-compiles bevestigen beide artefacten.
