### PR TITLE
YAML naar C++: Cooling – vraag en dispatch

### DIFF
--- a/openquatt/includes/control/oq_cooling_demand_logic.h
+++ b/openquatt/includes/control/oq_cooling_demand_logic.h
@@ -1,0 +1,310 @@
+#pragma once
+#include <algorithm>
+#include <math.h>
+#include <stdint.h>
+#include "oq_cooling_limiter_logic.h"
+namespace oq_cooling {
+enum GuardMode { GUARD_NONE = 0, GUARD_DEW = 1, GUARD_FALLBACK = 2, GUARD_USER_RESPONSIBILITY = 3 };
+struct DemandTuning {
+  float filter_tau_s = 60.0f;
+  uint32_t rate_window_ms = 60000UL, upscale_dwell_ms = 90000UL, downscale_dwell_ms = 30000UL;
+  float simmer_room_error_min_c = 0.20f;
+  LimiterTuning limiter;
+  OilReturnTuning oil_return;
+};
+struct DemandInput {
+  uint32_t now_ms = 0;
+  bool control_active = false, cycle_was_active = false, request_cleared = false, sensor_valid = false;
+  bool flow_permission_lost = false, core_permission_lost = false, oil_return_active = false;
+  bool cooling_hp_applied = false, restart_by_minimum_off_time = false, minimum_off_stop_pending = false;
+  bool minimum_off_wait_active = false;
+  GuardMode guard_mode = GUARD_NONE;
+  bool dew_mode = false, fallback_mode = false, room_error_valid = false;
+  float supply_c = NAN, target_c = NAN, dew_point_c = NAN, safety_margin_c = 0.0f, room_error_c = NAN;
+  float restart_delta_c = 1.0f, demand_max = 1.0f, kp = 0.0f, ki = 0.0f, kd = 0.0f;
+};
+struct GapFilterState {
+  bool ready = false, rate_reference_seen = false;
+  float filtered_gap_c = 0.0f, rate_reference_c = 0.0f, rate_c_per_min = 0.0f;
+  uint32_t rate_reference_ms = 0;
+};
+struct DemandState {
+  bool loop_seen = false, demand_change_seen = false, guard_seen = false;
+  uint32_t last_loop_ms = 0, last_demand_change_ms = 0;
+  GuardMode last_guard_mode = GUARD_NONE;
+  float integral = 0.0f, last_error_c = 0.0f, dew_gap_c = NAN, projected_gap_c = NAN;
+  int base_demand = 0, limited_demand = 0, allowed_max = 0, limiter_reason_code = REASON_INACTIVE;
+  GapFilterState filter;
+  LimiterState limiter;
+  OilReturnState oil_return;
+  WaterCycleState water_cycle;
+};
+struct DemandOutput {
+  bool control_active = false, guard_changed = false, arm_minimum_off_stop = false, pi_zero_stop = false;
+  bool event_limiter_active = false, event_hard_pause = false;
+};
+inline bool demand_finite(float value) { return isfinite(value); }
+inline int sanitize_demand_max(float value) {
+  return demand_finite(value) ? (int)lroundf(std::max(1.0f, std::min(10.0f, value))) : 1;
+}
+inline float sanitize_gain(float value, float maximum) {
+  return demand_finite(value) ? std::max(0.0f, std::min(maximum, value)) : 0.0f;
+}
+inline float sanitize_restart_delta(float value) {
+  return !demand_finite(value) || value < 0.0f ? 1.0f : std::min(5.0f, value);
+}
+inline float demand_loop_dt_s(uint32_t now_ms, DemandState& state) {
+  float dt_s = 5.0f;
+  if (state.loop_seen) {
+    const uint32_t elapsed_ms = now_ms - state.last_loop_ms;
+    if (elapsed_ms > 0) dt_s = (float)elapsed_ms / 1000.0f;
+  }
+  state.loop_seen = true;
+  state.last_loop_ms = now_ms;
+  return std::max(0.1f, std::min(15.0f, dt_s));
+}
+inline void reset_limiter_state(int capacity_cap, DemandState& state) {
+  state.limiter = {};
+  state.limiter.capacity_cap = capacity_cap;
+}
+inline DemandOutput reset_inactive_demand(const DemandInput& in, const DemandTuning& tuning, bool inputs_valid,
+                                          DemandState& state, bool arm_minimum_off_stop = false) {
+  state.integral = state.last_error_c = 0.0f;
+  state.base_demand = state.limited_demand = state.allowed_max = 0;
+  state.limiter_reason_code = REASON_INACTIVE;
+  state.water_cycle.active = false;
+  state.water_cycle.stop_reason_code = inactive_stop_reason(in.cycle_was_active, in.request_cleared, !inputs_valid,
+                                                            in.flow_permission_lost, in.core_permission_lost);
+  state.filter = {};
+  state.dew_gap_c = state.projected_gap_c = NAN;
+  state.demand_change_seen = false;
+  update_oil_return({in.now_ms, false, in.oil_return_active}, {}, tuning.oil_return, tuning.limiter, state.oil_return);
+  reset_limiter_state(sanitize_demand_max(in.demand_max), state);
+  return {false, false, arm_minimum_off_stop};
+}
+inline void reset_for_guard_change(float buffer_gap_c, DemandState& state) {
+  state.water_cycle = {};
+  state.filter.ready = state.filter.rate_reference_seen = false;
+  state.projected_gap_c = NAN;
+  state.demand_change_seen = false;
+  reset_oil_return_recovery(state.oil_return);
+  reset_limiter_state(10, state);
+  state.integral = 0.0f;
+  state.last_error_c = buffer_gap_c;
+}
+inline bool update_gap_filter(float buffer_gap_c, float dt_s, uint32_t now_ms, const DemandTuning& tuning,
+                              DemandState& state) {
+  auto& filter = state.filter;
+  if (!filter.ready || !demand_finite(filter.filtered_gap_c)) {
+    filter = {true, true, buffer_gap_c, buffer_gap_c, 0.0f, now_ms};
+    return true;
+  }
+  const float tau_s = demand_finite(tuning.filter_tau_s) && tuning.filter_tau_s > 0.0f ? tuning.filter_tau_s : 60.0f;
+  const float alpha = dt_s / (tau_s + dt_s);
+  filter.filtered_gap_c += alpha * (buffer_gap_c - filter.filtered_gap_c);
+  if (!demand_finite(filter.filtered_gap_c)) return false;
+  if (!filter.rate_reference_seen || !demand_finite(filter.rate_reference_c) || !demand_finite(filter.rate_c_per_min)) {
+    filter.rate_reference_seen = true;
+    filter.rate_reference_c = filter.filtered_gap_c;
+    filter.rate_reference_ms = now_ms;
+    filter.rate_c_per_min = 0.0f;
+    return true;
+  }
+  const uint32_t window_ms = tuning.rate_window_ms > 0 ? tuning.rate_window_ms : 60000UL;
+  const uint32_t elapsed_ms = now_ms - filter.rate_reference_ms;
+  if (elapsed_ms < window_ms) return true;
+  const float elapsed_min = (float)elapsed_ms / 60000.0f;
+  filter.rate_c_per_min = (filter.filtered_gap_c - filter.rate_reference_c) / elapsed_min;
+  filter.rate_reference_c = filter.filtered_gap_c;
+  filter.rate_reference_ms = now_ms;
+  return demand_finite(filter.rate_c_per_min);
+}
+inline int apply_demand_dwell(int candidate, int allowed_max, uint32_t now_ms, const DemandTuning& tuning,
+                              DemandState& state) {
+  const int previous = state.limited_demand;
+  const uint32_t elapsed_ms = state.demand_change_seen ? now_ms - state.last_demand_change_ms : UINT32_MAX;
+  int demand = candidate;
+  if (previous > 0 && allowed_max < previous) {
+    demand = std::min(candidate, allowed_max);
+  } else if (candidate > previous) {
+    if (previous == 0)
+      demand = std::min(candidate, 1);
+    else if (!state.demand_change_seen || elapsed_ms >= tuning.upscale_dwell_ms)
+      demand = std::min(candidate, previous + 1);
+    else
+      demand = previous;
+  } else if (candidate < previous) {
+    demand = !state.demand_change_seen || elapsed_ms >= tuning.downscale_dwell_ms ? candidate : previous;
+  }
+  demand = std::max(0, std::min(allowed_max, demand));
+  if (demand != previous) {
+    state.demand_change_seen = true;
+    state.last_demand_change_ms = now_ms;
+  }
+  return demand;
+}
+inline DemandOutput update_demand(const DemandInput& in, const DemandTuning& tuning, DemandState& state) {
+  const float dt_s = demand_loop_dt_s(in.now_ms, state);
+  const bool valid_guard = (in.guard_mode == GUARD_DEW && in.dew_mode && !in.fallback_mode) ||
+                           (in.guard_mode == GUARD_FALLBACK && !in.dew_mode && in.fallback_mode) ||
+                           (in.guard_mode == GUARD_USER_RESPONSIBILITY && !in.dew_mode && !in.fallback_mode);
+  const bool valid_config = demand_finite(in.restart_delta_c) && demand_finite(in.demand_max) && demand_finite(in.kp) &&
+                            demand_finite(in.ki) && demand_finite(in.kd) &&
+                            (!in.dew_mode || demand_finite(in.safety_margin_c));
+  const bool finite_sensors = in.sensor_valid && demand_finite(in.supply_c) && demand_finite(in.target_c) &&
+                              (!in.dew_mode || demand_finite(in.dew_point_c)) &&
+                              (!in.room_error_valid || demand_finite(in.room_error_c));
+  const float buffer_gap_c = finite_sensors ? in.supply_c - in.target_c : NAN;
+  const float dew_gap_c = finite_sensors && in.dew_mode ? in.supply_c - in.dew_point_c : NAN;
+  const bool inputs_valid = valid_guard && valid_config && finite_sensors && demand_finite(buffer_gap_c) &&
+                            (!in.dew_mode || demand_finite(dew_gap_c));
+  if (!in.control_active || !inputs_valid) return reset_inactive_demand(in, tuning, inputs_valid, state);
+  bool arm_minimum_off_stop =
+      cooling_minimum_off_stop_is_pending(in.restart_by_minimum_off_time, state.water_cycle.active,
+                                          state.water_cycle.stop_reason_code, in.minimum_off_wait_active);
+  bool guard_changed = false;
+  if (state.guard_seen && in.guard_mode != state.last_guard_mode) {
+    reset_for_guard_change(buffer_gap_c, state);
+    guard_changed = true;
+  }
+  state.guard_seen = true;
+  state.last_guard_mode = in.guard_mode;
+  if (!update_gap_filter(buffer_gap_c, dt_s, in.now_ms, tuning, state)) {
+    return reset_inactive_demand(in, tuning, false, state, arm_minimum_off_stop);
+  }
+  const float filtered_gap_c = state.filter.filtered_gap_c;
+  const float gap_rate_c_per_min = state.filter.rate_c_per_min;
+  const float projected_gap_c = filtered_gap_c + gap_rate_c_per_min * tuning.limiter.projection_horizon_min;
+  if (!demand_finite(projected_gap_c)) return reset_inactive_demand(in, tuning, false, state, arm_minimum_off_stop);
+  state.dew_gap_c = dew_gap_c;
+  const float safety_margin_c =
+      demand_finite(in.safety_margin_c) ? std::max(0.0f, std::min(2.0f, in.safety_margin_c)) : 0.0f;
+  const float kp = sanitize_gain(in.kp, 10.0f);
+  const float ki = sanitize_gain(in.ki, 2.0f);
+  const float kd = sanitize_gain(in.kd, 2.0f);
+  if (!demand_finite(state.integral)) state.integral = 0.0f;
+  float derivative = 0.0f;
+  if (demand_finite(state.last_error_c)) derivative = (buffer_gap_c - state.last_error_c) / dt_s;
+  if (!demand_finite(derivative)) return reset_inactive_demand(in, tuning, false, state, arm_minimum_off_stop);
+  int demand_max = sanitize_demand_max(in.demand_max);
+  const int capacity_demand_max = demand_max;
+  const bool room_error_valid = in.room_error_valid && demand_finite(in.room_error_c);
+  bool room_cap_active = false;
+  if (room_error_valid) {
+    const int before_room_cap = demand_max;
+    if (in.room_error_c < 0.4f)
+      demand_max = std::min(demand_max, 1);
+    else if (in.room_error_c < 0.8f)
+      demand_max = std::min(demand_max, 2);
+    else if (in.room_error_c < 1.2f)
+      demand_max = std::min(demand_max, 3);
+    room_cap_active = demand_max < before_room_cap;
+  }
+  LimiterInput limiter_input{in.now_ms,       demand_max,     capacity_demand_max, state.limited_demand,
+                             room_cap_active, in.dew_mode,    in.fallback_mode,    false,
+                             false,           buffer_gap_c,   filtered_gap_c,      gap_rate_c_per_min,
+                             state.dew_gap_c, safety_margin_c};
+  const auto oil_return = update_oil_return({in.now_ms, true, in.oil_return_active}, limiter_input, tuning.oil_return,
+                                            tuning.limiter, state.oil_return);
+  limiter_input.oil_return_mask_active = oil_return.mask_active;
+  limiter_input.oil_return_recovery_cap_active = oil_return.recovery_cap_active;
+  if (oil_return.reset_integral_and_dwell) {
+    state.integral = 0.0f;
+    state.demand_change_seen = true;
+    state.last_demand_change_ms = in.now_ms;
+  } else if (oil_return.mask_active || oil_return.recovery_cap_active) {
+    state.integral = fminf(state.integral, 0.0f);
+  }
+  const auto limiter = update_limiter(limiter_input, tuning.limiter, state.limiter);
+  if (limiter.reset_gap_rate_reference) {
+    state.filter.rate_reference_seen = true;
+    state.filter.rate_reference_c = filtered_gap_c;
+    state.filter.rate_reference_ms = in.now_ms;
+  }
+  if (limiter.clamp_integral_to_zero) state.integral = fminf(state.integral, 0.0f);
+  state.projected_gap_c = limiter.projected_gap_c;
+  state.allowed_max = limiter.allowed_max;
+  state.limiter_reason_code = limiter.reason_code;
+  arm_minimum_off_stop |=
+      guard_changed && in.restart_by_minimum_off_time && in.cooling_hp_applied && state.allowed_max <= 0;
+  const bool effective_minimum_off_stop_pending = in.minimum_off_stop_pending || arm_minimum_off_stop;
+  if (!state.water_cycle.active) {
+    const auto restart = evaluate_water_restart(in.restart_by_minimum_off_time, effective_minimum_off_stop_pending,
+                                                sanitize_restart_delta(in.restart_delta_c), limiter_input, limiter,
+                                                tuning.limiter, state.limiter, state.water_cycle);
+    state.water_cycle = restart.state;
+    if (!state.water_cycle.active) {
+      state.base_demand = state.limited_demand = 0;
+      state.limiter_reason_code = effective_minimum_off_stop_pending && limiter.allowed_max > 0
+                                      ? REASON_RESTART_WAIT
+                                      : restart.limiter_reason_code;
+      state.last_error_c = buffer_gap_c;
+      if (restart.reset_integral) state.integral = 0.0f;
+      return {true, guard_changed, arm_minimum_off_stop, false, true, true};
+    }
+  }
+  if (state.allowed_max <= 0) {
+    arm_minimum_off_stop |= in.restart_by_minimum_off_time && state.water_cycle.active && in.cooling_hp_applied;
+    state.base_demand = state.limited_demand = 0;
+    state.water_cycle.active = false;
+    state.water_cycle.stop_buffer_gap_c = filtered_gap_c;
+    state.water_cycle.stop_reason_code = state.limiter_reason_code == REASON_DEW_STOP         ? WATER_STOP_DEW
+                                         : state.limiter_reason_code == REASON_FALLBACK_FLOOR ? WATER_STOP_FALLBACK
+                                                                                              : WATER_STOP_LIMITER;
+    state.last_error_c = buffer_gap_c;
+    if (state.limiter_reason_code == REASON_DEW_STOP || state.limiter_reason_code == REASON_FALLBACK_FLOOR)
+      state.integral = 0.0f;
+    else if (state.limiter_reason_code != REASON_PROJECTED_FLOOR)
+      state.integral = fminf(state.integral, 0.0f);
+    return {true, guard_changed, arm_minimum_off_stop, false, true, true};
+  }
+  const float before_integral = kp * buffer_gap_c + ki * state.integral + kd * derivative;
+  if (!demand_finite(before_integral)) return reset_inactive_demand(in, tuning, false, state, arm_minimum_off_stop);
+  if (!(before_integral > (float)state.allowed_max && buffer_gap_c > 0.0f)) state.integral += buffer_gap_c * dt_s;
+  state.integral = demand_finite(state.integral) ? std::max(-20.0f, std::min(20.0f, state.integral)) : 0.0f;
+  const float controller_output = kp * buffer_gap_c + ki * state.integral + kd * derivative;
+  if (!demand_finite(controller_output)) return reset_inactive_demand(in, tuning, false, state, arm_minimum_off_stop);
+  state.base_demand = controller_output <= 0.0f                ? 0
+                      : controller_output >= (float)demand_max ? demand_max
+                                                               : (int)lroundf(controller_output);
+  int candidate = std::min(state.base_demand, state.allowed_max);
+  const bool oil_level1_hold = (state.limiter_reason_code == REASON_OIL_RETURN_HOLD ||
+                                state.limiter_reason_code == REASON_OIL_RETURN_RECOVERY) &&
+                               state.allowed_max >= 1;
+  const bool can_simmer = oil_level1_hold || ((!room_error_valid || in.room_error_c > tuning.simmer_room_error_min_c) &&
+                                              state.allowed_max >= 1 &&
+                                              (state.limiter_reason_code == REASON_SIMMER ||
+                                               state.limiter_reason_code == REASON_FALLING_GAP || in.fallback_mode));
+  if (can_simmer && candidate < 1) {
+    candidate = 1;
+    if (state.limiter_reason_code != REASON_FALLING_GAP && state.limiter_reason_code != REASON_FALLBACK_CAP1 &&
+        state.limiter_reason_code != REASON_OIL_RETURN_HOLD && state.limiter_reason_code != REASON_OIL_RETURN_RECOVERY)
+      state.limiter_reason_code = REASON_SIMMER;
+  }
+  const int previous = state.limited_demand;
+  state.limited_demand = apply_demand_dwell(candidate, state.allowed_max, in.now_ms, tuning, state);
+  const bool pi_zero_stop = record_pi_zero_stop(previous, state.limited_demand, filtered_gap_c, state.water_cycle);
+  if (pi_zero_stop) {
+    arm_minimum_off_stop |= in.restart_by_minimum_off_time && in.cooling_hp_applied;
+    state.limiter_reason_code = REASON_BUFFER_STOP;
+    state.integral = fminf(state.integral, 0.0f);
+  }
+  state.last_error_c = buffer_gap_c;
+  return {true,        guard_changed, arm_minimum_off_stop, pi_zero_stop, state.limiter_reason_code != REASON_FULL,
+          pi_zero_stop};
+}
+class DemandRuntime {
+ public:
+  DemandOutput tick(const DemandInput& input, const DemandTuning& tuning) {
+    return update_demand(input, tuning, state_);
+  }
+  const DemandState& state() const { return state_; }
+
+ private:
+  DemandState state_;
+};
+inline DemandRuntime& demand_runtime() {
+  static DemandRuntime runtime;
+  return runtime;
+}
+}  // namespace oq_cooling

