### PR TITLE
Voorkom scrollsprong bij PR-firmware

### DIFF
--- a/openquatt/web/js/src/features/firmware-actions.js
+++ b/openquatt/web/js/src/features/firmware-actions.js
@@ -564,7 +564,6 @@ import { render } from "../core/render-scheduler.js";
     state.controlNotice = "";
     state.updateTestFirmwareError = "";
     state.updateTestFirmwareBuild = null;
-    render();
 
     let flashRequested = false;
     try {

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -11,6 +11,8 @@ globalThis.window = {
 };
 
 const { state } = await import("../js/src/core/state.js");
+const { setRenderCallback } = await import("../js/src/core/render-scheduler.js");
+const { installFirmwareTestUpdate } = await import("../js/src/features/firmware-actions.js");
 const {
   getFirmwareModalCopy,
   getFirmwareProgressModel,
@@ -66,6 +68,71 @@ test("PR firmware uses deterministic release URLs without the GitHub REST API", 
     label: "PR 395 · Heatpump Controller Q Duo Wi-Fi",
   });
   assert.equal(getFirmwareTestAssetUrls("395/../../dev-latest", target), null);
+});
+
+test("PR firmware starts with one complete render before the first device write", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalLocation = window.location;
+  const originalState = { ...state };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalLocation === undefined) {
+      delete window.location;
+    } else {
+      window.location = originalLocation;
+    }
+    setRenderCallback(null);
+    for (const key of Object.keys(state)) {
+      if (!(key in originalState)) {
+        delete state[key];
+      }
+    }
+    Object.assign(state, originalState);
+  });
+
+  state.drafts = {};
+  state.entities = {
+    hardwareProfileText: { state: "heatpump_controller_q" },
+    installationTopology: { state: "duo" },
+    connectionText: { state: "wifi" },
+    installFirmwareTestOta: { state: "" },
+    firmwareTestOtaUrl: { state: "" },
+    firmwareTestOtaMd5Url: { state: "" },
+  };
+  state.updateTestFirmwarePr = "528";
+  state.updateTestFirmwareConfirmed = true;
+  window.location = { pathname: "/" };
+
+  const events = [];
+  setRenderCallback(() => {
+    events.push({
+      type: "render",
+      busy: state.updateInstallBusy,
+      build: state.updateTestFirmwareBuild,
+    });
+  });
+
+  globalThis.fetch = async () => {
+    events.push({ type: "fetch" });
+    return { ok: false, status: 503 };
+  };
+
+  const operation = installFirmwareTestUpdate();
+  await operation;
+
+  assert.deepEqual(events, [
+    {
+      type: "render",
+      busy: true,
+      build: "PR 528 · Heatpump Controller Q Duo Wi-Fi",
+    },
+    { type: "fetch" },
+    {
+      type: "render",
+      busy: false,
+      build: "PR 528 · Heatpump Controller Q Duo Wi-Fi",
+    },
+  ]);
 });
 
 test("dev firmware exposes an explicit confirmed downgrade to the older main release", () => {


### PR DESCRIPTION
# Wat verandert deze PR?

- Voorkomt dat de firmwaremodal in Safari omhoog springt bij `PR-firmware installeren`.
- Rendert busy-status en PR-buildlabel samen één keer vóór de eerste device-write.
- Voegt een regressietest toe voor de volgorde `render → device-write → eindrender`.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de render-volgorde van de webinterface verandert. De OTA-URL’s, device-writes en firmware-installatievolgorde blijven gelijk.

## Achtergrond

Sinds de PR-release-URL’s synchroon worden bepaald, deed de PR-firmwareflow twee volledige root-renders vóór de eerste device-write. De tweede render verloor in Safari het onderste modalanker. Deze wijziging laat alleen de complete render staan.

Closes #529.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt bestaand modalgedrag en introduceert geen nieuwe gebruikersworkflow of configuratie.

## Validatie

- `npm run check:web` — 296 tests geslaagd; webkwaliteit en bundlebudgetten geslaagd.
- Lokale browserpreview op 1280×720 — installatieknop bleef op dezelfde schermpositie tijdens de her-render (`592.83 → 592.92 px`) en bleef stabiel na 180 ms.
- `git diff --check` — geslaagd.
- Onafhankelijke koude review van de volledige diff tegen `dev` — geen findings.
- GitHub CI: web, C++-format, hosttests en docs zijn groen. `python-contracts` faalt op de bestaande `dev`-contracttest voor een verwijderde firmwarealias; deze PR wijzigt geen Python-, workflow- of releasescriptbestanden en dezelfde fout reproduceert lokaal.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen JavaScript-renderflow en testcode wijzigen; firmwareheap, PSRAM en task-stacks worden niet geraakt.
