### PR TITLE
YAML naar C++: Heating Curve – vraagregime

### DIFF
--- a/openquatt/includes/control/oq_heating_curve_logic.h
+++ b/openquatt/includes/control/oq_heating_curve_logic.h
@@ -47,6 +47,41 @@ struct RestartDecision {
   RestartReason reason = RESTART_NONE;
 };
 
+enum StopReason : uint8_t {
+  STOP_NONE = 0,
+  STOP_NORMAL = 1,
+  STOP_LOW_LOAD = 2,
+};
+struct OilReturnDecision {
+  uint32_t hold_until_ms = 0;
+  bool mask_active = false;
+};
+struct DemandState {
+  bool heat_request_active = false;
+  uint32_t stop_arm_ms = 0;
+  uint32_t off_since_ms = 0;
+  bool restart_inhibit_active = false;
+  bool restart_blocked_by_room = false;
+  int regime_code = 0;
+};
+struct DemandInput {
+  uint32_t now_ms = 0;
+  float pid_output = NAN, supply_target_c = NAN, supply_c = NAN;
+  float room_c = NAN, room_setpoint_c = NAN;
+  bool room_data_fresh = false;
+  bool oil_return_mask_active = false;
+  int applied_total_level = 0;
+  int demand_max = 0;
+};
+struct DemandDecision {
+  DemandState next;
+  float demand_continuous = NAN;
+  int demand = 0, demand_pre_guardrail = 0;
+  bool valid = false;
+  StopReason stop_reason = STOP_NONE;
+  RestartReason restart_reason = RESTART_NONE;
+};
+
 struct DispatchCandidate {
   bool valid = false;
   int hp1_level = 0;
@@ -113,7 +148,7 @@ inline RestartDecision evaluate_restart(bool below_restart_band, bool deep_under
                                         bool room_data_fresh, float room_c, float room_sp_c, float room_overheat_off_c,
                                         float room_resume_heat_c) {
   RestartDecision decision;
-  const bool room_values_valid = room_data_fresh && !isnan(room_c) && !isnan(room_sp_c);
+  const bool room_values_valid = room_data_fresh && isfinite(room_c) && isfinite(room_sp_c);
   const bool room_requests_heat = room_values_valid && room_c <= (room_sp_c - room_resume_heat_c);
   if (room_requests_heat) {
     decision.restart = true;
@@ -137,6 +172,131 @@ inline RestartDecision evaluate_restart(bool below_restart_band, bool deep_under
   decision.restart = true;
   decision.reason = RESTART_WATER_BAND;
   return decision;
+}
+
+inline uint32_t timestamp_ms(uint32_t now_ms) { return now_ms == 0 ? UINT32_MAX : now_ms; }
+
+inline OilReturnDecision update_oil_return_hold(uint32_t now_ms, bool oil_return_active, uint32_t hold_until_ms,
+                                                uint32_t hold_ms) {
+  if (oil_return_active) {
+    uint32_t deadline_ms = now_ms + hold_ms;
+    if (deadline_ms == 0) deadline_ms = 1;
+    return {deadline_ms, true};
+  }
+  if (hold_until_ms != 0 && static_cast<int32_t>(hold_until_ms - now_ms) > 0) return {hold_until_ms, true};
+  return {};
+}
+
+inline DemandDecision decide_demand(const DemandInput& in, const ControlProfileTuning& requested_tuning,
+                                    const DemandState& state) {
+  DemandDecision out;
+  const float tuning_values[] = {
+      requested_tuning.start_delta_c,      requested_tuning.stop_delta_c,    requested_tuning.room_overheat_off_c,
+      requested_tuning.room_resume_heat_c, requested_tuning.restart_delta_c, requested_tuning.restart_bypass_extra_c,
+      requested_tuning.recovery_enter_c,   requested_tuning.recovery_exit_c, requested_tuning.trim_start_c};
+  bool tuning_valid = true;
+  for (float value : tuning_values) tuning_valid = tuning_valid && isfinite(value);
+  if (in.demand_max <= 0 || !isfinite(in.pid_output) || !isfinite(in.supply_target_c) || !isfinite(in.supply_c) ||
+      !tuning_valid) {
+    return out;
+  }
+
+  ControlProfileTuning tuning = requested_tuning;
+  tuning.stop_delta_c = std::max(tuning.stop_delta_c, tuning.start_delta_c + 0.10f);
+  tuning.restart_delta_c = std::max(tuning.restart_delta_c, tuning.start_delta_c + 0.05f);
+  tuning.restart_bypass_extra_c = std::max(tuning.restart_bypass_extra_c, 0.20f);
+  tuning.off_pid_max_f = std::max(0, std::min(in.demand_max, tuning.off_pid_max_f));
+
+  float demand_continuous = in.pid_output <= 0.0f   ? 0.0f
+                            : in.pid_output >= 1.0f ? static_cast<float>(in.demand_max)
+                                                    : in.pid_output * static_cast<float>(in.demand_max);
+  int demand = std::max(0, std::min(in.demand_max, static_cast<int>(lroundf(demand_continuous))));
+  out.demand_pre_guardrail = demand;
+  out.next = state;
+  out.next.restart_inhibit_active = out.next.restart_blocked_by_room = false;
+
+  const bool room_valid = in.room_data_fresh && isfinite(in.room_c) && isfinite(in.room_setpoint_c);
+  const bool room_warm_for_off = room_valid && in.room_c >= in.room_setpoint_c + tuning.room_overheat_off_c;
+  const bool room_allows_off = !room_valid || room_warm_for_off;
+  const bool normal_stop = !in.oil_return_mask_active && in.supply_c >= in.supply_target_c + tuning.stop_delta_c &&
+                           demand <= tuning.off_pid_max_f && room_allows_off;
+  const bool low_load_stop = !in.oil_return_mask_active && state.heat_request_active && state.regime_code == 2 &&
+                             out.demand_pre_guardrail <= 0 &&
+                             (!room_valid || in.room_c >= in.room_setpoint_c - tuning.room_resume_heat_c) &&
+                             in.supply_c >= in.supply_target_c + 0.25f;
+
+  if (out.next.heat_request_active) {
+    if (normal_stop || low_load_stop) {
+      const uint32_t confirm_ms =
+          low_load_stop ? std::min<uint32_t>(tuning.off_confirm_ms, 90000UL) : tuning.off_confirm_ms;
+      if (out.next.stop_arm_ms == 0) {
+        out.next.stop_arm_ms = timestamp_ms(in.now_ms);
+      } else if (static_cast<uint32_t>(in.now_ms - out.next.stop_arm_ms) >= confirm_ms) {
+        out.next.heat_request_active = false;
+        out.next.stop_arm_ms = 0;
+        out.next.off_since_ms = timestamp_ms(in.now_ms);
+        out.stop_reason = low_load_stop ? STOP_LOW_LOAD : STOP_NORMAL;
+      }
+    } else {
+      out.next.stop_arm_ms = 0;
+    }
+  } else {
+    out.next.stop_arm_ms = 0;
+    const bool off_age_known = out.next.off_since_ms != 0;
+    if (!off_age_known) out.next.off_since_ms = timestamp_ms(in.now_ms);
+    const bool below_restart_band = in.supply_c <= in.supply_target_c - tuning.restart_delta_c;
+    const bool deep_undershoot =
+        in.supply_c <= in.supply_target_c - (tuning.restart_delta_c + tuning.restart_bypass_extra_c);
+    const bool off_lock_active = off_age_known && tuning.off_reentry_min_ms > 0 &&
+                                 static_cast<uint32_t>(in.now_ms - out.next.off_since_ms) < tuning.off_reentry_min_ms;
+    const auto restart = evaluate_restart(below_restart_band, deep_undershoot, off_lock_active, room_valid, in.room_c,
+                                          in.room_setpoint_c, tuning.room_overheat_off_c, tuning.room_resume_heat_c);
+    out.next.restart_inhibit_active = restart.blocked_by_off_lock;
+    out.next.restart_blocked_by_room = restart.blocked_by_room;
+    out.restart_reason = restart.reason;
+    if (restart.restart) {
+      out.next.heat_request_active = true;
+      out.next.off_since_ms = 0;
+    }
+  }
+
+  if (!out.next.heat_request_active) {
+    demand = 0;
+    out.next.regime_code = 0;
+  } else {
+    out.next.restart_inhibit_active = false;
+    out.next.restart_blocked_by_room = false;
+    out.next.off_since_ms = 0;
+    demand = std::max(1, demand);
+    const float supply_error_c = in.supply_target_c - in.supply_c;
+    int regime = out.next.regime_code;
+    if (regime != 1 && regime != 2) regime = supply_error_c >= tuning.recovery_enter_c ? 1 : 2;
+    if (regime == 1 && supply_error_c <= tuning.recovery_exit_c) {
+      regime = 2;
+    } else if (regime == 2 && !in.oil_return_mask_active && supply_error_c >= tuning.recovery_enter_c && demand >= 8 &&
+               (!room_valid || in.room_c <= in.room_setpoint_c + tuning.trim_start_c)) {
+      regime = 1;
+    }
+    out.next.regime_code = regime;
+    if (regime == 1) {
+      demand = std::max(demand, std::min(in.demand_max, std::max(2, in.applied_total_level + 1)));
+    } else {
+      static constexpr float thresholds[] = {0.00f, 0.10f, 0.20f, 0.35f, 0.50f, 0.70f, 0.90f};
+      static constexpr int caps[] = {1, 2, 3, 4, 5, 6, 8};
+      for (int i = 0; i < 7; ++i)
+        if (supply_error_c <= thresholds[i]) {
+          demand = std::min(demand, caps[i]);
+          break;
+        }
+    }
+  }
+
+  out.demand_continuous = !out.next.heat_request_active ? 0.0f
+                          : out.next.regime_code == 1   ? std::max(demand_continuous, static_cast<float>(demand))
+                                                        : std::min(demand_continuous, static_cast<float>(demand));
+  out.demand = demand;
+  out.valid = true;
+  return out;
 }
 
 inline void reset_control_state(float& demand_continuous, int& demand_curve, int& demand_pre_guardrail,

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -378,319 +378,104 @@ output:
               id(oq_curve_regime_code));
             return;
           }
-
           const int demand_max = (int) ${oq_strategy_demand_max_f};
-          if (isnan(state)) {
-            oq_curve::reset_control_state(
-              id(oq_curve_demand_continuous),
-              id(oq_demand_curve),
-              id(oq_curve_demand_pre_guardrail),
-              id(oq_curve_heat_request_active),
-              id(oq_curve_stop_arm_ms),
-              id(oq_curve_off_since_ms),
-              id(oq_curve_restart_inhibit_active),
-              id(oq_curve_restart_blocked_by_room),
-              id(oq_curve_regime_code));
-            return;
-          }
-
-          float d_cont = state * ${oq_strategy_demand_max_f};
-          if (d_cont < 0.0f) d_cont = 0.0f;
-          if (d_cont > (float) demand_max) d_cont = (float) demand_max;
-
-          int d = (int) lroundf(d_cont);
-          if (d < 0) d = 0;
-          if (d > demand_max) d = demand_max;
-          id(oq_curve_demand_pre_guardrail) = d;
-
           const float spw = id(oq_supply_target_temp).state;
           const float pv = id(oq_system_supply_temp).state;
-          if (isnan(spw) || isnan(pv)) {
-            oq_curve::reset_control_state(
-              id(oq_curve_demand_continuous),
-              id(oq_demand_curve),
-              id(oq_curve_demand_pre_guardrail),
-              id(oq_curve_heat_request_active),
-              id(oq_curve_stop_arm_ms),
-              id(oq_curve_off_since_ms),
-              id(oq_curve_restart_inhibit_active),
-              id(oq_curve_restart_blocked_by_room),
-              id(oq_curve_regime_code));
-            return;
-          }
-
-          auto tuning = oq_curve::control_profile(
+          const auto tuning = oq_curve::control_profile(
               id(oq_curve_control_profile).has_state()
                   ? id(oq_curve_control_profile).current_option()
                   : std::string());
-          float start_delta_c = tuning.start_delta_c;
-          float stop_delta_c = tuning.stop_delta_c;
-          int off_pid_max_f = tuning.off_pid_max_f;
-          uint32_t off_confirm_ms = tuning.off_confirm_ms;
-          float room_overheat_off_c = tuning.room_overheat_off_c;
-          float room_resume_heat_c = tuning.room_resume_heat_c;
-          float restart_delta_c = tuning.restart_delta_c;
-          float restart_bypass_extra_c = tuning.restart_bypass_extra_c;
-          uint32_t off_reentry_min_ms = tuning.off_reentry_min_ms;
-          float recovery_enter_c = tuning.recovery_enter_c;
-          float recovery_exit_c = tuning.recovery_exit_c;
-          if (stop_delta_c < start_delta_c + 0.10f) stop_delta_c = start_delta_c + 0.10f;
-          if (restart_delta_c < start_delta_c + 0.05f) restart_delta_c = start_delta_c + 0.05f;
-          if (restart_bypass_extra_c < 0.20f) restart_bypass_extra_c = 0.20f;
-          if (off_pid_max_f < 0) off_pid_max_f = 0;
-          if (off_pid_max_f > demand_max) off_pid_max_f = demand_max;
-
           const float room_c = id(room_temp_selected).state;
           const float room_sp_c = id(room_setpoint_selected).state;
-          const bool room_valid = !isnan(room_c) && !isnan(room_sp_c);
-
+          const bool room_valid = isfinite(room_c) && isfinite(room_sp_c);
           auto room_temperature_source_fresh = [&]() -> bool {
             if (!id(room_temp_source).has_state()) return false;
             const auto source = id(room_temp_source).current_option();
-            if (source == "HA input") {
-              return id(room_temp_valid_ha).state && id(thermostat_room_temp_ha).has_state() &&
-                     !isnan(id(thermostat_room_temp_ha).state) && !id(oq_room_temp_selected_hold_active);
-            }
-            if (source == "OT thermostat") {
-              return (${oq_ot_room_temperature_fresh_expr}) &&
-                     id(ot_thermostat_room_temp).has_state() && !isnan(id(ot_thermostat_room_temp).state);
-            }
-            if (source == "CIC") {
-              return id(feed_ok).has_state() && id(feed_ok).state &&
-                     id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
-                     id(cic_room_temp).has_state() && !isnan(id(cic_room_temp).state);
-            }
-            if (source == "API input") {
-              return id(api_input_room_temperature_valid).has_state() &&
-                     id(api_input_room_temperature_valid).state &&
-                     id(api_input_room_temperature).has_state() && !isnan(id(api_input_room_temperature).state);
-            }
-            if (source == "MQTT") {
-              return id(mqtt_room_temperature_valid).has_state() && id(mqtt_room_temperature_valid).state &&
-                     id(mqtt_room_temperature).has_state() && !isnan(id(mqtt_room_temperature).state);
-            }
-            return false;
+            return (source == "HA input" && id(room_temp_valid_ha).state &&
+                    id(thermostat_room_temp_ha).has_state() && isfinite(id(thermostat_room_temp_ha).state) && !id(oq_room_temp_selected_hold_active)) ||
+                   (source == "OT thermostat" && (${oq_ot_room_temperature_fresh_expr}) &&
+                    id(ot_thermostat_room_temp).has_state() && isfinite(id(ot_thermostat_room_temp).state)) ||
+                   (source == "CIC" && id(feed_ok).has_state() && id(feed_ok).state &&
+                    id(cic_data_stale).has_state() && !id(cic_data_stale).state && id(cic_room_temp).has_state() && isfinite(id(cic_room_temp).state)) ||
+                   (source == "API input" && id(api_input_room_temperature_valid).has_state() &&
+                    id(api_input_room_temperature_valid).state && id(api_input_room_temperature).has_state() && isfinite(id(api_input_room_temperature).state)) ||
+                   (source == "MQTT" && id(mqtt_room_temperature_valid).has_state() &&
+                    id(mqtt_room_temperature_valid).state && id(mqtt_room_temperature).has_state() && isfinite(id(mqtt_room_temperature).state));
           };
-
           auto room_setpoint_source_fresh = [&]() -> bool {
             if (!id(room_setpoint_source).has_state()) return false;
             const auto source = id(room_setpoint_source).current_option();
-            if (source == "HA input") {
-              return id(room_setpoint_valid_ha).state && id(thermostat_setpoint_ha).has_state() &&
-                     !isnan(id(thermostat_setpoint_ha).state) && !id(oq_room_setpoint_selected_hold_active);
-            }
-            if (source == "OT thermostat") {
-              return (${oq_ot_room_setpoint_fresh_expr}) &&
-                     id(ot_thermostat_room_setpoint).has_state() && !isnan(id(ot_thermostat_room_setpoint).state);
-            }
-            if (source == "CIC") {
-              return id(feed_ok).has_state() && id(feed_ok).state &&
-                     id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
-                     id(cic_room_setpoint).has_state() && !isnan(id(cic_room_setpoint).state);
-            }
-            if (source == "API input") {
-              return id(api_input_room_setpoint_valid).has_state() && id(api_input_room_setpoint_valid).state &&
-                     id(api_input_room_setpoint).has_state() && !isnan(id(api_input_room_setpoint).state);
-            }
-            if (source == "MQTT") {
-              return id(mqtt_room_setpoint_valid).has_state() && id(mqtt_room_setpoint_valid).state &&
-                     id(mqtt_room_setpoint).has_state() && !isnan(id(mqtt_room_setpoint).state);
-            }
-            return false;
+            return (source == "HA input" && id(room_setpoint_valid_ha).state &&
+                    id(thermostat_setpoint_ha).has_state() && isfinite(id(thermostat_setpoint_ha).state) && !id(oq_room_setpoint_selected_hold_active)) ||
+                   (source == "OT thermostat" && (${oq_ot_room_setpoint_fresh_expr}) &&
+                    id(ot_thermostat_room_setpoint).has_state() && isfinite(id(ot_thermostat_room_setpoint).state)) ||
+                   (source == "CIC" && id(feed_ok).has_state() && id(feed_ok).state &&
+                    id(cic_data_stale).has_state() && !id(cic_data_stale).state && id(cic_room_setpoint).has_state() && isfinite(id(cic_room_setpoint).state)) ||
+                   (source == "API input" && id(api_input_room_setpoint_valid).has_state() &&
+                    id(api_input_room_setpoint_valid).state && id(api_input_room_setpoint).has_state() && isfinite(id(api_input_room_setpoint).state)) ||
+                   (source == "MQTT" && id(mqtt_room_setpoint_valid).has_state() &&
+                    id(mqtt_room_setpoint_valid).state && id(mqtt_room_setpoint).has_state() && isfinite(id(mqtt_room_setpoint).state));
           };
 
           const bool room_data_fresh =
               room_valid && room_temperature_source_fresh() && room_setpoint_source_fresh();
-          const bool room_warm_for_off =
-              room_data_fresh && (room_c >= (room_sp_c + room_overheat_off_c));
-          const bool room_requests_heat =
-              room_data_fresh && (room_c <= (room_sp_c - room_resume_heat_c));
-          const bool room_allows_off = (!room_data_fresh) || room_warm_for_off;
-
           const uint32_t now_ms = (uint32_t) millis();
-          constexpr uint32_t oil_return_hold_ms = 180000UL;
           bool oil_return_active = id(hp1_prot_oil_return).state;
           #if OQ_TOPOLOGY_DUO
           oil_return_active = oil_return_active || id(${secondary_oil_return_id}).state;
           #endif
-          if (oil_return_active) {
-            id(oq_curve_oil_return_hold_until_ms) = now_ms + oil_return_hold_ms;
-          }
-          const bool oil_return_mask_active =
-              oil_return_active ||
-              (id(oq_curve_oil_return_hold_until_ms) > 0 &&
-               now_ms < id(oq_curve_oil_return_hold_until_ms));
-          static bool last_oil_return_mask_active = false;
-          if (oil_return_mask_active != last_oil_return_mask_active) {
-            ESP_LOGI("quatt.heatcurve", "Oil return hold %s", oil_return_mask_active ? "active" : "cleared");
-            last_oil_return_mask_active = oil_return_mask_active;
-          }
-          bool heat_request_active = id(oq_curve_heat_request_active);
-          const bool above_stop_band = pv >= (spw + stop_delta_c);
-          const bool low_pid_for_off = d <= off_pid_max_f;
-          const bool low_load_release_condition =
-              !oil_return_mask_active &&
-              heat_request_active &&
-              (id(oq_curve_regime_code) == 2) &&
-              (id(oq_curve_demand_pre_guardrail) <= 0) &&
-              ((!room_data_fresh) || (room_c >= (room_sp_c - room_resume_heat_c))) &&
-              (pv >= (spw + 0.25f));
-          const bool normal_stop_condition =
-              !oil_return_mask_active && above_stop_band && low_pid_for_off && room_allows_off;
-          const float restart_bypass_delta_c = restart_delta_c + restart_bypass_extra_c;
-          bool restart_inhibit_active = false;
-          const bool was_restart_blocked_by_room = id(oq_curve_restart_blocked_by_room);
-          bool restart_blocked_by_room = false;
-          uint32_t off_since_ms = id(oq_curve_off_since_ms);
-          const bool was_heat_request_active = heat_request_active;
-          if (heat_request_active) {
-            if (normal_stop_condition || low_load_release_condition) {
-              uint32_t armed_ms = id(oq_curve_stop_arm_ms);
-              const uint32_t confirm_ms =
-                  low_load_release_condition ? std::min<uint32_t>(off_confirm_ms, 90000UL)
-                                             : off_confirm_ms;
-              if (armed_ms == 0 || now_ms <= armed_ms) {
-                id(oq_curve_stop_arm_ms) = now_ms;
-              } else if ((now_ms - armed_ms) >= confirm_ms) {
-                heat_request_active = false;
-                id(oq_curve_stop_arm_ms) = 0;
+          const auto oil_return = oq_curve::update_oil_return_hold(
+              now_ms, oil_return_active, id(oq_curve_oil_return_hold_until_ms), 180000UL);
+          int applied_total = std::max(0, id(hp1_last_applied_level));
+          #if OQ_TOPOLOGY_DUO
+          applied_total += std::max(0, id(${secondary_last_applied_level_id}));
+          #endif
+          const oq_curve::DemandState previous{
+              id(oq_curve_heat_request_active), id(oq_curve_stop_arm_ms), id(oq_curve_off_since_ms),
+              id(oq_curve_restart_inhibit_active), id(oq_curve_restart_blocked_by_room), id(oq_curve_regime_code)};
+          const auto demand = oq_curve::decide_demand(
+              {now_ms, state, spw, pv, room_c, room_sp_c, room_data_fresh, oil_return.mask_active,
+               applied_total, demand_max},
+              tuning, previous);
+          id(oq_curve_oil_return_hold_until_ms) = oil_return.hold_until_ms;
+          if (demand.valid) {
+            static bool last_oil_return_mask_active = false;
+            if (oil_return.mask_active != last_oil_return_mask_active) {
+              ESP_LOGI("quatt.heatcurve", "Oil return hold %s", oil_return.mask_active ? "active" : "cleared");
+              last_oil_return_mask_active = oil_return.mask_active;
+            }
+            if (demand.next.restart_inhibit_active != previous.restart_inhibit_active) {
+              if (demand.next.restart_inhibit_active) {
+                ESP_LOGI("quatt.heatcurve", "Restart inhibit active: off-time hold (%u/%u s)",
+                         (unsigned int) ((uint32_t)(now_ms - demand.next.off_since_ms) / 1000UL),
+                         (unsigned int) (tuning.off_reentry_min_ms / 1000UL));
+              } else {
+                ESP_LOGI("quatt.heatcurve", "Restart inhibit cleared");
               }
-            } else {
-              id(oq_curve_stop_arm_ms) = 0;
             }
-            if (!heat_request_active && was_heat_request_active) {
-              off_since_ms = now_ms;
+            if (demand.next.restart_blocked_by_room != previous.restart_blocked_by_room) {
+              if (demand.next.restart_blocked_by_room)
+                ESP_LOGI("quatt.heatcurve", "Restart blocked: fresh room %.2f C is above %.2f C setpoint",
+                         room_c, room_sp_c);
+              else ESP_LOGI("quatt.heatcurve", "Warm-room restart block cleared");
             }
-          } else {
-            id(oq_curve_stop_arm_ms) = 0;
-            if (off_since_ms == 0 || now_ms <= off_since_ms) off_since_ms = now_ms;
-            const bool below_restart_band = pv <= (spw - restart_delta_c);
-            const bool deep_undershoot_restart = pv <= (spw - restart_bypass_delta_c);
-            bool off_lock_active = false;
-            if (off_reentry_min_ms > 0 && now_ms > off_since_ms) {
-              off_lock_active = (now_ms - off_since_ms) < off_reentry_min_ms;
-            }
-            const auto restart_decision = oq_curve::evaluate_restart(
-                below_restart_band, deep_undershoot_restart, off_lock_active, room_data_fresh, room_c, room_sp_c,
-                room_overheat_off_c, room_resume_heat_c);
-            restart_inhibit_active = restart_decision.blocked_by_off_lock;
-            restart_blocked_by_room = restart_decision.blocked_by_room;
-            if (restart_decision.restart) {
-              heat_request_active = true;
-              off_since_ms = 0;
+            if (demand.next.heat_request_active != previous.heat_request_active) {
+              const char *reason = demand.next.heat_request_active
+                  ? (demand.restart_reason == oq_curve::RESTART_ROOM_DEMAND ? "room demand" : "restart band reached")
+                  : (demand.stop_reason == oq_curve::STOP_LOW_LOAD ? "low-load release" : "normal stop");
+              ESP_LOGI("quatt.heatcurve", "Heat request %s: %s",
+                       demand.next.heat_request_active ? "resumed" : "stopped", reason);
             }
           }
-          static bool last_restart_inhibit_active = false;
-          if (restart_inhibit_active != last_restart_inhibit_active) {
-            if (restart_inhibit_active) {
-              const uint32_t off_age_ms = (off_since_ms > 0 && now_ms > off_since_ms) ? (now_ms - off_since_ms) : 0;
-              const uint32_t off_age_s = off_age_ms / 1000UL;
-              const uint32_t off_min_s = off_reentry_min_ms / 1000UL;
-              ESP_LOGI("quatt.heatcurve", "Restart inhibit active: off-time hold (%u/%u s)",
-                       (unsigned int) off_age_s, (unsigned int) off_min_s);
-            } else {
-              ESP_LOGI("quatt.heatcurve", "Restart inhibit cleared");
-            }
-            last_restart_inhibit_active = restart_inhibit_active;
-          }
-          if (heat_request_active) {
-            restart_inhibit_active = false;
-            restart_blocked_by_room = false;
-            off_since_ms = 0;
-          }
-
-          if (restart_blocked_by_room != was_restart_blocked_by_room) {
-            if (restart_blocked_by_room) {
-              ESP_LOGI("quatt.heatcurve", "Restart blocked: fresh room %.2f C is above %.2f C setpoint",
-                       room_c, room_sp_c);
-            } else {
-              ESP_LOGI("quatt.heatcurve", "Warm-room restart block cleared");
-            }
-          }
-
-          static bool last_heat_request_active = false;
-          if (heat_request_active != last_heat_request_active) {
-            if (heat_request_active) {
-              ESP_LOGI("quatt.heatcurve", "Heat request resumed: %s",
-                       room_requests_heat ? "room demand" : "restart band reached");
-            } else {
-              ESP_LOGI("quatt.heatcurve", "Heat request stopped: %s",
-                       low_load_release_condition ? "low-load release" : (normal_stop_condition ? "normal stop" : "oil return hold"));
-            }
-            last_heat_request_active = heat_request_active;
-          }
-
-          if (!heat_request_active) {
-            d = 0;
-            id(oq_curve_regime_code) = 0;
-          } else {
-            if (d < 1) d = 1;
-
-            auto total_applied_level = [&]() -> int {
-              int total = id(hp1_last_applied_level);
-              if (total < 0) total = 0;
-              #if OQ_TOPOLOGY_DUO
-              int secondary = id(${secondary_last_applied_level_id});
-              if (secondary > 0) total += secondary;
-              #endif
-              return total;
-            };
-
-            const float supply_error_c = spw - pv;
-            const int applied_total = total_applied_level();
-            int regime = id(oq_curve_regime_code);
-            if (regime != 1 && regime != 2) {
-              regime = (supply_error_c >= recovery_enter_c) ? 1 : 2;
-            }
-            const bool room_allows_recovery =
-                (!room_data_fresh) || (room_c <= (room_sp_c + tuning.trim_start_c));
-            constexpr int recovery_reenter_min_f = 8;
-            if (regime == 1) {
-              if (supply_error_c <= recovery_exit_c) regime = 2;
-            } else if (!oil_return_mask_active &&
-                       supply_error_c >= recovery_enter_c &&
-                       d >= recovery_reenter_min_f &&
-                       room_allows_recovery) {
-              regime = 1;
-            }
-
-            id(oq_curve_regime_code) = regime;
-            if (regime == 1) {
-              int recovery_floor = applied_total + 1;
-              if (recovery_floor < 2) recovery_floor = 2;
-              if (recovery_floor > demand_max) recovery_floor = demand_max;
-              if (d < recovery_floor) d = recovery_floor;
-            } else {
-              // Close to target, the plant still contains a lot of thermal momentum.
-              // Cap demand explicitly here so PID saturation cannot keep pushing
-              // high discrete requests deep into the maintain band.
-              int maintain_cap = demand_max;
-              if (supply_error_c <= 0.00f) maintain_cap = 1;
-              else if (supply_error_c <= 0.10f) maintain_cap = 2;
-              else if (supply_error_c <= 0.20f) maintain_cap = 3;
-              else if (supply_error_c <= 0.35f) maintain_cap = 4;
-              else if (supply_error_c <= 0.50f) maintain_cap = 5;
-              else if (supply_error_c <= 0.70f) maintain_cap = 6;
-              else if (supply_error_c <= 0.90f) maintain_cap = 8;
-              if (d > maintain_cap) d = maintain_cap;
-            }
-          }
-
-          float d_cont_effective = d_cont;
-          if (!heat_request_active) {
-            d_cont_effective = 0.0f;
-          } else if (id(oq_curve_regime_code) == 1) {
-            if (d_cont_effective < (float) d) d_cont_effective = (float) d;
-          } else if (d_cont_effective > (float) d) {
-            d_cont_effective = (float) d;
-          }
-
-          id(oq_curve_demand_continuous) = d_cont_effective;
-          id(oq_curve_heat_request_active) = heat_request_active;
-          id(oq_curve_off_since_ms) = off_since_ms;
-          id(oq_curve_restart_inhibit_active) = restart_inhibit_active;
-          id(oq_curve_restart_blocked_by_room) = restart_blocked_by_room;
-          id(oq_demand_curve) = d;
+          id(oq_curve_demand_continuous) = demand.demand_continuous;
+          id(oq_curve_demand_pre_guardrail) = demand.demand_pre_guardrail;
+          id(oq_curve_heat_request_active) = demand.next.heat_request_active;
+          id(oq_curve_stop_arm_ms) = demand.next.stop_arm_ms;
+          id(oq_curve_off_since_ms) = demand.next.off_since_ms;
+          id(oq_curve_restart_inhibit_active) = demand.next.restart_inhibit_active;
+          id(oq_curve_restart_blocked_by_room) = demand.next.restart_blocked_by_room;
+          id(oq_curve_regime_code) = demand.next.regime_code;
+          id(oq_demand_curve) = demand.demand;
 
 sensor:
   - platform: template

--- a/scripts/tests/test_heating_curve_demand_contract.py
+++ b/scripts/tests/test_heating_curve_demand_contract.py
@@ -1,0 +1,15 @@
+import unittest
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[2]
+YAML = (ROOT / "openquatt/oq_heating_curve_strategy.yaml").read_text()
+class HeatingCurveDemandContractTest(unittest.TestCase):
+    def test_yaml_delegates_demand_core_without_moving_wiring(self) -> None:
+        for marker in ("platform: pid", "write_action:", "room_temperature_source_fresh", "room_setpoint_source_fresh", "oq_curve::decide_demand("):
+            self.assertIn(marker, YAML)
+        for old_inline in ("recovery_reenter_min_f", "above_stop_band", "restart_bypass_delta_c", "maintain_cap = demand_max"):
+            self.assertNotIn(old_inline, YAML)
+        self.assertLess(YAML.index("id(oq_curve_oil_return_hold_until_ms) = oil_return.hold_until_ms"), YAML.index("if (demand.valid)"))
+        paths = ("openquatt/oq_heating_curve_strategy.yaml", "openquatt/includes/control/oq_heating_curve_logic.h", "tests/host/heating_curve_restart_logic_test.cpp", "scripts/tests/test_electrical_input_limit_contract.py", "scripts/tests/test_heating_curve_demand_contract.py")
+        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1878)
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host/heating_curve_restart_logic_test.cpp
+++ b/tests/host/heating_curve_restart_logic_test.cpp
@@ -1,137 +1,177 @@
 #include <assert.h>
 #include <math.h>
+#include <stdint.h>
 
 #include "../../openquatt/includes/control/oq_heating_curve_logic.h"
-
 namespace {
+using namespace oq_curve;
+bool near(float actual, float expected) { return fabsf(actual - expected) < 0.001f; }
+ControlProfileTuning tuning() { return control_profile("Balanced"); }
+DemandInput input() { return {1000U, 0.5f, 35.0f, 34.0f, 20.0f, 20.5f, false, false, 0, 20}; }
+DemandState active(int regime = 2) { return {true, 0, 0, false, false, regime}; }
 
-using oq_curve::evaluate_restart;
-using oq_curve::reset_control_state;
-using oq_curve::RESTART_NONE;
-using oq_curve::RESTART_ROOM_DEMAND;
-using oq_curve::RESTART_WATER_BAND;
-
-constexpr float ROOM_SETPOINT_C = 20.5f;
-constexpr float ROOM_OVERHEAT_OFF_C = 0.3f;
-constexpr float ROOM_RESUME_HEAT_C = 0.05f;
-
-void test_fresh_warm_room_blocks_water_restart() {
-  const auto decision =
-      evaluate_restart(true, false, false, true, 23.4f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
-
-  assert(!decision.restart);
-  assert(decision.blocked_by_room);
-  assert(!decision.blocked_by_off_lock);
-  assert(decision.reason == RESTART_NONE);
+void test_restart_matrix() {
+  struct Case {
+    bool below, deep, locked, fresh;
+    float room;
+    bool restart, room_block, lock_block;
+    RestartReason reason;
+  };
+  const Case cases[] = {
+      {true, false, false, true, 23.4f, false, true, false, RESTART_NONE},
+      {true, true, true, true, 23.4f, false, true, false, RESTART_NONE},
+      {false, false, true, true, 20.0f, true, false, false, RESTART_ROOM_DEMAND},
+      {true, false, false, false, 23.4f, true, false, false, RESTART_WATER_BAND},
+      {true, false, true, false, 19.0f, false, false, true, RESTART_NONE},
+      {true, true, true, true, 20.5f, true, false, false, RESTART_WATER_BAND},
+      {false, false, false, true, 23.4f, false, false, false, RESTART_NONE},
+      {true, false, false, true, NAN, true, false, false, RESTART_WATER_BAND},
+      {true, false, false, true, INFINITY, true, false, false, RESTART_WATER_BAND},
+  };
+  for (const auto& test : cases) {
+    const auto out = evaluate_restart(test.below, test.deep, test.locked, test.fresh, test.room, 20.5f, 0.3f, 0.05f);
+    assert(out.restart == test.restart && out.blocked_by_room == test.room_block &&
+           out.blocked_by_off_lock == test.lock_block && out.reason == test.reason);
+  }
 }
-
-void test_fresh_warm_room_also_blocks_deep_undershoot() {
-  const auto decision =
-      evaluate_restart(true, true, true, true, 23.4f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
-
-  assert(!decision.restart);
-  assert(decision.blocked_by_room);
-  assert(!decision.blocked_by_off_lock);
+void test_reset_and_power_cap() {
+  float continuous = 12.0f;
+  int demand = 8, pre = 7, regime = 2;
+  bool heat = true, inhibit = true, room_block = true;
+  uint32_t arm = 100, off = 200;
+  reset_control_state(continuous, demand, pre, heat, arm, off, inhibit, room_block, regime);
+  assert(isnan(continuous) && demand == 0 && pre == 0 && !heat && arm == 0 && off == 0 && !inhibit && !room_block &&
+         regime == 0);
+  const float capped = power_capped_demand_u(18.0f, 8, 20);
+  assert(capped == 0.4f && lroundf(capped * 10.0f) == 4);
+  assert(phase_target_power_w(true, capped, 10000.0f, 18000.0f) == 4000.0f);
+  assert(phase_target_power_w(false, capped, 10000.0f, 18000.0f) == 7200.0f);
+  assert(power_capped_demand_u(6.0f, 8, 20) == 0.3f && power_capped_demand_u(18.0f, 0, 20) == 0);
+  assert(power_capped_demand_u(NAN, 8, 20) == 0 && power_capped_demand_u(INFINITY, 8, 20) == 0);
 }
-
-void test_fresh_room_demand_has_highest_priority() {
-  const auto decision =
-      evaluate_restart(false, false, true, true, 20.0f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
-
-  assert(decision.restart);
-  assert(!decision.blocked_by_room);
-  assert(!decision.blocked_by_off_lock);
-  assert(decision.reason == RESTART_ROOM_DEMAND);
+void test_oil_return_hold_and_rollover() {
+  auto out = update_oil_return_hold(100U, true, 0, 180000U);
+  assert(out.mask_active && out.hold_until_ms == 180100U);
+  assert(update_oil_return_hold(180099U, false, out.hold_until_ms, 180000U).mask_active);
+  out = update_oil_return_hold(180100U, false, out.hold_until_ms, 180000U);
+  assert(!out.mask_active && out.hold_until_ms == 0);
+  out = update_oil_return_hold(UINT32_MAX - 179999U, true, 0, 180000U);
+  assert(out.mask_active && out.hold_until_ms == 1U);
+  assert(update_oil_return_hold(0U, false, out.hold_until_ms, 180000U).mask_active);
+  assert(!update_oil_return_hold(1U, false, out.hold_until_ms, 180000U).mask_active);
+  assert(!update_oil_return_hold(UINT32_MAX - 10U, false, 0, 180000U).mask_active);
 }
-
-void test_stale_warm_room_fails_open_to_water_restart() {
-  const auto decision =
-      evaluate_restart(true, false, false, false, 23.4f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
-
-  assert(decision.restart);
-  assert(!decision.blocked_by_room);
-  assert(decision.reason == RESTART_WATER_BAND);
+void test_invalid_inputs_fail_closed() {
+  const float bad[] = {NAN, INFINITY, -INFINITY};
+  float DemandInput::* fields[] = {&DemandInput::pid_output, &DemandInput::supply_target_c, &DemandInput::supply_c};
+  for (float value : bad) {
+    for (auto field : fields) {
+      auto in = input();
+      in.*field = value;
+      const auto out = decide_demand(in, tuning(), active(1));
+      assert(!out.valid && isnan(out.demand_continuous) && out.demand == 0 && !out.next.heat_request_active);
+    }
+  }
+  auto invalid_tuning = tuning();
+  invalid_tuning.recovery_enter_c = NAN;
+  assert(!decide_demand(input(), invalid_tuning, active()).valid);
+  auto invalid_max = input();
+  invalid_max.demand_max = 0;
+  assert(!decide_demand(invalid_max, tuning(), active()).valid);
 }
-
-void test_stale_room_does_not_bypass_off_lock() {
-  const auto decision =
-      evaluate_restart(true, false, true, false, 19.0f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
-
-  assert(!decision.restart);
-  assert(!decision.blocked_by_room);
-  assert(decision.blocked_by_off_lock);
+void test_stop_confirmation_and_rollover() {
+  auto in = input();
+  in.pid_output = 0.05f;
+  in.supply_c = 36.0f;
+  auto out = decide_demand(in, tuning(), active());
+  assert(out.valid && out.next.heat_request_active && out.next.stop_arm_ms == 1000U);
+  auto armed = out.next;
+  in.now_ms = 360999U;
+  assert(decide_demand(in, tuning(), armed).next.heat_request_active);
+  in.now_ms = 361000U;
+  out = decide_demand(in, tuning(), armed);
+  assert(!out.next.heat_request_active && out.next.off_since_ms == 361000U && out.stop_reason == STOP_NORMAL);
+  armed = active();
+  armed.stop_arm_ms = UINT32_MAX - 1000U;
+  in.now_ms = 358999U;
+  assert(!decide_demand(in, tuning(), armed).next.heat_request_active);
+  in.oil_return_mask_active = true;
+  assert(decide_demand(in, tuning(), active()).next.stop_arm_ms == 0);
+  in.oil_return_mask_active = false;
+  in.pid_output = 0;
+  in.supply_c = 35.3f;
+  armed = active();
+  armed.stop_arm_ms = 1000U;
+  in.now_ms = 91000U;
+  out = decide_demand(in, tuning(), armed);
+  assert(!out.next.heat_request_active && out.stop_reason == STOP_LOW_LOAD);
 }
-
-void test_deep_undershoot_keeps_existing_off_lock_bypass_without_room_veto() {
-  const auto decision =
-      evaluate_restart(true, true, true, true, 20.5f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
-
-  assert(decision.restart);
-  assert(!decision.blocked_by_room);
-  assert(!decision.blocked_by_off_lock);
-  assert(decision.reason == RESTART_WATER_BAND);
+void test_restart_lock_and_regimes() {
+  auto in = input();
+  DemandState off{false, 0, 1000U, false, false, 0};
+  in.now_ms = 2000U;
+  auto out = decide_demand(in, tuning(), off);
+  assert(!out.next.heat_request_active && out.next.restart_inhibit_active);
+  off.off_since_ms = UINT32_MAX - 1000U;
+  in.now_ms = 1000U;
+  out = decide_demand(in, tuning(), off);
+  assert(!out.next.heat_request_active && out.next.restart_inhibit_active);
+  off.off_since_ms = 0;
+  out = decide_demand(in, tuning(), off);
+  assert(out.next.heat_request_active && out.next.regime_code == 1 && out.demand >= 2);
+  in.supply_c = 35.0f;
+  in.room_data_fresh = true;
+  in.room_c = 20.0f;
+  out = decide_demand(in, tuning(), {});
+  assert(out.next.heat_request_active && out.restart_reason == RESTART_ROOM_DEMAND);
+  in.supply_c = 33.5f;
+  in.room_c = 23.0f;
+  out = decide_demand(in, tuning(), {});
+  assert(!out.next.heat_request_active && out.next.restart_blocked_by_room);
+  in = input();
+  in.pid_output = 0.2f;
+  in.applied_total_level = 7;
+  out = decide_demand(in, tuning(), active(0));
+  assert(out.next.regime_code == 1 && out.demand == 8 && near(out.demand_continuous, 8.0f));
+  in.supply_c = 34.85f;
+  out = decide_demand(in, tuning(), active(1));
+  assert(out.next.regime_code == 2 && out.demand == 3);
+  in.supply_c = 34.0f;
+  in.pid_output = 0.5f;
+  out = decide_demand(in, tuning(), active(2));
+  assert(out.next.regime_code == 1);
+  in.oil_return_mask_active = true;
+  assert(decide_demand(in, tuning(), active(2)).next.regime_code == 2);
+  in.oil_return_mask_active = false;
+  in.room_data_fresh = true;
+  in.room_c = 21.0f;
+  assert(decide_demand(in, tuning(), active(2)).next.regime_code == 2);
 }
-
-void test_no_water_restart_does_not_report_a_room_block() {
-  const auto decision =
-      evaluate_restart(false, false, false, true, 23.4f, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
-
-  assert(!decision.restart);
-  assert(!decision.blocked_by_room);
-  assert(!decision.blocked_by_off_lock);
-}
-
-void test_non_finite_room_values_cannot_block_restart() {
-  const auto decision =
-      evaluate_restart(true, false, false, true, NAN, ROOM_SETPOINT_C, ROOM_OVERHEAT_OFF_C, ROOM_RESUME_HEAT_C);
-
-  assert(decision.restart);
-  assert(!decision.blocked_by_room);
-  assert(decision.reason == RESTART_WATER_BAND);
-}
-
-void test_control_reset_clears_restart_diagnostics() {
-  float demand_continuous = 12.0f;
-  int demand_curve = 8;
-  int demand_pre_guardrail = 7;
-  bool heat_request_active = true;
-  uint32_t stop_arm_ms = 100U;
-  uint32_t off_since_ms = 200U;
-  bool restart_inhibit_active = true;
-  bool restart_blocked_by_room = true;
-  int regime_code = 2;
-
-  reset_control_state(demand_continuous, demand_curve, demand_pre_guardrail, heat_request_active, stop_arm_ms,
-                      off_since_ms, restart_inhibit_active, restart_blocked_by_room, regime_code);
-
-  assert(isnan(demand_continuous));
-  assert(demand_curve == 0);
-  assert(demand_pre_guardrail == 0);
-  assert(!heat_request_active);
-  assert(stop_arm_ms == 0U);
-  assert(off_since_ms == 0U);
-  assert(!restart_inhibit_active);
-  assert(!restart_blocked_by_room);
-  assert(regime_code == 0);
+void test_maintain_caps() {
+  struct Case {
+    float error_c;
+    int expected;
+  };
+  const Case cases[] = {{-0.1f, 1}, {0.05f, 2}, {0.15f, 3}, {0.30f, 4},
+                        {0.45f, 5}, {0.60f, 6}, {0.80f, 8}, {1.00f, 20}};
+  for (const auto& test : cases) {
+    auto in = input();
+    in.pid_output = 1.0f;
+    in.supply_c = in.supply_target_c - test.error_c;
+    in.oil_return_mask_active = true;
+    const auto out = decide_demand(in, tuning(), active(2));
+    assert(out.valid && out.next.regime_code == 2 && out.demand == test.expected &&
+           near(out.demand_continuous, static_cast<float>(test.expected)));
+  }
 }
 }  // namespace
-
 int main() {
-  test_fresh_warm_room_blocks_water_restart();
-  test_fresh_warm_room_also_blocks_deep_undershoot();
-  test_fresh_room_demand_has_highest_priority();
-  test_stale_warm_room_fails_open_to_water_restart();
-  test_stale_room_does_not_bypass_off_lock();
-  test_deep_undershoot_keeps_existing_off_lock_bypass_without_room_veto();
-  test_no_water_restart_does_not_report_a_room_block();
-  test_non_finite_room_values_cannot_block_restart();
-  test_control_reset_clears_restart_diagnostics();
-  const float capped_u = oq_curve::power_capped_demand_u(18.0f, 8, 20);
-  assert(capped_u == 0.4f && lroundf(capped_u * 10.0f) == 4);                              // Single cap.
-  assert(oq_curve::phase_target_power_w(true, capped_u, 10000.0f, 18000.0f) == 4000.0f);   // Duo recovery.
-  assert(oq_curve::phase_target_power_w(false, capped_u, 10000.0f, 18000.0f) == 7200.0f);  // Duo maintain.
-  assert(oq_curve::power_capped_demand_u(6.0f, 8, 20) == 0.3f && oq_curve::power_capped_demand_u(18.0f, 0, 20) == 0.0f);
-  assert(oq_curve::power_capped_demand_u(NAN, 8, 20) == 0.0f &&
-         oq_curve::power_capped_demand_u(INFINITY, 8, 20) == 0.0f);
+  test_restart_matrix();
+  test_reset_and_power_cap();
+  test_oil_return_hold_and_rollover();
+  test_invalid_inputs_fail_closed();
+  test_stop_confirmation_and_rollover();
+  test_restart_lock_and_regimes();
+  test_maintain_caps();
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst de Heating Curve-vraag-, stop/restart-, oil-return- en regimebeslissing uit `oq_heating_curve_strategy.yaml` naar een pure C++-kern.
- Houdt PID, ESPHome-entities, bron-freshness en global writes als compact YAML-contract; de YAML daalt van 1433 naar 1218 regels.
- Breidt table-driven regressietests uit voor restartprioriteit, stale roomdata, stopconfirmatie, minimum off-time, oil-return, RECOVERY/MAINTAIN, rollover en NaN/Inf.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De normale regeling blijft functioneel gelijk. Niet-eindige PID-, supply- en tuningwaarden falen nu expliciet gesloten. Stopconfirmatie, minimum off-time en oil-return hold zijn rollover-safe. De oil-return-deadline wordt ook bijgewerkt wanneer een andere control-input tijdelijk ongeldig is, zodat herstel het resterende holdvenster niet kan overslaan. Er komen geen globals, taken, containers of heapallocaties bij.

## Achtergrond

De PR staat als één zelfstandige commit op de actuele `dev`, na de gemergede Power House-vraaglogica uit #568. De extractie maakt het regelcontract onafhankelijk testbaar zonder YAML-simulatie.

Het afgesproken LOC-contract blijft exact gelijk: de vijf relevante productie- en testbestanden tellen voor en na deze PR 1878 regels. De zichtbare PR-diff telt 406 toevoegingen en 406 verwijderingen; `oq_heating_curve_strategy.yaml` zelf wordt 215 regels kleiner.

Een volledige diff-audit en een afzonderlijke koude review controleerden gedragspariteit, lifecycle/resetpaden, stale/fresh roomdata, Single/Duo, invalid inputs, oil-return tijdens ongeldige inputs, timer-rollover, fresh-install restart, logging, allocaties en gegenereerde configuraties. De gevonden oil-return-lifecyclekloof is vóór publicatie hersteld en met een integratiecontract afgedekt. Er zijn geen resterende blockers gevonden.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen user-facing entities, instellingen of normale bediening veranderen; dit is een interne contractextractie met fail-safe randgevalcorrecties.

## Validatie

- [x] `npm run check:cpp-format` — 174 bestanden groen
- [x] `scripts/run_host_regression_tests.sh` — 46/46 groen
- [x] `npm run check:python-contracts` — 146/146 groen
- [x] Config-only validatie van alle zes ondersteunde buildtargets
- [x] Volledige ESPHome-firmwarecompile `configs/heatpump_controller_q/duo_wifi.yaml`
- [x] `git diff --check`
- [x] HIL op exact commit `09099a19` met Q Duo-controller en ODU/OpenTherm-simulator: Heating Curve CM1→CM2, vraag 20, HP2 Single-owner, fysieke F1→F2-requests en simulatoracceptatie groen
- [x] Live oil-return-injectie en vrijgave: protectie volgde de simulator, vraag/regime bleven gecontroleerd en beide ODU-links bleven gezond zonder faults
- [x] Minimum-runtime/oil-return-afbouw gevolgd tot echte stopbevestiging; eindgate Power House, uitgeschakeld, CM0, F0/F0/Standby en ODU-request/acceptatie 0/0
- [x] OpenTherm-eindcounters: invalid/decode/timing alle 0
- [ ] Geheugenimpact gemeten als geïsoleerde cold-boot A/B op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen persistente state, heapallocaties of taken toegevoegd. Q Duo-build versus de directe #568-basis: DIRAM 211035 → 211027 bytes (-8); image 2181979 → 2182283 bytes (+304). Tijdens de finale HIL waren free internal heap 94779 B en largest block 51200 B; de minimum-watermark van 39828 B is cumulatief sinds boot en daarom geen geïsoleerde A/B-meting.

De finale candidatefirmware blijft op de testcontroller staan in de veilige normale uitgangstoestand. Het echte Single-firmwarepad is niet geflasht; Single/Duo-vertakkingen zijn wel door configvalidatie, compilematrix en hosttests afgedekt.
