### PR TITLE
YAML naar C++: Thermal Actuator – fail-closed besliskern

### DIFF
--- a/openquatt/includes/control/oq_thermal_actuator_logic.h
+++ b/openquatt/includes/control/oq_thermal_actuator_logic.h
@@ -7,6 +7,16 @@
 
 namespace oq_thermal_actuator {
 
+inline uint32_t minimum_off_remaining_ms(uint32_t now_ms, uint32_t last_stop_ms, uint32_t minimum_off_ms) {
+  if (last_stop_ms == 0 || minimum_off_ms == 0) return 0;
+  const uint32_t elapsed_ms = now_ms - last_stop_ms;
+  return elapsed_ms < minimum_off_ms ? minimum_off_ms - elapsed_ms : 0;
+}
+
+constexpr bool valid_level_command(int control_level, int physical_level) {
+  return control_level > 0 && control_level <= 10 && physical_level > 0 && physical_level <= 20;
+}
+
 struct ManualGuardInputs {
   int requested_level;
   int mode_code;
@@ -30,14 +40,26 @@ inline std::string manual_guard(const ManualGuardInputs& in, const std::string& 
   if (in.startup_inhibit_remaining_s > 0) {
     return "opstartblokkering na reboot: nog " + std::to_string(in.startup_inhibit_remaining_s) + " s";
   }
-  if (in.mode_code <= 0) return "kies eerst verwarmen of koelen";
+  if (in.mode_code != 1 && in.mode_code != 2) return "kies eerst verwarmen of koelen";
   if (in.mode_conflict) return "conflicterende werkmodus tussen HP1 en HP2";
-  if (in.last_stop_ms > 0 && static_cast<uint32_t>(in.now_ms - in.last_stop_ms) < in.minimum_off_ms) {
-    const uint32_t remaining_s =
-        (in.minimum_off_ms - static_cast<uint32_t>(in.now_ms - in.last_stop_ms) + 999UL) / 1000UL;
+  const uint32_t remaining_ms = minimum_off_remaining_ms(in.now_ms, in.last_stop_ms, in.minimum_off_ms);
+  if (remaining_ms > 0) {
+    const uint32_t remaining_s = (remaining_ms + 999UL) / 1000UL;
     return "minimale uit-tijd: nog " + std::to_string(remaining_s) + " s";
   }
   return current_guard;
+}
+
+enum class PreflightBlock : uint8_t { NONE, SAFE_ZERO, DEFROST, COOLING_REST, HP_REST, MODE };
+
+inline PreflightBlock decide_preflight(int guarded_level, int previous_level, bool retained_hold, int expected_mode,
+                                       uint32_t hp_rest_remaining_ms, bool bypass_holds, bool cooling_start_blocked) {
+  if (bypass_holds) return PreflightBlock::SAFE_ZERO;
+  if (retained_hold) return PreflightBlock::DEFROST;
+  if (guarded_level > 0 && cooling_start_blocked) return PreflightBlock::COOLING_REST;
+  if (guarded_level > 0 && previous_level == 0 && hp_rest_remaining_ms > 0) return PreflightBlock::HP_REST;
+  if (guarded_level > 0 && expected_mode != 1 && expected_mode != 2) return PreflightBlock::MODE;
+  return guarded_level > 0 ? PreflightBlock::NONE : PreflightBlock::SAFE_ZERO;
 }
 
 inline void accumulate_runtime(uint32_t dt_ms, uint32_t& accumulated_ms, int& runtime_minutes) {

--- a/openquatt/includes/control/oq_thermal_actuator_runtime.h
+++ b/openquatt/includes/control/oq_thermal_actuator_runtime.h
@@ -244,6 +244,7 @@ class Runtime {
   void write_level(bool is_hp1, int physical_level, bool force_write) {
     static const char* const level_options[21] = {"0",  "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9", "10",
                                                   "11", "12", "13", "14", "15", "16", "17", "18", "19", "20"};
+    if (physical_level < 0 || physical_level > 20) physical_level = 0;
     if (is_hp1) {
       const auto index = id(hp1_compressor_level).active_index();
       const int current = index.has_value() ? static_cast<int>(index.value()) : -1;
@@ -396,11 +397,27 @@ class Runtime {
     // -> valid mode -> frequency policy -> start/stop registration -> physical write.
     const auto incident_guard =
         oq_incident_actuator::decide({level, previous, incident.available_for_start, incident.must_stop});
-    level = incident_guard.guarded_level;
     if (incident_guard.bypass_runtime_and_defrost_holds) this->clear_retained_level(is_hp1);
     const auto retained = incident_guard.bypass_runtime_and_defrost_holds
                               ? oq_odu::RetainedLevel{}
                               : this->retained_level(is_hp1, cycle.frequency);
+    const bool cooling_start_blocked =
+        !cycle.manual_service_active && cycle.request_mode_code == 1 &&
+        oq_cooling::global_minimum_off_time_blocks_start(
+            cycle.cooling.remaining_ms,
+            cycle.restart_by_minimum_off_time && (cycle.cooling.confirmation_pending || cycle.cooling_stop_armed),
+            cycle.restart_by_minimum_off_time && cycle.cooling_stop_planned, previous);
+    const uint32_t hp_rest_remaining_ms = oq_thermal_actuator::minimum_off_remaining_ms(
+        cycle.config.now_ms, this->last_stop_ms_(is_hp1),
+        static_cast<uint32_t>(std::max(0, cycle.config.minimum_off_s)) * 1000UL);
+    const int expected_mode = this->requested_mode_code(is_hp1, true, cycle.request_mode_code,
+                                                        cycle.request_thermal_active, cycle.manual_service_active);
+    const bool defrost_hold = oq_odu::retained_level_should_override_request(retained, incident_guard.guarded_level,
+                                                                             cycle.manual_service_active);
+    const auto preflight = oq_thermal_actuator::decide_preflight(
+        incident_guard.guarded_level, previous, defrost_hold, expected_mode, hp_rest_remaining_ms,
+        incident_guard.bypass_runtime_and_defrost_holds, cooling_start_blocked);
+    level = preflight == oq_thermal_actuator::PreflightBlock::NONE ? incident_guard.guarded_level : 0;
     std::string block_reason;
     uint8_t candidate_reason = openquatt_decision_log::REASON_UNKNOWN;
     uint16_t candidate_aux_s = 0;
@@ -418,8 +435,6 @@ class Runtime {
       this->service_guard_(cycle, is_hp1) = "incidentbewaking blokkeert een nieuwe start";
     }
 
-    const bool defrost_hold =
-        oq_odu::retained_level_should_override_request(retained, level, cycle.manual_service_active);
     this->publish_defrost_hold_start(is_hp1, defrost_hold, retained, requested);
     if (defrost_hold) {
       char reason[96];
@@ -432,12 +447,7 @@ class Runtime {
       return retained.control_level;
     }
 
-    if (level > 0 && !cycle.manual_service_active && cycle.request_mode_code == 1 &&
-        oq_cooling::global_minimum_off_time_blocks_start(
-            cycle.cooling.remaining_ms,
-            cycle.restart_by_minimum_off_time && (cycle.cooling.confirmation_pending || cycle.cooling_stop_armed),
-            cycle.restart_by_minimum_off_time && cycle.cooling_stop_planned, previous)) {
-      level = 0;
+    if (preflight == oq_thermal_actuator::PreflightBlock::COOLING_REST) {
       candidate_reason = openquatt_decision_log::REASON_CANDIDATE_IN_REST;
       if (cycle.cooling.remaining_ms > 0) {
         const uint32_t remaining_s = (cycle.cooling.remaining_ms + 999UL) / 1000UL;
@@ -451,32 +461,20 @@ class Runtime {
       this->log_block_change(is_hp1, block_reason);
     }
 
-    const int minimum_off_s = std::max(0, cycle.config.minimum_off_s);
-    const uint32_t last_stop_ms = this->last_stop_ms_(is_hp1);
-    if (level > 0 && previous == 0 && minimum_off_s > 0 && last_stop_ms > 0 && cycle.config.now_ms > last_stop_ms) {
-      const uint32_t elapsed_ms = cycle.config.now_ms - last_stop_ms;
-      const uint32_t minimum_ms = static_cast<uint32_t>(minimum_off_s) * 1000UL;
-      if (elapsed_ms < minimum_ms) {
-        level = 0;
-        const uint32_t remaining_s = (minimum_ms - elapsed_ms + 999UL) / 1000UL;
-        char reason[144];
-        snprintf(reason, sizeof(reason), "minimum off-time remaining %u s after stop (requested %d)",
-                 static_cast<unsigned int>(remaining_s), requested);
-        block_reason = reason;
-        candidate_reason = openquatt_decision_log::REASON_CANDIDATE_IN_REST;
-        candidate_aux_s = this->cap_seconds_(remaining_s);
-        this->service_guard_(cycle, is_hp1) = "minimale uit-tijd: nog " + std::to_string(remaining_s) + " s";
-        this->log_block_change(is_hp1, reason);
-      }
+    if (preflight == oq_thermal_actuator::PreflightBlock::HP_REST) {
+      const uint32_t remaining_s = (hp_rest_remaining_ms + 999UL) / 1000UL;
+      char reason[144];
+      snprintf(reason, sizeof(reason), "minimum off-time remaining %u s after stop (requested %d)",
+               static_cast<unsigned int>(remaining_s), requested);
+      block_reason = reason;
+      candidate_reason = openquatt_decision_log::REASON_CANDIDATE_IN_REST;
+      candidate_aux_s = this->cap_seconds_(remaining_s);
+      this->service_guard_(cycle, is_hp1) = "minimale uit-tijd: nog " + std::to_string(remaining_s) + " s";
+      this->log_block_change(is_hp1, reason);
     }
 
     int applied = level;
-    const int expected_mode = level > 0
-                                  ? this->requested_mode_code(is_hp1, true, cycle.request_mode_code,
-                                                              cycle.request_thermal_active, cycle.manual_service_active)
-                                  : 0;
-    if (applied > 0 && expected_mode <= 0) {
-      applied = 0;
+    if (preflight == oq_thermal_actuator::PreflightBlock::MODE) {
       block_reason = "no valid thermal mode for compressor request";
       candidate_reason = openquatt_decision_log::REASON_CANDIDATE_UNAVAILABLE;
       this->service_guard_(cycle, is_hp1) = "geen geldige werkmodus voor compressorstart";
@@ -497,7 +495,7 @@ class Runtime {
                                                    expected_mode, applied)
                     : oq_odu::resolve_automatic_level(cycle.frequency.configured_v2, cycle.frequency.snapshot(is_hp1),
                                                       expected_mode, applied);
-      if (command.control_level <= 0 || command.physical_level <= 0) {
+      if (!oq_thermal_actuator::valid_level_command(command.control_level, command.physical_level)) {
         applied = 0;
         command = {};
         block_reason = "runtime frequency table cannot map compressor request";

--- a/scripts/tests/test_thermal_actuator_runtime_contract.py
+++ b/scripts/tests/test_thermal_actuator_runtime_contract.py
@@ -1,57 +1,38 @@
 from pathlib import Path
 import unittest
 
-
 ROOT = Path(__file__).resolve().parents[2]
 YAML = (ROOT / "openquatt" / "oq_thermal_actuator.yaml").read_text()
-RUNTIME = (
-    ROOT / "openquatt" / "includes" / "control" / "oq_thermal_actuator_runtime.h"
-).read_text()
+RUNTIME = (ROOT / "openquatt" / "includes" / "control" / "oq_thermal_actuator_runtime.h").read_text()
 
 
 class ThermalActuatorRuntimeContractTest(unittest.TestCase):
     def test_yaml_is_a_compact_runtime_contract(self) -> None:
         self.assertLessEqual(len(YAML.splitlines()), 50)
         self.assertEqual(YAML.count("oq_thermal_actuator_runtime::runtime().tick("), 1)
-        for implementation_detail in ("make_call()", "oq_incident_manager", "pick_allowed_level"):
-            self.assertNotIn(implementation_detail, YAML)
+        for detail in ("make_call()", "oq_incident_manager", "pick_allowed_level"):
+            self.assertNotIn(detail, YAML)
 
-    def test_safety_gates_keep_their_fail_closed_order(self) -> None:
-        markers = (
-            "const auto incident_guard",
-            "const auto retained",
-            "global_minimum_off_time_blocks_start(",
-            "const int minimum_off_s",
-            "const int expected_mode",
-            "cycle.frequency.pick_allowed_level(",
-            "apply_start_gate_before_active_write(",
-            "apply_stop_notification_before_safe_write(",
-            "this->write_level(is_hp1, command.physical_level",
-        )
+    def test_runtime_delegates_ordered_safety_gates_to_the_tested_core(self) -> None:
+        markers = ("const auto incident_guard", "const auto retained", "oq_thermal_actuator::minimum_off_remaining_ms(",
+                   "oq_thermal_actuator::decide_preflight(", "cycle.frequency.pick_allowed_level(",
+                   "oq_thermal_actuator::valid_level_command(", "apply_start_gate_before_active_write(",
+                   "apply_stop_notification_before_safe_write(", "this->write_level(is_hp1, command.physical_level")
         positions = [RUNTIME.index(marker) for marker in markers]
         self.assertEqual(positions, sorted(positions))
-        self.assertIn("incident_guard.bypass_runtime_and_defrost_holds", RUNTIME)
-        self.assertIn("cycle.cooling.confirmation_pending || cycle.cooling_stop_armed", RUNTIME)
+        self.assertEqual(RUNTIME.count("oq_thermal_actuator::decide_preflight("), 1)
 
     def test_lifecycle_state_is_owned_by_the_runtime(self) -> None:
-        for state in (
-            "last_defrost_seen_",
-            "retained_levels_",
-            "last_safe_stop_write_ms_",
-            "last_manual_guard_status_",
-        ):
+        for state in ("last_defrost_seen_", "retained_levels_", "last_safe_stop_write_ms_", "last_manual_guard_status_"):
             self.assertIn(state, RUNTIME)
             self.assertNotIn(state, YAML)
 
-    def test_module_and_new_regressions_do_not_increase_lines(self) -> None:
-        paths = (
-            "openquatt/oq_thermal_actuator.yaml",
-            "openquatt/includes/control/oq_thermal_actuator_logic.h",
-            "openquatt/includes/control/oq_thermal_actuator_runtime.h",
-            "tests/host/thermal_actuator_logic_test.cpp",
-            "scripts/tests/test_thermal_actuator_runtime_contract.py",
-        )
-        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1011)
+    def test_complete_runtime_stack_stays_net_smaller(self) -> None:
+        paths = ("openquatt/oq_thermal_actuator.yaml", "openquatt/includes/control/oq_thermal_actuator_logic.h",
+                 "openquatt/includes/control/oq_thermal_actuator_runtime.h", "tests/host/thermal_actuator_logic_test.cpp",
+                 "scripts/tests/test_thermal_actuator_runtime_contract.py", "scripts/tests/test_v2_compressor_level_contract.py",
+                 "scripts/tests/test_compressor_frequency_policy_contract.py")
+        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1287)
 
 
 if __name__ == "__main__":

--- a/tests/host/thermal_actuator_logic_test.cpp
+++ b/tests/host/thermal_actuator_logic_test.cpp
@@ -2,16 +2,10 @@
 #include <stdint.h>
 
 #include "../../openquatt/includes/control/oq_thermal_actuator_logic.h"
-
 int main() {
-  using oq_thermal_actuator::accumulate_runtime;
-  using oq_thermal_actuator::manual_guard;
-  using oq_thermal_actuator::ManualGuardInputs;
-  using oq_thermal_actuator::topology_state;
-
+  using namespace oq_thermal_actuator;
   ManualGuardInputs input{5, 2, 10000U, 0U, 300000U, 0U, false, false, false, true, false};
   assert(manual_guard(input, "Vrijgegeven") == "Vrijgegeven");
-
   input.stop_requested = true;
   input.water_temperature_trip = true;
   assert(manual_guard(input, "Vrijgegeven") == "stopverzoek wordt veilig afgerond");
@@ -23,17 +17,17 @@ int main() {
   input.low_flow_fault = false;
   input.flow_valid = false;
   assert(manual_guard(input, "Vrijgegeven") == "onvoldoende flow voor compressorstart");
-
   input.flow_valid = true;
   input.startup_inhibit_remaining_s = 17;
   assert(manual_guard(input, "Vrijgegeven") == "opstartblokkering na reboot: nog 17 s");
   input.startup_inhibit_remaining_s = 0;
   input.mode_code = 0;
   assert(manual_guard(input, "Vrijgegeven") == "kies eerst verwarmen of koelen");
+  input.mode_code = 3;
+  assert(manual_guard(input, "Vrijgegeven") == "kies eerst verwarmen of koelen");
   input.mode_code = 2;
   input.mode_conflict = true;
   assert(manual_guard(input, "Vrijgegeven") == "conflicterende werkmodus tussen HP1 en HP2");
-
   input.mode_conflict = false;
   input.now_ms = 25U;
   input.last_stop_ms = UINT32_MAX - 50U;
@@ -42,7 +36,18 @@ int main() {
   assert(manual_guard(input, "Bestaande blokkering") == "Bestaande blokkering");
   input.requested_level = 0;
   assert(manual_guard(input, "Vrijgegeven") == "Vrijgegeven");
-
+  using Block = PreflightBlock;
+  assert(decide_preflight(5, 0, false, 2, 0U, false, false) == Block::NONE);
+  assert(decide_preflight(0, 5, true, 3, 1000U, true, true) == Block::SAFE_ZERO);
+  assert(decide_preflight(0, 0, false, 3, 1000U, false, true) == Block::SAFE_ZERO);
+  assert(decide_preflight(0, 0, true, 2, 0U, false, true) == Block::DEFROST);
+  assert(decide_preflight(1, 0, true, 3, 1000U, false, true) == Block::DEFROST);
+  assert(decide_preflight(5, 0, false, 3, 1000U, false, true) == Block::COOLING_REST);
+  assert(decide_preflight(5, 0, false, 3, 1000U, false, false) == Block::HP_REST);
+  assert(decide_preflight(5, 0, false, 3, 0U, false, false) == Block::MODE);
+  assert(minimum_off_remaining_ms(25U, UINT32_MAX - 50U, 1000U) == 924U);
+  assert(minimum_off_remaining_ms(1000U, 500U, 500U) == 0U);
+  assert(valid_level_command(5, 20) && !valid_level_command(0, 7) && !valid_level_command(5, 21));
   uint32_t accumulated_ms = 55000U;
   int runtime_minutes = 7;
   accumulate_runtime(125000U, accumulated_ms, runtime_minutes);
@@ -52,9 +57,6 @@ int main() {
   accumulate_runtime(20U, accumulated_ms, runtime_minutes);
   assert(accumulated_ms == 0U);
   assert(runtime_minutes == 11);
-
-  assert(topology_state(0, 4, 5, 6) == 4);
-  assert(topology_state(1, 4, 5, 6) == 5);
-  assert(topology_state(2, 4, 5, 6) == 6);
+  assert(topology_state(0, 4, 5, 6) == 4 && topology_state(1, 4, 5, 6) == 5 && topology_state(2, 4, 5, 6) == 6);
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Delegeert de geordende actuator-preflight naar een pure, host-testbare C++-besliskern.
- Maakt ongeldige werkmodi en compressorlevels fail-closed en herstelt de minimum-uit-tijd over een `millis()`-rollover.
- Breidt regressies uit voor incident-, defrost-, cooling-rest-, per-HP-rest- en mode-dominantie.

Vervolg op de inmiddels gemergde runtime-extractie uit #564.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Normale requests behouden dezelfde safety-volgorde. Alleen ongeldige modecodes, ongeldige fysieke mappings en minimum-uit-tijd rond tellerrollover worden strenger naar een veilige stop geleid. Er komen geen entities, persistent state of allocaties bij.

## Achtergrond

De runtime-extractie uit #564 maakte de YAML compact. Deze vervolg-PR maakt de belangrijkste veiligheidsbeslissingen rechtstreeks regressietestbaar. #566 voegt afzonderlijk 3 regels toe; de gecombineerde #564+#566 Thermal Actuator-stack blijft netto 3 regels kleiner inclusief tests. De volledige stack telt 1286 regels bij een contractlimiet van 1287.

De complete diff tegen actuele `dev` is afzonderlijk geaudit op safety-gatevolgorde, Single/Duo-compatibiliteit, rollover, lifecycle, retries, fresh-installgedrag en foutpaden. Een tweede koude review vond geen blockers.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een interne testability- en fail-closed-versterking zonder nieuwe bediening, configuratie of entities.

## Validatie

- `npm run check:cpp-format` — groen, 174 bestanden gecontroleerd.
- `npm run check:python-contracts` — 143 tests groen.
- `scripts/run_host_regression_tests.sh` — 46 hosttests groen.
- `python3 scripts/dev.py validate --config-only` — alle zes configuraties groen: Waveshare Single/Duo WiFi, listener Single/Duo en Q Single/Duo WiFi.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — groen op de actuele `dev`-basis.
- Bestaande HIL-validatie op controller en Quatt ODU-simulator: normale Duo F5, defrost-hold bij requestwijziging, response-loss/incidentstop met HP-isolatie, herstel en minimum-runtime-stop gecontroleerd; simulator na afloop veilig genormaliseerd.
- `git diff --check` en volledige LOC-gate groen.
- GitHub CI — 14/14 checks groen.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe long-lived state, buffers, taken of allocaties. Actuele Q Duo-candidate: 211035/341760 bytes DIRAM en 2181351/5242880 bytes flash.