--- a/openquatt/includes/control/oq_cooling_dispatch_logic.h
+++ b/openquatt/includes/control/oq_cooling_dispatch_logic.h
@@ -1,0 +1,118 @@
+#pragma once
+#include <algorithm>
+#include <stdint.h>
+#include "oq_cooling_limiter_logic.h"
+#include "oq_hp_candidate_logic.h"
+namespace oq_cooling {
+struct DispatchHpInput {
+  oq_hp_candidate::HpCandidateState candidate;
+  uint32_t last_start_ms = 0, last_stop_ms = 0;
+  bool has_allowed_level = false;
+};
+struct DispatchInput {
+  uint32_t now_ms = 0, cadence_ms = 5000, hp_min_off_ms = 0, global_min_off_remaining_ms = 0;
+  int raw_demand = 0, demand_max = 10, power_cap = 10, stored_owner = 0;
+  bool cooling_mode = false, duo = false, lead_is_hp1 = true;
+  bool minimum_off_enabled = false, stop_confirmation_pending = false;
+  DispatchHpInput hp1, hp2;
+};
+struct DispatchState {
+  bool loop_seen = false;
+  uint32_t last_loop_ms = 0;
+};
+struct DispatchOutput {
+  bool evaluated = false, hp1_restart_blocked = false, hp2_restart_blocked = false;
+  bool start_blocked = false;
+  int raw_demand = 0, demand = 0, hp1_request = 0, hp2_request = 0, owner_before_hold = 0, owner = 0;
+};
+inline bool hp_minimum_off_blocks_start(uint32_t now_ms, uint32_t last_stop_ms, int previous_applied_level,
+                                        uint32_t minimum_off_ms) {
+  return previous_applied_level <= 0 && last_stop_ms != 0 && minimum_off_ms > 0 &&
+         now_ms - last_stop_ms < minimum_off_ms;
+}
+inline uint32_t hp_minimum_off_remaining_s(uint32_t now_ms, uint32_t last_stop_ms, int previous_applied_level,
+                                           uint32_t minimum_off_ms) {
+  if (!hp_minimum_off_blocks_start(now_ms, last_stop_ms, previous_applied_level, minimum_off_ms)) return 0;
+  return (minimum_off_ms - (now_ms - last_stop_ms) + 999UL) / 1000UL;
+}
+inline uint32_t latest_activity_age(uint32_t now_ms, uint32_t last_start_ms, uint32_t last_stop_ms) {
+  if (last_start_ms == 0 && last_stop_ms == 0) return UINT32_MAX;
+  if (last_start_ms == 0) return now_ms - last_stop_ms;
+  if (last_stop_ms == 0) return now_ms - last_start_ms;
+  return std::min(now_ms - last_start_ms, now_ms - last_stop_ms);
+}
+inline int recent_activity_owner(const DispatchInput& in) {
+  const uint32_t hp1_age = latest_activity_age(in.now_ms, in.hp1.last_start_ms, in.hp1.last_stop_ms);
+  const uint32_t hp2_age = latest_activity_age(in.now_ms, in.hp2.last_start_ms, in.hp2.last_stop_ms);
+  return hp1_age == hp2_age ? 0 : (hp1_age < hp2_age ? 1 : 2);
+}
+inline bool dispatch_hp_can_serve(const DispatchInput& in, const DispatchHpInput& hp, bool restart_blocked) {
+  return oq_hp_candidate::may_serve_candidate(hp.candidate) && hp.has_allowed_level && !restart_blocked &&
+         !global_minimum_off_time_blocks_start(in.global_min_off_remaining_ms,
+                                               in.minimum_off_enabled && in.stop_confirmation_pending, false,
+                                               hp.candidate.previous_applied_level);
+}
+inline DispatchOutput update_dispatch(const DispatchInput& in, DispatchState& state) {
+  DispatchOutput out;
+  if (!in.cooling_mode) {
+    state = {};
+    out.evaluated = true;
+    return out;
+  }
+  if (state.loop_seen && in.now_ms - state.last_loop_ms < in.cadence_ms) return out;
+  state.loop_seen = true;
+  state.last_loop_ms = in.now_ms;
+  out.evaluated = true;
+  const int demand_max = std::max(0, std::min(10, in.demand_max));
+  out.raw_demand = std::max(0, std::min(demand_max, in.raw_demand));
+  out.demand = std::min(out.raw_demand, std::max(0, std::min(demand_max, in.power_cap)));
+  out.hp1_restart_blocked = hp_minimum_off_blocks_start(in.now_ms, in.hp1.last_stop_ms,
+                                                        in.hp1.candidate.previous_applied_level, in.hp_min_off_ms);
+  out.hp2_restart_blocked =
+      in.duo && hp_minimum_off_blocks_start(in.now_ms, in.hp2.last_stop_ms, in.hp2.candidate.previous_applied_level,
+                                            in.hp_min_off_ms);
+  const bool hp1_can_serve = dispatch_hp_can_serve(in, in.hp1, out.hp1_restart_blocked);
+  const bool hp2_can_serve = in.duo && dispatch_hp_can_serve(in, in.hp2, out.hp2_restart_blocked);
+  const bool demand_active = out.demand > 0;
+  int owner = in.stored_owner;
+  if (!demand_active)
+    owner = 0;
+  else if (in.duo && in.hp1.candidate.previous_applied_level > 0 && in.hp2.candidate.previous_applied_level <= 0 &&
+           hp1_can_serve)
+    owner = 1;
+  else if (in.duo && in.hp2.candidate.previous_applied_level > 0 && in.hp1.candidate.previous_applied_level <= 0 &&
+           hp2_can_serve)
+    owner = 2;
+  else if (!in.duo)
+    owner = hp1_can_serve ? 1 : 0;
+  else if (!((owner == 1 && hp1_can_serve) || (owner == 2 && hp2_can_serve))) {
+    const int recent_owner = recent_activity_owner(in);
+    if (recent_owner == 1 && hp1_can_serve)
+      owner = 1;
+    else if (recent_owner == 2 && hp2_can_serve)
+      owner = 2;
+    else if (in.lead_is_hp1 && hp1_can_serve)
+      owner = 1;
+    else if (!in.lead_is_hp1 && hp2_can_serve)
+      owner = 2;
+    else if (hp1_can_serve != hp2_can_serve)
+      owner = hp1_can_serve ? 1 : 2;
+    else
+      owner = hp1_can_serve ? (in.lead_is_hp1 ? 1 : 2) : 0;
+  }
+  out.owner_before_hold = owner;
+  int hp1_request = owner == 1 ? out.demand : 0;
+  int hp2_request = owner == 2 ? out.demand : 0;
+  const auto hold = oq_hp_candidate::preserve_active_topology_during_suspect(
+      {hp1_request, hp2_request, in.hp1.candidate, in.hp2.candidate, demand_active});
+  out.hp1_request = hold.hp1_level;
+  out.hp2_request = in.duo ? hold.hp2_level : 0;
+  out.owner = in.duo ? hold.owner_hp : (out.hp1_request > 0 ? 1 : 0);
+  out.start_blocked = demand_active && out.owner_before_hold == 0 && !hp1_can_serve && !hp2_can_serve;
+  return out;
+}
+inline DispatchOutput dispatch_tick(const DispatchInput& input) {
+  static DispatchState state;
+  return update_dispatch(input, state);
+}
+}  // namespace oq_cooling

--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -208,7 +208,7 @@ inline int clamp_level(int value, int min_value, int max_value) {
   return std::max(min_value, std::min(max_value, value));
 }
 
-inline bool finite_float(float value) { return !isnan(value); }
+inline bool finite_float(float value) { return isfinite(value); }
 
 inline float hard_dew_restart_gap(const LimiterInput& in, const LimiterTuning& tuning) {
   return tuning.hard_dew_stop_base_gap_c + tuning.hard_dew_stop_margin_gain_c * in.safety_margin_c +

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -1,245 +1,74 @@
 # ==============================================================================
 # OpenQuatt - Cooling Strategy
 # ==============================================================================
-#
-# Goal:
-#   Own the complete cooling path on top of the cooling safety signals.
-#   This layer produces the cooling supply target, a cooling demand `f`, and the
-#   downstream cooling compressor requests. Room comfort decides whether cooling
-#   is needed; this strategy decides how much cooling is safe on the water side.
-#
-# Scope:
-#   - Derive the cooling supply target from the configured floor and dew-point
-#     or fallback safety floor
-#   - Run a water-temperature PI(D) loop with a safe-floor limiter
-#   - Publish `oq_cooling_demand_raw` (0..10)
-#   - Choose the active cooling owner HP and publish cooling requests
-#
-# Control model:
-#   1. The cooling safety layer latches room demand and computes the minimum
-#      safe supply temperature.
-#   2. `Cooling Supply Target` is the coldest allowed water target. It does not
-#      include a comfort offset; comfort hysteresis stays in the room layer.
-#   3. `buffer_gap = supply - target` controls modulation. Positive gap means
-#      water is still warmer than target and cooling may increase.
-#   4. `dew_gap = supply - dew_point` is only a safety distance. Raw dew_gap can
-#      stop cooling immediately, while filtered buffer_gap and its trend drive
-#      normal modulation.
-#   5. The safe-floor limiter caps the PI output before it reaches the compressor:
-#      it projects the filtered water gap forward with its current trend, allows
-#      the PI output while that projection stays safely above the floor, brakes
-#      back to level 1 when higher levels move toward the floor too quickly, and
-#      stops hard only at/under the stop zone or too close to the real/fallback
-#      floor. Projection never creates a stop by itself.
-#   6. `Cooling Restart Delta` only applies after a real water-side stop. Normal
-#      room-demand stops can restart from the current limiter state.
-#
-# ==============================================================================
-
+# Owns the supply target, safe water-side demand (0..10), and downstream HP requests.
+# Room safety latches demand and provides the real/fallback minimum supply temperature.
+# `buffer_gap = supply - target` drives PI modulation; positive means cooling may rise.
+# Raw `dew_gap = supply - dew_point` may stop immediately. Filtered buffer gap and trend
+# drive normal limiting. Projection may brake to F1 but never creates a stop by itself.
+# `Cooling Restart Delta` applies only after a water-side stop, not a room-demand stop.
 globals:
   - id: oq_cooling_demand_raw
     type: int
     restore_value: false
     initial_value: '0'
-
-  - id: oq_cooling_pid_integral
-    type: float
-    restore_value: false
-    initial_value: '0.0'
-
-  - id: oq_cooling_pid_last_error_c
-    type: float
-    restore_value: false
-    initial_value: '0.0'
-
-  - id: oq_cooling_buffer_gap_filtered_c
-    type: float
-    restore_value: false
-    initial_value: '0.0'
-
-  - id: oq_cooling_buffer_gap_rate_ref_c
-    type: float
-    restore_value: false
-    initial_value: '0.0'
-
-  - id: oq_cooling_buffer_gap_rate_c_per_min
-    type: float
-    restore_value: false
-    initial_value: '0.0'
-
-  - id: oq_cooling_dew_gap_c
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-
-  - id: oq_cooling_stop_buffer_gap_c
-    type: float
-    restore_value: false
-    initial_value: '0.0'
-
-  - id: oq_cooling_gap_filter_ready
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_cooling_simmer_allowed
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_cooling_projection_brake_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_cooling_projected_gap_c
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-
-  - id: oq_cooling_limiter_allowed_max
-    type: int
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_base_demand_raw
-    type: int
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_limited_demand
-    type: int
-    restore_value: false
-    initial_value: '0'
-
-  # 0=inactive, 1=full, 2=projected_floor, 3=simmer, 4=falling_gap, 5=buffer_stop,
-  # 6=dew_stop, 7=fallback_floor, 8=restart_wait, 9=room_cap, 10=fallback_cap1,
-  # 11=level1_hold, 12=oil_return_hold, 13=oil_return_recovery, 14=capacity_cap
-  - id: oq_cooling_limiter_reason_code
-    type: int
-    restore_value: false
-    initial_value: '0'
-
   # 0=none, 1=limiter, 2=dew, 3=fallback, 4=projected_floor (legacy), 5=request_cleared,
   # 6=flow_permission_lost, 7=core_permission_lost
   - id: oq_cooling_stop_reason_code
     type: int
     restore_value: false
     initial_value: '0'
-
-  - id: oq_cooling_last_loop_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_buffer_gap_rate_ref_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_last_demand_change_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_stop_candidate_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_dew_stop_candidate_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_capacity_cap
-    type: int
-    restore_value: false
-    initial_value: '10'
-
-  - id: oq_cooling_capacity_last_change_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_capacity_recovery_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_capacity_full_recovery_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-
-  - id: oq_cooling_water_cycle_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
   - id: oq_cooling_request_last_loop_ms
     type: uint32_t
     restore_value: false
     initial_value: '0'
-
   - id: oq_cooling_request_hp1_level
     type: int
     restore_value: false
     initial_value: '0'
-
   - id: oq_cooling_request_hp2_level
     type: int
     restore_value: false
     initial_value: '0'
-
   - id: oq_cooling_request_owner_hp
     type: int
     restore_value: false
     initial_value: '0'
-
   - id: oq_cooling_owner_hp
     type: int
     restore_value: false
     initial_value: '0'
-
   # Shared confirmed automatic-cooling stop anchor. In minimum-off-time mode
   # this blocks both HPs, so Duo cannot restart on the other compressor.
   - id: oq_cooling_last_confirmed_stop_ms
     type: uint32_t
     restore_value: false
     initial_value: '0'
-
   - id: oq_cooling_confirmed_stop_seen
     type: bool
     restore_value: false
     initial_value: 'false'
-
   - id: oq_cooling_stop_confirmation_pending_hp1
     type: bool
     restore_value: false
     initial_value: 'false'
-
   - id: oq_cooling_stop_confirmation_pending_hp2
     type: bool
     restore_value: false
     initial_value: 'false'
-
   - id: oq_cooling_boot_min_off_elapsed
     type: bool
     restore_value: false
     initial_value: 'false'
-
   - id: oq_cooling_min_off_stop_pending
     type: bool
     restore_value: false
     initial_value: 'false'
-
   # 0=idle, 1=owner_hp1, 2=owner_hp2
   - id: oq_cooling_request_reason_code
     type: int
     restore_value: false
     initial_value: '0'
-
 select:
   - platform: template
     id: cooling_restart_mode
@@ -252,7 +81,6 @@ select:
     options:
       - "Water temperature"
       - "Minimum off time"
-
 number:
   - platform: template
     id: cooling_min_supply_temp
@@ -267,7 +95,6 @@ number:
     restore_value: true
     initial_value: 14.0
     entity_category: config
-
   - platform: template
     id: cooling_demand_max_f
     name: "Cooling Demand Max"
@@ -281,7 +108,6 @@ number:
     restore_value: true
     initial_value: 4
     entity_category: config
-
   - platform: template
     id: cooling_restart_delta
     name: "Cooling Restart Delta"
@@ -295,7 +121,6 @@ number:
     restore_value: true
     initial_value: 1.0
     entity_category: config
-
   - platform: template
     id: cooling_minimum_off_time
     name: "Cooling Minimum Off Time"
@@ -309,7 +134,6 @@ number:
     restore_value: true
     initial_value: 600
     entity_category: config
-
   - platform: template
     id: cooling_pid_kp
     name: "Cooling PID Kp"
@@ -322,7 +146,6 @@ number:
     restore_value: true
     initial_value: 3.0
     entity_category: config
-
   - platform: template
     id: cooling_pid_ki
     name: "Cooling PID Ki"
@@ -335,7 +158,6 @@ number:
     restore_value: true
     initial_value: 0.12
     entity_category: config
-
   - platform: template
     id: cooling_pid_kd
     name: "Cooling PID Kd"
@@ -348,7 +170,6 @@ number:
     restore_value: true
     initial_value: 0.0
     entity_category: config
-
 sensor:
   - platform: template
     id: cooling_supply_target
@@ -367,7 +188,6 @@ sensor:
         base_floor_c = fmaxf(base_floor_c, id(cooling_effective_min_supply_temp).state);
       }
       return base_floor_c;
