### PR TITLE
YAML naar C++: Power House – vraaglogica

### DIFF
--- a/openquatt/includes/control/oq_power_house_demand_logic.h
+++ b/openquatt/includes/control/oq_power_house_demand_logic.h
@@ -4,76 +4,170 @@
 #include <stdint.h>
 
 namespace oq_power_house {
-
-// Identifies which source produced a cached external demand. Kept as a small
-// code so the selected-value lambda can persist it in a global alongside the
-// cached watts and timestamp.
 constexpr uint8_t kDemandSourceNone = 0;
 constexpr uint8_t kDemandSourceHaInput = 1;
 constexpr uint8_t kDemandSourceApiInput = 2;
-
-// Outcome of choosing the Power House feedforward term for one control tick.
 struct Feedforward {
   float house_power_w = 0.0f;
   bool external = false;
 };
-
+struct CadenceDecision {
+  bool due = false;
+  float dt_s = 0.0f;
+};
+struct DemandInput {
+  uint32_t now_ms = 0;
+  float outside_c = NAN, cold_c = NAN, zero_power_c = NAN, rated_w = NAN;
+  float room_c = NAN, setpoint_c = NAN, external_w = NAN;
+  float water_limit_factor = NAN;
+  bool external_valid = false;
+};
+struct DemandTuning {
+  float temperature_guard_c = 0.0f, reaction_w_per_k = NAN;
+  float comfort_below_c = NAN, comfort_above_c = NAN;
+  float rise_time_min = NAN, fall_time_min = NAN;
+  int demand_max = 0;
+};
+struct DemandState {
+  float last_w = 0.0f;
+  uint32_t last_ms = 0;
+  float comfort_memory_c = 0.0f;
+};
+struct DemandDecision {
+  DemandState next;
+  float requested_w = 0.0f;
+  int raw_demand = 0;
+  bool external = false;
+  bool valid = false;
+};
+struct FilterDecision {
+  int previous = 0, filtered = 0;
+  float ramp_budget = 0.0f;
+};
 inline float clamp_power(float value, float low, float high) {
   if (value < low) return low;
   if (value > high) return high;
   return value;
 }
-
-// Modelled house power: linear between the zero-power outdoor temperature and
-// the full-load point, saturated at both ends. Returns NAN when the house model
-// itself is unusable, which the strategy lambda already guards upstream.
 inline float modelled_house_power_w(float zero_power_temp_c, float cold_temp_c, float outside_temp_c,
                                     float rated_power_w) {
   if (!isfinite(zero_power_temp_c) || !isfinite(cold_temp_c) || !isfinite(outside_temp_c) || !isfinite(rated_power_w) ||
-      !(zero_power_temp_c > cold_temp_c)) {
+      rated_power_w <= 0.0f || !(zero_power_temp_c > cold_temp_c)) {
     return NAN;
   }
   const float load = clamp_power((zero_power_temp_c - outside_temp_c) / (zero_power_temp_c - cold_temp_c), 0.0f, 1.0f);
   return rated_power_w * load;
 }
-
-// Choose the feedforward term. A valid external demand replaces the modelled
-// value; anything else degrades to the model rather than to no heat at all, so
-// a stale or absent planner link returns the installation to its normal
-// behaviour. Only the feedforward moves here: the comfort trim, the saturation
-// clamp, the slew limiter and the water-temperature limiter stay firmware-owned
-// downstream of this call.
 inline Feedforward select_feedforward(float modelled_power_w, float external_power_w, bool external_valid,
                                       float rated_power_w) {
-  Feedforward result;
-  result.house_power_w = modelled_power_w;
-  result.external = false;
-
-  // Without a usable rating there is no scale to clamp an external demand
-  // against, and the demand mapping downstream divides by it.
+  Feedforward result{modelled_power_w, false};
   if (!external_valid || !isfinite(external_power_w) || !isfinite(rated_power_w) || rated_power_w <= 0.0f) {
     return result;
   }
-
   result.house_power_w = clamp_power(external_power_w, 0.0f, rated_power_w);
   result.external = true;
   return result;
 }
-
-// Decide whether a cached external demand may bridge a short dropout. The
-// cache belongs to the source that produced it: after a source change it
-// describes a different origin, so replaying it would keep a stale sample from
-// the previous source driving the request for a full hold window. Elapsed time
-// is computed in unsigned arithmetic so the window survives a millis() wrap.
 inline bool hold_cached_demand(uint8_t cached_source, uint8_t current_source, float cached_power_w, uint32_t cached_ms,
                                uint32_t now_ms, uint32_t hold_ms) {
-  if (hold_ms == 0 || cached_ms == 0 || !isfinite(cached_power_w)) {
-    return false;
-  }
-  if (cached_source == kDemandSourceNone || cached_source != current_source) {
-    return false;
-  }
+  if (hold_ms == 0 || cached_ms == 0 || !isfinite(cached_power_w)) return false;
+  if (cached_source == kDemandSourceNone || cached_source != current_source) return false;
   return static_cast<uint32_t>(now_ms - cached_ms) < hold_ms;
 }
-
+// Unsigned elapsed time keeps the cadence valid across one millis() rollover.
+inline CadenceDecision decide_cadence(uint32_t now_ms, uint32_t last_ms, uint32_t target_ms) {
+  if (target_ms == 0) return {};
+  if (last_ms == 0) return {true, static_cast<float>(target_ms) / 1000.0f};
+  const uint32_t elapsed_ms = static_cast<uint32_t>(now_ms - last_ms);
+  if (elapsed_ms < target_ms) return {};
+  return {true, static_cast<float>(elapsed_ms) / 1000.0f};
+}
+inline DemandDecision decide_demand(const DemandInput& in, const DemandTuning& tuning, const DemandState& state) {
+  DemandDecision out;
+  out.next.last_ms = in.now_ms == 0 ? UINT32_MAX : in.now_ms;
+  const bool valid =
+      isfinite(in.outside_c) && isfinite(in.cold_c) && isfinite(in.zero_power_c) && isfinite(in.rated_w) &&
+      in.rated_w > 0.0f && isfinite(in.room_c) && isfinite(in.setpoint_c) && isfinite(in.water_limit_factor) &&
+      isfinite(tuning.temperature_guard_c) && tuning.temperature_guard_c >= 0.0f && isfinite(tuning.reaction_w_per_k) &&
+      tuning.reaction_w_per_k >= 0.0f && isfinite(tuning.comfort_below_c) && isfinite(tuning.comfort_above_c) &&
+      isfinite(tuning.rise_time_min) && isfinite(tuning.fall_time_min) && tuning.demand_max > 0 &&
+      in.zero_power_c > in.cold_c + tuning.temperature_guard_c;
+  if (!valid) return out;
+  const float modelled_w = modelled_house_power_w(in.zero_power_c, in.cold_c, in.outside_c, in.rated_w);
+  const Feedforward feedforward = select_feedforward(modelled_w, in.external_w, in.external_valid, in.rated_w);
+  if (!isfinite(modelled_w) || !isfinite(feedforward.house_power_w)) return out;
+  const float below_c = clamp_power(tuning.comfort_below_c, 0.0f, 2.0f);
+  const float above_c = clamp_power(tuning.comfort_above_c, 0.0f, 2.0f);
+  const float low_base_c = in.setpoint_c - below_c;
+  const float high_base_c = in.setpoint_c + above_c;
+  const float mid_base_c = low_base_c + 0.5f * (high_base_c - low_base_c);
+  const float memory_max_c = clamp_power(0.05f + 0.50f * above_c, 0.08f, 0.20f);
+  float memory_c = isfinite(state.comfort_memory_c) ? state.comfort_memory_c : 0.0f;
+  memory_c = clamp_power(memory_c, 0.0f, memory_max_c);
+  float dt_s = 0.0f;
+  float last_w = feedforward.house_power_w;
+  if (state.last_ms != 0) {
+    dt_s = static_cast<float>(static_cast<uint32_t>(in.now_ms - state.last_ms)) / 1000.0f;
+    if (isfinite(state.last_w)) last_w = clamp_power(state.last_w, 0.0f, in.rated_w);
+  }
+  if (in.room_c < low_base_c) {
+    const float undershoot = clamp_power((low_base_c - in.room_c) / 0.45f, 0.0f, 1.0f);
+    const float build_per_min = memory_max_c / 90.0f + (memory_max_c / 24.0f - memory_max_c / 90.0f) * undershoot;
+    memory_c += build_per_min * dt_s / 60.0f;
+  } else if (in.room_c > mid_base_c) {
+    const float decay_minutes = in.room_c <= high_base_c ? 40.0f : 12.0f;
+    memory_c -= (memory_max_c / decay_minutes) * dt_s / 60.0f;
+  }
+  memory_c = clamp_power(memory_c, 0.0f, memory_max_c);
+  const float effective_setpoint_c = in.setpoint_c + memory_c;
+  const float low_c = effective_setpoint_c - below_c;
+  float error_c = 0.0f;
+  if (in.room_c < low_c)
+    error_c = low_c - in.room_c;
+  else if (in.room_c > in.setpoint_c)
+    error_c = in.setpoint_c - in.room_c;
+  const float raw_w = clamp_power(feedforward.house_power_w + tuning.reaction_w_per_k * error_c, 0.0f, in.rated_w);
+  if (!isfinite(error_c) || !isfinite(raw_w)) return out;
+  const float rise_min = clamp_power(tuning.rise_time_min, 2.0f, 20.0f);
+  const float fall_min = clamp_power(tuning.fall_time_min, 1.0f, 10.0f);
+  float limited_w = raw_w;
+  if (dt_s > 0.0f && raw_w > last_w)
+    limited_w = fminf(raw_w, last_w + in.rated_w * dt_s / (rise_min * 60.0f));
+  else if (dt_s > 0.0f && raw_w < last_w)
+    limited_w = fmaxf(raw_w, last_w - in.rated_w * dt_s / (fall_min * 60.0f));
+  out.requested_w = limited_w * clamp_power(in.water_limit_factor, 0.0f, 1.0f);
+  out.raw_demand = static_cast<int>(lroundf(tuning.demand_max * (out.requested_w / in.rated_w)));
+  if (out.raw_demand < 0) out.raw_demand = 0;
+  if (out.raw_demand > tuning.demand_max) out.raw_demand = tuning.demand_max;
+  out.external = feedforward.external;
+  out.valid = true;
+  out.next = {out.requested_w, out.next.last_ms, memory_c};
+  return out;
+}
+inline FilterDecision filter_demand(int raw, int current, float ramp_budget, float ramp_step_min, float dt_s,
+                                    int demand_max) {
+  FilterDecision out;
+  if (demand_max <= 0) return out;
+  raw = raw < 0 ? 0 : (raw > demand_max ? demand_max : raw);
+  current = current < 0 ? 0 : (current > demand_max ? demand_max : current);
+  out.previous = current;
+  const bool ramp_valid = isfinite(ramp_budget) && isfinite(ramp_step_min) && isfinite(dt_s) && dt_s >= 0.0f;
+  float budget = ramp_valid ? clamp_power(ramp_budget, 0.0f, static_cast<float>(demand_max)) : 0.0f;
+  int steps = 0;
+  if (ramp_valid) {
+    const float step_min = lroundf(clamp_power(ramp_step_min, 1.0f, static_cast<float>(demand_max)));
+    budget = fminf(static_cast<float>(demand_max), budget + step_min * dt_s / 60.0f);
+    steps = static_cast<int>(floorf(budget));
+    budget -= static_cast<float>(steps);
+  }
+  if (raw > current && steps > 0)
+    current = current + steps < raw ? current + steps : raw;
+  else if (raw == 0 && current == 1)
+    current = 0;
+  else if (raw <= current - 2)
+    current = raw;
+  out.filtered = current;
+  out.ramp_budget = budget;
+  return out;
+}
 }  // namespace oq_power_house

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -372,155 +372,39 @@ interval:
             oil_return_hold_until_ms = 0;
             return;
           }
