### PR TITLE
YAML naar C++: Power House – dispatch

### DIFF
--- a/openquatt/includes/control/oq_power_house_dispatch_logic.h
+++ b/openquatt/includes/control/oq_power_house_dispatch_logic.h
@@ -1,0 +1,381 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+
+#include "oq_hp_candidate_logic.h"
+
+namespace oq_power_house_dispatch {
+constexpr int kMaxLevel = 10;
+constexpr uint32_t kTopologyHoldMs = 180000, kDefrostHoldMs = 180000, kOilReturnHoldMs = 120000;
+// clang-format off
+enum class Reason : uint8_t {
+  IDLE = 0, FALLBACK_IDLE = 1, FALLBACK_HP1 = 2, FALLBACK_HP2 = 3,
+  FALLBACK_DUO = 4, KEEP_CURRENT = 5, HOLD_ACTIVE = 6, DEFROST_HOLD = 7,
+  BETTER_HEAT = 8, SOFT_GUARD = 9, LESS_POWER = 10, NO_CANDIDATE = 11,
+  DEFROST_BOOST = 12, RUNTIME_LEAD = 13, SINGLE_TOPOLOGY = 14, OIL_RETURN_HOLD = 15,
+};
+// clang-format on
+inline const char* request_reason_name(int code) {
+  // clang-format off
+  static constexpr const char* names[] = {
+      "ph_idle", "ph_fallback_idle", "ph_fallback_single_hp1", "ph_fallback_single_hp2",
+      "ph_fallback_duo", "keep_current", "hold_active", "defrost_hold", "better_heat", "soft_guard",
+      "less_power", "no_candidate", "defrost_boost", "runtime_lead", "ph_single_topology", "oil_return_hold",
+  };
+  // clang-format on
+  return code >= 0 && code < static_cast<int>(sizeof(names) / sizeof(names[0])) ? names[code] : names[0];
+}
+struct LevelEstimate {
+  bool allowed = false, thermal_valid = false, electrical_valid = false;
+  float thermal_w = 0.0f, electrical_w = 0.0f;
+};
+struct HpInput {
+  oq_hp_candidate::HpCandidateState candidate;
+  bool defrost = false, valve_defrost = false;
+  std::array<LevelEstimate, kMaxLevel + 1> levels{};
+};
+struct TimedTail {
+  bool previous_active = false, armed = false;
+  uint32_t started_ms = 0;
+};
+struct DispatchState {
+  TimedTail hp1_defrost;
+  TimedTail hp2_defrost;
+  TimedTail oil_return;
+  bool topology_initialized = false, topology_hold_armed = false;
+  int applied_topology = 0;
+  uint32_t topology_hold_started_ms = 0;
+};
+struct ProtectionObservation {
+  uint32_t now_ms = 0;
+  bool hp1_valve_defrost = false, hp2_valve_defrost = false, oil_return = false;
+  int hp1_applied_level = 0, hp2_applied_level = 0;
+};
+struct DispatchInput {
+  uint32_t now_ms = 0;
+  int demand_level = 0;
+  float requested_w = NAN;
+  bool duo = false, performance_valid = false, lead_hp1 = true;
+  HpInput hp1, hp2;
+};
+struct DispatchTuning {
+  float soft_limit_w = NAN, peak_limit_w = NAN;
+  float over_soft_penalty_per_w = 5.0f;
+  float topology_power_margin_w = 150.0f, topology_heat_advantage_w = 450.0f;
+  int defrost_boost_min_level = 6, defrost_boost_steps = 1;
+};
+struct DispatchDecision {
+  int hp1_level = 0, hp2_level = 0, owner_hp = 0;
+  Reason reason = Reason::IDLE;
+  float capacity_w = 0.0f, deficit_w = 0.0f;
+  float expected_w = NAN;
+  bool output_valid = false, saturated = false;
+};
+struct Candidate {
+  bool valid = false;
+  int hp1_level = 0, hp2_level = 0;
+  float thermal_w = 0.0f, electrical_w = 0.0f, error_w = 0.0f, over_soft_w = 0.0f;
+  int level_moves = 0, active_count = 0;
+  bool single_on_lead = false;
+};
+inline int topology(int hp1_level, int hp2_level) { return (hp1_level > 0 ? 1 : 0) + (hp2_level > 0 ? 1 : 0); }
+inline int owner(int hp1_level, int hp2_level) {
+  return hp1_level > 0 && hp2_level <= 0 ? 1 : hp2_level > 0 && hp1_level <= 0 ? 2 : 0;
+}
+inline int applied_level(const HpInput& hp) {
+  const int level = hp.candidate.previous_applied_level;
+  return level >= 0 && level <= kMaxLevel ? level : 0;
+}
+inline oq_hp_candidate::HpCandidateState sanitized_candidate(const HpInput& hp) {
+  auto candidate = hp.candidate;
+  candidate.previous_applied_level = applied_level(hp);
+  return candidate;
+}
+inline bool hp_may_serve(const HpInput& hp) {
+  return !hp.candidate.must_stop && (hp.candidate.available_for_start || applied_level(hp) > 0);
+}
+inline void observe_tail(TimedTail& tail, bool active, uint32_t now_ms, uint32_t duration_ms) {
+  if (active || tail.previous_active) {
+    tail.armed = true;
+    tail.started_ms = now_ms;
+  } else if (tail.armed && static_cast<uint32_t>(now_ms - tail.started_ms) >= duration_ms)
+    tail.armed = false;
+  tail.previous_active = active;
+}
+inline bool tail_active(const TimedTail& tail, uint32_t now_ms, uint32_t duration_ms) {
+  return tail.previous_active ||
+         (tail.armed && duration_ms > 0 && static_cast<uint32_t>(now_ms - tail.started_ms) < duration_ms);
+}
+inline DispatchState observe_protection(DispatchState state, const ProtectionObservation& observation) {
+  observe_tail(state.hp1_defrost, observation.hp1_valve_defrost, observation.now_ms, kDefrostHoldMs);
+  observe_tail(state.hp2_defrost, observation.hp2_valve_defrost, observation.now_ms, kDefrostHoldMs);
+  observe_tail(state.oil_return, observation.oil_return, observation.now_ms, kOilReturnHoldMs);
+  if (state.topology_hold_armed &&
+      static_cast<uint32_t>(observation.now_ms - state.topology_hold_started_ms) >= kTopologyHoldMs)
+    state.topology_hold_armed = false;
+  const int applied_topology = topology(observation.hp1_applied_level, observation.hp2_applied_level);
+  if (state.topology_initialized && state.applied_topology > 0 && applied_topology > 0 &&
+      state.applied_topology != applied_topology) {
+    state.topology_hold_armed = true;
+    state.topology_hold_started_ms = observation.now_ms;
+  }
+  state.topology_initialized = true;
+  state.applied_topology = applied_topology;
+  return state;
+}
+inline bool topology_hold_active(const DispatchState& state, uint32_t now_ms, uint32_t duration_ms) {
+  return state.topology_hold_armed && duration_ms > 0 &&
+         static_cast<uint32_t>(now_ms - state.topology_hold_started_ms) < duration_ms;
+}
+inline bool electrical_limits_valid(const DispatchTuning& tuning) {
+  return std::isfinite(tuning.soft_limit_w) && std::isfinite(tuning.peak_limit_w) && tuning.soft_limit_w >= 0.0f &&
+         tuning.peak_limit_w >= tuning.soft_limit_w;
+}
+inline Candidate make_candidate(const DispatchInput& in, const DispatchTuning& tuning, int hp1_level, int hp2_level,
+                                float target_w) {
+  Candidate result;
+  result.hp1_level = hp1_level;
+  result.hp2_level = in.duo ? hp2_level : 0;
+  result.active_count = topology(result.hp1_level, result.hp2_level);
+  result.single_on_lead =
+      result.active_count == 1 && owner(result.hp1_level, result.hp2_level) == (in.lead_hp1 ? 1 : 2);
+  if (!electrical_limits_valid(tuning) || !std::isfinite(target_w) || target_w < 0.0f || result.hp1_level < 0 ||
+      result.hp2_level < 0 || result.hp1_level > kMaxLevel || result.hp2_level > kMaxLevel)
+    return result;
+  auto add_hp = [&](const HpInput& hp, int level) {
+    if (level <= 0) return true;
+    if (!hp_may_serve(hp)) return false;
+    const auto& estimate = hp.levels[level];
+    if (!estimate.allowed || !estimate.thermal_valid || !estimate.electrical_valid ||
+        !std::isfinite(estimate.thermal_w) || !std::isfinite(estimate.electrical_w) || estimate.thermal_w < 0.0f ||
+        estimate.electrical_w < 0.0f)
+      return false;
+    result.thermal_w += estimate.thermal_w;
+    result.electrical_w += estimate.electrical_w;
+    return true;
+  };
+  if (!add_hp(in.hp1, result.hp1_level) || !add_hp(in.hp2, result.hp2_level) || !std::isfinite(result.thermal_w) ||
+      !std::isfinite(result.electrical_w) || result.electrical_w > tuning.peak_limit_w)
+    return result;
+  result.valid = true;
+  result.error_w = std::fabs(result.thermal_w - target_w);
+  result.over_soft_w = std::max(0.0f, result.electrical_w - tuning.soft_limit_w);
+  result.level_moves =
+      std::abs(result.hp1_level - applied_level(in.hp1)) + std::abs(result.hp2_level - applied_level(in.hp2));
+  return result;
+}
+inline bool better_candidate(const Candidate& a, const Candidate& b) {
+  if (std::fabs(a.over_soft_w - b.over_soft_w) > 1.0f) return a.over_soft_w < b.over_soft_w;
+  if (std::fabs(a.electrical_w - b.electrical_w) > 1.0f) return a.electrical_w < b.electrical_w;
+  if (std::fabs(a.error_w - b.error_w) > 1.0f) return a.error_w < b.error_w;
+  if (a.level_moves != b.level_moves) return a.level_moves < b.level_moves;
+  const int a_balance = std::abs(a.hp1_level - a.hp2_level);
+  const int b_balance = std::abs(b.hp1_level - b.hp2_level);
+  if (a.active_count == 2 && b.active_count == 2 && a_balance != b_balance) return a_balance < b_balance;
+  if (a.active_count == 1 && b.active_count == 1 && a_balance == b_balance && a.single_on_lead != b.single_on_lead)
+    return a.single_on_lead;
+  return a.hp1_level != b.hp1_level ? a.hp1_level < b.hp1_level : a.hp2_level < b.hp2_level;
+}
+inline Candidate pick_topology(const DispatchInput& in, const DispatchTuning& tuning, float target_w, int active_count,
+                               float tie_band_w) {
+  Candidate chosen;
+  float best_error_w = INFINITY;
+  for (int hp1 = 0; hp1 <= kMaxLevel; ++hp1)
+    for (int hp2 = 0; hp2 <= (in.duo ? kMaxLevel : 0); ++hp2) {
+      const auto candidate = make_candidate(in, tuning, hp1, hp2, target_w);
+      if (candidate.valid && candidate.active_count == active_count)
+        best_error_w = std::min(best_error_w, candidate.error_w);
+    }
+  for (int hp1 = 0; hp1 <= kMaxLevel; ++hp1)
+    for (int hp2 = 0; hp2 <= (in.duo ? kMaxLevel : 0); ++hp2) {
+      const auto candidate = make_candidate(in, tuning, hp1, hp2, target_w);
+      if (candidate.valid && candidate.active_count == active_count && candidate.error_w <= best_error_w + tie_band_w &&
+          (!chosen.valid || better_candidate(candidate, chosen)))
+        chosen = candidate;
+    }
+  return chosen;
+}
+inline float dispatch_capacity(const DispatchInput& in, const DispatchTuning& tuning) {
+  if (!in.performance_valid || !electrical_limits_valid(tuning)) return 0.0f;
+  float capacity_w = 0.0f;
+  for (int hp1 = 0; hp1 <= kMaxLevel; ++hp1)
+    for (int hp2 = 0; hp2 <= (in.duo ? kMaxLevel : 0); ++hp2) {
+      const auto candidate = make_candidate(in, tuning, hp1, hp2, 0.0f);
+      if (candidate.valid && candidate.thermal_w > capacity_w) capacity_w = candidate.thermal_w;
+    }
+  return capacity_w;
+}
+inline DispatchDecision decide_dispatch(const DispatchInput& in, const DispatchTuning& tuning,
+                                        const DispatchState& state) {
+  DispatchDecision out;
+  const bool request_valid = std::isfinite(in.requested_w) && in.requested_w >= 0.0f;
+  out.capacity_w = dispatch_capacity(in, tuning);
+  out.deficit_w = request_valid ? std::max(0.0f, in.requested_w - out.capacity_w) : 0.0f;
+  out.saturated = in.demand_level > 0 && out.deficit_w > 0.0f;
+  if (in.demand_level <= 0) {
+    out.output_valid = request_valid && in.performance_valid;
+    if (out.output_valid) out.expected_w = 0.0f;
+    return out;
+  }
+  auto finish = [&](const Candidate& candidate, Reason reason) {
+    if (!candidate.valid) {
+      out.reason = Reason::NO_CANDIDATE;
+      return;
+    }
+    out.hp1_level = candidate.hp1_level;
+    out.hp2_level = candidate.hp2_level;
+    out.owner_hp = owner(out.hp1_level, out.hp2_level);
+    out.reason = reason;
+    out.expected_w = candidate.thermal_w;
+    out.output_valid = request_valid;
+  };
+  if (!request_valid) {
+    out.reason = Reason::FALLBACK_IDLE;
+    return out;
+  }
+  if (!electrical_limits_valid(tuning)) {
+    out.reason = Reason::NO_CANDIDATE;
+    return out;
+  }
+  if (!in.performance_valid) {
+    auto retained = [&](const HpInput& hp) {
+      const int level = applied_level(hp);
+      return level > 0 && level <= kMaxLevel && !hp.candidate.must_stop && hp.levels[level].allowed ? level : 0;
+    };
+    out.hp1_level = retained(in.hp1);
+    out.hp2_level = in.duo ? retained(in.hp2) : 0;
+    out.owner_hp = owner(out.hp1_level, out.hp2_level);
+    out.reason = topology(out.hp1_level, out.hp2_level) == 0 ? Reason::FALLBACK_IDLE
+                 : out.owner_hp == 1                         ? Reason::FALLBACK_HP1
+                 : out.owner_hp == 2                         ? Reason::FALLBACK_HP2
+                                                             : Reason::FALLBACK_DUO;
+    return out;
+  }
+  const float target_w = std::max(0.0f, std::min(in.requested_w, out.capacity_w));
+  if (!in.duo) {
+    Candidate best;
+    float best_cost = INFINITY;
+    bool active_candidate = false;
+    for (int level = 0; level <= kMaxLevel; ++level) {
+      const auto candidate = make_candidate(in, tuning, level, 0, target_w);
+      if (!candidate.valid) continue;
+      active_candidate |= level > 0;
+      const float penalty = std::isfinite(tuning.over_soft_penalty_per_w) && tuning.over_soft_penalty_per_w >= 0.0f
+                                ? tuning.over_soft_penalty_per_w
+                                : 0.0f;
+      const float cost = candidate.error_w + 50.0f * candidate.level_moves + penalty * candidate.over_soft_w;
+      if (cost < best_cost) {
+        best = candidate;
+        best_cost = cost;
+      }
+    }
+    if (!active_candidate)
+      out.reason = Reason::NO_CANDIDATE;
+    else
+      finish(best, best.hp1_level > 0 ? Reason::SINGLE_TOPOLOGY : Reason::IDLE);
+  } else {
+    const float tie_band_w = std::max(150.0f, 0.05f * std::max(target_w, 1000.0f));
+    const float keep_margin_w = std::min(90.0f, tie_band_w * 0.5f);
+    const float power_margin_w = std::isfinite(tuning.topology_power_margin_w) && tuning.topology_power_margin_w >= 0.0f
+                                     ? tuning.topology_power_margin_w
+                                     : 150.0f;
+    const float heat_advantage_w =
+        std::isfinite(tuning.topology_heat_advantage_w) && tuning.topology_heat_advantage_w >= 0.0f
+            ? tuning.topology_heat_advantage_w
+            : 450.0f;
+    const Candidate single = pick_topology(in, tuning, target_w, 1, tie_band_w);
+    const Candidate duo = pick_topology(in, tuning, target_w, 2, tie_band_w);
+    Candidate best;
+    const bool have_best = single.valid || duo.valid;
+    if (single.valid && duo.valid) {
+      const Candidate* preferred = duo.electrical_w < single.electrical_w ? &duo : &single;
+      const Candidate* alternate = preferred == &duo ? &single : &duo;
+      best = alternate->error_w + heat_advantage_w < preferred->error_w ? *alternate : *preferred;
+    } else if (single.valid)
+      best = single;
+    else if (duo.valid)
+      best = duo;
+    const Candidate current = make_candidate(in, tuning, applied_level(in.hp1), applied_level(in.hp2), target_w);
+    const bool valve_defrost = in.hp1.valve_defrost || in.hp2.valve_defrost;
+    if (valve_defrost && topology(current.hp1_level, current.hp2_level) == 1 && single.valid && have_best &&
+        best.active_count == 2)
+      best = single;
+    bool keep_current = false;
+    Reason reason = Reason::BETTER_HEAT;
+    if (have_best && current.valid) {
+      const bool heat_ok = current.error_w <= best.error_w + keep_margin_w;
+      const bool topology_change =
+          current.active_count > 0 && best.active_count > 0 && current.active_count != best.active_count;
+      const bool owner_swap =
+          current.active_count == 1 && best.active_count == 1 && ((current.hp1_level > 0) != (best.hp1_level > 0));
+      const bool change_allowed = !topology_change || best.error_w + heat_advantage_w < current.error_w ||
+                                  best.electrical_w + power_margin_w < current.electrical_w;
+      const bool defrost_hold = owner_swap && (tail_active(state.hp1_defrost, in.now_ms, kDefrostHoldMs) ||
+                                               tail_active(state.hp2_defrost, in.now_ms, kDefrostHoldMs));
+      const bool oil_hold =
+          heat_ok && (topology_change || owner_swap) && tail_active(state.oil_return, in.now_ms, kOilReturnHoldMs);
+      const bool ordinary_hold =
+          topology_change && heat_ok && !change_allowed && topology_hold_active(state, in.now_ms, kTopologyHoldMs);
+      if (defrost_hold)
+        keep_current = true, reason = Reason::DEFROST_HOLD;
+      else if (oil_hold)
+        keep_current = true, reason = Reason::OIL_RETURN_HOLD;
+      else if (ordinary_hold || (topology_change && !change_allowed && heat_ok))
+        keep_current = true, reason = ordinary_hold && valve_defrost ? Reason::DEFROST_HOLD : Reason::HOLD_ACTIVE;
+      else if (!heat_ok)
+        reason = Reason::BETTER_HEAT;
+      else if (current.over_soft_w > best.over_soft_w + 40.0f)
+        reason = Reason::SOFT_GUARD;
+      else if (current.electrical_w > best.electrical_w + (topology_change ? power_margin_w : 150.0f))
+        reason = Reason::LESS_POWER;
+      else
+        keep_current = true, reason = Reason::KEEP_CURRENT;
+    } else if (!have_best) {
+      keep_current = current.valid && current.active_count > 0;
+      reason = keep_current ? Reason::KEEP_CURRENT : Reason::NO_CANDIDATE;
+    }
+    Candidate chosen = keep_current && current.valid ? current : best;
+    const int boost_steps = std::max(0, std::min(3, tuning.defrost_boost_steps));
+    if (chosen.valid && chosen.active_count == 2 && boost_steps > 0 &&
+        in.demand_level >= tuning.defrost_boost_min_level && chosen.thermal_w + tie_band_w < target_w &&
+        (in.hp1.valve_defrost != in.hp2.valve_defrost)) {
+      for (int step = boost_steps; step > 0; --step) {
+        const int hp1 = in.hp2.valve_defrost ? std::min(kMaxLevel, chosen.hp1_level + step) : chosen.hp1_level;
+        const int hp2 = in.hp1.valve_defrost ? std::min(kMaxLevel, chosen.hp2_level + step) : chosen.hp2_level;
+        const auto boosted = make_candidate(in, tuning, hp1, hp2, target_w);
+        if (boosted.valid && (hp1 > chosen.hp1_level || hp2 > chosen.hp2_level)) {
+          chosen = boosted;
+          reason = Reason::DEFROST_BOOST;
+          break;
+        }
+      }
+    }
+    if (chosen.valid && chosen.active_count == 1 && applied_level(in.hp1) <= 0 && applied_level(in.hp2) <= 0 &&
+        !in.hp1.defrost && !in.hp2.defrost && !valve_defrost) {
+      const int level = chosen.hp1_level > 0 ? chosen.hp1_level : chosen.hp2_level;
+      const auto lead = make_candidate(in, tuning, in.lead_hp1 ? level : 0, in.lead_hp1 ? 0 : level, target_w);
+      const auto lag = make_candidate(in, tuning, in.lead_hp1 ? 0 : level, in.lead_hp1 ? level : 0, target_w);
+      if (lead.valid && lag.valid) chosen = lead, reason = Reason::RUNTIME_LEAD;
+    }
+    if (chosen.valid) {
+      const auto suspect = oq_hp_candidate::preserve_active_topology_during_suspect(
+          {chosen.hp1_level, chosen.hp2_level, sanitized_candidate(in.hp1), sanitized_candidate(in.hp2), true});
+      if (suspect.active) {
+        auto retained_level = [](const HpInput& hp, int proposed) {
+          const int previous = applied_level(hp);
+          if (hp.candidate.must_stop || previous <= 0) return 0;
+          return proposed > 0 ? proposed : previous;
+        };
+        const auto retained = make_candidate(in, tuning, retained_level(in.hp1, chosen.hp1_level),
+                                             retained_level(in.hp2, chosen.hp2_level), target_w);
+        if (retained.valid) chosen = retained, reason = Reason::KEEP_CURRENT;
+      }
+    }
+    finish(chosen, reason);
+  }
+  return out;
+}
+}  // namespace oq_power_house_dispatch

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -1,27 +1,12 @@
 # ==============================================================================
 # OpenQuatt - Power House Strategy
 # ==============================================================================