-
   - platform: template
     id: cooling_supply_error
     name: "Cooling Supply Error"
@@ -381,7 +201,6 @@ sensor:
       if (!id(oq_system_supply_temp).has_state() || isnan(id(oq_system_supply_temp).state)) return NAN;
       // Positive error means the supply is warmer than target, so more cooling may be requested.
       return id(oq_system_supply_temp).state - id(cooling_supply_target).state;
-
   - platform: template
     id: oq_cooling_demand_raw_sensor
     name: "Cooling Demand (raw)"
@@ -392,7 +211,6 @@ sensor:
     update_interval: 5s
     lambda: |-
       return (float) id(oq_cooling_demand_raw);
-
   - platform: template
     id: oq_cooling_base_demand_raw_sensor
     name: "Cooling base demand raw"
@@ -403,8 +221,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return (float) id(oq_cooling_base_demand_raw);
-
+      return (float) oq_cooling::demand_runtime().state().base_demand;
   - platform: template
     id: oq_cooling_limited_demand_sensor
     name: "Cooling limited demand"
@@ -415,8 +232,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return (float) id(oq_cooling_limited_demand);
-
+      return (float) oq_cooling::demand_runtime().state().limited_demand;
   - platform: template
     id: oq_cooling_limiter_allowed_max_sensor
     name: "Cooling limiter allowed max"
@@ -427,8 +243,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return (float) id(oq_cooling_limiter_allowed_max);
-
+      return (float) oq_cooling::demand_runtime().state().allowed_max;
   - platform: template
     id: oq_cooling_buffer_gap_filtered_sensor
     name: "Cooling buffer gap filtered"
@@ -439,8 +254,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return id(oq_cooling_buffer_gap_filtered_c);
-
+      return oq_cooling::demand_runtime().state().filter.filtered_gap_c;
   - platform: template
     id: oq_cooling_buffer_gap_rate_sensor
     name: "Cooling buffer gap rate"
@@ -451,8 +265,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return id(oq_cooling_buffer_gap_rate_c_per_min);
-
+      return oq_cooling::demand_runtime().state().filter.rate_c_per_min;
   - platform: template
     id: oq_cooling_projected_gap_sensor
     name: "Cooling projected gap"
@@ -463,8 +276,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return id(oq_cooling_projected_gap_c);
-
+      return oq_cooling::demand_runtime().state().projected_gap_c;
   - platform: template
     id: oq_cooling_projection_brake_active_sensor
     name: "Cooling projection brake active"
@@ -474,8 +286,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return id(oq_cooling_projection_brake_active) ? 1.0f : 0.0f;
-
+      return oq_cooling::demand_runtime().state().limiter.projection_brake_active ? 1.0f : 0.0f;
   - platform: template
     id: oq_cooling_dew_gap_sensor
     name: "Cooling dew gap"
@@ -486,8 +297,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return id(oq_cooling_dew_gap_c);
-
+      return oq_cooling::demand_runtime().state().dew_gap_c;
   - platform: template
     id: oq_cooling_stop_buffer_gap_sensor
     name: "Cooling stop buffer gap"
@@ -498,8 +308,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return id(oq_cooling_stop_buffer_gap_c);
-
+      return oq_cooling::demand_runtime().state().water_cycle.stop_buffer_gap_c;
   - platform: template
     id: oq_cooling_limiter_reason_code_sensor
     name: "Cooling limiter reason code"
@@ -509,8 +318,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return (float) id(oq_cooling_limiter_reason_code);
-
+      return (float) oq_cooling::demand_runtime().state().limiter_reason_code;
   - platform: template
     id: oq_cooling_stop_reason_code_sensor
     name: "Cooling stop reason code"
@@ -521,7 +329,6 @@ sensor:
     entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_stop_reason_code);
-
   - platform: template
     id: oq_cooling_request_reason_code_sensor
     name: "Cooling request reason code"
@@ -532,7 +339,6 @@ sensor:
     entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_request_reason_code);
-
   - platform: template
     id: oq_cooling_request_hp1_level_sensor
     name: "Cooling request HP1 level"
@@ -544,7 +350,6 @@ sensor:
     entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_request_hp1_level);
-
   - platform: template
     id: oq_cooling_request_hp2_level_sensor
     name: "Cooling request HP2 level"
@@ -556,7 +361,6 @@ sensor:
     entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_request_hp2_level);
-
   - platform: template
     id: oq_cooling_request_owner_hp_sensor
     name: "Cooling request owner HP"
@@ -567,7 +371,6 @@ sensor:
     entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_request_owner_hp);
-
   - platform: template
     id: oq_cooling_owner_hp_sensor
     name: "Cooling owner HP"
@@ -578,7 +381,6 @@ sensor:
     entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_owner_hp);
-
   - platform: template
     id: oq_cooling_water_cycle_active_sensor
     name: "Cooling water cycle active"
@@ -588,8 +390,7 @@ sensor:
     update_interval: 5s
     entity_category: diagnostic
     lambda: |-
-      return id(oq_cooling_water_cycle_active) ? 1.0f : 0.0f;
-
+      return oq_cooling::demand_runtime().state().water_cycle.active ? 1.0f : 0.0f;
   - platform: template
     id: oq_cooling_minimum_off_time_remaining_sensor
     name: "Cooling Minimum Off Time Remaining"
@@ -604,7 +405,6 @@ sensor:
           id(cooling_restart_mode).has_state() &&
           id(cooling_restart_mode).current_option() == "Minimum off time";
       if (!restart_by_minimum_off_time) return 0.0f;
-
       const float configured_state = id(cooling_minimum_off_time).state;
       int configured_s =
           isnan(configured_state) ? 600 : (int) lroundf(configured_state);
@@ -627,33 +427,14 @@ sensor:
       // configured duration is the minimum remaining wait visible to support.
       if (stop_confirmation_pending) remaining_ms = std::max(remaining_ms, configured_ms);
       return (float) ((remaining_ms + 999UL) / 1000UL);
-
 interval:
   - interval: 5s
     then:
       - lambda: |-
-          // Internal controller constants. They intentionally are not user settings:
-          // the public tuning surface stays small, while the limiter still has
-          // enough shape to behave across low-mass and high-mass water systems.
-          const float filter_tau_s = 60.0f;
-          const uint32_t rate_window_ms = 60000UL;
-          oq_cooling::OilReturnTuning oil_return_tuning{(uint32_t) (${oq_cooling_oil_return_hold_s} * 1000UL)};
-          oq_cooling::LimiterTuning limiter_tuning;
-          limiter_tuning.limiter_stop_confirm_ms = (uint32_t) (${oq_cooling_limiter_stop_confirm_s} * 1000UL);
-          const uint32_t upscale_dwell_ms = 90000UL;
-          const uint32_t downscale_dwell_ms = 30000UL;
-          const float simmer_room_error_min_c = 0.20f;
-
-          // Resolve loop timing and reset the controller cleanly when cooling is not allowed.
-          const uint32_t now_ms = (uint32_t) millis();
-          float dt_s = 5.0f;
-          if (id(oq_cooling_last_loop_ms) > 0 && now_ms > id(oq_cooling_last_loop_ms)) {
-            dt_s = (float) (now_ms - id(oq_cooling_last_loop_ms)) / 1000.0f;
-          }
-          if (dt_s < 0.1f) dt_s = 0.1f;
-          if (dt_s > 15.0f) dt_s = 15.0f;
-          id(oq_cooling_last_loop_ms) = now_ms;
-
+          oq_cooling::DemandTuning tuning;
+          tuning.oil_return.hold_ms = (uint32_t) (${oq_cooling_oil_return_hold_s} * 1000UL);
+          tuning.limiter.limiter_stop_confirm_ms =
+              (uint32_t) (${oq_cooling_limiter_stop_confirm_s} * 1000UL);
           auto publish_cooling_limiter_event = [&](bool limiter_active,
                                                    int limiter_reason,
                                                    int limited_demand,
@@ -713,21 +494,13 @@ interval:
             }
             last_pause_active = pause_active;
           };
-
           bool oil_return_active = id(hp1_prot_oil_return).state;
           #if OQ_TOPOLOGY_DUO
           oil_return_active = oil_return_active || id(${secondary_oil_return_id}).state;
           #endif
-          static oq_cooling::OilReturnState oil_return_state;
-
-          const bool active =
-              id(cooling_enable_selected).state &&
-              id(cooling_request_active).state &&
-              id(cooling_permitted).state;
+          const auto &previous = oq_cooling::demand_runtime().state();
           const bool cooling_cycle_was_active =
-              id(oq_cooling_water_cycle_active) ||
-              id(oq_cooling_limited_demand) > 0 ||
-              id(oq_cooling_base_demand_raw) > 0 ||
+              previous.water_cycle.active || previous.limited_demand > 0 || previous.base_demand > 0 ||
               id(oq_cooling_request_hp1_level) > 0 ||
               id(oq_cooling_request_hp2_level) > 0;
           const bool cooling_request_cleared =
@@ -744,50 +517,6 @@ interval:
               cooling_request_still_active &&
               id(cooling_permitted_core).has_state() && id(cooling_permitted_core).state &&
               (!id(cooling_permitted).has_state() || !id(cooling_permitted).state);
-          const bool cooling_sensor_missing =
-              !id(cooling_supply_target).has_state() || isnan(id(cooling_supply_target).state) ||
-              !id(oq_system_supply_temp).has_state() || isnan(id(oq_system_supply_temp).state);
-
-          if (!active || cooling_sensor_missing) {
-            id(oq_cooling_demand_raw) = 0;
-            id(oq_cooling_pid_integral) = 0.0f;
-            id(oq_cooling_pid_last_error_c) = 0.0f;
-            id(oq_cooling_water_cycle_active) = false;
-            id(oq_cooling_gap_filter_ready) = false;
-            id(oq_cooling_projected_gap_c) = NAN;
-            id(oq_cooling_limiter_allowed_max) = 0;
-            id(oq_cooling_base_demand_raw) = 0;
-            id(oq_cooling_limited_demand) = 0;
-            id(oq_cooling_limiter_reason_code) = 0;
-            id(oq_cooling_stop_reason_code) = oq_cooling::inactive_stop_reason(
-                cooling_cycle_was_active, cooling_request_cleared, cooling_sensor_missing,
-                cooling_flow_permission_lost, cooling_core_permission_lost);
-            id(oq_cooling_buffer_gap_rate_ref_ms) = 0;
-            id(oq_cooling_last_demand_change_ms) = 0;
-            oq_cooling::update_oil_return(
-                {now_ms, false, oil_return_active}, {}, oil_return_tuning, limiter_tuning, oil_return_state);
-            const int reset_capacity_cap = oq_cooling::clamp_level((int) lroundf(id(cooling_demand_max_f).state), 1, 10);
-            id(oq_cooling_simmer_allowed) = false;
-            id(oq_cooling_projection_brake_active) = false;
-            id(oq_cooling_stop_candidate_since_ms) = 0;
-            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
-            publish_cooling_limiter_event(false, 0, 0, 0, NAN);
-            id(oq_cooling_capacity_cap) = reset_capacity_cap;
-            id(oq_cooling_capacity_last_change_ms) = 0;
-            id(oq_cooling_capacity_recovery_since_ms) = 0;
-            id(oq_cooling_capacity_full_recovery_since_ms) = 0;
-            return;
-          }
-
-          // Cooling PI(D): positive buffer gap means the system supply is still warmer than target.
-          // This is the regulation error. It is deliberately separate from dew_gap:
-          // buffer_gap is comfort/control room, dew_gap is condensation safety.
-          const float supply_c = id(oq_system_supply_temp).state;
-          const float target_c = id(cooling_supply_target).state;
-          const float buffer_gap_c = supply_c - target_c;
-          float restart_delta_c = id(cooling_restart_delta).state;
-          if (isnan(restart_delta_c) || restart_delta_c < 0.0f) restart_delta_c = 1.0f;
-          if (restart_delta_c > 5.0f) restart_delta_c = 5.0f;
           const bool restart_by_minimum_off_time =
               id(cooling_restart_mode).has_state() &&
               id(cooling_restart_mode).current_option() == "Minimum off time";
@@ -805,325 +534,85 @@ interval:
               || id(oq_cooling_stop_confirmation_pending_hp2)
               #endif
               ;
-          if (oq_cooling::cooling_minimum_off_stop_is_pending(
-                         restart_by_minimum_off_time,
-                         id(oq_cooling_water_cycle_active),
-                         id(oq_cooling_stop_reason_code),
-                         cooling_minimum_off_wait_active)) {
-            // Preserve a water-side stop already in progress when the user
-            // switches from temperature restart to minimum off-time.
-            id(oq_cooling_min_off_stop_pending) = true;
-          }
-
           const bool user_responsibility_mode =
               id(cooling_without_dew_point_user_responsibility_enabled).has_state() &&
               id(cooling_without_dew_point_user_responsibility_enabled).state;
           const bool dew_mode =
               !user_responsibility_mode &&
               id(cooling_dew_point_available).has_state() && id(cooling_dew_point_available).state &&
