### PR TITLE
Herstel firmwarebestanden voor release-aliases

### DIFF
--- a/scripts/build_targets.py
+++ b/scripts/build_targets.py
@@ -70,7 +70,7 @@ def filter_targets(targets: list[dict[str, str]], status: str) -> list[dict[str,
 
 
 def artifact_names(target: dict[str, str]) -> list[str]:
-    """Return the canonical artifact name followed by manifest compatibility aliases."""
+    """Return the canonical artifact name followed by compatibility aliases."""
     names = [target["artifact_name"]]
     aliases = target.get("artifact_aliases", "")
     names.extend(alias.strip() for alias in aliases.split(",") if alias.strip())
@@ -104,11 +104,14 @@ def display_name_for_artifact(target: dict[str, str], artifact_name: str) -> str
 
 def release_asset_names(target: dict[str, str]) -> list[str]:
     """Return every file name that should exist on a release for this target."""
-    artifact_name = target["artifact_name"]
-    names = [
-        f"{artifact_name}.firmware.ota.bin",
-        f"{artifact_name}.firmware.factory.bin",
-    ]
+    names: list[str] = []
+    for published_name in artifact_names(target):
+        names.extend(
+            [
+                f"{published_name}.firmware.ota.bin",
+                f"{published_name}.firmware.factory.bin",
+            ]
+        )
     names.extend(manifest_name_for_artifact(target, published_name) for published_name in artifact_names(target))
     return names
 
@@ -163,16 +166,15 @@ def prepare_release_assets(version: str, base_url: str, release_url: str) -> Non
         if not ota_source.is_file() or not factory_source.is_file():
             raise SystemExit(f"Artifact {artifact_name} is missing firmware.ota.bin or firmware.factory.bin")
 
-        ota_name = f"{artifact_name}.firmware.ota.bin"
-        factory_name = f"{artifact_name}.firmware.factory.bin"
-        ota_dest = dist_dir / ota_name
-        factory_dest = dist_dir / factory_name
-        shutil.copy2(ota_source, ota_dest)
-        shutil.copy2(factory_source, factory_dest)
-        ota_md5 = md5sum(ota_dest)
-
         for published_name in artifact_names(target):
             published_display_name = display_name_for_artifact(target, published_name)
+            ota_name = f"{published_name}.firmware.ota.bin"
+            factory_name = f"{published_name}.firmware.factory.bin"
+            ota_dest = dist_dir / ota_name
+            factory_dest = dist_dir / factory_name
+            shutil.copy2(ota_source, ota_dest)
+            shutil.copy2(factory_source, factory_dest)
+
             manifest = {
                 "name": published_display_name,
                 "version": version,
@@ -181,7 +183,7 @@ def prepare_release_assets(version: str, base_url: str, release_url: str) -> Non
                         "chipFamily": target["chip_family"],
                         "ota": {
                             "path": f"{base_url}/{ota_name}",
-                            "md5": ota_md5,
+                            "md5": md5sum(ota_dest),
                             "release_url": release_url,
                             "summary": f"{published_display_name} firmware {version}",
                         },
@@ -256,7 +258,8 @@ def command_list_configs(args: argparse.Namespace) -> int:
 
 def command_factory_files(args: argparse.Namespace) -> int:
     for target in filter_targets(load_targets(), args.status):
-        print(f"{target['artifact_name']}.firmware.factory.bin")
+        for artifact_name in artifact_names(target):
+            print(f"{artifact_name}.firmware.factory.bin")
     return 0
 
 

--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -209,6 +209,20 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
                 mock.patch.object(build_targets, "REPO_ROOT", repo_root),
                 mock.patch.object(build_targets, "TARGETS_FILE", targets_file),
             ):
+                self.assertEqual(
+                    [
+                        "openquatt-test.firmware.ota.bin",
+                        "openquatt-test.firmware.factory.bin",
+                        "openquatt-test-wifi.firmware.ota.bin",
+                        "openquatt-test-wifi.firmware.factory.bin",
+                        "openquatt-test-eth.firmware.ota.bin",
+                        "openquatt-test-eth.firmware.factory.bin",
+                        "openquatt-test-ota.manifest.json",
+                        "openquatt-test-wifi-ota.manifest.json",
+                        "openquatt-test-eth-ota.manifest.json",
+                    ],
+                    build_targets.release_asset_names(build_targets.load_targets()[0]),
+                )
                 build_targets.prepare_release_assets(
                     "v1.2.3",
                     "https://example.invalid/download",


### PR DESCRIPTION
# Wat verandert deze PR?

- Herstelt byte-identieke OTA- en factory-binaries voor canonical Q-firmware en de Wi-Fi-/Ethernet-release-aliases.
- Laat elk aliasmanifest naar het bijpassende alias-OTA-bestand en dezelfde MD5 verwijzen.
- Neemt aliasbinaries op in `release-files` en `factory-files`, zodat de `dev-latest`-pruning ze niet direct weer verwijdert.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen het release-publicatiepad verandert. De gebouwde firmwarebytes zelf blijven ongewijzigd; dezelfde canonical build wordt onder de compatibiliteitsnamen gepubliceerd.

## Achtergrond

Op `dev` maakte `prepare_release_assets()` alleen canonical binaries aan, terwijl het bestaande contract en de legacy downloadnamen ook byte-identieke release-aliases vereisen. Daardoor faalde `test_release_aliases_are_byte_identical_and_get_matching_manifests` met `FileNotFoundError` voor `openquatt-test-wifi.firmware.ota.bin`. De oorzaak zat in het productiepad, niet in de fixture of de artifact-directoryselectie. PR #574 is niet gewijzigd.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De bestaande handmatige-installatiedocumentatie noemt de compatibiliteitsbestanden al; deze fix brengt het releasepad weer in lijn met die documentatie.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact
- `npm run check:python-contracts` — 130 tests geslaagd.
- `python3 -m unittest scripts.tests.test_pr_test_firmware_workflows -v` — 13 tests geslaagd.
- `python3 scripts/build_targets.py release-files --status enabled` en `factory-files --status enabled` gecontroleerd op canonical en alias-assets.
- Een tijdelijke matrixcontrole valideerde alle 6 ingeschakelde firmwareprofielen en alle 30 verwachte release-assets: bytegelijkheid, manifestpad en MD5.

Heap/stack-impact:

Niet van toepassing; geen firmware-, heap- of task-stackcode gewijzigd.

## Diff-audit

De volledige diff tegen `origin/dev` is gecontroleerd op correctness, publicatie- en opschoonpaden, foutafhandeling, compatibiliteit en verse release-uitvoer. Daarbij zijn zowel `.github/workflows/release-build.yml` als `.github/workflows/dev-build.yml`, het bestaande PR-testfirmwarepad, alle buildprofielen en de installer-/documentatienamen nagelopen.

Een afzonderlijke koude review vond geen open bevindingen: profielen zonder aliases behouden hetzelfde gedrag, ontbrekende bronartifacts blijven vóór publicatie falen, aliasmanifests verwijzen naar bestaande aliasbinaries en de dev-pruning verwacht exact de geproduceerde set.