-#
-# Goal:
-#   Owns the complete Power House strategy implementation and its compressor-request output.
-#
-# Ownership:
-#   - Computes Power House requested heat and compatible demand from room/outside state
-#   - Publishes Power House tuning and diagnostics
-#   - Computes filtered Power House demand from oq_demand_raw
-#   - Chooses the Power House topology / compressor requests
-#   - Publishes request outputs for oq_thermal_request_control through the
-#     shared request interface before downstream actuator handling
-# ==============================================================================
 
 globals:
   - id: oq_phouse_demand_external
     type: bool
     restore_value: false
     initial_value: 'false'
-  # Power House requested thermal power (W).
-  # This is strategy-specific diagnostics/state and is not part of the generic
-  # heating-strategy interface.
   - id: oq_phouse_req_w
     type: float
     restore_value: false
@@ -37,10 +22,6 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # Internal comfort memory that slowly builds when the room stays on the cold
-  # side for longer. This nudges the effective cold-side target upward so Power
-  # House behaves more like the older warm-leaning model, without exposing the
-  # old bias/tau controls in the UI.
   - id: oq_phouse_comfort_memory_c
     type: float
     restore_value: false
@@ -71,11 +52,6 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  # 0=idle, 1=fallback_idle, 2=fallback_single_hp1, 3=fallback_single_hp2,
-  # 4=fallback_duo, 5=keep_current, 6=hold_active, 7=defrost_hold,
-  # 8=better_heat, 9=soft_guard, 10=less_power, 11=no_candidate,
-  # 12=defrost_boost, 13=runtime_lead, 14=single_topology,
-  # 15=oil_return_hold
   - id: oq_ph_request_reason_code
     type: int
     restore_value: false