-              id(cooling_dew_point_selected).has_state() && !isnan(id(cooling_dew_point_selected).state);
+              id(cooling_dew_point_selected).has_state() && isfinite(id(cooling_dew_point_selected).state);
           const bool fallback_mode =
               !user_responsibility_mode &&
               !dew_mode && id(cooling_fallback_active).has_state() && id(cooling_fallback_active).state;
-          const int guard_mode =
-              user_responsibility_mode ? 3 : (dew_mode ? 1 : (fallback_mode ? 2 : 0));
-          static int last_guard_mode = -1;
-          if (last_guard_mode >= 0 && guard_mode != last_guard_mode) {
-            id(oq_cooling_water_cycle_active) = false;
-            id(oq_cooling_gap_filter_ready) = false;
-            id(oq_cooling_projected_gap_c) = NAN;
-            id(oq_cooling_stop_reason_code) = 0;
-            id(oq_cooling_stop_buffer_gap_c) = 0.0f;
-            id(oq_cooling_last_demand_change_ms) = 0;
-            oq_cooling::reset_oil_return_recovery(oil_return_state);
-            id(oq_cooling_simmer_allowed) = false;
-            id(oq_cooling_projection_brake_active) = false;
-            id(oq_cooling_stop_candidate_since_ms) = 0;
-            id(oq_cooling_dew_stop_candidate_since_ms) = 0;
-            id(oq_cooling_capacity_cap) = 10;
-            id(oq_cooling_capacity_last_change_ms) = 0;
-            id(oq_cooling_capacity_recovery_since_ms) = 0;
-            id(oq_cooling_capacity_full_recovery_since_ms) = 0;
-            id(oq_cooling_buffer_gap_rate_ref_ms) = 0;
-            id(oq_cooling_pid_integral) = 0.0f;
-            id(oq_cooling_pid_last_error_c) = buffer_gap_c;
-            ESP_LOGI("quatt.cool", "Cooling guard mode changed: reset restart latch");
-          }
-          last_guard_mode = guard_mode;
-
-          // Use raw temperatures for hard safety, but filter the water-side gap
-          // before modulation. Small systems can move 0.1-0.2 C in seconds; the
-          // 60s EMA/rate prevents that noise from becoming level chatter.
-          float filtered_gap_c = buffer_gap_c;
-          if (!id(oq_cooling_gap_filter_ready)) {
-            id(oq_cooling_buffer_gap_filtered_c) = buffer_gap_c;
-            id(oq_cooling_buffer_gap_rate_ref_c) = buffer_gap_c;
-            id(oq_cooling_buffer_gap_rate_c_per_min) = 0.0f;
-            id(oq_cooling_buffer_gap_rate_ref_ms) = now_ms;
-            id(oq_cooling_gap_filter_ready) = true;
-          } else {
-            const float alpha = dt_s / (filter_tau_s + dt_s);
-            id(oq_cooling_buffer_gap_filtered_c) += alpha * (buffer_gap_c - id(oq_cooling_buffer_gap_filtered_c));
-            if (id(oq_cooling_buffer_gap_rate_ref_ms) == 0 || now_ms <= id(oq_cooling_buffer_gap_rate_ref_ms)) {
-              id(oq_cooling_buffer_gap_rate_ref_c) = id(oq_cooling_buffer_gap_filtered_c);
-              id(oq_cooling_buffer_gap_rate_ref_ms) = now_ms;
-              id(oq_cooling_buffer_gap_rate_c_per_min) = 0.0f;
-            } else if ((uint32_t)(now_ms - id(oq_cooling_buffer_gap_rate_ref_ms)) >= rate_window_ms) {
-              const float elapsed_min = ((float) (now_ms - id(oq_cooling_buffer_gap_rate_ref_ms))) / 60000.0f;
-              if (elapsed_min > 0.0f) {
-                id(oq_cooling_buffer_gap_rate_c_per_min) =
-                    (id(oq_cooling_buffer_gap_filtered_c) - id(oq_cooling_buffer_gap_rate_ref_c)) / elapsed_min;
-              }
-              id(oq_cooling_buffer_gap_rate_ref_c) = id(oq_cooling_buffer_gap_filtered_c);
-              id(oq_cooling_buffer_gap_rate_ref_ms) = now_ms;
-            }
-          }
-          filtered_gap_c = id(oq_cooling_buffer_gap_filtered_c);
-          const float gap_rate_c_per_min = id(oq_cooling_buffer_gap_rate_c_per_min);
-
-          const float dew_gap_c = dew_mode ? (supply_c - id(cooling_dew_point_selected).state) : NAN;
-          id(oq_cooling_dew_gap_c) = dew_gap_c;
-          float safety_margin_c = 0.0f;
-          if (id(cooling_safety_margin_selected).has_state() && !isnan(id(cooling_safety_margin_selected).state)) {
-            safety_margin_c = id(cooling_safety_margin_selected).state;
-          }
-          safety_margin_c = fmaxf(0.0f, fminf(2.0f, safety_margin_c));
-          float kp = id(cooling_pid_kp).state;
-          float ki = id(cooling_pid_ki).state;
-          float kd = id(cooling_pid_kd).state;
-          if (isnan(kp) || kp < 0.0f) kp = 0.0f;
-          if (isnan(ki) || ki < 0.0f) ki = 0.0f;
-          if (isnan(kd) || kd < 0.0f) kd = 0.0f;
-
-          float integral = id(oq_cooling_pid_integral);
-          float derivative = 0.0f;
-          if (dt_s > 0.0f) {
-            derivative = (buffer_gap_c - id(oq_cooling_pid_last_error_c)) / dt_s;
-          }
-
           float room_error_c = NAN;
           bool room_error_valid = false;
-          if (id(room_temp_selected).has_state() && !isnan(id(room_temp_selected).state) &&
-              id(room_setpoint_selected).has_state() && !isnan(id(room_setpoint_selected).state)) {
+          if (id(room_temp_selected).has_state() && isfinite(id(room_temp_selected).state) &&
+              id(room_setpoint_selected).has_state() && isfinite(id(room_setpoint_selected).state)) {
             room_error_c = id(room_temp_selected).state - id(room_setpoint_selected).state;
-            room_error_valid = true;
+            room_error_valid = isfinite(room_error_c);
           }
-
-          int demand_max = oq_cooling::clamp_level((int) lroundf(id(cooling_demand_max_f).state), 1, 10);
-          const int capacity_demand_max = demand_max;
-
-          bool room_cap_active = false;
-          if (room_error_valid) {
-            const int before_room_cap = demand_max;
-            if (room_error_c < 0.4f) demand_max = std::min(demand_max, 1);
-            else if (room_error_c < 0.8f) demand_max = std::min(demand_max, 2);
-            else if (room_error_c < 1.2f) demand_max = std::min(demand_max, 3);
-            room_cap_active = demand_max < before_room_cap;
-          }
-
-          oq_cooling::LimiterState limiter_state{id(oq_cooling_simmer_allowed), id(oq_cooling_projection_brake_active),
-              id(oq_cooling_stop_candidate_since_ms), id(oq_cooling_dew_stop_candidate_since_ms),
-              id(oq_cooling_capacity_cap), id(oq_cooling_capacity_last_change_ms),
-              id(oq_cooling_capacity_recovery_since_ms), id(oq_cooling_capacity_full_recovery_since_ms)};
-          oq_cooling::LimiterInput limiter_input{now_ms, demand_max, capacity_demand_max, id(oq_cooling_limited_demand),
-              room_cap_active, dew_mode, fallback_mode, false, false, buffer_gap_c,
-              filtered_gap_c, gap_rate_c_per_min, dew_gap_c, safety_margin_c};
-
-          const auto oil_return_decision = oq_cooling::update_oil_return({now_ms, true, oil_return_active}, limiter_input,
-              oil_return_tuning, limiter_tuning, oil_return_state);
-          limiter_input.oil_return_mask_active = oil_return_decision.mask_active;
-          limiter_input.oil_return_recovery_cap_active = oil_return_decision.recovery_cap_active;
-          if (oil_return_decision.reset_integral_and_dwell) {
-            integral = id(oq_cooling_pid_integral) = 0.0f;
-            id(oq_cooling_last_demand_change_ms) = now_ms;
-          } else if (oil_return_decision.mask_active || oil_return_decision.recovery_cap_active) {
-            integral = fminf(integral, 0.0f);
-          }
+          const bool supply_valid = id(oq_system_supply_temp).has_state() &&
+                                    isfinite(id(oq_system_supply_temp).state);
+          const bool target_valid = id(cooling_supply_target).has_state() &&
+                                    isfinite(id(cooling_supply_target).state);
+          oq_cooling::DemandInput input;
+          input.now_ms = (uint32_t) millis();
+          input.control_active = id(cooling_enable_selected).has_state() && id(cooling_enable_selected).state &&
+                                 id(cooling_request_active).has_state() && id(cooling_request_active).state &&
+                                 id(cooling_permitted).has_state() && id(cooling_permitted).state;
+          input.cycle_was_active = cooling_cycle_was_active;
+          input.request_cleared = cooling_request_cleared;
+          input.sensor_valid = supply_valid && target_valid;
+          input.flow_permission_lost = cooling_flow_permission_lost;
+          input.core_permission_lost = cooling_core_permission_lost;
+          input.oil_return_active = oil_return_active;
+          input.cooling_hp_applied = cooling_hp_applied;
+          input.restart_by_minimum_off_time = restart_by_minimum_off_time;
+          input.minimum_off_stop_pending = id(oq_cooling_min_off_stop_pending);
+          input.minimum_off_wait_active = cooling_minimum_off_wait_active;
+          input.guard_mode = user_responsibility_mode ? oq_cooling::GUARD_USER_RESPONSIBILITY
+                             : dew_mode              ? oq_cooling::GUARD_DEW
+                             : fallback_mode         ? oq_cooling::GUARD_FALLBACK
+                                                     : oq_cooling::GUARD_NONE;
+          input.dew_mode = dew_mode;
+          input.fallback_mode = fallback_mode;
+          input.room_error_valid = room_error_valid;
+          input.supply_c = supply_valid ? id(oq_system_supply_temp).state : NAN;
+          input.target_c = target_valid ? id(cooling_supply_target).state : NAN;
+          input.dew_point_c = dew_mode ? id(cooling_dew_point_selected).state : NAN;
+          input.safety_margin_c = id(cooling_safety_margin_selected).has_state()
+                                      ? id(cooling_safety_margin_selected).state : NAN;
+          input.room_error_c = room_error_c;
+          input.restart_delta_c = id(cooling_restart_delta).has_state() ? id(cooling_restart_delta).state : NAN;
+          input.demand_max = id(cooling_demand_max_f).has_state() ? id(cooling_demand_max_f).state : NAN;
+          input.kp = id(cooling_pid_kp).has_state() ? id(cooling_pid_kp).state : NAN;
+          input.ki = id(cooling_pid_ki).has_state() ? id(cooling_pid_ki).state : NAN;
+          input.kd = id(cooling_pid_kd).has_state() ? id(cooling_pid_kd).state : NAN;
+          const auto decision = oq_cooling::demand_runtime().tick(input, tuning);
+          const auto &cooling = oq_cooling::demand_runtime().state();
+          id(oq_cooling_demand_raw) = cooling.limited_demand;
+          id(oq_cooling_stop_reason_code) = cooling.water_cycle.stop_reason_code;
+          if (decision.arm_minimum_off_stop) id(oq_cooling_min_off_stop_pending) = true;
           static bool last_oil_return_mask_active = false;
-          if (oil_return_decision.mask_active != last_oil_return_mask_active) {
+          const bool oil_return_mask_active =
+              cooling.limiter_reason_code == oq_cooling::REASON_OIL_RETURN_HOLD;
+          if (decision.control_active && oil_return_mask_active != last_oil_return_mask_active) {
             ESP_LOGI("quatt.cool", "Cooling oil-return recovery %s",
-                     oil_return_decision.mask_active ? "active" : "cleared");
-            last_oil_return_mask_active = oil_return_decision.mask_active;
+                     oil_return_mask_active ? "active" : "cleared");
+            last_oil_return_mask_active = oil_return_mask_active;
           }
-
-          const auto limiter_output = oq_cooling::update_limiter(limiter_input, limiter_tuning, limiter_state);
-          if (limiter_output.reset_gap_rate_reference) {
-            id(oq_cooling_buffer_gap_rate_ref_c) = filtered_gap_c;
-            id(oq_cooling_buffer_gap_rate_ref_ms) = now_ms;
-          }
-          if (limiter_output.clamp_integral_to_zero) integral = fminf(integral, 0.0f);
-          id(oq_cooling_simmer_allowed) = limiter_state.simmer_allowed;
-          id(oq_cooling_projection_brake_active) = limiter_state.projection_brake_active;
-          id(oq_cooling_stop_candidate_since_ms) = limiter_state.stop_candidate_since_ms;
-          id(oq_cooling_dew_stop_candidate_since_ms) = limiter_state.dew_stop_candidate_since_ms;
-          id(oq_cooling_capacity_cap) = limiter_state.capacity_cap;
-          id(oq_cooling_capacity_last_change_ms) = limiter_state.capacity_last_change_ms;
-          id(oq_cooling_capacity_recovery_since_ms) = limiter_state.capacity_recovery_since_ms;
-          id(oq_cooling_capacity_full_recovery_since_ms) = limiter_state.capacity_full_recovery_since_ms;
-          id(oq_cooling_projected_gap_c) = limiter_output.projected_gap_c;
-
-          const int allowed_max = limiter_output.allowed_max;
-          int reason_code = limiter_output.reason_code;
-          id(oq_cooling_limiter_allowed_max) = allowed_max;
-
-          // Water-side stops use restart hysteresis; a cleared room request may
-          // restart immediately when the current limiter allows it.
-          bool water_cycle_active = id(oq_cooling_water_cycle_active);
-          if (!water_cycle_active) {
-            const auto restart = oq_cooling::evaluate_water_restart(
-                restart_by_minimum_off_time, id(oq_cooling_min_off_stop_pending), restart_delta_c,
-                limiter_input, limiter_output, limiter_tuning, limiter_state,
-                {false, id(oq_cooling_stop_buffer_gap_c), id(oq_cooling_stop_reason_code)});
-            water_cycle_active = restart.state.active;
-            id(oq_cooling_stop_buffer_gap_c) = restart.state.stop_buffer_gap_c;
-            id(oq_cooling_stop_reason_code) = restart.state.stop_reason_code;
-            if (!restart.state.active) {
-              id(oq_cooling_demand_raw) = 0;
-              id(oq_cooling_base_demand_raw) = 0;
-              id(oq_cooling_limited_demand) = 0;
-              id(oq_cooling_limiter_reason_code) = restart.limiter_reason_code;
-              id(oq_cooling_pid_last_error_c) = buffer_gap_c;
-              if (restart.reset_integral) id(oq_cooling_pid_integral) = 0.0f;
-              publish_cooling_limiter_event(true, id(oq_cooling_limiter_reason_code), 0, 0, dew_gap_c, true);
-              return;
-            }
-          }
-
-          if (allowed_max <= 0) {
-            if (restart_by_minimum_off_time && water_cycle_active && cooling_hp_applied) {
-              id(oq_cooling_min_off_stop_pending) = true;
-            }
-            id(oq_cooling_demand_raw) = 0;
-            id(oq_cooling_base_demand_raw) = 0;
-            id(oq_cooling_limited_demand) = 0;
-            id(oq_cooling_limiter_reason_code) = reason_code;
-            id(oq_cooling_water_cycle_active) = false;
-            id(oq_cooling_stop_buffer_gap_c) = filtered_gap_c;
-            id(oq_cooling_stop_reason_code) =
-                reason_code == oq_cooling::REASON_DEW_STOP ? 2 :
-                (reason_code == oq_cooling::REASON_FALLBACK_FLOOR ? 3 : 1);
-            id(oq_cooling_pid_last_error_c) = buffer_gap_c;
-            if (reason_code == oq_cooling::REASON_DEW_STOP ||
-                reason_code == oq_cooling::REASON_FALLBACK_FLOOR) {
-              id(oq_cooling_pid_integral) = 0.0f;
-            } else if (reason_code != oq_cooling::REASON_PROJECTED_FLOOR) {
-              integral = fminf(integral, 0.0f);
-            }
-            id(oq_cooling_pid_integral) = integral;
-
-            static int last_reason = -1;
-            if (reason_code != last_reason) {
-              ESP_LOGI("quatt.cool", "Cooling limiter: %s gap=%.2f ema=%.2f rate=%.2f dew=%.2f",
-                       oq_cooling::reason_name(reason_code), buffer_gap_c, filtered_gap_c,
-                       gap_rate_c_per_min, dew_gap_c);
-              last_reason = reason_code;
-            }
-            publish_cooling_limiter_event(true, reason_code, 0, 0, dew_gap_c, true);
-            return;
-          }
-
-          id(oq_cooling_water_cycle_active) = water_cycle_active;
-
-          // Keep the integrator from winding up while the safe-floor limiter caps output.
-          const float out_before_integral_update = (kp * buffer_gap_c) + (ki * integral) + (kd * derivative);
-          const bool capped_high = out_before_integral_update > (float) allowed_max;
-          if (!(capped_high && buffer_gap_c > 0.0f)) {
-            integral += buffer_gap_c * dt_s;
-          }
-          if (integral < -20.0f) integral = -20.0f;
-          if (integral > 20.0f) integral = 20.0f;
-
-          float out = (kp * buffer_gap_c) + (ki * integral) + (kd * derivative);
-          if (out < 0.0f) out = 0.0f;
-          int base_demand = (int) lroundf(out);
-          if (base_demand < 0) base_demand = 0;
-          if (base_demand > demand_max) base_demand = demand_max;
-          id(oq_cooling_base_demand_raw) = base_demand;
-
-          // Level-1 simmer is a post-PI permission, not a PI feedback signal. It
-          // may hold level 1 when the PI would round to zero, but only if the
-          // limiter says level 1 is safe and the room still has meaningful demand.
-          int demand_candidate = std::min(base_demand, allowed_max);
-          const bool oil_return_level1_hold =
-              (reason_code == oq_cooling::REASON_OIL_RETURN_HOLD ||
-               reason_code == oq_cooling::REASON_OIL_RETURN_RECOVERY) && allowed_max >= 1;
-          const bool can_simmer =
-              oil_return_level1_hold ||
-              ((!room_error_valid || room_error_c > simmer_room_error_min_c) &&
-               allowed_max >= 1 &&
-               (reason_code == oq_cooling::REASON_SIMMER ||
-                reason_code == oq_cooling::REASON_FALLING_GAP ||
-                fallback_mode));
-          if (can_simmer && demand_candidate < 1) {
-            demand_candidate = 1;
-            if (reason_code != oq_cooling::REASON_FALLING_GAP &&
-                reason_code != oq_cooling::REASON_FALLBACK_CAP1 &&
-                reason_code != oq_cooling::REASON_OIL_RETURN_HOLD &&
-                reason_code != oq_cooling::REASON_OIL_RETURN_RECOVERY) {
-              reason_code = oq_cooling::REASON_SIMMER;
-            }
-          }
-
-          // Slow upward changes for comfort and compressor calmness; allow
-          // limiter-driven downscaling immediately because it protects the floor.
-          int demand = demand_candidate;
-          const int prev_limited = id(oq_cooling_limited_demand);
-          const uint32_t last_change_ms = id(oq_cooling_last_demand_change_ms);
-          const uint32_t elapsed_change_ms =
-              (last_change_ms > 0 && now_ms > last_change_ms) ? (uint32_t)(now_ms - last_change_ms) : 0;
-          if (prev_limited > 0 && allowed_max < prev_limited) {
-            demand = std::min(demand_candidate, allowed_max);
-          } else if (demand_candidate > prev_limited) {
-            if (prev_limited == 0) {
-              // Start every new cooling run at level 1. If level 1 cannot pull
-              // the water gap down, the normal up-dwell can still promote it.
-              demand = std::min(demand_candidate, 1);
-            } else if (last_change_ms == 0 || elapsed_change_ms >= upscale_dwell_ms) {
-              demand = std::min(demand_candidate, prev_limited + 1);
-            } else {
-              demand = prev_limited;
-            }
-          } else if (demand_candidate < prev_limited) {
-            if (elapsed_change_ms >= downscale_dwell_ms) demand = demand_candidate;
-            else demand = prev_limited;
-          }
-          if (demand > allowed_max) demand = allowed_max;
-          if (demand < 0) demand = 0;
-          if (demand != prev_limited) id(oq_cooling_last_demand_change_ms) = now_ms;
-
-          oq_cooling::WaterCycleState water_cycle_state{
-              water_cycle_active,
-              id(oq_cooling_stop_buffer_gap_c),
-              id(oq_cooling_stop_reason_code),
-          };
-          const bool pi_zero_stop =
-              oq_cooling::record_pi_zero_stop(prev_limited, demand, filtered_gap_c, water_cycle_state);
-          if (pi_zero_stop) {
-            if (restart_by_minimum_off_time && cooling_hp_applied) {
-              id(oq_cooling_min_off_stop_pending) = true;
-            }
-            id(oq_cooling_water_cycle_active) = water_cycle_state.active;
-            id(oq_cooling_stop_buffer_gap_c) = water_cycle_state.stop_buffer_gap_c;
-            id(oq_cooling_stop_reason_code) = water_cycle_state.stop_reason_code;
-            reason_code = oq_cooling::REASON_BUFFER_STOP;
-            integral = fminf(integral, 0.0f);
-          }
-
-          id(oq_cooling_limited_demand) = demand;
-          id(oq_cooling_limiter_reason_code) = reason_code;
-          id(oq_cooling_pid_integral) = integral;
-          id(oq_cooling_pid_last_error_c) = buffer_gap_c;
-          id(oq_cooling_demand_raw) = demand;
-          publish_cooling_limiter_event(reason_code != 1, reason_code, demand, base_demand, dew_gap_c, pi_zero_stop);
-
+          if (decision.guard_changed) ESP_LOGI("quatt.cool", "Cooling guard mode changed: reset restart latch");
+          publish_cooling_limiter_event(decision.event_limiter_active, cooling.limiter_reason_code,
+                                        cooling.limited_demand, cooling.base_demand, cooling.dew_gap_c,
+                                        decision.event_hard_pause);
           static int last_reason = -1;
-          if (reason_code != last_reason) {
+          if (decision.control_active && cooling.limiter_reason_code != last_reason) {
             ESP_LOGI("quatt.cool", "Cooling limiter: %s f=%d raw=%d lim=%d gap=%.2f ema=%.2f rate=%.2f dew=%.2f",
-                     oq_cooling::reason_name(reason_code), demand, base_demand, allowed_max,
-                     buffer_gap_c, filtered_gap_c, gap_rate_c_per_min, dew_gap_c);
-            last_reason = reason_code;
+                     oq_cooling::reason_name(cooling.limiter_reason_code), cooling.limited_demand,
+                     cooling.base_demand, cooling.allowed_max, input.supply_c - input.target_c,
+                     cooling.filter.filtered_gap_c, cooling.filter.rate_c_per_min, cooling.dew_gap_c);
+            last_reason = cooling.limiter_reason_code;
           }
-
   - interval: ${oq_heat_loop_tick_s}s
     startup_delay: 4000ms
     then:
@@ -1139,7 +628,6 @@ interval:
             id(oq_cooling_request_reason_code) = 0;
             return;
           }
