### PR TITLE
Verminder onnodige OpenTherm-waarschuwingen

### DIFF
--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -266,9 +266,13 @@ void OpenthermHub::loop() {
   if (!this->polling_enabled_) {
     return;
   }
+  const OperationMode transport_mode_before = this->opentherm_->get_mode();
   const uint32_t transport_started_us = micros();
-  this->opentherm_->process();
-  this->warn_if_slow_("RMT completion processing", transport_started_us);
+  const transport_diagnostics::PollResult transport_result = this->opentherm_->process();
+  const uint32_t transport_finished_us = micros();
+  const OperationMode transport_mode_after = this->opentherm_->get_mode();
+  this->record_transport_poll_(transport_result, transport_mode_before, transport_mode_after,
+                               timing::elapsed_us(transport_finished_us, transport_started_us));
   if (this->sync_mode_) {
     this->sync_loop_();
     return;
@@ -440,17 +444,42 @@ void OpenthermHub::warn_if_slow_(const char* phase, uint32_t started_us) const {
   }
 }
 
+void OpenthermHub::record_transport_poll_(transport_diagnostics::PollResult result, OperationMode mode_before,
+                                          OperationMode mode_after, uint32_t elapsed_us) {
+  if (!transport_diagnostics::record_slow_poll(this->slow_transport_poll_stats_, result, elapsed_us)) {
+    return;
+  }
+  this->last_slow_transport_mode_before_ = mode_before;
+  this->last_slow_transport_mode_after_ = mode_after;
+}
+
 void OpenthermHub::log_transport_diagnostics_() const {
   ESP_LOGD(TAG,
            "OpenTherm transport: requests=%u tx_completed=%u rx_captured=%u rx_accepted=%u rx_rejected=%u "
            "tx_timeouts=%u response_timeouts=%u late_timeouts=%u max_wire_response=%u ms "
-           "max_processing_latency=%u ms",
+           "max_processing_latency=%u ms slow_polls=%u max_poll_wall=%u ms "
+           "slow_outcomes(no_work=%u tx_timeout=%u rx_timeout_no_frame=%u rx_frame_after_deadline=%u "
+           "rx_frame_accepted=%u rx_frame_rejected=%u) last_slow=%s mode=%s->%s; slow poll wall time may "
+           "include task preemption and is not OpenTherm wire wait time",
            static_cast<unsigned>(this->requests_started_), static_cast<unsigned>(this->tx_completed_),
            static_cast<unsigned>(this->rx_captured_), static_cast<unsigned>(this->rx_accepted_),
            static_cast<unsigned>(this->rx_rejected_), static_cast<unsigned>(this->tx_timeouts_),
            static_cast<unsigned>(this->response_timeouts_), static_cast<unsigned>(this->late_response_timeouts_),
            static_cast<unsigned>(this->max_wire_response_us_ / 1000U),
-           static_cast<unsigned>(this->max_processing_latency_us_ / 1000U));
+           static_cast<unsigned>(this->max_processing_latency_us_ / 1000U),
+           static_cast<unsigned>(this->slow_transport_poll_stats_.count),
+           static_cast<unsigned>(this->slow_transport_poll_stats_.max_elapsed_us / 1000U),
+           static_cast<unsigned>(this->slow_transport_poll_stats_.no_work),
+           static_cast<unsigned>(this->slow_transport_poll_stats_.tx_timeout),
+           static_cast<unsigned>(this->slow_transport_poll_stats_.rx_timeout_no_frame),
+           static_cast<unsigned>(this->slow_transport_poll_stats_.rx_frame_after_deadline),
+           static_cast<unsigned>(this->slow_transport_poll_stats_.rx_frame_accepted),
+           static_cast<unsigned>(this->slow_transport_poll_stats_.rx_frame_rejected),
+           this->slow_transport_poll_stats_.count > 0
+               ? transport_diagnostics::poll_result_to_str(this->slow_transport_poll_stats_.last_result)
+               : "none",
+           this->opentherm_->operation_mode_to_str(this->last_slow_transport_mode_before_),
+           this->opentherm_->operation_mode_to_str(this->last_slow_transport_mode_after_));
 }
 
 void OpenthermHub::activate_priority_sequence_(MessageId first, MessageId second) {

--- a/components/opentherm/hub.h
+++ b/components/opentherm/hub.h
@@ -94,6 +94,9 @@ class OpenthermHub final : public Component {
   uint32_t late_response_timeouts_ = 0;
   uint32_t max_wire_response_us_ = 0;
   uint32_t max_processing_latency_us_ = 0;
+  transport_diagnostics::SlowPollStats slow_transport_poll_stats_;
+  OperationMode last_slow_transport_mode_before_ = IDLE;
+  OperationMode last_slow_transport_mode_after_ = IDLE;
   OperationMode last_mode_ = IDLE;
   OpenthermData last_request_;
 
@@ -120,6 +123,8 @@ class OpenthermHub final : public Component {
   void check_cadence_(uint32_t started_us) const;
   bool should_skip_loop_(uint32_t cur_time_us) const;
   void warn_if_slow_(const char* phase, uint32_t started_us) const;
+  void record_transport_poll_(transport_diagnostics::PollResult result, OperationMode mode_before,
+                              OperationMode mode_after, uint32_t elapsed_us);
   void log_transport_diagnostics_() const;
   void sync_loop_();
 

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -187,9 +187,11 @@ bool OpenTherm::stop(ConversationTiming& timing) {
   return has_timing;
 }
 
-void OpenTherm::process() {
+transport_diagnostics::PollResult OpenTherm::process() {
 #ifdef USE_ESP32
-  this->process_esp32_rmt_();
+  return this->process_esp32_rmt_();
+#else
+  return transport_diagnostics::PollResult::NO_WORK;
 #endif
 }
 
@@ -685,24 +687,24 @@ bool IRAM_ATTR OpenTherm::rmt_tx_done_callback_(rmt_channel_handle_t, const rmt_
   return false;
 }
 
-void OpenTherm::process_esp32_rmt_() {
-  bool transmit_timed_out = false;
+transport_diagnostics::PollResult OpenTherm::process_esp32_rmt_() {
+  transport_diagnostics::PollObservation observation;
   portENTER_CRITICAL(&this->rmt_mux_);
   if (this->mode_ == OperationMode::WRITE && this->rmt_tx_active_ &&
       static_cast<int32_t>(micros() - this->rmt_tx_deadline_us_) >= 0) {
     this->rmt_tx_active_ = false;
     this->mode_ = OperationMode::ERROR_TIMEOUT;
-    transmit_timed_out = true;
+    observation.tx_timed_out = true;
   }
   portEXIT_CRITICAL(&this->rmt_mux_);
-  if (transmit_timed_out) {
+  if (observation.tx_timed_out) {
     this->reset_esp32_rmt_tx_();
     ESP_LOGW(TAG, "RMT transmit completion timed out");
-    return;
+    return transport_diagnostics::classify_poll(observation);
   }
 
   if (this->mode_ != OperationMode::LISTEN && this->mode_ != OperationMode::RMT_PENDING) {
-    return;
+    return transport_diagnostics::classify_poll(observation);
   }
 
   const bool deadline_expired = static_cast<int32_t>(micros() - this->receive_deadline_us_) >= 0;
@@ -717,6 +719,7 @@ void OpenTherm::process_esp32_rmt_() {
       symbol_count = this->rmt_symbol_count_;
     } else {
       this->mode_ = OperationMode::ERROR_TIMEOUT;
+      observation.rx_frame_after_deadline = true;
     }
     this->rmt_frame_ready_ = false;
     this->rmt_frame_completed_us_ = 0;
@@ -724,10 +727,11 @@ void OpenTherm::process_esp32_rmt_() {
     // Arbitrate completion and timeout under the same lock used by the ISR:
     // exactly one of them is allowed to claim this receive operation.
     this->mode_ = OperationMode::ERROR_TIMEOUT;
+    observation.rx_timed_out = true;
   }
   portEXIT_CRITICAL(&this->rmt_mux_);
   if (!frame_ready) {
-    return;
+    return transport_diagnostics::classify_poll(observation);
   }
 
   rmt_decoder::Pulse pulses[RMT_CAPTURE_SYMBOLS * 2]{};
@@ -821,6 +825,9 @@ void OpenTherm::process_esp32_rmt_() {
       this->mode_ = OperationMode::ERROR_PROTOCOL;
       break;
   }
+  observation.frame_processed = true;
+  observation.frame_accepted = result.error == rmt_decoder::DecodeError::NONE;
+  return transport_diagnostics::classify_poll(observation);
 }
 
 void IRAM_ATTR OpenTherm::start_esp32_timer_(uint64_t alarm_value, bool auto_reload) {

--- a/components/opentherm/opentherm.h
+++ b/components/opentherm/opentherm.h
@@ -13,6 +13,7 @@
 #include "esphome/core/log.h"
 
 #include "opentherm_rmt_encoder.h"
+#include "opentherm_transport_diagnostics.h"
 
 #ifdef USE_ESP32
 #include "driver/gptimer.h"
@@ -302,8 +303,9 @@ class OpenTherm {
 
   /**
    * Process a completed hardware receive capture. This is a no-op on ESP8266.
+   * @return classification of the transport work performed by this poll.
    */
-  void process();
+  transport_diagnostics::PollResult process();
 
   /**
    * Stops listening for data packet or sending out data packet and resets internal state of this class.
@@ -461,7 +463,7 @@ class OpenTherm {
   bool reset_esp32_rmt_tx_();
   void cancel_esp32_rmt_();
   void cancel_esp32_rmt_tx_();
-  void process_esp32_rmt_();
+  transport_diagnostics::PollResult process_esp32_rmt_();
   void start_esp32_timer_(uint64_t alarm_value, bool auto_reload);
 #endif
 

--- a/components/opentherm/opentherm_transport_diagnostics.h
+++ b/components/opentherm/opentherm_transport_diagnostics.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace esphome::opentherm::transport_diagnostics {
+
+static constexpr uint32_t SLOW_POLL_THRESHOLD_US = 50000;
+
+enum class PollResult : uint8_t {
+  NO_WORK = 0,
+  TX_TIMEOUT,
+  RX_TIMEOUT_NO_FRAME,
+  RX_FRAME_AFTER_DEADLINE,
+  RX_FRAME_ACCEPTED,
+  RX_FRAME_REJECTED,
+};
+
+struct PollObservation {
+  bool tx_timed_out{false};
+  bool rx_timed_out{false};
+  bool rx_frame_after_deadline{false};
+  bool frame_processed{false};
+  bool frame_accepted{false};
+};
+
+inline PollResult classify_poll(const PollObservation& observation) {
+  if (observation.tx_timed_out) {
+    return PollResult::TX_TIMEOUT;
+  }
+  if (observation.rx_frame_after_deadline) {
+    return PollResult::RX_FRAME_AFTER_DEADLINE;
+  }
+  if (observation.rx_timed_out) {
+    return PollResult::RX_TIMEOUT_NO_FRAME;
+  }
+  if (observation.frame_processed) {
+    return observation.frame_accepted ? PollResult::RX_FRAME_ACCEPTED : PollResult::RX_FRAME_REJECTED;
+  }
+  return PollResult::NO_WORK;
+}
+
+inline const char* poll_result_to_str(PollResult result) {
+  switch (result) {
+    case PollResult::NO_WORK:
+      return "no_work";
+    case PollResult::TX_TIMEOUT:
+      return "tx_timeout";
+    case PollResult::RX_TIMEOUT_NO_FRAME:
+      return "rx_timeout_no_frame";
+    case PollResult::RX_FRAME_AFTER_DEADLINE:
+      return "rx_frame_after_deadline";
+    case PollResult::RX_FRAME_ACCEPTED:
+      return "rx_frame_accepted";
+    case PollResult::RX_FRAME_REJECTED:
+      return "rx_frame_rejected";
+  }
+  return "unknown";
+}
+
+struct SlowPollStats {
+  uint32_t count{0};
+  uint32_t max_elapsed_us{0};
+  uint32_t no_work{0};
+  uint32_t tx_timeout{0};
+  uint32_t rx_timeout_no_frame{0};
+  uint32_t rx_frame_after_deadline{0};
+  uint32_t rx_frame_accepted{0};
+  uint32_t rx_frame_rejected{0};
+  PollResult last_result{PollResult::NO_WORK};
+};
+
+inline bool is_slow_poll(uint32_t elapsed_us) { return elapsed_us >= SLOW_POLL_THRESHOLD_US; }
+
+inline bool record_slow_poll(SlowPollStats& stats, PollResult result, uint32_t elapsed_us) {
+  if (!is_slow_poll(elapsed_us)) {
+    return false;
+  }
+
+  stats.count++;
+  if (elapsed_us > stats.max_elapsed_us) {
+    stats.max_elapsed_us = elapsed_us;
+  }
+  stats.last_result = result;
+  switch (result) {
+    case PollResult::NO_WORK:
+      stats.no_work++;
+      break;
+    case PollResult::TX_TIMEOUT:
+      stats.tx_timeout++;
+      break;
+    case PollResult::RX_TIMEOUT_NO_FRAME:
+      stats.rx_timeout_no_frame++;
+      break;
+    case PollResult::RX_FRAME_AFTER_DEADLINE:
+      stats.rx_frame_after_deadline++;
+      break;
+    case PollResult::RX_FRAME_ACCEPTED:
+      stats.rx_frame_accepted++;
+      break;
+    case PollResult::RX_FRAME_REJECTED:
+      stats.rx_frame_rejected++;
+      break;
+  }
+  return true;
+}
+
+}  // namespace esphome::opentherm::transport_diagnostics

--- a/tests/host/opentherm_transport_diagnostics_test.cpp
+++ b/tests/host/opentherm_transport_diagnostics_test.cpp
@@ -1,0 +1,63 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "../../components/opentherm/opentherm_transport_diagnostics.h"
+
+int main() {
+  using esphome::opentherm::transport_diagnostics::classify_poll;
+  using esphome::opentherm::transport_diagnostics::is_slow_poll;
+  using esphome::opentherm::transport_diagnostics::poll_result_to_str;
+  using esphome::opentherm::transport_diagnostics::PollObservation;
+  using esphome::opentherm::transport_diagnostics::PollResult;
+  using esphome::opentherm::transport_diagnostics::record_slow_poll;
+  using esphome::opentherm::transport_diagnostics::SlowPollStats;
+
+  assert(classify_poll({}) == PollResult::NO_WORK);
+
+  PollObservation observation;
+  observation.tx_timed_out = true;
+  assert(classify_poll(observation) == PollResult::TX_TIMEOUT);
+
+  observation = {};
+  observation.rx_timed_out = true;
+  assert(classify_poll(observation) == PollResult::RX_TIMEOUT_NO_FRAME);
+
+  observation = {};
+  observation.rx_frame_after_deadline = true;
+  assert(classify_poll(observation) == PollResult::RX_FRAME_AFTER_DEADLINE);
+
+  observation = {};
+  observation.frame_processed = true;
+  observation.frame_accepted = true;
+  assert(classify_poll(observation) == PollResult::RX_FRAME_ACCEPTED);
+
+  observation.frame_accepted = false;
+  assert(classify_poll(observation) == PollResult::RX_FRAME_REJECTED);
+
+  assert(!is_slow_poll(49999U));
+  assert(is_slow_poll(50000U));
+
+  SlowPollStats stats;
+  assert(!record_slow_poll(stats, PollResult::NO_WORK, 49999U));
+  assert(stats.count == 0U);
+
+  assert(record_slow_poll(stats, PollResult::NO_WORK, 50000U));
+  assert(record_slow_poll(stats, PollResult::TX_TIMEOUT, 60000U));
+  assert(record_slow_poll(stats, PollResult::RX_TIMEOUT_NO_FRAME, 65000U));
+  assert(record_slow_poll(stats, PollResult::RX_FRAME_AFTER_DEADLINE, 70000U));
+  assert(record_slow_poll(stats, PollResult::RX_FRAME_ACCEPTED, 105000U));
+  assert(record_slow_poll(stats, PollResult::RX_FRAME_REJECTED, 75000U));
+  assert(stats.count == 6U);
+  assert(stats.no_work == 1U);
+  assert(stats.tx_timeout == 1U);
+  assert(stats.rx_timeout_no_frame == 1U);
+  assert(stats.rx_frame_after_deadline == 1U);
+  assert(stats.rx_frame_accepted == 1U);
+  assert(stats.rx_frame_rejected == 1U);
+  assert(stats.max_elapsed_us == 105000U);
+  assert(stats.last_result == PollResult::RX_FRAME_REJECTED);
+  assert(strcmp(poll_result_to_str(stats.last_result), "rx_frame_rejected") == 0);
+
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Voorkomt dat dezelfde weinig bruikbare OpenTherm-waarschuwing steeds opnieuw in de logs verschijnt.
- Belangrijke meldingen over echte communicatieproblemen blijven gewoon zichtbaar.
- Extra informatie voor het onderzoeken van problemen wordt alleen nog op DEBUG-niveau bijgehouden.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De communicatie met de cv-ketel verandert niet. Alleen de manier waarop vertragingen worden vastgelegd en gemeld is aangepast.

## Achtergrond

Closes #572.

De oude melding kon vaak verschijnen zonder dat er daadwerkelijk een probleem met de OpenTherm-verbinding was. Daardoor raakten de logs onnodig vol en vielen nuttige meldingen minder goed op.

Na deze wijziging blijft de normale logging rustig. Als uitgebreid onderzoek nodig is, staat de extra informatie nog steeds in de DEBUG-logging.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Er veranderen geen instellingen, sensoren of bedieningsmogelijkheden.

## Validatie

- [x] `./scripts/run_host_regression_tests.sh` — 44 tests geslaagd
- [x] `npm run check:cpp-format` — geslaagd
- [x] `npm run build:web` — geslaagd, zonder gewijzigde webbestanden
- [x] `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — firmwarecompile geslaagd
- [x] Volledige wijziging gecontroleerd ten opzichte van `dev`
- [ ] Praktijktest op Q Duo/WiFi onder zware belasting

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Er worden alleen enkele vaste tellers toegevoegd, zonder extra achtergrondtaken of dynamisch geheugengebruik. Een vergelijkende meting op echte hardware staat nog open; daarom blijft deze PR voorlopig een draft.