-
           const uint32_t now_ms = (uint32_t) millis();
           const uint32_t loop_target_ms = (uint32_t) (${oq_heat_loop_powerhouse_s} * 1000UL);
-          float dt_s = (float) loop_target_ms / 1000.0f;
-          if (id(oq_ph_request_last_loop_ms) > 0 && now_ms > id(oq_ph_request_last_loop_ms)) {
-            const uint32_t elapsed_ms = now_ms - id(oq_ph_request_last_loop_ms);
-            if (elapsed_ms < loop_target_ms) return;
-            dt_s = (float) elapsed_ms / 1000.0f;
-          }
-          id(oq_ph_request_last_loop_ms) = now_ms;
-
-          constexpr float seconds_per_minute = 60.0f;
+          const auto cadence = oq_power_house::decide_cadence(now_ms, id(oq_ph_request_last_loop_ms), loop_target_ms);
+          if (!cadence.due) return;
+          id(oq_ph_request_last_loop_ms) = now_ms == 0 ? UINT32_MAX : now_ms;
           const int demand_max_f = (int) ${oq_strategy_demand_max_f};
-          auto clampf = [&](float v, float lo, float hi)->float {
-            if (v < lo) return lo;
-            if (v > hi) return hi;
-            return v;
-          };
-          auto clamp_demand = [&](int demand)->int {
-            if (demand < 0) return 0;
-            if (demand > demand_max_f) return demand_max_f;
-            return demand;
-          };
-
-          const float Tout = id(outside_temp_selected).state;
-          const float Tc = id(house_cold_temp_c).state;
-          const float T0 = id(house_zero_power_temp_c).state;
-          const float house_power_rating_w = id(house_rated_power_w).state;
-          const float Tr = id(room_temp_selected).state;
-          const float Trsp = id(room_setpoint_selected).state;
-
-          if (isnan(Tout) || isnan(Tc) || isnan(T0) || isnan(house_power_rating_w) || (house_power_rating_w <= 0.0f) ||
-              isnan(Tr) || isnan(Trsp) || (T0 <= Tc + ${oq_temp_guard_delta_c}f)) {
-            id(oq_phouse_req_w) = 0.0f;
-            id(oq_phouse_comfort_memory_c) = 0.0f;
-            id(oq_phouse_demand_external) = false;
-            id(oq_demand_raw) = 0;
-          } else {
-            // Feedforward only: an external planner may replace the modelled
-            // house power, but the comfort trim, saturation clamp, slew limiter
-            // and water-temperature limiter below stay firmware-owned.
-            const float P_model = oq_power_house::modelled_house_power_w(T0, Tc, Tout, house_power_rating_w);
-            const bool demand_present =
-                id(external_heat_demand_selected).has_state() && !isnan(id(external_heat_demand_selected).state);
-            const oq_power_house::Feedforward feedforward = oq_power_house::select_feedforward(
-                P_model, demand_present ? id(external_heat_demand_selected).state : NAN, demand_present,
-                house_power_rating_w);
-            const float P_house = feedforward.house_power_w;
-            id(oq_phouse_demand_external) = feedforward.external;
-
-            const float comfort_below = clampf(id(ph_comfort_band_below_c).state, 0.0f, 2.0f);
-            const float comfort_above = clampf(id(ph_comfort_band_above_c).state, 0.0f, 2.0f);
-            const float Tr_low_base = Trsp - comfort_below;
-            const float Tr_high_base = Trsp + comfort_above;
-            const float Tr_mid_base = Tr_low_base + 0.5f * (Tr_high_base - Tr_low_base);
-
-            uint32_t last = id(oq_phouse_last_ms);
-            float lastw = id(oq_phouse_last_w);
-            if (last == 0) {
-              last = now_ms;
-              lastw = P_house;
-            }
-
-            const float dt_power_s = (now_ms >= last) ? ((now_ms - last) / 1000.0f) : 0.0f;
-            const float comfort_memory_max_c = clampf(0.05f + (0.50f * comfort_above), 0.08f, 0.20f);
-            float comfort_memory_c = id(oq_phouse_comfort_memory_c);
-            if (isnan(comfort_memory_c) || comfort_memory_c < 0.0f) comfort_memory_c = 0.0f;
-
-            if (Tr < Tr_low_base) {
-              const float undershoot_norm = clampf((Tr_low_base - Tr) / 0.45f, 0.0f, 1.0f);
-              const float build_min_c_per_min = comfort_memory_max_c / 90.0f;
-              const float build_max_c_per_min = comfort_memory_max_c / 24.0f;
-              const float build_c_per_s =
-                  (build_min_c_per_min + (build_max_c_per_min - build_min_c_per_min) * undershoot_norm) /
-                  seconds_per_minute;
-              comfort_memory_c += build_c_per_s * dt_power_s;
-            } else if (Tr <= Tr_mid_base) {
-              // Keep the accumulated comfort memory through the colder half of
-              // the band so the room does not drift persistently low.
-            } else if (Tr <= Tr_high_base) {
-              const float decay_c_per_s = (comfort_memory_max_c / 40.0f) / seconds_per_minute;
-              comfort_memory_c -= decay_c_per_s * dt_power_s;
-            } else {
-              const float fast_decay_c_per_s = (comfort_memory_max_c / 12.0f) / seconds_per_minute;
-              comfort_memory_c -= fast_decay_c_per_s * dt_power_s;
-            }
-            comfort_memory_c = clampf(comfort_memory_c, 0.0f, comfort_memory_max_c);
-            id(oq_phouse_comfort_memory_c) = comfort_memory_c;
-
-            const float Trsp_effective = Trsp + comfort_memory_c;
-            const float Tr_low = Trsp_effective - comfort_below;
-
-            float e = 0.0f;
-            if (Tr < Tr_low) e = Tr_low - Tr;
-            else if (Tr > Trsp) e = Trsp - Tr;
-
-            const float temperature_reaction_w_per_k = id(ph_kp_w_per_k).state;
-            float P_raw = P_house + temperature_reaction_w_per_k * e;
-            P_raw = clampf(P_raw, 0.0f, house_power_rating_w);
-
-            const float rise_time_min = clampf(id(ph_demand_rise_time_min).state, 2.0f, 20.0f);
-            const float fall_time_min = clampf(id(ph_demand_fall_time_min).state, 1.0f, 10.0f);
-            const float up = (house_power_rating_w / rise_time_min) / seconds_per_minute;
-            const float dn = (house_power_rating_w / fall_time_min) / seconds_per_minute;
-
-            float P_limited = P_raw;
-            if (dt_power_s > 0.0f) {
-              if (P_raw > lastw && up > 0.0f) {
-                P_limited = std::min(P_raw, lastw + up * dt_power_s);
-              } else if (P_raw < lastw && dn > 0.0f) {
-                P_limited = std::max(P_raw, lastw - dn * dt_power_s);
-              }
-            }
-
-            const float P_effective = P_limited * id(oq_water_temp_limit_factor);
-            id(oq_phouse_req_w) = P_effective;
-            id(oq_phouse_last_w) = P_effective;
-            id(oq_phouse_last_ms) = now_ms;
-            id(oq_demand_raw) = clamp_demand((int) lroundf(${oq_strategy_demand_max_f} * (P_effective / house_power_rating_w)));
-          }
-
-          int raw = id(oq_demand_raw);
-          raw = std::max(0, std::min(demand_max_f, raw));
-
-          int ramp_up_step_min = (int) lroundf(id(oq_demand_filter_ramp_up_step_min).state);
-          if (ramp_up_step_min < 1) ramp_up_step_min = 1;
-          if (ramp_up_step_min > demand_max_f) ramp_up_step_min = demand_max_f;
-
-          int f = id(oq_demand_filtered);
-          f = std::max(0, std::min(demand_max_f, f));
-          id(oq_demand_filtered_prev) = f;
-
-          float ramp_budget = id(oq_demand_filter_ramp_up_budget) + (((float) ramp_up_step_min) / 60.0f) * dt_s;
-          if (ramp_budget > (float) demand_max_f) ramp_budget = (float) demand_max_f;
-          int ramp_steps = (int) floorf(ramp_budget);
-          if (ramp_steps < 0) ramp_steps = 0;
-          id(oq_demand_filter_ramp_up_budget) = ramp_budget - (float) ramp_steps;
-
-          if (raw > f) {
-            if (ramp_steps > 0) f = std::min(f + ramp_steps, raw);
-          } else if (raw == 0 && f == 1) {
-            f = 0;
-          } else if (raw <= (f - 2)) {
-            f = raw;
-          }
-
-          f = std::max(0, std::min(demand_max_f, f));
-          id(oq_demand_filtered) = f;
-          id(oq_heating_demand_filtered) = f;
+          const bool external_valid = id(external_heat_demand_selected).has_state();
+          const oq_power_house::DemandInput demand_input{
+              now_ms, id(outside_temp_selected).state, id(house_cold_temp_c).state,
+              id(house_zero_power_temp_c).state, id(house_rated_power_w).state, id(room_temp_selected).state,
+              id(room_setpoint_selected).state, id(external_heat_demand_selected).state,
+              id(oq_water_temp_limit_factor), external_valid};
+          const oq_power_house::DemandTuning demand_tuning{
+              ${oq_temp_guard_delta_c}f, id(ph_kp_w_per_k).state, id(ph_comfort_band_below_c).state,
+              id(ph_comfort_band_above_c).state, id(ph_demand_rise_time_min).state,
+              id(ph_demand_fall_time_min).state, demand_max_f};
+          const oq_power_house::DemandState demand_state{
+              id(oq_phouse_last_w), id(oq_phouse_last_ms), id(oq_phouse_comfort_memory_c)};
+          const auto demand = oq_power_house::decide_demand(demand_input, demand_tuning, demand_state);
+          id(oq_phouse_req_w) = demand.requested_w;
+          id(oq_phouse_last_w) = demand.next.last_w;
+          id(oq_phouse_last_ms) = demand.next.last_ms;
+          id(oq_phouse_comfort_memory_c) = demand.next.comfort_memory_c;
+          id(oq_phouse_demand_external) = demand.external;
+          id(oq_demand_raw) = demand.raw_demand;
+          const auto filtered = oq_power_house::filter_demand(
+              demand.raw_demand, id(oq_demand_filtered), id(oq_demand_filter_ramp_up_budget),
+              id(oq_demand_filter_ramp_up_step_min).state, cadence.dt_s, demand_max_f);
+          id(oq_demand_filtered_prev) = filtered.previous;
+          id(oq_demand_filter_ramp_up_budget) = filtered.ramp_budget;
+          id(oq_demand_filtered) = filtered.filtered;
+          id(oq_heating_demand_filtered) = filtered.filtered;
+          int f = filtered.filtered;
 
           int f_cap = id(oq_power_cap_f);
           f_cap = std::max(0, std::min(demand_max_f, f_cap));