-
           const uint32_t now_ms = (uint32_t) millis();
           // Cooling demand is already filtered and dwell-limited upstream. Keep
           // the HP owner/request bridge on the 5s tick so level changes do not
@@ -1150,21 +638,17 @@ interval:
             if (elapsed_ms < loop_target_ms) return;
           }
           id(oq_cooling_request_last_loop_ms) = now_ms;
-
           constexpr int max_level = 10;
           const int demand_max_f = (int) ${oq_strategy_demand_max_f};
           int raw = id(oq_cooling_demand_raw);
           raw = std::max(0, std::min(demand_max_f, raw));
-
           id(oq_demand_filtered_prev) = id(oq_demand_filtered);
           id(oq_demand_filtered) = raw;
           id(oq_heating_demand_filtered) = 0;
-
           int f = raw;
           int f_cap = id(oq_power_cap_f);
           f_cap = std::max(0, std::min(demand_max_f, f_cap));
           if (f > f_cap) f = f_cap;
-
           const bool demand_active = (f > 0);
           const bool restart_by_minimum_off_time =
               id(cooling_restart_mode).has_state() &&
@@ -1194,22 +678,17 @@ interval:
               (restart_by_minimum_off_time && cooling_stop_confirmation_pending);
           const uint32_t global_cooling_restart_remaining_s =
               (global_minimum_off_remaining_ms + 999UL) / 1000UL;
-
           #if OQ_TOPOLOGY_DUO
           const bool lead_is_hp1 = (id(hp1_minutes) <= id(${secondary_minutes_id}));
           #else
           const bool lead_is_hp1 = true;
           #endif
-
           const int lead_code = lead_is_hp1 ? 1 : 2;
           if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
-
           const auto frequency_runtime = oq_frequency_runtime::capture();
-
           auto level_allowed = [&](bool is_hp1, int level)->bool {
             return frequency_runtime.frequency_allowed(is_hp1, 1, level);
           };
