### PR TITLE
YAML naar C++: Heating Curve – borg vermogenslimiet

### DIFF
--- a/openquatt/includes/control/oq_heating_curve_logic.h
+++ b/openquatt/includes/control/oq_heating_curve_logic.h
@@ -172,19 +172,15 @@ inline void reset_request_state(uint32_t& request_last_loop_ms, int& request_tot
 
 inline DispatchCandidate invalid_dispatch_candidate() { return DispatchCandidate{}; }
 
-inline float normalized_demand_u(float demand_continuous, int demand_max_f) {
-  if (demand_max_f <= 0) return 0.0f;
-  if (isnan(demand_continuous)) return 0.0f;
-  const float clamped = std::max(0.0f, std::min((float)demand_max_f, demand_continuous));
-  return clamped / (float)demand_max_f;
+inline float power_capped_demand_u(float demand, int cap_f, int max_f) {
+  if (max_f <= 0 || cap_f <= 0 || !isfinite(demand)) return 0.0f;  // Invalid continuous demand fails closed.
+  return std::max(0.0f, std::min({demand, (float)cap_f, (float)max_f})) / (float)max_f;
 }
 
-inline float phase_target_power_w(bool heat_phase, float demand_u, float dispatch_u, float single_cap_w,
-                                  float duo_cap_w) {
-  const float effective_u = heat_phase ? demand_u : std::min(demand_u, dispatch_u);
-  if (effective_u <= 0.0f) return 0.0f;
-  const float single_target_w = isnan(single_cap_w) ? 0.0f : (single_cap_w * effective_u);
-  const float duo_target_w = isnan(duo_cap_w) ? single_target_w : (duo_cap_w * effective_u);
+inline float phase_target_power_w(bool heat_phase, float capped_demand_u, float single_cap_w, float duo_cap_w) {
+  if (!isfinite(capped_demand_u) || capped_demand_u <= 0.0f) return 0.0f;
+  const float single_target_w = isfinite(single_cap_w) ? (single_cap_w * capped_demand_u) : 0.0f;
+  const float duo_target_w = isfinite(duo_cap_w) ? (duo_cap_w * capped_demand_u) : single_target_w;
   return heat_phase ? single_target_w : duo_target_w;
 }
 

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -1095,19 +1095,15 @@ interval:
           }
           id(oq_curve_request_last_loop_ms) = now_ms;
 
-          constexpr int max_level = 10;
+          constexpr int level_cap = 10;
           const int demand_max_f = (int) ${oq_strategy_demand_max_f};
-          int raw = id(oq_demand_raw);
-          raw = std::max(0, std::min(demand_max_f, raw));
+          const int raw = std::max(0, std::min(demand_max_f, id(oq_demand_raw)));
 
           id(oq_demand_filtered_prev) = id(oq_demand_filtered);
           id(oq_demand_filtered) = raw;
           id(oq_heating_demand_filtered) = raw;
 
-          int f = raw;
-          int f_cap = id(oq_power_cap_f);
-          f_cap = std::max(0, std::min(demand_max_f, f_cap));
-          if (f > f_cap) f = f_cap;
+          const int f = std::min(raw, std::max(0, std::min(demand_max_f, id(oq_power_cap_f))));
 
           #if OQ_TOPOLOGY_DUO
           const bool lead_is_hp1 = (id(hp1_minutes) <= id(${secondary_minutes_id}));
@@ -1131,8 +1127,6 @@ interval:
             return false;
             #endif
           };
-
-          const int level_cap = max_level;
 
           const bool hp1_valve_def = valve_defrost_active(true);
           #if OQ_TOPOLOGY_DUO
@@ -1168,13 +1162,10 @@ interval:
           const bool hp2_candidate_available = false;
           #endif
 
-          int owner = 0;
-          int dispatch_hp1 = 0;
-          int dispatch_hp2 = 0;
-          float demand_continuous = id(oq_curve_demand_continuous);
-          if (isnan(demand_continuous)) demand_continuous = (float) f;
-          const float demand_u = oq_curve::normalized_demand_u(demand_continuous, demand_max_f);
-          const float dispatch_u = oq_curve::normalized_demand_u((float) f, demand_max_f);
+          int owner = 0, dispatch_hp1 = 0, dispatch_hp2 = 0;
+          const float demand_u = oq_curve::power_capped_demand_u(id(oq_curve_demand_continuous), f, demand_max_f);
+          const float dispatch_u = demand_max_f > 0 ? (float) f / (float) demand_max_f : 0.0f;
+          const bool demand_active = demand_u > 0.0f;
           #if OQ_TOPOLOGY_DUO
           const auto tuning = oq_curve::control_profile(
               id(oq_curve_control_profile).has_state()
@@ -1185,7 +1176,6 @@ interval:
           if (!isnan(id(oq_supply_target_temp).state) && !isnan(id(oq_system_supply_temp).state)) {
             temp_err_c = id(oq_supply_target_temp).state - id(oq_system_supply_temp).state;
           }
-          const bool demand_active = (f > 0);
           const bool heat_phase = demand_active && (id(oq_curve_regime_code) == 1);
           const int prev_curve_post = id(oq_demand_filtered_prev);
 
@@ -1269,7 +1259,7 @@ interval:
 
           const bool demand_rundown = (f < prev_curve_post);
           const float target_power_w =
-              demand_active ? oq_curve::phase_target_power_w(heat_phase, demand_u, dispatch_u, owner_cap_w, duo_cap_w) : 0.0f;
+              demand_active ? oq_curve::phase_target_power_w(heat_phase, demand_u, owner_cap_w, duo_cap_w) : 0.0f;
 
           oq_curve::DispatchCandidate best_single = oq_curve::invalid_dispatch_candidate();
           if (demand_active && single_owner == 1) {
@@ -1411,9 +1401,9 @@ interval:
               id(oq_curve_single_owner_hp),
               id(oq_duo_request_hold_until_ms),
               1);
-          owner = (demand_u > 0.0f && hp1_candidate_available) ? 1 : 0;
+          owner = (demand_active && hp1_candidate_available) ? 1 : 0;
           dispatch_hp1 = hp1_candidate_available
-              ? std::max(0, std::min(max_level, (int) lroundf(demand_u * (float) max_level)))
+              ? std::max(0, std::min(level_cap, (int) lroundf(demand_u * (float) level_cap)))
               : 0;
           dispatch_hp2 = 0;
           id(oq_curve_capacity_mode_code) = (dispatch_hp1 > 0) ? 1 : 0;
@@ -1426,7 +1416,7 @@ interval:
                       dispatch_hp2,
                       hp1_candidate_state,
                       hp2_candidate_state,
-                      f > 0,
+                      demand_active,
                   });
           if (suspect_topology_hold.active) {
             dispatch_hp1 = suspect_topology_hold.hp1_level;

--- a/scripts/tests/test_electrical_input_limit_contract.py
+++ b/scripts/tests/test_electrical_input_limit_contract.py
@@ -56,6 +56,13 @@ class ElectricalInputLimitContractTest(unittest.TestCase):
         self.assertNotIn("oq_power_limit_peak_w", HEATING_CURVE)
         self.assertNotIn("oq_power_limit_peak_w", COOLING)
 
+    def test_heating_curve_dispatch_uses_power_capped_continuous_demand(self) -> None:
+        for marker in ("oq_curve::power_capped_demand_u(id(oq_curve_demand_continuous), f, demand_max_f)", "phase_target_power_w(heat_phase, demand_u, owner_cap_w, duo_cap_w)", "lroundf(demand_u * (float) level_cap)", "const float dispatch_u = demand_max_f > 0 ? (float) f / (float) demand_max_f : 0.0f;", "(dispatch_u >= 0.95f)", "(dispatch_u >= duo_enable_min_u)", "(dispatch_u <= duo_disable_max_u)", "const bool demand_active = demand_u > 0.0f;", "hp2_candidate_state,\n                      demand_active,"):
+            self.assertIn(marker, HEATING_CURVE)
+        self.assertNotIn("if (isnan(demand_continuous))", HEATING_CURVE)
+        paths = ("openquatt/oq_heating_curve_strategy.yaml", "openquatt/includes/control/oq_heating_curve_logic.h", "tests/host/heating_curve_restart_logic_test.cpp", "scripts/tests/test_electrical_input_limit_contract.py")
+        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1879)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/host/heating_curve_restart_logic_test.cpp
+++ b/tests/host/heating_curve_restart_logic_test.cpp
@@ -114,7 +114,6 @@ void test_control_reset_clears_restart_diagnostics() {
   assert(!restart_blocked_by_room);
   assert(regime_code == 0);
 }