@@ -693,10 +577,10 @@ interval:
               if (on_hold < 1) on_hold = 1;
               if (off_hold < 1) off_hold = 1;
 
-              if (f >= dual_on_f) id(oq_dual_hp_enable_hold_elapsed_accum_min) += dt_s / 60.0f;
+              if (f >= dual_on_f) id(oq_dual_hp_enable_hold_elapsed_accum_min) += cadence.dt_s / 60.0f;
               else id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
 
-              if (f <= dual_off_f) id(oq_dual_hp_disable_hold_elapsed_accum_min) += dt_s / 60.0f;
+              if (f <= dual_off_f) id(oq_dual_hp_disable_hold_elapsed_accum_min) += cadence.dt_s / 60.0f;
               else id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
 
               if (!id(oq_dual_hp_enabled) && id(oq_dual_hp_enable_hold_elapsed_accum_min) >= (float) on_hold) {
@@ -1183,5 +1067,5 @@ interval:
           snprintf(
             debug_buf, sizeof(debug_buf),
             "ph f=%d raw=%d preq=%.0f owner=%d reason=%d",
-            f, raw, id(oq_phouse_req_w), request_owner_hp, request_reason_code);
+            f, demand.raw_demand, id(oq_phouse_req_w), request_owner_hp, request_reason_code);
           ESP_LOGD("quatt.strategy", "%s", debug_buf);