-
           auto hp_has_any_allowed_level = [&](bool is_hp1)->bool {
             for (int lvl = 1; lvl <= max_level; lvl++) {
               if (level_allowed(is_hp1, lvl)) return true;
@@ -1445,17 +924,18 @@ interval:
           id(oq_strategy_phase_text).publish_state((f > 0) ? "cool" : "idle");
 
           char debug_buf[240];
+          const auto &cooling = oq_cooling::demand_runtime().state();
           snprintf(
             debug_buf, sizeof(debug_buf),
             "cool f=%d raw=%d lim=%d owner=%d gap=%.2f ema=%.2f rate=%.2f dew=%.2f reason=%s target=%.2f",
             f,
-            id(oq_cooling_base_demand_raw),
-            id(oq_cooling_limiter_allowed_max),
+            cooling.base_demand,
+            cooling.allowed_max,
             owner,
             id(oq_system_supply_temp).state - id(cooling_supply_target).state,
-            id(oq_cooling_buffer_gap_filtered_c),
-            id(oq_cooling_buffer_gap_rate_c_per_min),
-            id(oq_cooling_dew_gap_c),
-            oq_cooling::reason_name(id(oq_cooling_limiter_reason_code)),
+            cooling.filter.filtered_gap_c,
+            cooling.filter.rate_c_per_min,
+            cooling.dew_gap_c,
+            oq_cooling::reason_name(cooling.limiter_reason_code),
             id(cooling_supply_target).state);
           ESP_LOGD("quatt.strategy", "%s", debug_buf);

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -18,10 +18,6 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'
-  - id: oq_cooling_request_last_loop_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
   - id: oq_cooling_request_hp1_level
     type: int
     restore_value: false
@@ -184,7 +180,7 @@ sensor:
       // Keep room comfort in the room-demand hysteresis. The water target is only
       // the coldest allowed supply target from configuration and dew-point safety.
       float base_floor_c = id(cooling_min_supply_temp).state;
-      if (id(cooling_effective_min_supply_temp).has_state() && !isnan(id(cooling_effective_min_supply_temp).state)) {
+      if (id(cooling_effective_min_supply_temp).has_state() && isfinite(id(cooling_effective_min_supply_temp).state)) {
         base_floor_c = fmaxf(base_floor_c, id(cooling_effective_min_supply_temp).state);
       }
       return base_floor_c;
@@ -197,8 +193,8 @@ sensor:
     accuracy_decimals: 2
     update_interval: 5s
     lambda: |-
-      if (!id(cooling_supply_target).has_state() || isnan(id(cooling_supply_target).state)) return NAN;
-      if (!id(oq_system_supply_temp).has_state() || isnan(id(oq_system_supply_temp).state)) return NAN;
+      if (!id(cooling_supply_target).has_state() || !isfinite(id(cooling_supply_target).state)) return NAN;
+      if (!id(oq_system_supply_temp).has_state() || !isfinite(id(oq_system_supply_temp).state)) return NAN;
       // Positive error means the supply is warmer than target, so more cooling may be requested.
       return id(oq_system_supply_temp).state - id(cooling_supply_target).state;
   - platform: template
@@ -407,7 +403,7 @@ sensor:
       if (!restart_by_minimum_off_time) return 0.0f;
       const float configured_state = id(cooling_minimum_off_time).state;
       int configured_s =
-          isnan(configured_state) ? 600 : (int) lroundf(configured_state);
+          !isfinite(configured_state) ? 600 : (int) lroundf(configured_state);
       configured_s = std::max(240, std::min(3600, configured_s));
       const uint32_t configured_ms = (uint32_t) configured_s * 1000UL;
       uint32_t remaining_ms = oq_cooling::global_minimum_off_time_remaining_ms(
@@ -481,7 +477,7 @@ interval:
                   openquatt_decision_log::STATE_LIMITED,
                   (int16_t) limited_demand,
                   (int16_t) raw_demand,
-                  isnan(dew_gap) ? 0 : (int16_t) lroundf(dew_gap * 100.0f));
+                  !isfinite(dew_gap) ? 0 : (int16_t) lroundf(dew_gap * 100.0f));
             } else if (last_pause_active) {
               id(oq_decision_log).emit(
                   openquatt_decision_log::EVENT_COOLING_RELEASED,
@@ -617,67 +613,32 @@ interval:
     startup_delay: 4000ms
     then:
       - lambda: |-
-          // Cooling strategy: owns single-owner cooling requests for CM5.
-          const int cm_code = id(oq_control_mode_code);
-          if (cm_code != 5) {
-            id(oq_cooling_request_last_loop_ms) = 0;
-            id(oq_cooling_request_hp1_level) = 0;
-            id(oq_cooling_request_hp2_level) = 0;
-            id(oq_cooling_request_owner_hp) = 0;
-            id(oq_cooling_owner_hp) = 0;
+          // Map live ESPHome entities into the pure single-owner Cooling dispatch contract.
+          const uint32_t now_ms = (uint32_t) millis();
+          if (id(oq_control_mode_code) != 5) {
+            oq_cooling::DispatchInput reset; reset.now_ms = now_ms;
+            oq_cooling::dispatch_tick(reset);
+            id(oq_cooling_request_hp1_level) = 0; id(oq_cooling_request_hp2_level) = 0;
+            id(oq_cooling_request_owner_hp) = 0; id(oq_cooling_owner_hp) = 0;
             id(oq_cooling_request_reason_code) = 0;
             return;
           }
-          const uint32_t now_ms = (uint32_t) millis();
-          // Cooling demand is already filtered and dwell-limited upstream. Keep
-          // the HP owner/request bridge on the 5s tick so level changes do not
-          // wait for the slower heating-curve cadence.
-          const uint32_t loop_target_ms = (uint32_t) (${oq_heat_loop_tick_s} * 1000UL);
-          if (id(oq_cooling_request_last_loop_ms) > 0 && now_ms > id(oq_cooling_request_last_loop_ms)) {
-            const uint32_t elapsed_ms = now_ms - id(oq_cooling_request_last_loop_ms);
-            if (elapsed_ms < loop_target_ms) return;
-          }
-          id(oq_cooling_request_last_loop_ms) = now_ms;
-          constexpr int max_level = 10;
-          const int demand_max_f = (int) ${oq_strategy_demand_max_f};
-          int raw = id(oq_cooling_demand_raw);
-          raw = std::max(0, std::min(demand_max_f, raw));
-          id(oq_demand_filtered_prev) = id(oq_demand_filtered);
-          id(oq_demand_filtered) = raw;
-          id(oq_heating_demand_filtered) = 0;
-          int f = raw;
-          int f_cap = id(oq_power_cap_f);
-          f_cap = std::max(0, std::min(demand_max_f, f_cap));
-          if (f > f_cap) f = f_cap;
-          const bool demand_active = (f > 0);
-          const bool restart_by_minimum_off_time =
-              id(cooling_restart_mode).has_state() &&
-              id(cooling_restart_mode).current_option() == "Minimum off time";
+          const bool restart_by_minimum_off_time = id(cooling_restart_mode).has_state() &&
+                                                   id(cooling_restart_mode).current_option() == "Minimum off time";
           const float cooling_minimum_off_state = id(cooling_minimum_off_time).state;
-          int cooling_minimum_off_s =
-              isnan(cooling_minimum_off_state) ? 600 : (int) lroundf(cooling_minimum_off_state);
+          int cooling_minimum_off_s = !isfinite(cooling_minimum_off_state) ? 600 : (int) lroundf(cooling_minimum_off_state);
           cooling_minimum_off_s = std::max(240, std::min(3600, cooling_minimum_off_s));
-          const uint32_t cooling_minimum_off_ms =
-              (uint32_t) cooling_minimum_off_s * 1000UL;
+          const uint32_t cooling_minimum_off_ms = (uint32_t) cooling_minimum_off_s * 1000UL;
           const uint32_t global_minimum_off_remaining_ms =
-              oq_cooling::global_minimum_off_time_remaining_ms(
-                  restart_by_minimum_off_time,
-                  now_ms,
-                  id(oq_cooling_confirmed_stop_seen),
-                  id(oq_cooling_last_confirmed_stop_ms),
-                  id(oq_cooling_boot_min_off_elapsed),
-                  cooling_minimum_off_ms);
+              oq_cooling::global_minimum_off_time_remaining_ms(restart_by_minimum_off_time, now_ms,
+                  id(oq_cooling_confirmed_stop_seen), id(oq_cooling_last_confirmed_stop_ms),
+                  id(oq_cooling_boot_min_off_elapsed), cooling_minimum_off_ms);
           const bool cooling_stop_confirmation_pending =
               id(oq_cooling_stop_confirmation_pending_hp1)
               #if OQ_TOPOLOGY_DUO
               || id(oq_cooling_stop_confirmation_pending_hp2)
               #endif
               ;
-          const bool global_cooling_restart_blocked =
-              global_minimum_off_remaining_ms > 0 ||
-              (restart_by_minimum_off_time && cooling_stop_confirmation_pending);
-          const uint32_t global_cooling_restart_remaining_s =
-              (global_minimum_off_remaining_ms + 999UL) / 1000UL;
           #if OQ_TOPOLOGY_DUO
           const bool lead_is_hp1 = (id(hp1_minutes) <= id(${secondary_minutes_id}));
           #else
@@ -686,256 +647,82 @@ interval:
           const int lead_code = lead_is_hp1 ? 1 : 2;
           if (id(oq_last_lead_hp) != lead_code) id(oq_last_lead_hp) = lead_code;
           const auto frequency_runtime = oq_frequency_runtime::capture();
-          auto level_allowed = [&](bool is_hp1, int level)->bool {
-            return frequency_runtime.frequency_allowed(is_hp1, 1, level);
-          };
           auto hp_has_any_allowed_level = [&](bool is_hp1)->bool {
-            for (int lvl = 1; lvl <= max_level; lvl++) {
-              if (level_allowed(is_hp1, lvl)) return true;
+            for (int level = 1; level <= 10; level++) {
+              if (frequency_runtime.frequency_allowed(is_hp1, 1, level)) return true;
             }
             return false;
           };
-
-          auto hp_restart_blocked = [&](bool is_hp1)->bool {
-            const int prev_applied = is_hp1 ? id(hp1_last_applied_level) : id(${secondary_last_applied_level_id});
-            if (prev_applied > 0) return false;
-
-            int min_off_s = (int) ${oq_hp_min_off_s};
-            if (min_off_s <= 0) return false;
-
-            const uint32_t last_stop_ms = is_hp1 ? id(hp1_last_stop_ms) : id(${secondary_last_stop_ms_id});
-            if (last_stop_ms == 0 || now_ms <= last_stop_ms) return false;
-
-            const uint32_t min_off_ms = (uint32_t) min_off_s * 1000UL;
-            return (uint32_t)(now_ms - last_stop_ms) < min_off_ms;
-          };
-
-          auto hp_can_take_cooling_start = [&](bool is_hp1)->bool {
-            const auto outputs =
-                id(oq_incident_manager).get_outputs(is_hp1 ? 1 : 2);
-            const int previous_applied =
-                is_hp1 ? id(hp1_last_applied_level)
-                       : id(${secondary_last_applied_level_id});
-            return oq_hp_candidate::may_serve_candidate(
-                       outputs.available_for_start,
-                       outputs.must_stop,
-                       previous_applied) &&
-                   hp_has_any_allowed_level(is_hp1) &&
-                   !hp_restart_blocked(is_hp1) &&
-                   !oq_cooling::global_minimum_off_time_blocks_start(
-                       global_minimum_off_remaining_ms,
-                       restart_by_minimum_off_time && cooling_stop_confirmation_pending,
-                       false,
-                       previous_applied);
-          };
-
-          auto hp_restart_remaining_s = [&](bool is_hp1)->uint32_t {
-            int min_off_s = (int) ${oq_hp_min_off_s};
-            if (min_off_s <= 0) return 0;
-            const uint32_t last_stop_ms = is_hp1 ? id(hp1_last_stop_ms) : id(${secondary_last_stop_ms_id});
-            if (last_stop_ms == 0 || now_ms <= last_stop_ms) return 0;
-            const uint32_t min_off_ms = (uint32_t) min_off_s * 1000UL;
-            const uint32_t elapsed_off_ms = now_ms - last_stop_ms;
-            if (elapsed_off_ms >= min_off_ms) return 0;
-            return (min_off_ms - elapsed_off_ms + 999UL) / 1000UL;
-          };
-
-          static bool last_hp1_restart_blocked = false;
-          static bool last_hp2_restart_blocked = false;
-          const bool hp1_restart_blocked_now = hp_restart_blocked(true);
-          const bool hp2_restart_blocked_now = hp_restart_blocked(false);
-          if (hp1_restart_blocked_now != last_hp1_restart_blocked) {
-            if (hp1_restart_blocked_now) {
-              ESP_LOGI("quatt.cool", "HP1 cooling start blocked: minimum off-time remaining %u s",
-                       (unsigned int) hp_restart_remaining_s(true));
-            } else {
-              ESP_LOGI("quatt.cool", "HP1 cooling start block cleared");
-            }
-            last_hp1_restart_blocked = hp1_restart_blocked_now;
-          }
-          if (hp2_restart_blocked_now != last_hp2_restart_blocked) {
-            if (hp2_restart_blocked_now) {
-              ESP_LOGI("quatt.cool", "HP2 cooling start blocked: minimum off-time remaining %u s",
-                       (unsigned int) hp_restart_remaining_s(false));
-            } else {
-              ESP_LOGI("quatt.cool", "HP2 cooling start block cleared");
-            }
-            last_hp2_restart_blocked = hp2_restart_blocked_now;
-          }
-
-          auto hp_last_activity_ms = [&](bool is_hp1)->uint32_t {
-            const uint32_t last_start_ms =
-                is_hp1 ? id(hp1_last_start_ms) : id(${secondary_last_start_ms_id});
-            const uint32_t last_stop_ms =
-                is_hp1 ? id(hp1_last_stop_ms) : id(${secondary_last_stop_ms_id});
-            return std::max(last_start_ms, last_stop_ms);
-          };
-
-          int hp1_req = 0;
-          int hp2_req = 0;
-          int owner = 0;
-
+          const auto hp1_candidate = oq_hp_candidate::candidate_state(id(oq_incident_manager).get_outputs(1), id(hp1_last_applied_level));
           #if OQ_TOPOLOGY_DUO
-          const bool prev_hp1_on = (id(hp1_last_applied_level) > 0);
-          const bool prev_hp2_on = (id(${secondary_last_applied_level_id}) > 0);
-          const bool hp1_can_start_cooling = hp_can_take_cooling_start(true);
-          const bool hp2_can_start_cooling = hp_can_take_cooling_start(false);
-          const uint32_t hp1_last_active_ms = hp_last_activity_ms(true);
-          const uint32_t hp2_last_active_ms = hp_last_activity_ms(false);
-          const int recent_owner =
-              (hp1_last_active_ms > hp2_last_active_ms) ? 1 :
-              (hp2_last_active_ms > hp1_last_active_ms) ? 2 : 0;
-
-          owner = id(oq_cooling_owner_hp);
-          if (!demand_active) {
-            owner = 0;
-          } else if (prev_hp1_on && !prev_hp2_on &&
-                     hp1_can_start_cooling) {
-            owner = 1;
-          } else if (prev_hp2_on && !prev_hp1_on &&
-                     hp2_can_start_cooling) {
-            owner = 2;
-          } else {
-            const bool owner_ok =
-                (owner == 1 && hp1_can_start_cooling) ||
-                (owner == 2 && hp2_can_start_cooling);
-            if (!owner_ok) {
-              if (recent_owner == 1 && hp1_can_start_cooling) owner = 1;
-              else if (recent_owner == 2 && hp2_can_start_cooling) owner = 2;
-              else if (lead_is_hp1 && hp1_can_start_cooling) owner = 1;
-              else if (!lead_is_hp1 && hp2_can_start_cooling) owner = 2;
-              else if (hp1_can_start_cooling && !hp2_can_start_cooling) owner = 1;
-              else if (hp2_can_start_cooling && !hp1_can_start_cooling) owner = 2;
-              else if (hp1_can_start_cooling && hp2_can_start_cooling) owner = lead_is_hp1 ? 1 : 2;
-              else owner = 0;
-            }
-          }
-
+          const auto hp2_candidate = oq_hp_candidate::candidate_state(id(oq_incident_manager).get_outputs(2), id(${secondary_last_applied_level_id}));
+          #else
+          const oq_hp_candidate::HpCandidateState hp2_candidate;
+          #endif
+          oq_cooling::DispatchInput dispatch;
+          dispatch.now_ms = now_ms; dispatch.cadence_ms = (uint32_t) (${oq_heat_loop_tick_s} * 1000UL);
+          dispatch.hp_min_off_ms = (uint32_t) std::max(0, (int) ${oq_hp_min_off_s}) * 1000UL;
+          dispatch.global_min_off_remaining_ms = global_minimum_off_remaining_ms;
+          dispatch.raw_demand = id(oq_cooling_demand_raw); dispatch.demand_max = (int) ${oq_strategy_demand_max_f};
+          dispatch.power_cap = id(oq_power_cap_f); dispatch.stored_owner = id(oq_cooling_owner_hp);
+          dispatch.cooling_mode = true; dispatch.lead_is_hp1 = lead_is_hp1;
+          dispatch.minimum_off_enabled = restart_by_minimum_off_time;
+          dispatch.stop_confirmation_pending = cooling_stop_confirmation_pending;
+          dispatch.hp1 = {hp1_candidate, id(hp1_last_start_ms), id(hp1_last_stop_ms), hp_has_any_allowed_level(true)};
+          #if OQ_TOPOLOGY_DUO
+          dispatch.duo = true;
+          dispatch.hp2 = {hp2_candidate, id(${secondary_last_start_ms_id}), id(${secondary_last_stop_ms_id}),
+                          hp_has_any_allowed_level(false)};
+          #endif
+          const auto routing = oq_cooling::dispatch_tick(dispatch);
+          if (!routing.evaluated) return;
+          id(oq_demand_filtered_prev) = id(oq_demand_filtered); id(oq_demand_filtered) = routing.raw_demand; id(oq_heating_demand_filtered) = 0;
           static bool last_cooling_start_blocked = false;
-          const bool cooling_start_blocked = demand_active && owner == 0 && !hp1_can_start_cooling && !hp2_can_start_cooling;
-          if (cooling_start_blocked != last_cooling_start_blocked) {
-            if (cooling_start_blocked) {
-              if (global_cooling_restart_blocked) {
-                if (cooling_stop_confirmation_pending) {
-                  ESP_LOGI("quatt.cool", "Cooling request blocked: waiting for confirmed cooling stop");
-                } else {
-                  ESP_LOGI("quatt.cool", "Cooling request blocked: global minimum off-time remaining %u s",
-                           (unsigned int) global_cooling_restart_remaining_s);
-                }
-              } else {
-                ESP_LOGI("quatt.cool", "Cooling request blocked: both HPs are still in minimum off-time or unavailable");
-              }
+          if (routing.start_blocked != last_cooling_start_blocked) {
+            if (routing.start_blocked) {
+              const uint32_t hp1_remaining_s = oq_cooling::hp_minimum_off_remaining_s(
+                  now_ms, id(hp1_last_stop_ms), id(hp1_last_applied_level), dispatch.hp_min_off_ms);
+              #if OQ_TOPOLOGY_DUO
+              const uint32_t hp2_remaining_s = oq_cooling::hp_minimum_off_remaining_s(
+                  now_ms, id(${secondary_last_stop_ms_id}), id(${secondary_last_applied_level_id}),
+                  dispatch.hp_min_off_ms);
+              #else
+              const uint32_t hp2_remaining_s = 0;
+              #endif
+              ESP_LOGI("quatt.cool", "Cooling request blocked: global=%u s confirm=%d hp1=%u s hp2=%u s/unavailable",
+                       (unsigned int) ((global_minimum_off_remaining_ms + 999UL) / 1000UL),
+                       cooling_stop_confirmation_pending, (unsigned int) hp1_remaining_s,
+                       (unsigned int) hp2_remaining_s);
             } else {
               ESP_LOGI("quatt.cool", "Cooling request block cleared");
             }
-            last_cooling_start_blocked = cooling_start_blocked;
+            last_cooling_start_blocked = routing.start_blocked;
           }
-
           oq_request::reset_dual_runtime_state(
-              id(oq_dual_hp_enabled),
-              id(oq_dual_hp_enable_hold_elapsed_accum_min),
-              id(oq_dual_hp_disable_hold_elapsed_accum_min),
-              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
-              id(oq_cooling_owner_hp),
-              id(oq_duo_request_hold_until_ms),
-              owner);
-          if (owner == 1) hp1_req = f;
-          else if (owner == 2) hp2_req = f;
-          #else
-          oq_request::reset_dual_runtime_state(
-              id(oq_dual_hp_enabled),
-              id(oq_dual_hp_enable_hold_elapsed_accum_min),
-              id(oq_dual_hp_disable_hold_elapsed_accum_min),
-              id(oq_dual_hp_emergency_hold_elapsed_accum_min),
-              id(oq_cooling_owner_hp),
-              id(oq_duo_request_hold_until_ms),
+              id(oq_dual_hp_enabled), id(oq_dual_hp_enable_hold_elapsed_accum_min),
+              id(oq_dual_hp_disable_hold_elapsed_accum_min), id(oq_dual_hp_emergency_hold_elapsed_accum_min),
+              id(oq_cooling_owner_hp), id(oq_duo_request_hold_until_ms),
+              #if OQ_TOPOLOGY_DUO
+              routing.owner_before_hold);
+              #else
               1);
-          const bool hp1_can_start_cooling =
-              hp_can_take_cooling_start(true);
-          owner = (f > 0 && hp1_can_start_cooling) ? 1 : 0;
-          static bool last_cooling_start_blocked = false;
-          const bool cooling_start_blocked = demand_active && !hp_can_take_cooling_start(true);
-          if (cooling_start_blocked != last_cooling_start_blocked) {
-            if (cooling_start_blocked) {
-              if (global_cooling_restart_blocked) {
-                if (cooling_stop_confirmation_pending) {
-                  ESP_LOGI("quatt.cool", "Cooling request blocked: waiting for confirmed cooling stop");
-                } else {
-                  ESP_LOGI("quatt.cool", "Cooling request blocked: global minimum off-time remaining %u s",
-                           (unsigned int) global_cooling_restart_remaining_s);
-                }
-              } else {
-                ESP_LOGI("quatt.cool", "Cooling request blocked: HP1 is still in minimum off-time or unavailable");
-              }
-            } else {
-              ESP_LOGI("quatt.cool", "Cooling request block cleared");
-            }
-            last_cooling_start_blocked = cooling_start_blocked;
-          }
-          hp1_req = (owner == 1) ? f : 0;
-          hp2_req = 0;
           #endif
-
-          const auto hp1_hold_candidate =
-              oq_hp_candidate::candidate_state(
-                  id(oq_incident_manager).get_outputs(1),
-                  id(hp1_last_applied_level));
           #if OQ_TOPOLOGY_DUO
-          const auto hp2_hold_candidate =
-              oq_hp_candidate::candidate_state(
-                  id(oq_incident_manager).get_outputs(2),
-                  id(${secondary_last_applied_level_id}));
-          #else
-          const oq_hp_candidate::HpCandidateState hp2_hold_candidate;
+          id(oq_cooling_owner_hp) = routing.owner;
           #endif
-          const auto suspect_topology_hold =
-              oq_hp_candidate::preserve_active_topology_during_suspect(
-                  {
-                      hp1_req,
-                      hp2_req,
-                      hp1_hold_candidate,
-                      hp2_hold_candidate,
-                      demand_active,
-                  });
-          if (suspect_topology_hold.active) {
-            hp1_req = suspect_topology_hold.hp1_level;
-            hp2_req = suspect_topology_hold.hp2_level;
-            owner = suspect_topology_hold.owner_hp;
-            id(oq_cooling_owner_hp) = owner;
-          }
-
-          id(oq_P_hp_cap_w) = 0.0f;
-          id(oq_P_deficit_w) = 0.0f;
-
-          id(oq_cooling_request_hp1_level) = hp1_req;
-          id(oq_cooling_request_hp2_level) = hp2_req;
-          id(oq_cooling_request_owner_hp) = owner;
-          if (owner == 1) id(oq_cooling_request_reason_code) = 1;
-          else if (owner == 2) id(oq_cooling_request_reason_code) = 2;
-          else id(oq_cooling_request_reason_code) = 0;
-
-          id(oq_strategy_phase_code) = (f > 0) ? 1 : 0;
-          id(oq_strategy_requested_power_w) = NAN;
-          id(oq_strategy_supply_target_temp) = id(cooling_supply_target).state;
-          id(oq_strategy_heat_request_active) = (f > 0);
-          id(oq_strategy_output_valid) = !isnan(id(cooling_supply_target).state);
-          id(oq_strategy_output_source_code) = 1;
-          id(oq_strategy_output_updated_ms) = now_ms;
-          id(oq_strategy_phase_text).publish_state((f > 0) ? "cool" : "idle");
-
-          char debug_buf[240];
+          id(oq_P_hp_cap_w) = 0.0f; id(oq_P_deficit_w) = 0.0f;
+          id(oq_cooling_request_hp1_level) = routing.hp1_request; id(oq_cooling_request_hp2_level) = routing.hp2_request;
+          id(oq_cooling_request_owner_hp) = routing.owner; id(oq_cooling_request_reason_code) = routing.owner;
+          id(oq_strategy_phase_code) = (routing.demand > 0) ? 1 : 0; id(oq_strategy_requested_power_w) = NAN;
+          id(oq_strategy_supply_target_temp) = id(cooling_supply_target).state; id(oq_strategy_heat_request_active) = (routing.demand > 0);
+          id(oq_strategy_output_valid) = isfinite(id(cooling_supply_target).state);
+          id(oq_strategy_output_source_code) = 1; id(oq_strategy_output_updated_ms) = now_ms;
+          id(oq_strategy_phase_text).publish_state((routing.demand > 0) ? "cool" : "idle");
           const auto &cooling = oq_cooling::demand_runtime().state();
-          snprintf(
-            debug_buf, sizeof(debug_buf),
+          ESP_LOGD(
+            "quatt.strategy",
             "cool f=%d raw=%d lim=%d owner=%d gap=%.2f ema=%.2f rate=%.2f dew=%.2f reason=%s target=%.2f",
-            f,
-            cooling.base_demand,
-            cooling.allowed_max,
-            owner,
+            routing.demand, cooling.base_demand, cooling.allowed_max, routing.owner,
             id(oq_system_supply_temp).state - id(cooling_supply_target).state,
-            cooling.filter.filtered_gap_c,
-            cooling.filter.rate_c_per_min,
-            cooling.dew_gap_c,
-            oq_cooling::reason_name(cooling.limiter_reason_code),
-            id(cooling_supply_target).state);
-          ESP_LOGD("quatt.strategy", "%s", debug_buf);
+            cooling.filter.filtered_gap_c, cooling.filter.rate_c_per_min, cooling.dew_gap_c,
+            oq_cooling::reason_name(cooling.limiter_reason_code), id(cooling_supply_target).state);

--- a/scripts/tests/test_cooling_recovery_delegation_contract.py
+++ b/scripts/tests/test_cooling_recovery_delegation_contract.py
@@ -3,26 +3,27 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 YAML = (ROOT / "openquatt/oq_cooling_strategy.yaml").read_text()
 CORE = (ROOT / "openquatt/includes/control/oq_cooling_demand_logic.h").read_text()
-ACTUATOR = (ROOT / "openquatt/oq_thermal_actuator.yaml").read_text()
+DISPATCH = (ROOT / "openquatt/includes/control/oq_cooling_dispatch_logic.h").read_text()
+ACTUATOR_RUNTIME = (ROOT / "openquatt/includes/control/oq_thermal_actuator_runtime.h").read_text()
 DEFROST_TEST = (ROOT / "tests/host/oq_odu_compressor_levels_test.cpp").read_text()
 class CoolingRecoveryDelegationContractTest(unittest.TestCase):
     def test_yaml_delegates_and_live_safety_paths_stay_fail_closed(self) -> None:
         for marker in ("demand_runtime().tick", "DemandInput input", "input.sensor_valid = supply_valid && target_valid",
-                       "hp_can_take_cooling_start", "publish_cooling_limiter_event"):
+                       "dispatch_tick(dispatch)", "DispatchInput dispatch", "publish_cooling_limiter_event"):
             self.assertIn(marker, YAML)
-        for marker in ("update_oil_return(", "evaluate_water_restart(", "oq_cooling_pid_integral",
-                       "oq_cooling_last_demand_change_ms", "out_before_integral_update", "demand_candidate"):
+        for marker in ("update_oil_return(", "evaluate_water_restart(", "oq_cooling_pid_integral", "oq_cooling_last_demand_change_ms",
+                       "hp_can_take_cooling_start", "recent_owner", "id(oq_cooling_min_off_stop_pending) = false"):
             self.assertNotIn(marker, YAML)
-        for marker in ("update_gap_filter(", "apply_demand_dwell(", "update_demand(",
-                       "effective_minimum_off_stop_pending", "isfinite(value)"):
+        for marker in ("update_gap_filter(", "apply_demand_dwell(", "update_demand(", "effective_minimum_off_stop_pending", "isfinite(value)"):
             self.assertIn(marker, CORE)
-        self.assertNotIn("id(oq_cooling_min_off_stop_pending) = false", YAML)
-        self.assertIn("id(oq_cooling_min_off_stop_pending) = false", ACTUATOR)
-        for marker in ("resolve_retained_level(true, true", "no_cooling_hold.control_level == 0",
-                       "no_cooling_hold.physical_level == 0"):
+        for marker in ("update_dispatch(", "recent_activity_owner(", "hp_minimum_off_blocks_start("):
+            self.assertIn(marker, DISPATCH)
+        self.assertIn("id(oq_cooling_min_off_stop_pending) = false", ACTUATOR_RUNTIME)
+        for marker in ("resolve_retained_level(true, true", "no_cooling_hold.control_level == 0", "no_cooling_hold.physical_level == 0"):
             self.assertIn(marker, DEFROST_TEST)
         paths = ("openquatt/oq_cooling_strategy.yaml", "openquatt/includes/control/oq_cooling_limiter_logic.h",
-                 "openquatt/includes/control/oq_cooling_demand_logic.h", "tests/host/cooling_limiter_logic_test.cpp",
-                 "tests/host/cooling_demand_logic_test.cpp", "tests/host/thermal_request_logic_test.cpp")
+                 "openquatt/includes/control/oq_cooling_demand_logic.h", "openquatt/includes/control/oq_cooling_dispatch_logic.h",
+                 "tests/host/cooling_limiter_logic_test.cpp", "tests/host/cooling_demand_logic_test.cpp", "tests/host/cooling_dispatch_logic_test.cpp",
+                 "tests/host/thermal_request_logic_test.cpp")
         files = [ROOT / path for path in paths] + [Path(__file__)]
         self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in files), 2309)

--- a/scripts/tests/test_cooling_recovery_delegation_contract.py
+++ b/scripts/tests/test_cooling_recovery_delegation_contract.py
@@ -1,21 +1,28 @@
 from pathlib import Path
 import unittest
-
 ROOT = Path(__file__).resolve().parents[2]
 YAML = (ROOT / "openquatt/oq_cooling_strategy.yaml").read_text()
+CORE = (ROOT / "openquatt/includes/control/oq_cooling_demand_logic.h").read_text()
+ACTUATOR = (ROOT / "openquatt/oq_thermal_actuator.yaml").read_text()
 DEFROST_TEST = (ROOT / "tests/host/oq_odu_compressor_levels_test.cpp").read_text()
-
 class CoolingRecoveryDelegationContractTest(unittest.TestCase):
-    def test_yaml_delegates_and_live_defrost_path_stays_fail_closed(self) -> None:
-        for marker in ("update_oil_return(", "evaluate_water_restart(", "inactive_stop_reason(",
-                       "id(cooling_pid_kp).state", "hp_can_take_cooling_start", "publish_cooling_limiter_event"):
+    def test_yaml_delegates_and_live_safety_paths_stay_fail_closed(self) -> None:
+        for marker in ("demand_runtime().tick", "DemandInput input", "input.sensor_valid = supply_valid && target_valid",
+                       "hp_can_take_cooling_start", "publish_cooling_limiter_event"):
             self.assertIn(marker, YAML)
-        for marker in ("oq_cooling_oil_return_hold_until_ms", "oil_return_recovery_not_needed"):
+        for marker in ("update_oil_return(", "evaluate_water_restart(", "oq_cooling_pid_integral",
+                       "oq_cooling_last_demand_change_ms", "out_before_integral_update", "demand_candidate"):
             self.assertNotIn(marker, YAML)
+        for marker in ("update_gap_filter(", "apply_demand_dwell(", "update_demand(",
+                       "effective_minimum_off_stop_pending", "isfinite(value)"):
+            self.assertIn(marker, CORE)
+        self.assertNotIn("id(oq_cooling_min_off_stop_pending) = false", YAML)
+        self.assertIn("id(oq_cooling_min_off_stop_pending) = false", ACTUATOR)
         for marker in ("resolve_retained_level(true, true", "no_cooling_hold.control_level == 0",
                        "no_cooling_hold.physical_level == 0"):
             self.assertIn(marker, DEFROST_TEST)
         paths = ("openquatt/oq_cooling_strategy.yaml", "openquatt/includes/control/oq_cooling_limiter_logic.h",
-                 "tests/host/cooling_limiter_logic_test.cpp", "tests/host/thermal_request_logic_test.cpp")
+                 "openquatt/includes/control/oq_cooling_demand_logic.h", "tests/host/cooling_limiter_logic_test.cpp",
+                 "tests/host/cooling_demand_logic_test.cpp", "tests/host/thermal_request_logic_test.cpp")
         files = [ROOT / path for path in paths] + [Path(__file__)]
-        self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in files), 2310)
+        self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in files), 2309)