@@ -106,7 +82,7 @@ select:
     set_action:
       then:
         - lambda: |-
-            // Preset wrapper around the canonical rise/fall response-time knobs.
+            // Map the response preset to the canonical rise/fall knobs.
             auto set_number_value = [](auto *num, float value) {
               if (num == nullptr) return;
               auto c = num->make_call();
@@ -246,7 +222,6 @@ number:
     initial_value: 1
 
 text_sensor:
-  # DEBUG-RUNTIME START: Duo Power House request reason
   - platform: template
     id: oq_duo_optimizer_reason
     name: "Duo optimizer reason"
@@ -261,8 +236,6 @@ text_sensor:
       #else
       return std::string("single_topology");
       #endif
-  # DEBUG-RUNTIME END
-
   - platform: template
     id: oq_phouse_demand_source
     name: "Power House – demand source"
@@ -270,7 +243,6 @@ text_sensor:
     entity_category: diagnostic
     update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
-      // Separate a live external feedforward from a fallback to the house model.
       return std::string(id(oq_phouse_demand_external) ? "external" : "model");
 
 sensor:
@@ -292,8 +264,6 @@ sensor:
       if (isnan(Tout) || isnan(Tc) || isnan(T0) || isnan(Pr)) return NAN;
       if (T0 <= Tc + ${oq_temp_guard_delta_c}f) return NAN;
 
-      // Always the modelled value, also while an external demand is driving the
-      // feedforward: it stays the reference the strategy falls back to.
       return oq_power_house::modelled_house_power_w(T0, Tc, Tout, Pr);
 
   - platform: template
@@ -344,16 +314,11 @@ interval:
     then:
       - lambda: |-
           // Power House strategy: owns filtered demand and PH topology selection.
-          static bool hp1_prev_valve_def = false;
-          static bool hp2_prev_valve_def = false;
-          static bool hp1_prev_oil_return = false;
-          static bool hp2_prev_oil_return = false;
-          static uint32_t hp1_defrost_owner_hold_until_ms = 0;
-          static uint32_t hp2_defrost_owner_hold_until_ms = 0;
-          static uint32_t oil_return_hold_until_ms = 0;
+          static oq_power_house_dispatch::DispatchState dispatch_state;
           const int cm_code = id(oq_control_mode_code);
           const bool active = (cm_code != 5) && (id(oq_heat_mode_code) != 1);
           if (!active) {
+            dispatch_state = {};
             id(oq_ph_request_last_loop_ms) = 0;
             id(oq_ph_request_hp1_level) = 0;
             id(oq_ph_request_hp2_level) = 0;
@@ -363,34 +328,47 @@ interval:
             id(oq_phouse_last_w) = 0.0f;
             id(oq_phouse_comfort_memory_c) = 0.0f;
             id(oq_phouse_demand_external) = false;
-            hp1_prev_valve_def = false;
-            hp2_prev_valve_def = false;
-            hp1_prev_oil_return = false;
-            hp2_prev_oil_return = false;
-            hp1_defrost_owner_hold_until_ms = 0;
-            hp2_defrost_owner_hold_until_ms = 0;
-            oil_return_hold_until_ms = 0;
+            id(oq_P_hp_cap_w) = 0.0f;
+            id(oq_P_deficit_w) = 0.0f;
             return;
           }
+
           const uint32_t now_ms = (uint32_t) millis();
+          if (id(oq_strategy_output_source_code) != 3) dispatch_state = {};
+          const bool hp1_valve_def = id(hp1_4_way_valve).state;
+          const bool hp1_oil_return = id(hp1_prot_oil_return).state;
+          #if OQ_TOPOLOGY_DUO
+          const bool hp2_valve_def = id(${secondary_4_way_valve_id}).state;
+          const bool hp2_oil_return = id(${secondary_oil_return_id}).state;
+          const int hp2_applied_level = id(${secondary_last_applied_level_id});
+          #else
+          const bool hp2_valve_def = false;
+          const bool hp2_oil_return = false;
+          const int hp2_applied_level = 0;
+          #endif
+          dispatch_state = oq_power_house_dispatch::observe_protection(
+              dispatch_state, {now_ms, hp1_valve_def, hp2_valve_def, hp1_oil_return || hp2_oil_return,
+                               id(hp1_last_applied_level), hp2_applied_level});
+
           const uint32_t loop_target_ms = (uint32_t) (${oq_heat_loop_powerhouse_s} * 1000UL);
-          const auto cadence = oq_power_house::decide_cadence(now_ms, id(oq_ph_request_last_loop_ms), loop_target_ms);
+          const auto cadence =
+              oq_power_house::decide_cadence(now_ms, id(oq_ph_request_last_loop_ms), loop_target_ms);
           if (!cadence.due) return;
           id(oq_ph_request_last_loop_ms) = now_ms == 0 ? UINT32_MAX : now_ms;
+
           const int demand_max_f = (int) ${oq_strategy_demand_max_f};
-          const bool external_valid = id(external_heat_demand_selected).has_state();
           const oq_power_house::DemandInput demand_input{
               now_ms, id(outside_temp_selected).state, id(house_cold_temp_c).state,
               id(house_zero_power_temp_c).state, id(house_rated_power_w).state, id(room_temp_selected).state,
               id(room_setpoint_selected).state, id(external_heat_demand_selected).state,
-              id(oq_water_temp_limit_factor), external_valid};
+              id(oq_water_temp_limit_factor), id(external_heat_demand_selected).has_state()};
           const oq_power_house::DemandTuning demand_tuning{
               ${oq_temp_guard_delta_c}f, id(ph_kp_w_per_k).state, id(ph_comfort_band_below_c).state,
               id(ph_comfort_band_above_c).state, id(ph_demand_rise_time_min).state,
               id(ph_demand_fall_time_min).state, demand_max_f};
-          const oq_power_house::DemandState demand_state{
-              id(oq_phouse_last_w), id(oq_phouse_last_ms), id(oq_phouse_comfort_memory_c)};
-          const auto demand = oq_power_house::decide_demand(demand_input, demand_tuning, demand_state);
+          const auto demand = oq_power_house::decide_demand(
+              demand_input, demand_tuning,
+              {id(oq_phouse_last_w), id(oq_phouse_last_ms), id(oq_phouse_comfort_memory_c)});
           id(oq_phouse_req_w) = demand.requested_w;
           id(oq_phouse_last_w) = demand.next.last_w;
           id(oq_phouse_last_ms) = demand.next.last_ms;
@@ -404,668 +382,112 @@ interval:
           id(oq_demand_filter_ramp_up_budget) = filtered.ramp_budget;
           id(oq_demand_filtered) = filtered.filtered;
           id(oq_heating_demand_filtered) = filtered.filtered;
-          int f = filtered.filtered;
-
-          int f_cap = id(oq_power_cap_f);
-          f_cap = std::max(0, std::min(demand_max_f, f_cap));
-          if (f > f_cap) f = f_cap;
+          int f = std::min(filtered.filtered, std::max(0, std::min(demand_max_f, id(oq_power_cap_f))));
 
           #if OQ_TOPOLOGY_DUO
-          const bool lead_is_hp1 = (id(hp1_minutes) <= id(${secondary_minutes_id}));
+          const bool lead_is_hp1 = id(hp1_minutes) <= id(${secondary_minutes_id});
+          const bool duo = true;
           #else
           const bool lead_is_hp1 = true;
+          const bool duo = false;
           #endif
-          const int lead_code = lead_is_hp1 ? 1 : 2;
-          if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
+          id(oq_last_lead_hp) = lead_is_hp1 ? 1 : 2;
 
           const auto frequency_runtime = oq_frequency_runtime::capture();
