### PR TITLE
YAML naar C++: Cooling – herstel en timing

### DIFF
--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -41,6 +41,21 @@ struct WaterCycleState {
   int stop_reason_code = WATER_STOP_NONE;
 };
 
+struct WaterRestartDecision {
+  WaterCycleState state;
+  bool reset_integral = false;
+  int limiter_reason_code = REASON_INACTIVE;
+};
+
+inline int inactive_stop_reason(bool cycle_was_active, bool request_cleared, bool sensor_missing,
+                                bool flow_permission_lost, bool core_permission_lost) {
+  if (cycle_was_active && request_cleared) return WATER_STOP_REQUEST_CLEARED;
+  if (cycle_was_active && sensor_missing) return WATER_STOP_FALLBACK;
+  if (flow_permission_lost) return WATER_STOP_FLOW_PERMISSION_LOST;
+  if (core_permission_lost) return WATER_STOP_CORE_PERMISSION_LOST;
+  return WATER_STOP_NONE;
+}
+
 inline bool record_pi_zero_stop(int previous_demand, int demand, float filtered_gap_c, WaterCycleState& state) {
   if (!state.active || previous_demand <= 0 || demand > 0) return false;
 
@@ -121,6 +136,26 @@ struct LimiterTuning {
   float capacity_recovery_min_rate_c_per_min = -0.02f;
 };
 
+struct OilReturnTuning {
+  uint32_t hold_ms = 1200000UL, recovery_stable_ms = 120000UL, recovery_cap_ms = 120000UL;
+  float recovery_dew_extra_c = 0.30f, recovery_projected_extra_c = 0.15f;
+  float recovery_min_rate_c_per_min = -0.05f;
+};
+
+struct OilReturnState {
+  uint32_t hold_since_ms = 0, recovery_stable_since_ms = 0, recovery_cap_since_ms = 0;
+  bool hold_expired_pending = false;
+};
+
+struct OilReturnInput {
+  uint32_t now_ms = 0;
+  bool control_active = false, oil_return_active = false;
+};
+
+struct OilReturnDecision {
+  bool mask_active = false, recovery_cap_active = false, reset_integral_and_dwell = false;
+};
+
 struct LimiterState {
   bool simmer_allowed = false;
   bool projection_brake_active = false;
@@ -175,8 +210,111 @@ inline int clamp_level(int value, int min_value, int max_value) {
 
 inline bool finite_float(float value) { return !isnan(value); }
 
+inline float hard_dew_restart_gap(const LimiterInput& in, const LimiterTuning& tuning) {
+  return tuning.hard_dew_stop_base_gap_c + tuning.hard_dew_stop_margin_gain_c * in.safety_margin_c +
+         tuning.hard_dew_restart_hyst_c;
+}
+
+inline uint32_t nonzero_timestamp_ms(uint32_t now_ms) { return now_ms == 0 ? UINT32_MAX : now_ms; }
+
 inline bool elapsed(uint32_t now_ms, uint32_t since_ms, uint32_t duration_ms) {
-  return since_ms > 0 && now_ms > since_ms && (uint32_t)(now_ms - since_ms) >= duration_ms;
+  return since_ms > 0 && (uint32_t)(now_ms - since_ms) >= duration_ms;
+}
+
+inline bool window_active(uint32_t now_ms, uint32_t since_ms, uint32_t duration_ms) {
+  return duration_ms > 0 && since_ms > 0 && (uint32_t)(now_ms - since_ms) < duration_ms;
+}
+
+inline void reset_oil_return_recovery(OilReturnState& state) {
+  state.recovery_stable_since_ms = state.recovery_cap_since_ms = 0;
+}
+
+inline OilReturnDecision update_oil_return(const OilReturnInput& in, const LimiterInput& conditions,
+                                           const OilReturnTuning& tuning, const LimiterTuning& limiter_tuning,
+                                           OilReturnState& state) {
+  if (in.oil_return_active) {
+    state.hold_since_ms = nonzero_timestamp_ms(in.now_ms);
+    state.hold_expired_pending = false;
+    reset_oil_return_recovery(state);
+  }
+  if (!in.control_active) {
+    const bool hold_active = window_active(in.now_ms, state.hold_since_ms, tuning.hold_ms);
+    if (!in.oil_return_active && state.hold_since_ms != 0 && !hold_active) {
+      state.hold_since_ms = 0;
+      state.hold_expired_pending = true;
+    }
+    reset_oil_return_recovery(state);
+    return {in.oil_return_active || hold_active, false, false};
+  }
+  if (in.oil_return_active) return {true, false, false};
+
+  const bool hold_active = window_active(in.now_ms, state.hold_since_ms, tuning.hold_ms);
+  if (state.recovery_cap_since_ms != 0 &&
+      !window_active(in.now_ms, state.recovery_cap_since_ms, tuning.recovery_cap_ms))
+    state.recovery_cap_since_ms = 0;
+  const bool recovery_not_needed = !conditions.dew_mode && !conditions.fallback_mode;
+  const float hard_dew_restart_gap_c = hard_dew_restart_gap(conditions, limiter_tuning);
+  const float projected_gap_c =
+      conditions.filtered_gap_c + conditions.gap_rate_c_per_min * limiter_tuning.projection_horizon_min;
+  const bool recovery_safe =
+      !recovery_not_needed &&
+      (!conditions.dew_mode || (finite_float(conditions.dew_gap_c) &&
+                                conditions.dew_gap_c >= hard_dew_restart_gap_c + tuning.recovery_dew_extra_c)) &&
+      (!conditions.fallback_mode ||
+       conditions.filtered_gap_c >= limiter_tuning.fallback_cap1_gap_c + tuning.recovery_dew_extra_c) &&
+      (conditions.filtered_gap_c >= 0.0f ||
+       (conditions.filtered_gap_c > limiter_tuning.limiter_soft_stop_gap_c && conditions.gap_rate_c_per_min > 0.10f)) &&
+      projected_gap_c >= limiter_tuning.projected_floor_release_gap_c + tuning.recovery_projected_extra_c &&
+      conditions.gap_rate_c_per_min >= tuning.recovery_min_rate_c_per_min;
+  if (!hold_active || !recovery_safe) {
+    state.recovery_stable_since_ms = 0;
+  } else if (state.recovery_stable_since_ms == 0)
+    state.recovery_stable_since_ms = nonzero_timestamp_ms(in.now_ms);
+  const bool recovery_stable = elapsed(in.now_ms, state.recovery_stable_since_ms, tuning.recovery_stable_ms);
+
+  const bool release_hold = (hold_active && (recovery_not_needed || recovery_stable)) || state.hold_expired_pending ||
+                            (state.hold_since_ms != 0 && !hold_active);
+  bool reset_integral_and_dwell = false;
+  if (release_hold) {
+    reset_integral_and_dwell = !recovery_not_needed;
+    state = {0, 0, reset_integral_and_dwell ? nonzero_timestamp_ms(in.now_ms) : 0, false};
+  }
+  return {window_active(in.now_ms, state.hold_since_ms, tuning.hold_ms),
+          window_active(in.now_ms, state.recovery_cap_since_ms, tuning.recovery_cap_ms), reset_integral_and_dwell};
+}
+
+inline WaterRestartDecision evaluate_water_restart(bool restart_by_minimum_off_time, bool minimum_off_stop_pending,
+                                                   float restart_delta_c, const LimiterInput& conditions,
+                                                   const LimiterOutput& limiter, const LimiterTuning& tuning,
+                                                   const LimiterState& limiter_state, WaterCycleState state) {
+  if (state.active) return {state, false, limiter.reason_code};
+  if (state.stop_reason_code == WATER_STOP_REQUEST_CLEARED) state.stop_reason_code = WATER_STOP_NONE;
+  const bool safety_stop = limiter.reason_code == REASON_DEW_STOP || limiter.reason_code == REASON_FALLBACK_FLOOR;
+  if (state.stop_reason_code == WATER_STOP_PROJECTED_FLOOR && safety_stop) {
+    state.stop_reason_code = limiter.reason_code == REASON_DEW_STOP ? WATER_STOP_DEW : WATER_STOP_FALLBACK;
+    state.stop_buffer_gap_c = conditions.filtered_gap_c;
+  }
+  const bool restart_after_water_stop = state.stop_reason_code != WATER_STOP_NONE;
+  const bool projected_floor_pause = state.stop_reason_code == WATER_STOP_PROJECTED_FLOOR;
+  const bool projected_floor_recovered = !projected_floor_pause || !limiter_state.projection_brake_active ||
+                                         limiter.projected_gap_c >= tuning.projected_floor_release_gap_c ||
+                                         conditions.gap_rate_c_per_min >= 0.0f;
+  const bool recovered =
+      conditions.oil_return_mask_active ||
+      ((restart_by_minimum_off_time ? !minimum_off_stop_pending
+                                    : water_restart_gap_recovered(state, conditions.filtered_gap_c, restart_delta_c)) &&
+       (!conditions.dew_mode || !finite_float(conditions.dew_gap_c) ||
+        conditions.dew_gap_c > hard_dew_restart_gap(conditions, tuning)) &&
+       (restart_by_minimum_off_time || !conditions.fallback_mode || !restart_after_water_stop ||
+        projected_floor_pause || conditions.filtered_gap_c > state.stop_buffer_gap_c + restart_delta_c) &&
+       projected_floor_recovered);
+  if (recovered && limiter.allowed_max > 0) {
+    state.active = true;
+    state.stop_reason_code = WATER_STOP_NONE;
+  }
+  const bool keep_limiter_reason =
+      state.active || safety_stop || !restart_after_water_stop || (projected_floor_pause && !projected_floor_recovered);
+  return {state, !state.active && safety_stop, keep_limiter_reason ? limiter.reason_code : REASON_RESTART_WAIT};
 }
 
 inline void apply_cap(int cap, int reason, int& allowed_cap, int& reason_code) {
@@ -238,7 +376,7 @@ inline void update_hysteretic_capacity_cap(const LimiterInput& in, const Limiter
 
   if (risk_cap < current_cap) {
     current_cap = risk_cap;
-    state.capacity_last_change_ms = in.now_ms;
+    state.capacity_last_change_ms = nonzero_timestamp_ms(in.now_ms);
     state.capacity_recovery_since_ms = 0;
     state.capacity_full_recovery_since_ms = 0;
     out.clamp_integral_to_zero = true;
@@ -258,17 +396,14 @@ inline void update_hysteretic_capacity_cap(const LimiterInput& in, const Limiter
     const bool full_recovery_ready = staged_recovery_ready && risk_cap >= capacity_demand_max && current_cap >= 3;
 
     if (recovery_ready) {
-      if (state.capacity_recovery_since_ms == 0 || in.now_ms <= state.capacity_recovery_since_ms) {
-        state.capacity_recovery_since_ms = in.now_ms;
-      }
+      if (state.capacity_recovery_since_ms == 0) state.capacity_recovery_since_ms = nonzero_timestamp_ms(in.now_ms);
       if (full_recovery_ready) {
-        if (state.capacity_full_recovery_since_ms == 0 || in.now_ms <= state.capacity_full_recovery_since_ms) {
-          state.capacity_full_recovery_since_ms = in.now_ms;
-        }
+        if (state.capacity_full_recovery_since_ms == 0)
+          state.capacity_full_recovery_since_ms = nonzero_timestamp_ms(in.now_ms);
       } else {
         state.capacity_full_recovery_since_ms = 0;
       }
-      const bool hold_elapsed = state.capacity_last_change_ms == 0 || in.now_ms <= state.capacity_last_change_ms ||
+      const bool hold_elapsed = state.capacity_last_change_ms == 0 ||
                                 (uint32_t)(in.now_ms - state.capacity_last_change_ms) >= tuning.capacity_min_hold_ms;
       if (hold_elapsed && elapsed(in.now_ms, state.capacity_recovery_since_ms, tuning.capacity_recovery_stable_ms)) {
         const bool full_capacity_recovered =
@@ -280,7 +415,7 @@ inline void update_hysteretic_capacity_cap(const LimiterInput& in, const Limiter
                                  : std::min(non_full_capacity_max, std::min(risk_cap, current_cap + 1));
         if (next_cap > current_cap) {
           current_cap = next_cap;
-          state.capacity_last_change_ms = in.now_ms;
+          state.capacity_last_change_ms = nonzero_timestamp_ms(in.now_ms);
           state.capacity_recovery_since_ms = 0;
           state.capacity_full_recovery_since_ms = 0;
         }
@@ -334,9 +469,7 @@ inline LimiterOutput update_limiter(const LimiterInput& in, const LimiterTuning&
       !in.oil_return_mask_active && in.dew_mode && finite_float(in.dew_gap_c) && in.dew_gap_c <= hard_dew_stop_gap_c;
   bool dew_hard_stop = false;
   if (dew_hard_stop_candidate) {
-    if (state.dew_stop_candidate_since_ms == 0 || in.now_ms <= state.dew_stop_candidate_since_ms) {
-      state.dew_stop_candidate_since_ms = in.now_ms;
-    }
+    if (state.dew_stop_candidate_since_ms == 0) state.dew_stop_candidate_since_ms = nonzero_timestamp_ms(in.now_ms);
     dew_hard_stop = elapsed(in.now_ms, state.dew_stop_candidate_since_ms, tuning.limiter_stop_confirm_ms);
   } else {
     state.dew_stop_candidate_since_ms = 0;
@@ -391,9 +524,7 @@ inline LimiterOutput update_limiter(const LimiterInput& in, const LimiterTuning&
       out.reason_code = REASON_LEVEL1_HOLD;
       state.stop_candidate_since_ms = 0;
     } else if (in.filtered_gap_c > tuning.limiter_soft_stop_gap_c) {
-      if (state.stop_candidate_since_ms == 0 || in.now_ms <= state.stop_candidate_since_ms) {
-        state.stop_candidate_since_ms = in.now_ms;
-      }
+      if (state.stop_candidate_since_ms == 0) state.stop_candidate_since_ms = nonzero_timestamp_ms(in.now_ms);
       if (!elapsed(in.now_ms, state.stop_candidate_since_ms, tuning.limiter_stop_confirm_ms)) {
         out.allowed_max = 1;
         out.reason_code = REASON_LEVEL1_HOLD;

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -152,21 +152,6 @@ globals:
     restore_value: false
     initial_value: '0'
 
-  - id: oq_cooling_oil_return_hold_until_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_oil_return_recovery_stable_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_oil_return_recovery_cap_until_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
   - id: oq_cooling_capacity_cap
     type: int
     restore_value: false
@@ -652,16 +637,9 @@ interval:
           // enough shape to behave across low-mass and high-mass water systems.
           const float filter_tau_s = 60.0f;
           const uint32_t rate_window_ms = 60000UL;
-          const uint32_t oil_return_recovery_stable_ms = 120000UL;
-          const uint32_t oil_return_recovery_cap_ms = 120000UL;
-          const float oil_return_recovery_dew_extra_c = 0.30f;
-          const float oil_return_recovery_projected_extra_c = 0.15f;
-          const float oil_return_recovery_fast_fall_rate_c_per_min = -0.05f;
-          const uint32_t oil_return_hold_ms =
-              (uint32_t) (${oq_cooling_oil_return_hold_s} * 1000UL);
+          oq_cooling::OilReturnTuning oil_return_tuning{(uint32_t) (${oq_cooling_oil_return_hold_s} * 1000UL)};
           oq_cooling::LimiterTuning limiter_tuning;
-          limiter_tuning.limiter_stop_confirm_ms =
-              (uint32_t) (${oq_cooling_limiter_stop_confirm_s} * 1000UL);
+          limiter_tuning.limiter_stop_confirm_ms = (uint32_t) (${oq_cooling_limiter_stop_confirm_s} * 1000UL);
           const uint32_t upscale_dwell_ms = 90000UL;
           const uint32_t downscale_dwell_ms = 30000UL;
           const float simmer_room_error_min_c = 0.20f;
@@ -740,11 +718,7 @@ interval:
           #if OQ_TOPOLOGY_DUO
           oil_return_active = oil_return_active || id(${secondary_oil_return_id}).state;
           #endif
-          if (oil_return_active) {
-            id(oq_cooling_oil_return_hold_until_ms) = now_ms + oil_return_hold_ms;
-            id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
-            id(oq_cooling_oil_return_recovery_cap_until_ms) = 0;
-          }
+          static oq_cooling::OilReturnState oil_return_state;
 
           const bool active =
               id(cooling_enable_selected).state &&
@@ -785,18 +759,14 @@ interval:
             id(oq_cooling_base_demand_raw) = 0;
             id(oq_cooling_limited_demand) = 0;
             id(oq_cooling_limiter_reason_code) = 0;
-            id(oq_cooling_stop_reason_code) =
-                (cooling_cycle_was_active && cooling_request_cleared) ? 5 :
-                (cooling_cycle_was_active && cooling_sensor_missing) ? 3 :
-                cooling_flow_permission_lost ? 6 :
-                cooling_core_permission_lost ? 7 : 0;
+            id(oq_cooling_stop_reason_code) = oq_cooling::inactive_stop_reason(
+                cooling_cycle_was_active, cooling_request_cleared, cooling_sensor_missing,
+                cooling_flow_permission_lost, cooling_core_permission_lost);
             id(oq_cooling_buffer_gap_rate_ref_ms) = 0;
             id(oq_cooling_last_demand_change_ms) = 0;
-            id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
-            id(oq_cooling_oil_return_recovery_cap_until_ms) = 0;
-            int reset_capacity_cap = (int) lroundf(id(cooling_demand_max_f).state);
-            if (reset_capacity_cap < 1) reset_capacity_cap = 1;
-            if (reset_capacity_cap > 10) reset_capacity_cap = 10;
+            oq_cooling::update_oil_return(
+                {now_ms, false, oil_return_active}, {}, oil_return_tuning, limiter_tuning, oil_return_state);
+            const int reset_capacity_cap = oq_cooling::clamp_level((int) lroundf(id(cooling_demand_max_f).state), 1, 10);
             id(oq_cooling_simmer_allowed) = false;
             id(oq_cooling_projection_brake_active) = false;
             id(oq_cooling_stop_candidate_since_ms) = 0;
@@ -865,8 +835,7 @@ interval:
             id(oq_cooling_stop_reason_code) = 0;
             id(oq_cooling_stop_buffer_gap_c) = 0.0f;
             id(oq_cooling_last_demand_change_ms) = 0;
-            id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
-            id(oq_cooling_oil_return_recovery_cap_until_ms) = 0;
+            oq_cooling::reset_oil_return_recovery(oil_return_state);
             id(oq_cooling_simmer_allowed) = false;
             id(oq_cooling_projection_brake_active) = false;
             id(oq_cooling_stop_candidate_since_ms) = 0;
@@ -918,107 +887,7 @@ interval:
           if (id(cooling_safety_margin_selected).has_state() && !isnan(id(cooling_safety_margin_selected).state)) {
             safety_margin_c = id(cooling_safety_margin_selected).state;
           }
-          if (safety_margin_c < 0.0f) safety_margin_c = 0.0f;
-          if (safety_margin_c > 2.0f) safety_margin_c = 2.0f;
-          const float hard_dew_stop_gap_c =
-              limiter_tuning.hard_dew_stop_base_gap_c +
-              (limiter_tuning.hard_dew_stop_margin_gain_c * safety_margin_c);
-          const float hard_dew_restart_gap_c =
-              hard_dew_stop_gap_c + limiter_tuning.hard_dew_restart_hyst_c;
-
-          const float projected_gap_c =
-              filtered_gap_c + (gap_rate_c_per_min * limiter_tuning.projection_horizon_min);
-          id(oq_cooling_projected_gap_c) = projected_gap_c;
-
-          bool oil_return_hold_window_active =
-              id(oq_cooling_oil_return_hold_until_ms) > 0 &&
-              now_ms < id(oq_cooling_oil_return_hold_until_ms);
-          bool oil_return_mask_active = oil_return_active || oil_return_hold_window_active;
-          bool oil_return_recovery_cap_active =
-              id(oq_cooling_oil_return_recovery_cap_until_ms) > 0 &&
-              now_ms < id(oq_cooling_oil_return_recovery_cap_until_ms);
-          if (!oil_return_recovery_cap_active &&
-              id(oq_cooling_oil_return_recovery_cap_until_ms) > 0) {
-            id(oq_cooling_oil_return_recovery_cap_until_ms) = 0;
-          }
-
-          const bool oil_return_recovery_not_needed = !dew_mode && !fallback_mode;
-          const bool oil_return_dew_recovered =
-              !dew_mode ||
-              (!isnan(dew_gap_c) &&
-               dew_gap_c >= hard_dew_restart_gap_c + oil_return_recovery_dew_extra_c);
-          const bool oil_return_fallback_recovered =
-              !fallback_mode ||
-              filtered_gap_c >= limiter_tuning.fallback_cap1_gap_c + oil_return_recovery_dew_extra_c;
-          const bool oil_return_filtered_recovered =
-              filtered_gap_c >= 0.0f ||
-              (filtered_gap_c > limiter_tuning.limiter_soft_stop_gap_c && gap_rate_c_per_min > 0.10f);
-          const bool oil_return_projected_recovered =
-              projected_gap_c >= limiter_tuning.projected_floor_release_gap_c + oil_return_recovery_projected_extra_c;
-          const bool oil_return_trend_recovered =
-              gap_rate_c_per_min >= oil_return_recovery_fast_fall_rate_c_per_min;
-          const bool oil_return_recovery_safe =
-              !oil_return_recovery_not_needed &&
-              oil_return_dew_recovered &&
-              oil_return_fallback_recovered &&
-              oil_return_filtered_recovered &&
-              oil_return_projected_recovered &&
-              oil_return_trend_recovered;
-
-          bool oil_return_recovery_stable = false;
-          if (!oil_return_active && oil_return_hold_window_active && oil_return_recovery_safe) {
-            uint32_t stable_since_ms = id(oq_cooling_oil_return_recovery_stable_since_ms);
-            if (stable_since_ms == 0 || now_ms <= stable_since_ms) {
-              id(oq_cooling_oil_return_recovery_stable_since_ms) = now_ms;
-              stable_since_ms = now_ms;
-            }
-            oil_return_recovery_stable =
-                (uint32_t)(now_ms - stable_since_ms) >= oil_return_recovery_stable_ms;
-          } else if (!oil_return_active) {
-            id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
-          }
-
-          if (!oil_return_active && oil_return_hold_window_active && oil_return_recovery_not_needed) {
-            id(oq_cooling_oil_return_hold_until_ms) = 0;
-            id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
-            id(oq_cooling_oil_return_recovery_cap_until_ms) = 0;
-            oil_return_hold_window_active = false;
-            oil_return_mask_active = false;
-            oil_return_recovery_cap_active = false;
-          } else if (!oil_return_active && oil_return_hold_window_active && oil_return_recovery_stable) {
-            id(oq_cooling_oil_return_hold_until_ms) = 0;
-            id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
-            id(oq_cooling_oil_return_recovery_cap_until_ms) = now_ms + oil_return_recovery_cap_ms;
-            id(oq_cooling_pid_integral) = 0.0f;
-            id(oq_cooling_last_demand_change_ms) = now_ms;
-            oil_return_hold_window_active = false;
-            oil_return_mask_active = false;
-            oil_return_recovery_cap_active = true;
-          } else if (!oil_return_active &&
-              id(oq_cooling_oil_return_hold_until_ms) > 0 &&
-              !oil_return_hold_window_active) {
-            id(oq_cooling_oil_return_hold_until_ms) = 0;
-            id(oq_cooling_oil_return_recovery_stable_since_ms) = 0;
-            if (oil_return_recovery_not_needed) {
-              id(oq_cooling_oil_return_recovery_cap_until_ms) = 0;
-              oil_return_recovery_cap_active = false;
-            } else {
-              id(oq_cooling_oil_return_recovery_cap_until_ms) = now_ms + oil_return_recovery_cap_ms;
-              id(oq_cooling_pid_integral) = 0.0f;
-              id(oq_cooling_last_demand_change_ms) = now_ms;
-              oil_return_recovery_cap_active = true;
-            }
-            oil_return_mask_active = false;
-          }
-          static bool last_oil_return_mask_active = false;
-          if (oil_return_mask_active != last_oil_return_mask_active) {
-            ESP_LOGI(
-                "quatt.cool",
-                "Cooling oil-return recovery %s",
-                oil_return_mask_active ? "active" : "cleared");
-            last_oil_return_mask_active = oil_return_mask_active;
-          }
-
+          safety_margin_c = fmaxf(0.0f, fminf(2.0f, safety_margin_c));
           float kp = id(cooling_pid_kp).state;
           float ki = id(cooling_pid_ki).state;
           float kd = id(cooling_pid_kd).state;
@@ -1027,10 +896,6 @@ interval:
           if (isnan(kd) || kd < 0.0f) kd = 0.0f;
 
           float integral = id(oq_cooling_pid_integral);
-          if (oil_return_mask_active || oil_return_recovery_cap_active) {
-            integral = fminf(integral, 0.0f);
-          }
-
           float derivative = 0.0f;
           if (dt_s > 0.0f) {
             derivative = (buffer_gap_c - id(oq_cooling_pid_last_error_c)) / dt_s;
@@ -1044,9 +909,7 @@ interval:
             room_error_valid = true;
           }
 
-          int demand_max = (int) lroundf(id(cooling_demand_max_f).state);
-          if (demand_max < 1) demand_max = 1;
-          if (demand_max > 10) demand_max = 10;
+          int demand_max = oq_cooling::clamp_level((int) lroundf(id(cooling_demand_max_f).state), 1, 10);
           const int capacity_demand_max = demand_max;
 
           bool room_cap_active = false;
@@ -1058,34 +921,32 @@ interval:
             room_cap_active = demand_max < before_room_cap;
           }
 
-          oq_cooling::LimiterState limiter_state;
-          limiter_state.simmer_allowed = id(oq_cooling_simmer_allowed);
-          limiter_state.projection_brake_active = id(oq_cooling_projection_brake_active);
-          limiter_state.stop_candidate_since_ms = id(oq_cooling_stop_candidate_since_ms);
-          limiter_state.dew_stop_candidate_since_ms = id(oq_cooling_dew_stop_candidate_since_ms);
-          limiter_state.capacity_cap = id(oq_cooling_capacity_cap);
-          limiter_state.capacity_last_change_ms = id(oq_cooling_capacity_last_change_ms);
-          limiter_state.capacity_recovery_since_ms = id(oq_cooling_capacity_recovery_since_ms);
-          limiter_state.capacity_full_recovery_since_ms = id(oq_cooling_capacity_full_recovery_since_ms);
+          oq_cooling::LimiterState limiter_state{id(oq_cooling_simmer_allowed), id(oq_cooling_projection_brake_active),
+              id(oq_cooling_stop_candidate_since_ms), id(oq_cooling_dew_stop_candidate_since_ms),
+              id(oq_cooling_capacity_cap), id(oq_cooling_capacity_last_change_ms),
+              id(oq_cooling_capacity_recovery_since_ms), id(oq_cooling_capacity_full_recovery_since_ms)};
+          oq_cooling::LimiterInput limiter_input{now_ms, demand_max, capacity_demand_max, id(oq_cooling_limited_demand),
+              room_cap_active, dew_mode, fallback_mode, false, false, buffer_gap_c,
+              filtered_gap_c, gap_rate_c_per_min, dew_gap_c, safety_margin_c};
 
-          oq_cooling::LimiterInput limiter_input;
-          limiter_input.now_ms = now_ms;
-          limiter_input.demand_max = demand_max;
-          limiter_input.capacity_demand_max = capacity_demand_max;
-          limiter_input.previous_limited_demand = id(oq_cooling_limited_demand);
-          limiter_input.room_cap_active = room_cap_active;
-          limiter_input.dew_mode = dew_mode;
-          limiter_input.fallback_mode = fallback_mode;
-          limiter_input.oil_return_mask_active = oil_return_mask_active;
-          limiter_input.oil_return_recovery_cap_active = oil_return_recovery_cap_active;
-          limiter_input.buffer_gap_c = buffer_gap_c;
-          limiter_input.filtered_gap_c = filtered_gap_c;
-          limiter_input.gap_rate_c_per_min = gap_rate_c_per_min;
-          limiter_input.dew_gap_c = dew_gap_c;
-          limiter_input.safety_margin_c = safety_margin_c;
+          const auto oil_return_decision = oq_cooling::update_oil_return({now_ms, true, oil_return_active}, limiter_input,
+              oil_return_tuning, limiter_tuning, oil_return_state);
+          limiter_input.oil_return_mask_active = oil_return_decision.mask_active;
+          limiter_input.oil_return_recovery_cap_active = oil_return_decision.recovery_cap_active;
+          if (oil_return_decision.reset_integral_and_dwell) {
+            integral = id(oq_cooling_pid_integral) = 0.0f;
+            id(oq_cooling_last_demand_change_ms) = now_ms;
+          } else if (oil_return_decision.mask_active || oil_return_decision.recovery_cap_active) {
+            integral = fminf(integral, 0.0f);
+          }
+          static bool last_oil_return_mask_active = false;
+          if (oil_return_decision.mask_active != last_oil_return_mask_active) {
+            ESP_LOGI("quatt.cool", "Cooling oil-return recovery %s",
+                     oil_return_decision.mask_active ? "active" : "cleared");
+            last_oil_return_mask_active = oil_return_decision.mask_active;
+          }
 
-          const auto limiter_output =
-              oq_cooling::update_limiter(limiter_input, limiter_tuning, limiter_state);
+          const auto limiter_output = oq_cooling::update_limiter(limiter_input, limiter_tuning, limiter_state);
           if (limiter_output.reset_gap_rate_reference) {
             id(oq_cooling_buffer_gap_rate_ref_c) = filtered_gap_c;
             id(oq_cooling_buffer_gap_rate_ref_ms) = now_ms;
@@ -1105,68 +966,24 @@ interval:
           int reason_code = limiter_output.reason_code;
           id(oq_cooling_limiter_allowed_max) = allowed_max;
 
-          // Restart hysteresis is only for water-side stops. If cooling stopped
-          // because the room demand disappeared, the next room request may start
-          // immediately as long as the current limiter allows it.
+          // Water-side stops use restart hysteresis; a cleared room request may
+          // restart immediately when the current limiter allows it.
           bool water_cycle_active = id(oq_cooling_water_cycle_active);
           if (!water_cycle_active) {
-            int stop_reason_code = id(oq_cooling_stop_reason_code);
-            if (stop_reason_code == 5) {
-              // Request-cleared is informational for the decision log. It must
-              // not trigger water-side restart hysteresis.
-              stop_reason_code = 0;
-              id(oq_cooling_stop_reason_code) = 0;
-            }
-            if (stop_reason_code == 4 &&
-                (reason_code == oq_cooling::REASON_DEW_STOP ||
-                 reason_code == oq_cooling::REASON_FALLBACK_FLOOR)) {
-              stop_reason_code = reason_code == oq_cooling::REASON_DEW_STOP ? 2 : 3;
-              id(oq_cooling_stop_reason_code) = stop_reason_code;
-              id(oq_cooling_stop_buffer_gap_c) = filtered_gap_c;
-            }
-            const bool restart_after_water_stop = stop_reason_code != 0;
-            const bool projected_floor_pause = stop_reason_code == 4;
-            const oq_cooling::WaterCycleState stopped_cycle{
-                false,
-                id(oq_cooling_stop_buffer_gap_c),
-                stop_reason_code,
-            };
-            const float restart_threshold_c = stopped_cycle.stop_buffer_gap_c + restart_delta_c;
-            const bool restart_gap_recovered = restart_by_minimum_off_time
-                ? !id(oq_cooling_min_off_stop_pending)
-                : oq_cooling::water_restart_gap_recovered(stopped_cycle, filtered_gap_c, restart_delta_c);
-            const bool dew_recovered = !dew_mode || isnan(dew_gap_c) || dew_gap_c > hard_dew_restart_gap_c;
-            const bool fallback_recovered =
-                restart_by_minimum_off_time || !fallback_mode ||
-                !restart_after_water_stop || projected_floor_pause ||
-                filtered_gap_c > restart_threshold_c;
-            const bool projected_floor_recovered =
-                !projected_floor_pause ||
-                !limiter_state.projection_brake_active ||
-                projected_gap_c >= limiter_tuning.projected_floor_release_gap_c ||
-                gap_rate_c_per_min >= 0.0f;
-            const bool restart_recovered =
-                oil_return_mask_active ||
-                (restart_gap_recovered && dew_recovered && fallback_recovered && projected_floor_recovered);
-            if (restart_recovered && allowed_max > 0) {
-              water_cycle_active = true;
-              id(oq_cooling_stop_reason_code) = 0;
-            } else {
+            const auto restart = oq_cooling::evaluate_water_restart(
+                restart_by_minimum_off_time, id(oq_cooling_min_off_stop_pending), restart_delta_c,
+                limiter_input, limiter_output, limiter_tuning, limiter_state,
+                {false, id(oq_cooling_stop_buffer_gap_c), id(oq_cooling_stop_reason_code)});
+            water_cycle_active = restart.state.active;
+            id(oq_cooling_stop_buffer_gap_c) = restart.state.stop_buffer_gap_c;
+            id(oq_cooling_stop_reason_code) = restart.state.stop_reason_code;
+            if (!restart.state.active) {
               id(oq_cooling_demand_raw) = 0;
               id(oq_cooling_base_demand_raw) = 0;
               id(oq_cooling_limited_demand) = 0;
-              id(oq_cooling_limiter_reason_code) =
-                  (reason_code == oq_cooling::REASON_DEW_STOP ||
-                   reason_code == oq_cooling::REASON_FALLBACK_FLOOR ||
-                   !restart_after_water_stop ||
-                   (projected_floor_pause && !projected_floor_recovered))
-                      ? reason_code
-                      : oq_cooling::REASON_RESTART_WAIT;
+              id(oq_cooling_limiter_reason_code) = restart.limiter_reason_code;
               id(oq_cooling_pid_last_error_c) = buffer_gap_c;
-              if (reason_code == oq_cooling::REASON_DEW_STOP ||
-                  reason_code == oq_cooling::REASON_FALLBACK_FLOOR) {
-                id(oq_cooling_pid_integral) = 0.0f;
-              }
+              if (restart.reset_integral) id(oq_cooling_pid_integral) = 0.0f;
               publish_cooling_limiter_event(true, id(oq_cooling_limiter_reason_code), 0, 0, dew_gap_c, true);
               return;
             }

--- a/scripts/tests/test_cooling_recovery_delegation_contract.py
+++ b/scripts/tests/test_cooling_recovery_delegation_contract.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+YAML = (ROOT / "openquatt/oq_cooling_strategy.yaml").read_text()
+DEFROST_TEST = (ROOT / "tests/host/oq_odu_compressor_levels_test.cpp").read_text()
+
+class CoolingRecoveryDelegationContractTest(unittest.TestCase):
+    def test_yaml_delegates_and_live_defrost_path_stays_fail_closed(self) -> None:
+        for marker in ("update_oil_return(", "evaluate_water_restart(", "inactive_stop_reason(",
+                       "id(cooling_pid_kp).state", "hp_can_take_cooling_start", "publish_cooling_limiter_event"):
+            self.assertIn(marker, YAML)
+        for marker in ("oq_cooling_oil_return_hold_until_ms", "oil_return_recovery_not_needed"):
+            self.assertNotIn(marker, YAML)
+        for marker in ("resolve_retained_level(true, true", "no_cooling_hold.control_level == 0",
+                       "no_cooling_hold.physical_level == 0"):
+            self.assertIn(marker, DEFROST_TEST)
+        paths = ("openquatt/oq_cooling_strategy.yaml", "openquatt/includes/control/oq_cooling_limiter_logic.h",
+                 "tests/host/cooling_limiter_logic_test.cpp", "tests/host/thermal_request_logic_test.cpp")
+        files = [ROOT / path for path in paths] + [Path(__file__)]
+        self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in files), 2310)

--- a/tests/host/cooling_limiter_logic_test.cpp
+++ b/tests/host/cooling_limiter_logic_test.cpp
@@ -2,152 +2,192 @@
 
 #include "../../openquatt/includes/control/oq_cooling_limiter_logic.h"
 
-namespace {
+using namespace oq_cooling;
 
-using oq_cooling::apply_hp2_before_hp1_for_cooling_handover;
-using oq_cooling::cooling_minimum_off_stop_is_pending;
-using oq_cooling::cooling_stop_is_planned;
-using oq_cooling::global_minimum_off_time_blocks_start;
-using oq_cooling::global_minimum_off_time_remaining_ms;
-using oq_cooling::record_confirmed_cooling_stop;
-using oq_cooling::record_pi_zero_stop;
-using oq_cooling::water_restart_gap_recovered;
-using oq_cooling::WATER_STOP_DEW;
-using oq_cooling::WATER_STOP_LIMITER;
-using oq_cooling::WATER_STOP_NONE;
-using oq_cooling::WATER_STOP_PROJECTED_FLOOR;
-using oq_cooling::WATER_STOP_REQUEST_CLEARED;
-using oq_cooling::WaterCycleState;
-
-void test_pi_zero_stop_requires_an_active_nonzero_run() {
-  WaterCycleState inactive;
-  assert(!record_pi_zero_stop(1, 0, 0.0f, inactive));
-
-  WaterCycleState not_started{true, 0.0f, WATER_STOP_NONE};
-  assert(!record_pi_zero_stop(0, 0, 0.0f, not_started));
-  assert(not_started.active);
-
-  WaterCycleState still_running{true, 0.0f, WATER_STOP_NONE};
-  assert(!record_pi_zero_stop(1, 1, 0.0f, still_running));
-  assert(still_running.active);
+LimiterInput safe_conditions(uint32_t now_ms = 1000) {
+  LimiterInput in;
+  in.now_ms = now_ms;
+  in.demand_max = in.capacity_demand_max = 3;
+  in.previous_limited_demand = 1;
+  in.buffer_gap_c = in.filtered_gap_c = 1.0f;
+  return in;
 }
 
-void test_low_load_pi_zero_stop_waits_for_restart_delta() {
-  constexpr float stop_gap_c = 0.05f;
-  constexpr float restart_delta_c = 1.0f;
+void test_existing_water_and_minimum_off_contracts() {
   WaterCycleState cycle{true, 0.0f, WATER_STOP_NONE};
-
-  assert(record_pi_zero_stop(1, 0, stop_gap_c, cycle));
-  assert(!cycle.active);
-  assert(cycle.stop_reason_code == WATER_STOP_LIMITER);
-  assert(cycle.stop_buffer_gap_c == stop_gap_c);
-
-  // Repeated PI recovery attempts stay blocked, so no Duo owner can receive a
-  // new request while the just-stopped owner is still in minimum off-time.
-  assert(!water_restart_gap_recovered(cycle, 0.20f, restart_delta_c));
-  assert(!water_restart_gap_recovered(cycle, 0.60f, restart_delta_c));
-  assert(!water_restart_gap_recovered(cycle, 1.04f, restart_delta_c));
-  assert(water_restart_gap_recovered(cycle, 1.05f, restart_delta_c));
-}
-
-void test_pi_zero_stop_preserves_higher_priority_reason() {
-  WaterCycleState dew_stop{true, 0.0f, WATER_STOP_DEW};
-
-  assert(record_pi_zero_stop(1, 0, 0.10f, dew_stop));
-  assert(!dew_stop.active);
-  assert(dew_stop.stop_reason_code == WATER_STOP_DEW);
-  assert(dew_stop.stop_buffer_gap_c == 0.10f);
-}
-
-void test_existing_restart_exceptions_remain_unchanged() {
-  const WaterCycleState no_water_stop{false, 0.0f, WATER_STOP_NONE};
-  assert(water_restart_gap_recovered(no_water_stop, -1.0f, 1.0f));
-
-  const WaterCycleState projected_floor_pause{false, 0.0f, WATER_STOP_PROJECTED_FLOOR};
-  assert(water_restart_gap_recovered(projected_floor_pause, -1.0f, 1.0f));
-}
-
-void test_global_minimum_off_time_blocks_boot_and_both_owner_candidates() {
-  constexpr uint32_t minimum_off_ms = 600000UL;
-
-  assert(global_minimum_off_time_remaining_ms(false, 1000UL, false, 0, false, minimum_off_ms) == 0);
-  assert(global_minimum_off_time_remaining_ms(true, 300000UL, false, 0, false, minimum_off_ms) == 300000UL);
-  assert(global_minimum_off_time_remaining_ms(true, minimum_off_ms, false, 0, true, minimum_off_ms) == 0);
-
-  constexpr uint32_t stop_ms = 900000UL;
-  assert(global_minimum_off_time_remaining_ms(true, stop_ms + 120000UL, true, stop_ms, true, minimum_off_ms) ==
-         480000UL);
-  assert(global_minimum_off_time_remaining_ms(true, stop_ms + minimum_off_ms, true, stop_ms, true, minimum_off_ms) ==
-         0);
-  assert(global_minimum_off_time_blocks_start(480000UL, false, false, 0));
-  assert(global_minimum_off_time_blocks_start(480000UL, false, false, -1));
-  assert(!global_minimum_off_time_blocks_start(480000UL, false, false, 1));
-  assert(!global_minimum_off_time_blocks_start(0, false, false, 0));
-}
-
-void test_pending_or_same_tick_cooling_stop_blocks_duo_replacement_start() {
-  // The original strategy request remains authoritative when the downstream
-  // minimum-runtime floor temporarily keeps the outgoing HP at level 1.
-  const bool outgoing_stop_planned = cooling_stop_is_planned(true, 3, 0);
-  assert(outgoing_stop_planned);
-  assert(!cooling_stop_is_planned(false, 3, 0));
-  assert(!cooling_stop_is_planned(true, 0, 0));
-  assert(!cooling_stop_is_planned(true, 3, 2));
-
+  assert(record_pi_zero_stop(1, 0, 0.05f, cycle));
+  assert(!cycle.active && cycle.stop_reason_code == WATER_STOP_LIMITER && cycle.stop_buffer_gap_c == 0.05f);
+  for (float gap : {0.20f, 0.60f, 1.04f}) assert(!water_restart_gap_recovered(cycle, gap, 1.0f));
+  assert(water_restart_gap_recovered(cycle, 1.05f, 1.0f));
+  for (WaterCycleState state : {WaterCycleState{}, {false, 0, WATER_STOP_PROJECTED_FLOOR}})
+    assert(water_restart_gap_recovered(state, -1.0f, 1.0f));
+  WaterCycleState dew{true, 0, WATER_STOP_DEW};
+  assert(record_pi_zero_stop(1, 0, 0.1f, dew) && !dew.active && dew.stop_reason_code == WATER_STOP_DEW &&
+         dew.stop_buffer_gap_c == 0.1f);
+  WaterCycleState inactive, not_started{true, 0, WATER_STOP_NONE};
+  assert(!record_pi_zero_stop(1, 0, 0, inactive) && !inactive.active);
+  assert(!record_pi_zero_stop(0, 0, 0, not_started) && not_started.active);
+  WaterCycleState still_running{true, 0, WATER_STOP_NONE};
+  assert(!record_pi_zero_stop(1, 1, 0, still_running) && still_running.active);
+  constexpr uint32_t off = 600000, stop = 900000;
+  assert(global_minimum_off_time_remaining_ms(false, 1000, false, 0, false, off) == 0);
+  assert(global_minimum_off_time_remaining_ms(true, 300000, false, 0, false, off) == 300000);
+  assert(global_minimum_off_time_remaining_ms(true, off, false, 0, true, off) == 0);
+  assert(global_minimum_off_time_remaining_ms(true, stop + 120000, true, stop, true, off) == 480000);
+  assert(global_minimum_off_time_remaining_ms(true, stop + off, true, stop, true, off) == 0);
+  assert(global_minimum_off_time_remaining_ms(true, 2000, true, UINT32_MAX - 3000, true, 10000) == 4999);
+  assert(global_minimum_off_time_blocks_start(1, false, false, 0));
+  assert(global_minimum_off_time_blocks_start(1, false, false, -1));
   assert(global_minimum_off_time_blocks_start(0, true, false, 0));
-  assert(global_minimum_off_time_blocks_start(0, false, outgoing_stop_planned, 0));
-  assert(!global_minimum_off_time_blocks_start(0, true, true, 2));
-}
-
-void test_active_cooling_owner_is_applied_before_a_stopped_duo_candidate() {
-  assert(!apply_hp2_before_hp1_for_cooling_handover(true, false));
-  assert(apply_hp2_before_hp1_for_cooling_handover(false, true));
-  assert(!apply_hp2_before_hp1_for_cooling_handover(true, true));
-  assert(!apply_hp2_before_hp1_for_cooling_handover(false, false));
-}
-
-void test_minimum_off_time_waits_for_confirmed_physical_stop() {
-  uint32_t last_confirmed_stop_ms = 1234UL;
-  bool confirmed_stop_seen = false;
-  assert(!record_confirmed_cooling_stop(false, true, 2000UL, last_confirmed_stop_ms, confirmed_stop_seen));
-  assert(last_confirmed_stop_ms == 1234UL);
-  assert(!confirmed_stop_seen);
-  assert(!record_confirmed_cooling_stop(true, false, 3000UL, last_confirmed_stop_ms, confirmed_stop_seen));
-  assert(last_confirmed_stop_ms == 1234UL);
-  assert(!confirmed_stop_seen);
-  assert(record_confirmed_cooling_stop(true, true, 4000UL, last_confirmed_stop_ms, confirmed_stop_seen));
-  assert(last_confirmed_stop_ms == 4000UL);
-  assert(confirmed_stop_seen);
-}
-
-void test_global_minimum_off_time_is_millis_wrap_safe() {
-  constexpr uint32_t stop_ms = UINT32_MAX - 3000UL;
-  constexpr uint32_t now_ms = 2000UL;
-  assert(global_minimum_off_time_remaining_ms(true, now_ms, true, stop_ms, true, 10000UL) == 4999UL);
-}
-
-void test_minimum_off_time_preserves_an_applied_water_stop_during_mode_switch() {
-  // An applied stop or an active confirmation/countdown preserves the water
-  // stop latch while minimum-off-time mode is selected.
+  assert(global_minimum_off_time_blocks_start(0, false, true, 0));
+  assert(!global_minimum_off_time_blocks_start(1, true, true, 1));
+  assert(!global_minimum_off_time_blocks_start(0, false, false, 0));
+  assert(cooling_stop_is_planned(true, 3, 0) && !cooling_stop_is_planned(false, 3, 0) &&
+         !cooling_stop_is_planned(true, 0, 0) && !cooling_stop_is_planned(true, 3, 2));
+  assert(apply_hp2_before_hp1_for_cooling_handover(false, true) &&
+         !apply_hp2_before_hp1_for_cooling_handover(true, false) &&
+         !apply_hp2_before_hp1_for_cooling_handover(true, true) &&
+         !apply_hp2_before_hp1_for_cooling_handover(false, false));
+  uint32_t confirmed_at = 1234;
+  bool seen = false;
+  assert(!record_confirmed_cooling_stop(false, true, 2000, confirmed_at, seen) && confirmed_at == 1234 && !seen);
+  assert(!record_confirmed_cooling_stop(true, false, 3000, confirmed_at, seen) && confirmed_at == 1234 && !seen);
+  assert(record_confirmed_cooling_stop(true, true, 4000, confirmed_at, seen) && seen && confirmed_at == 4000);
   assert(cooling_minimum_off_stop_is_pending(true, false, WATER_STOP_LIMITER, true));
   assert(!cooling_minimum_off_stop_is_pending(true, false, WATER_STOP_REQUEST_CLEARED, true));
   assert(!cooling_minimum_off_stop_is_pending(true, false, WATER_STOP_LIMITER, false));
   assert(!cooling_minimum_off_stop_is_pending(true, true, WATER_STOP_LIMITER, true));
   assert(!cooling_minimum_off_stop_is_pending(false, false, WATER_STOP_LIMITER, true));
 }
+enum RestartFlags { MIN_OFF = 1, PENDING = 2, DEW = 4, FALLBACK = 8, OIL = 16, BRAKE = 32 };
+WaterRestartDecision restart_case(float filtered, int stop_reason, int flags = 0, float dew_gap = NAN,
+                                  float projected = 1, float rate = 0, int allowed = 1,
+                                  int limiter_reason = REASON_FULL, float stop_gap = 0.05f) {
+  LimiterInput in{
+      1000, 3,        3,    1,       false, (bool)(flags & DEW), (bool)(flags & FALLBACK), (bool)(flags & OIL), false,
+      1,    filtered, rate, dew_gap, 1};
+  LimiterState limiter_state{false, (bool)(flags & BRAKE)};
+  return evaluate_water_restart(flags & MIN_OFF, flags & PENDING, 1.0f, in, {allowed, limiter_reason, projected}, {},
+                                limiter_state, {false, stop_gap, stop_reason});
+}
 
-}  // namespace
+void test_stop_reason_and_water_restart_matrix() {
+  const int cases[][6] = {{false, false, false, false, false, WATER_STOP_NONE},
+                          {true, true, true, true, true, WATER_STOP_REQUEST_CLEARED},
+                          {true, false, true, true, true, WATER_STOP_FALLBACK},
+                          {false, false, true, true, true, WATER_STOP_FLOW_PERMISSION_LOST},
+                          {false, false, false, false, true, WATER_STOP_CORE_PERMISSION_LOST}};
+  for (const auto& c : cases) assert(inactive_stop_reason(c[0], c[1], c[2], c[3], c[4]) == c[5]);
+  assert(!restart_case(1.049f, WATER_STOP_LIMITER).state.active);
+  assert(restart_case(1.05f, WATER_STOP_LIMITER).state.active);
+  assert(!restart_case(1.05f, WATER_STOP_LIMITER, MIN_OFF | PENDING).state.active);
+  assert(restart_case(-10, WATER_STOP_LIMITER, MIN_OFF).state.active);
+  assert(!restart_case(10, WATER_STOP_NONE, DEW, 0.65f).state.active);
+  assert(restart_case(10, WATER_STOP_NONE, DEW, 0.66f).state.active);
+  assert(!restart_case(1, WATER_STOP_LIMITER, FALLBACK, NAN, 1, 0, 1, REASON_FULL, 0).state.active);
+  assert(restart_case(1.001f, WATER_STOP_LIMITER, FALLBACK, NAN, 1, 0, 1, REASON_FULL, 0).state.active);
+  assert(!restart_case(1, WATER_STOP_PROJECTED_FLOOR, BRAKE, NAN, 0.44f, -0.01f).state.active);
+  assert(restart_case(1, WATER_STOP_PROJECTED_FLOOR, BRAKE, NAN, 0.44f, 0).state.active);
+  assert(restart_case(-10, WATER_STOP_LIMITER, OIL | DEW, 0).state.active);
+  assert(!restart_case(10, WATER_STOP_REQUEST_CLEARED, 0, NAN, 1, 0, 0).state.active);
+  const auto escalated = restart_case(0.2f, WATER_STOP_PROJECTED_FLOOR, 0, NAN, 1, 0, 1, REASON_DEW_STOP, 0);
+  assert(!escalated.state.active && escalated.reset_integral && escalated.state.stop_reason_code == WATER_STOP_DEW);
+}
 
+void test_oil_return_and_limiter_safety() {
+  LimiterTuning limiter_tuning;
+  OilReturnTuning tuning{1000, 100, 100, 0.30f, 0.15f, -0.05f};
+  LimiterInput in = safe_conditions();
+  in.dew_mode = true;
+  in.dew_gap_c = 1.0f;
+  in.filtered_gap_c = 0.60f;
+  auto run = [&](OilReturnState& state, uint32_t now, bool control, bool oil) {
+    in.now_ms = now;
+    return update_oil_return({now, control, oil}, in, tuning, limiter_tuning, state);
+  };
+  OilReturnState state;
+  assert(run(state, 100, true, true).mask_active && state.hold_since_ms == 100);
+  assert(run(state, 200, true, false).mask_active && run(state, 299, true, false).mask_active);
+  auto recovered = run(state, 300, true, false);
+  assert(!recovered.mask_active && recovered.recovery_cap_active && recovered.reset_integral_and_dwell);
+  assert(run(state, 399, true, false).recovery_cap_active && !run(state, 400, true, false).recovery_cap_active);
+  struct RecoveryCase {
+    bool fallback, releases;
+    float dew, filtered, rate, horizon;
+  };
+  const RecoveryCase cases[] = {
+      {false, true, .651f, 1, 0, 3},      {false, false, .649f, 1, 0, 3},       {true, true, NAN, .601f, .1f, 3},
+      {true, false, NAN, .599f, .1f, 3},  {false, true, 1, .601f, 0, 3},        {false, false, 1, .599f, 0, 3},
+      {false, true, 1, .001f, .099f, 10}, {false, false, 1, -.001f, .099f, 10}, {false, true, 1, -.099f, .24f, 3},
+      {false, false, 1, -.101f, .24f, 3}, {false, true, 1, -.09f, .101f, 10},   {false, false, 1, -.09f, .099f, 10},
+      {false, true, 1, 1, -.049f, 3},     {false, false, 1, 1, -.051f, 3}};
+  for (const auto& c : cases) {
+    in = {1000, 3, 3, 1, false, !c.fallback, c.fallback, false, false, 1, c.filtered, c.rate, c.dew, 0};
+    limiter_tuning.projection_horizon_min = c.horizon;
+    state = {};
+    assert(run(state, 100, true, true).mask_active && run(state, 200, true, false).mask_active);
+    const auto decision = run(state, 300, true, false);
+    assert(decision.recovery_cap_active == c.releases && decision.mask_active != c.releases);
+  }
+  state = {};
+  run(state, 500, true, true);
+  run(state, 600, true, false);
+  in.gap_rate_c_per_min = -0.10f;
+  run(state, 650, true, false);
+  assert(state.recovery_stable_since_ms == 0);
+  in.gap_rate_c_per_min = 0;
+  assert(run(state, 700, true, false).mask_active && run(state, 799, true, false).mask_active);
+  assert(run(state, 800, true, false).recovery_cap_active);
+  state = {};
+  run(state, 1000, true, true);
+  assert(!run(state, 2000, false, false).mask_active && state.hold_expired_pending);
+  assert(run(state, 2100, true, false).recovery_cap_active);
+  in.dew_mode = false;
+  state = {};
+  run(state, 3000, true, true);
+  recovered = run(state, 3001, true, false);
+  assert(!recovered.mask_active && !recovered.recovery_cap_active && state.hold_since_ms == 0);
+  in.dew_mode = true;
+  state = {};
+  assert(run(state, UINT32_MAX - 999, true, true).mask_active);
+  recovered = run(state, 0, true, false);
+  assert(!recovered.mask_active && recovered.recovery_cap_active);
+  // A millis()==0 start maps to UINT32_MAX: expiry may be 1 ms early, never more.
+  state = {};
+  assert(run(state, 0, true, true).mask_active && state.hold_since_ms == UINT32_MAX);
+  assert(run(state, 998, true, false).mask_active && !run(state, 999, true, false).mask_active);
+  limiter_tuning.limiter_stop_confirm_ms = 30;
+  LimiterState limiter_state;
+  in = safe_conditions();
+  auto out = update_limiter(in, limiter_tuning, limiter_state);
+  assert(out.allowed_max == 3 && out.reason_code == REASON_FULL);
+  in.fallback_mode = true;
+  in.filtered_gap_c = 0;
+  out = update_limiter(in, limiter_tuning, limiter_state);
+  assert(out.allowed_max == 0 && out.reason_code == REASON_FALLBACK_FLOOR);
+  in = safe_conditions();
+  in.dew_mode = in.oil_return_mask_active = true;
+  in.dew_gap_c = 0;
+  out = update_limiter(in, limiter_tuning, limiter_state);
+  assert(out.allowed_max == 1 && out.reason_code == REASON_OIL_RETURN_HOLD);
+  in.oil_return_mask_active = false;
+  in.oil_return_recovery_cap_active = true;
+  in.now_ms = 9;
+  limiter_state.dew_stop_candidate_since_ms = UINT32_MAX - 20;
+  out = update_limiter(in, limiter_tuning, limiter_state);
+  assert(out.allowed_max == 0 && out.reason_code == REASON_DEW_STOP);
+  limiter_tuning.capacity_min_hold_ms = limiter_tuning.capacity_recovery_stable_ms = 30;
+  in = safe_conditions(UINT32_MAX - 20);
+  in.dew_mode = true;
+  in.dew_gap_c = 2;
+  limiter_state = {false, false, 0, 0, 1, UINT32_MAX - 50};
+  assert(update_limiter(in, limiter_tuning, limiter_state).allowed_max == 1);
+  in.now_ms = 9;
+  assert(update_limiter(in, limiter_tuning, limiter_state).allowed_max == 2);
+}
 int main() {
-  test_pi_zero_stop_requires_an_active_nonzero_run();
-  test_low_load_pi_zero_stop_waits_for_restart_delta();
-  test_pi_zero_stop_preserves_higher_priority_reason();
-  test_existing_restart_exceptions_remain_unchanged();
-  test_global_minimum_off_time_blocks_boot_and_both_owner_candidates();
-  test_pending_or_same_tick_cooling_stop_blocks_duo_replacement_start();
-  test_active_cooling_owner_is_applied_before_a_stopped_duo_candidate();
-  test_minimum_off_time_waits_for_confirmed_physical_stop();
-  test_global_minimum_off_time_is_millis_wrap_safe();
-  test_minimum_off_time_preserves_an_applied_water_stop_during_mode_switch();
+  test_existing_water_and_minimum_off_contracts();
+  test_stop_reason_and_water_restart_matrix();
+  test_oil_return_and_limiter_safety();
   return 0;
 }

--- a/tests/host/thermal_request_logic_test.cpp
+++ b/tests/host/thermal_request_logic_test.cpp
@@ -8,19 +8,16 @@ int main() {
   using oq_request::min_runtime_window_active;
 
   const auto automatic_request = make_published_request(2, 20, 20, 1);
-  assert(automatic_request.hp1_level == 10);
-  assert(automatic_request.hp2_level == 10);
+  assert(automatic_request.hp1_level == 10 && automatic_request.hp2_level == 10);
 
   const auto manual_request = make_published_request(2, 20, 20, 4, 20, 10);
-  assert(manual_request.hp1_level == 20);
-  assert(manual_request.hp2_level == 10);
+  assert(manual_request.hp1_level == 20 && manual_request.hp2_level == 10);
 
   constexpr uint32_t start_ms = 1000UL;
   constexpr uint32_t min_runtime_ms = 300000UL;
 
   const bool runtime_active = min_runtime_window_active(start_ms + 120000UL, start_ms, min_runtime_ms);
-  assert(runtime_active);
-  assert(min_runtime_window_active(start_ms, start_ms, min_runtime_ms));
+  assert(runtime_active && min_runtime_window_active(start_ms, start_ms, min_runtime_ms));
 
   // Unsigned elapsed-time arithmetic keeps the hold valid across millis() wrap.
   constexpr uint32_t wrap_start_ms = UINT32_MAX - 1000UL;
@@ -28,23 +25,16 @@ int main() {
   assert(!min_runtime_window_active(1000UL, 0, min_runtime_ms));
   assert(!min_runtime_window_active(start_ms, start_ms, 0));
 
-  // A normal zero request, including a cooling floor/dew-point stop, keeps an
-  // already running compressor active until its minimum runtime expires.
-  assert(min_runtime_hold_required(0, false, runtime_active, 1, true));
-
-  // The same policy applies independently to either compressor in a duo setup.
-  assert(min_runtime_hold_required(0, false, runtime_active, 4, false));
-
-  // An active request needs no runtime hold, and an idle compressor must never
-  // be started only to satisfy a stale runtime timestamp.
-  assert(!min_runtime_hold_required(1, false, runtime_active, 1, true));
-  assert(!min_runtime_hold_required(0, false, runtime_active, 0, false));
-
   const bool runtime_expired = min_runtime_window_active(start_ms + min_runtime_ms, start_ms, min_runtime_ms);
   assert(!runtime_expired);
-  assert(!min_runtime_hold_required(0, false, runtime_expired, 1, true));
-
-  // Absolute safety and startup inhibition retain priority over the runtime floor.
-  assert(!min_runtime_hold_required(0, true, runtime_active, 1, true));
+  struct HoldCase {
+    int request, applied;
+    bool inhibit, window, cooling, expected;
+  };
+  const HoldCase cases[] = {{0, 1, false, runtime_active, true, true},   {0, 4, false, runtime_active, false, true},
+                            {1, 1, false, runtime_active, true, false},  {0, 0, false, runtime_active, false, false},
+                            {0, 1, false, runtime_expired, true, false}, {0, 1, true, runtime_active, true, false}};
+  for (const auto& c : cases)
+    assert(min_runtime_hold_required(c.request, c.inhibit, c.window, c.applied, c.cooling) == c.expected);
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst oil-return hold/recovery, water-restart en inactieve stopredenlogica uit `oq_cooling_strategy.yaml` naar pure, hosttestbare C++.
- Maakt de betrokken oil/dew/capacity-timers rolloverveilig met behoud van de bestaande safetyvolgorde.
- Reduceert `oq_cooling_strategy.yaml` met 183 regels; de volledige PR is inclusief regressietests netto 1 regel kleiner (404 toevoegingen, 405 verwijderingen).

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De controlsemantiek en hardwarewrites blijven gelijk. De bewuste gedragswijziging is rolloverveilige unsigned timing voor oil-return, limiterconfirmatie en capacity-recovery. Exact bij `millis()==0` kan de niet-nul timestampcodering maximaal 1 ms eerder aflopen; dit is expliciet getest en kleiner dan de 5 s controlcadans. PID, freshness/entity-adapters, eigenaarselectie en actuatorwrites blijven in YAML en zijn buiten scope.

## Achtergrond

De Cooling-YAML bevatte safetykritische timing en restartarbitrage die niet direct regressietestbaar was. Deze PR introduceert compacte `Input`/`State`/`Decision`-contracten zonder heapallocaties of nieuwe taken. Rebootgedrag blijft gelijk: de vervangen globals hadden `restore_value: false` en de nieuwe statische state start eveneens leeg.

Bewuste follow-up: `oq_cooling_last_demand_change_ms` en eigenaarselectie blijven buiten deze PR en worden in de volgende Cooling-runtime-PR's behandeld.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen user-facing configuratie, entity, service of bedieningsgedrag wijzigt; dit is een interne controlrefactor met timinghardening en regressiedekking.

## Validatie

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Lokaal op actuele `dev` na #571:

- `npm run check:cpp-format` — groen (176 bestanden).
- `CXX=g++-15 ./scripts/run_host_regression_tests.sh` — groen (47/47).
- `npm run check:python-contracts` — groen (147/147).
- `python3 scripts/dev.py validate --config-only --config <config>` — alle zes Q-profielen groen: Duo/Single × basis/Ethernet/WiFi.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — groen; DIRAM 211.027 B, image 2.182.319 B.
- `esphome compile configs/heatpump_controller_q/single_wifi.yaml` — groen; DIRAM 193.435 B, image 2.137.007 B.
- Volledige diff-audit en afzonderlijke cold adversarial review — lifecycle, rollover, reboot, ontbrekende/stale input, Single/Duo, stopbevestiging, safety-precedence en foutpaden gecontroleerd; geen blockers.

Gerichte simulator-HIL op de actuele kandidaat:

- Vanaf een schone boot: nominal Cooling in CM5, één eigenaar, request en acceptatie niveau 1, limiter `full`/cap 8.
- Oil-return op de niet-actieve ODU: limiter `oil_return_hold`/cap 1; werkelijk request én acceptatie bleven niveau 1.
- Na clear: 120 s stabiele recovery gevolgd door `oil_return_recovery`/cap 1; na de daaropvolgende 120 s automatische vrijgave naar `full`/cap 8.
- Harde fout op de actieve eigenaar: `must_stop` actief en beide controller- en simulatorrequests/acceptaties 0.
- Alle bewaakte OpenTherm- en ODU-protocoltellers bleven 0; geen reboot of allocatiefout.
- Alleen voor HIL waren CM1 en de gesimuleerde flowdrempel tijdelijk aangepast; productie-minimum-off, oil-return- en recoverytijden bleven exact.
- Na afloop is de exacte `duo_wifi.yaml` teruggezet en de safe gate gecontroleerd: CM0, F0/F0, working modes 0/0, simulatorrequests 0/0 en beide ODU-links gezond.

Beperking: HIL gebruikt de simulator, niet een echte ODU. Hard no-flow en overige precedencecombinaties zijn hostmatig gedekt; deze run injecteerde oil-return en een harde ODU-fout.

Heap/stack-impact:

- Tegen de directe `dev`-basis: Duo DIRAM -24 B en image -80 B; Single DIRAM -24 B en image -112 B.
- De pure core alloceert niet en creëert geen taak; er is geen nieuwe task-stack.
- De intensieve parallelle REST-sampler bereikte tijdens HIL minimum internal heap 17.312 B zonder allocatiefout of reboot. Na herstel en reboot met de exacte productieconfiguratie: current 95.327 B, minimum 39.828 B, largest internal block 49.152 B en fragmentatie 48,4%.