--- a/tests/host/cooling_demand_logic_test.cpp
+++ b/tests/host/cooling_demand_logic_test.cpp
@@ -1,0 +1,205 @@
+#include <assert.h>
+#include <float.h>
+#include "../../openquatt/includes/control/oq_cooling_demand_logic.h"
+using namespace oq_cooling;
+DemandInput active_input(uint32_t now_ms = 0) {
+  DemandInput in;
+  in.now_ms = now_ms;
+  in.control_active = in.sensor_valid = true;
+  in.guard_mode = GUARD_USER_RESPONSIBILITY;
+  in.supply_c = 20;
+  in.target_c = 19;
+  in.demand_max = 4;
+  in.kp = 3;
+  return in;
+}
+void test_timing_filter_and_dwell_rollover() {
+  DemandState timing;
+  assert(demand_loop_dt_s(0, timing) == 5 && timing.loop_seen && timing.last_loop_ms == 0);
+  timing.last_loop_ms = UINT32_MAX - 1999U;
+  assert(demand_loop_dt_s(2000U, timing) == 4);
+  DemandTuning tuning;
+  DemandState filter;
+  filter.filter = {true, true, 0, 0, 0, UINT32_MAX - 29999U};
+  assert(update_gap_filter(1, 5, 30000U, tuning, filter));
+  assert(fabsf(filter.filter.filtered_gap_c - 1.0f / 13) < .00001f &&
+         fabsf(filter.filter.rate_c_per_min - 1.0f / 13) < .00001f && filter.filter.rate_reference_ms == 30000U);
+  struct Case {
+    int previous, candidate, allowed, expected;
+    bool seen;
+    uint32_t since, now;
+  };
+  const Case cases[] = {{1, 4, 4, 1, true, 0, 89999},
+                        {1, 4, 4, 2, true, 0, 90000},
+                        {1, 4, 4, 1, true, UINT32_MAX - 44999U, 44999},
+                        {1, 4, 4, 2, true, UINT32_MAX - 44999U, 45000},
+                        {4, 2, 4, 4, true, UINT32_MAX - 14999U, 14999},
+                        {4, 2, 4, 2, true, UINT32_MAX - 14999U, 15000},
+                        {4, 2, 4, 2, false, 0, 123},
+                        {4, 4, 2, 2, true, 100, 101},
+                        {0, 4, 4, 1, false, 0, 0}};
+  for (const auto& c : cases) {
+    DemandState state;
+    state.limited_demand = c.previous;
+    state.demand_change_seen = c.seen;
+    state.last_demand_change_ms = c.since;
+    const int actual = apply_demand_dwell(c.candidate, c.allowed, c.now, tuning, state);
+    assert(actual == c.expected && state.demand_change_seen == (c.seen || actual != c.previous));
+    assert(state.last_demand_change_ms == (actual == c.previous ? c.since : c.now));
+  }
+}
+void test_room_caps_guard_switch_and_pi() {
+  struct Cap {
+    float room;
+    int allowed, base, demand, reason;
+  };
+  const Cap caps[] = {{.399f, 1, 1, 1, REASON_ROOM_CAP},  {.4f, 2, 2, 1, REASON_ROOM_CAP},
+                      {.799f, 2, 2, 1, REASON_ROOM_CAP},  {.8f, 3, 3, 1, REASON_ROOM_CAP},
+                      {1.199f, 3, 3, 1, REASON_ROOM_CAP}, {1.2f, 4, 3, 1, REASON_FULL}};
+  for (const auto& c : caps) {
+    DemandState state;
+    auto in = active_input();
+    in.room_error_valid = true;
+    in.room_error_c = c.room;
+    update_demand(in, {}, state);
+    assert(state.allowed_max == c.allowed && state.base_demand == c.base && state.limited_demand == c.demand &&
+           state.limiter_reason_code == c.reason);
+  }
+  struct Guard {
+    int previous;
+    float kp;
+    int expected;
+  };
+  for (const Guard c : {Guard{4, 2, 2}, {4, 6, 5}, {0, 2, 1}}) {
+    DemandState state;
+    state.guard_seen = state.water_cycle.active = state.demand_change_seen = true;
+    state.last_guard_mode = GUARD_DEW;
+    state.limited_demand = c.previous;
+    state.last_demand_change_ms = 1;
+    auto in = active_input(100);
+    in.kp = c.kp;
+    in.demand_max = 10;
+    const auto out = update_demand(in, {}, state);
+    assert(out.guard_changed && state.limited_demand == c.expected && state.demand_change_seen &&
+           state.last_demand_change_ms == 100);
+  }
+  DemandState state;
+  auto in = active_input();
+  in.kp = 10;
+  in.ki = 1;
+  update_demand(in, {}, state);
+  assert(state.base_demand == 4 && state.integral == 0);
+  state.integral = 19;
+  in.now_ms = 5000;
+  in.supply_c = 18;
+  update_demand(in, {}, state);
+  assert(state.integral == 14);
+}
+void test_invalid_inputs_fail_closed() {
+  struct Invalid {
+    float supply, target, dew;
+    bool dew_mode, valid;
+  };
+  const Invalid cases[] = {{NAN, 19, NAN, false, true},       {INFINITY, 19, NAN, false, true},
+                           {20, -INFINITY, NAN, false, true}, {20, 19, INFINITY, true, true},
+                           {20, 19, NAN, false, false},       {FLT_MAX, -FLT_MAX, NAN, false, true}};
+  for (const auto& c : cases) {
+    DemandState state;
+    state.water_cycle.active = true;
+    auto in = active_input();
+    in.cycle_was_active = true;
+    in.supply_c = c.supply;
+    in.target_c = c.target;
+    in.dew_point_c = c.dew;
+    in.dew_mode = c.dew_mode;
+    in.guard_mode = c.dew_mode ? GUARD_DEW : GUARD_USER_RESPONSIBILITY;
+    in.sensor_valid = c.valid;
+    assert(!update_demand(in, {}, state).control_active && state.limited_demand == 0 &&
+           state.water_cycle.stop_reason_code == WATER_STOP_FALLBACK);
+  }
+  DemandState state;
+  state.water_cycle.active = true;
+  auto in = active_input();
+  in.cycle_was_active = true;
+  in.demand_max = in.kp = in.ki = in.kd = INFINITY;
+  assert(!update_demand(in, {}, state).control_active && state.limited_demand == 0 && state.integral == 0);
+  state.filter = {true, true, -.75f * FLT_MAX, 0, 0, 0};
+  in = active_input(5000);
+  in.supply_c = .75f * FLT_MAX;
+  assert(!update_demand(in, {}, state).control_active && state.limited_demand == 0 &&
+         isfinite(state.filter.filtered_gap_c));
+  in = active_input();
+  in.guard_mode = GUARD_NONE;
+  assert(!update_demand(in, {}, state).control_active && state.limited_demand == 0);
+  struct Arithmetic {
+    float supply, last;
+  };
+  for (const Arithmetic c : {Arithmetic{0.5f * FLT_MAX, 0}, {0.75f * FLT_MAX, -0.75f * FLT_MAX}}) {
+    DemandState arithmetic;
+    arithmetic.last_error_c = c.last;
+    in = active_input();
+    in.supply_c = c.supply;
+    in.target_c = 0;
+    assert(!update_demand(in, {}, arithmetic).control_active && arithmetic.limited_demand == 0);
+  }
+  DemandState projected;
+  projected.water_cycle = {false, 0, WATER_STOP_LIMITER};
+  projected.filter = {true, true, 0, -0.5f * FLT_MAX, 0, 0};
+  in = active_input(60000);
+  in.restart_by_minimum_off_time = in.minimum_off_wait_active = true;
+  const auto overflow_stop = update_demand(in, {}, projected);
+  assert(!overflow_stop.control_active && overflow_stop.arm_minimum_off_stop && projected.limited_demand == 0);
+}
+void test_minimum_off_simmer_and_pi_zero() {
+  DemandState stopped;
+  stopped.guard_seen = true;
+  stopped.last_guard_mode = GUARD_DEW;
+  stopped.water_cycle = {false, 0, WATER_STOP_LIMITER};
+  auto in = active_input(1000);
+  in.restart_by_minimum_off_time = in.minimum_off_wait_active = true;
+  auto out = update_demand(in, {}, stopped);
+  assert(out.guard_changed && out.arm_minimum_off_stop && !stopped.water_cycle.active &&
+         stopped.limiter_reason_code == REASON_RESTART_WAIT);
+  in.minimum_off_wait_active = false;
+  in.minimum_off_stop_pending = true;
+  update_demand(in, {}, stopped);
+  assert(!stopped.water_cycle.active);
+  in.minimum_off_stop_pending = false;
+  update_demand(in, {}, stopped);
+  assert(stopped.water_cycle.active && stopped.limited_demand == 1);
+  in.guard_mode = GUARD_FALLBACK;
+  in.fallback_mode = true;
+  in.supply_c = in.target_c;
+  in.cooling_hp_applied = true;
+  out = update_demand(in, {}, stopped);
+  assert(out.guard_changed && out.arm_minimum_off_stop && !stopped.water_cycle.active &&
+         stopped.limiter_reason_code == REASON_FALLBACK_FLOOR);
+  DemandState simmer;
+  in = active_input();
+  in.supply_c = 18.95f;
+  in.kp = 0;
+  update_demand(in, {}, simmer);
+  assert(simmer.limited_demand == 1 && simmer.limiter_reason_code == REASON_SIMMER);
+  DemandState oil;
+  in = active_input(100);
+  in.oil_return_active = true;
+  update_demand(in, {}, oil);
+  assert(oil.limited_demand == 1 && oil.limiter_reason_code == REASON_OIL_RETURN_HOLD);
+  DemandState zero;
+  zero.guard_seen = zero.water_cycle.active = zero.demand_change_seen = true;
+  zero.last_guard_mode = GUARD_USER_RESPONSIBILITY;
+  zero.limited_demand = 1;
+  in = active_input(30000);
+  in.kp = 0;
+  in.restart_by_minimum_off_time = in.cooling_hp_applied = true;
+  out = update_demand(in, {}, zero);
+  assert(out.pi_zero_stop && out.arm_minimum_off_stop && !zero.water_cycle.active && zero.limited_demand == 0 &&
+         zero.water_cycle.stop_reason_code == WATER_STOP_LIMITER && zero.limiter_reason_code == REASON_BUFFER_STOP);
+}
+int main() {
+  test_timing_filter_and_dwell_rollover();
+  test_room_caps_guard_switch_and_pi();
+  test_invalid_inputs_fail_closed();
+  test_minimum_off_simmer_and_pi_zero();
+  return 0;
+}