--- a/scripts/tests/test_power_house_demand_contract.py
+++ b/scripts/tests/test_power_house_demand_contract.py
@@ -1,0 +1,12 @@
+import pathlib, unittest
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+FILES = (ROOT / "openquatt/oq_power_house_strategy.yaml", ROOT / "openquatt/includes/control/oq_power_house_demand_logic.h", ROOT / "tests/host/oq_power_house_demand_logic_test.cpp", pathlib.Path(__file__))
+class PowerHouseDemandContractTest(unittest.TestCase):
+    def test_delegation_and_line_budget(self) -> None:
+        text = FILES[0].read_text()
+        positions = [text.index(marker) for marker in ("decide_cadence(", "decide_demand(", "filter_demand(")]
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn("id(oq_ph_request_last_loop_ms) = now_ms == 0 ? UINT32_MAX : now_ms;", text)
+        self.assertNotIn("now_ms > id(oq_ph_request_last_loop_ms)", text)
+        self.assertNotIn("float ramp_budget = id(oq_demand_filter_ramp_up_budget)", text)
+        self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in FILES), 1415)

--- a/tests/host/oq_power_house_demand_logic_test.cpp
+++ b/tests/host/oq_power_house_demand_logic_test.cpp
@@ -5,145 +5,155 @@
 #include "../../openquatt/includes/control/oq_power_house_demand_logic.h"
 
 namespace {
-
-bool nearly_equal(float a, float b) { return fabsf(a - b) < 0.01f; }
-
-constexpr float kT0 = 16.0f;
-constexpr float kTc = -10.0f;
-constexpr float kRated = 7020.0f;
-
-// One shared operating point at 3 degC outside, i.e. half rated power.
-float reference_modelled_w() { return oq_power_house::modelled_house_power_w(kT0, kTc, 3.0f, kRated); }
-
-// The modelled feedforward is the reference every fallback must return to.
-void test_modelled_house_power() {
-  using oq_power_house::modelled_house_power_w;
-
-  // No heating demand at and above the zero-power outdoor temperature.
-  assert(nearly_equal(modelled_house_power_w(kT0, kTc, kT0, kRated), 0.0f));
-  assert(nearly_equal(modelled_house_power_w(kT0, kTc, kT0 + 5.0f, kRated), 0.0f));
-
-  // Full rated power at and below the full-load point.
-  assert(nearly_equal(modelled_house_power_w(kT0, kTc, kTc, kRated), kRated));
-  assert(nearly_equal(modelled_house_power_w(kT0, kTc, kTc - 10.0f, kRated), kRated));
-
-  // Linear in between: the midpoint of the outdoor range is half the power.
-  assert(nearly_equal(modelled_house_power_w(kT0, kTc, 3.0f, kRated), kRated * 0.5f));
-
-  // An unusable house model yields no modelled value at all.
-  assert(isnan(modelled_house_power_w(kTc, kT0, 3.0f, kRated)));
-  assert(isnan(modelled_house_power_w(kT0, kTc, NAN, kRated)));
-  assert(isnan(modelled_house_power_w(kT0, kT0, 3.0f, kRated)));
+using namespace oq_power_house;
+bool near(float actual, float expected) { return fabsf(actual - expected) < 0.01f; }
+DemandInput input() { return {60001U, 3.0f, -10.0f, 16.0f, 6000.0f, 20.0f, 20.0f, NAN, 1.0f, false}; }
+DemandTuning tuning() { return {0.5f, 3000.0f, 0.1f, 0.3f, 10.0f, 5.0f, 20}; }
+void test_model_and_feedforward() {
+  struct ModelCase {
+    float outside_c, expected_w;
+  };
+  const ModelCase models[] = {{21.0f, 0.0f}, {16.0f, 0.0f}, {3.0f, 3000.0f}, {-10.0f, 6000.0f}, {-20.0f, 6000.0f}};
+  for (const auto& test : models)
+    assert(near(modelled_house_power_w(16.0f, -10.0f, test.outside_c, 6000.0f), test.expected_w));
+  assert(isnan(modelled_house_power_w(16.0f, -10.0f, NAN, 6000.0f)));
+  assert(isnan(modelled_house_power_w(16.0f, -10.0f, 3.0f, 0.0f)));
+  assert(isnan(modelled_house_power_w(16.0f, 16.0f, 3.0f, 6000.0f)));
+  assert(isnan(modelled_house_power_w(-10.0f, 16.0f, 3.0f, 6000.0f)));
+  struct FeedCase {
+    float external_w, rated_w, expected_w;
+    bool present, external;
+  };
+  const FeedCase cases[] = {{3000, 6000, 3000, true, true}, {0, 6000, 0, true, true},
+                            {-500, 6000, 0, true, true},    {6000, 6000, 6000, true, true},
+                            {9000, 6000, 6000, true, true}, {3000, 6000, 2500, false, false},
+                            {NAN, 6000, 2500, true, false}, {INFINITY, 6000, 2500, true, false},
+                            {3000, 0, 2500, true, false},   {3000, NAN, 2500, true, false}};
+  for (const auto& test : cases) {
+    const auto result = select_feedforward(2500.0f, test.external_w, test.present, test.rated_w);
+    assert(result.external == test.external && near(result.house_power_w, test.expected_w));
+  }
 }
-
-// An absent or unusable external demand must degrade to the modelled value,
-// never to zero: a dropped planner link falls back to today's behaviour.
-void test_fallback_to_model() {
-  using oq_power_house::select_feedforward;
-
-  const float modelled_w = reference_modelled_w();
-
-  const auto no_source = select_feedforward(modelled_w, NAN, false, kRated);
-  assert(!no_source.external);
-  assert(nearly_equal(no_source.house_power_w, modelled_w));
-
-  // A valid flag with a NaN payload is still not a usable demand.
-  const auto nan_payload = select_feedforward(modelled_w, NAN, true, kRated);
-  assert(!nan_payload.external);
-  assert(nearly_equal(nan_payload.house_power_w, modelled_w));
-
-  const auto infinite_payload = select_feedforward(modelled_w, INFINITY, true, kRated);
-  assert(!infinite_payload.external);
-  assert(nearly_equal(infinite_payload.house_power_w, modelled_w));
-
-  // Without a usable rating there is no scale to clamp against, so the model
-  // stays in charge.
-  const auto no_rating = select_feedforward(modelled_w, 3000.0f, true, 0.0f);
-  assert(!no_rating.external);
-  assert(nearly_equal(no_rating.house_power_w, modelled_w));
-
-  const auto nan_rating = select_feedforward(modelled_w, 3000.0f, true, NAN);
-  assert(!nan_rating.external);
-  assert(nearly_equal(nan_rating.house_power_w, modelled_w));
+void test_cache_and_cadence_rollover() {
+  constexpr uint32_t hold_ms = 300000U;
+  struct CacheCase {
+    uint8_t cached, current;
+    float watts;
+    uint32_t cached_ms, now_ms, window_ms;
+    bool expected;
+  };
+  const CacheCase cache[] = {
+      {kDemandSourceHaInput, kDemandSourceHaInput, 3000, UINT32_MAX - 1000U, 1000U, hold_ms, true},
+      {kDemandSourceApiInput, kDemandSourceHaInput, 3000, 1000U, 2000U, hold_ms, false},
+      {kDemandSourceHaInput, kDemandSourceApiInput, 3000, 1000U, 2000U, hold_ms, false},
+      {kDemandSourceNone, kDemandSourceHaInput, 3000, 1000U, 2000U, hold_ms, false},
+      {kDemandSourceHaInput, kDemandSourceNone, 3000, 1000U, 2000U, hold_ms, false},
+      {kDemandSourceHaInput, kDemandSourceHaInput, 3000, 0, 2000U, hold_ms, false},
+      {kDemandSourceHaInput, kDemandSourceHaInput, 3000, 1000U, 1000U + hold_ms, hold_ms, false},
+      {kDemandSourceHaInput, kDemandSourceHaInput, 3000, 1000U, 2000U, 0, false},
+      {kDemandSourceHaInput, kDemandSourceHaInput, NAN, 1000U, 2000U, hold_ms, false}};
+  for (const auto& test : cache)
+    assert(hold_cached_demand(test.cached, test.current, test.watts, test.cached_ms, test.now_ms, test.window_ms) ==
+           test.expected);
+  struct Case {
+    uint32_t now_ms, last_ms, target_ms;
+    bool due;
+    float dt_s;
+  };
+  const Case cases[] = {{4000, 0, 60000, true, 60},
+                        {59999, 1, 60000, false, 0},
+                        {60001, 1, 60000, true, 60},
+                        {1000, UINT32_MAX - 1000U, 3000, false, 0},
+                        {29999, UINT32_MAX - 30000U, 60000, true, 60},
+                        {5000, UINT32_MAX, 60000, false, 0},
+                        {60000, 1, 0, false, 0}};
+  for (const auto& test : cases) {
+    const auto result = decide_cadence(test.now_ms, test.last_ms, test.target_ms);
+    assert(result.due == test.due && near(result.dt_s, test.dt_s));
+  }
 }
-
-// A valid external demand replaces the feedforward and is clamped to the same
-// [0, rated] window that P_raw already uses.
-void test_external_demand() {
-  using oq_power_house::select_feedforward;
-
-  const float modelled_w = reference_modelled_w();
-
-  const auto normal = select_feedforward(modelled_w, 3000.0f, true, kRated);
-  assert(normal.external);
-  assert(nearly_equal(normal.house_power_w, 3000.0f));
-
-  // Zero watt is a legitimate request: a planner must be able to say "no heat
-  // right now". It must not be mistaken for a missing value.
-  const auto zero = select_feedforward(modelled_w, 0.0f, true, kRated);
-  assert(zero.external);
-  assert(nearly_equal(zero.house_power_w, 0.0f));
-
-  const auto above_rated = select_feedforward(modelled_w, kRated + 5000.0f, true, kRated);
-  assert(above_rated.external);
-  assert(nearly_equal(above_rated.house_power_w, kRated));
-
-  const auto negative = select_feedforward(modelled_w, -500.0f, true, kRated);
-  assert(negative.external);
-  assert(nearly_equal(negative.house_power_w, 0.0f));
-
-  const auto exactly_rated = select_feedforward(modelled_w, kRated, true, kRated);
-  assert(exactly_rated.external);
-  assert(nearly_equal(exactly_rated.house_power_w, kRated));
+void test_demand_finite_contract() {
+  const float bad[] = {NAN, INFINITY, -INFINITY};
+  float DemandInput::* input_fields[] = {
+      &DemandInput::outside_c, &DemandInput::cold_c,     &DemandInput::zero_power_c,      &DemandInput::rated_w,
+      &DemandInput::room_c,    &DemandInput::setpoint_c, &DemandInput::water_limit_factor};
+  float DemandTuning::* tuning_fields[] = {&DemandTuning::temperature_guard_c, &DemandTuning::reaction_w_per_k,
+                                           &DemandTuning::comfort_below_c,     &DemandTuning::comfort_above_c,
+                                           &DemandTuning::rise_time_min,       &DemandTuning::fall_time_min};
+  for (float value : bad) {
+    for (auto field : input_fields) {
+      auto in = input();
+      in.*field = value;
+      const auto out = decide_demand(in, tuning(), {1000, 1000, 0.1f});
+      assert(!out.valid && out.requested_w == 0 && out.raw_demand == 0 && out.next.last_w == 0);
+      assert(out.next.last_ms == in.now_ms && out.next.comfort_memory_c == 0);
+    }
+    for (auto field : tuning_fields) {
+      auto cfg = tuning();
+      cfg.*field = value;
+      assert(!decide_demand(input(), cfg, {}).valid);
+    }
+  }
+  for (float value : bad) {
+    auto in = input();
+    in.external_valid = true;
+    in.external_w = value;
+    const auto out = decide_demand(in, tuning(), {});
+    assert(out.valid && !out.external && near(out.requested_w, 3000));
+  }
+  auto invalid = input();
+  invalid.room_c = NAN;
+  const auto stopped = decide_demand(invalid, tuning(), {3000, 1U, 0.1f});
+  assert(stopped.next.last_w == 0 && stopped.next.comfort_memory_c == 0 && stopped.next.last_ms == invalid.now_ms);
+  auto recovered = input();
+  recovered.now_ms = stopped.next.last_ms + 60000U;
+  assert(near(decide_demand(recovered, tuning(), stopped.next).requested_w, 600.0f));
+  assert(!decide_demand({60001U, 3, 10, 9, 6000, 20, 20, NAN, 1, false}, {-2, 3000, 0.1f, 0.3f, 10, 5, 20}, {}).valid);
+  assert(!decide_demand({60001U, 3, -10, 16, 6000, -0x1.fffffep+127f, 0x1.fffffep+127f, NAN, 1, false},
+                        {0.5f, 0, 0.1f, 0.3f, 10, 5, 20}, {})
+              .valid);
 }
-
-// A cached demand belongs to the source that produced it. After a source change
-// the cache must not be replayed, or a stale sample from the previous source
-// keeps driving the request for a full hold window.
-void test_cached_demand_hold() {
-  using oq_power_house::hold_cached_demand;
-  using oq_power_house::kDemandSourceApiInput;
-  using oq_power_house::kDemandSourceHaInput;
-  using oq_power_house::kDemandSourceNone;
-
-  constexpr uint32_t kHoldMs = 300000UL;
-  constexpr uint32_t kCachedMs = 1000UL;
-  constexpr float kCachedW = 3000.0f;
-
-  // A brief dropout of the same source is exactly what the hold is for.
-  assert(
-      hold_cached_demand(kDemandSourceHaInput, kDemandSourceHaInput, kCachedW, kCachedMs, kCachedMs + 1000UL, kHoldMs));
-
-  // Switching away from API input must not replay the API sample under HA input.
-  assert(!hold_cached_demand(kDemandSourceApiInput, kDemandSourceHaInput, kCachedW, kCachedMs, kCachedMs + 1000UL,
-                             kHoldMs));
-  assert(!hold_cached_demand(kDemandSourceHaInput, kDemandSourceApiInput, kCachedW, kCachedMs, kCachedMs + 1000UL,
-                             kHoldMs));
-
-  // Nothing cached yet, or cached before any source was known.
-  assert(
-      !hold_cached_demand(kDemandSourceNone, kDemandSourceHaInput, kCachedW, kCachedMs, kCachedMs + 1000UL, kHoldMs));
-  assert(
-      !hold_cached_demand(kDemandSourceHaInput, kDemandSourceNone, kCachedW, kCachedMs, kCachedMs + 1000UL, kHoldMs));
-  assert(!hold_cached_demand(kDemandSourceHaInput, kDemandSourceHaInput, kCachedW, 0, kCachedMs, kHoldMs));
-
-  // An expired or disabled hold falls through to the house model.
-  assert(!hold_cached_demand(kDemandSourceHaInput, kDemandSourceHaInput, kCachedW, kCachedMs, kCachedMs + kHoldMs,
-                             kHoldMs));
-  assert(!hold_cached_demand(kDemandSourceHaInput, kDemandSourceHaInput, kCachedW, kCachedMs, kCachedMs + 1000UL, 0));
-  assert(!hold_cached_demand(kDemandSourceHaInput, kDemandSourceHaInput, NAN, kCachedMs, kCachedMs + 1000UL, kHoldMs));
-
-  // Unsigned elapsed-time arithmetic keeps the hold valid across millis() wrap.
-  assert(
-      hold_cached_demand(kDemandSourceHaInput, kDemandSourceHaInput, kCachedW, UINT32_MAX - 1000UL, 1000UL, kHoldMs));
+void test_demand_slew_and_limits() {
+  auto rise = input();
+  rise.room_c = 18.0f;
+  assert(near(decide_demand(rise, tuning(), {0, 1U, 0}).requested_w, 600.0f));
+  auto fall = input();
+  fall.room_c = 22.0f;
+  assert(near(decide_demand(fall, tuning(), {6000, 1U, 0}).requested_w, 4800.0f));
+  rise.now_ms = 29999U;
+  assert(near(decide_demand(rise, tuning(), {0, UINT32_MAX - 30000U, 0}).requested_w, 600.0f));
+  auto limited = input();
+  limited.water_limit_factor = 0.5f;
+  const auto out = decide_demand(limited, tuning(), {});
+  assert(out.valid && near(out.requested_w, 1500.0f) && out.raw_demand == 5);
+  const auto colder = decide_demand(rise, tuning(), {3000, 1U, 0});
+  assert(colder.next.comfort_memory_c > 0.0f);
+  auto warm = input();
+  warm.room_c = 22.0f;
+  assert(decide_demand(warm, tuning(), {3000, 1U, 0.1f}).next.comfort_memory_c < 0.1f);
 }
-
+void test_filter_table() {
+  struct Case {
+    int raw, current;
+    float budget, step_min, dt_s;
+    int expected;
+    float expected_budget;
+  };
+  const Case cases[] = {{10, 2, 0, 1, 60, 3, 0},   {10, 2, 0, 1, 30, 2, 0.5f},     {10, 2, 0, 20, 60, 10, 0},
+                        {4, 5, 0, 1, 60, 5, 0},    {3, 5, 0, 1, 60, 3, 0},         {0, 1, 0, 1, 60, 0, 0},
+                        {10, 2, NAN, 1, 60, 2, 0}, {10, 2, 0, INFINITY, 60, 2, 0}, {10, 2, 0, 1, INFINITY, 2, 0}};
+  for (const auto& test : cases) {
+    const auto out = filter_demand(test.raw, test.current, test.budget, test.step_min, test.dt_s, 20);
+    assert(out.previous == test.current && out.filtered == test.expected &&
+           near(out.ramp_budget, test.expected_budget));
+  }
+}
 }  // namespace
-
 int main() {
-  test_modelled_house_power();
-  test_fallback_to_model();
-  test_external_demand();
-  test_cached_demand_hold();
+  test_model_and_feedforward();
+  test_cache_and_cadence_rollover();
+  test_demand_finite_contract();
+  test_demand_slew_and_limits();
+  test_filter_table();
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst cadence, warmtevraag, comfortcorrectie, slew-limiting en demandfilter uit `oq_power_house_strategy.yaml` naar een pure, host-testbare C++-kern.
- Maakt millis-rollover en ongeldige of afgeleide niet-finite waarden expliciet fail-closed, met gecontroleerde ramp-up na herstel.
- Houdt het contract compact: Power House-YAML daalt op actuele `dev` van 1187 naar 1071 regels; alle vier gewijzigde/geteste bestanden samen blijven exact op 1415 regels.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Het normale Power House-regelgedrag en de Single/Duo-dispatch blijven gelijk. Bij ongeldige configuratie/sensorwaarden valt de vraag nu volledig dicht en herstelt zij via de bestaande stijgsnelheid. Cadence en vraag-slew blijven correct over `millis()`-rollover. Er zijn geen entity-, opslag- of migratiewijzigingen.

## Achtergrond

Dit is het eerste zelfstandige Power House-deel van de YAML-naar-C++-opsplitsing. De resterende optimizer/dispatch en de korte defrost/oil-return-eventsampling blijven bewust vervolgwerk.

De complete diff is opnieuw op actuele `dev` opgebouwd en gecontroleerd op normale model/feedforward-pariteit, comfortgeheugen, stijg-/daalsnelheid, waterbegrenzing, filtergedrag, invalid-input herstel, rollover, inactief/actief lifecycle, Single/Duo-compilatie en fresh-install/default state. Een afzonderlijke koude review vond geen blockers. De LOC-gate is na de eerdere upstream YAML-reductie aangescherpt van 1466 naar 1415 regels.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen gebruikersgerichte configuratie, entity of bediening verandert; dit is een interne regelkernextractie met extra veiligheidscontracten.

## Validatie

- `npm run check:cpp-format` — groen, 174 C/C++-bestanden.
- `scripts/run_host_regression_tests.sh` — 46/46 groen.
- `npm run check:python-contracts` — 145/145 groen.
- `python3 scripts/dev.py validate --config-only` — alle zes configuraties groen: Waveshare Single/Duo WiFi, listener Single/Duo en Q Single/Duo.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — groen op actuele `dev`; DIRAM 211035 bytes, image 2181979 bytes.
- `git diff --check` en LOC-gate 1415 <= 1415 — groen.
- Afzonderlijke koude diff-review — blocker-vrij.
- Bestaande HIL op de controller met V1.5 Duo-simulator:
  - 3000 W API-feedforward werd als `external` herkend; waterlimiter en demandfilter bouwden gecontroleerd op.
  - Normale lifecycle doorliep CM0 → CM1 → CM2, circa 802 L/h per gesimuleerde ODU, runtime-lead HP2 en F2 als hoogste aanvraag.
  - Ongeldig huiscontract (`cold=5`, `zero-power=5`) viel in dezelfde controlcyclus naar `P_req/raw/filtered=0`.
  - Na herstel volgde de verwachte rise-limited eerste stap van circa 878 W/F1; een stale API-kamertemperatuur viel eveneens fail-closed naar nul.
  - Minimum-runtime hield HP2 veilig op F1 en bevestigde daarna autonoom de stop.
  - Eindtoestand hersteld: oorspronkelijke bronselecties/configwaarden, CM0, beide compressors F0, alle ODU-injecties uit en `drop/exc/bad_addr/bad_write/cap=0`; OpenTherm queue/overlap/TX-fouttellers bleven nul.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe globale state, heap-/PSRAM-allocaties, taken of netwerkbuffers. De contracttypen zijn kleine POD-waarden binnen de bestaande control-lambda en worden inline gecompileerd; de firmwarebuild toont geen nieuwe statische geheugenklasse.