-
 }  // namespace
 
 int main() {
@@ -127,5 +126,12 @@ int main() {
   test_no_water_restart_does_not_report_a_room_block();
   test_non_finite_room_values_cannot_block_restart();
   test_control_reset_clears_restart_diagnostics();
+  const float capped_u = oq_curve::power_capped_demand_u(18.0f, 8, 20);
+  assert(capped_u == 0.4f && lroundf(capped_u * 10.0f) == 4);                              // Single cap.
+  assert(oq_curve::phase_target_power_w(true, capped_u, 10000.0f, 18000.0f) == 4000.0f);   // Duo recovery.
+  assert(oq_curve::phase_target_power_w(false, capped_u, 10000.0f, 18000.0f) == 7200.0f);  // Duo maintain.
+  assert(oq_curve::power_capped_demand_u(6.0f, 8, 20) == 0.3f && oq_curve::power_capped_demand_u(18.0f, 0, 20) == 0.0f);
+  assert(oq_curve::power_capped_demand_u(NAN, 8, 20) == 0.0f &&
+         oq_curve::power_capped_demand_u(INFINITY, 8, 20) == 0.0f);
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Begrens de continue Heating Curve-vraag vóór Single-dispatch en het Duo-vermogensdoel met `oq_power_cap_f`.
- Laat cap 0, hard trip en niet-eindige continue vraag fail-closed eindigen, ook vóór suspect-topologyretentie.
- Voeg pure hostregressies en een YAML-contract/LOC-gate toe; de volledige PR is netto 1 regel kleiner inclusief tests.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Voorheen kon `oq_curve_demand_continuous` de gecapte integer request omzeilen. Bij demand 18, cap 8 en maximum 20 vroeg Single daardoor level 9 in plaats van 4; Duo RECOVERY richtte zich op 9 kW in plaats van 4 kW bij 10 kW Single-capaciteit. De bestaande discrete Duo emergency/enable/disable-hysterese blijft exact op `f / demand_max_f` werken.

## Achtergrond

Dit is een kleine Heating Curve-slice vóór de grotere runtime-extractie. De ESPHome PID, entities, state machine en dispatchoptimizer blijven verder ongewijzigd.

De complete diff is opnieuw op de actuele `dev`-tip opgebouwd en afzonderlijk geaudit op Single, Duo RECOVERY/MAINTAIN, hard trip, niet-eindige input, incident/suspectretentie, lifecycle, fresh install en afrondingsgrenzen van de bestaande Duo-hysterese. Een tweede koude review vond geen blockers. De LOC-gate is na de eerdere upstream YAML-reductie aangescherpt van 1930 naar 1879 regels; de kandidaat telt 1878 regels.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne fail-closed correctie zonder nieuwe bediening, configuratie of entities.

## Validatie

- `npm run check:cpp-format` — groen, 174 C/C++-bestanden.
- `scripts/run_host_regression_tests.sh` — 46/46 groen.
- `npm run check:python-contracts` — 144/144 groen.
- `python3 scripts/dev.py validate --config-only` — alle zes configuraties groen: Waveshare Single/Duo WiFi, listener Single/Duo en Q Single/Duo.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — groen op de actuele `dev`-basis.
- `git diff --check` en LOC-gate 1878 <= 1879 — groen.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe state, buffers, taken of allocaties; alleen pure scalair-berekening en bestaande lokale waarden. Actuele Q Duo-candidate: 211035/341760 bytes DIRAM en 2181427/5242880 bytes flash.
