### PR TITLE
Maak bronselectie compacter met focuspaneel

### DIFF
--- a/openquatt/web/css/src/17-settings-integrations-controls.css
+++ b/openquatt/web/css/src/17-settings-integrations-controls.css
@@ -349,56 +349,67 @@
   color: var(--oq-helper-accent-deep);
 }
 
-.oq-settings-source-grid {
-  container-type: inline-size;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 12px;
+.oq-settings-source-shell {
+  container: oq-settings-sources / inline-size;
+  min-width: 0;
 }
 
-.oq-settings-source-card {
+.oq-settings-source-workspace {
   display: grid;
-  align-content: start;
+  grid-template-columns: minmax(300px, 0.88fr) minmax(360px, 1.12fr);
   min-width: 0;
-  overflow: hidden;
-  padding: 0;
   border: 1px solid var(--oq-helper-line);
   border-radius: var(--oq-helper-radius-md);
   background: var(--oq-theme-surface-1uy3, var(--oq-helper-card));
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  box-shadow: var(--oq-theme-shadow-ziq9, 0 1px 2px rgba(15, 23, 42, 0.04));
 }
 
-.oq-settings-source-card:has(.oq-settings-info.is-open) {
-  position: relative;
-  z-index: 5;
-  overflow: visible;
+.oq-settings-source-nav {
+  min-width: 0;
+  padding: 12px;
+  border-right: 1px solid var(--oq-helper-line);
+  border-radius: calc(var(--oq-helper-radius-md) - 1px) 0 0 calc(var(--oq-helper-radius-md) - 1px);
+  background: var(--oq-theme-surface-1hci, rgba(248, 250, 252, 0.72));
 }
 
-.oq-settings-source-card-head {
+.oq-settings-source-category {
+  min-width: 0;
+  overflow: hidden;
+  margin-bottom: 12px;
+  border: 1px solid var(--oq-helper-line);
+  border-radius: var(--oq-helper-radius-md);
+  background: var(--oq-theme-surface-1uy3, var(--oq-helper-card));
+}
+
+.oq-settings-source-category:last-child {
+  margin-bottom: 0;
+}
+
+.oq-settings-source-category-head {
   display: flex;
   align-items: center;
-  gap: 10px;
-  min-width: 0;
-  padding: 14px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
-  background: var(--oq-theme-surface-w5r3, linear-gradient(180deg, rgba(248, 250, 252, 0.84), rgba(255, 255, 255, 0.96)));
+  gap: 11px;
+  min-height: 58px;
+  padding: 10px 13px;
+  border-bottom: 1px solid var(--oq-helper-line);
+  background: var(--oq-theme-surface-w5r3, linear-gradient(180deg, rgba(241, 245, 249, 0.94), rgba(248, 250, 252, 0.98)));
 }
 
-.oq-settings-source-card-icon {
+.oq-settings-source-category-icon {
   display: grid;
   flex: 0 0 34px;
   width: 34px;
   height: 34px;
   place-items: center;
-  border: 1px solid rgba(37, 99, 235, 0.14);
+  border: 1px solid var(--oq-theme-border-7jb1, rgba(37, 99, 235, 0.16));
   border-radius: 50%;
-  background: var(--oq-theme-surface-1mjj, rgba(37, 99, 235, 0.08));
+  background: var(--oq-theme-surface-1uy3, var(--oq-helper-card));
   color: var(--oq-theme-color-7hmo, #1d4ed8);
 }
 
-.oq-settings-source-card-icon-svg {
-  width: 19px;
-  height: 19px;
+.oq-settings-source-category-icon-svg {
+  width: 18px;
+  height: 18px;
   fill: none;
   stroke: currentColor;
   stroke-width: 2.05;
@@ -406,119 +417,295 @@
   stroke-linejoin: round;
 }
 
-.oq-settings-source-card-head h4 {
-  margin: 0;
-  min-width: 0;
-  color: var(--oq-helper-ink);
-  font-size: 1.06rem;
-  line-height: 1.2;
-  letter-spacing: 0;
-}
-
-.oq-settings-source-group {
+.oq-settings-source-category-copy {
   display: grid;
-  align-content: start;
-  gap: 8px;
+  gap: 2px;
   min-width: 0;
-  padding: 12px 14px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
 }
 
-.oq-settings-source-group--config {
-  box-sizing: border-box;
-}
-
-.oq-settings-source-group--active {
-  min-height: 104px;
-  box-sizing: border-box;
-  background: var(--oq-theme-surface-1hci, rgba(248, 250, 252, 0.56));
-}
-
-@container (min-width: 1156px) {
-  .oq-settings-source-card:nth-child(-n + 4) .oq-settings-source-group--config {
-    min-height: 192px;
-  }
-
-  .oq-settings-source-card:nth-child(n + 5) .oq-settings-source-group--config {
-    min-height: 118px;
-  }
-}
-
-@container (min-width: 864px) and (max-width: 1155px) {
-  .oq-settings-source-card:nth-child(-n + 6) .oq-settings-source-group--config {
-    min-height: 192px;
-  }
-}
-
-@container (min-width: 572px) and (max-width: 863px) {
-  .oq-settings-source-card:nth-child(-n + 2) .oq-settings-source-group--config {
-    min-height: 170px;
-  }
-
-  .oq-settings-source-card:nth-child(3),
-  .oq-settings-source-card:nth-child(4) {
-    --oq-settings-source-config-height: 192px;
-  }
-
-  .oq-settings-source-card:nth-child(5),
-  .oq-settings-source-card:nth-child(6) {
-    --oq-settings-source-config-height: 118px;
-  }
-
-  .oq-settings-source-card .oq-settings-source-group--config {
-    min-height: var(--oq-settings-source-config-height, 0);
-  }
-}
-
-.oq-settings-source-group:last-child {
-  border-bottom: 0;
-}
-
-.oq-settings-source-group h5 {
-  display: flex;
-  align-items: center;
-  gap: 7px;
+.oq-settings-source-category-copy h4,
+.oq-settings-source-category-copy strong {
   margin: 0;
   color: var(--oq-helper-ink);
-  font-size: 0.86rem;
+  font-size: 0.98rem;
   font-weight: 850;
   line-height: 1.2;
-  letter-spacing: 0;
+  letter-spacing: -0.01em;
 }
 
-.oq-settings-source-group-icon {
+.oq-settings-source-category-copy small,
+.oq-settings-source-category-count {
+  color: var(--oq-helper-faint);
+  font-size: 0.72rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.oq-settings-source-category-index {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--oq-helper-faint);
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+}
+
+.oq-settings-source-signal {
+  appearance: none;
   display: grid;
-  flex: 0 0 20px;
-  width: 20px;
-  height: 20px;
-  place-items: center;
-  border-radius: 50%;
-  background: var(--oq-theme-surface-1mjj, rgba(37, 99, 235, 0.08));
-  color: var(--oq-theme-color-7hmo, #2563eb);
+  grid-template-columns: minmax(0, 1fr) auto 18px;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  min-height: 60px;
+  padding: 8px 12px 8px 15px;
+  border: 0;
+  border-top: 1px solid var(--oq-helper-line);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: background 160ms ease, box-shadow 160ms ease;
 }
 
-.oq-settings-source-group-icon-svg {
-  width: 13px;
-  height: 13px;
+.oq-settings-source-category-head + .oq-settings-source-signal {
+  border-top: 0;
+}
+
+.oq-settings-source-signal:hover {
+  background: var(--oq-theme-surface-rwx2, rgba(248, 250, 252, 0.92));
+}
+
+.oq-settings-source-signal:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--oq-helper-accent);
+  outline-offset: -2px;
+}
+
+.oq-settings-source-signal.is-active,
+.oq-settings-source-signal[aria-current="true"] {
+  background: var(--oq-settings-group-active-background);
+  box-shadow: inset 3px 0 var(--oq-helper-accent);
+}
+
+.oq-settings-source-signal.is-warning {
+  background: var(--oq-theme-surface-1s04, var(--oq-helper-accent-soft));
+  box-shadow: inset 3px 0 var(--oq-helper-accent-deep);
+}
+
+.oq-settings-source-signal-name {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  color: var(--oq-helper-ink);
+  font-size: 0.9rem;
+  font-weight: 780;
+  line-height: 1.25;
+}
+
+.oq-settings-source-signal-title {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.oq-settings-source-signal-warning {
+  display: inline-grid;
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  border: 1px solid var(--oq-theme-border-h3ux, rgba(194, 65, 12, 0.28));
+  border-radius: 50%;
+  background: var(--oq-theme-surface-1s04, var(--oq-helper-accent-soft));
+  color: var(--oq-theme-color-11rp, var(--oq-helper-accent-deep));
+  font-size: 0.7rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.oq-settings-source-signal-icon {
+  display: grid;
+  flex: 0 0 26px;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  color: var(--oq-helper-faint);
+}
+
+.oq-settings-source-signal-icon-svg {
+  width: 17px;
+  height: 17px;
   fill: none;
   stroke: currentColor;
-  stroke-width: 2.1;
+  stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
 
-.oq-settings-source-group-content {
+.oq-settings-source-signal-summary {
   display: grid;
+  justify-items: end;
+  min-width: 96px;
+  color: var(--oq-helper-ink);
+  text-align: right;
+}
+
+.oq-settings-source-signal-summary strong {
+  min-width: 0;
+  font-size: 0.88rem;
+  font-weight: 820;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.oq-settings-source-signal-summary small {
+  margin-top: 2px;
+  color: var(--oq-helper-faint);
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.oq-settings-source-signal-source-path {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0 4px;
+}
+
+.oq-settings-source-signal-source-arrow {
+  color: var(--oq-theme-color-7hmo, var(--oq-helper-accent));
+  font-weight: 800;
+}
+
+.oq-settings-source-signal-chevron {
+  color: var(--oq-helper-faint);
+  font-size: 1.45rem;
+  font-weight: 400;
+  line-height: 1;
+  text-align: center;
+}
+
+.oq-settings-source-inspector {
+  position: sticky;
+  top: 12px;
+  align-self: start;
+  min-width: 0;
+  padding: 26px clamp(20px, 3vw, 38px) 30px;
+  border-radius: 0 calc(var(--oq-helper-radius-md) - 1px) calc(var(--oq-helper-radius-md) - 1px) 0;
+  background: var(--oq-theme-surface-1uy3, var(--oq-helper-card));
+}
+
+.oq-settings-source-inspector:has(.oq-settings-info.is-open) {
+  z-index: 5;
+}
+
+.oq-settings-source-inspector-back {
+  display: none;
+  align-items: center;
   gap: 8px;
+  min-height: 44px;
+  margin: -8px 0 12px;
+  padding: 0 4px;
+  border: 0;
+  background: transparent;
+  color: var(--oq-theme-color-7hmo, #1d4ed8);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.oq-settings-source-inspector-back:focus-visible {
+  border-radius: 8px;
+  outline: 2px solid var(--oq-helper-accent);
+  outline-offset: 2px;
+}
+
+.oq-settings-source-inspector-kicker {
+  margin: 0 0 6px;
+  color: var(--oq-theme-color-11rp, var(--oq-helper-accent-deep));
+  font-size: 0.68rem;
+  font-weight: 850;
+  line-height: 1.2;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.oq-settings-source-inspector h4,
+.oq-settings-source-inspector-title {
+  margin: 0;
+  color: var(--oq-helper-ink);
+  font-size: clamp(1.2rem, 2.2vw, 1.45rem);
+  font-weight: 850;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+}
+
+.oq-settings-source-inspector > .oq-settings-source-warning {
+  margin-top: 14px;
+}
+
+.oq-settings-source-inspector-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  margin: 20px 0;
+  padding: 16px 0;
+  border-block: 1px solid var(--oq-helper-line);
+}
+
+.oq-settings-source-inspector-summary > div {
   min-width: 0;
 }
 
-.oq-settings-source-group-copy {
-  margin: -1px 0 0;
+.oq-settings-source-inspector-summary > div:last-child {
+  text-align: right;
+}
+
+.oq-settings-source-inspector-summary > div:last-child > .oq-settings-info {
+  display: inline-block;
+  margin-top: 4px;
+}
+
+.oq-settings-source-inspector-summary span {
+  display: block;
   color: var(--oq-helper-faint);
-  font-size: 0.76rem;
-  font-weight: 550;
-  line-height: 1.35;
+  font-size: 0.74rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.oq-settings-source-inspector-summary strong {
+  display: block;
+  min-width: 0;
+  margin-top: 3px;
+  color: var(--oq-helper-ink);
+  font-size: 1rem;
+  font-weight: 820;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.oq-settings-source-inspector-section-title {
+  margin: 20px 0 8px;
+  color: var(--oq-helper-ink);
+  font-size: 0.8rem;
+  font-weight: 830;
+  line-height: 1.25;
+}
+
+.oq-settings-source-empty {
+  margin: 0;
+  color: var(--oq-helper-faint);
+  font-size: 0.82rem;
+  line-height: 1.45;
 }
 
 .oq-settings-source-controls {
@@ -571,8 +758,8 @@
   padding: 7px 9px;
   border: 1px solid rgba(234, 88, 12, 0.24);
   border-radius: 9px;
-  background: var(--oq-helper-accent-soft);
-  color: var(--oq-helper-accent-deep);
+  background: var(--oq-theme-surface-1s04, var(--oq-helper-accent-soft));
+  color: var(--oq-theme-color-11rp, var(--oq-helper-accent-deep));
   font-size: 0.78rem;
   font-weight: 700;
   line-height: 1.35;
@@ -632,21 +819,147 @@
 }
 
 .oq-settings-source-row.is-active strong {
-  color: #15803d;
+  color: var(--oq-theme-color-12vw, #15803d);
 }
 
-.oq-helper-shell--dark .oq-settings-source-card-icon,
-.oq-helper-modal-backdrop--dark .oq-settings-source-card-icon,
-.oq-helper-shell--dark .oq-settings-source-group-icon,
-.oq-helper-modal-backdrop--dark .oq-settings-source-group-icon {
-  border-color: rgba(96, 165, 250, 0.22);
-  
-  
+.oq-settings-source-row.is-effective {
+  margin-inline: -8px;
+  padding: 7px 8px;
+  border-radius: 8px;
+  background: var(--oq-theme-surface-f6pj, rgba(239, 246, 255, 0.72));
 }
 
-@media (max-width: 720px) {
-  .oq-settings-source-group--active {
-    min-height: 0;
+.oq-settings-source-row.is-effective strong {
+  color: var(--oq-theme-color-7hmo, #1d4ed8);
+}
+
+.oq-helper-shell--dark .oq-settings-source-workspace,
+.oq-helper-modal-backdrop--dark .oq-settings-source-workspace {
+  box-shadow: var(--oq-theme-shadow-ziq9, inset 0 1px 0 rgba(255, 255, 255, 0.04));
+}
+
+.oq-helper-shell--dark .oq-settings-source-category-icon,
+.oq-helper-modal-backdrop--dark .oq-settings-source-category-icon {
+  border-color: var(--oq-theme-border-7jb1, rgba(96, 165, 250, 0.22));
+}
+
+@container oq-settings-sources (max-width: 759px) {
+  .oq-settings-source-workspace {
+    display: block;
+  }
+
+  .oq-settings-source-nav {
+    border-right: 0;
+    border-radius: calc(var(--oq-helper-radius-md) - 1px);
+  }
+
+  .oq-settings-source-inspector {
+    position: static;
+    display: none;
+    padding: 22px 18px 26px;
+    border-radius: calc(var(--oq-helper-radius-md) - 1px);
+  }
+
+  .oq-settings-source-workspace.is-detail-open .oq-settings-source-nav,
+  .oq-settings-source-shell.is-detail-open .oq-settings-source-nav {
+    display: none;
+  }
+
+  .oq-settings-source-workspace.is-detail-open .oq-settings-source-inspector,
+  .oq-settings-source-shell.is-detail-open .oq-settings-source-inspector {
+    display: block;
+  }
+
+  .oq-settings-source-inspector-back {
+    display: inline-flex;
+  }
+
+  .oq-settings-source-category-head {
+    min-height: 56px;
+  }
+
+  .oq-settings-source-signal {
+    min-height: 62px;
+  }
+}
+
+@container oq-settings-sources (max-width: 420px) {
+  .oq-settings-source-nav {
+    padding: 9px;
+  }
+
+  .oq-settings-source-category {
+    margin-bottom: 9px;
+  }
+
+  .oq-settings-source-category-head {
+    gap: 9px;
+    padding: 9px 11px;
+  }
+
+  .oq-settings-source-category-icon {
+    flex-basis: 32px;
+    width: 32px;
+    height: 32px;
+  }
+
+  .oq-settings-source-signal {
+    grid-template-areas:
+      "name chevron"
+      "summary chevron";
+    grid-template-columns: minmax(0, 1fr) 14px;
+    gap: 3px 8px;
+    padding: 10px 9px 10px 11px;
+  }
+
+  .oq-settings-source-signal-name {
+    grid-area: name;
+    gap: 6px;
+    font-size: 0.86rem;
+  }
+
+  .oq-settings-source-signal-icon {
+    flex-basis: 22px;
+    width: 22px;
+    height: 22px;
+  }
+
+  .oq-settings-source-signal-summary {
+    grid-area: summary;
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 3px 8px;
+    min-width: 0;
+    margin-left: 28px;
+    text-align: left;
+  }
+
+  .oq-settings-source-signal-summary strong {
+    font-size: 0.84rem;
+    white-space: nowrap;
+  }
+
+  .oq-settings-source-signal-summary small {
+    margin-top: 0;
+  }
+
+  .oq-settings-source-signal-source-path {
+    justify-content: flex-start;
+  }
+
+  .oq-settings-source-signal-chevron {
+    grid-area: chevron;
+    align-self: center;
+  }
+
+  .oq-settings-source-inspector {
+    padding-inline: 15px;
+  }
+
+  .oq-settings-source-inspector-summary {
+    gap: 12px;
   }
 }
 

--- a/openquatt/web/css/src/17-settings-integrations-controls.css
+++ b/openquatt/web/css/src/17-settings-integrations-controls.css
@@ -306,7 +306,8 @@
   margin: 0;
 }
 
-.oq-settings-integration-diagnostic-item {
+.oq-settings-integration-diagnostic-item,
+.oq-settings-source-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: baseline;
@@ -316,12 +317,14 @@
   border-top: 1px solid rgba(148, 163, 184, 0.16);
 }
 
-.oq-settings-integration-diagnostic-item:first-child {
+.oq-settings-integration-diagnostic-item:first-child,
+.oq-settings-source-row:first-child {
   border-top: 0;
   padding-top: 0;
 }
 
-.oq-settings-integration-diagnostic-item:last-child {
+.oq-settings-integration-diagnostic-item:last-child,
+.oq-settings-source-row:last-child {
   padding-bottom: 0;
 }
 
@@ -338,7 +341,8 @@
   font-weight: 650;
 }
 
-.oq-settings-integration-diagnostic-item dd {
+.oq-settings-integration-diagnostic-item dd,
+.oq-settings-source-row strong {
   color: var(--oq-helper-ink);
   font-weight: 800;
   text-align: right;
@@ -423,8 +427,7 @@
   min-width: 0;
 }
 
-.oq-settings-source-category-copy h4,
-.oq-settings-source-category-copy strong {
+.oq-settings-source-category-copy h4 {
   margin: 0;
   color: var(--oq-helper-ink);
   font-size: 0.98rem;
@@ -433,7 +436,6 @@
   letter-spacing: -0.01em;
 }
 
-.oq-settings-source-category-copy small,
 .oq-settings-source-category-count {
   color: var(--oq-helper-faint);
   font-size: 0.72rem;
@@ -485,7 +487,6 @@
   outline-offset: -2px;
 }
 
-.oq-settings-source-signal.is-active,
 .oq-settings-source-signal[aria-current="true"] {
   background: var(--oq-settings-group-active-background);
   box-shadow: inset 3px 0 var(--oq-helper-accent);
@@ -638,8 +639,7 @@
   text-transform: uppercase;
 }
 
-.oq-settings-source-inspector h4,
-.oq-settings-source-inspector-title {
+.oq-settings-source-inspector h4 {
   margin: 0;
   color: var(--oq-helper-ink);
   font-size: clamp(1.2rem, 2.2vw, 1.45rem);
@@ -771,25 +771,6 @@
   min-width: 0;
 }
 
-.oq-settings-source-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: baseline;
-  gap: 10px;
-  min-width: 0;
-  padding: 6px 0;
-  border-top: 1px solid rgba(148, 163, 184, 0.16);
-}
-
-.oq-settings-source-row:first-child {
-  border-top: 0;
-  padding-top: 0;
-}
-
-.oq-settings-source-row:last-child {
-  padding-bottom: 0;
-}
-
 .oq-settings-source-row-label,
 .oq-settings-source-row strong {
   min-width: 0;
@@ -807,19 +788,8 @@
   font-weight: 650;
 }
 
-.oq-settings-source-row strong {
-  color: var(--oq-helper-ink);
-  font-weight: 800;
-  text-align: right;
-  word-break: break-word;
-}
-
 .oq-settings-source-row.is-warning strong {
   color: var(--oq-theme-color-11rp, var(--oq-helper-accent-deep));
-}
-
-.oq-settings-source-row.is-active strong {
-  color: var(--oq-theme-color-12vw, #15803d);
 }
 
 .oq-settings-source-row.is-effective {
@@ -860,13 +830,11 @@
     border-radius: calc(var(--oq-helper-radius-md) - 1px);
   }
 
-  .oq-settings-source-workspace.is-detail-open .oq-settings-source-nav,
-  .oq-settings-source-shell.is-detail-open .oq-settings-source-nav {
+  .oq-settings-source-workspace.is-detail-open .oq-settings-source-nav {
     display: none;
   }
 
-  .oq-settings-source-workspace.is-detail-open .oq-settings-source-inspector,
-  .oq-settings-source-shell.is-detail-open .oq-settings-source-inspector {
+  .oq-settings-source-workspace.is-detail-open .oq-settings-source-inspector {
     display: block;
   }
 

--- a/openquatt/web/css/src/17-settings-integrations-controls.css
+++ b/openquatt/web/css/src/17-settings-integrations-controls.css
@@ -369,6 +369,8 @@
 }
 
 .oq-settings-source-nav {
+  display: grid;
+  gap: 12px;
   min-width: 0;
   padding: 12px;
   border-right: 1px solid var(--oq-helper-line);
@@ -379,14 +381,9 @@
 .oq-settings-source-category {
   min-width: 0;
   overflow: hidden;
-  margin-bottom: 12px;
   border: 1px solid var(--oq-helper-line);
   border-radius: var(--oq-helper-radius-md);
   background: var(--oq-theme-surface-1uy3, var(--oq-helper-card));
-}
-
-.oq-settings-source-category:last-child {
-  margin-bottom: 0;
 }
 
 .oq-settings-source-category-head {
@@ -399,26 +396,34 @@
   background: var(--oq-theme-surface-w5r3, linear-gradient(180deg, rgba(241, 245, 249, 0.94), rgba(248, 250, 252, 0.98)));
 }
 
-.oq-settings-source-category-icon {
+.oq-settings-source-category-icon,
+.oq-settings-source-signal-icon {
   display: grid;
+  place-items: center;
+}
+
+.oq-settings-source-category-icon {
   flex: 0 0 34px;
   width: 34px;
   height: 34px;
-  place-items: center;
   border: 1px solid var(--oq-theme-border-7jb1, rgba(37, 99, 235, 0.16));
   border-radius: 50%;
   background: var(--oq-theme-surface-1uy3, var(--oq-helper-card));
   color: var(--oq-theme-color-7hmo, #1d4ed8);
 }
 
+.oq-settings-source-category-icon-svg,
+.oq-settings-source-signal-icon-svg {
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .oq-settings-source-category-icon-svg {
   width: 18px;
   height: 18px;
-  fill: none;
-  stroke: currentColor;
   stroke-width: 2.05;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 .oq-settings-source-category-copy {
@@ -529,22 +534,16 @@
 }
 
 .oq-settings-source-signal-icon {
-  display: grid;
   flex: 0 0 26px;
   width: 26px;
   height: 26px;
-  place-items: center;
   color: var(--oq-helper-faint);
 }
 
 .oq-settings-source-signal-icon-svg {
   width: 17px;
   height: 17px;
-  fill: none;
-  stroke: currentColor;
   stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 .oq-settings-source-signal-summary {
@@ -788,10 +787,6 @@
   font-weight: 650;
 }
 
-.oq-settings-source-row.is-warning strong {
-  color: var(--oq-theme-color-11rp, var(--oq-helper-accent-deep));
-}
-
 .oq-settings-source-row.is-effective {
   margin-inline: -8px;
   padding: 7px 8px;
@@ -853,11 +848,8 @@
 
 @container oq-settings-sources (max-width: 420px) {
   .oq-settings-source-nav {
+    gap: 9px;
     padding: 9px;
-  }
-
-  .oq-settings-source-category {
-    margin-bottom: 9px;
   }
 
   .oq-settings-source-category-head {

--- a/openquatt/web/css/src/17-settings-integrations-controls.css
+++ b/openquatt/web/css/src/17-settings-integrations-controls.css
@@ -448,15 +448,6 @@
   line-height: 1.25;
 }
 
-.oq-settings-source-category-index {
-  flex: 0 0 auto;
-  margin-left: auto;
-  color: var(--oq-helper-faint);
-  font-size: 0.68rem;
-  font-weight: 850;
-  letter-spacing: 0.08em;
-}
-
 .oq-settings-source-signal {
   appearance: none;
   display: grid;

--- a/openquatt/web/js/src/core/settings-focus-continuity.js
+++ b/openquatt/web/js/src/core/settings-focus-continuity.js
@@ -1,0 +1,36 @@
+export function captureSettingsFocusContinuity(root, appView, documentRef = document) {
+  const active = documentRef.activeElement;
+  const field = active?.dataset?.oqField || "";
+  const focusKey = active?.dataset?.oqFocusKey || "";
+  if (appView !== "settings" || !root?.contains(active) || (!field && !focusKey)) {
+    return null;
+  }
+  return {
+    field,
+    focusKey,
+    modalId: active.closest?.("[data-oq-modal]")?.dataset.oqModal || "",
+    selectionStart: active.selectionStart,
+    selectionEnd: active.selectionEnd,
+  };
+}
+
+export function restoreSettingsFocusContinuity(root, focusState, documentRef = document) {
+  if (!focusState || !root) {
+    return;
+  }
+  const modal = documentRef.activeElement?.closest?.("[data-oq-modal]");
+  if ((modal?.dataset.oqModal || "") !== focusState.modalId) {
+    return;
+  }
+  const selector = focusState.field
+    ? `[data-oq-field="${focusState.field}"]`
+    : `[data-oq-focus-key="${focusState.focusKey}"]`;
+  const control = (modal || root).querySelector(selector);
+  if (!control || control.disabled) {
+    return;
+  }
+  control.focus({ preventScroll: true });
+  if (typeof focusState.selectionStart === "number" && typeof control.setSelectionRange === "function") {
+    control.setSelectionRange(focusState.selectionStart, focusState.selectionEnd);
+  }
+}

--- a/openquatt/web/js/src/core/state-slices.js
+++ b/openquatt/web/js/src/core/state-slices.js
@@ -133,6 +133,8 @@ export function createSettingsState() {
     renderedSettingsGroup: "",
     settingsPageScrollRestoreToken: 0,
     settingsInfoOpen: "",
+    settingsSourceFocusKey: "room-temperature",
+    settingsSourceDetailOpen: false,
     settingsAdvancedOpen: {},
     pendingControlModeOverride: "",
     installationMonitoringDetailsOpen: false,

--- a/openquatt/web/js/src/features/view-actions.js
+++ b/openquatt/web/js/src/features/view-actions.js
@@ -90,6 +90,43 @@ const viewActionHandlers = {
     render();
     void syncEntities({ forceFast: true });
   },
+  "select-settings-source": (button) => {
+    const key = String(button.dataset.sourceKey || "").trim().replace(/[^a-z0-9_-]/gi, "");
+    if (!key) {
+      return;
+    }
+    state.settingsSourceFocusKey = key;
+    state.settingsSourceDetailOpen = true;
+    state.settingsInfoOpen = "";
+    render();
+    state.settingsPageScrollRestoreToken = (state.settingsPageScrollRestoreToken || 0) + 1;
+    window.requestAnimationFrame(() => {
+      const inspector = state.root?.querySelector("[data-oq-source-inspector]");
+      const backButton = inspector?.querySelector('[data-oq-action="close-settings-source-detail"]');
+      if (inspector && backButton && backButton.offsetParent !== null) {
+        inspector.scrollIntoView({ block: "start", behavior: "auto" });
+        backButton.focus({ preventScroll: true });
+        return;
+      }
+      state.root?.querySelector(`[data-source-key="${key}"]`)?.focus({ preventScroll: true });
+    });
+  },
+  "close-settings-source-detail": () => {
+    const key = String(state.settingsSourceFocusKey || "").trim();
+    const safeKey = key.replace(/[^a-z0-9_-]/gi, "");
+    state.settingsSourceDetailOpen = false;
+    state.settingsInfoOpen = "";
+    render();
+    state.settingsPageScrollRestoreToken = (state.settingsPageScrollRestoreToken || 0) + 1;
+    if (!safeKey) {
+      return;
+    }
+    window.requestAnimationFrame(() => {
+      const signal = state.root?.querySelector(`[data-source-key="${safeKey}"]`);
+      signal?.focus({ preventScroll: true });
+      signal?.scrollIntoView({ block: "nearest", behavior: "auto" });
+    });
+  },
   "toggle-overview-theme": () => {
     setOverviewTheme(state.overviewTheme === "light" ? "dark" : "light");
     render();

--- a/openquatt/web/js/src/settings/core.js
+++ b/openquatt/web/js/src/settings/core.js
@@ -130,7 +130,7 @@ function syncFrequencyRangeControl(control) {
     }
 
     const activeGroup = SETTINGS_GROUP_IDS.has(state.settingsGroup) ? state.settingsGroup : SETTINGS_GROUPS[0].id;
-    if (activeGroup === "service") {
+    if (activeGroup === "service" || (activeGroup === "integrations" && state.focusedField)) {
       return false;
     }
 

--- a/openquatt/web/js/src/settings/integrations.js
+++ b/openquatt/web/js/src/settings/integrations.js
@@ -1009,7 +1009,9 @@ import { escapeHtml } from "../core/html.js";
           optionLabels: { Disabled: "Niet gebruiken", "API input": "API-invoer" },
           infoCopy: "Vervangt alleen de vermogensschatting van het huismodel in Power House. Valt de bron weg of veroudert hij, dan rekent Power House weer met het huismodel.",
         }),
-        summaryValue: getSettingsStatValue("externalHeatDemandSelected"),
+        summaryValue: externalHeatDemandConfiguredSource === "Niet gebruiken"
+          ? "Niet gebruikt"
+          : getSettingsStatValue("externalHeatDemandSelected"),
         summarySource: externalHeatDemandUsedSource,
         routeWarning: String(getEntityValue("externalHeatDemandSource") || "") === "Disabled"
           ? ""
@@ -1043,11 +1045,16 @@ import { escapeHtml } from "../core/html.js";
       state.settingsSourceFocusKey = focusedSignal.key;
     }
     const focusedCategory = visibleCategories.find((category) => category.id === focusedSignal.group) || visibleCategories[0];
-    const categoryMarkup = visibleCategories.map((category, categoryIndex) => {
+    const categoryMarkup = visibleCategories.map((category) => {
       const count = category.signals.length;
       const categoryTitleId = `oq-settings-source-category-${category.id}`;
       const signalsMarkup = category.signals.map((signal) => {
         const active = signal.key === focusedSignal.key;
+        const showUsedSource = signal.summarySource !== "—"
+          || !sourcesMatch(signal.configuredSource, "Niet gebruiken");
+        const sourcePathLabel = showUsedSource
+          ? `Ingesteld: ${signal.configuredSource}. Gebruikt: ${signal.summarySource}`
+          : `Ingesteld: ${signal.configuredSource}`;
         return `
           <button
             class="oq-settings-source-signal${signal.warningCopy ? " is-warning" : ""}"
@@ -1067,10 +1074,10 @@ import { escapeHtml } from "../core/html.js";
               <strong>${escapeHtml(signal.summaryValue)}</strong>
               <small
                 class="oq-settings-source-signal-source-path"
-                aria-label="Ingesteld: ${escapeHtml(signal.configuredSource)}. Gebruikt: ${escapeHtml(signal.summarySource)}"
+                aria-label="${escapeHtml(sourcePathLabel)}"
               >
                 <span>${escapeHtml(signal.configuredSource)}</span>
-                ${signal.configuredSource !== signal.summarySource ? `
+                ${showUsedSource && signal.configuredSource !== signal.summarySource ? `
                   <span class="oq-settings-source-signal-source-arrow" aria-hidden="true">→</span>
                   <span>${escapeHtml(signal.summarySource)}</span>
                 ` : ""}
@@ -1088,7 +1095,6 @@ import { escapeHtml } from "../core/html.js";
               <h4 id="${escapeHtml(categoryTitleId)}">${escapeHtml(category.title)}</h4>
               <small class="oq-settings-source-category-count">${count} ${count === 1 ? "signaal" : "signalen"}</small>
             </div>
-            <span class="oq-settings-source-category-index" aria-hidden="true">${String(categoryIndex + 1).padStart(2, "0")}</span>
           </header>
           ${signalsMarkup}
         </section>

--- a/openquatt/web/js/src/settings/integrations.js
+++ b/openquatt/web/js/src/settings/integrations.js
@@ -242,6 +242,15 @@ import { escapeHtml } from "../core/html.js";
       mqttHeatingEnable: "heating_enable",
       mqttCoolingEnable: "cooling_enable",
     };
+    const mqttValidKeyByTopicKey = {
+      cooling_dew_point: "mqttCoolingDewPointValid",
+      outside_temperature: "mqttOutsideTemperatureValid",
+      room_temperature: "mqttRoomTemperatureValid",
+      room_setpoint: "mqttRoomSetpointValid",
+      heating_enable: "mqttHeatingEnableValid",
+      cooling_enable: "mqttCoolingEnableValid",
+    };
+    const isHaInputOption = (option) => /^(?:ha input|home assistant)$/i.test(String(option || "").trim());
     const isApiInputOption = (option) => /^api input$/i.test(String(option || "").trim());
     const hasApiInputSource = (config = {}) => Boolean(config.apiValueKey) && hasEntity(config.apiValueKey);
     const mqttAvailable = state.mqttStatus?.enabled !== false;
@@ -273,7 +282,7 @@ import { escapeHtml } from "../core/html.js";
       if (option === "OT thermostat") {
         return otAvailable;
       }
-      if (option === "HA input") {
+      if (isHaInputOption(option)) {
         return hasHaSource(config);
       }
       if (option === "CIC or HA input") {
@@ -300,7 +309,7 @@ import { escapeHtml } from "../core/html.js";
       if (option === "OT thermostat" && !otAvailable) {
         return "OpenTherm staat uit";
       }
-      if (option === "HA input" && !hasHaSource(config)) {
+      if (isHaInputOption(option) && !hasHaSource(config)) {
         return "HA-bron ongeldig";
       }
       if (option === "CIC or HA input" && !cicAvailable && !hasHaSource(config)) {
@@ -326,6 +335,23 @@ import { escapeHtml } from "../core/html.js";
       }
       return isInstallationMonitoringBinaryActive(key) ? activeLabel : inactiveLabel;
     };
+    const hasUsableSourceValue = (key) => {
+      if (!key || !hasEntity(key)) {
+        return true;
+      }
+      const value = getEntityValue(key);
+      if (typeof value === "number") {
+        return Number.isFinite(value);
+      }
+      if (typeof value === "boolean") {
+        return true;
+      }
+      const text = String(value ?? state.entities[key]?.state ?? "").trim().toLowerCase();
+      return Boolean(text) && !["nan", "unknown", "unavailable", "none", "null", "—"].includes(text);
+    };
+    const invalidSourceValueWarning = (key) => hasUsableSourceValue(key)
+      ? ""
+      : "De ingestelde bron levert momenteel geen geldige waarde.";
     const formatSourceOptionLabel = (option, config = {}) => {
       const value = String(option || "").trim();
       if (!value) {
@@ -463,41 +489,117 @@ import { escapeHtml } from "../core/html.js";
       }
       return source ? formatSettingsOptionLabel(source) : "Auto";
     };
-    const renderSourceRow = ({ label, value = "", key = "", active = false, status = "", statusTone = "", statusTitle = "" }) => {
+    const sourceKinds = (value = "") => {
+      const text = String(value || "").trim().toLowerCase();
+      const kinds = new Set();
+      if (/\b(ha|home assistant)\b/.test(text)) {
+        kinds.add("ha");
+      }
+      if (/\bapi\b/.test(text)) {
+        kinds.add("api");
+      }
+      if (/\bmqtt\b/.test(text)) {
+        kinds.add("mqtt");
+      }
+      if (/\bcic\b/.test(text)) {
+        kinds.add("cic");
+      }
+      if (/\b(opentherm|ot thermostat|ot-thermostaat)\b/.test(text)) {
+        kinds.add("ot");
+      }
+      if (/\b(outdoor unit|buitenunit|quatt-flow)\b/.test(text)) {
+        kinds.add("outdoor");
+      }
+      if (/\b(local|lokaal|controller)\b/.test(text)) {
+        kinds.add("local");
+      }
+      if (/\bpt1000\b/.test(text)) {
+        kinds.add("pt1000");
+      }
+      if (/\bds18b20\b/.test(text)) {
+        kinds.add("ds18b20");
+      }
+      if (/\b(manual|handmatig)\b/.test(text)) {
+        kinds.add("manual");
+      }
+      if (/\bhp1\b/.test(text)) {
+        kinds.add("hp1");
+      }
+      if (/\bhp2\b/.test(text)) {
+        kinds.add("hp2");
+      }
+      if (/\b(disabled|niet gebruiken|none)\b/.test(text) || text === "—" || text === "") {
+        kinds.add("disabled");
+      }
+      if (!kinds.size) {
+        kinds.add(text.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "other");
+      }
+      return kinds;
+    };
+    const sourcesMatch = (left = "", right = "") => {
+      const leftKinds = sourceKinds(left);
+      return [...sourceKinds(right)].some((kind) => leftKinds.has(kind));
+    };
+    const isConfiguredSource = (key, source) => sourcesMatch(getEntityValue(key), source);
+    const renderSourceRow = ({
+      label,
+      value = "",
+      key = "",
+      active = false,
+      status = "",
+      statusTone = "",
+      statusTitle = "",
+      sourceKind = "",
+      sourceState = "",
+      effective = false,
+    }) => {
       const text = value || (key ? getSettingsStatValue(key) : "");
       if (!text && !status) {
         return "";
       }
       const safeStatusTone = String(statusTone || "").replace(/[^a-z0-9_-]/gi, "");
+      const safeSourceKind = String(sourceKind || "").replace(/[^a-z0-9_-]/gi, "");
+      const safeSourceState = String(sourceState || "").replace(/[^a-z0-9_-]/gi, "");
       const infoText = statusTitle || status;
       const statusMarkup = status
         ? renderSettingsInfoToggle(`${key}-info`, label, infoText, status, `oq-settings-source-info oq-settings-source-info--${safeStatusTone}${status === "i" ? " oq-settings-source-info--circle" : ""}`)
         : "";
       return `
-        <div class="oq-settings-source-row${active ? " is-warning" : ""}${status ? " has-status" : ""}">
+        <div
+          class="oq-settings-source-row${active ? " is-warning" : ""}${status ? " has-status" : ""}${effective ? " is-effective" : ""}"
+          ${safeSourceKind ? `data-source-kind="${escapeHtml(safeSourceKind)}"` : ""}
+          ${safeSourceState ? `data-source-state="${escapeHtml(safeSourceState)}"` : ""}
+          ${effective ? 'data-source-effective="true"' : ""}
+        >
           <div class="oq-settings-source-row-label">${escapeHtml(label)}${statusMarkup}</div>
           <strong>${escapeHtml(text)}</strong>
         </div>
       `;
     };
-    const renderHaSourceRows = ({ label = "HA-invoer", valueKey = "", validKey = "", value = "" }) => {
+    const renderHaSourceRows = ({ label = "HA-invoer", valueKey = "", validKey = "", value = "", forceVisible = false, effective = false }) => {
       if (!valueKey || !validKey || !hasEntity(valueKey) || !hasEntity(validKey)) {
         return [];
       }
       const valid = isInstallationMonitoringBinaryActive(validKey);
+      if (!valid && !forceVisible && !effective) {
+        return [];
+      }
       const statusTitle = valid
         ? "Home Assistant geeft dit signaal geldig door. OpenQuatt mag deze HA-invoer gebruiken."
         : "Home Assistant geeft dit signaal niet geldig door. OpenQuatt gebruikt deze HA-invoer dan niet als bron.";
       return [renderSourceRow({
         label,
         key: valueKey,
-        value,
-        status: valid ? "Geldig" : "Ongeldig",
+        value: valid ? value : "—",
+        status: valid ? "Beschikbaar" : "Niet geldig",
         statusTone: valid ? "valid" : "invalid",
         statusTitle,
+        sourceKind: "ha",
+        sourceState: valid ? "valid" : "invalid",
+        effective,
       })];
     };
-    const renderMqttSourceRows = ({ label = "MQTT", valueKey = "", validKey = "", value = "", topicKey = "" }) => {
+    const renderMqttSourceRows = ({ label = "MQTT", valueKey = "", validKey = "", value = "", topicKey = "", forceVisible = false, effective = false }) => {
       if (!valueKey || !validKey || !hasEntity(valueKey) || !hasEntity(validKey)) {
         return [];
       }
@@ -505,6 +607,9 @@ import { escapeHtml } from "../core/html.js";
         return [];
       }
       const valid = isInstallationMonitoringBinaryActive(validKey);
+      if (!valid && !forceVisible && !effective) {
+        return [];
+      }
       const statusTitle = valid
         ? "MQTT heeft een geldige, recente waarde ontvangen. OpenQuatt mag deze MQTT-invoer gebruiken."
         : "MQTT heeft nog geen geldige recente waarde ontvangen. OpenQuatt gebruikt deze MQTT-invoer dan niet als bron.";
@@ -515,41 +620,37 @@ import { escapeHtml } from "../core/html.js";
         status: getMqttValidityLabel(validKey),
         statusTone: valid ? "valid" : "invalid",
         statusTitle,
+        sourceKind: "mqtt",
+        sourceState: valid ? "valid" : "invalid",
+        effective,
       })];
     };
-    const renderApiSourceRows = ({ label = "API-invoer", valueKey = "", validKey = "", value = "" }) => {
+    const renderApiSourceRows = ({ label = "API-invoer", valueKey = "", validKey = "", ageKey = "", value = "", forceVisible = false, effective = false }) => {
       if (!valueKey || !validKey || !hasEntity(valueKey) || !hasEntity(validKey)) {
         return [];
       }
       const valid = isInstallationMonitoringBinaryActive(validKey);
+      if (!valid && !forceVisible && !effective) {
+        return [];
+      }
+      const age = ageKey && hasEntity(ageKey) ? getNumericSourceValue(ageKey) : NaN;
+      const inactiveStatus = Number.isFinite(age) ? "Verouderd" : "Wacht op data";
       const statusTitle = valid
         ? "API-invoer heeft een geldige, recente waarde. OpenQuatt mag deze bron gebruiken."
-        : "API-invoer heeft nog geen geldige recente waarde. OpenQuatt gebruikt deze bron dan niet.";
+        : Number.isFinite(age)
+          ? "API-invoer heeft geen geldige recente waarde meer. OpenQuatt gebruikt deze bron dan niet."
+          : "API-invoer heeft nog geen geldige waarde ontvangen. OpenQuatt gebruikt deze bron dan niet.";
       return [renderSourceRow({
         label,
         key: valueKey,
         value: valid ? value : "—",
-        status: valid ? "Geldig" : "Ongeldig",
+        status: valid ? "Beschikbaar" : inactiveStatus,
         statusTone: valid ? "valid" : "invalid",
         statusTitle,
+        sourceKind: "api",
+        sourceState: valid ? "valid" : Number.isFinite(age) ? "stale" : "missing",
+        effective,
       })];
-    };
-    const renderSourceGroup = ({ title, icon = "", content = "", rows = [], copy = "", className = "" }) => {
-      const rowMarkup = rows.filter(Boolean).join("");
-      if (!content && !rowMarkup && !copy) {
-        return "";
-      }
-      return `
-        <section class="oq-settings-source-group${className ? ` ${escapeHtml(className)}` : ""}">
-          <h5>
-            ${icon ? `<span class="oq-settings-source-group-icon">${renderOqIcon(icon, "oq-settings-source-group-icon-svg")}</span>` : ""}
-            <span>${escapeHtml(title)}</span>
-          </h5>
-          ${content ? `<div class="oq-settings-source-group-content">${content}</div>` : ""}
-          ${rowMarkup ? `<div class="oq-settings-source-rows">${rowMarkup}</div>` : ""}
-          ${copy ? `<p class="oq-settings-source-group-copy">${escapeHtml(copy)}</p>` : ""}
-        </section>
-      `;
     };
     const renderSourceSelect = (key, config = {}) => {
       if (!hasEntity(key)) {
@@ -563,11 +664,17 @@ import { escapeHtml } from "../core/html.js";
       const availableOptions = allOptions.filter((option) => !hiddenOptions.has(option) && isSourceAvailable(option, config));
       const currentUnavailable = current && !isSourceAvailable(current, config);
       const hideUnavailableCurrent = (
-        isMqttOption(current) && !mqttAvailable
+        currentHidden && currentUnavailable
       ) || (
-        current === "HA input" && config.keepUnavailableCurrent !== true
+        isMqttOption(current) && !isMqttInputTopicEnabled(getMqttTopicKey(config))
+      ) || (
+        isHaInputOption(current) && config.keepUnavailableCurrent !== true
+      ) || (
+        current === "CIC" && !cicAvailable
+      ) || (
+        current === "OT thermostat" && !otAvailable
       );
-      const renderOptions = currentHidden && !availableOptions.includes(current)
+      const renderOptions = currentHidden && !hideUnavailableCurrent && !availableOptions.includes(current)
         ? [current, ...availableOptions]
         : currentUnavailable && !hideUnavailableCurrent && !availableOptions.includes(current)
         ? [current, ...availableOptions]
@@ -577,7 +684,7 @@ import { escapeHtml } from "../core/html.js";
         return `<option value="${escapeHtml(option)}" ${option === current ? "selected" : ""}>${escapeHtml(displayLabel)}</option>`;
       }).join("");
       const unavailableCurrentPlaceholder = currentUnavailable && hideUnavailableCurrent
-        ? '<option value="" selected disabled>Kies een beschikbare bron</option>'
+        ? `<option value="${escapeHtml(current)}" selected disabled>Kies een beschikbare bron</option>`
         : "";
       return {
         markup: `
@@ -591,22 +698,28 @@ import { escapeHtml } from "../core/html.js";
             </select>
           </label>
         `,
-        warning: currentHidden
+        warning: currentHidden && currentUnavailable
+          ? `Huidige legacybron niet beschikbaar: ${getUnavailableSourceReason(current, config)}; kies een nieuwe bron.`
+          : currentHidden
           ? "Huidige bron is legacy; kies een nieuwe bron."
           : currentUnavailable ? `Huidige bron niet beschikbaar: ${getUnavailableSourceReason(current, config)}` : "",
       };
     };
-    const renderSourceCard = ({
+    const buildSourceSignal = ({
       key,
+      group,
       title,
       icon = "",
       select,
       secondarySelect = null,
       secondarySelects = null,
-      activeRows = [],
+      summaryValue = "",
+      summarySource = "",
+      summaryInfo = "",
       measurementRows = [],
-      rows = [],
+      measurementTitle = "Beschikbare metingen",
       warning = "",
+      routeWarning = "",
     }) => {
       const mainSelect = select && select.when !== false
         ? renderSourceSelect(select.key, select)
@@ -620,51 +733,50 @@ import { escapeHtml } from "../core/html.js";
         .filter((item) => item.markup);
       const secondaryMarkup = secondaries.map((item) => item.markup).join("");
       const secondaryWarning = secondaries.map((item) => item.warning).find(Boolean) || "";
-      const bodyRows = rows.filter(Boolean).join("");
       const controlsMarkup = `${mainSelect.markup}${secondaryMarkup}`;
-      const warningCopy = mainSelect.warning || secondaryWarning || warning;
-      const groupedMarkup = [
-        renderSourceGroup({
-          title: "Configuratie",
-          icon: "settings",
-          className: "oq-settings-source-group--config",
-          content: controlsMarkup ? `
-            <div class="oq-settings-source-controls">
-              ${controlsMarkup}
-            </div>
-            ${warningCopy ? `<p class="oq-settings-source-warning">${escapeHtml(warningCopy)}</p>` : ""}
-          ` : "",
-        }),
-        renderSourceGroup({ title: "Actief", icon: "target", rows: activeRows, className: "oq-settings-source-group--active" }),
-        renderSourceGroup({ title: key === "water-supply" ? "Ruwe metingen" : "Metingen", icon: "activity", rows: measurementRows, className: "oq-settings-source-group--measurements" }),
-      ].filter(Boolean).join("");
-      if (!groupedMarkup && !controlsMarkup && !bodyRows) {
+      const current = select?.key ? String(getEntityValue(select.key) || "") : "";
+      const mqttValidKey = mqttValidKeyByTopicKey[getMqttTopicKey(select || {})] || "";
+      const selectedInputWarning = isApiInputOption(current) && select?.apiValidKey
+        && (!hasEntity(select.apiValidKey) || !isInstallationMonitoringBinaryActive(select.apiValidKey))
+          ? "De ingestelde API-invoer heeft nog geen geldige, recente waarde."
+          : isMqttOption(current) && mqttValidKey
+            && (!hasEntity(mqttValidKey) || !isInstallationMonitoringBinaryActive(mqttValidKey))
+              ? "De ingestelde MQTT-invoer heeft nog geen geldige, recente waarde."
+              : "";
+      const warningCopy = mainSelect.warning || secondaryWarning || warning || selectedInputWarning || routeWarning;
+      if (!controlsMarkup && !summaryValue && !summarySource && !measurementRows.some(Boolean)) {
         return "";
       }
-      return `
-        <article class="oq-settings-source-card" data-oq-settings-field="${escapeHtml(key || select.key)}">
-          <div class="oq-settings-source-card-head">
-            ${icon ? `<span class="oq-settings-source-card-icon">${renderOqIcon(icon, "oq-settings-source-card-icon-svg")}</span>` : ""}
-            <h4>${escapeHtml(title)}</h4>
-          </div>
-          ${groupedMarkup || `
-            ${controlsMarkup ? `
-              <div class="oq-settings-source-controls">
-                ${controlsMarkup}
-              </div>
-            ` : ""}
-            ${warningCopy ? `<p class="oq-settings-source-warning">${escapeHtml(warningCopy)}</p>` : ""}
-            ${bodyRows ? `<div class="oq-settings-source-rows">${bodyRows}</div>` : ""}
-          `}
-        </article>
-      `;
+      return {
+        key,
+        group,
+        title,
+        icon,
+        fieldKey: select?.key || key,
+        configuredSource: current ? formatSourceOptionLabel(current, select || {}) : "—",
+        summaryValue: summaryValue || "—",
+        summarySource: summarySource || "—",
+        summaryInfo,
+        controlsMarkup,
+        warningCopy,
+        measurementRows: measurementRows.filter(Boolean),
+        measurementTitle,
+      };
     };
     const currentWaterSupplySource = String(getEntityValue("waterSupplySource") || "");
+    const currentLocalWaterSupplySource = String(getEntityValue("localWaterSupplyTempSource") || "");
     const currentFlowSource = String(getEntityValue("flowSource") || "");
     const currentQFlowSource = String(getEntityValue("qFlowSource") || "");
     const currentOutsideTempSource = String(getEntityValue("outsideTempSource") || "").trim();
     const waterSupplyCorrection = getWaterSupplyCorrectionView();
     const waterSupplyCalibrated = waterSupplyCorrection.calibrationActive;
+    const localWaterSupplyWarning = currentWaterSupplySource === "Local" && currentLocalWaterSupplySource === "PT1000"
+      && (isInstallationMonitoringBinaryActive("pt1000ReadProblem") || !hasUsableSourceValue("waterSupplyTempPt1000"))
+        ? "De ingestelde lokale PT1000-bron levert geen geldige waarde; OpenQuatt gebruikt een fallback."
+        : currentWaterSupplySource === "Local" && currentLocalWaterSupplySource === "DS18B20"
+          && !hasUsableSourceValue("waterSupplyTempDs18b20")
+            ? "De ingestelde lokale DS18B20-bron levert geen geldige waarde; OpenQuatt gebruikt een fallback."
+            : "";
     const supplyInfo = waterSupplyCalibrated
       ? "Gekalibreerd; ruwe metingen hieronder."
       : waterSupplyCorrection.calibrationRequired
@@ -676,6 +788,7 @@ import { escapeHtml } from "../core/html.js";
       "API input": "API-invoer",
     };
     const heatingEnableSourceLabel = formattedSourceValue("heatingEnableSource", { optionLabels: heatingEnableSourceLabels });
+    const heatingEnableEffectiveSource = formattedEffectivePermissionSourceValue("heatingEnableEffectiveSource");
     const coolingEnableSourceDisabled = String(getEntityValue("coolingEnableSource") || "").trim() === "Disabled";
     const coolingEnableSourceLabels = {
       Disabled: "Niet gebruiken / handmatig",
@@ -692,9 +805,36 @@ import { escapeHtml } from "../core/html.js";
       : hasValidHaSource("outsideTempHa", "outsideTempHaValid")
         ? "Auto gebruikt de laagste geldige buitentemperatuurbron van de buitenunit, HA-invoer en API-invoer. Is er maar een bron geldig, dan wordt die gebruikt."
         : "Auto gebruikt de laagste geldige buitentemperatuurbron.";
-    const sourceCards = [
-      renderSourceCard({
+    const roomTemperatureUsedSource = firstAvailableSourceLabel(
+      formattedTextSourceValue("roomTempEffectiveSource"),
+      formattedSourceValue("roomTempSource"),
+    );
+    const roomSetpointUsedSource = firstAvailableSourceLabel(
+      formattedTextSourceValue("roomSetpointEffectiveSource"),
+      formattedSourceValue("roomSetpointSource"),
+    );
+    const waterSupplyUsedSource = getWaterSupplyUsedSource();
+    const flowUsedSource = getFlowUsedSource();
+    const outsideTemperatureUsedSource = getOutsideTempUsedSource();
+    const heatingEnableUsedSource = heatingEnableSourceDisabled
+      ? "—"
+      : firstAvailableSourceLabel(heatingEnableEffectiveSource, heatingEnableSourceLabel);
+    const coolingEnableUsedSource = firstAvailableSourceLabel(
+      coolingEnableEffectiveSource,
+      coolingEnableSourceDisabled ? "Handmatig" : coolingEnableSourceLabel,
+    );
+    const coolingDewPointUsedSource = getCoolingDewPointUsedSource();
+    const externalHeatDemandConfiguredSource = formattedSourceValue("externalHeatDemandSource", {
+      optionLabels: { Disabled: "Niet gebruiken", "API input": "API-invoer" },
+    });
+    const powerHouseDemandSource = String(getSettingsTextStatValue("powerHouseDemandSource", "") || "").trim().toLowerCase();
+    const externalHeatDemandUsedSource = powerHouseDemandSource === "external"
+      ? externalHeatDemandConfiguredSource
+      : powerHouseDemandSource === "model" ? "Huismodel" : "—";
+    const sourceSignals = [
+      buildSourceSignal({
         key: "room-temperature",
+        group: "room-outside",
         title: "Kamertemperatuur",
         icon: "thermometer",
         select: {
@@ -706,20 +846,36 @@ import { escapeHtml } from "../core/html.js";
           apiValidKey: "apiInputRoomTemperatureValid",
           mqttTopicKey: "room_temperature",
         },
-        activeRows: [
-          renderSourceRow({ label: "Waarde", key: "roomTemp" }),
-          renderSourceRow({ label: "Bron", value: formattedTextSourceValue("roomTempEffectiveSource") }),
-        ],
+        summaryValue: getSettingsStatValue("roomTemp"),
+        summarySource: roomTemperatureUsedSource,
+        routeWarning: invalidSourceValueWarning("roomTemp"),
         measurementRows: [
-          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicRoomTemp" }) : "",
-          otAvailable ? renderSourceRow({ label: "OpenTherm", key: "otRoomTemp" }) : "",
-          ...renderHaSourceRows({ valueKey: "roomTempHa", validKey: "roomTempHaValid" }),
-          ...renderApiSourceRows({ valueKey: "apiInputRoomTemperature", validKey: "apiInputRoomTemperatureValid" }),
-          ...renderMqttSourceRows({ valueKey: "mqttRoomTemperature", validKey: "mqttRoomTemperatureValid" }),
+          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicRoomTemp", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(roomTemperatureUsedSource, "CIC") }) : "",
+          otAvailable ? renderSourceRow({ label: "OpenTherm", key: "otRoomTemp", sourceKind: "ot", sourceState: "available", effective: sourcesMatch(roomTemperatureUsedSource, "OpenTherm") }) : "",
+          ...renderHaSourceRows({
+            valueKey: "roomTempHa",
+            validKey: "roomTempHaValid",
+            forceVisible: isConfiguredSource("roomTempSource", "HA input"),
+            effective: sourcesMatch(roomTemperatureUsedSource, "HA input"),
+          }),
+          ...renderApiSourceRows({
+            valueKey: "apiInputRoomTemperature",
+            validKey: "apiInputRoomTemperatureValid",
+            ageKey: "apiInputRoomTemperatureAge",
+            forceVisible: isConfiguredSource("roomTempSource", "API input"),
+            effective: sourcesMatch(roomTemperatureUsedSource, "API input"),
+          }),
+          ...renderMqttSourceRows({
+            valueKey: "mqttRoomTemperature",
+            validKey: "mqttRoomTemperatureValid",
+            forceVisible: isConfiguredSource("roomTempSource", "MQTT"),
+            effective: sourcesMatch(roomTemperatureUsedSource, "MQTT"),
+          }),
         ],
       }),
-      renderSourceCard({
+      buildSourceSignal({
         key: "room-setpoint",
+        group: "room-outside",
         title: "Kamer setpoint",
         icon: "target",
         select: {
@@ -731,20 +887,36 @@ import { escapeHtml } from "../core/html.js";
           apiValidKey: "apiInputRoomSetpointValid",
           mqttTopicKey: "room_setpoint",
         },
-        activeRows: [
-          renderSourceRow({ label: "Waarde", key: "roomSetpoint" }),
-          renderSourceRow({ label: "Bron", value: formattedTextSourceValue("roomSetpointEffectiveSource") }),
-        ],
+        summaryValue: getSettingsStatValue("roomSetpoint"),
+        summarySource: roomSetpointUsedSource,
+        routeWarning: invalidSourceValueWarning("roomSetpoint"),
         measurementRows: [
-          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicRoomSetpoint" }) : "",
-          otAvailable ? renderSourceRow({ label: "OpenTherm", key: "otRoomSetpoint" }) : "",
-          ...renderHaSourceRows({ valueKey: "roomSetpointHa", validKey: "roomSetpointHaValid" }),
-          ...renderApiSourceRows({ valueKey: "apiInputRoomSetpoint", validKey: "apiInputRoomSetpointValid" }),
-          ...renderMqttSourceRows({ valueKey: "mqttRoomSetpoint", validKey: "mqttRoomSetpointValid" }),
+          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicRoomSetpoint", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(roomSetpointUsedSource, "CIC") }) : "",
+          otAvailable ? renderSourceRow({ label: "OpenTherm", key: "otRoomSetpoint", sourceKind: "ot", sourceState: "available", effective: sourcesMatch(roomSetpointUsedSource, "OpenTherm") }) : "",
+          ...renderHaSourceRows({
+            valueKey: "roomSetpointHa",
+            validKey: "roomSetpointHaValid",
+            forceVisible: isConfiguredSource("roomSetpointSource", "HA input"),
+            effective: sourcesMatch(roomSetpointUsedSource, "HA input"),
+          }),
+          ...renderApiSourceRows({
+            valueKey: "apiInputRoomSetpoint",
+            validKey: "apiInputRoomSetpointValid",
+            ageKey: "apiInputRoomSetpointAge",
+            forceVisible: isConfiguredSource("roomSetpointSource", "API input"),
+            effective: sourcesMatch(roomSetpointUsedSource, "API input"),
+          }),
+          ...renderMqttSourceRows({
+            valueKey: "mqttRoomSetpoint",
+            validKey: "mqttRoomSetpointValid",
+            forceVisible: isConfiguredSource("roomSetpointSource", "MQTT"),
+            effective: sourcesMatch(roomSetpointUsedSource, "MQTT"),
+          }),
         ],
       }),
-      renderSourceCard({
+      buildSourceSignal({
         key: "water-supply",
+        group: "water-circuit",
         title: "Aanvoertemperatuur",
         icon: "droplet",
         select: { key: "waterSupplySource", label: "Bron", haKeys: ["waterSupplyTempHa", "waterSupplyTempHaValid"] },
@@ -753,29 +925,36 @@ import { escapeHtml } from "../core/html.js";
           label: "Lokale sensor",
           when: currentWaterSupplySource === "Local" && hasEntity("localWaterSupplyTempSource"),
         },
-        activeRows: [
-          renderSourceRow({
-            label: "Gebruikte waarde",
-            key: "supplyTemp",
-            status: "i",
-            statusTone: waterSupplyCalibrated ? "valid" : "error",
-            statusTitle: supplyInfo,
-          }),
-          renderSourceRow({ label: "Bron", value: getWaterSupplyUsedSource() }),
-        ],
-        warning: waterSupplyCorrection.calibrationRequired
+        summaryValue: getSettingsStatValue("supplyTemp"),
+        summarySource: waterSupplyUsedSource,
+        summaryInfo: renderSettingsInfoToggle(
+          "supplyTemp-info",
+          "Gebruikte waarde",
+          supplyInfo,
+          "i",
+          `oq-settings-source-info oq-settings-source-info--${waterSupplyCalibrated ? "valid" : "error"} oq-settings-source-info--circle`,
+        ),
+        warning: localWaterSupplyWarning || (waterSupplyCorrection.calibrationRequired
           ? "De aanvoerbron of bronconfiguratie is gewijzigd. De oude correctie is uitgeschakeld; voer de temperatuurkalibratie opnieuw uit."
-          : "",
+          : ""),
+        routeWarning: invalidSourceValueWarning("supplyTemp"),
         measurementRows: [
-          renderSourceRow({ label: "Lokale selectie", key: "waterSupplyTempEsp" }),
-          renderSourceRow({ label: "PT1000", key: "waterSupplyTempPt1000" }),
-          renderSourceRow({ label: "DS18B20", key: "waterSupplyTempDs18b20" }),
-          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicWaterSupplyTemp" }) : "",
-          ...renderHaSourceRows({ valueKey: "waterSupplyTempHa", validKey: "waterSupplyTempHaValid" }),
+          renderSourceRow({ label: "Lokale selectie", key: "waterSupplyTempEsp", sourceKind: "local", sourceState: "available", effective: sourcesMatch(waterSupplyUsedSource, "Local") }),
+          renderSourceRow({ label: "PT1000", key: "waterSupplyTempPt1000", sourceKind: "pt1000", sourceState: "available", effective: sourcesMatch(waterSupplyUsedSource, "PT1000") }),
+          renderSourceRow({ label: "DS18B20", key: "waterSupplyTempDs18b20", sourceKind: "ds18b20", sourceState: "available", effective: sourcesMatch(waterSupplyUsedSource, "DS18B20") }),
+          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicWaterSupplyTemp", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(waterSupplyUsedSource, "CIC") }) : "",
+          ...renderHaSourceRows({
+            valueKey: "waterSupplyTempHa",
+            validKey: "waterSupplyTempHaValid",
+            forceVisible: isConfiguredSource("waterSupplySource", "HA input"),
+            effective: sourcesMatch(waterSupplyUsedSource, "HA input"),
+          }),
         ],
+        measurementTitle: "Ruwe metingen",
       }),
-      renderSourceCard({
+      buildSourceSignal({
         key: "flow-source",
+        group: "water-circuit",
         title: "Flow",
         icon: "waves",
         select: { key: "flowSource", label: "Bron", optionLabels: { "Outdoor unit": "Quatt-flow" }, when: cicAvailable || currentFlowSource === "CIC" },
@@ -795,20 +974,20 @@ import { escapeHtml } from "../core/html.js";
             when: currentFlowSource === "Outdoor unit" && hasEntity("outdoorUnitFlowMode") && (!hasEntity("qFlowSource") || currentQFlowSource !== "Local"),
           },
         ],
-        activeRows: [
-          renderSourceRow({ label: "OpenQuatt-flow", key: "flowSelected" }),
-          renderSourceRow({ label: "Bron", value: getFlowUsedSource() }),
-        ],
+        summaryValue: getSettingsStatValue("flowSelected"),
+        summarySource: flowUsedSource,
+        routeWarning: invalidSourceValueWarning("flowSelected"),
         measurementRows: [
-          renderSourceRow({ label: "Controller-flowmeter", key: "controllerFlow" }),
-          renderSourceRow({ label: "Gecombineerd HP1/HP2", key: "flowLocal" }),
-          renderSourceRow({ label: "Flowmeter HP1", key: "hp1Flow" }),
-          renderSourceRow({ label: "Flowmeter HP2", key: "hp2Flow" }),
-          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicFlowrate" }) : "",
+          renderSourceRow({ label: "Controller-flowmeter", key: "controllerFlow", sourceKind: "local", sourceState: "available", effective: sourcesMatch(flowUsedSource, "Lokaal") }),
+          renderSourceRow({ label: "Gecombineerd HP1/HP2", key: "flowLocal", sourceKind: "outdoor", sourceState: "available", effective: /gecombineerd/i.test(flowUsedSource) }),
+          renderSourceRow({ label: "Flowmeter HP1", key: "hp1Flow", sourceKind: "hp1", sourceState: "available", effective: sourcesMatch(flowUsedSource, "HP1") && !sourcesMatch(flowUsedSource, "HP2") }),
+          renderSourceRow({ label: "Flowmeter HP2", key: "hp2Flow", sourceKind: "hp2", sourceState: "available", effective: sourcesMatch(flowUsedSource, "HP2") && !sourcesMatch(flowUsedSource, "HP1") }),
+          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicFlowrate", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(flowUsedSource, "CIC") }) : "",
         ],
       }),
-      renderSourceCard({
+      buildSourceSignal({
         key: "outside-temperature",
+        group: "room-outside",
         title: "Buitentemperatuur",
         icon: "sun",
         warning: currentOutsideTempSource === "MQTT"
@@ -825,19 +1004,35 @@ import { escapeHtml } from "../core/html.js";
           infoId: "outsideTempSource-auto-info",
           infoCopy: outsideTemperatureAutoInfo,
         },
-        activeRows: [
-          renderSourceRow({ label: "Waarde", key: "outsideTempSelected" }),
-          renderSourceRow({ label: "Bron", value: getOutsideTempUsedSource() }),
-        ],
+        summaryValue: getSettingsStatValue("outsideTempSelected"),
+        summarySource: outsideTemperatureUsedSource,
+        routeWarning: invalidSourceValueWarning("outsideTempSelected"),
         measurementRows: [
-          renderSourceRow({ label: "Buitenunit", key: "outsideTempLocalAggregated" }),
-          ...renderHaSourceRows({ valueKey: "outsideTempHa", validKey: "outsideTempHaValid" }),
-          ...renderApiSourceRows({ valueKey: "apiInputOutsideTemperature", validKey: "apiInputOutsideTemperatureValid" }),
-          ...renderMqttSourceRows({ valueKey: "mqttOutsideTemperature", validKey: "mqttOutsideTemperatureValid" }),
+          renderSourceRow({ label: "Buitenunit", key: "outsideTempLocalAggregated", sourceKind: "outdoor", sourceState: "available", effective: sourcesMatch(outsideTemperatureUsedSource, "Buitenunit") }),
+          ...renderHaSourceRows({
+            valueKey: "outsideTempHa",
+            validKey: "outsideTempHaValid",
+            forceVisible: isConfiguredSource("outsideTempSource", "HA input"),
+            effective: sourcesMatch(outsideTemperatureUsedSource, "HA input"),
+          }),
+          ...renderApiSourceRows({
+            valueKey: "apiInputOutsideTemperature",
+            validKey: "apiInputOutsideTemperatureValid",
+            ageKey: "apiInputOutsideTemperatureAge",
+            forceVisible: isConfiguredSource("outsideTempSource", "API input"),
+            effective: sourcesMatch(outsideTemperatureUsedSource, "API input"),
+          }),
+          ...renderMqttSourceRows({
+            valueKey: "mqttOutsideTemperature",
+            validKey: "mqttOutsideTemperatureValid",
+            forceVisible: isConfiguredSource("outsideTempSource", "MQTT"),
+            effective: sourcesMatch(outsideTemperatureUsedSource, "MQTT"),
+          }),
         ],
       }),
-      renderSourceCard({
+      buildSourceSignal({
         key: "heating-enable",
+        group: "heating",
         title: "Warmtetoestemming",
         icon: "flame",
         select: {
@@ -852,38 +1047,41 @@ import { escapeHtml } from "../core/html.js";
           mqttTopicKey: "heating_enable",
           keepUnavailableCurrent: true,
         },
-        activeRows: [
-          renderSourceRow({
-            label: "Toestemming",
-            value: heatingEnableSourceDisabled ? "Niet gebruikt" : sourceStateText("heatingEnableSelected", "Toegestaan", "Geblokkeerd"),
-            status: heatingEnableSourceDisabled ? "i" : "",
-            statusTone: heatingEnableSourceDisabled ? "valid" : "",
-            statusTitle: heatingEnableSourceDisabled ? "Geen externe gate; de strategie bepaalt zelf of warmte nodig is." : "",
-          }),
-          !heatingEnableSourceDisabled ? renderSourceRow({ label: "Bron", value: heatingEnableSourceLabel }) : "",
-        ],
+        summaryValue: heatingEnableSourceDisabled
+          ? "Niet gebruikt"
+          : sourceStateText("heatingEnableSelected", "Toegestaan", "Geblokkeerd"),
+        summarySource: heatingEnableUsedSource,
+        routeWarning: heatingEnableSourceDisabled ? "" : invalidSourceValueWarning("heatingEnableSelected"),
         measurementRows: [
-          otAvailable ? renderSourceRow({ label: "OpenTherm", value: sourceStateText("otThermostatChEnable", "Toegestaan", "Geblokkeerd") }) : "",
-          cicAvailable ? renderSourceRow({ label: "CIC", value: sourceStateText("cicChEnabled", "Toegestaan", "Geblokkeerd") }) : "",
+          otAvailable ? renderSourceRow({ label: "OpenTherm", value: sourceStateText("otThermostatChEnable", "Toegestaan", "Geblokkeerd"), sourceKind: "ot", sourceState: "available", effective: sourcesMatch(heatingEnableUsedSource, "OpenTherm") }) : "",
+          cicAvailable ? renderSourceRow({ label: "CIC", value: sourceStateText("cicChEnabled", "Toegestaan", "Geblokkeerd"), sourceKind: "cic", sourceState: "available", effective: sourcesMatch(heatingEnableUsedSource, "CIC") }) : "",
           ...renderHaSourceRows({
             valueKey: "heatingEnableHa",
             validKey: "heatingEnableHaValid",
             value: sourceStateText("heatingEnableHa", "Toegestaan", "Geblokkeerd"),
+            forceVisible: isConfiguredSource("heatingEnableSource", "HA input"),
+            effective: sourcesMatch(heatingEnableUsedSource, "HA input"),
           }),
           ...renderApiSourceRows({
             valueKey: "apiInputHeatingEnable",
             validKey: "apiInputHeatingEnableValid",
+            ageKey: "apiInputHeatingEnableAge",
             value: sourceStateText("apiInputHeatingEnable", "Toegestaan", "Geblokkeerd"),
+            forceVisible: isConfiguredSource("heatingEnableSource", "API input"),
+            effective: sourcesMatch(heatingEnableUsedSource, "API input"),
           }),
           ...renderMqttSourceRows({
             valueKey: "mqttHeatingEnable",
             validKey: "mqttHeatingEnableValid",
             value: sourceStateText("mqttHeatingEnable", "Toegestaan", "Geblokkeerd"),
+            forceVisible: isConfiguredSource("heatingEnableSource", "MQTT"),
+            effective: sourcesMatch(heatingEnableUsedSource, "MQTT"),
           }),
         ],
       }),
-      renderSourceCard({
+      buildSourceSignal({
         key: "cooling-enable",
+        group: "cooling",
         title: "Koeltoestemming",
         icon: "snowflake",
         select: {
@@ -897,35 +1095,39 @@ import { escapeHtml } from "../core/html.js";
           mqttTopicKey: "cooling_enable",
           keepUnavailableCurrent: true,
         },
-        activeRows: [
-          renderSourceRow({ label: "Toestemming", value: sourceStateText("coolingEnableSelected", "Toegestaan", "Geblokkeerd") }),
-          !coolingEnableSourceDisabled ? renderSourceRow({ label: "Bron", value: coolingEnableSourceLabel }) : "",
-          coolingEnableEffectiveSource && coolingEnableEffectiveSource !== coolingEnableSourceLabel
-            ? renderSourceRow({ label: "Via", value: coolingEnableEffectiveSource })
-            : "",
-        ],
+        summaryValue: sourceStateText("coolingEnableSelected", "Toegestaan", "Geblokkeerd"),
+        summarySource: coolingEnableUsedSource,
+        routeWarning: invalidSourceValueWarning("coolingEnableSelected"),
         measurementRows: [
-          renderSourceRow({ label: "Handmatig", value: sourceStateText("manualCoolingEnable", "Aan", "Uit") }),
-          otAvailable ? renderSourceRow({ label: "OpenTherm", value: sourceStateText("otThermostatCoolingEnable", "Toegestaan", "Geblokkeerd") }) : "",
+          renderSourceRow({ label: "Handmatig", value: sourceStateText("manualCoolingEnable", "Aan", "Uit"), sourceKind: "manual", sourceState: "available", effective: sourcesMatch(coolingEnableUsedSource, "Handmatig") }),
+          otAvailable ? renderSourceRow({ label: "OpenTherm", value: sourceStateText("otThermostatCoolingEnable", "Toegestaan", "Geblokkeerd"), sourceKind: "ot", sourceState: "available", effective: sourcesMatch(coolingEnableUsedSource, "OpenTherm") }) : "",
           ...renderHaSourceRows({
             valueKey: "coolingEnableHa",
             validKey: "coolingEnableHaValid",
             value: sourceStateText("coolingEnableHa", "Toegestaan", "Geblokkeerd"),
+            forceVisible: isConfiguredSource("coolingEnableSource", "HA input"),
+            effective: sourcesMatch(coolingEnableUsedSource, "HA input"),
           }),
           ...renderApiSourceRows({
             valueKey: "apiInputCoolingEnable",
             validKey: "apiInputCoolingEnableValid",
+            ageKey: "apiInputCoolingEnableAge",
             value: sourceStateText("apiInputCoolingEnable", "Toegestaan", "Geblokkeerd"),
+            forceVisible: isConfiguredSource("coolingEnableSource", "API input"),
+            effective: sourcesMatch(coolingEnableUsedSource, "API input"),
           }),
           ...renderMqttSourceRows({
             valueKey: "mqttCoolingEnable",
             validKey: "mqttCoolingEnableValid",
             value: sourceStateText("mqttCoolingEnable", "Toegestaan", "Geblokkeerd"),
+            forceVisible: isConfiguredSource("coolingEnableSource", "MQTT"),
+            effective: sourcesMatch(coolingEnableUsedSource, "MQTT"),
           }),
         ],
       }),
-      renderSourceCard({
+      buildSourceSignal({
         key: "cooling-dew-point",
+        group: "cooling",
         title: "Koelingsdauwpunt",
         icon: "thermometer",
         select: {
@@ -941,18 +1143,34 @@ import { escapeHtml } from "../core/html.js";
             ? "Auto gebruikt de hoogste geldige waarde als Home Assistant, API-invoer en MQTT tegelijk geldig zijn. Kies Home Assistant, API input of MQTT om die bron expliciet te vereisen."
             : "Auto gebruikt een geldige Home Assistant-waarde wanneer die beschikbaar is. Kies Home Assistant om die bron expliciet te vereisen.",
         },
-        activeRows: [
-          renderSourceRow({ label: "Waarde", key: "coolingDewPointSelected" }),
-          renderSourceRow({ label: "Bron", value: getCoolingDewPointUsedSource() }),
-        ],
+        summaryValue: getSettingsStatValue("coolingDewPointSelected"),
+        summarySource: coolingDewPointUsedSource,
+        routeWarning: invalidSourceValueWarning("coolingDewPointSelected"),
         measurementRows: [
-          ...renderHaSourceRows({ valueKey: "coolingDewPointHa", validKey: "coolingDewPointHaValid" }),
-          ...renderApiSourceRows({ valueKey: "apiInputCoolingDewPoint", validKey: "apiInputCoolingDewPointValid" }),
-          ...renderMqttSourceRows({ valueKey: "mqttCoolingDewPoint", validKey: "mqttCoolingDewPointValid" }),
+          ...renderHaSourceRows({
+            valueKey: "coolingDewPointHa",
+            validKey: "coolingDewPointHaValid",
+            forceVisible: isConfiguredSource("coolingDewPointSource", "HA input"),
+            effective: sourcesMatch(coolingDewPointUsedSource, "HA input"),
+          }),
+          ...renderApiSourceRows({
+            valueKey: "apiInputCoolingDewPoint",
+            validKey: "apiInputCoolingDewPointValid",
+            ageKey: "apiInputCoolingDewPointAge",
+            forceVisible: isConfiguredSource("coolingDewPointSource", "API input"),
+            effective: sourcesMatch(coolingDewPointUsedSource, "API input"),
+          }),
+          ...renderMqttSourceRows({
+            valueKey: "mqttCoolingDewPoint",
+            validKey: "mqttCoolingDewPointValid",
+            forceVisible: isConfiguredSource("coolingDewPointSource", "MQTT"),
+            effective: sourcesMatch(coolingDewPointUsedSource, "MQTT"),
+          }),
         ],
       }),
-      renderSourceCard({
+      buildSourceSignal({
         key: "external-heat-demand",
+        group: "heating",
         title: "Externe warmtevraag",
         icon: "zap",
         select: {
@@ -964,20 +1182,170 @@ import { escapeHtml } from "../core/html.js";
           apiValidKey: "apiInputExternalHeatDemandValid",
           infoCopy: "Vervangt alleen de vermogensschatting van het huismodel in Power House. Valt de bron weg of veroudert hij, dan rekent Power House weer met het huismodel.",
         },
-        activeRows: [
-          renderSourceRow({ label: "Waarde", key: "externalHeatDemandSelected" }),
-          renderSourceRow({ label: "Power House gebruikt", value: formattedTextSourceValue("powerHouseDemandSource") }),
-        ],
+        summaryValue: getSettingsStatValue("externalHeatDemandSelected"),
+        summarySource: externalHeatDemandUsedSource,
+        routeWarning: String(getEntityValue("externalHeatDemandSource") || "") === "Disabled"
+          ? ""
+          : invalidSourceValueWarning("externalHeatDemandSelected"),
         measurementRows: [
-          ...renderHaSourceRows({ valueKey: "externalHeatDemandHa", validKey: "externalHeatDemandHaValid" }),
-          ...renderApiSourceRows({ valueKey: "apiInputExternalHeatDemand", validKey: "apiInputExternalHeatDemandValid" }),
+          ...renderHaSourceRows({
+            valueKey: "externalHeatDemandHa",
+            validKey: "externalHeatDemandHaValid",
+            forceVisible: isConfiguredSource("externalHeatDemandSource", "HA input"),
+            effective: sourcesMatch(externalHeatDemandUsedSource, "HA input"),
+          }),
+          ...renderApiSourceRows({
+            valueKey: "apiInputExternalHeatDemand",
+            validKey: "apiInputExternalHeatDemandValid",
+            ageKey: "apiInputExternalHeatDemandAge",
+            forceVisible: isConfiguredSource("externalHeatDemandSource", "API input"),
+            effective: sourcesMatch(externalHeatDemandUsedSource, "API input"),
+          }),
         ],
       }),
     ].filter(Boolean);
 
-    if (!sourceCards.length) {
+    if (!sourceSignals.length) {
       return "";
     }
+
+    const sourceCategories = [
+      {
+        id: "room-outside",
+        title: "Ruimte & buiten",
+        icon: "home-cog",
+        keys: ["room-temperature", "room-setpoint", "outside-temperature"],
+      },
+      {
+        id: "water-circuit",
+        title: "Watercircuit",
+        icon: "droplet",
+        keys: ["water-supply", "flow-source"],
+      },
+      {
+        id: "heating",
+        title: "Verwarmen",
+        icon: "flame",
+        keys: ["external-heat-demand", "heating-enable"],
+      },
+      {
+        id: "cooling",
+        title: "Koelen",
+        icon: "snowflake",
+        keys: ["cooling-enable", "cooling-dew-point"],
+      },
+    ];
+    const signalByKey = new Map(sourceSignals.map((signal) => [signal.key, signal]));
+    const visibleCategories = sourceCategories
+      .map((category) => ({
+        ...category,
+        signals: category.keys.map((key) => signalByKey.get(key)).filter(Boolean),
+      }))
+      .filter((category) => category.signals.length);
+    const requestedFocusKey = String(state.settingsSourceFocusKey || "").trim();
+    const focusedSignal = signalByKey.get(requestedFocusKey) || visibleCategories[0]?.signals[0] || sourceSignals[0];
+    if (state.settingsSourceFocusKey !== focusedSignal.key) {
+      state.settingsSourceFocusKey = focusedSignal.key;
+    }
+    const focusedCategory = visibleCategories.find((category) => category.id === focusedSignal.group) || visibleCategories[0];
+    const categoryMarkup = visibleCategories.map((category, categoryIndex) => {
+      const count = category.signals.length;
+      const categoryTitleId = `oq-settings-source-category-${category.id}`;
+      const signalsMarkup = category.signals.map((signal) => {
+        const active = signal.key === focusedSignal.key;
+        return `
+          <button
+            class="oq-settings-source-signal${active ? " is-active" : ""}${signal.warningCopy ? " is-warning" : ""}"
+            type="button"
+            data-oq-action="select-settings-source"
+            data-source-key="${escapeHtml(signal.key)}"
+            data-oq-focus-key="settings-source-${escapeHtml(signal.key)}"
+            aria-controls="oq-settings-source-inspector"
+            ${active ? 'aria-current="true"' : ""}
+          >
+            <span class="oq-settings-source-signal-name">
+              <span class="oq-settings-source-signal-icon">${renderOqIcon(signal.icon, "oq-settings-source-signal-icon-svg")}</span>
+              <span class="oq-settings-source-signal-title">${escapeHtml(signal.title)}</span>
+              ${signal.warningCopy ? `<span class="oq-settings-source-signal-warning" aria-label="Bronprobleem: ${escapeHtml(signal.warningCopy)}" title="Waarschuwing: bekijk de details">!</span>` : ""}
+            </span>
+            <span class="oq-settings-source-signal-summary">
+              <strong>${escapeHtml(signal.summaryValue)}</strong>
+              <small
+                class="oq-settings-source-signal-source-path"
+                aria-label="Ingesteld: ${escapeHtml(signal.configuredSource)}. Gebruikt: ${escapeHtml(signal.summarySource)}"
+              >
+                <span>${escapeHtml(signal.configuredSource)}</span>
+                ${signal.configuredSource !== signal.summarySource ? `
+                  <span class="oq-settings-source-signal-source-arrow" aria-hidden="true">→</span>
+                  <span>${escapeHtml(signal.summarySource)}</span>
+                ` : ""}
+              </small>
+            </span>
+            <span class="oq-settings-source-signal-chevron" aria-hidden="true">›</span>
+          </button>
+        `;
+      }).join("");
+      return `
+        <section class="oq-settings-source-category" data-source-category="${escapeHtml(category.id)}" aria-labelledby="${escapeHtml(categoryTitleId)}">
+          <header class="oq-settings-source-category-head">
+            <span class="oq-settings-source-category-icon">${renderOqIcon(category.icon, "oq-settings-source-category-icon-svg")}</span>
+            <div class="oq-settings-source-category-copy">
+              <h4 id="${escapeHtml(categoryTitleId)}">${escapeHtml(category.title)}</h4>
+              <small class="oq-settings-source-category-count">${count} ${count === 1 ? "signaal" : "signalen"}</small>
+            </div>
+            <span class="oq-settings-source-category-index" aria-hidden="true">${String(categoryIndex + 1).padStart(2, "0")}</span>
+          </header>
+          ${signalsMarkup}
+        </section>
+      `;
+    }).join("");
+    const inspectorMarkup = `
+      <article
+        id="oq-settings-source-inspector"
+        class="oq-settings-source-inspector"
+        data-oq-source-inspector
+        data-source-key="${escapeHtml(focusedSignal.key)}"
+        data-oq-settings-field="${escapeHtml(focusedSignal.fieldKey)}"
+      >
+        <button class="oq-settings-source-inspector-back" type="button" data-oq-action="close-settings-source-detail" data-oq-focus-key="settings-source-detail-back">
+          <span aria-hidden="true">←</span>
+          Alle signalen
+        </button>
+        <p class="oq-settings-source-inspector-kicker">${escapeHtml(focusedCategory?.title || "Bronnen")}</p>
+        <h4>${escapeHtml(focusedSignal.title)}</h4>
+        ${focusedSignal.warningCopy ? `<p class="oq-settings-source-warning" data-oq-source-warning>${escapeHtml(focusedSignal.warningCopy)}</p>` : ""}
+        <div class="oq-settings-source-inspector-summary">
+          <div>
+            <span>Ingesteld</span>
+            <strong>${escapeHtml(focusedSignal.configuredSource)}</strong>
+          </div>
+          <div>
+            <span>Gebruikt</span>
+            ${focusedSignal.summaryInfo}
+            <strong>${escapeHtml(focusedSignal.summaryValue)}</strong>
+            <span>${escapeHtml(focusedSignal.summarySource)}</span>
+          </div>
+        </div>
+        ${focusedSignal.controlsMarkup ? `
+          <h5 class="oq-settings-source-inspector-section-title">Bronkeuze</h5>
+          <div class="oq-settings-source-controls">${focusedSignal.controlsMarkup}</div>
+        ` : ""}
+        <h5 class="oq-settings-source-inspector-section-title">${escapeHtml(focusedSignal.measurementTitle)}</h5>
+        ${focusedSignal.measurementRows.length
+          ? `<div class="oq-settings-source-rows">${focusedSignal.measurementRows.join("")}</div>`
+          : '<p class="oq-settings-source-empty">Nog geen relevante metingen beschikbaar.</p>'}
+      </article>
+    `;
+    const sourceWorkspaceMarkup = `
+      <div class="oq-settings-source-shell" data-oq-source-workspace>
+        <div class="oq-settings-source-workspace${state.settingsSourceDetailOpen ? " is-detail-open" : ""}">
+          <nav class="oq-settings-source-nav" aria-label="Signalen">
+            ${categoryMarkup}
+          </nav>
+          ${inspectorMarkup}
+        </div>
+      </div>
+    `;
 
     const heatingAdvice = hasEntity("heatingEnableSource") ? getHeatingEnableAdvice() : null;
     const heatingAdviceHeaderAction = hasEntity("heatingEnableSource") ? `<button class="oq-helper-button ${heatingAdvice && heatingAdvice.deviant ? "oq-helper-button--warning-soft" : "oq-helper-button--ghost"}" type="button" data-oq-action="open-heating-strategy-advice-modal">${heatingAdvice && heatingAdvice.deviant ? '<span class="oq-advice-warn-icon"><svg viewBox="0 0 20 18" aria-hidden="true"><path d="M10 1.6 L18.2 16.4 H1.8 Z"/><rect x="9.1" y="5.4" width="1.8" height="5.8" rx="0.9"/><circle cx="10" cy="13.6" r="1.1"/></svg></span> Advies per strategie' : "Advies per strategie"}</button>` : "";
@@ -985,7 +1353,7 @@ import { escapeHtml } from "../core/html.js";
       "Bronnen",
       "Sensorselectie",
       "Kies welke bron OpenQuatt gebruikt voor metingen en vraag-signalen. Uitgeschakelde integraties verdwijnen uit de keuzes.",
-      `<div class="oq-settings-source-grid">${sourceCards.join("")}</div>`,
+      sourceWorkspaceMarkup,
       "",
       "",
       heatingAdviceHeaderAction,

--- a/openquatt/web/js/src/settings/integrations.js
+++ b/openquatt/web/js/src/settings/integrations.js
@@ -489,48 +489,24 @@ import { escapeHtml } from "../core/html.js";
       }
       return source ? formatSettingsOptionLabel(source) : "Auto";
     };
+    const sourceKindPatterns = [
+      ["ha", /\b(?:ha|home assistant)\b/],
+      ["api", /\bapi\b/],
+      ["mqtt", /\bmqtt\b/],
+      ["cic", /\bcic\b/],
+      ["ot", /\b(?:opentherm|ot thermostat|ot-thermostaat)\b/],
+      ["outdoor", /\b(?:outdoor unit|buitenunit|quatt-flow)\b/],
+      ["local", /\b(?:local|lokaal|controller)\b/],
+      ["pt1000", /\bpt1000\b/],
+      ["ds18b20", /\bds18b20\b/],
+      ["manual", /\b(?:manual|handmatig)\b/],
+      ["hp1", /\bhp1\b/],
+      ["hp2", /\bhp2\b/],
+      ["disabled", /\b(?:disabled|niet gebruiken|none)\b|^—$|^$/],
+    ];
     const sourceKinds = (value = "") => {
       const text = String(value || "").trim().toLowerCase();
-      const kinds = new Set();
-      if (/\b(ha|home assistant)\b/.test(text)) {
-        kinds.add("ha");
-      }
-      if (/\bapi\b/.test(text)) {
-        kinds.add("api");
-      }
-      if (/\bmqtt\b/.test(text)) {
-        kinds.add("mqtt");
-      }
-      if (/\bcic\b/.test(text)) {
-        kinds.add("cic");
-      }
-      if (/\b(opentherm|ot thermostat|ot-thermostaat)\b/.test(text)) {
-        kinds.add("ot");
-      }
-      if (/\b(outdoor unit|buitenunit|quatt-flow)\b/.test(text)) {
-        kinds.add("outdoor");
-      }
-      if (/\b(local|lokaal|controller)\b/.test(text)) {
-        kinds.add("local");
-      }
-      if (/\bpt1000\b/.test(text)) {
-        kinds.add("pt1000");
-      }
-      if (/\bds18b20\b/.test(text)) {
-        kinds.add("ds18b20");
-      }
-      if (/\b(manual|handmatig)\b/.test(text)) {
-        kinds.add("manual");
-      }
-      if (/\bhp1\b/.test(text)) {
-        kinds.add("hp1");
-      }
-      if (/\bhp2\b/.test(text)) {
-        kinds.add("hp2");
-      }
-      if (/\b(disabled|niet gebruiken|none)\b/.test(text) || text === "—" || text === "") {
-        kinds.add("disabled");
-      }
+      const kinds = new Set(sourceKindPatterns.filter(([, pattern]) => pattern.test(text)).map(([kind]) => kind));
       if (!kinds.size) {
         kinds.add(text.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "other");
       }
@@ -576,57 +552,29 @@ import { escapeHtml } from "../core/html.js";
         </div>
       `;
     };
-    const renderHaSourceRows = ({ label = "HA-invoer", valueKey = "", validKey = "", value = "", forceVisible = false, effective = false }) => {
-      if (!valueKey || !validKey || !hasEntity(valueKey) || !hasEntity(validKey)) {
-        return [];
-      }
-      const valid = isInstallationMonitoringBinaryActive(validKey);
-      if (!valid && !forceVisible && !effective) {
-        return [];
-      }
-      const statusTitle = valid
-        ? "Home Assistant geeft dit signaal geldig door. OpenQuatt mag deze HA-invoer gebruiken."
-        : "Home Assistant geeft dit signaal niet geldig door. OpenQuatt gebruikt deze HA-invoer dan niet als bron.";
-      return [renderSourceRow({
-        label,
-        key: valueKey,
-        value: valid ? value : "—",
-        status: valid ? "Beschikbaar" : "Niet geldig",
-        statusTone: valid ? "valid" : "invalid",
-        statusTitle,
-        sourceKind: "ha",
-        sourceState: valid ? "valid" : "invalid",
-        effective,
-      })];
+    const inputSourceCopy = {
+      ha: {
+        label: "HA-invoer",
+        valid: ["Beschikbaar", "Home Assistant geeft dit signaal geldig door. OpenQuatt mag deze HA-invoer gebruiken."],
+        invalid: ["Niet geldig", "Home Assistant geeft dit signaal niet geldig door. OpenQuatt gebruikt deze HA-invoer dan niet als bron."],
+      },
+      mqtt: {
+        label: "MQTT",
+        valid: ["Geldig", "MQTT heeft een geldige, recente waarde ontvangen. OpenQuatt mag deze MQTT-invoer gebruiken."],
+        invalid: ["Ongeldig", "MQTT heeft nog geen geldige recente waarde ontvangen. OpenQuatt gebruikt deze MQTT-invoer dan niet als bron."],
+      },
+      api: {
+        label: "API-invoer",
+        valid: ["Beschikbaar", "API-invoer heeft een geldige, recente waarde. OpenQuatt mag deze bron gebruiken."],
+        stale: ["Verouderd", "API-invoer heeft geen geldige recente waarde meer. OpenQuatt gebruikt deze bron dan niet."],
+        missing: ["Wacht op data", "API-invoer heeft nog geen geldige waarde ontvangen. OpenQuatt gebruikt deze bron dan niet."],
+      },
     };
-    const renderMqttSourceRows = ({ label = "MQTT", valueKey = "", validKey = "", value = "", topicKey = "", forceVisible = false, effective = false }) => {
+    const renderInputSourceRows = ({ kind, label = "", valueKey = "", validKey = "", ageKey = "", value = "", topicKey = "", forceVisible = false, effective = false }) => {
       if (!valueKey || !validKey || !hasEntity(valueKey) || !hasEntity(validKey)) {
         return [];
       }
-      if (!isMqttInputTopicEnabled(topicKey || mqttTopicKeyByValueKey[valueKey])) {
-        return [];
-      }
-      const valid = isInstallationMonitoringBinaryActive(validKey);
-      if (!valid && !forceVisible && !effective) {
-        return [];
-      }
-      const statusTitle = valid
-        ? "MQTT heeft een geldige, recente waarde ontvangen. OpenQuatt mag deze MQTT-invoer gebruiken."
-        : "MQTT heeft nog geen geldige recente waarde ontvangen. OpenQuatt gebruikt deze MQTT-invoer dan niet als bron.";
-      return [renderSourceRow({
-        label,
-        key: valueKey,
-        value: valid ? value : "—",
-        status: getMqttValidityLabel(validKey),
-        statusTone: valid ? "valid" : "invalid",
-        statusTitle,
-        sourceKind: "mqtt",
-        sourceState: valid ? "valid" : "invalid",
-        effective,
-      })];
-    };
-    const renderApiSourceRows = ({ label = "API-invoer", valueKey = "", validKey = "", ageKey = "", value = "", forceVisible = false, effective = false }) => {
-      if (!valueKey || !validKey || !hasEntity(valueKey) || !hasEntity(validKey)) {
+      if (kind === "mqtt" && !isMqttInputTopicEnabled(topicKey || mqttTopicKeyByValueKey[valueKey])) {
         return [];
       }
       const valid = isInstallationMonitoringBinaryActive(validKey);
@@ -634,24 +582,37 @@ import { escapeHtml } from "../core/html.js";
         return [];
       }
       const age = ageKey && hasEntity(ageKey) ? getNumericSourceValue(ageKey) : NaN;
-      const inactiveStatus = Number.isFinite(age) ? "Verouderd" : "Wacht op data";
-      const statusTitle = valid
-        ? "API-invoer heeft een geldige, recente waarde. OpenQuatt mag deze bron gebruiken."
-        : Number.isFinite(age)
-          ? "API-invoer heeft geen geldige recente waarde meer. OpenQuatt gebruikt deze bron dan niet."
-          : "API-invoer heeft nog geen geldige waarde ontvangen. OpenQuatt gebruikt deze bron dan niet.";
+      const sourceState = valid ? "valid" : kind === "api" ? (Number.isFinite(age) ? "stale" : "missing") : "invalid";
+      const [defaultStatus, statusTitle] = inputSourceCopy[kind][sourceState];
       return [renderSourceRow({
-        label,
+        label: label || inputSourceCopy[kind].label,
         key: valueKey,
         value: valid ? value : "—",
-        status: valid ? "Beschikbaar" : inactiveStatus,
+        status: kind === "mqtt" ? getMqttValidityLabel(validKey) : defaultStatus,
         statusTone: valid ? "valid" : "invalid",
         statusTitle,
-        sourceKind: "api",
-        sourceState: valid ? "valid" : Number.isFinite(age) ? "stale" : "missing",
+        sourceKind: kind,
+        sourceState,
         effective,
       })];
     };
+    const inputOptionByKind = { ha: "HA input", api: "API input", mqtt: "MQTT" };
+    const renderExternalSourceRows = (selectKey, effectiveSource, sources, formatValue = null) => (
+      Object.entries(sources).flatMap(([kind, keys]) => {
+        const [valueKey, validKey, ageKey = "", topicKey = ""] = keys;
+        const option = inputOptionByKind[kind];
+        return renderInputSourceRows({
+          kind,
+          valueKey,
+          validKey,
+          ageKey,
+          topicKey,
+          value: formatValue ? formatValue(valueKey) : "",
+          forceVisible: isConfiguredSource(selectKey, option),
+          effective: sourcesMatch(effectiveSource, option),
+        });
+      })
+    );
     const renderSourceSelect = (key, config = {}) => {
       if (!hasEntity(key)) {
         return { markup: "", warning: "" };
@@ -674,11 +635,8 @@ import { escapeHtml } from "../core/html.js";
       ) || (
         current === "OT thermostat" && !otAvailable
       );
-      const renderOptions = currentHidden && !hideUnavailableCurrent && !availableOptions.includes(current)
-        ? [current, ...availableOptions]
-        : currentUnavailable && !hideUnavailableCurrent && !availableOptions.includes(current)
-        ? [current, ...availableOptions]
-        : availableOptions;
+      const keepCurrent = (currentHidden || currentUnavailable) && !hideUnavailableCurrent && !availableOptions.includes(current);
+      const renderOptions = keepCurrent ? [current, ...availableOptions] : availableOptions;
       const optionMarkup = renderOptions.map((option) => {
         const displayLabel = formatSourceOptionLabel(option, config);
         return `<option value="${escapeHtml(option)}" ${option === current ? "selected" : ""}>${escapeHtml(displayLabel)}</option>`;
@@ -852,24 +810,10 @@ import { escapeHtml } from "../core/html.js";
         measurementRows: [
           cicAvailable ? renderSourceRow({ label: "CIC", key: "cicRoomTemp", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(roomTemperatureUsedSource, "CIC") }) : "",
           otAvailable ? renderSourceRow({ label: "OpenTherm", key: "otRoomTemp", sourceKind: "ot", sourceState: "available", effective: sourcesMatch(roomTemperatureUsedSource, "OpenTherm") }) : "",
-          ...renderHaSourceRows({
-            valueKey: "roomTempHa",
-            validKey: "roomTempHaValid",
-            forceVisible: isConfiguredSource("roomTempSource", "HA input"),
-            effective: sourcesMatch(roomTemperatureUsedSource, "HA input"),
-          }),
-          ...renderApiSourceRows({
-            valueKey: "apiInputRoomTemperature",
-            validKey: "apiInputRoomTemperatureValid",
-            ageKey: "apiInputRoomTemperatureAge",
-            forceVisible: isConfiguredSource("roomTempSource", "API input"),
-            effective: sourcesMatch(roomTemperatureUsedSource, "API input"),
-          }),
-          ...renderMqttSourceRows({
-            valueKey: "mqttRoomTemperature",
-            validKey: "mqttRoomTemperatureValid",
-            forceVisible: isConfiguredSource("roomTempSource", "MQTT"),
-            effective: sourcesMatch(roomTemperatureUsedSource, "MQTT"),
+          ...renderExternalSourceRows("roomTempSource", roomTemperatureUsedSource, {
+            ha: ["roomTempHa", "roomTempHaValid"],
+            api: ["apiInputRoomTemperature", "apiInputRoomTemperatureValid", "apiInputRoomTemperatureAge"],
+            mqtt: ["mqttRoomTemperature", "mqttRoomTemperatureValid"],
           }),
         ],
       }),
@@ -893,24 +837,10 @@ import { escapeHtml } from "../core/html.js";
         measurementRows: [
           cicAvailable ? renderSourceRow({ label: "CIC", key: "cicRoomSetpoint", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(roomSetpointUsedSource, "CIC") }) : "",
           otAvailable ? renderSourceRow({ label: "OpenTherm", key: "otRoomSetpoint", sourceKind: "ot", sourceState: "available", effective: sourcesMatch(roomSetpointUsedSource, "OpenTherm") }) : "",
-          ...renderHaSourceRows({
-            valueKey: "roomSetpointHa",
-            validKey: "roomSetpointHaValid",
-            forceVisible: isConfiguredSource("roomSetpointSource", "HA input"),
-            effective: sourcesMatch(roomSetpointUsedSource, "HA input"),
-          }),
-          ...renderApiSourceRows({
-            valueKey: "apiInputRoomSetpoint",
-            validKey: "apiInputRoomSetpointValid",
-            ageKey: "apiInputRoomSetpointAge",
-            forceVisible: isConfiguredSource("roomSetpointSource", "API input"),
-            effective: sourcesMatch(roomSetpointUsedSource, "API input"),
-          }),
-          ...renderMqttSourceRows({
-            valueKey: "mqttRoomSetpoint",
-            validKey: "mqttRoomSetpointValid",
-            forceVisible: isConfiguredSource("roomSetpointSource", "MQTT"),
-            effective: sourcesMatch(roomSetpointUsedSource, "MQTT"),
+          ...renderExternalSourceRows("roomSetpointSource", roomSetpointUsedSource, {
+            ha: ["roomSetpointHa", "roomSetpointHaValid"],
+            api: ["apiInputRoomSetpoint", "apiInputRoomSetpointValid", "apiInputRoomSetpointAge"],
+            mqtt: ["mqttRoomSetpoint", "mqttRoomSetpointValid"],
           }),
         ],
       }),
@@ -943,11 +873,8 @@ import { escapeHtml } from "../core/html.js";
           renderSourceRow({ label: "PT1000", key: "waterSupplyTempPt1000", sourceKind: "pt1000", sourceState: "available", effective: sourcesMatch(waterSupplyUsedSource, "PT1000") }),
           renderSourceRow({ label: "DS18B20", key: "waterSupplyTempDs18b20", sourceKind: "ds18b20", sourceState: "available", effective: sourcesMatch(waterSupplyUsedSource, "DS18B20") }),
           cicAvailable ? renderSourceRow({ label: "CIC", key: "cicWaterSupplyTemp", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(waterSupplyUsedSource, "CIC") }) : "",
-          ...renderHaSourceRows({
-            valueKey: "waterSupplyTempHa",
-            validKey: "waterSupplyTempHaValid",
-            forceVisible: isConfiguredSource("waterSupplySource", "HA input"),
-            effective: sourcesMatch(waterSupplyUsedSource, "HA input"),
+          ...renderExternalSourceRows("waterSupplySource", waterSupplyUsedSource, {
+            ha: ["waterSupplyTempHa", "waterSupplyTempHaValid"],
           }),
         ],
         measurementTitle: "Ruwe metingen",
@@ -1009,24 +936,10 @@ import { escapeHtml } from "../core/html.js";
         routeWarning: invalidSourceValueWarning("outsideTempSelected"),
         measurementRows: [
           renderSourceRow({ label: "Buitenunit", key: "outsideTempLocalAggregated", sourceKind: "outdoor", sourceState: "available", effective: sourcesMatch(outsideTemperatureUsedSource, "Buitenunit") }),
-          ...renderHaSourceRows({
-            valueKey: "outsideTempHa",
-            validKey: "outsideTempHaValid",
-            forceVisible: isConfiguredSource("outsideTempSource", "HA input"),
-            effective: sourcesMatch(outsideTemperatureUsedSource, "HA input"),
-          }),
-          ...renderApiSourceRows({
-            valueKey: "apiInputOutsideTemperature",
-            validKey: "apiInputOutsideTemperatureValid",
-            ageKey: "apiInputOutsideTemperatureAge",
-            forceVisible: isConfiguredSource("outsideTempSource", "API input"),
-            effective: sourcesMatch(outsideTemperatureUsedSource, "API input"),
-          }),
-          ...renderMqttSourceRows({
-            valueKey: "mqttOutsideTemperature",
-            validKey: "mqttOutsideTemperatureValid",
-            forceVisible: isConfiguredSource("outsideTempSource", "MQTT"),
-            effective: sourcesMatch(outsideTemperatureUsedSource, "MQTT"),
+          ...renderExternalSourceRows("outsideTempSource", outsideTemperatureUsedSource, {
+            ha: ["outsideTempHa", "outsideTempHaValid"],
+            api: ["apiInputOutsideTemperature", "apiInputOutsideTemperatureValid", "apiInputOutsideTemperatureAge"],
+            mqtt: ["mqttOutsideTemperature", "mqttOutsideTemperatureValid"],
           }),
         ],
       }),
@@ -1055,28 +968,11 @@ import { escapeHtml } from "../core/html.js";
         measurementRows: [
           otAvailable ? renderSourceRow({ label: "OpenTherm", value: sourceStateText("otThermostatChEnable", "Toegestaan", "Geblokkeerd"), sourceKind: "ot", sourceState: "available", effective: sourcesMatch(heatingEnableUsedSource, "OpenTherm") }) : "",
           cicAvailable ? renderSourceRow({ label: "CIC", value: sourceStateText("cicChEnabled", "Toegestaan", "Geblokkeerd"), sourceKind: "cic", sourceState: "available", effective: sourcesMatch(heatingEnableUsedSource, "CIC") }) : "",
-          ...renderHaSourceRows({
-            valueKey: "heatingEnableHa",
-            validKey: "heatingEnableHaValid",
-            value: sourceStateText("heatingEnableHa", "Toegestaan", "Geblokkeerd"),
-            forceVisible: isConfiguredSource("heatingEnableSource", "HA input"),
-            effective: sourcesMatch(heatingEnableUsedSource, "HA input"),
-          }),
-          ...renderApiSourceRows({
-            valueKey: "apiInputHeatingEnable",
-            validKey: "apiInputHeatingEnableValid",
-            ageKey: "apiInputHeatingEnableAge",
-            value: sourceStateText("apiInputHeatingEnable", "Toegestaan", "Geblokkeerd"),
-            forceVisible: isConfiguredSource("heatingEnableSource", "API input"),
-            effective: sourcesMatch(heatingEnableUsedSource, "API input"),
-          }),
-          ...renderMqttSourceRows({
-            valueKey: "mqttHeatingEnable",
-            validKey: "mqttHeatingEnableValid",
-            value: sourceStateText("mqttHeatingEnable", "Toegestaan", "Geblokkeerd"),
-            forceVisible: isConfiguredSource("heatingEnableSource", "MQTT"),
-            effective: sourcesMatch(heatingEnableUsedSource, "MQTT"),
-          }),
+          ...renderExternalSourceRows("heatingEnableSource", heatingEnableUsedSource, {
+            ha: ["heatingEnableHa", "heatingEnableHaValid"],
+            api: ["apiInputHeatingEnable", "apiInputHeatingEnableValid", "apiInputHeatingEnableAge"],
+            mqtt: ["mqttHeatingEnable", "mqttHeatingEnableValid"],
+          }, (key) => sourceStateText(key, "Toegestaan", "Geblokkeerd")),
         ],
       }),
       buildSourceSignal({
@@ -1101,28 +997,11 @@ import { escapeHtml } from "../core/html.js";
         measurementRows: [
           renderSourceRow({ label: "Handmatig", value: sourceStateText("manualCoolingEnable", "Aan", "Uit"), sourceKind: "manual", sourceState: "available", effective: sourcesMatch(coolingEnableUsedSource, "Handmatig") }),
           otAvailable ? renderSourceRow({ label: "OpenTherm", value: sourceStateText("otThermostatCoolingEnable", "Toegestaan", "Geblokkeerd"), sourceKind: "ot", sourceState: "available", effective: sourcesMatch(coolingEnableUsedSource, "OpenTherm") }) : "",
-          ...renderHaSourceRows({
-            valueKey: "coolingEnableHa",
-            validKey: "coolingEnableHaValid",
-            value: sourceStateText("coolingEnableHa", "Toegestaan", "Geblokkeerd"),
-            forceVisible: isConfiguredSource("coolingEnableSource", "HA input"),
-            effective: sourcesMatch(coolingEnableUsedSource, "HA input"),
-          }),
-          ...renderApiSourceRows({
-            valueKey: "apiInputCoolingEnable",
-            validKey: "apiInputCoolingEnableValid",
-            ageKey: "apiInputCoolingEnableAge",
-            value: sourceStateText("apiInputCoolingEnable", "Toegestaan", "Geblokkeerd"),
-            forceVisible: isConfiguredSource("coolingEnableSource", "API input"),
-            effective: sourcesMatch(coolingEnableUsedSource, "API input"),
-          }),
-          ...renderMqttSourceRows({
-            valueKey: "mqttCoolingEnable",
-            validKey: "mqttCoolingEnableValid",
-            value: sourceStateText("mqttCoolingEnable", "Toegestaan", "Geblokkeerd"),
-            forceVisible: isConfiguredSource("coolingEnableSource", "MQTT"),
-            effective: sourcesMatch(coolingEnableUsedSource, "MQTT"),
-          }),
+          ...renderExternalSourceRows("coolingEnableSource", coolingEnableUsedSource, {
+            ha: ["coolingEnableHa", "coolingEnableHaValid"],
+            api: ["apiInputCoolingEnable", "apiInputCoolingEnableValid", "apiInputCoolingEnableAge"],
+            mqtt: ["mqttCoolingEnable", "mqttCoolingEnableValid"],
+          }, (key) => sourceStateText(key, "Toegestaan", "Geblokkeerd")),
         ],
       }),
       buildSourceSignal({
@@ -1147,24 +1026,10 @@ import { escapeHtml } from "../core/html.js";
         summarySource: coolingDewPointUsedSource,
         routeWarning: invalidSourceValueWarning("coolingDewPointSelected"),
         measurementRows: [
-          ...renderHaSourceRows({
-            valueKey: "coolingDewPointHa",
-            validKey: "coolingDewPointHaValid",
-            forceVisible: isConfiguredSource("coolingDewPointSource", "HA input"),
-            effective: sourcesMatch(coolingDewPointUsedSource, "HA input"),
-          }),
-          ...renderApiSourceRows({
-            valueKey: "apiInputCoolingDewPoint",
-            validKey: "apiInputCoolingDewPointValid",
-            ageKey: "apiInputCoolingDewPointAge",
-            forceVisible: isConfiguredSource("coolingDewPointSource", "API input"),
-            effective: sourcesMatch(coolingDewPointUsedSource, "API input"),
-          }),
-          ...renderMqttSourceRows({
-            valueKey: "mqttCoolingDewPoint",
-            validKey: "mqttCoolingDewPointValid",
-            forceVisible: isConfiguredSource("coolingDewPointSource", "MQTT"),
-            effective: sourcesMatch(coolingDewPointUsedSource, "MQTT"),
+          ...renderExternalSourceRows("coolingDewPointSource", coolingDewPointUsedSource, {
+            ha: ["coolingDewPointHa", "coolingDewPointHaValid"],
+            api: ["apiInputCoolingDewPoint", "apiInputCoolingDewPointValid", "apiInputCoolingDewPointAge"],
+            mqtt: ["mqttCoolingDewPoint", "mqttCoolingDewPointValid"],
           }),
         ],
       }),
@@ -1188,18 +1053,9 @@ import { escapeHtml } from "../core/html.js";
           ? ""
           : invalidSourceValueWarning("externalHeatDemandSelected"),
         measurementRows: [
-          ...renderHaSourceRows({
-            valueKey: "externalHeatDemandHa",
-            validKey: "externalHeatDemandHaValid",
-            forceVisible: isConfiguredSource("externalHeatDemandSource", "HA input"),
-            effective: sourcesMatch(externalHeatDemandUsedSource, "HA input"),
-          }),
-          ...renderApiSourceRows({
-            valueKey: "apiInputExternalHeatDemand",
-            validKey: "apiInputExternalHeatDemandValid",
-            ageKey: "apiInputExternalHeatDemandAge",
-            forceVisible: isConfiguredSource("externalHeatDemandSource", "API input"),
-            effective: sourcesMatch(externalHeatDemandUsedSource, "API input"),
+          ...renderExternalSourceRows("externalHeatDemandSource", externalHeatDemandUsedSource, {
+            ha: ["externalHeatDemandHa", "externalHeatDemandHaValid"],
+            api: ["apiInputExternalHeatDemand", "apiInputExternalHeatDemandValid", "apiInputExternalHeatDemandAge"],
           }),
         ],
       }),

--- a/openquatt/web/js/src/settings/integrations.js
+++ b/openquatt/web/js/src/settings/integrations.js
@@ -521,7 +521,6 @@ import { escapeHtml } from "../core/html.js";
       label,
       value = "",
       key = "",
-      active = false,
       status = "",
       statusTone = "",
       statusTitle = "",
@@ -542,7 +541,7 @@ import { escapeHtml } from "../core/html.js";
         : "";
       return `
         <div
-          class="oq-settings-source-row${active ? " is-warning" : ""}${status ? " has-status" : ""}${effective ? " is-effective" : ""}"
+          class="oq-settings-source-row${effective ? " is-effective" : ""}"
           ${safeSourceKind ? `data-source-kind="${escapeHtml(safeSourceKind)}"` : ""}
           ${safeSourceState ? `data-source-state="${escapeHtml(safeSourceState)}"` : ""}
           ${effective ? 'data-source-effective="true"' : ""}
@@ -663,14 +662,28 @@ import { escapeHtml } from "../core/html.js";
           : currentUnavailable ? `Huidige bron niet beschikbaar: ${getUnavailableSourceReason(current, config)}` : "",
       };
     };
+    const buildExternalSourceSelect = (stem, externalStem, mqttTopicKey = "", extra = {}) => ({
+      key: `${stem}Source`,
+      label: "Bron",
+      optionLabels: { "API input": "API-invoer" },
+      haKeys: [`${stem}Ha`, `${stem}HaValid`],
+      apiValueKey: `apiInput${externalStem}`,
+      apiValidKey: `apiInput${externalStem}Valid`,
+      mqttTopicKey,
+      ...extra,
+    });
+    const buildExternalSourceKeys = (stem, externalStem, includeMqtt = true) => ({
+      ha: [`${stem}Ha`, `${stem}HaValid`],
+      api: [`apiInput${externalStem}`, `apiInput${externalStem}Valid`, `apiInput${externalStem}Age`],
+      ...(includeMqtt ? { mqtt: [`mqtt${externalStem}`, `mqtt${externalStem}Valid`] } : {}),
+    });
     const buildSourceSignal = ({
       key,
       group,
       title,
       icon = "",
       select,
-      secondarySelect = null,
-      secondarySelects = null,
+      secondarySelects = [],
       summaryValue = "",
       summarySource = "",
       summaryInfo = "",
@@ -682,10 +695,7 @@ import { escapeHtml } from "../core/html.js";
       const mainSelect = select && select.when !== false
         ? renderSourceSelect(select.key, select)
         : { markup: "", warning: "" };
-      const secondaryConfigs = Array.isArray(secondarySelects)
-        ? secondarySelects
-        : secondarySelect ? [secondarySelect] : [];
-      const secondaries = secondaryConfigs
+      const secondaries = secondarySelects
         .filter((config) => config && config.when !== false)
         .map((config) => renderSourceSelect(config.key, config))
         .filter((item) => item.markup);
@@ -789,60 +799,64 @@ import { escapeHtml } from "../core/html.js";
     const externalHeatDemandUsedSource = powerHouseDemandSource === "external"
       ? externalHeatDemandConfiguredSource
       : powerHouseDemandSource === "model" ? "Huismodel" : "—";
-    const sourceSignals = [
-      buildSourceSignal({
-        key: "room-temperature",
+    const buildRoomSignal = ({ key, title, icon, stem, externalStem, mqttTopic, usedSource }) => {
+      const entityStem = `${stem[0].toUpperCase()}${stem.slice(1)}`;
+      return buildSourceSignal({
+        key,
         group: "room-outside",
+        title,
+        icon,
+        select: buildExternalSourceSelect(stem, externalStem, mqttTopic),
+        summaryValue: getSettingsStatValue(stem),
+        summarySource: usedSource,
+        routeWarning: invalidSourceValueWarning(stem),
+        measurementRows: [
+          cicAvailable ? renderSourceRow({ label: "CIC", key: `cic${entityStem}`, sourceKind: "cic", sourceState: "available", effective: sourcesMatch(usedSource, "CIC") }) : "",
+          otAvailable ? renderSourceRow({ label: "OpenTherm", key: `ot${entityStem}`, sourceKind: "ot", sourceState: "available", effective: sourcesMatch(usedSource, "OpenTherm") }) : "",
+          ...renderExternalSourceRows(`${stem}Source`, usedSource, buildExternalSourceKeys(stem, externalStem)),
+        ],
+      });
+    };
+    const buildPermissionSignal = ({ mode, title, icon, usedSource, optionLabels, selectExtra = {}, summaryValue, routeWarning, measurementRows }) => {
+      const stem = `${mode}Enable`;
+      const externalStem = `${mode[0].toUpperCase()}${mode.slice(1)}Enable`;
+      return buildSourceSignal({
+        key: `${mode}-enable`,
+        group: mode,
+        title,
+        icon,
+        select: buildExternalSourceSelect(stem, externalStem, `${mode}_enable`, {
+          optionLabels,
+          keepUnavailableCurrent: true,
+          ...selectExtra,
+        }),
+        summaryValue,
+        summarySource: usedSource,
+        routeWarning,
+        measurementRows: [
+          ...measurementRows,
+          ...renderExternalSourceRows(`${stem}Source`, usedSource, buildExternalSourceKeys(stem, externalStem), (key) => sourceStateText(key, "Toegestaan", "Geblokkeerd")),
+        ],
+      });
+    };
+    const sourceSignals = [
+      buildRoomSignal({
+        key: "room-temperature",
         title: "Kamertemperatuur",
         icon: "thermometer",
-        select: {
-          key: "roomTempSource",
-          label: "Bron",
-          optionLabels: { "API input": "API-invoer" },
-          haKeys: ["roomTempHa", "roomTempHaValid"],
-          apiValueKey: "apiInputRoomTemperature",
-          apiValidKey: "apiInputRoomTemperatureValid",
-          mqttTopicKey: "room_temperature",
-        },
-        summaryValue: getSettingsStatValue("roomTemp"),
-        summarySource: roomTemperatureUsedSource,
-        routeWarning: invalidSourceValueWarning("roomTemp"),
-        measurementRows: [
-          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicRoomTemp", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(roomTemperatureUsedSource, "CIC") }) : "",
-          otAvailable ? renderSourceRow({ label: "OpenTherm", key: "otRoomTemp", sourceKind: "ot", sourceState: "available", effective: sourcesMatch(roomTemperatureUsedSource, "OpenTherm") }) : "",
-          ...renderExternalSourceRows("roomTempSource", roomTemperatureUsedSource, {
-            ha: ["roomTempHa", "roomTempHaValid"],
-            api: ["apiInputRoomTemperature", "apiInputRoomTemperatureValid", "apiInputRoomTemperatureAge"],
-            mqtt: ["mqttRoomTemperature", "mqttRoomTemperatureValid"],
-          }),
-        ],
+        stem: "roomTemp",
+        externalStem: "RoomTemperature",
+        mqttTopic: "room_temperature",
+        usedSource: roomTemperatureUsedSource,
       }),
-      buildSourceSignal({
+      buildRoomSignal({
         key: "room-setpoint",
-        group: "room-outside",
         title: "Kamer setpoint",
         icon: "target",
-        select: {
-          key: "roomSetpointSource",
-          label: "Bron",
-          optionLabels: { "API input": "API-invoer" },
-          haKeys: ["roomSetpointHa", "roomSetpointHaValid"],
-          apiValueKey: "apiInputRoomSetpoint",
-          apiValidKey: "apiInputRoomSetpointValid",
-          mqttTopicKey: "room_setpoint",
-        },
-        summaryValue: getSettingsStatValue("roomSetpoint"),
-        summarySource: roomSetpointUsedSource,
-        routeWarning: invalidSourceValueWarning("roomSetpoint"),
-        measurementRows: [
-          cicAvailable ? renderSourceRow({ label: "CIC", key: "cicRoomSetpoint", sourceKind: "cic", sourceState: "available", effective: sourcesMatch(roomSetpointUsedSource, "CIC") }) : "",
-          otAvailable ? renderSourceRow({ label: "OpenTherm", key: "otRoomSetpoint", sourceKind: "ot", sourceState: "available", effective: sourcesMatch(roomSetpointUsedSource, "OpenTherm") }) : "",
-          ...renderExternalSourceRows("roomSetpointSource", roomSetpointUsedSource, {
-            ha: ["roomSetpointHa", "roomSetpointHaValid"],
-            api: ["apiInputRoomSetpoint", "apiInputRoomSetpointValid", "apiInputRoomSetpointAge"],
-            mqtt: ["mqttRoomSetpoint", "mqttRoomSetpointValid"],
-          }),
-        ],
+        stem: "roomSetpoint",
+        externalStem: "RoomSetpoint",
+        mqttTopic: "room_setpoint",
+        usedSource: roomSetpointUsedSource,
       }),
       buildSourceSignal({
         key: "water-supply",
@@ -850,11 +864,11 @@ import { escapeHtml } from "../core/html.js";
         title: "Aanvoertemperatuur",
         icon: "droplet",
         select: { key: "waterSupplySource", label: "Bron", haKeys: ["waterSupplyTempHa", "waterSupplyTempHaValid"] },
-        secondarySelect: {
+        secondarySelects: [{
           key: "localWaterSupplyTempSource",
           label: "Lokale sensor",
           when: currentWaterSupplySource === "Local" && hasEntity("localWaterSupplyTempSource"),
-        },
+        }],
         summaryValue: getSettingsStatValue("supplyTemp"),
         summarySource: waterSupplyUsedSource,
         summaryInfo: renderSettingsInfoToggle(
@@ -920,88 +934,52 @@ import { escapeHtml } from "../core/html.js";
         warning: currentOutsideTempSource === "MQTT"
           ? "Na een (her)start is de MQTT-buitentemperatuur pas geldig na een nieuwe live publicatie. Tot die tijd ontbreekt de buitentemperatuur en kan OpenQuatt naar CM98 (antivriescirculatie) gaan. De wachttijd hangt af van het publicatie-interval. Overweeg daarom Auto; dan kan OpenQuatt tijdens het wachten een andere geldige buitentemperatuurbron gebruiken."
           : "",
-        select: {
-          key: "outsideTempSource",
+        select: buildExternalSourceSelect("outsideTemp", "OutsideTemperature", "outside_temperature", {
           label: "Buiten bron",
-          optionLabels: { "API input": "API-invoer" },
-          haKeys: ["outsideTempHa", "outsideTempHaValid"],
-          apiValueKey: "apiInputOutsideTemperature",
-          apiValidKey: "apiInputOutsideTemperatureValid",
-          mqttTopicKey: "outside_temperature",
           infoId: "outsideTempSource-auto-info",
           infoCopy: outsideTemperatureAutoInfo,
-        },
+        }),
         summaryValue: getSettingsStatValue("outsideTempSelected"),
         summarySource: outsideTemperatureUsedSource,
         routeWarning: invalidSourceValueWarning("outsideTempSelected"),
         measurementRows: [
           renderSourceRow({ label: "Buitenunit", key: "outsideTempLocalAggregated", sourceKind: "outdoor", sourceState: "available", effective: sourcesMatch(outsideTemperatureUsedSource, "Buitenunit") }),
-          ...renderExternalSourceRows("outsideTempSource", outsideTemperatureUsedSource, {
-            ha: ["outsideTempHa", "outsideTempHaValid"],
-            api: ["apiInputOutsideTemperature", "apiInputOutsideTemperatureValid", "apiInputOutsideTemperatureAge"],
-            mqtt: ["mqttOutsideTemperature", "mqttOutsideTemperatureValid"],
-          }),
+          ...renderExternalSourceRows("outsideTempSource", outsideTemperatureUsedSource, buildExternalSourceKeys("outsideTemp", "OutsideTemperature")),
         ],
       }),
-      buildSourceSignal({
-        key: "heating-enable",
-        group: "heating",
+      buildPermissionSignal({
+        mode: "heating",
         title: "Warmtetoestemming",
         icon: "flame",
-        select: {
-          key: "heatingEnableSource",
-          label: "Bron",
-          optionLabels: heatingEnableSourceLabels,
+        usedSource: heatingEnableUsedSource,
+        optionLabels: heatingEnableSourceLabels,
+        selectExtra: {
           infoId: "heatingEnableSource-info",
           infoCopy: "Niet gebruiken = geen externe gate; de strategie bepaalt zelf of warmte nodig is.",
-          haKeys: ["heatingEnableHa", "heatingEnableHaValid"],
-          apiValueKey: "apiInputHeatingEnable",
-          apiValidKey: "apiInputHeatingEnableValid",
-          mqttTopicKey: "heating_enable",
-          keepUnavailableCurrent: true,
         },
         summaryValue: heatingEnableSourceDisabled
           ? "Niet gebruikt"
           : sourceStateText("heatingEnableSelected", "Toegestaan", "Geblokkeerd"),
-        summarySource: heatingEnableUsedSource,
         routeWarning: heatingEnableSourceDisabled ? "" : invalidSourceValueWarning("heatingEnableSelected"),
         measurementRows: [
           otAvailable ? renderSourceRow({ label: "OpenTherm", value: sourceStateText("otThermostatChEnable", "Toegestaan", "Geblokkeerd"), sourceKind: "ot", sourceState: "available", effective: sourcesMatch(heatingEnableUsedSource, "OpenTherm") }) : "",
           cicAvailable ? renderSourceRow({ label: "CIC", value: sourceStateText("cicChEnabled", "Toegestaan", "Geblokkeerd"), sourceKind: "cic", sourceState: "available", effective: sourcesMatch(heatingEnableUsedSource, "CIC") }) : "",
-          ...renderExternalSourceRows("heatingEnableSource", heatingEnableUsedSource, {
-            ha: ["heatingEnableHa", "heatingEnableHaValid"],
-            api: ["apiInputHeatingEnable", "apiInputHeatingEnableValid", "apiInputHeatingEnableAge"],
-            mqtt: ["mqttHeatingEnable", "mqttHeatingEnableValid"],
-          }, (key) => sourceStateText(key, "Toegestaan", "Geblokkeerd")),
         ],
       }),
-      buildSourceSignal({
-        key: "cooling-enable",
-        group: "cooling",
+      buildPermissionSignal({
+        mode: "cooling",
         title: "Koeltoestemming",
         icon: "snowflake",
-        select: {
-          key: "coolingEnableSource",
-          label: "Bron",
-          optionLabels: coolingEnableSourceLabels,
+        usedSource: coolingEnableUsedSource,
+        optionLabels: coolingEnableSourceLabels,
+        selectExtra: {
           hiddenOptions: ["CIC", "CIC or HA input"],
-          haKeys: ["coolingEnableHa", "coolingEnableHaValid"],
-          apiValueKey: "apiInputCoolingEnable",
-          apiValidKey: "apiInputCoolingEnableValid",
-          mqttTopicKey: "cooling_enable",
-          keepUnavailableCurrent: true,
         },
         summaryValue: sourceStateText("coolingEnableSelected", "Toegestaan", "Geblokkeerd"),
-        summarySource: coolingEnableUsedSource,
         routeWarning: invalidSourceValueWarning("coolingEnableSelected"),
         measurementRows: [
           renderSourceRow({ label: "Handmatig", value: sourceStateText("manualCoolingEnable", "Aan", "Uit"), sourceKind: "manual", sourceState: "available", effective: sourcesMatch(coolingEnableUsedSource, "Handmatig") }),
           otAvailable ? renderSourceRow({ label: "OpenTherm", value: sourceStateText("otThermostatCoolingEnable", "Toegestaan", "Geblokkeerd"), sourceKind: "ot", sourceState: "available", effective: sourcesMatch(coolingEnableUsedSource, "OpenTherm") }) : "",
-          ...renderExternalSourceRows("coolingEnableSource", coolingEnableUsedSource, {
-            ha: ["coolingEnableHa", "coolingEnableHaValid"],
-            api: ["apiInputCoolingEnable", "apiInputCoolingEnableValid", "apiInputCoolingEnableAge"],
-            mqtt: ["mqttCoolingEnable", "mqttCoolingEnableValid"],
-          }, (key) => sourceStateText(key, "Toegestaan", "Geblokkeerd")),
         ],
       }),
       buildSourceSignal({
@@ -1009,28 +987,17 @@ import { escapeHtml } from "../core/html.js";
         group: "cooling",
         title: "Koelingsdauwpunt",
         icon: "thermometer",
-        select: {
-          key: "coolingDewPointSource",
-          label: "Bron",
-          optionLabels: { "API input": "API-invoer" },
-          haKeys: ["coolingDewPointHa", "coolingDewPointHaValid"],
-          apiValueKey: "apiInputCoolingDewPoint",
-          apiValidKey: "apiInputCoolingDewPointValid",
-          mqttTopicKey: "cooling_dew_point",
+        select: buildExternalSourceSelect("coolingDewPoint", "CoolingDewPoint", "cooling_dew_point", {
           infoId: "coolingDewPointSource-info",
           infoCopy: mqttAvailable
             ? "Auto gebruikt de hoogste geldige waarde als Home Assistant, API-invoer en MQTT tegelijk geldig zijn. Kies Home Assistant, API input of MQTT om die bron expliciet te vereisen."
             : "Auto gebruikt een geldige Home Assistant-waarde wanneer die beschikbaar is. Kies Home Assistant om die bron expliciet te vereisen.",
-        },
+        }),
         summaryValue: getSettingsStatValue("coolingDewPointSelected"),
         summarySource: coolingDewPointUsedSource,
         routeWarning: invalidSourceValueWarning("coolingDewPointSelected"),
         measurementRows: [
-          ...renderExternalSourceRows("coolingDewPointSource", coolingDewPointUsedSource, {
-            ha: ["coolingDewPointHa", "coolingDewPointHaValid"],
-            api: ["apiInputCoolingDewPoint", "apiInputCoolingDewPointValid", "apiInputCoolingDewPointAge"],
-            mqtt: ["mqttCoolingDewPoint", "mqttCoolingDewPointValid"],
-          }),
+          ...renderExternalSourceRows("coolingDewPointSource", coolingDewPointUsedSource, buildExternalSourceKeys("coolingDewPoint", "CoolingDewPoint")),
         ],
       }),
       buildSourceSignal({
@@ -1038,25 +1005,17 @@ import { escapeHtml } from "../core/html.js";
         group: "heating",
         title: "Externe warmtevraag",
         icon: "zap",
-        select: {
-          key: "externalHeatDemandSource",
-          label: "Bron",
+        select: buildExternalSourceSelect("externalHeatDemand", "ExternalHeatDemand", "", {
           optionLabels: { Disabled: "Niet gebruiken", "API input": "API-invoer" },
-          haKeys: ["externalHeatDemandHa", "externalHeatDemandHaValid"],
-          apiValueKey: "apiInputExternalHeatDemand",
-          apiValidKey: "apiInputExternalHeatDemandValid",
           infoCopy: "Vervangt alleen de vermogensschatting van het huismodel in Power House. Valt de bron weg of veroudert hij, dan rekent Power House weer met het huismodel.",
-        },
+        }),
         summaryValue: getSettingsStatValue("externalHeatDemandSelected"),
         summarySource: externalHeatDemandUsedSource,
         routeWarning: String(getEntityValue("externalHeatDemandSource") || "") === "Disabled"
           ? ""
           : invalidSourceValueWarning("externalHeatDemandSelected"),
         measurementRows: [
-          ...renderExternalSourceRows("externalHeatDemandSource", externalHeatDemandUsedSource, {
-            ha: ["externalHeatDemandHa", "externalHeatDemandHaValid"],
-            api: ["apiInputExternalHeatDemand", "apiInputExternalHeatDemandValid", "apiInputExternalHeatDemandAge"],
-          }),
+          ...renderExternalSourceRows("externalHeatDemandSource", externalHeatDemandUsedSource, buildExternalSourceKeys("externalHeatDemand", "ExternalHeatDemand", false)),
         ],
       }),
     ].filter(Boolean);
@@ -1066,30 +1025,10 @@ import { escapeHtml } from "../core/html.js";
     }
 
     const sourceCategories = [
-      {
-        id: "room-outside",
-        title: "Ruimte & buiten",
-        icon: "home-cog",
-        keys: ["room-temperature", "room-setpoint", "outside-temperature"],
-      },
-      {
-        id: "water-circuit",
-        title: "Watercircuit",
-        icon: "droplet",
-        keys: ["water-supply", "flow-source"],
-      },
-      {
-        id: "heating",
-        title: "Verwarmen",
-        icon: "flame",
-        keys: ["external-heat-demand", "heating-enable"],
-      },
-      {
-        id: "cooling",
-        title: "Koelen",
-        icon: "snowflake",
-        keys: ["cooling-enable", "cooling-dew-point"],
-      },
+      { id: "room-outside", title: "Ruimte & buiten", icon: "home-cog", keys: ["room-temperature", "room-setpoint", "outside-temperature"] },
+      { id: "water-circuit", title: "Watercircuit", icon: "droplet", keys: ["water-supply", "flow-source"] },
+      { id: "heating", title: "Verwarmen", icon: "flame", keys: ["external-heat-demand", "heating-enable"] },
+      { id: "cooling", title: "Koelen", icon: "snowflake", keys: ["cooling-enable", "cooling-dew-point"] },
     ];
     const signalByKey = new Map(sourceSignals.map((signal) => [signal.key, signal]));
     const visibleCategories = sourceCategories
@@ -1111,7 +1050,7 @@ import { escapeHtml } from "../core/html.js";
         const active = signal.key === focusedSignal.key;
         return `
           <button
-            class="oq-settings-source-signal${active ? " is-active" : ""}${signal.warningCopy ? " is-warning" : ""}"
+            class="oq-settings-source-signal${signal.warningCopy ? " is-warning" : ""}"
             type="button"
             data-oq-action="select-settings-source"
             data-source-key="${escapeHtml(signal.key)}"

--- a/openquatt/web/js/src/views/shell.js
+++ b/openquatt/web/js/src/views/shell.js
@@ -4,6 +4,7 @@ import { getSettingsRenderSignature } from "../core/render-signatures.js";
 import { escapeHtml } from "../core/html.js";
 import { renderModalShell, syncModalFocus } from "../core/modal-shell.js";
 import { captureModalContinuity, restoreModalContinuity } from "../core/modal-continuity.js";
+import { captureSettingsFocusContinuity, restoreSettingsFocusContinuity } from "../core/settings-focus-continuity.js";
 import { setRenderCallback } from "../core/render-scheduler.js";
 import { state } from "../core/state.js";
 import { clearLegacyMotionVariables, startMotionLoop, stopMotionLoop } from "../core/motion.js";
@@ -20,39 +21,8 @@ import { renderControlReplayView } from "../features/control-replay-view.js";
 import { renderOverviewView, syncTechTooltipLayers } from "./heatpump.js";
 import { renderDiagnosisView, syncOverviewTrendInteractions } from "./overview.js";
 
-function captureFocusedSettingsField() {
-  const active = document.activeElement;
-  if (state.appView !== "settings" || !state.root?.contains(active) || !active?.dataset?.oqField) {
-    return null;
-  }
-  return {
-    field: active.dataset.oqField,
-    modalId: active.closest("[data-oq-modal]")?.dataset.oqModal || "",
-    selectionStart: active.selectionStart,
-    selectionEnd: active.selectionEnd,
-  };
-}
-
-function restoreFocusedSettingsField(focusState) {
-  if (!focusState || !state.root) {
-    return;
-  }
-
-  const modal = document.activeElement.closest("[data-oq-modal]");
-  if ((modal?.dataset.oqModal || "") !== focusState.modalId) {
-    return;
-  }
-
-  const input = (modal || state.root).querySelector(`[data-oq-field="${focusState.field}"]`);
-  if (!input || input.disabled) {
-    return;
-  }
-
-  input.focus({ preventScroll: true });
-  if (typeof focusState.selectionStart === "number" && typeof input.setSelectionRange === "function") {
-    input.setSelectionRange(focusState.selectionStart, focusState.selectionEnd);
-  }
-}
+const captureFocusedSettingsField = () => captureSettingsFocusContinuity(state.root, state.appView);
+const restoreFocusedSettingsField = (focusState) => restoreSettingsFocusContinuity(state.root, focusState);
 
 export function renderSettingsView() {
     return `

--- a/openquatt/web/tests/settings-integrations.test.mjs
+++ b/openquatt/web/tests/settings-integrations.test.mjs
@@ -3,13 +3,17 @@ import test from "node:test";
 
 globalThis.__OQ_PREVIEW__ = false;
 globalThis.window = {
+  requestAnimationFrame: (callback) => callback(),
   localStorage: {
     getItem: () => null,
   },
 };
 
 const { state } = await import("../js/src/core/state.js");
+const { setRenderCallback } = await import("../js/src/core/render-scheduler.js");
 const { SETTINGS_GROUP_KEY_MAP } = await import("../js/src/core/entity-sync.js");
+const { handleViewAction } = await import("../js/src/features/view-actions.js");
+const { captureSettingsFocusContinuity, restoreSettingsFocusContinuity } = await import("../js/src/core/settings-focus-continuity.js");
 const { renderSettingsOpenThermCicSection, renderSettingsSensorSelectionSection } = await import("../js/src/settings/integrations.js");
 
 const MQTT_SOURCE_SELECT_KEYS = [
@@ -21,15 +25,61 @@ const MQTT_SOURCE_SELECT_KEYS = [
   "coolingDewPointSource",
 ];
 
+const SOURCE_KEY_BY_SELECT_KEY = {
+  roomTempSource: "room-temperature",
+  roomSetpointSource: "room-setpoint",
+  outsideTempSource: "outside-temperature",
+  heatingEnableSource: "heating-enable",
+  coolingEnableSource: "cooling-enable",
+  coolingDewPointSource: "cooling-dew-point",
+};
+
 function getSelectMarkup(markup, key) {
   const match = markup.match(new RegExp(`<select[^>]+data-oq-field="${key}"[^>]*>([\\s\\S]*?)<\\/select>`));
   assert.ok(match, `select ${key} ontbreekt`);
   return match[1];
 }
 
+function getInspectorMarkup(markup) {
+  const match = markup.match(/<article\s+[\s\S]*?data-oq-source-inspector[\s\S]*?<\/article>/);
+  assert.ok(match, "focus-inspector ontbreekt");
+  return match[0];
+}
+
+function getCategoryMarkup(markup, key) {
+  const match = markup.match(new RegExp(`<section[^>]+data-source-category="${key}"[\\s\\S]*?<\\/section>`));
+  assert.ok(match, `broncategorie ${key} ontbreekt`);
+  return match[0];
+}
+
+function assertMarkupOrder(markup, values) {
+  let previousIndex = -1;
+  values.forEach((value) => {
+    const index = markup.indexOf(value);
+    assert.ok(index > previousIndex, `${value} staat niet in de verwachte volgorde`);
+    previousIndex = index;
+  });
+}
+
+function renderFocusedSource(key) {
+  state.settingsSourceFocusKey = key;
+  return renderSettingsSensorSelectionSection();
+}
+
+function binaryEntity(active) {
+  return { value: active, state: active ? "ON" : "OFF" };
+}
+
+function valueEntity(value, uom = "") {
+  return { value, state: value == null ? "nan" : String(value), uom };
+}
+
 function setSourceSelectionState(mqttEnabled) {
   state.loadingEntities = false;
   state.drafts = {};
+  state.settingsInfoOpen = "";
+  state.settingsSourceFocusKey = "room-temperature";
+  state.settingsSourceDetailOpen = true;
   state.mqttStatus = {
     enabled: mqttEnabled,
     input_enabled: {
@@ -42,12 +92,57 @@ function setSourceSelectionState(mqttEnabled) {
     },
   };
   state.entities = {
-    roomTempSource: { value: "OT thermostat", option: ["OT thermostat", "MQTT"] },
-    roomSetpointSource: { value: "OT thermostat", option: ["OT thermostat", "MQTT"] },
-    outsideTempSource: { value: "Outdoor unit", option: ["Outdoor unit", "MQTT"] },
-    heatingEnableSource: { value: "Disabled", option: ["Disabled", "MQTT"] },
-    coolingEnableSource: { value: "Disabled", option: ["Disabled", "MQTT"] },
-    coolingDewPointSource: { value: "Auto", option: ["Auto", "MQTT"] },
+    otEnabled: binaryEntity(true),
+    cicPollingEnabled: binaryEntity(true),
+    roomTempSource: { value: "OT thermostat", option: ["OT thermostat", "CIC", "HA input", "API input", "MQTT"] },
+    roomSetpointSource: { value: "OT thermostat", option: ["OT thermostat", "CIC", "HA input", "API input", "MQTT"] },
+    waterSupplySource: { value: "Local", option: ["Local", "CIC", "HA input"] },
+    localWaterSupplyTempSource: { value: "PT1000", option: ["PT1000", "DS18B20"] },
+    flowSource: { value: "Outdoor unit", option: ["Outdoor unit", "CIC"] },
+    qFlowSource: { value: "Auto", option: ["Auto", "Local", "Outdoor unit"] },
+    outdoorUnitFlowMode: { value: "Local aggregate HP1/HP2", option: ["Flowmeter HP1", "Flowmeter HP2", "Local aggregate HP1/HP2"] },
+    outsideTempSource: { value: "Outdoor unit", option: ["Auto", "Outdoor unit", "HA input", "API input", "MQTT"] },
+    heatingEnableSource: { value: "Disabled", option: ["Disabled", "OT thermostat", "CIC", "HA input", "API input", "MQTT"] },
+    coolingEnableSource: { value: "Disabled", option: ["Disabled", "OT thermostat", "HA input", "API input", "MQTT"] },
+    coolingDewPointSource: { value: "Auto", option: ["Auto", "Home Assistant", "API input", "MQTT"] },
+    externalHeatDemandSource: { value: "Disabled", option: ["Disabled", "HA input", "API input"] },
+    roomTemp: valueEntity(21.8, "°C"),
+    roomTempEffectiveSource: valueEntity("OT thermostat"),
+    roomSetpoint: valueEntity(20, "°C"),
+    roomSetpointEffectiveSource: valueEntity("OT thermostat"),
+    supplyTemp: valueEntity(31.4, "°C"),
+    waterSupplyTempEffectiveSource: valueEntity("PT1000"),
+    waterSupplyTempEsp: valueEntity(31.4, "°C"),
+    waterSupplyTempPt1000: valueEntity(31.4, "°C"),
+    waterSupplyTempDs18b20: valueEntity(31.2, "°C"),
+    flowSelected: valueEntity(788, "L/h"),
+    controllerFlow: valueEntity(782, "L/h"),
+    flowLocal: valueEntity(788, "L/h"),
+    hp1Flow: valueEntity(790, "L/h"),
+    hp2Flow: valueEntity(786, "L/h"),
+    outsideTempSelected: valueEntity(17.2, "°C"),
+    outsideTempLocalAggregated: valueEntity(17.2, "°C"),
+    heatingEnableSelected: binaryEntity(true),
+    heatingEnableEffectiveSource: valueEntity("None"),
+    coolingEnableSelected: binaryEntity(false),
+    coolingEnableEffectiveSource: valueEntity("Manual"),
+    manualCoolingEnable: binaryEntity(false),
+    coolingDewPointSelected: valueEntity(15.8, "°C"),
+    externalHeatDemandSelected: valueEntity(0, "kW"),
+    powerHouseDemandSource: valueEntity("model"),
+    cicRoomTemp: valueEntity(21.7, "°C"),
+    cicRoomSetpoint: valueEntity(20, "°C"),
+    cicWaterSupplyTemp: valueEntity(31.3, "°C"),
+    cicFlowrate: valueEntity(780, "L/h"),
+    cicChEnabled: binaryEntity(true),
+    otRoomTemp: valueEntity(21.8, "°C"),
+    otRoomSetpoint: valueEntity(20, "°C"),
+    otThermostatChEnable: binaryEntity(true),
+    otThermostatCoolingEnable: binaryEntity(false),
+    roomTempHa: valueEntity(21.6, "°C"),
+    roomTempHaValid: binaryEntity(true),
+    apiInputRoomTemperature: valueEntity(0, "°C"),
+    apiInputRoomTemperatureValid: binaryEntity(false),
     mqttRoomTemperature: { value: 20, uom: "°C" },
     mqttRoomTemperatureValid: { value: true, state: "ON" },
     mqttRoomSetpoint: { value: 20, uom: "°C" },
@@ -86,46 +181,400 @@ test("CIC-diagnostiek toont waterdruk alleen wanneer de sensor aanwezig is", () 
   assert.ok(SETTINGS_GROUP_KEY_MAP.integrations.includes("cicBoilerWaterPressure"));
 });
 
+test("focuspaneel groepeert alle signalen in vaste volgorde en rendert één inspector", () => {
+  setSourceSelectionState(true);
+  Object.assign(state.entities, {
+    outsideTempSource: { value: "Auto", option: ["Auto", "Outdoor unit", "HA input", "API input", "MQTT"] },
+    outsideTempHa: valueEntity(16.6, "°C"),
+    outsideTempHaValid: binaryEntity(true),
+  });
+  state.mqttStatus.input_enabled.outside_temperature = false;
+  const markup = renderSettingsSensorSelectionSection();
+
+  assert.match(markup, /data-oq-source-workspace/);
+  assert.equal((markup.match(/data-source-category=/g) || []).length, 4);
+  assert.equal((markup.match(/data-oq-action="select-settings-source"/g) || []).length, 9);
+  assert.equal((markup.match(/data-oq-focus-key="settings-source-[^"]+"/g) || []).length, 10);
+  assert.equal((markup.match(/\sdata-oq-source-inspector(?:\s|>)/g) || []).length, 1);
+  assertMarkupOrder(markup, [
+    'data-source-category="room-outside"',
+    'data-source-category="water-circuit"',
+    'data-source-category="heating"',
+    'data-source-category="cooling"',
+  ]);
+  assertMarkupOrder(getCategoryMarkup(markup, "room-outside"), [
+    'data-source-key="room-temperature"',
+    'data-source-key="room-setpoint"',
+    'data-source-key="outside-temperature"',
+  ]);
+  assertMarkupOrder(getCategoryMarkup(markup, "water-circuit"), [
+    'data-source-key="water-supply"',
+    'data-source-key="flow-source"',
+  ]);
+  assertMarkupOrder(getCategoryMarkup(markup, "heating"), [
+    'data-source-key="external-heat-demand"',
+    'data-source-key="heating-enable"',
+  ]);
+  assertMarkupOrder(getCategoryMarkup(markup, "cooling"), [
+    'data-source-key="cooling-enable"',
+    'data-source-key="cooling-dew-point"',
+  ]);
+  assert.match(getInspectorMarkup(markup), /data-source-key="room-temperature"/);
+  assert.match(getInspectorMarkup(markup), /data-oq-focus-key="settings-source-detail-back"/);
+  assert.match(getCategoryMarkup(markup, "room-outside"), /aria-label="Ingesteld: Auto\. Gebruikt: HA-invoer"/);
+  assert.match(getCategoryMarkup(markup, "room-outside"), /<span>Auto<\/span>[\s\S]*?<span class="oq-settings-source-signal-source-arrow" aria-hidden="true">→<\/span>[\s\S]*?<span>HA-invoer<\/span>/);
+  assert.doesNotMatch(markup, /Bronwaarden tonen|>Relevant<|>Alles</);
+});
+
+test("focus blijft behouden bij nieuwe bronwaarden en valt veilig terug wanneer het signaal ontbreekt", () => {
+  setSourceSelectionState(true);
+  state.settingsInfoOpen = "mqttRoomTemperature-info";
+  assert.equal(handleViewAction("select-settings-source", { dataset: { sourceKey: "cooling-dew-point" } }), true);
+  assert.equal(state.settingsSourceFocusKey, "cooling-dew-point");
+  assert.equal(state.settingsSourceDetailOpen, true);
+  assert.equal(state.settingsInfoOpen, "");
+
+  let markup = renderSettingsSensorSelectionSection();
+  assert.match(getInspectorMarkup(markup), /data-source-key="cooling-dew-point"/);
+  assert.match(getSelectMarkup(markup, "coolingDewPointSource"), /<option value="Auto" selected>/);
+  assert.equal((getInspectorMarkup(markup).match(/<select\b/g) || []).length, 1);
+
+  state.entities.coolingDewPointSelected = valueEntity(16.1, "°C");
+  markup = renderSettingsSensorSelectionSection();
+  assert.equal(state.settingsSourceFocusKey, "cooling-dew-point");
+  assert.match(getInspectorMarkup(markup), /data-source-key="cooling-dew-point"/);
+  assert.match(getInspectorMarkup(markup), /16\.1 °C/);
+
+  state.settingsSourceFocusKey = "niet-bestaand-signaal";
+  markup = renderSettingsSensorSelectionSection();
+  assert.equal(state.settingsSourceFocusKey, "room-temperature");
+  assert.match(getInspectorMarkup(markup), /data-source-key="room-temperature"/);
+});
+
+test("mobiele bronnavigatie draagt focus en scroll over tussen lijst en inspector", () => {
+  setSourceSelectionState(true);
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  let queuedFrame = null;
+  const events = [];
+  const backButton = {
+    offsetParent: {},
+    focus: (options) => events.push(["back-focus", options]),
+  };
+  const inspector = {
+    querySelector: () => backButton,
+    scrollIntoView: (options) => events.push(["inspector-scroll", options]),
+  };
+  const signal = {
+    focus: (options) => events.push(["signal-focus", options]),
+    scrollIntoView: (options) => events.push(["signal-scroll", options]),
+  };
+  state.root = {
+    querySelector: (selector) => selector === "[data-oq-source-inspector]" ? inspector : signal,
+  };
+  setRenderCallback(() => {});
+  window.requestAnimationFrame = (callback) => {
+    queuedFrame = callback;
+  };
+
+  handleViewAction("select-settings-source", { dataset: { sourceKey: "water-supply" } });
+  queuedFrame();
+  assert.deepEqual(events, [
+    ["inspector-scroll", { block: "start", behavior: "auto" }],
+    ["back-focus", { preventScroll: true }],
+  ]);
+
+  events.length = 0;
+  handleViewAction("close-settings-source-detail", { dataset: {} });
+  queuedFrame();
+  assert.deepEqual(events, [
+    ["signal-focus", { preventScroll: true }],
+    ["signal-scroll", { block: "nearest", behavior: "auto" }],
+  ]);
+
+  state.root = null;
+  window.requestAnimationFrame = originalRequestAnimationFrame;
+});
+
+test("bronnavigatiefocus wordt over een poll-render hersteld zonder invoervelden te blokkeren", () => {
+  setSourceSelectionState(true);
+  const originalDocument = globalThis.document;
+  const focusEvents = [];
+  const activeSignal = {
+    dataset: { oqFocusKey: "settings-source-room-temperature" },
+    closest: () => null,
+  };
+  const replacementSignal = {
+    disabled: false,
+    focus: (options) => focusEvents.push(options),
+  };
+  state.appView = "settings";
+  state.focusedField = "";
+  state.root = {
+    contains: (element) => element === activeSignal,
+    querySelector: (selector) => selector === '[data-oq-focus-key="settings-source-room-temperature"]'
+      ? replacementSignal
+      : null,
+  };
+  globalThis.document = { activeElement: activeSignal };
+
+  const continuity = captureSettingsFocusContinuity(state.root, state.appView, globalThis.document);
+  assert.equal(continuity.focusKey, "settings-source-room-temperature");
+  assert.equal(continuity.field, "");
+  assert.equal(state.focusedField, "");
+
+  state.entities.roomTemp = valueEntity(22.1, "°C");
+  assert.match(renderFocusedSource("room-temperature"), /22\.1 °C/);
+  globalThis.document.activeElement = { closest: () => null };
+  restoreSettingsFocusContinuity(state.root, continuity, globalThis.document);
+  assert.deepEqual(focusEvents, [{ preventScroll: true }]);
+
+  state.root = null;
+  if (originalDocument === undefined) {
+    delete globalThis.document;
+  } else {
+    globalThis.document = originalDocument;
+  }
+});
+
+test("Auto zonder geldige kandidaat toont een bronprobleem", () => {
+  setSourceSelectionState(true);
+  const missing = { value: Number.NaN, state: "nan", uom: "°C" };
+  Object.assign(state.entities, {
+    outsideTempSource: { value: "Auto", option: ["Auto", "Outdoor unit", "HA input", "API input", "MQTT"] },
+    outsideTempSelected: missing,
+    outsideTempLocalAggregated: missing,
+    outsideTempHa: missing,
+    outsideTempHaValid: binaryEntity(false),
+    apiInputOutsideTemperature: missing,
+    apiInputOutsideTemperatureValid: binaryEntity(false),
+    mqttOutsideTemperature: missing,
+    mqttOutsideTemperatureValid: binaryEntity(false),
+  });
+
+  const markup = renderFocusedSource("outside-temperature");
+  assert.match(getInspectorMarkup(markup), /data-oq-source-warning/);
+  assert.match(markup, /aria-label="Bronprobleem: De ingestelde bron levert momenteel geen geldige waarde\."/);
+});
+
+test("Relevant toont geldige bronnen en pint een ongeldige ingestelde of effectieve bron", () => {
+  setSourceSelectionState(true);
+  let inspector = getInspectorMarkup(renderFocusedSource("room-temperature"));
+  assert.match(inspector, /data-source-kind="ha"\s+data-source-state="valid"/);
+  assert.match(inspector, /data-source-kind="mqtt"\s+data-source-state="valid"/);
+  assert.match(inspector, /data-source-kind="ot"\s+data-source-state="available"\s+data-source-effective="true"/);
+  assert.doesNotMatch(inspector, /data-source-kind="api"/);
+
+  state.entities.roomTempHaValid = binaryEntity(false);
+  state.entities.mqttRoomTemperatureValid = binaryEntity(false);
+  inspector = getInspectorMarkup(renderFocusedSource("room-temperature"));
+  assert.doesNotMatch(inspector, /data-source-kind="ha"|data-source-kind="api"|data-source-kind="mqtt"/);
+
+  state.entities.roomTempSource.value = "API input";
+  inspector = getInspectorMarkup(renderFocusedSource("room-temperature"));
+  assert.match(inspector, /data-oq-source-warning/);
+  assert.match(inspector, /data-source-kind="api"\s+data-source-state="missing"/);
+  assert.match(inspector, /data-source-kind="ot"\s+data-source-state="available"\s+data-source-effective="true"/);
+
+  state.entities.roomTempSource.value = "MQTT";
+  inspector = getInspectorMarkup(renderFocusedSource("room-temperature"));
+  assert.match(inspector, /data-oq-source-warning/);
+  assert.match(inspector, /data-source-kind="mqtt"\s+data-source-state="invalid"/);
+
+  state.entities.roomTempSource.value = "HA input";
+  inspector = getInspectorMarkup(renderFocusedSource("room-temperature"));
+  assert.match(inspector, /data-oq-source-warning/);
+  assert.match(inspector, /data-source-kind="ha"\s+data-source-state="invalid"/);
+
+  state.entities.roomTempSource.value = "OT thermostat";
+  state.entities.roomTempEffectiveSource = valueEntity("API input");
+  inspector = getInspectorMarkup(renderFocusedSource("room-temperature"));
+  assert.match(inspector, /data-source-kind="api"\s+data-source-state="missing"\s+data-source-effective="true"/);
+  assert.doesNotMatch(inspector, /data-oq-source-warning/);
+});
+
+test("API-invoer onderscheidt wachten van verouderde data en behoudt geldige false/0-waarden", () => {
+  setSourceSelectionState(true);
+  state.entities.roomTempSource.value = "API input";
+
+  let inspector = getInspectorMarkup(renderFocusedSource("room-temperature"));
+  assert.match(inspector, /data-source-kind="api"\s+data-source-state="missing"/);
+  assert.match(inspector, /Wacht op data/);
+
+  state.entities.apiInputRoomTemperatureAge = valueEntity(180, "s");
+  inspector = getInspectorMarkup(renderFocusedSource("room-temperature"));
+  assert.match(inspector, /data-source-kind="api"\s+data-source-state="stale"/);
+  assert.match(inspector, /Verouderd/);
+
+  Object.assign(state.entities, {
+    apiInputCoolingEnable: binaryEntity(false),
+    apiInputCoolingEnableValid: binaryEntity(true),
+  });
+  inspector = getInspectorMarkup(renderFocusedSource("cooling-enable"));
+  assert.match(inspector, /data-source-kind="api"\s+data-source-state="valid"/);
+  assert.match(inspector, /Geblokkeerd/);
+
+  Object.assign(state.entities, {
+    externalHeatDemandSource: { value: "API input", option: ["Disabled", "HA input", "API input"] },
+    apiInputExternalHeatDemand: valueEntity(0, "kW"),
+    apiInputExternalHeatDemandValid: binaryEntity(true),
+  });
+  inspector = getInspectorMarkup(renderFocusedSource("external-heat-demand"));
+  assert.match(inspector, /data-source-kind="api"\s+data-source-state="valid"/);
+  assert.match(inspector, /<strong>0 kW<\/strong>/);
+});
+
+test("Power House vertaalt de firmwarebron naar de werkelijk gebruikte externe route", () => {
+  setSourceSelectionState(true);
+  Object.assign(state.entities, {
+    externalHeatDemandSource: { value: "API input", option: ["Disabled", "HA input", "API input"] },
+    apiInputExternalHeatDemand: valueEntity(1.4, "kW"),
+    apiInputExternalHeatDemandValid: binaryEntity(true),
+    powerHouseDemandSource: valueEntity("external"),
+  });
+
+  let markup = renderFocusedSource("external-heat-demand");
+  assert.match(markup, /aria-label="Ingesteld: API-invoer\. Gebruikt: API-invoer"/);
+  assert.match(getInspectorMarkup(markup), /data-source-kind="api"\s+data-source-state="valid"\s+data-source-effective="true"/);
+
+  state.entities.powerHouseDemandSource = valueEntity("model");
+  markup = renderFocusedSource("external-heat-demand");
+  assert.match(markup, /aria-label="Ingesteld: API-invoer\. Gebruikt: Huismodel"/);
+  assert.doesNotMatch(getInspectorMarkup(markup), /data-source-kind="api"[^>]+data-source-effective="true"/);
+
+  delete state.entities.powerHouseDemandSource;
+  markup = renderFocusedSource("external-heat-demand");
+  assert.match(markup, /aria-label="Ingesteld: API-invoer\. Gebruikt: —"/);
+});
+
+test("ongeldige Home Assistant-dauwpuntbron blijft zichtbaar als gekozen bronprobleem", () => {
+  setSourceSelectionState(true);
+  Object.assign(state.entities, {
+    coolingDewPointSource: { value: "Home Assistant", option: ["Auto", "Home Assistant", "API input", "MQTT"] },
+    coolingDewPointHa: valueEntity(15.2, "°C"),
+    coolingDewPointHaValid: binaryEntity(false),
+  });
+
+  const markup = renderFocusedSource("cooling-dew-point");
+  assert.match(getInspectorMarkup(markup), /Huidige bron niet beschikbaar: HA-bron ongeldig/);
+  assert.match(getSelectMarkup(markup, "coolingDewPointSource"), /<option value="Home Assistant" selected disabled>Kies een beschikbare bron<\/option>/);
+  assert.doesNotMatch(getSelectMarkup(markup, "coolingDewPointSource"), />Home Assistant<\/option>/);
+  assert.match(getInspectorMarkup(markup), /data-source-kind="ha"\s+data-source-state="invalid"/);
+});
+
+test("uitgeschakelde CIC en OpenTherm verdwijnen uit keuzes en metingen", () => {
+  setSourceSelectionState(true);
+  state.entities.roomTempSource.value = "HA input";
+  state.entities.cicPollingEnabled = binaryEntity(false);
+  state.entities.otEnabled = binaryEntity(false);
+
+  let markup = renderFocusedSource("room-temperature");
+  let inspector = getInspectorMarkup(markup);
+  assert.doesNotMatch(getSelectMarkup(markup, "roomTempSource"), /<option value="(?:CIC|OT thermostat)"/);
+  assert.doesNotMatch(inspector, /data-source-kind="(?:cic|ot)"/);
+
+  state.entities.roomTempSource.value = "OT thermostat";
+  markup = renderFocusedSource("room-temperature");
+  inspector = getInspectorMarkup(markup);
+  assert.match(inspector, /Huidige bron niet beschikbaar: OpenTherm staat uit/);
+  assert.match(getSelectMarkup(markup, "roomTempSource"), /<option value="OT thermostat" selected disabled>Kies een beschikbare bron<\/option>/);
+  assert.doesNotMatch(getSelectMarkup(markup, "roomTempSource"), />OT-thermostaat<\/option>/);
+  assert.doesNotMatch(inspector, /data-source-kind="ot"/);
+
+  state.entities.roomTempSource.value = "CIC";
+  markup = renderFocusedSource("room-temperature");
+  inspector = getInspectorMarkup(markup);
+  assert.match(inspector, /Huidige bron niet beschikbaar: CIC-polling staat uit/);
+  assert.match(getSelectMarkup(markup, "roomTempSource"), /<option value="CIC" selected disabled>Kies een beschikbare bron<\/option>/);
+  assert.doesNotMatch(getSelectMarkup(markup, "roomTempSource"), />CIC<\/option>/);
+  assert.doesNotMatch(inspector, /data-source-kind="cic"/);
+
+  state.entities.coolingEnableSource.value = "CIC";
+  markup = renderFocusedSource("cooling-enable");
+  inspector = getInspectorMarkup(markup);
+  assert.match(inspector, /Huidige legacybron niet beschikbaar: CIC-polling staat uit; kies een nieuwe bron\./);
+  assert.match(getSelectMarkup(markup, "coolingEnableSource"), /<option value="CIC" selected disabled>Kies een beschikbare bron<\/option>/);
+  assert.doesNotMatch(getSelectMarkup(markup, "coolingEnableSource"), />CIC \(legacy\)<\/option>/);
+});
+
+test("secundaire bronselecties blijven alleen zichtbaar wanneer hun hoofdkeuze ze gebruikt", () => {
+  setSourceSelectionState(true);
+
+  let markup = renderFocusedSource("water-supply");
+  assert.match(getSelectMarkup(markup, "localWaterSupplyTempSource"), /<option value="PT1000" selected>/);
+  state.entities.waterSupplySource.value = "CIC";
+  markup = renderFocusedSource("water-supply");
+  assert.doesNotMatch(getInspectorMarkup(markup), /data-oq-field="localWaterSupplyTempSource"/);
+
+  state.entities.flowSource.value = "Outdoor unit";
+  state.entities.qFlowSource.value = "Auto";
+  markup = renderFocusedSource("flow-source");
+  getSelectMarkup(markup, "qFlowSource");
+  getSelectMarkup(markup, "outdoorUnitFlowMode");
+
+  state.entities.qFlowSource.value = "Local";
+  markup = renderFocusedSource("flow-source");
+  getSelectMarkup(markup, "qFlowSource");
+  assert.doesNotMatch(getInspectorMarkup(markup), /data-oq-field="outdoorUnitFlowMode"/);
+
+  state.entities.flowSource.value = "CIC";
+  markup = renderFocusedSource("flow-source");
+  assert.doesNotMatch(getInspectorMarkup(markup), /data-oq-field="qFlowSource"|data-oq-field="outdoorUnitFlowMode"/);
+});
+
 test("MQTT verdwijnt uit alle bronselecties en metingen wanneer de integratie uitstaat", () => {
   setSourceSelectionState(true);
-  const enabledMarkup = renderSettingsSensorSelectionSection();
   MQTT_SOURCE_SELECT_KEYS.forEach((key) => {
+    const enabledMarkup = renderFocusedSource(SOURCE_KEY_BY_SELECT_KEY[key]);
     assert.match(getSelectMarkup(enabledMarkup, key), /<option value="MQTT"/);
   });
-  assert.match(enabledMarkup, /<div class="oq-settings-source-row has-status">\s*<div class="oq-settings-source-row-label">MQTT/);
+  assert.match(renderFocusedSource("room-temperature"), /data-source-kind="mqtt"\s+data-source-state="valid"/);
 
   setSourceSelectionState(false);
-  const disabledMarkup = renderSettingsSensorSelectionSection();
   MQTT_SOURCE_SELECT_KEYS.forEach((key) => {
+    const disabledMarkup = renderFocusedSource(SOURCE_KEY_BY_SELECT_KEY[key]);
     assert.doesNotMatch(getSelectMarkup(disabledMarkup, key), /<option value="MQTT"/);
+    assert.doesNotMatch(getInspectorMarkup(disabledMarkup), /data-source-kind="mqtt"/);
   });
-  assert.doesNotMatch(disabledMarkup, /MQTT/);
 
   MQTT_SOURCE_SELECT_KEYS.forEach((key) => {
     state.entities[key].value = "MQTT";
-  });
-  const disabledCurrentMarkup = renderSettingsSensorSelectionSection();
-  MQTT_SOURCE_SELECT_KEYS.forEach((key) => {
+    const disabledCurrentMarkup = renderFocusedSource(SOURCE_KEY_BY_SELECT_KEY[key]);
     const selectMarkup = getSelectMarkup(disabledCurrentMarkup, key);
-    assert.match(selectMarkup, /<option value="" selected disabled>Kies een beschikbare bron<\/option>/);
-    assert.doesNotMatch(selectMarkup, /<option value="MQTT"/);
+    assert.match(selectMarkup, /<option value="MQTT" selected disabled>Kies een beschikbare bron<\/option>/);
+    assert.doesNotMatch(selectMarkup, />MQTT<\/option>/);
+    assert.match(getInspectorMarkup(disabledCurrentMarkup), /Huidige bron niet beschikbaar: MQTT staat uit/);
+    assert.doesNotMatch(getInspectorMarkup(disabledCurrentMarkup), /data-source-kind="mqtt"/);
   });
-  assert.match(disabledCurrentMarkup, /Huidige bron niet beschikbaar: MQTT staat uit/);
-  assert.doesNotMatch(disabledCurrentMarkup, /MQTT-topic staat uit/);
+});
+
+test("een uitgeschakeld MQTT-inputtopic verdwijnt alleen bij het bijbehorende signaal", () => {
+  setSourceSelectionState(true);
+  state.mqttStatus.input_enabled.room_temperature = false;
+
+  let markup = renderFocusedSource("room-temperature");
+  assert.doesNotMatch(getSelectMarkup(markup, "roomTempSource"), /<option value="MQTT"/);
+  assert.doesNotMatch(getInspectorMarkup(markup), /data-source-kind="mqtt"/);
+  assert.match(getSelectMarkup(renderFocusedSource("room-setpoint"), "roomSetpointSource"), /<option value="MQTT"/);
+
+  state.entities.roomTempSource.value = "MQTT";
+  markup = renderFocusedSource("room-temperature");
+  assert.match(getSelectMarkup(markup, "roomTempSource"), /<option value="MQTT" selected disabled>Kies een beschikbare bron<\/option>/);
+  assert.match(getInspectorMarkup(markup), /Huidige bron niet beschikbaar: MQTT-topic staat uit/);
+  assert.doesNotMatch(getInspectorMarkup(markup), /data-source-kind="mqtt"/);
 });
 
 test("MQTT als buitentemperatuurbron waarschuwt voor ontbrekende opstartwaarde en CM98", () => {
   setSourceSelectionState(true);
   state.entities.outsideTempSource.value = "MQTT";
 
-  const mqttMarkup = renderSettingsSensorSelectionSection();
+  const mqttMarkup = renderFocusedSource("outside-temperature");
   assert.match(mqttMarkup, /Na een \(her\)start is de MQTT-buitentemperatuur pas geldig na een nieuwe live publicatie\./);
   assert.match(mqttMarkup, /kan OpenQuatt naar CM98 \(antivriescirculatie\) gaan/);
   assert.match(mqttMarkup, /De wachttijd hangt af van het publicatie-interval\./);
   assert.match(mqttMarkup, /Overweeg daarom Auto; dan kan OpenQuatt tijdens het wachten een andere geldige buitentemperatuurbron gebruiken\./);
 
   state.entities.outsideTempSource.value = "Outdoor unit";
-  const outdoorUnitMarkup = renderSettingsSensorSelectionSection();
+  const outdoorUnitMarkup = renderFocusedSource("outside-temperature");
   assert.doesNotMatch(outdoorUnitMarkup, /kan OpenQuatt naar CM98 \(antivriescirculatie\) gaan/);
 });
 
@@ -154,12 +603,14 @@ test("ongeldige PT1000 toont geen misleidende nulwaarde", () => {
     pt1000ReadProblem: { value: true, state: "ON" },
   });
 
-  const markup = renderSettingsSensorSelectionSection();
+  const markup = renderFocusedSource("water-supply");
 
   assert.match(markup, /<div class="oq-settings-source-row-label">PT1000<\/div>\s*<strong>—<\/strong>/);
   assert.doesNotMatch(markup, /<div class="oq-settings-source-row-label">PT1000<\/div>\s*<strong>0 °C<\/strong>/);
   assert.match(markup, /<div class="oq-settings-source-row-label">DS18B20<\/div>\s*<strong>0 °C<\/strong>/);
-  assert.match(markup, /<div class="oq-settings-source-row-label">Bron<\/div>\s*<strong>HP2 uitgaand water \(fallback\)<\/strong>/);
+  assert.match(getInspectorMarkup(markup), /<span>Gebruikt<\/span>[\s\S]*?<span>HP2 uitgaand water \(fallback\)<\/span>/);
+  assert.match(getInspectorMarkup(markup), /De ingestelde lokale PT1000-bron levert geen geldige waarde; OpenQuatt gebruikt een fallback\./);
+  assert.match(markup, /aria-label="Bronprobleem: De ingestelde lokale PT1000-bron levert geen geldige waarde; OpenQuatt gebruikt een fallback\."/);
 });
 
 test("gewijzigde bronconfiguratie toont dat de aanvoerkalibratie opnieuw moet", () => {
@@ -172,9 +623,9 @@ test("gewijzigde bronconfiguratie toont dat de aanvoerkalibratie opnieuw moet", 
     waterSupplyCalibrationRequired: { value: true, state: "ON" },
   });
 
-  const markup = renderSettingsSensorSelectionSection();
+  const markup = renderFocusedSource("water-supply");
 
-  assert.match(markup, /Gebruikte waarde\s*<div class="oq-settings-info oq-settings-source-info oq-settings-source-info--error oq-settings-source-info--circle"/);
+  assert.match(markup, /class="oq-settings-info oq-settings-source-info oq-settings-source-info--error oq-settings-source-info--circle"/);
   assert.match(markup, /<button[^>]*data-oq-action="toggle-settings-info"[^>]*data-info-id="supplyTemp-info"[^>]*aria-expanded="false"[^>]*>i<\/button>/s);
   assert.match(markup, /Ruwe waarde; kalibreer via Service\./);
   assert.match(markup, /Ruwe metingen/);
@@ -185,15 +636,15 @@ test("gewijzigde bronconfiguratie toont dat de aanvoerkalibratie opnieuw moet", 
   state.entities.waterSupplyCalibrationStatus = { value: "Calibrated: CIC", state: "Calibrated: CIC" };
   state.entities.waterSupplyCalibrationRequired = { value: false, state: "OFF" };
   state.entities.waterSupplyCalibrationOffset = { value: -0.6, uom: "°C" };
-  const calibratedMarkup = renderSettingsSensorSelectionSection();
+  const calibratedMarkup = renderFocusedSource("water-supply");
 
-  assert.match(calibratedMarkup, /Gebruikte waarde\s*<div class="oq-settings-info oq-settings-source-info oq-settings-source-info--valid oq-settings-source-info--circle"/);
+  assert.match(calibratedMarkup, /class="oq-settings-info oq-settings-source-info oq-settings-source-info--valid oq-settings-source-info--circle"/);
   assert.match(calibratedMarkup, /aria-label="Uitleg bij Gebruikte waarde"/);
   assert.match(calibratedMarkup, /Gekalibreerd; ruwe metingen hieronder\./);
   assert.doesNotMatch(calibratedMarkup, /<span>Kalibratie<\/span>|voer de temperatuurkalibratie opnieuw uit/);
 
   state.settingsInfoOpen = "supplyTemp-info";
-  const openInfoMarkup = renderSettingsSensorSelectionSection();
+  const openInfoMarkup = renderFocusedSource("water-supply");
   assert.match(openInfoMarkup, /data-info-id="supplyTemp-info"[^>]*aria-expanded="true"/s);
   assert.match(openInfoMarkup, /class="oq-settings-info-popover"\s*>/);
   state.settingsInfoOpen = "";

--- a/openquatt/web/tests/settings-integrations.test.mjs
+++ b/openquatt/web/tests/settings-integrations.test.mjs
@@ -16,23 +16,14 @@ const { handleViewAction } = await import("../js/src/features/view-actions.js");
 const { captureSettingsFocusContinuity, restoreSettingsFocusContinuity } = await import("../js/src/core/settings-focus-continuity.js");
 const { renderSettingsOpenThermCicSection, renderSettingsSensorSelectionSection } = await import("../js/src/settings/integrations.js");
 
-const MQTT_SOURCE_SELECT_KEYS = [
-  "roomTempSource",
-  "roomSetpointSource",
-  "outsideTempSource",
-  "heatingEnableSource",
-  "coolingEnableSource",
-  "coolingDewPointSource",
+const MQTT_SOURCE_SELECTS = [
+  ["roomTempSource", "room-temperature"],
+  ["roomSetpointSource", "room-setpoint"],
+  ["outsideTempSource", "outside-temperature"],
+  ["heatingEnableSource", "heating-enable"],
+  ["coolingEnableSource", "cooling-enable"],
+  ["coolingDewPointSource", "cooling-dew-point"],
 ];
-
-const SOURCE_KEY_BY_SELECT_KEY = {
-  roomTempSource: "room-temperature",
-  roomSetpointSource: "room-setpoint",
-  outsideTempSource: "outside-temperature",
-  heatingEnableSource: "heating-enable",
-  coolingEnableSource: "cooling-enable",
-  coolingDewPointSource: "cooling-dew-point",
-};
 
 function getSelectMarkup(markup, key) {
   const match = markup.match(new RegExp(`<select[^>]+data-oq-field="${key}"[^>]*>([\\s\\S]*?)<\\/select>`));
@@ -196,29 +187,16 @@ test("focuspaneel groepeert alle signalen in vaste volgorde en rendert één ins
   assert.equal((markup.match(/data-oq-action="select-settings-source"/g) || []).length, 9);
   assert.equal((markup.match(/data-oq-focus-key="settings-source-[^"]+"/g) || []).length, 10);
   assert.equal((markup.match(/\sdata-oq-source-inspector(?:\s|>)/g) || []).length, 1);
-  assertMarkupOrder(markup, [
-    'data-source-category="room-outside"',
-    'data-source-category="water-circuit"',
-    'data-source-category="heating"',
-    'data-source-category="cooling"',
-  ]);
-  assertMarkupOrder(getCategoryMarkup(markup, "room-outside"), [
-    'data-source-key="room-temperature"',
-    'data-source-key="room-setpoint"',
-    'data-source-key="outside-temperature"',
-  ]);
-  assertMarkupOrder(getCategoryMarkup(markup, "water-circuit"), [
-    'data-source-key="water-supply"',
-    'data-source-key="flow-source"',
-  ]);
-  assertMarkupOrder(getCategoryMarkup(markup, "heating"), [
-    'data-source-key="external-heat-demand"',
-    'data-source-key="heating-enable"',
-  ]);
-  assertMarkupOrder(getCategoryMarkup(markup, "cooling"), [
-    'data-source-key="cooling-enable"',
-    'data-source-key="cooling-dew-point"',
-  ]);
+  const expectedSources = [
+    ["room-outside", ["room-temperature", "room-setpoint", "outside-temperature"]],
+    ["water-circuit", ["water-supply", "flow-source"]],
+    ["heating", ["external-heat-demand", "heating-enable"]],
+    ["cooling", ["cooling-enable", "cooling-dew-point"]],
+  ];
+  assertMarkupOrder(markup, expectedSources.map(([category]) => `data-source-category="${category}"`));
+  expectedSources.forEach(([category, sources]) => {
+    assertMarkupOrder(getCategoryMarkup(markup, category), sources.map((source) => `data-source-key="${source}"`));
+  });
   assert.match(getInspectorMarkup(markup), /data-source-key="room-temperature"/);
   assert.match(getInspectorMarkup(markup), /data-oq-focus-key="settings-source-detail-back"/);
   assert.match(getCategoryMarkup(markup, "room-outside"), /aria-label="Ingesteld: Auto\. Gebruikt: HA-invoer"/);
@@ -523,22 +501,19 @@ test("secundaire bronselecties blijven alleen zichtbaar wanneer hun hoofdkeuze z
 
 test("MQTT verdwijnt uit alle bronselecties en metingen wanneer de integratie uitstaat", () => {
   setSourceSelectionState(true);
-  MQTT_SOURCE_SELECT_KEYS.forEach((key) => {
-    const enabledMarkup = renderFocusedSource(SOURCE_KEY_BY_SELECT_KEY[key]);
+  MQTT_SOURCE_SELECTS.forEach(([key, sourceKey]) => {
+    const enabledMarkup = renderFocusedSource(sourceKey);
     assert.match(getSelectMarkup(enabledMarkup, key), /<option value="MQTT"/);
   });
   assert.match(renderFocusedSource("room-temperature"), /data-source-kind="mqtt"\s+data-source-state="valid"/);
 
   setSourceSelectionState(false);
-  MQTT_SOURCE_SELECT_KEYS.forEach((key) => {
-    const disabledMarkup = renderFocusedSource(SOURCE_KEY_BY_SELECT_KEY[key]);
+  MQTT_SOURCE_SELECTS.forEach(([key, sourceKey]) => {
+    const disabledMarkup = renderFocusedSource(sourceKey);
     assert.doesNotMatch(getSelectMarkup(disabledMarkup, key), /<option value="MQTT"/);
     assert.doesNotMatch(getInspectorMarkup(disabledMarkup), /data-source-kind="mqtt"/);
-  });
-
-  MQTT_SOURCE_SELECT_KEYS.forEach((key) => {
     state.entities[key].value = "MQTT";
-    const disabledCurrentMarkup = renderFocusedSource(SOURCE_KEY_BY_SELECT_KEY[key]);
+    const disabledCurrentMarkup = renderFocusedSource(sourceKey);
     const selectMarkup = getSelectMarkup(disabledCurrentMarkup, key);
     assert.match(selectMarkup, /<option value="MQTT" selected disabled>Kies een beschikbare bron<\/option>/);
     assert.doesNotMatch(selectMarkup, />MQTT<\/option>/);

--- a/openquatt/web/tests/settings-integrations.test.mjs
+++ b/openquatt/web/tests/settings-integrations.test.mjs
@@ -450,21 +450,18 @@ test("uitgeschakelde CIC en OpenTherm verdwijnen uit keuzes en metingen", () => 
   assert.doesNotMatch(getSelectMarkup(markup, "roomTempSource"), /<option value="(?:CIC|OT thermostat)"/);
   assert.doesNotMatch(inspector, /data-source-kind="(?:cic|ot)"/);
 
-  state.entities.roomTempSource.value = "OT thermostat";
-  markup = renderFocusedSource("room-temperature");
-  inspector = getInspectorMarkup(markup);
-  assert.match(inspector, /Huidige bron niet beschikbaar: OpenTherm staat uit/);
-  assert.match(getSelectMarkup(markup, "roomTempSource"), /<option value="OT thermostat" selected disabled>Kies een beschikbare bron<\/option>/);
-  assert.doesNotMatch(getSelectMarkup(markup, "roomTempSource"), />OT-thermostaat<\/option>/);
-  assert.doesNotMatch(inspector, /data-source-kind="ot"/);
-
-  state.entities.roomTempSource.value = "CIC";
-  markup = renderFocusedSource("room-temperature");
-  inspector = getInspectorMarkup(markup);
-  assert.match(inspector, /Huidige bron niet beschikbaar: CIC-polling staat uit/);
-  assert.match(getSelectMarkup(markup, "roomTempSource"), /<option value="CIC" selected disabled>Kies een beschikbare bron<\/option>/);
-  assert.doesNotMatch(getSelectMarkup(markup, "roomTempSource"), />CIC<\/option>/);
-  assert.doesNotMatch(inspector, /data-source-kind="cic"/);
+  [
+    ["OT thermostat", /OpenTherm staat uit/, />OT-thermostaat<\/option>/, /data-source-kind="ot"/],
+    ["CIC", /CIC-polling staat uit/, />CIC<\/option>/, /data-source-kind="cic"/],
+  ].forEach(([source, warning, option, measurement]) => {
+    state.entities.roomTempSource.value = source;
+    markup = renderFocusedSource("room-temperature");
+    inspector = getInspectorMarkup(markup);
+    assert.match(inspector, warning);
+    assert.match(getSelectMarkup(markup, "roomTempSource"), new RegExp(`<option value="${source}" selected disabled>Kies een beschikbare bron<\\/option>`));
+    assert.doesNotMatch(getSelectMarkup(markup, "roomTempSource"), option);
+    assert.doesNotMatch(inspector, measurement);
+  });
 
   state.entities.coolingEnableSource.value = "CIC";
   markup = renderFocusedSource("cooling-enable");

--- a/openquatt/web/tests/settings-integrations.test.mjs
+++ b/openquatt/web/tests/settings-integrations.test.mjs
@@ -43,6 +43,12 @@ function getCategoryMarkup(markup, key) {
   return match[0];
 }
 
+function getSignalMarkup(markup, key) {
+  const match = markup.match(new RegExp(`<button[^>]+data-source-key="${key}"[\\s\\S]*?<\\/button>`));
+  assert.ok(match, `bronsignaal ${key} ontbreekt`);
+  return match[0];
+}
+
 function assertMarkupOrder(markup, values) {
   let previousIndex = -1;
   values.forEach((value) => {
@@ -201,6 +207,13 @@ test("focuspaneel groepeert alle signalen in vaste volgorde en rendert één ins
   assert.match(getInspectorMarkup(markup), /data-oq-focus-key="settings-source-detail-back"/);
   assert.match(getCategoryMarkup(markup, "room-outside"), /aria-label="Ingesteld: Auto\. Gebruikt: HA-invoer"/);
   assert.match(getCategoryMarkup(markup, "room-outside"), /<span>Auto<\/span>[\s\S]*?<span class="oq-settings-source-signal-source-arrow" aria-hidden="true">→<\/span>[\s\S]*?<span>HA-invoer<\/span>/);
+  const heatingEnableMarkup = getSignalMarkup(markup, "heating-enable");
+  assert.match(heatingEnableMarkup, /aria-label="Ingesteld: Niet gebruiken"/);
+  assert.doesNotMatch(heatingEnableMarkup, /oq-settings-source-signal-source-arrow|>—<\/span>/);
+  const externalHeatDemandMarkup = getSignalMarkup(markup, "external-heat-demand");
+  assert.match(externalHeatDemandMarkup, /<strong>Niet gebruikt<\/strong>[\s\S]*?<span>Niet gebruiken<\/span>/);
+  assert.doesNotMatch(externalHeatDemandMarkup, /<strong>0(?: kW)?<\/strong>/);
+  assert.doesNotMatch(markup, /oq-settings-source-category-index/);
   assert.doesNotMatch(markup, /Bronwaarden tonen|>Relevant<|>Alles</);
 });
 

--- a/openquatt/web/web-budgets.mjs
+++ b/openquatt/web/web-budgets.mjs
@@ -22,14 +22,17 @@ export const WEB_BUNDLE_BUDGETS = [
     // the issue-536 boiler-result quality and confirmed empirical Apply flow,
     // the compact per-ODU compressor profile for safe manual F-levels,
     // the unified Q-firmware network preference and active-connection controls,
+    // the issue-471 grouped source focus panel with configured/effective paths,
+    // relevant-source diagnostics, warnings and stable keyboard focus,
     // and frequency-based day/silent limits and exclusion ranges per ODU.
-    raw: 966_000,
+    raw: 979_000,
     // One-time migration ceiling for structured incident monitoring, replay,
     // the CSRF-protected deferred recovery actions, and their compact editor.
     // Once this bundle is the base, the normal gzip growth limit applies again.
     gzipBaselineCeiling: 238_000,
   },
   // Includes the compact, dark-safe ODU generation picker with unified header action and distinct badge/button,
-  // plus the warmtetoestemming-advies modal (3 summary cards, comparison, matrix, sticky footer).
-  { file: "css/openquatt-app.css", raw: 295_000 },
+  // the warmtetoestemming-advies modal (3 summary cards, comparison, matrix, sticky footer),
+  // and the responsive issue-471 master/detail source focus panel.
+  { file: "css/openquatt-app.css", raw: 302_000 },
 ];


### PR DESCRIPTION
# Wat verandert deze PR?

- Vervangt de losse bronkaarten door een rustig master/detail-focuspaneel met duidelijke, ongenummerde categorieën voor Ruimte & buiten, Watercircuit, Verwarmen en Koelen.
- Toont per signaal compact de actuele waarde en het betekenisvolle pad `ingesteld → gebruikt`; bij een uitgeschakelde bron wordt geen betekenisloze `→ —` getoond. De bronselectors en relevante diagnostiek staan pas in het focuspaneel.
- Past standaard stil de weergave Relevant toe: geldige bronnen blijven zichtbaar, gekozen/effectieve ongeldige bronnen worden vastgezet met een waarschuwing, en uitgeschakelde MQTT-, CIC- en OpenTherm-bronnen verdwijnen uit de keuzes.
- Presenteert uitgeschakelde verwarmingssignalen consequent als `Niet gebruikt`, terwijl een echte nulwaarde zichtbaar blijft zodra de externe bron actief is.

Closes #471

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alle wijzigingen zitten in de webpresentatie en de bijbehorende browsertests. Bestaande entity-writes, firmwarebronlogica en regelgedrag blijven ongewijzigd.

## Achtergrond

Het focuspaneel houdt de normale weergave scanbaar zonder diagnostiek weg te nemen. Op desktop staan lijst en inspector naast elkaar; mobiel wordt dit een drill-in met expliciete terugactie. HA/API/MQTT-bronnen zonder geldige waarde verdwijnen alleen wanneer ze niet ingesteld of effectief zijn. Een ingestelde route zonder bruikbare waarde, een lokale sensorfallback of een uitgeschakelde integratie blijft juist zichtbaar als bronprobleem.

De Power House-diagnostiek vertaalt de firmwarewaarden `external` en `model` expliciet naar de werkelijk gebruikte externe bron of het huismodel. Bij ontbrekende oudere diagnostiek wordt geen effectieve bron verzonnen.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit wijzigt alleen de bestaande bronselectie-interface; er komen geen nieuwe instellingen, entities of gebruikersstappen bij. De nieuwe labels en probleemmeldingen zijn rechtstreeks in de UI uitgelegd.

## Validatie

- [x] `npm run check:web` — 308/308 tests en web quality geslaagd
- [x] `npm run smoke:web` — web smoke geslaagd
- [x] Browser-QA — desktop, 390 px mobiel, drill-in/terug, dark mode, lange bronpaden, uitgeschakelde integraties en focusbehoud gecontroleerd
- [x] `git diff --check origin/dev...HEAD` — schoon
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen webbroncode en bundelbudgetten veranderen; geen firmware-, heap-, PSRAM- of task-stackwijzigingen.

Bundelmeting tegen dezelfde actuele `origin/dev`-commit en dezelfde `npm run build:web`-build:

- JS: +7.397 B raw (+0,77%), +2.510 B gzip (+0,95%)
- CSS: +5.142 B raw (+1,74%), +872 B gzip (+1,91%)
- Totaal: +12.539 B raw (+0,99%), +3.382 B gzip (+1,10%)

## Pre-PR-audit

De complete diff tegen `origin/dev` is gecontroleerd op correctheid, dynamische HTML-escaping, focus/scroll-lifecycle, live polling, ontbrekende en legacy entities, geldige `false`/`0`-waarden, stale API-input, per-topic MQTT-uitval en fresh-install/oudere-firmwaregedrag. Een aparte koude review op architectuur, requirements, responsive CSS, toegankelijkheid en de uitgeschakelde-bronpresentatie is verwerkt; de volledige gate is daarna opnieuw uitgevoerd.

Twee aanvullende omvangsaudits behouden dezelfde UX en 19 gerichte regressietests, maar vervangen herhaling door gedeelde bronconfiguratie, toestemmingssignalen en bestaande diagnostiek-CSS. Dode toestandspaden zijn verwijderd en de uitgeschakelde-brontests zijn compacter data-driven gemaakt. De complete PR-diff is daarmee teruggebracht van netto +1.180 naar +917 regels: 263 netto regels minder.