-
-          auto publish_optimizer_reason = [&](const char* reason)->void {
-            #if OQ_TOPOLOGY_DUO
-            static std::string last_optimizer_reason = "";
-            const std::string s(reason);
-            if (s != last_optimizer_reason) {
-              id(oq_duo_optimizer_reason).publish_state(s.c_str());
-              last_optimizer_reason = s;
-            }
-            #else
-            (void) reason;
-            #endif
-          };
-
-          constexpr int max_level = 10;
-          auto level_allowed = [&](bool is_hp1, int level)->bool {
+          auto level_allowed = [&](bool is_hp1, int level) -> bool {
             return frequency_runtime.frequency_allowed(is_hp1, 2, level);
           };
 
-          auto valve_defrost_active = [&](bool is_hp1)->bool {
-            if (is_hp1) return id(hp1_4_way_valve).state;
-            #if OQ_TOPOLOGY_DUO
-            return id(${secondary_4_way_valve_id}).state;
-            #else
-            return false;
-            #endif
-          };
-
-          const float Tamb = id(outside_temp_selected).state;
-          const float Tsup = id(oq_system_supply_temp).state;
-          const int level_cap = max_level;
-
-          const bool hp1_def = id(hp1_defrost).state;
-          const bool hp1_valve_def = valve_defrost_active(true);
-          const bool hp1_oil_return = id(hp1_prot_oil_return).state;
-          const auto hp1_incident_outputs =
-              id(oq_incident_manager).get_outputs(1);
-          const int hp1_previous_applied_level =
-              id(hp1_last_applied_level);
-          const auto hp1_candidate_state =
-              oq_hp_candidate::candidate_state(
-                  hp1_incident_outputs,
-                  hp1_previous_applied_level);
-          const bool hp1_available =
-              oq_hp_candidate::may_serve_candidate(hp1_candidate_state);
+          const float outside_c = id(outside_temp_selected).state;
+          const float supply_c = id(oq_system_supply_temp).state;
+          const bool performance_valid = isfinite(outside_c) && isfinite(supply_c);
+          const auto hp1_incident = id(oq_incident_manager).get_outputs(1);
+          const auto hp1_candidate =
+              oq_hp_candidate::candidate_state(hp1_incident, id(hp1_last_applied_level));
+          const bool hp1_defrost_active = id(hp1_defrost).state;
           #if OQ_TOPOLOGY_DUO
-          const bool hp2_def = id(${secondary_defrost_id}).state;
-          const bool hp2_valve_def = valve_defrost_active(false);
-          const bool hp2_oil_return = id(${secondary_oil_return_id}).state;
-          const auto hp2_incident_outputs =
-              id(oq_incident_manager).get_outputs(2);
-          const int hp2_previous_applied_level =
-              id(${secondary_last_applied_level_id});
-          const auto hp2_candidate_state =
-              oq_hp_candidate::candidate_state(
-                  hp2_incident_outputs,
-                  hp2_previous_applied_level);
-          const bool hp2_available =
-              oq_hp_candidate::may_serve_candidate(hp2_candidate_state);
+          const auto hp2_incident = id(oq_incident_manager).get_outputs(2);
+          const auto hp2_candidate =
+              oq_hp_candidate::candidate_state(hp2_incident, hp2_applied_level);
+          const bool hp2_defrost_active = id(${secondary_defrost_id}).state;
           #else
-          const bool hp2_def = false;
-          const bool hp2_valve_def = false;
-          const bool hp2_oil_return = false;
-          const oq_hp_candidate::HpCandidateState hp2_candidate_state;
-          const bool hp2_available = false;
+          const oq_hp_candidate::HpCandidateState hp2_candidate;
+          const bool hp2_defrost_active = false;
           #endif
 
-          constexpr uint32_t defrost_owner_hold_ms = 180000UL;
-          if (hp1_valve_def || hp1_prev_valve_def) hp1_defrost_owner_hold_until_ms = now_ms + defrost_owner_hold_ms;
-          if (hp2_valve_def || hp2_prev_valve_def) hp2_defrost_owner_hold_until_ms = now_ms + defrost_owner_hold_ms;
-          hp1_prev_valve_def = hp1_valve_def;
-          hp2_prev_valve_def = hp2_valve_def;
-
-          constexpr uint32_t oil_return_hold_ms = 120000UL;
-          const bool oil_return_active = hp1_oil_return || hp2_oil_return;
-          if (oil_return_active || hp1_prev_oil_return || hp2_prev_oil_return) {
-            oil_return_hold_until_ms = now_ms + oil_return_hold_ms;
-          }
-          hp1_prev_oil_return = hp1_oil_return;
-          hp2_prev_oil_return = hp2_oil_return;
-          const bool oil_return_hold_active =
-              oil_return_active ||
-              (oil_return_hold_until_ms > 0 && now_ms < oil_return_hold_until_ms);
-
-          float def_fac_cfg = ${oq_defrost_power_factor};
-          if (isnan(def_fac_cfg)) def_fac_cfg = 0.55f;
-          const float def_fac = fmaxf(0.10f, fminf(1.00f, def_fac_cfg));
-          const float hp1_th_fac = hp1_valve_def ? def_fac : 1.0f;
-          const float hp2_th_fac = hp2_valve_def ? def_fac : 1.0f;
-
-          auto max_cap_hp = [&](bool is_hp1)->float {
-            if ((is_hp1 && !hp1_available) || (!is_hp1 && !hp2_available)) return 0.0f;
-            float best = 0.0f;
-            for (int lvl = 1; lvl <= level_cap; lvl++) {
-              if (!level_allowed(is_hp1, lvl)) continue;
-              float p = oq_perf::interp_power_th_w_hz(
-                  oq_perf::model_frequency_hz(lvl), Tamb, Tsup);
-              if (!isnan(p)) p *= is_hp1 ? hp1_th_fac : hp2_th_fac;
-              if (!isnan(p) && p > best) best = p;
+          float defrost_factor = ${oq_defrost_power_factor};
+          if (!isfinite(defrost_factor)) defrost_factor = 0.55f;
+          defrost_factor = fmaxf(0.10f, fminf(1.00f, defrost_factor));
+          auto build_hp = [&](oq_power_house_dispatch::HpInput& result,
+                              bool hp1,
+                              const oq_hp_candidate::HpCandidateState& candidate,
+                              bool defrost,
+                              bool valve_defrost) {
+            result.candidate = candidate;
+            result.defrost = defrost;
+            result.valve_defrost = valve_defrost;
+            result.levels[0] = {true, true, true, 0.0f, 0.0f};
+            for (int level = 1; level <= oq_power_house_dispatch::kMaxLevel; ++level) {
+              const bool allowed = level_allowed(hp1, level);
+              float thermal_w = NAN;
+              float electrical_w = NAN;
+              if (performance_valid) {
+                const float frequency_hz = oq_perf::model_frequency_hz(level);
+                thermal_w = oq_perf::interp_power_th_w_hz(frequency_hz, outside_c, supply_c);
+                electrical_w = oq_perf::interp_power_el_w_hz(frequency_hz, outside_c, supply_c);
+                if (valve_defrost && isfinite(thermal_w)) thermal_w *= defrost_factor;
+              }
+              result.levels[level] = {allowed, isfinite(thermal_w) && thermal_w >= 0.0f,
+                                      isfinite(electrical_w) && electrical_w >= 0.0f,
+                                      thermal_w, electrical_w};
             }
-            return best;
           };
 
-          auto publish_capacity_and_deficit = [&](float requested_w)->float {
-            float cap_total = 0.0f;
-            if (!isnan(Tamb) && !isnan(Tsup)) {
-              cap_total = max_cap_hp(true) + max_cap_hp(false);
-            }
-            id(oq_P_hp_cap_w) = cap_total;
-
-            float req = requested_w;
-            if (isnan(req)) req = 0.0f;
-            float deficit = req - cap_total;
-            if (deficit < 0.0f) deficit = 0.0f;
-            id(oq_P_deficit_w) = deficit;
-            return cap_total;
-          };
-
-          int hp1_req = 0;
-          int hp2_req = 0;
-          int request_owner_hp = 0;
-          int request_reason_code = 0;
-
-          const float strategy_rated_power_w = id(house_rated_power_w).state;
-          float P_req_total = id(oq_phouse_req_w);
-          float strategy_power_cap_w = NAN;
-          if (!isnan(strategy_rated_power_w) && strategy_rated_power_w > 0.0f) {
-            strategy_power_cap_w =
-                strategy_rated_power_w * ((float) f / (float) demand_max_f);
+          float requested_w = id(oq_phouse_req_w);
+          const float rated_w = id(house_rated_power_w).state;
+          if (isfinite(requested_w) && isfinite(rated_w) && rated_w > 0.0f) {
+            requested_w = std::min(requested_w, rated_w * (float) f / (float) demand_max_f);
           }
-          if (!isnan(strategy_power_cap_w)) {
-            P_req_total = std::min(P_req_total, strategy_power_cap_w);
-          }
+          oq_power_house_dispatch::DispatchInput dispatch_input{
+              now_ms, f, requested_w, duo, performance_valid, lead_is_hp1};
+          build_hp(dispatch_input.hp1, true, hp1_candidate, hp1_defrost_active, hp1_valve_def);
+          #if OQ_TOPOLOGY_DUO
+          build_hp(dispatch_input.hp2, false, hp2_candidate, hp2_defrost_active, hp2_valve_def);
+          #endif
+          const oq_power_house_dispatch::DispatchTuning dispatch_tuning{
+              id(oq_power_limit_soft_w), id(oq_power_limit_peak_w), ${oq_optimizer_penalty_per_w},
+              ${oq_optimizer_topology_power_margin_w}, ${oq_optimizer_topology_heat_advantage_w},
+              (int) roundf(${oq_defrost_comp_min_f}), (int) roundf(${oq_defrost_comp_boost_steps})};
+          const auto dispatch = oq_power_house_dispatch::decide_dispatch(
+              dispatch_input, dispatch_tuning, dispatch_state);
+          id(oq_ph_request_hp1_level) = dispatch.hp1_level;
+          id(oq_ph_request_hp2_level) = dispatch.hp2_level;
+          id(oq_ph_request_owner_hp) = dispatch.owner_hp;
+          id(oq_ph_request_reason_code) = (int) dispatch.reason;
+          id(oq_P_hp_cap_w) = dispatch.capacity_w;
+          id(oq_P_deficit_w) = dispatch.deficit_w;
 
           #if OQ_TOPOLOGY_DUO
-          const float cap_total = publish_capacity_and_deficit(P_req_total);
-          const bool perf_inputs_valid = !isnan(Tamb) && !isnan(Tsup) && level_cap > 0;
-          if (!perf_inputs_valid) {
-            request_reason_code = 1;
-            id(oq_duo_request_hold_until_ms) = 0;
-            // Use a fixed fallback threshold now that the tuning entity is gone.
-            int dual_on_f = std::max(2, std::min(9, demand_max_f));
-            int dual_off_f = dual_on_f - 2;
-            if (dual_off_f < 1) dual_off_f = 1;
-
-            const bool prefer_single = (f > 0 && f <= dual_on_f && !(hp1_def && hp2_def));
-            if (!prefer_single) {
-              oq_request::reset_dual_hold_state(
-                  id(oq_dual_hp_enabled),
-                  id(oq_dual_hp_enable_hold_elapsed_accum_min),
-                  id(oq_dual_hp_disable_hold_elapsed_accum_min),
-                  id(oq_dual_hp_emergency_hold_elapsed_accum_min));
-            } else {
-              int on_hold = (int) roundf(id(oq_dual_hp_enable_hold_min).state);
-              int off_hold = (int) roundf(id(oq_dual_hp_disable_hold_min).state);
-              if (on_hold < 1) on_hold = 1;
-              if (off_hold < 1) off_hold = 1;
-
-              if (f >= dual_on_f) id(oq_dual_hp_enable_hold_elapsed_accum_min) += cadence.dt_s / 60.0f;
-              else id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
-
-              if (f <= dual_off_f) id(oq_dual_hp_disable_hold_elapsed_accum_min) += cadence.dt_s / 60.0f;
-              else id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
-
-              if (!id(oq_dual_hp_enabled) && id(oq_dual_hp_enable_hold_elapsed_accum_min) >= (float) on_hold) {
-                id(oq_dual_hp_enabled) = true;
-                id(oq_dual_hp_disable_hold_elapsed_accum_min) = 0.0f;
-              } else if (id(oq_dual_hp_enabled) && id(oq_dual_hp_disable_hold_elapsed_accum_min) >= (float) off_hold) {
-                id(oq_dual_hp_enabled) = false;
-                id(oq_dual_hp_enable_hold_elapsed_accum_min) = 0.0f;
-              }
-            }
-            const bool needs_dual = (f > dual_on_f) || (prefer_single && id(oq_dual_hp_enabled));
-
-            if (!hp1_available && !hp2_available) {
-              oq_request::reset_dual_hold_state(
-                  id(oq_dual_hp_enabled),
-                  id(oq_dual_hp_enable_hold_elapsed_accum_min),
-                  id(oq_dual_hp_disable_hold_elapsed_accum_min),
-                  id(oq_dual_hp_emergency_hold_elapsed_accum_min));
-              request_reason_code = 11;
-            } else if (hp1_available != hp2_available) {
-              oq_request::reset_dual_hold_state(
-                  id(oq_dual_hp_enabled),
-                  id(oq_dual_hp_enable_hold_elapsed_accum_min),
-                  id(oq_dual_hp_disable_hold_elapsed_accum_min),
-                  id(oq_dual_hp_emergency_hold_elapsed_accum_min));
-              const int available_request = std::min(max_level, f);
-              hp1_req = hp1_available ? available_request : 0;
-              hp2_req = hp2_available ? available_request : 0;
-              request_owner_hp = hp1_available ? 1 : 2;
-              request_reason_code = 13;
-            } else if (prefer_single && !needs_dual) {
-              if (lead_is_hp1) hp1_req = f;
-              else hp2_req = f;
-              request_owner_hp = lead_is_hp1 ? 1 : 2;
-              request_reason_code = lead_is_hp1 ? 2 : 3;
-            } else {
-              hp1_req = f / 2;
-              hp2_req = f / 2;
-              if ((f % 2) == 1) {
-                if (lead_is_hp1) hp1_req += 1;
-                else hp2_req += 1;
-              }
-              request_owner_hp = 0;
-              request_reason_code = 4;
-            }
-          } else {
-            float P_target = P_req_total;
-            if (isnan(P_target)) P_target = 0.0f;
-            if (P_target > cap_total) P_target = cap_total;
-            if (P_target < 0.0f) P_target = 0.0f;
-
-            const int last1 = id(hp1_last_applied_level);
-            const int last2 = id(${secondary_last_applied_level_id});
-            const float P_EL_SOFT_W = id(oq_power_limit_soft_w);
-            const float P_EL_PEAK_W = id(oq_power_limit_peak_w);
-            const float thermal_tie_band_w = fmaxf(150.0f, 0.05f * fmaxf(P_target, 1000.0f));
-            const float thermal_keep_margin_w = fminf(90.0f, thermal_tie_band_w * 0.5f);
-            float topology_power_margin_w = ${oq_optimizer_topology_power_margin_w};
-            if (isnan(topology_power_margin_w) || topology_power_margin_w < 0.0f) topology_power_margin_w = 150.0f;
-            float topology_heat_advantage_w = ${oq_optimizer_topology_heat_advantage_w};
-            if (isnan(topology_heat_advantage_w) || topology_heat_advantage_w < 0.0f) topology_heat_advantage_w = 450.0f;
-            const float pel_switch_margin_w = 150.0f;
-            const float soft_switch_margin_w = 40.0f;
-            struct DuoCandidate {
-              bool valid;
-              int l1;
-              int l2;
-              float p_th_w;
-              float p_el_w;
-              float err_w;
-              float over_soft_w;
-              int level_moves;
-              int active_hp_count;
-              int balance_steps;
-              bool single_on_lead;
-            };
-
-            auto build_duo_candidate = [&](int l1, int l2)->DuoCandidate {
-              DuoCandidate c{};
-              c.valid = false;
-              c.l1 = l1;
-              c.l2 = l2;
-
-              if (l1 > 0) {
-                if (!hp1_available || !level_allowed(true, l1)) return c;
-              }
-              if (l2 > 0) {
-                if (!hp2_available || !level_allowed(false, l2)) return c;
-              }
-
-              float p1 = (l1 == 0) ? 0.0f : oq_perf::interp_power_th_w_hz(
-                  oq_perf::model_frequency_hz(l1), Tamb, Tsup);
-              if (l1 > 0 && isnan(p1)) return c;
-              p1 *= hp1_th_fac;
-
-              float p2 = (l2 == 0) ? 0.0f : oq_perf::interp_power_th_w_hz(
-                  oq_perf::model_frequency_hz(l2), Tamb, Tsup);
-              if (l2 > 0 && isnan(p2)) return c;
-              p2 *= hp2_th_fac;
-
-              float pel1 = (l1 == 0) ? 0.0f : oq_perf::interp_power_el_w_hz(
-                  oq_perf::model_frequency_hz(l1), Tamb, Tsup);
-              if (l1 > 0 && isnan(pel1)) pel1 = 0.0f;
-              float pel2 = (l2 == 0) ? 0.0f : oq_perf::interp_power_el_w_hz(
-                  oq_perf::model_frequency_hz(l2), Tamb, Tsup);
-              if (l2 > 0 && isnan(pel2)) pel2 = 0.0f;
-
-              const float pel_sum = pel1 + pel2;
-              if (pel_sum > P_EL_PEAK_W) return c;
-
-              c.valid = true;
-              c.p_th_w = p1 + p2;
-              c.p_el_w = pel_sum;
-              c.err_w = fabsf(c.p_th_w - P_target);
-              c.over_soft_w = fmaxf(0.0f, pel_sum - P_EL_SOFT_W);
-              c.level_moves = abs(l1 - last1) + abs(l2 - last2);
-              c.active_hp_count = (l1 > 0 ? 1 : 0) + (l2 > 0 ? 1 : 0);
-              c.balance_steps = abs(l1 - l2);
-              c.single_on_lead =
-                  (c.active_hp_count == 1) &&
-                  (((l1 > 0) && lead_is_hp1) || ((l2 > 0) && !lead_is_hp1));
-              return c;
-            };
-
-            auto better_duo_candidate = [&](const DuoCandidate &a, const DuoCandidate &b)->bool {
-              const float soft_eps_w = 1.0f;
-              const float pel_eps_w = 1.0f;
-              const float err_eps_w = 1.0f;
-              if (fabsf(a.over_soft_w - b.over_soft_w) > soft_eps_w) return a.over_soft_w < b.over_soft_w;
-              if (fabsf(a.p_el_w - b.p_el_w) > pel_eps_w) return a.p_el_w < b.p_el_w;
-              if (fabsf(a.err_w - b.err_w) > err_eps_w) return a.err_w < b.err_w;
-              if (a.level_moves != b.level_moves) return a.level_moves < b.level_moves;
-              if (a.active_hp_count == 2 && b.active_hp_count == 2 && a.balance_steps != b.balance_steps) {
-                return a.balance_steps < b.balance_steps;
-              }
-              if (a.active_hp_count == 1 && b.active_hp_count == 1) {
-                const int a_single = (a.l1 > 0) ? a.l1 : a.l2;
-                const int b_single = (b.l1 > 0) ? b.l1 : b.l2;
-                if (a_single == b_single && a.single_on_lead != b.single_on_lead) return a.single_on_lead;
-              }
-              if (a.l1 != b.l1) return a.l1 < b.l1;
-              return a.l2 < b.l2;
-            };
-
-            const DuoCandidate current_candidate = build_duo_candidate(last1, last2);
-            auto pick_topology_candidate = [&](int active_hp_count, DuoCandidate &chosen)->bool {
-              float topology_best_err_w = 1e12f;
-              bool have_topology_candidate = false;
-              for (int l1 = 0; l1 <= level_cap; l1++) {
-                for (int l2 = 0; l2 <= level_cap; l2++) {
-                  const DuoCandidate c = build_duo_candidate(l1, l2);
-                  if (!c.valid || c.active_hp_count != active_hp_count) continue;
-                  have_topology_candidate = true;
-                  if (c.err_w < topology_best_err_w) topology_best_err_w = c.err_w;
-                }
-              }
-              if (!have_topology_candidate) return false;
-
-              bool have_chosen = false;
-              for (int l1 = 0; l1 <= level_cap; l1++) {
-                for (int l2 = 0; l2 <= level_cap; l2++) {
-                  const DuoCandidate c = build_duo_candidate(l1, l2);
-                  if (!c.valid || c.active_hp_count != active_hp_count) continue;
-                  if (c.err_w > (topology_best_err_w + thermal_tie_band_w)) continue;
-                  if (!have_chosen || better_duo_candidate(c, chosen)) {
-                    chosen = c;
-                    have_chosen = true;
-                  }
-                }
-              }
-              return have_chosen;
-            };
-
-            DuoCandidate best_single_candidate{};
-            const bool have_best_single = pick_topology_candidate(1, best_single_candidate);
-            DuoCandidate best_duo_candidate{};
-            const bool have_best_duo = pick_topology_candidate(2, best_duo_candidate);
-            const bool valve_defrost_any = hp1_valve_def || hp2_valve_def;
-            const bool hp1_single_active = (last1 > 0) && (last2 <= 0);
-            const bool hp2_single_active = (last1 <= 0) && (last2 > 0);
-            const bool single_topology_active = hp1_single_active || hp2_single_active;
-
-            DuoCandidate best_candidate{};
-            bool have_best_candidate = false;
-            if (have_best_single && have_best_duo) {
-              const DuoCandidate *preferred_candidate = &best_single_candidate;
-              const DuoCandidate *alternate_candidate = &best_duo_candidate;
-              if (best_duo_candidate.p_el_w < best_single_candidate.p_el_w) {
-                preferred_candidate = &best_duo_candidate;
-                alternate_candidate = &best_single_candidate;
-              }
-              best_candidate = *preferred_candidate;
-              if (alternate_candidate->err_w + topology_heat_advantage_w < preferred_candidate->err_w) {
-                best_candidate = *alternate_candidate;
-              }
-              have_best_candidate = true;
-            } else if (have_best_single) {
-              best_candidate = best_single_candidate;
-              have_best_candidate = true;
-            } else if (have_best_duo) {
-              best_candidate = best_duo_candidate;
-              have_best_candidate = true;
-            }
-
-            if (valve_defrost_any && single_topology_active && have_best_single &&
-                have_best_candidate && (best_candidate.active_hp_count == 2)) {
-              best_candidate = best_single_candidate;
-            }
-            if (valve_defrost_any && have_best_single && best_candidate.active_hp_count == 1) {
-              if (hp1_single_active && best_candidate.l1 <= 0 && best_single_candidate.l1 > 0) {
-                best_candidate = best_single_candidate;
-              }
-              if (hp2_single_active && best_candidate.l2 <= 0 && best_single_candidate.l2 > 0) {
-                best_candidate = best_single_candidate;
-              }
-            }
-
-            bool keep_current = false;
-            int optimizer_reason_code = 2;
-            if (have_best_candidate && current_candidate.valid) {
-              const bool current_heat_ok = current_candidate.err_w <= (best_candidate.err_w + thermal_keep_margin_w);
-              const bool topology_change =
-                  (current_candidate.active_hp_count > 0) &&
-                  (best_candidate.active_hp_count > 0) &&
-                  (current_candidate.active_hp_count != best_candidate.active_hp_count);
-              const bool single_owner_swap =
-                  (current_candidate.active_hp_count == 1) &&
-                  (best_candidate.active_hp_count == 1) &&
-                  ((current_candidate.l1 > 0) != (best_candidate.l1 > 0));
-              const bool hold_window_active =
-                  (id(oq_duo_request_hold_until_ms) > 0) &&
-                  (now_ms < id(oq_duo_request_hold_until_ms));
-              const bool defrost_owner_hold_active =
-                  single_owner_swap &&
-                  ((hp1_valve_def || hp2_valve_def) ||
-                   (hp1_defrost_owner_hold_until_ms > now_ms) ||
-                   (hp2_defrost_owner_hold_until_ms > now_ms));
-              const bool oil_return_topology_hold_active =
-                  oil_return_hold_active &&
-                  current_heat_ok &&
-                  (topology_change || single_owner_swap);
-              const bool topology_change_allowed =
-                  !topology_change ||
-                  (best_candidate.err_w + topology_heat_advantage_w < current_candidate.err_w) ||
-                  (best_candidate.p_el_w + topology_power_margin_w < current_candidate.p_el_w);
-              const bool hold_active =
-                  hold_window_active &&
-                  current_heat_ok &&
-                  topology_change &&
-                  !topology_change_allowed;
-              const bool better_soft_guard =
-                  current_candidate.over_soft_w > (best_candidate.over_soft_w + soft_switch_margin_w);
-              const float efficiency_switch_margin_w =
-                  topology_change ? topology_power_margin_w : pel_switch_margin_w;
-              const bool better_efficiency =
-                  current_candidate.p_el_w > (best_candidate.p_el_w + efficiency_switch_margin_w);
-
-              if (defrost_owner_hold_active) {
-                keep_current = true;
-                optimizer_reason_code = 7;
-              } else if (oil_return_topology_hold_active) {
-                keep_current = true;
-                optimizer_reason_code = 15;
-              } else if (hold_active && current_heat_ok) {
-                keep_current = true;
-                optimizer_reason_code = (hp1_valve_def || hp2_valve_def) ? 7 : 6;
-              } else if (topology_change && !topology_change_allowed && current_heat_ok) {
-                keep_current = true;
-                optimizer_reason_code = 6;
-              } else if (!current_heat_ok) {
-                optimizer_reason_code = 8;
-              } else if (better_soft_guard) {
-                optimizer_reason_code = 9;
-              } else if (better_efficiency) {
-                optimizer_reason_code = 10;
-              } else {
-                keep_current = true;
-                optimizer_reason_code = 5;
-              }
-            } else if (!have_best_candidate) {
-              keep_current = current_candidate.valid;
-              optimizer_reason_code = keep_current ? 5 : 11;
-            } else {
-              optimizer_reason_code = 8;
-            }
-
-            const DuoCandidate chosen_candidate =
-                (keep_current && current_candidate.valid) ? current_candidate : best_candidate;
-            hp1_req = chosen_candidate.valid ? chosen_candidate.l1 : 0;
-            hp2_req = chosen_candidate.valid ? chosen_candidate.l2 : 0;
-            request_reason_code = optimizer_reason_code;
-
-            switch (optimizer_reason_code) {
-              case 5: publish_optimizer_reason("keep_current"); break;
-              case 6: publish_optimizer_reason("hold_active"); break;
-              case 7: publish_optimizer_reason("defrost_hold"); break;
-              case 8: publish_optimizer_reason("better_heat"); break;
-              case 9: publish_optimizer_reason("soft_guard"); break;
-              case 10: publish_optimizer_reason("less_power"); break;
-              case 11: publish_optimizer_reason("no_candidate"); break;
-              case 15: publish_optimizer_reason("oil_return_hold"); break;
-              default: break;
-            }
-
-            int def_comp_min_f = (int) roundf(${oq_defrost_comp_min_f});
-            if (def_comp_min_f < 0) def_comp_min_f = 0;
-            if (def_comp_min_f > demand_max_f) def_comp_min_f = demand_max_f;
-            int def_comp_boost = (int) roundf(${oq_defrost_comp_boost_steps});
-            if (def_comp_boost < 0) def_comp_boost = 0;
-            if (def_comp_boost > 3) def_comp_boost = 3;
-            const bool chosen_underdelivers =
-                chosen_candidate.valid && (chosen_candidate.p_th_w + thermal_tie_band_w < P_target);
-            const bool allow_defrost_boost =
-                (def_comp_boost > 0) &&
-                (f >= def_comp_min_f) &&
-                chosen_underdelivers &&
-                chosen_candidate.valid &&
-                (chosen_candidate.active_hp_count == 2);
-            auto boosted_allowed_level = [&](bool is_hp1, int current_level) {
-              const int target_level =
-                  std::min(level_cap, current_level + def_comp_boost);
-              for (int level = target_level; level > current_level; --level) {
-                if (level_allowed(is_hp1, level)) return level;
-              }
-              return current_level;
-            };
-            if (allow_defrost_boost) {
-              if (hp1_valve_def && !hp2_valve_def && hp2_req > 0) {
-                const int boosted_level =
-                    boosted_allowed_level(false, hp2_req);
-                if (boosted_level > hp2_req) {
-                  hp2_req = boosted_level;
-                  request_reason_code = 12;
-                  publish_optimizer_reason("defrost_boost");
-                }
-              }
-              if (hp2_valve_def && !hp1_valve_def && hp1_req > 0) {
-                const int boosted_level =
-                    boosted_allowed_level(true, hp1_req);
-                if (boosted_level > hp1_req) {
-                  hp1_req = boosted_level;
-                  request_reason_code = 12;
-                  publish_optimizer_reason("defrost_boost");
-                }
-              }
-            }
-            if (hp1_req > 0 && hp2_req == 0) request_owner_hp = 1;
-            else if (hp2_req > 0 && hp1_req == 0) request_owner_hp = 2;
-            else request_owner_hp = 0;
-
-            const bool single_req = ((hp1_req > 0) != (hp2_req > 0));
-            const bool both_idle_prev = (id(hp1_last_applied_level) <= 0 && id(${secondary_last_applied_level_id}) <= 0);
-            if (single_req && both_idle_prev && !(hp1_def || hp2_def) && !(hp1_valve_def || hp2_valve_def)) {
-              const int req_single = (hp1_req > 0) ? hp1_req : hp2_req;
-              const bool lead_can =
-                  (lead_is_hp1 ? hp1_available : hp2_available) &&
-                  level_allowed(lead_is_hp1, req_single);
-              const bool lag_can =
-                  (lead_is_hp1 ? hp2_available : hp1_available) &&
-                  level_allowed(!lead_is_hp1, req_single);
-              if (lead_can && lag_can) {
-                if (lead_is_hp1) {
-                  hp1_req = req_single;
-                  hp2_req = 0;
-                  request_owner_hp = 1;
-                } else {
-                  hp2_req = req_single;
-                  hp1_req = 0;
-                  request_owner_hp = 2;
-                }
-                request_reason_code = 13;
-                publish_optimizer_reason("runtime_lead");
-              }
-            }
+          static std::string last_optimizer_reason;
+          const std::string optimizer_reason(
+              oq_power_house_dispatch::request_reason_name((int) dispatch.reason));
+          if (optimizer_reason != last_optimizer_reason) {
+            id(oq_duo_optimizer_reason).publish_state(optimizer_reason.c_str());
+            last_optimizer_reason = optimizer_reason;
           }
-          #else
-          publish_optimizer_reason("single_topology");
-          const float cap_total = publish_capacity_and_deficit(P_req_total);
-          const bool perf_inputs_valid = !isnan(Tamb) && !isnan(Tsup) && level_cap > 0;
-          if (!perf_inputs_valid) {
-            hp1_req = hp1_available ? f : 0;
-            request_reason_code = (hp1_req > 0) ? 2 : 11;
-          } else {
-            float P_target = P_req_total;
-            if (isnan(P_target)) P_target = 0.0f;
-            if (P_target > cap_total) P_target = cap_total;
-            if (P_target < 0.0f) P_target = 0.0f;
-
-            const int last1 = id(hp1_last_applied_level);
-            float best_cost = 1e12f;
-            int best_l1 = 0;
-            const float W_change_penalty_per_step = 50.0f;
-            const float P_EL_SOFT_W = id(oq_power_limit_soft_w);
-            const float P_EL_PEAK_W = id(oq_power_limit_peak_w);
-            const float W_el_over_soft_penalty_per_W = ${oq_optimizer_penalty_per_w};
-
-            for (int l1 = 0; l1 <= level_cap; l1++) {
-              if (l1 > 0 && !hp1_available) continue;
-              if (l1 > 0 && !level_allowed(true, l1)) continue;
-
-              float p1 = (l1 == 0) ? 0.0f : oq_perf::interp_power_th_w_hz(
-                  oq_perf::model_frequency_hz(l1), Tamb, Tsup);
-              if (l1 > 0 && isnan(p1)) continue;
-              p1 *= hp1_th_fac;
-
-              float pel1 = (l1 == 0) ? 0.0f : oq_perf::interp_power_el_w_hz(
-                  oq_perf::model_frequency_hz(l1), Tamb, Tsup);
-              if (l1 > 0 && isnan(pel1)) pel1 = 0.0f;
-              if (pel1 > P_EL_PEAK_W) continue;
-
-              float cost = fabsf(p1 - P_target);
-              cost += W_change_penalty_per_step * (float) abs(l1 - last1);
-              if (pel1 > P_EL_SOFT_W) cost += (pel1 - P_EL_SOFT_W) * W_el_over_soft_penalty_per_W;
-
-              if (cost < best_cost) {
-                best_cost = cost;
-                best_l1 = l1;
-              }
-            }
-            hp1_req = best_l1;
-            request_reason_code = (best_l1 > 0) ? 14 : 0;
-          }
-          request_owner_hp = (hp1_req > 0) ? 1 : 0;
-          hp2_req = 0;
           #endif
 
-          const auto suspect_topology_hold =
-              oq_hp_candidate::preserve_active_topology_during_suspect(
-                  {
-                      hp1_req,
-                      hp2_req,
-                      hp1_candidate_state,
-                      hp2_candidate_state,
-                      f > 0,
-                  });
-          if (suspect_topology_hold.active) {
-            hp1_req = suspect_topology_hold.hp1_level;
-            hp2_req = suspect_topology_hold.hp2_level;
-            request_owner_hp = suspect_topology_hold.owner_hp;
-            request_reason_code = 5;
-            publish_optimizer_reason("keep_current");
-          }
-
-          id(oq_ph_request_hp1_level) = hp1_req;
-          id(oq_ph_request_hp2_level) = hp2_req;
-          id(oq_ph_request_owner_hp) = request_owner_hp;
-          id(oq_ph_request_reason_code) = request_reason_code;
-
-          float hp_expected_power_w = 0.0f;
-          bool hp_expected_power_valid = !isnan(Tamb) && !isnan(Tsup);
-          if (hp_expected_power_valid && hp1_req > 0) {
-            const float hp1_expected_w =
-                oq_perf::interp_power_th_w_hz(
-                    oq_perf::model_frequency_hz(hp1_req), Tamb, Tsup) *
-                hp1_th_fac;
-            if (isnan(hp1_expected_w)) hp_expected_power_valid = false;
-            else hp_expected_power_w += hp1_expected_w;
-          }
-          if (hp_expected_power_valid && hp2_req > 0) {
-            const float hp2_expected_w =
-                oq_perf::interp_power_th_w_hz(
-                    oq_perf::model_frequency_hz(hp2_req), Tamb, Tsup) *
-                hp2_th_fac;
-            if (isnan(hp2_expected_w)) hp_expected_power_valid = false;
-            else hp_expected_power_w += hp2_expected_w;
-          }
-
-          id(oq_strategy_phase_code) = (f > 0) ? 1 : 0;
-          id(oq_strategy_requested_power_w) = P_req_total;
+          id(oq_strategy_phase_code) = f > 0 ? 1 : 0;
+          id(oq_strategy_requested_power_w) = requested_w;
           id(oq_strategy_supply_target_temp) = NAN;
-          id(oq_strategy_heat_request_active) = (f > 0);
-          id(oq_strategy_hp_expected_power_w) =
-              hp_expected_power_valid ? hp_expected_power_w : NAN;
-          id(oq_strategy_hp_max_power_w) = id(oq_P_hp_cap_w);
-          id(oq_strategy_hp_saturated) =
-              (f > 0) && !isnan(id(oq_P_deficit_w)) && id(oq_P_deficit_w) > 0.0f;
-          id(oq_strategy_output_valid) =
-              !isnan(P_req_total) && hp_expected_power_valid;
+          id(oq_strategy_heat_request_active) = f > 0;
+          id(oq_strategy_hp_expected_power_w) = dispatch.expected_w;
+          id(oq_strategy_hp_max_power_w) = dispatch.capacity_w;
+          id(oq_strategy_hp_saturated) = dispatch.saturated;
+          id(oq_strategy_output_valid) = dispatch.output_valid;
           id(oq_strategy_output_source_code) = 3;
           id(oq_strategy_output_updated_ms) = now_ms;
-          id(oq_strategy_phase_text).publish_state((f > 0) ? "heat" : "idle");
+          id(oq_strategy_phase_text).publish_state(f > 0 ? "heat" : "idle");
 
-          char debug_buf[160];
-          snprintf(
-            debug_buf, sizeof(debug_buf),
-            "ph f=%d raw=%d preq=%.0f owner=%d reason=%d",
-            f, demand.raw_demand, id(oq_phouse_req_w), request_owner_hp, request_reason_code);
-          ESP_LOGD("quatt.strategy", "%s", debug_buf);
+          ESP_LOGD("quatt.strategy", "ph f=%d raw=%d preq=%.0f owner=%d reason=%d",
+                   f, demand.raw_demand, requested_w, dispatch.owner_hp, (int) dispatch.reason);

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -1183,22 +1183,8 @@ interval:
             hp1_req = id(oq_ph_request_hp1_level);
             hp2_req = id(oq_ph_request_hp2_level);
             request_owner_hp = id(oq_ph_request_owner_hp);
-            switch (id(oq_ph_request_reason_code)) {
-              case 1: request_reason = "ph_fallback_idle"; break;
-              case 2: request_reason = "ph_fallback_single_hp1"; break;
-              case 3: request_reason = "ph_fallback_single_hp2"; break;
-              case 4: request_reason = "ph_fallback_duo"; break;
-              case 5: request_reason = "keep_current"; break;
-              case 6: request_reason = "hold_active"; break;
-              case 7: request_reason = "defrost_hold"; break;
-              case 8: request_reason = "better_heat"; break;
-              case 9: request_reason = "soft_guard"; break;
-              case 10: request_reason = "less_power"; break;
-              case 11: request_reason = "no_candidate"; break;
-              case 12: request_reason = "defrost_boost"; break;
-              case 13: request_reason = "runtime_lead"; break;
-              default: request_reason = "ph_idle"; break;
-            }
+            request_reason = oq_power_house_dispatch::request_reason_name(
+                id(oq_ph_request_reason_code));
           }
           #else
           oq_request::reset_dual_runtime_state(
@@ -1222,12 +1208,8 @@ interval:
           } else {
             hp1_req = id(oq_ph_request_hp1_level);
             request_owner_hp = id(oq_ph_request_owner_hp);
-            switch (id(oq_ph_request_reason_code)) {
-              case 1: request_reason = "ph_fallback_idle"; break;
-              case 2: request_reason = "ph_fallback_single_hp1"; break;
-              case 14: request_reason = "ph_single_topology"; break;
-              default: request_reason = "ph_idle"; break;
-            }
+            request_reason = oq_power_house_dispatch::request_reason_name(
+                id(oq_ph_request_reason_code));
           }
           hp2_req = 0;
           #endif

--- a/scripts/tests/test_compressor_frequency_policy_contract.py
+++ b/scripts/tests/test_compressor_frequency_policy_contract.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import unittest
 
-
 ROOT = Path(__file__).resolve().parents[2]
 HP_IO = (ROOT / "openquatt" / "oq_HP_io.yaml").read_text()
 SUPERVISORY = (ROOT / "openquatt" / "oq_supervisory_controlmode.yaml").read_text()
@@ -21,8 +20,8 @@ POLICY = (
 RUNTIME = (
     ROOT / "openquatt" / "includes" / "control" / "oq_compressor_frequency_runtime.h"
 ).read_text()
+DISPATCH = (ROOT / "openquatt" / "includes" / "control" / "oq_power_house_dispatch_logic.h").read_text()
 WEB_CONFIG = (ROOT / "openquatt" / "web" / "js" / "src" / "core" / "config.js").read_text()
-
 
 class CompressorFrequencyPolicyContractTest(unittest.TestCase):
     def test_day_and_silent_caps_have_direct_persistent_defaults(self) -> None:
@@ -78,8 +77,9 @@ class CompressorFrequencyPolicyContractTest(unittest.TestCase):
     def test_strategies_only_offer_allowed_runtime_frequencies(self) -> None:
         self.assertEqual(STRATEGIES.count("oq_frequency_runtime::capture()"), 3)
         self.assertEqual(STRATEGIES.count("frequency_runtime.frequency_allowed("), 3)
-        self.assertIn("boosted_allowed_level", STRATEGIES)
-        self.assertIn("level_allowed(is_hp1, level)", STRATEGIES)
+        self.assertIn("const auto boosted = make_candidate(", DISPATCH)
+        self.assertIn("estimate.allowed", DISPATCH)
+        self.assertIn("level_allowed(hp1, level)", STRATEGIES)
 
     def test_runtime_inputs_are_captured_once_per_control_callback(self) -> None:
         control_sources = STRATEGIES + REQUEST + ACTUATOR

--- a/scripts/tests/test_electrical_input_limit_contract.py
+++ b/scripts/tests/test_electrical_input_limit_contract.py
@@ -1,14 +1,13 @@
 from pathlib import Path
 import unittest
 
-
 ROOT = Path(__file__).resolve().parents[2]
 SUPERVISOR = (ROOT / "openquatt" / "oq_supervisory_controlmode.yaml").read_text()
 POWER_HOUSE = (ROOT / "openquatt" / "oq_power_house_strategy.yaml").read_text()
+DISPATCH = (ROOT / "openquatt" / "includes" / "control" / "oq_power_house_dispatch_logic.h").read_text()
 HEATING_CURVE = (ROOT / "openquatt" / "oq_heating_curve_strategy.yaml").read_text()
 COOLING = (ROOT / "openquatt" / "oq_cooling_strategy.yaml").read_text()
 HP_IO = (ROOT / "openquatt" / "oq_HP_io.yaml").read_text()
-
 
 class ElectricalInputLimitContractTest(unittest.TestCase):
     def test_setting_is_persistent_and_keeps_generation_defaults(self) -> None:
@@ -49,8 +48,10 @@ class ElectricalInputLimitContractTest(unittest.TestCase):
         )
 
     def test_power_house_alone_uses_predictive_thresholds(self) -> None:
-        self.assertEqual(POWER_HOUSE.count("const float P_EL_SOFT_W = id(oq_power_limit_soft_w);"), 2)
-        self.assertEqual(POWER_HOUSE.count("const float P_EL_PEAK_W = id(oq_power_limit_peak_w);"), 2)
+        self.assertEqual(POWER_HOUSE.count("id(oq_power_limit_soft_w)"), 1)
+        self.assertEqual(POWER_HOUSE.count("id(oq_power_limit_peak_w)"), 1)
+        self.assertIn("electrical_limits_valid", DISPATCH)
+        self.assertIn("result.electrical_w > tuning.peak_limit_w", DISPATCH)
         self.assertIn("id(oq_power_cap_f)", HEATING_CURVE)
         self.assertIn("id(oq_power_cap_f)", COOLING)
         self.assertNotIn("oq_power_limit_peak_w", HEATING_CURVE)
@@ -62,7 +63,6 @@ class ElectricalInputLimitContractTest(unittest.TestCase):
         self.assertNotIn("if (isnan(demand_continuous))", HEATING_CURVE)
         paths = ("openquatt/oq_heating_curve_strategy.yaml", "openquatt/includes/control/oq_heating_curve_logic.h", "tests/host/heating_curve_restart_logic_test.cpp", "scripts/tests/test_electrical_input_limit_contract.py")
         self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1879)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_power_house_demand_contract.py
+++ b/scripts/tests/test_power_house_demand_contract.py
@@ -1,12 +1,12 @@
 import pathlib, unittest
 ROOT = pathlib.Path(__file__).resolve().parents[2]
-FILES = (ROOT / "openquatt/oq_power_house_strategy.yaml", ROOT / "openquatt/includes/control/oq_power_house_demand_logic.h", ROOT / "tests/host/oq_power_house_demand_logic_test.cpp", pathlib.Path(__file__))
+FILES = (ROOT / "openquatt/oq_power_house_strategy.yaml", ROOT / "openquatt/includes/control/oq_power_house_demand_logic.h", ROOT / "tests/host/oq_power_house_demand_logic_test.cpp", ROOT / "openquatt/includes/control/oq_power_house_dispatch_logic.h", ROOT / "tests/host/oq_power_house_dispatch_logic_test.cpp", ROOT / "openquatt/oq_thermal_request_control.yaml", ROOT / "scripts/tests/test_compressor_frequency_policy_contract.py", ROOT / "scripts/tests/test_electrical_input_limit_contract.py", pathlib.Path(__file__))
 class PowerHouseDemandContractTest(unittest.TestCase):
     def test_delegation_and_line_budget(self) -> None:
         text = FILES[0].read_text()
-        positions = [text.index(marker) for marker in ("decide_cadence(", "decide_demand(", "filter_demand(")]
+        positions = [text.index(marker) for marker in ("observe_protection(", "decide_cadence(", "decide_demand(", "filter_demand(", "decide_dispatch(")]
         self.assertEqual(positions, sorted(positions))
         self.assertIn("id(oq_ph_request_last_loop_ms) = now_ms == 0 ? UINT32_MAX : now_ms;", text)
-        self.assertNotIn("now_ms > id(oq_ph_request_last_loop_ms)", text)
-        self.assertNotIn("float ramp_budget = id(oq_demand_filter_ramp_up_budget)", text)
-        self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in FILES), 1415)
+        for marker in ("now_ms > id(oq_ph_request_last_loop_ms)", "float ramp_budget = id(oq_demand_filter_ramp_up_budget)", "fminf(requested_w", "struct DuoCandidate"):
+            self.assertNotIn(marker, text)
+        self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in FILES), 3044)