--- a/tests/host/cooling_demand_logic_test.cpp
+++ b/tests/host/cooling_demand_logic_test.cpp
@@ -4,16 +4,13 @@
 using namespace oq_cooling;
 DemandInput active_input(uint32_t now_ms = 0) {
   DemandInput in;
-  in.now_ms = now_ms;
-  in.control_active = in.sensor_valid = true;
+  in.now_ms = now_ms, in.control_active = in.sensor_valid = true;
   in.guard_mode = GUARD_USER_RESPONSIBILITY;
-  in.supply_c = 20;
-  in.target_c = 19;
-  in.demand_max = 4;
-  in.kp = 3;
+  in.supply_c = 20, in.target_c = 19;
+  in.demand_max = 4, in.kp = 3;
   return in;
 }
-void test_timing_filter_and_dwell_rollover() {
+void test_timing() {
   DemandState timing;
   assert(demand_loop_dt_s(0, timing) == 5 && timing.loop_seen && timing.last_loop_ms == 0);
   timing.last_loop_ms = UINT32_MAX - 1999U;
@@ -48,7 +45,7 @@ void test_timing_filter_and_dwell_rollover() {
     assert(state.last_demand_change_ms == (actual == c.previous ? c.since : c.now));
   }
 }
-void test_room_caps_guard_switch_and_pi() {
+void test_pi() {
   struct Cap {
     float room;
     int allowed, base, demand, reason;
@@ -95,7 +92,7 @@ void test_room_caps_guard_switch_and_pi() {
   update_demand(in, {}, state);
   assert(state.integral == 14);
 }
-void test_invalid_inputs_fail_closed() {
+void test_invalid() {
   struct Invalid {
     float supply, target, dew;
     bool dew_mode, valid;
@@ -150,7 +147,7 @@ void test_invalid_inputs_fail_closed() {
   const auto overflow_stop = update_demand(in, {}, projected);
   assert(!overflow_stop.control_active && overflow_stop.arm_minimum_off_stop && projected.limited_demand == 0);
 }
-void test_minimum_off_simmer_and_pi_zero() {
+void test_stops() {
   DemandState stopped;
   stopped.guard_seen = true;
   stopped.last_guard_mode = GUARD_DEW;
@@ -196,10 +193,4 @@ void test_minimum_off_simmer_and_pi_zero() {
   assert(out.pi_zero_stop && out.arm_minimum_off_stop && !zero.water_cycle.active && zero.limited_demand == 0 &&
          zero.water_cycle.stop_reason_code == WATER_STOP_LIMITER && zero.limiter_reason_code == REASON_BUFFER_STOP);
 }
-int main() {
-  test_timing_filter_and_dwell_rollover();
-  test_room_caps_guard_switch_and_pi();
-  test_invalid_inputs_fail_closed();
-  test_minimum_off_simmer_and_pi_zero();
-  return 0;
-}
+int main() { return (test_timing(), test_pi(), test_invalid(), test_stops(), 0); }

--- a/tests/host/cooling_dispatch_logic_test.cpp
+++ b/tests/host/cooling_dispatch_logic_test.cpp
@@ -1,0 +1,100 @@
+#include <assert.h>
+#include "../../openquatt/includes/control/oq_cooling_dispatch_logic.h"
+using namespace oq_cooling;
+DispatchInput active_input(uint32_t now_ms = 10000) {
+  DispatchInput in;
+  in.now_ms = now_ms;
+  in.cooling_mode = true;
+  in.raw_demand = in.demand_max = in.power_cap = 4;
+  in.hp1.candidate = {0, true, false, false};
+  in.hp1.has_allowed_level = true;
+  return in;
+}
+void test_timing() {
+  DispatchState state;
+  auto in = active_input(UINT32_MAX - 1999U);
+  assert(update_dispatch(in, state).evaluated);
+  in.now_ms = 1999U;
+  assert(!update_dispatch(in, state).evaluated);
+  in.now_ms = 3000U;
+  assert(update_dispatch(in, state).evaluated);
+  assert(!hp_minimum_off_blocks_start(100, 0, 0, 600000));
+  assert(!hp_minimum_off_blocks_start(100, UINT32_MAX - 99U, 1, 600000));
+  assert(hp_minimum_off_blocks_start(599899U, UINT32_MAX - 99U, 0, 600000));
+  assert(!hp_minimum_off_blocks_start(599900U, UINT32_MAX - 99U, 0, 600000));
+  assert(hp_minimum_off_remaining_s(100, UINT32_MAX - 99U, 0, 600000) == 600);
+}
+void test_single() {
+  DispatchState state;
+  auto in = active_input();
+  in.raw_demand = 9;
+  in.demand_max = 6;
+  in.power_cap = 3;
+  auto out = update_dispatch(in, state);
+  assert(out.raw_demand == 6 && out.demand == 3 && out.owner == 1 && out.hp1_request == 3);
+  in.now_ms += in.cadence_ms;
+  in.hp1.last_stop_ms = in.now_ms - 239999U;
+  in.hp_min_off_ms = 240000U;
+  out = update_dispatch(in, state);
+  assert(out.hp1_restart_blocked && out.start_blocked && out.owner == 0);
+  in.now_ms++;
+  assert(!update_dispatch(in, state).evaluated);
+  in.now_ms += in.cadence_ms;
+  in.minimum_off_enabled = in.stop_confirmation_pending = true;
+  out = update_dispatch(in, state);
+  assert(out.start_blocked && out.owner == 0);
+  in.hp1.candidate.previous_applied_level = 2;
+  in.now_ms += in.cadence_ms;
+  out = update_dispatch(in, state);
+  assert(!out.start_blocked && out.owner == 1 && out.hp1_request == 3);
+}
+void test_duo() {
+  DispatchInput in = active_input(200);
+  in.duo = true;
+  in.hp2.candidate = {0, true, false, false};
+  in.hp2.has_allowed_level = true;
+  in.hp1.last_start_ms = UINT32_MAX - 999U;
+  in.hp2.last_stop_ms = UINT32_MAX - 1999U;
+  assert(recent_activity_owner(in) == 1);
+  DispatchState state;
+  in.lead_is_hp1 = false;
+  auto out = update_dispatch(in, state);
+  assert(out.owner == 1);
+  in.now_ms += in.cadence_ms;
+  in.hp1.last_start_ms = in.hp2.last_stop_ms = 0;
+  in.stored_owner = 2;
+  out = update_dispatch(in, state);
+  assert(out.owner == 2);
+  in.now_ms += in.cadence_ms;
+  in.stored_owner = 0;
+  in.hp1.candidate.previous_applied_level = 2;
+  out = update_dispatch(in, state);
+  assert(out.owner == 1);
+  in.now_ms += in.cadence_ms;
+  in.hp1.candidate.previous_applied_level = 0;
+  in.hp1.candidate.available_for_start = false;
+  out = update_dispatch(in, state);
+  assert(out.owner == 2);
+}
+void test_stops() {
+  DispatchState state;
+  auto in = active_input();
+  in.duo = true;
+  in.hp2.candidate = {2, false, false, true};
+  in.hp2.has_allowed_level = true;
+  in.stored_owner = 2;
+  auto out = update_dispatch(in, state);
+  assert(out.owner_before_hold == 2 && out.owner == 2 && out.hp2_request == 4);
+  in.now_ms += in.cadence_ms;
+  in.hp2.candidate.must_stop = true;
+  out = update_dispatch(in, state);
+  assert(out.owner == 1 && out.hp1_request == 4 && out.hp2_request == 0);
+  in.now_ms += in.cadence_ms;
+  in.raw_demand = 0;
+  in.hp2.candidate.must_stop = false;
+  out = update_dispatch(in, state);
+  assert(out.owner == 0 && out.hp1_request == 0 && out.hp2_request == 0);
+  in.cooling_mode = false;
+  assert(update_dispatch(in, state).evaluated && !state.loop_seen);
+}
+int main() { return (test_timing(), test_single(), test_duo(), test_stops(), 0); }


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst de Cooling PI-regelaar, gapfiltering, dwell en limiterorkestratie naar een hosttestbare C++-runtime.
- Verplaatst Single/Duo-eigenaarskeuze, vermogenscap en minimum-off-gating naar een afzonderlijk C++-dispatchcontract.
- Reduceert `oq_cooling_strategy.yaml` van 1461 naar 728 regels; de complete PR inclusief tests is netto 1 regel kleiner.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De regel- en dispatchcontracten behouden de bestaande Cooling-semantiek. Niet-eindige invoer en rekenuitkomsten eindigen nu expliciet fail-closed met vraag 0. Loop-, dwell-, minimum-off- en recente-activiteitstiming zijn rolloverveilig. De dispatch in deze PR behoudt de bestaande directe Duo-failover; bevestigde overdracht volgt afzonderlijk.

## Achtergrond

YAML houdt entities, instellingen, inputmapping, diagnostiek en publicatie. Stateful regel- en dispatchlogica staat in kleine C++-contracten met hostregressietests.

De volledige diff is beoordeeld op PI-state en anti-windup, guardwissels, water-side restart, oil-return, limitercaps, minimum-off, Single/Duo-eigenaarschap, suspect links, harde faults, reboot/init, ontbrekende of niet-eindige sensoren en `millis()`-rollover. Een afzonderlijke koude review vond geen blocker. Verwijderde globals hebben geen resterende productieconsumenten.

Netto diff inclusief tests: +907/-908 (-1 regel).

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Er veranderen geen gebruikersgerichte entities, instellingen, namen of standaardwaarden.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen dynamische allocaties, nieuwe taken of netwerkbuffers. Vaste C++-state vervangt niet-persistente YAML-globals. Exacte Q-builds: Duo DIRAM 210707 bytes (-320) en Single DIRAM 193115 bytes (-320); flash respectievelijk +392 en +528 bytes tegenover de directe `dev`-basis.

Uitgevoerd:

- `./scripts/run_host_regression_tests.sh` — 49/49 geslaagd
- `npm run check:python-contracts` — 147/147 geslaagd
- `npm run check:cpp-format` — 180 bestanden geslaagd
- `python3 scripts/dev.py validate --config-only --config <config>` — alle zes Q Single/Duo × base/Ethernet/WiFi-configuraties geslaagd
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd
- `esphome compile configs/heatpump_controller_q/single_wifi.yaml` — geslaagd
- HIL op Q Duo met ODU/OpenTherm-simulator — nominale CM5-dispatch, fysieke oil-return cap naar level 1, herstelhold en vrijgave, harde fault-stop en directe failover zonder fysieke overlap geslaagd; protocolfouttellers bleven 0
- Na de test is exact `configs/heatpump_controller_q/duo_wifi.yaml` teruggezet; eindgate: CM0, beide requests/accepts 0, gezonde links en bevestigde stops