--- a/tests/host/oq_power_house_dispatch_logic_test.cpp
+++ b/tests/host/oq_power_house_dispatch_logic_test.cpp
@@ -1,0 +1,207 @@
+#include <assert.h>
+#include <float.h>
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "../../openquatt/includes/control/oq_power_house_dispatch_logic.h"
+
+namespace {
+using namespace oq_power_house_dispatch;
+static_assert(sizeof(DispatchState) <= 40);
+HpInput hp(int previous = 0, bool available = true) {
+  HpInput result;
+  result.candidate = {previous, available, false, false};
+  for (int level = 0; level <= kMaxLevel; ++level)
+    result.levels[level] = {true, true, true, 1000.0f * level, 100.0f * level};
+  return result;
+}
+DispatchInput input(bool duo = false) { return {60000, 3, 3000.0f, duo, true, true, hp(), hp()}; }
+DispatchTuning tuning() { return {9000.0f, 10000.0f, 5.0f, 150.0f, 450.0f, 6, 1}; }
+void expect_safe(const DispatchDecision& out, const DispatchInput& in, const DispatchTuning& cfg) {
+  assert(out.hp1_level >= 0 && out.hp1_level <= kMaxLevel && out.hp2_level >= 0 && out.hp2_level <= kMaxLevel);
+  assert((in.duo || out.hp2_level == 0) && out.owner_hp == owner(out.hp1_level, out.hp2_level));
+  if (in.demand_level <= 0) assert(out.hp1_level == 0 && out.hp2_level == 0);
+  if (in.hp1.candidate.must_stop) assert(out.hp1_level == 0);
+  if (in.hp2.candidate.must_stop) assert(out.hp2_level == 0);
+  if (out.output_valid) assert(isfinite(out.expected_w));
+  if (!out.output_valid || out.hp1_level + out.hp2_level == 0) return;
+  float electrical_w = 0.0f;
+  for (const auto* selected : {&in.hp1, &in.hp2}) {
+    const int level = selected == &in.hp1 ? out.hp1_level : out.hp2_level;
+    if (level <= 0) continue;
+    const auto& estimate = selected->levels[level];
+    assert(estimate.allowed && estimate.thermal_valid && estimate.electrical_valid);
+    assert(isfinite(estimate.thermal_w) && estimate.thermal_w >= 0.0f && isfinite(estimate.electrical_w) &&
+           estimate.electrical_w >= 0.0f);
+    electrical_w += estimate.electrical_w;
+  }
+  assert(isfinite(cfg.peak_limit_w) && electrical_w <= cfg.peak_limit_w);
+}
+void test_timing_and_matrix() {
+  auto state = observe_protection({}, {UINT32_MAX - 4U, true, false, false, 3, 0});
+  state = observe_protection(state, {UINT32_MAX - 2U, false, false, false, 3, 0});
+  assert(tail_active(state.hp1_defrost, 6U, 10U) && !tail_active(state.hp1_defrost, 7U, 10U));
+  const uint32_t expired_ms = UINT32_MAX - 2U + kDefrostHoldMs;
+  state = observe_protection(state, {expired_ms, false, false, false, 3, 0});
+  assert(!state.hp1_defrost.armed);
+  state = observe_protection(state, {expired_ms - 1U, false, false, false, 3, 0});
+  assert(!tail_active(state.hp1_defrost, expired_ms - 1U, kDefrostHoldMs));
+  state = observe_protection({}, {10U, false, false, false, 3, 0});
+  state = observe_protection(state, {20U, false, false, true, 3, 3});
+  assert(topology_hold_active(state, 20U + kTopologyHoldMs - 1U, kTopologyHoldMs));
+  state = observe_protection(state, {20U + kTopologyHoldMs, false, false, false, 3, 3});
+  assert(!state.topology_hold_armed);
+  state = observe_protection(state, {19U + kTopologyHoldMs, false, false, false, 3, 3});
+  assert(!topology_hold_active(state, 19U + kTopologyHoldMs, kTopologyHoldMs));
+  state = observe_protection({}, {20U, false, false, true, 3, 3});
+  state = observe_protection(state, {21U, false, false, false, 3, 3});
+  assert(tail_active(state.oil_return, 25U, 5U));
+  for (bool duo : {false, true})
+    for (int demand : {0, 1, 10, 20})
+      for (int previous : {-1, 0, 3, 11})
+        for (int stops = 0; stops < 4; ++stops)
+          for (float cap : {0.0f, 299.0f, 300.0f, 10000.0f}) {
+            auto in = input(duo);
+            in.demand_level = demand;
+            in.hp1.candidate = {previous, true, (stops & 1) != 0, true};
+            in.hp2.candidate = {previous, true, (stops & 2) != 0, true};
+            auto cfg = tuning();
+            cfg.soft_limit_w = cfg.peak_limit_w = cap;
+            expect_safe(decide_dispatch(in, cfg, {}), in, cfg);
+          }
+}
+void test_single_and_failures() {
+  auto cfg = tuning();
+  auto in = input(true);
+  in.demand_level = 20;
+  in.performance_valid = false;
+  in.hp1.candidate.previous_applied_level = 4;
+  in.hp2.candidate.previous_applied_level = 3;
+  auto out = decide_dispatch(in, cfg, {});
+  assert(out.hp1_level == 4 && out.hp2_level == 3 && out.reason == Reason::FALLBACK_DUO && !out.output_valid);
+  in.hp1.candidate.must_stop = true;
+  assert(decide_dispatch(in, cfg, {}).reason == Reason::FALLBACK_HP2);
+  in.hp2.candidate = {};
+  for (int previous : {-1, 11, 20}) {
+    in.hp1.candidate = {previous, true, false, false};
+    assert(decide_dispatch(in, cfg, {}).reason == Reason::FALLBACK_IDLE);
+  }
+  in.requested_w = NAN;
+  in.performance_valid = true;
+  out = decide_dispatch(in, cfg, {});
+  assert(out.hp1_level == 0 && out.hp2_level == 0 && !out.output_valid);
+  in.requested_w = 3000;
+  in.demand_level = 0;
+  in.performance_valid = false;
+  assert(!decide_dispatch(in, cfg, {}).output_valid);
+  in = input(true);
+  in.hp1.candidate = {11, false, false, true};
+  out = decide_dispatch(in, cfg, {});
+  assert(out.hp1_level == 0 && out.hp2_level > 0);
+  cfg = tuning();
+  in = input();
+  assert(decide_dispatch(in, cfg, {}).hp1_level == 3);
+  in.requested_w = 2500;
+  in.hp1.candidate.previous_applied_level = 3;
+  assert(decide_dispatch(in, cfg, {}).hp1_level == 3);
+  in = input();
+  cfg.soft_limit_w = cfg.peak_limit_w = 300;
+  assert(decide_dispatch(in, cfg, {}).hp1_level == 3);
+  cfg.soft_limit_w = cfg.peak_limit_w = 299;
+  assert(decide_dispatch(in, cfg, {}).hp1_level <= 2);
+  const float bad[] = {NAN, INFINITY, -INFINITY, -1.0f};
+  for (float value : bad)
+    for (int fault = 0; fault < 5; ++fault) {
+      in = input();
+      cfg = tuning();
+      if (fault == 0) in.requested_w = value;
+      if (fault == 1) cfg.soft_limit_w = value;
+      if (fault == 2) cfg.peak_limit_w = value;
+      for (int level = 1; level <= kMaxLevel && fault >= 3; ++level)
+        (fault == 3 ? in.hp1.levels[level].thermal_w : in.hp1.levels[level].electrical_w) = value;
+      const auto failed = decide_dispatch(in, cfg, {});
+      expect_safe(failed, in, cfg);
+      assert(failed.hp1_level == 0 && failed.hp2_level == 0 && !failed.output_valid);
+    }
+  in = input();
+  for (int level = 4; level <= kMaxLevel; ++level) in.hp1.levels[level].electrical_valid = false;
+  out = decide_dispatch(in, tuning(), {});
+  assert(out.hp1_level == 3 && out.capacity_w == 3000 && out.output_valid);
+  in = input(true);
+  cfg = tuning();
+  cfg.soft_limit_w = cfg.peak_limit_w = FLT_MAX;
+  in.hp1.levels[1].electrical_w = in.hp2.levels[1].electrical_w = FLT_MAX;
+  assert(!make_candidate(in, cfg, 1, 1, 1000.0f).valid);
+  for (auto* selected : {&in.hp1, &in.hp2})
+    for (int level = 1; level <= kMaxLevel; ++level) selected->levels[level].thermal_w = FLT_MAX;
+  out = decide_dispatch(in, cfg, {});
+  assert(isfinite(out.capacity_w));
+}
+void test_duo_holds_and_boost() {
+  auto in = input(true);
+  auto cfg = tuning();
+  in.lead_hp1 = false;
+  auto out = decide_dispatch(in, cfg, {});
+  assert(out.hp2_level == 3 && out.reason == Reason::RUNTIME_LEAD);
+  in.hp2.candidate.available_for_start = false;
+  assert(decide_dispatch(in, cfg, {}).hp1_level > 0);
+  in = input(true);
+  in.hp1.candidate.previous_applied_level = 3;
+  for (int level = 1; level <= kMaxLevel; ++level) {
+    in.hp1.levels[level].electrical_w = 500.0f * level;
+    in.hp2.levels[level].electrical_w = 100.0f * level;
+  }
+  out = decide_dispatch(in, cfg, {});
+  assert(out.hp2_level == 3 && out.reason == Reason::LESS_POWER);
+  out = decide_dispatch(in, cfg, observe_protection({}, {10, true, false, false, 3, 0}));
+  assert(out.hp1_level == 3 && out.reason == Reason::DEFROST_HOLD);
+  out = decide_dispatch(in, cfg, observe_protection({}, {10, false, false, true, 3, 0}));
+  assert(out.hp1_level == 3 && out.reason == Reason::OIL_RETURN_HOLD);
+  in.hp1.candidate.link_suspect = true;
+  out = decide_dispatch(in, cfg, {});
+  assert(out.hp1_level == 3 && out.hp2_level == 0 && out.reason == Reason::KEEP_CURRENT);
+  in.hp1.candidate.must_stop = true;
+  expect_safe(decide_dispatch(in, cfg, {}), in, cfg);
+  in = input(true);
+  cfg = tuning();
+  in.hp2.candidate.available_for_start = false;
+  for (int level = 1; level <= kMaxLevel; ++level) in.hp1.levels[level].allowed = false;
+  in.hp1.levels[1] = {true, true, true, 1000, 300};
+  in.hp1.levels[2] = {true, true, true, 1140, 200};
+  in.hp1.levels[3] = {true, true, true, 1280, 100};
+  assert(pick_topology(in, cfg, 1000, 1, 150).hp1_level == 2);
+  in = input(true);
+  in.hp1.defrost = true;
+  assert(decide_dispatch(in, cfg, {}).owner_hp == 1);
+  cfg = tuning();
+  cfg.soft_limit_w = cfg.peak_limit_w = 1000;
+  in = input(true);
+  in.demand_level = 7;
+  in.requested_w = 7000;
+  in.hp1.valve_defrost = true;
+  for (auto* selected : {&in.hp1, &in.hp2})
+    for (int level = 1; level <= kMaxLevel; ++level)
+      selected->levels[level] =
+          level <= 3 ? LevelEstimate{true, true, true, 2000.0f * level, level == 3 ? 500.0f : 50.0f * (level + 1)}
+                     : LevelEstimate{};
+  out = decide_dispatch(in, cfg, {});
+  assert(out.reason == Reason::DEFROST_BOOST && out.hp1_level + out.hp2_level == 4);
+  expect_safe(out, in, cfg);
+  cfg.soft_limit_w = cfg.peak_limit_w = 550;
+  out = decide_dispatch(in, cfg, {});
+  assert(out.reason != Reason::DEFROST_BOOST && out.hp1_level + out.hp2_level == 3);
+  assert(out.capacity_w == 8000.0f);
+  expect_safe(out, in, cfg);
+  assert(strcmp(request_reason_name(0), "ph_idle") == 0);
+  assert(strcmp(request_reason_name(14), "ph_single_topology") == 0);
+  assert(strcmp(request_reason_name(15), "oil_return_hold") == 0);
+  assert(strcmp(request_reason_name(16), "ph_idle") == 0);
+}
+}  // namespace
+int main() {
+  test_timing_and_matrix();
+  test_single_and_failures();
+  test_duo_holds_and_boost();
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst Power House Single/Duo-dispatch, kandidaatselectie en beschermings-holds uit YAML naar een pure, host-testbare C++-core.
- Reduceert `openquatt/oq_power_house_strategy.yaml` van 1.071 naar 493 regels; de complete PR inclusief 207 regels nieuwe hosttests is netto 8 regels kleiner (+717/-725).
- Maakt foutgrenzen expliciet fail-closed voor ontbrekende/ongeldige performance, elektrische limieten, `must_stop`, defrost, oil-return, suspect links en ongeldige applied-leveltelemetrie.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De nominale Power House-verdeling blijft gelijk. Ontbrekende performance mag een reeds actief geldig level 1..10 behouden, maar mag geen start of wissel veroorzaken. Ongeldige elektrische/thermische waarden en limieten leveren geen kandidaat op; capacity/deficit telt alleen uitvoerbare combinaties onder de peaklimiet. `must_stop`, verboden frequenties en ongeldige applied levels winnen altijd. Defrost-boost wordt opnieuw tegen frequentie- en peakbeleid gevalideerd en alle hold-timers zijn rollover-safe.

## Achtergrond

De YAML blijft het compacte ESPHome-contract voor configuratie, entitykoppelingen, performance-tabellen en resultaatpublicatie. De C++-core gebruikt uitsluitend vaste structs en `std::array`, zonder heapallocaties of eigen tasks; `DispatchState` is 36 bytes.

De volledige diff tegen actuele `dev` is eerst functioneel geaudit en daarna afzonderlijk cold/adversarial gereviewd op nominale pariteit, lifecycle/reset, timer-rollover, retries en stale/ontbrekende telemetrie, Single/Duo, defrost/oil-return, incident/fault, electrical/frequency caps, boiler-deficit, fresh-install/upgrade en embedded geheugen. De gevonden grensgevallen rond ongeldige applied levels en te optimistische capacity zijn opgelost en hebben regressietests.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Er wijzigen geen gebruikersgerichte entities, instellingen of bedieningscontracten; dit is interne regelcode met explicietere foutafhandeling.

## Validatie

- `./scripts/run_host_regression_tests.sh` — 47/47 groen.
- `npm run check:python-contracts` — 146/146 groen.
- `npm run check:cpp-format` — 176 C/C++-bestanden groen.
- Configvalidatie groen voor alle zes Q-targets: Duo/Single × gecombineerd/WiFi/Ethernet.
- Volledige ESPHome-compile groen voor `configs/heatpump_controller_q/duo_wifi.yaml` en `configs/heatpump_controller_q/single_wifi.yaml`.
- CI: alle vereiste checks groen; alleen de twee verwachte testfirmware-metadatajobs zijn overgeslagen.
- HIL op Q Duo met ODU/OpenTherm-simulator: Power House 2.500 W ging naar CM2 en één actieve ODU (HP2 level 2); controller request en simulator requested/accepted level kwamen overeen. Defrost en oil-return werden gezien met behoud van de actieve aanvraag. Een hard-fault op de actieve ODU zette `must_stop` en bracht controllerlevel, simulator request/accepted en frequentie naar 0. Alle ODU- en OpenTherm-protocolfouttellers bleven 0.
- De actieve HIL-reeks gebruikte alleen een tijdelijke, niet-gecommitte timing-/simulatoroverlay: 5 s Power House-cadans/startconfirmatie/CM1-preflow en 0 L/h flowdrempel omdat Q Duo ODU-flow onderdrukt wanneer de gesimuleerde ODU-pomprelais uit staan. De productieve 300 s minimum-runtimevloer bleef intact; cleanup gebruikte de bestaande hard-safetyroute.
- Na HIL is exact de productieve `duo_wifi.yaml` opnieuw gecompileerd en via OTA teruggezet. De afsluitende onafhankelijke gate was groen: CM0, F0/F0, beide ODU-modi 0 en gezonde incidentlinks.

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- Exacte Q Duo-productiebuild: 211.051 bytes DIRAM en 2.182.399 bytes image; tegenover de direct voorafgaande #570-build is dat +24 bytes DIRAM en +116 bytes image.
- Exacte Q Single-productiebuild: 193.459 bytes DIRAM en 2.137.119 bytes image.
- Tijdens HIL bleef de minimum internal heap 39.828 bytes en het grootste vrije blok minimaal 47.104 bytes; er waren geen allocatiefouten, onverwachte reboots of protocolfouten.
- De nieuwe core alloceert niet dynamisch en maakt geen tasks. ASan/UBSan op de exacte finale commit kon lokaal niet worden gelinkt door de beschikbare Apple/Homebrew-toolchaincombinatie; de normale hostbuild draaide wel met `-Wall -Wextra -Werror`.
