### PR TITLE
YAML naar C++: Cooling – safety-policy en bevestigde overdracht

### DIFF
--- a/openquatt/includes/control/oq_cooling_dispatch_logic.h
+++ b/openquatt/includes/control/oq_cooling_dispatch_logic.h
@@ -13,7 +13,7 @@ struct DispatchInput {
   uint32_t now_ms = 0, cadence_ms = 5000, hp_min_off_ms = 0, global_min_off_remaining_ms = 0;
   int raw_demand = 0, demand_max = 10, power_cap = 10, stored_owner = 0;
   bool cooling_mode = false, duo = false, lead_is_hp1 = true;
-  bool minimum_off_enabled = false, stop_confirmation_pending = false;
+  bool stop_confirmation_pending = false;
   DispatchHpInput hp1, hp2;
 };
 struct DispatchState {
@@ -48,8 +48,7 @@ inline int recent_activity_owner(const DispatchInput& in) {
 }
 inline bool dispatch_hp_can_serve(const DispatchInput& in, const DispatchHpInput& hp, bool restart_blocked) {
   return oq_hp_candidate::may_serve_candidate(hp.candidate) && hp.has_allowed_level && !restart_blocked &&
-         !global_minimum_off_time_blocks_start(in.global_min_off_remaining_ms,
-                                               in.minimum_off_enabled && in.stop_confirmation_pending, false,
+         !global_minimum_off_time_blocks_start(in.global_min_off_remaining_ms, in.stop_confirmation_pending, false,
                                                hp.candidate.previous_applied_level);
 }
 inline DispatchOutput update_dispatch(const DispatchInput& in, DispatchState& state) {

--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -94,7 +94,15 @@ inline bool next_applied_cooling(bool was_cooling, int applied_level, int reques
   return applied_level > 0 && (request_mode_code == 1 || (request_mode_code != 2 && was_cooling));
 }
 inline int cooling_minimum_off_floor_s(int configured_floor_s) {
-  return std::max(1, std::min(240, configured_floor_s));
+  return std::max(1, std::min(3600, configured_floor_s));
+}
+inline bool cooling_stop_confirmation_blocks_start(bool confirmation_pending, bool armed_this_tick,
+                                                   int previous_applied_level) {
+  return previous_applied_level <= 0 && (confirmation_pending || armed_this_tick);
+}
+inline bool cooling_stop_requires_confirmation(bool was_cooling, int previous_applied_level, bool running_confirmed,
+                                               int applied_level) {
+  return was_cooling && applied_level <= 0 && (previous_applied_level > 0 || running_confirmed);
 }
 inline bool record_confirmed_cooling_stop(bool confirmation_pending, bool stop_confirmed, uint32_t now_ms,
                                           uint32_t& last_confirmed_stop_ms, bool& confirmed_stop_seen) {

--- a/openquatt/includes/control/oq_cooling_limiter_logic.h
+++ b/openquatt/includes/control/oq_cooling_limiter_logic.h
@@ -87,11 +87,15 @@ inline uint32_t global_minimum_off_time_remaining_ms(bool enabled, uint32_t now_
 inline bool cooling_stop_is_planned(bool was_cooling, int previous_applied_level, int requested_level) {
   return was_cooling && previous_applied_level > 0 && requested_level <= 0;
 }
-
 inline bool apply_hp2_before_hp1_for_cooling_handover(bool hp1_was_cooling, bool hp2_was_cooling) {
   return !hp1_was_cooling && hp2_was_cooling;
 }
-
+inline bool next_applied_cooling(bool was_cooling, int applied_level, int request_mode_code) {
+  return applied_level > 0 && (request_mode_code == 1 || (request_mode_code != 2 && was_cooling));
+}
+inline int cooling_minimum_off_floor_s(int configured_floor_s) {
+  return std::max(1, std::min(240, configured_floor_s));
+}
 inline bool record_confirmed_cooling_stop(bool confirmation_pending, bool stop_confirmed, uint32_t now_ms,
                                           uint32_t& last_confirmed_stop_ms, bool& confirmed_stop_seen) {
   if (!confirmation_pending || !stop_confirmed) return false;

--- a/openquatt/includes/control/oq_cooling_safety_logic.h
+++ b/openquatt/includes/control/oq_cooling_safety_logic.h
@@ -25,16 +25,15 @@ class CoolingSafetyRuntime {
                           id(cooling_without_dew_point_enabled).state, fallback_min_valid());
   }
   bool request_active() {
-    RoomRequestInput input;
-    input.room_required = id(cooling_room_request_required).state;
-    input.enabled_valid = id(cooling_enable_selected).has_state();
-    input.enabled = id(cooling_enable_selected).state;
-    input.room_valid = room_valid();
-    input.room_c = id(room_temp_selected).state;
-    input.setpoint_valid = setpoint_valid();
-    input.setpoint_c = id(room_setpoint_selected).state;
-    input.on_delta_c = id(cooling_request_on_delta).state;
-    input.off_delta_c = id(cooling_request_off_delta).state;
+    const RoomRequestInput input{id(cooling_room_request_required).state,
+                                 id(cooling_enable_selected).has_state(),
+                                 id(cooling_enable_selected).state,
+                                 room_valid(),
+                                 setpoint_valid(),
+                                 id(room_temp_selected).state,
+                                 id(room_setpoint_selected).state,
+                                 id(cooling_request_on_delta).state,
+                                 id(cooling_request_off_delta).state};
     return update_room_request(input, request_latched_);
   }
   bool permitted(float min_flow_lph) {

--- a/openquatt/includes/control/oq_cooling_safety_logic.h
+++ b/openquatt/includes/control/oq_cooling_safety_logic.h
@@ -1,11 +1,9 @@
 #pragma once
-
 #include <math.h>
 #include <stdint.h>
 #include <string>
-
+#include "oq_cooling_safety_policy.h"
 namespace oq_cooling_safety {
-
 class CoolingSafetyRuntime {
  public:
   bool without_dew_point_enabled() {
@@ -20,40 +18,28 @@ class CoolingSafetyRuntime {
     return !dew_selected_valid() && id(cooling_without_dew_point_enabled).state && fallback_min_valid();
   }
   bool permitted_core() {
-    const bool dew_ok = id(cooling_dew_point_available).state && dew_selected_valid() &&
-                        id(minimum_safe_supply_temp).has_state() && finite(id(minimum_safe_supply_temp).state);
-    const bool fallback_ok = id(cooling_without_dew_point_enabled).state && fallback_min_valid();
-    const bool user_ok = id(cooling_without_dew_point_user_responsibility_enabled).state &&
-                         id(cooling_min_supply_temp).has_state() && finite(id(cooling_min_supply_temp).state);
-    return id(cooling_without_dew_point_user_responsibility_enabled).state ? user_ok
-                                                                           : (dew_ok || fallback_ok || user_ok);
+    return core_permitted(id(cooling_without_dew_point_user_responsibility_enabled).state,
+                          id(cooling_min_supply_temp).has_state() && finite_value(id(cooling_min_supply_temp).state),
+                          id(cooling_dew_point_available).state && dew_selected_valid(),
+                          id(minimum_safe_supply_temp).has_state() && finite_value(id(minimum_safe_supply_temp).state),
+                          id(cooling_without_dew_point_enabled).state, fallback_min_valid());
   }
   bool request_active() {
-    if (!id(cooling_room_request_required).state) {
-      id(oq_cooling_request_latched) = false;
-      return id(cooling_enable_selected).has_state() && id(cooling_enable_selected).state;
-    }
-    if (!room_valid() || !setpoint_valid()) {
-      id(oq_cooling_request_latched) = false;
-      return false;
-    }
-    float on_delta_c = id(cooling_request_on_delta).state;
-    float off_delta_c = id(cooling_request_off_delta).state;
-    if (!finite(on_delta_c) || on_delta_c < 0.0f) on_delta_c = 0.4f;
-    if (!finite(off_delta_c) || off_delta_c < 0.0f) off_delta_c = 0.1f;
-    if (off_delta_c > on_delta_c) off_delta_c = on_delta_c;
-    const float room_c = id(room_temp_selected).state;
-    const float setpoint_c = id(room_setpoint_selected).state;
-    if (!id(oq_cooling_request_latched) && room_c > (setpoint_c + on_delta_c)) {
-      id(oq_cooling_request_latched) = true;
-    } else if (id(oq_cooling_request_latched) && room_c < (setpoint_c + off_delta_c)) {
-      id(oq_cooling_request_latched) = false;
-    }
-    return id(oq_cooling_request_latched);
+    RoomRequestInput input;
+    input.room_required = id(cooling_room_request_required).state;
+    input.enabled_valid = id(cooling_enable_selected).has_state();
+    input.enabled = id(cooling_enable_selected).state;
+    input.room_valid = room_valid();
+    input.room_c = id(room_temp_selected).state;
+    input.setpoint_valid = setpoint_valid();
+    input.setpoint_c = id(room_setpoint_selected).state;
+    input.on_delta_c = id(cooling_request_on_delta).state;
+    input.off_delta_c = id(cooling_request_off_delta).state;
+    return update_room_request(input, request_latched_);
   }
   bool permitted(float min_flow_lph) {
-    return id(cooling_permitted_core).has_state() && id(cooling_permitted_core).state && flow_valid() &&
-           id(flow_rate_selected).state >= min_flow_lph && !id(oq_lowflow_fault_active);
+    return flow_permitted(id(cooling_permitted_core).has_state() && id(cooling_permitted_core).state, flow_valid(),
+                          id(flow_rate_selected).state, min_flow_lph, id(oq_lowflow_fault_active));
   }
   const char* guard_mode() {
     if (id(cooling_without_dew_point_user_responsibility_enabled).state) return "User responsibility";
@@ -74,7 +60,7 @@ class CoolingSafetyRuntime {
     }
     if (!id(oq_enabled).state) return "OpenQuatt paused";
     if (id(cooling_without_dew_point_user_responsibility_enabled).state &&
-        (!id(cooling_min_supply_temp).has_state() || !finite(id(cooling_min_supply_temp).state))) {
+        (!id(cooling_min_supply_temp).has_state() || !finite_value(id(cooling_min_supply_temp).state))) {
       return "Cooling minimum unavailable";
     }
     if (!id(cooling_dew_point_available).state && !id(cooling_without_dew_point_user_responsibility_enabled).state) {
@@ -90,99 +76,44 @@ class CoolingSafetyRuntime {
     if (id(oq_lowflow_fault_active) || id(flow_rate_selected).state < min_flow_lph) return "Flow too low";
     return "Ready";
   }
-  float safety_margin_selected() { return clamp_float(id(cooling_safety_margin).state, 0.0f, 4.0f); }
+  float safety_margin_selected() { return clamp_finite(id(cooling_safety_margin).state, 0.0f, 4.0f); }
   float selected_dew_point(uint32_t now_ms, uint32_t hold_ms) {
     const int source_mode_code = dew_source_mode_code();
-    const bool ha_ok = ha_dew_valid();
-    const bool api_ok = api_dew_valid();
-    const bool mqtt_ok = mqtt_dew_valid();
-    float selected_c = NAN;
-    int selected_route_code = 0;
-    if (source_mode_code == 2 && mqtt_ok) {
-      selected_c = id(mqtt_cooling_dew_point).state;
-      selected_route_code = 2;
-    }
-    if (source_mode_code == 4 && api_ok) {
-      selected_c = id(api_input_cooling_dew_point).state;
-      selected_route_code = 4;
-    }
-    if (source_mode_code == 1 && ha_ok) {
-      selected_c = id(cooling_dew_point_ha).state;
-      selected_route_code = 1;
-    }
-    if (source_mode_code == 3) {
-      if (mqtt_ok) {
-        selected_c = id(mqtt_cooling_dew_point).state;
-        selected_route_code = 2;
-      }
-      if (api_ok && (!finite(selected_c) || id(api_input_cooling_dew_point).state > selected_c)) {
-        selected_c = id(api_input_cooling_dew_point).state;
-        selected_route_code = 4;
-      }
-      if (ha_ok && (!finite(selected_c) || id(cooling_dew_point_ha).state > selected_c)) {
-        selected_c = id(cooling_dew_point_ha).state;
-        selected_route_code = 1;
-      }
-    }
-    if (finite(selected_c)) {
-      id(oq_cooling_dew_point_selected_last_valid_c) = selected_c;
-      id(oq_cooling_dew_point_selected_last_valid_ms) = now_ms;
-      id(oq_cooling_dew_point_selected_last_mode_code) = source_mode_code;
-      id(oq_cooling_dew_point_selected_last_route_code) = selected_route_code;
-      id(oq_cooling_dew_point_selected_hold_active) = false;
-      return selected_c;
-    }
-    id(oq_cooling_dew_point_selected_hold_active) = false;
-    if (hold_ms > 0 && id(oq_cooling_dew_point_selected_last_route_code) == 1 &&
-        id(oq_cooling_dew_point_selected_last_valid_ms) > 0 &&
-        id(oq_cooling_dew_point_selected_last_mode_code) == source_mode_code &&
-        (uint32_t)(now_ms - id(oq_cooling_dew_point_selected_last_valid_ms)) < hold_ms &&
-        finite(id(oq_cooling_dew_point_selected_last_valid_c))) {
-      id(oq_cooling_dew_point_selected_hold_active) = true;
-      return id(oq_cooling_dew_point_selected_last_valid_c);
-    }
-    return NAN;
+    const DewPointSources sources{id(cooling_dew_point_ha).state,
+                                  id(api_input_cooling_dew_point).state,
+                                  id(mqtt_cooling_dew_point).state,
+                                  ha_dew_valid(),
+                                  api_dew_valid(),
+                                  mqtt_dew_valid()};
+    const auto selected = select_dew_point(source_mode_code, sources, now_ms, hold_ms, dew_selection_);
+    id(oq_cooling_dew_point_selected_hold_active) = selected.held;
+    return selected.value;
   }
   float minimum_safe_supply() {
     return dew_selected_valid() && id(cooling_safety_margin_selected).has_state() &&
-                   finite(id(cooling_safety_margin_selected).state)
+                   finite_value(id(cooling_safety_margin_selected).state)
                ? id(cooling_dew_point_selected).state + id(cooling_safety_margin_selected).state
                : NAN;
   }
   float fallback_night_min_outdoor_temp() {
     if (!id(oq_time).now().is_valid()) return NAN;
     const auto now = id(oq_time).now();
-    if (now.hour < 6 && id(oq_cooling_fallback_night_window_day_key) >= 0 &&
-        finite(id(oq_cooling_fallback_night_min_current_c))) {
-      return id(oq_cooling_fallback_night_min_current_c);
+    if (now.hour < 6 && fallback_night_window_day_key_ >= 0 && finite_value(fallback_night_min_current_c_)) {
+      return fallback_night_min_current_c_;
     }
-    return finite(id(oq_cooling_fallback_night_min_last_c)) ? id(oq_cooling_fallback_night_min_last_c) : NAN;
+    return finite_value(id(oq_cooling_fallback_night_min_last_c)) ? id(oq_cooling_fallback_night_min_last_c) : NAN;
   }
   float fallback_min_supply_temp() {
-    if (!outside_valid() || id(outside_temp_selected).state < 20.0f) return NAN;
-    const float outside_c = id(outside_temp_selected).state;
-    float fallback_floor_c = clamp_float(19.0f + ((outside_c - 20.0f) * 0.25f), 19.0f, 22.0f);
-    if (fallback_night_min_valid()) {
-      const float night_min_c = id(cooling_fallback_night_min_outdoor_temp).state;
-      if (night_min_c >= 20.0f)
-        fallback_floor_c += 1.5f;
-      else if (night_min_c >= 19.0f)
-        fallback_floor_c += 1.0f;
-      else if (night_min_c >= 18.0f)
-        fallback_floor_c += 0.5f;
-    }
-    if (room_valid()) {
-      const float room_usability_floor_c = id(room_temp_selected).state - 1.0f;
-      if (room_usability_floor_c >= 20.0f) fallback_floor_c = fminf(fallback_floor_c, room_usability_floor_c);
-    }
-    return fallback_floor_c;
+    return fallback_minimum_supply(outside_valid(), id(outside_temp_selected).state, fallback_night_min_valid(),
+                                   id(cooling_fallback_night_min_outdoor_temp).state, room_valid(),
+                                   id(room_temp_selected).state);
   }
   float effective_min_supply_temp() {
     if (id(cooling_without_dew_point_user_responsibility_enabled).state && id(cooling_min_supply_temp).has_state() &&
-        finite(id(cooling_min_supply_temp).state)) {
+        finite_value(id(cooling_min_supply_temp).state)) {
       return id(cooling_min_supply_temp).state;
     }
-    if (id(minimum_safe_supply_temp).has_state() && finite(id(minimum_safe_supply_temp).state)) {
+    if (id(minimum_safe_supply_temp).has_state() && finite_value(id(minimum_safe_supply_temp).state)) {
       return id(minimum_safe_supply_temp).state;
     }
     return id(cooling_fallback_active).state && fallback_min_valid() ? id(cooling_fallback_min_supply_temp).state : NAN;
@@ -192,30 +123,27 @@ class CoolingSafetyRuntime {
     const auto now = id(oq_time).now();
     const int day_key = (now.year * 10000) + (now.month * 100) + now.day_of_month;
     if (now.hour < 6) {
-      if (id(oq_cooling_fallback_night_window_day_key) != day_key ||
-          !finite(id(oq_cooling_fallback_night_min_current_c))) {
-        id(oq_cooling_fallback_night_window_day_key) = day_key;
-        id(oq_cooling_fallback_night_min_current_c) = id(outside_temp_selected).state;
+      if (fallback_night_window_day_key_ != day_key || !finite_value(fallback_night_min_current_c_)) {
+        fallback_night_window_day_key_ = day_key;
+        fallback_night_min_current_c_ = id(outside_temp_selected).state;
       } else {
-        id(oq_cooling_fallback_night_min_current_c) =
-            fminf(id(oq_cooling_fallback_night_min_current_c), id(outside_temp_selected).state);
+        fallback_night_min_current_c_ = fminf(fallback_night_min_current_c_, id(outside_temp_selected).state);
       }
       return;
     }
-    if (id(oq_cooling_fallback_night_window_day_key) >= 0 &&
-        id(oq_cooling_fallback_night_window_day_key) != id(oq_cooling_fallback_night_min_last_day_key) &&
-        finite(id(oq_cooling_fallback_night_min_current_c))) {
-      id(oq_cooling_fallback_night_min_last_c) = id(oq_cooling_fallback_night_min_current_c);
-      id(oq_cooling_fallback_night_min_last_day_key) = id(oq_cooling_fallback_night_window_day_key);
+    if (fallback_night_window_day_key_ >= 0 &&
+        fallback_night_window_day_key_ != id(oq_cooling_fallback_night_min_last_day_key) &&
+        finite_value(fallback_night_min_current_c_)) {
+      id(oq_cooling_fallback_night_min_last_c) = fallback_night_min_current_c_;
+      id(oq_cooling_fallback_night_min_last_day_key) = fallback_night_window_day_key_;
     }
   }
 
  private:
-  bool finite(float value) const { return !isnan(value); }
-  float clamp_float(float value, float min_value, float max_value) const {
-    if (value < min_value) return min_value;
-    return value > max_value ? max_value : value;
-  }
+  bool request_latched_ = false;
+  float fallback_night_min_current_c_ = NAN;
+  int fallback_night_window_day_key_ = -1;
+  DewPointSelectionState dew_selection_;
   bool option_allows_fallback(const std::string& option) const {
     return option == "Allow without dew point, use dew point approximation" ||
            option == "Allow without dew point, use fallback" || option == "Allow without dew point";
@@ -250,39 +178,38 @@ class CoolingSafetyRuntime {
     return "Fallback active";
   }
   bool dew_selected_valid() const {
-    return id(cooling_dew_point_selected).has_state() && finite(id(cooling_dew_point_selected).state);
+    return id(cooling_dew_point_selected).has_state() && finite_value(id(cooling_dew_point_selected).state);
   }
   bool fallback_min_valid() const {
-    return id(cooling_fallback_min_supply_temp).has_state() && finite(id(cooling_fallback_min_supply_temp).state);
+    return id(cooling_fallback_min_supply_temp).has_state() && finite_value(id(cooling_fallback_min_supply_temp).state);
   }
   bool fallback_night_min_valid() const {
     return id(cooling_fallback_night_min_outdoor_temp).has_state() &&
-           finite(id(cooling_fallback_night_min_outdoor_temp).state);
+           finite_value(id(cooling_fallback_night_min_outdoor_temp).state);
   }
   bool outside_valid() const {
-    return id(outside_temp_selected).has_state() && finite(id(outside_temp_selected).state);
+    return id(outside_temp_selected).has_state() && finite_value(id(outside_temp_selected).state);
   }
-  bool room_valid() const { return id(room_temp_selected).has_state() && finite(id(room_temp_selected).state); }
+  bool room_valid() const { return id(room_temp_selected).has_state() && finite_value(id(room_temp_selected).state); }
   bool setpoint_valid() const {
-    return id(room_setpoint_selected).has_state() && finite(id(room_setpoint_selected).state);
+    return id(room_setpoint_selected).has_state() && finite_value(id(room_setpoint_selected).state);
   }
-  bool flow_valid() const { return id(flow_rate_selected).has_state() && finite(id(flow_rate_selected).state); }
+  bool flow_valid() const { return id(flow_rate_selected).has_state() && finite_value(id(flow_rate_selected).state); }
   bool ha_dew_valid() const {
     return id(cooling_dew_point_valid_ha).has_state() && id(cooling_dew_point_valid_ha).state &&
-           id(cooling_dew_point_ha).has_state() && finite(id(cooling_dew_point_ha).state);
+           id(cooling_dew_point_ha).has_state() && finite_value(id(cooling_dew_point_ha).state);
   }
   bool mqtt_dew_valid() const {
     return id(mqtt_cooling_dew_point_valid).has_state() && id(mqtt_cooling_dew_point_valid).state &&
-           id(mqtt_cooling_dew_point).has_state() && finite(id(mqtt_cooling_dew_point).state);
+           id(mqtt_cooling_dew_point).has_state() && finite_value(id(mqtt_cooling_dew_point).state);
   }
   bool api_dew_valid() const {
     return id(api_input_cooling_dew_point_valid).has_state() && id(api_input_cooling_dew_point_valid).state &&
-           id(api_input_cooling_dew_point).has_state() && finite(id(api_input_cooling_dew_point).state);
+           id(api_input_cooling_dew_point).has_state() && finite_value(id(api_input_cooling_dew_point).state);
   }
 };
 inline CoolingSafetyRuntime& runtime() {
   static CoolingSafetyRuntime instance;
   return instance;
 }
-
 }  // namespace oq_cooling_safety

--- a/openquatt/includes/control/oq_cooling_safety_policy.h
+++ b/openquatt/includes/control/oq_cooling_safety_policy.h
@@ -1,0 +1,94 @@
+#pragma once
+#include <math.h>
+#include <stdint.h>
+namespace oq_cooling_safety {
+inline bool finite_value(float value) { return isfinite(value); }
+inline float clamp_finite(float value, float low, float high) {
+  if (!finite_value(value)) return NAN;
+  return value < low ? low : (value > high ? high : value);
+}
+struct DewPointSources {
+  float ha = NAN, api = NAN, mqtt = NAN;
+  bool ha_valid = false, api_valid = false, mqtt_valid = false;
+};
+struct DewPointSelectionState {
+  float last_valid = NAN;
+  uint32_t last_valid_ms = 0;
+  int last_mode = 0, last_route = 0;
+};
+struct DewPointSelection {
+  float value = NAN;
+  int route = 0;
+  bool held = false;
+};
+inline DewPointSelection select_dew_point(int mode, const DewPointSources& sources, uint32_t now_ms, uint32_t hold_ms,
+                                          DewPointSelectionState& state) {
+  DewPointSelection out;
+  auto take = [&](float value, bool valid, int route) {
+    if (valid && finite_value(value) && (!finite_value(out.value) || value > out.value)) {
+      out.value = value;
+      out.route = route;
+    }
+  };
+  if (mode == 1)
+    take(sources.ha, sources.ha_valid, 1);
+  else if (mode == 2)
+    take(sources.mqtt, sources.mqtt_valid, 2);
+  else if (mode == 4)
+    take(sources.api, sources.api_valid, 4);
+  else {
+    take(sources.mqtt, sources.mqtt_valid, 2);
+    take(sources.api, sources.api_valid, 4);
+    take(sources.ha, sources.ha_valid, 1);
+  }
+  if (finite_value(out.value)) {
+    state = {out.value, now_ms, mode, out.route};
+    return out;
+  }
+  const bool may_hold = hold_ms > 0 && state.last_route == 1 && state.last_mode == mode &&
+                        now_ms - state.last_valid_ms < hold_ms && finite_value(state.last_valid);
+  if (may_hold) return {state.last_valid, 1, true};
+  return out;
+}
+struct RoomRequestInput {
+  bool room_required = true, enabled_valid = false, enabled = false, room_valid = false, setpoint_valid = false;
+  float room_c = NAN, setpoint_c = NAN, on_delta_c = NAN, off_delta_c = NAN;
+};
+inline bool update_room_request(const RoomRequestInput& in, bool& latched) {
+  if (!in.room_required) {
+    latched = false;
+    return in.enabled_valid && in.enabled;
+  }
+  if (!in.room_valid || !in.setpoint_valid || !finite_value(in.room_c) || !finite_value(in.setpoint_c)) {
+    latched = false;
+    return false;
+  }
+  const float on = finite_value(in.on_delta_c) && in.on_delta_c >= 0 ? in.on_delta_c : 0.4f;
+  float off = finite_value(in.off_delta_c) && in.off_delta_c >= 0 ? in.off_delta_c : 0.1f;
+  if (off > on) off = on;
+  if (!latched && in.room_c > in.setpoint_c + on)
+    latched = true;
+  else if (latched && in.room_c < in.setpoint_c + off)
+    latched = false;
+  return latched;
+}
+inline bool core_permitted(bool user_responsibility, bool cooling_min_valid, bool dew_available,
+                           bool minimum_safe_valid, bool fallback_enabled, bool fallback_min_valid) {
+  return user_responsibility ? cooling_min_valid
+                             : ((dew_available && minimum_safe_valid) || (fallback_enabled && fallback_min_valid));
+}
+inline bool flow_permitted(bool core_valid, bool flow_valid, float flow_lph, float minimum_flow_lph,
+                           bool lowflow_fault) {
+  return core_valid && flow_valid && finite_value(flow_lph) && finite_value(minimum_flow_lph) &&
+         flow_lph >= minimum_flow_lph && !lowflow_fault;
+}
+inline float fallback_minimum_supply(bool outside_valid, float outside_c, bool night_valid, float night_min_c,
+                                     bool room_valid, float room_c) {
+  if (!outside_valid || !finite_value(outside_c) || outside_c < 20.0f) return NAN;
+  float floor = clamp_finite(19.0f + (outside_c - 20.0f) * 0.25f, 19.0f, 22.0f);
+  if (night_valid && finite_value(night_min_c))
+    floor += night_min_c >= 20.0f ? 1.5f : (night_min_c >= 19.0f ? 1.0f : (night_min_c >= 18.0f ? 0.5f : 0));
+  if (room_valid && finite_value(room_c) && room_c - 1.0f >= 20.0f && room_c - 1.0f < floor) floor = room_c - 1.0f;
+  return floor;
+}
+}  // namespace oq_cooling_safety

--- a/openquatt/includes/control/oq_cooling_safety_policy.h
+++ b/openquatt/includes/control/oq_cooling_safety_policy.h
@@ -36,7 +36,7 @@ inline DewPointSelection select_dew_point(int mode, const DewPointSources& sourc
     take(sources.mqtt, sources.mqtt_valid, 2);
   else if (mode == 4)
     take(sources.api, sources.api_valid, 4);
-  else {
+  else if (mode == 3) {
     take(sources.mqtt, sources.mqtt_valid, 2);
     take(sources.api, sources.api_valid, 4);
     take(sources.ha, sources.ha_valid, 1);

--- a/openquatt/includes/control/oq_thermal_actuator_runtime.h
+++ b/openquatt/includes/control/oq_thermal_actuator_runtime.h
@@ -74,7 +74,6 @@ class Runtime {
                                     restart_by_minimum_off_time),
     };
     this->publish_defrost_events(config.now_ms);
-
     const bool hp1_was_cooling = this->applied_cooling_[0] || this->applied_mode_is_cooling_(true, request_mode_code);
 #if OQ_TOPOLOGY_DUO
     const bool hp2_was_cooling = this->applied_cooling_[1] || this->applied_mode_is_cooling_(false, request_mode_code);
@@ -88,12 +87,10 @@ class Runtime {
         cycle.cooling_stop_planned || oq_cooling::cooling_stop_is_planned(hp2_was_cooling, id(hp2_last_applied_level),
                                                                           id(oq_cooling_request_hp2_level));
 #endif
-
     int hp1_applied = 0;
     int hp2_applied = 0;
 #if OQ_TOPOLOGY_DUO
-    const bool hp2_first = !manual_service_active && request_mode_code == 1 &&
-                           oq_cooling::apply_hp2_before_hp1_for_cooling_handover(hp1_was_cooling, hp2_was_cooling);
+    const bool hp2_first = oq_cooling::apply_hp2_before_hp1_for_cooling_handover(hp1_was_cooling, hp2_was_cooling);
     if (hp2_first) {
       hp2_applied = this->apply_level_(false, id(oq_actuator_hp2_req), hp2_was_cooling, cycle);
       hp1_applied = this->apply_level_(true, id(oq_actuator_hp1_req), hp1_was_cooling, cycle);
@@ -115,7 +112,6 @@ class Runtime {
                                          this->requested_mode_code(false, hp2_applied > 0, request_mode_code,
                                                                    request_thermal_active, manual_service_active));
 #endif
-
     if (manual_service_active) {
       this->publish_manual_guard(static_cast<int>(roundf(id(oq_manual_hp1_level).state)),
                                  static_cast<int>(roundf(id(oq_manual_hp2_level).state)), hp1_applied, hp2_applied,
@@ -133,7 +129,6 @@ class Runtime {
     if (!id(oq_cooling_boot_min_off_elapsed) && now_ms >= minimum_off_ms) {
       id(oq_cooling_boot_min_off_elapsed) = true;
     }
-
     this->confirm_cooling_stop_(true, now_ms);
 #if OQ_TOPOLOGY_DUO
     this->confirm_cooling_stop_(false, now_ms);
@@ -413,16 +408,17 @@ class Runtime {
     const auto retained = incident_guard.bypass_runtime_and_defrost_holds
                               ? oq_odu::RetainedLevel{}
                               : this->retained_level(is_hp1, cycle.frequency);
-    const bool cooling_start_blocked =
-        !cycle.manual_service_active && cycle.request_mode_code == 1 &&
-        oq_cooling::global_minimum_off_time_blocks_start(
-            cycle.cooling.remaining_ms, cycle.cooling.confirmation_pending || cycle.cooling_stop_armed,
-            cycle.restart_by_minimum_off_time && cycle.cooling_stop_planned, previous);
+    const int expected_mode = this->requested_mode_code(is_hp1, true, cycle.request_mode_code,
+                                                        cycle.request_thermal_active, cycle.manual_service_active);
+    const bool cooling_start_blocked = oq_cooling::cooling_stop_confirmation_blocks_start(
+                                           cycle.cooling.confirmation_pending, cycle.cooling_stop_armed, previous) ||
+                                       (!cycle.manual_service_active && cycle.request_mode_code == 1 &&
+                                        oq_cooling::global_minimum_off_time_blocks_start(
+                                            cycle.cooling.remaining_ms, false,
+                                            cycle.restart_by_minimum_off_time && cycle.cooling_stop_planned, previous));
     const uint32_t hp_rest_remaining_ms = oq_thermal_actuator::minimum_off_remaining_ms(
         cycle.config.now_ms, this->last_stop_ms_(is_hp1),
         static_cast<uint32_t>(std::max(0, cycle.config.minimum_off_s)) * 1000UL);
-    const int expected_mode = this->requested_mode_code(is_hp1, true, cycle.request_mode_code,
-                                                        cycle.request_thermal_active, cycle.manual_service_active);
     const bool defrost_hold = oq_odu::retained_level_should_override_request(retained, incident_guard.guarded_level,
                                                                              cycle.manual_service_active);
     const auto preflight = oq_thermal_actuator::decide_preflight(
@@ -521,7 +517,7 @@ class Runtime {
       this->publish_optimizer_reason("defrost_protect_hold");
       return retained.control_level;
     }
-    if (applied == 0 && previous > 0 && was_cooling) {
+    if (oq_cooling::cooling_stop_requires_confirmation(was_cooling, previous, incident.running_confirmed, applied)) {
       this->cooling_confirmation_pending_(is_hp1) = true;
       cycle.cooling_stop_armed = true;
     }
@@ -553,7 +549,7 @@ class Runtime {
       }
     }
     if (applied == 0 && !safe_mode_written) {
-      const bool register_initial_stop = previous > 0 || register_incident_stop;
+      const bool register_initial_stop = previous > 0 || incident.running_confirmed || register_incident_stop;
       const bool notify_stop = oq_incident_actuator::requires_stop_notification(
           register_initial_stop, incident.must_stop, incident.stop_confirmed, incident.stop_confirmation_pending);
       oq_incident_actuator::apply_stop_notification_before_safe_write(
@@ -610,8 +606,10 @@ class Runtime {
   }
 
   bool applied_mode_is_cooling_(bool is_hp1, int request_mode_code) const {
-    return this->previous_applied_(is_hp1) > 0 && (request_mode_code == 1 || id(oq_control_mode_code) == 5 ||
-                                                   this->mode_is(is_hp1, 1) || this->mode_target_is(is_hp1, 1));
+    const auto incident = id(oq_incident_manager).get_outputs(is_hp1 ? 1U : 2U);
+    const bool running = this->previous_applied_(is_hp1) > 0 || incident.running_confirmed;
+    return running && (request_mode_code == 1 || id(oq_control_mode_code) == 5 || this->mode_is(is_hp1, 1) ||
+                       this->mode_target_is(is_hp1, 1));
   }
 
   void publish_topology_change_(int hp1_applied, int hp2_applied, uint32_t now_ms) {

--- a/openquatt/includes/control/oq_thermal_actuator_runtime.h
+++ b/openquatt/includes/control/oq_thermal_actuator_runtime.h
@@ -32,6 +32,7 @@ struct TickConfig {
   uint32_t now_ms;
   uint32_t dt_ms;
   int minimum_off_s;
+  int cooling_minimum_off_min_s;
   float minimum_flow_lph;
 };
 
@@ -53,8 +54,9 @@ class Runtime {
  public:
   void tick(const TickConfig& config) {
     const float cooling_off_state = id(cooling_minimum_off_time).state;
-    int cooling_off_s = isnan(cooling_off_state) ? 600 : static_cast<int>(lroundf(cooling_off_state));
-    cooling_off_s = std::max(240, std::min(3600, cooling_off_s));
+    int cooling_off_s = !isfinite(cooling_off_state) ? 600 : static_cast<int>(lroundf(cooling_off_state));
+    const int cooling_off_floor_s = oq_cooling::cooling_minimum_off_floor_s(config.cooling_minimum_off_min_s);
+    cooling_off_s = std::max(cooling_off_floor_s, std::min(3600, cooling_off_s));
     const bool restart_by_minimum_off_time =
         id(cooling_restart_mode).has_state() && id(cooling_restart_mode).current_option() == "Minimum off time";
     const int request_mode_code = id(oq_request_mode_code);
@@ -73,9 +75,9 @@ class Runtime {
     };
     this->publish_defrost_events(config.now_ms);
 
-    const bool hp1_was_cooling = this->applied_mode_is_cooling_(true, request_mode_code);
+    const bool hp1_was_cooling = this->applied_cooling_[0] || this->applied_mode_is_cooling_(true, request_mode_code);
 #if OQ_TOPOLOGY_DUO
-    const bool hp2_was_cooling = this->applied_mode_is_cooling_(false, request_mode_code);
+    const bool hp2_was_cooling = this->applied_cooling_[1] || this->applied_mode_is_cooling_(false, request_mode_code);
 #else
     constexpr bool hp2_was_cooling = false;
 #endif
@@ -90,7 +92,7 @@ class Runtime {
     int hp1_applied = 0;
     int hp2_applied = 0;
 #if OQ_TOPOLOGY_DUO
-    const bool hp2_first = restart_by_minimum_off_time && !manual_service_active && request_mode_code == 1 &&
+    const bool hp2_first = !manual_service_active && request_mode_code == 1 &&
                            oq_cooling::apply_hp2_before_hp1_for_cooling_handover(hp1_was_cooling, hp2_was_cooling);
     if (hp2_first) {
       hp2_applied = this->apply_level_(false, id(oq_actuator_hp2_req), hp2_was_cooling, cycle);
@@ -102,6 +104,16 @@ class Runtime {
     this->publish_topology_change_(hp1_applied, hp2_applied, config.now_ms);
 #else
     hp1_applied = this->apply_level_(true, id(oq_actuator_hp1_req), hp1_was_cooling, cycle);
+#endif
+    this->applied_cooling_[0] =
+        oq_cooling::next_applied_cooling(hp1_was_cooling, hp1_applied,
+                                         this->requested_mode_code(true, hp1_applied > 0, request_mode_code,
+                                                                   request_thermal_active, manual_service_active));
+#if OQ_TOPOLOGY_DUO
+    this->applied_cooling_[1] =
+        oq_cooling::next_applied_cooling(hp2_was_cooling, hp2_applied,
+                                         this->requested_mode_code(false, hp2_applied > 0, request_mode_code,
+                                                                   request_thermal_active, manual_service_active));
 #endif
 
     if (manual_service_active) {
@@ -404,8 +416,7 @@ class Runtime {
     const bool cooling_start_blocked =
         !cycle.manual_service_active && cycle.request_mode_code == 1 &&
         oq_cooling::global_minimum_off_time_blocks_start(
-            cycle.cooling.remaining_ms,
-            cycle.restart_by_minimum_off_time && (cycle.cooling.confirmation_pending || cycle.cooling_stop_armed),
+            cycle.cooling.remaining_ms, cycle.cooling.confirmation_pending || cycle.cooling_stop_armed,
             cycle.restart_by_minimum_off_time && cycle.cooling_stop_planned, previous);
     const uint32_t hp_rest_remaining_ms = oq_thermal_actuator::minimum_off_remaining_ms(
         cycle.config.now_ms, this->last_stop_ms_(is_hp1),
@@ -770,6 +781,7 @@ class Runtime {
   std::string last_manual_guard_status_;
   bool last_defrost_seen_[2]{false, false};
   bool last_defrost_holds_[2]{false, false};
+  bool applied_cooling_[2]{false, false};
   uint32_t defrost_started_ms_[2]{0, 0};
   uint32_t last_safe_stop_write_ms_[2]{0, 0};
   oq_odu::RetainedLevel retained_levels_[2]{};

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -70,10 +70,7 @@ select:
     entity_category: config
     optimistic: true
     restore_value: true
-    options:
-      - "Dew point required"
-      - "Allow without dew point, use dew point approximation"
-      - "Allow without dew point, user responsibility"
+    options: ["Dew point required", "Allow without dew point, use dew point approximation", "Allow without dew point, user responsibility"]
     initial_option: Dew point required
 binary_sensor:
   - platform: template
@@ -160,7 +157,8 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      return oq_cooling_safety::runtime().selected_dew_point((uint32_t) millis(), (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL));
+      return oq_cooling_safety::runtime().selected_dew_point((uint32_t) millis(),
+                                                            (uint32_t) (${oq_selected_input_stale_hold_s}UL * 1000UL));
     filters:
       - exponential_moving_average:
           alpha: 0.3

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -1,34 +1,7 @@
 # ==============================================================================
-# OpenQuatt - Cooling Safety Inputs and Derived Signals
+# OpenQuatt - Cooling Safety Entities (policy lives in C++)
 # ==============================================================================
-#
-# Goal:
-#   Build the cooling safety layer from one HA-provided aggregate dew point and
-#   one optional MQTT-provided external dew point.
-#
-# Scope:
-#   - Home Assistant can calculate the highest valid dew point across configured
-#     cooling rooms.
-#   - MQTT can provide one external aggregate dew point on a fixed topic.
-#   - ESPHome consumes the aggregate values and selects the configured source.
-#   - Derive the minimum safe supply temperature and fallback guardrails.
-#
-# ==============================================================================
-
 globals:
-  - id: oq_cooling_request_latched
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_cooling_fallback_night_min_current_c
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-  - id: oq_cooling_fallback_night_window_day_key
-    type: int
-    restore_value: false
-    initial_value: '-1'
   - id: oq_cooling_fallback_night_min_last_c
     type: float
     restore_value: true
@@ -37,28 +10,10 @@ globals:
     type: int
     restore_value: true
     initial_value: '-1'
-
-  - id: oq_cooling_dew_point_selected_last_valid_c
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-  - id: oq_cooling_dew_point_selected_last_valid_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
   - id: oq_cooling_dew_point_selected_hold_active
     type: bool
     restore_value: false
     initial_value: 'false'
-  - id: oq_cooling_dew_point_selected_last_mode_code
-    type: int
-    restore_value: false
-    initial_value: '0'
-  - id: oq_cooling_dew_point_selected_last_route_code
-    type: int
-    restore_value: false
-    initial_value: '0'
-
 switch:
   - platform: template
     id: cooling_room_request_required
@@ -67,7 +22,6 @@ switch:
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: true
     entity_category: config
-
 number:
   - platform: template
     id: cooling_safety_margin
@@ -82,7 +36,6 @@ number:
     restore_value: true
     initial_value: 1.0
     entity_category: config
-
   - platform: template
     id: cooling_request_on_delta
     name: "Cooling Request On Delta"
@@ -96,7 +49,6 @@ number:
     restore_value: true
     initial_value: 0.4
     entity_category: config
-
   - platform: template
     id: cooling_request_off_delta
     name: "Cooling Request Off Delta"
@@ -110,7 +62,6 @@ number:
     restore_value: true
     initial_value: 0.1
     entity_category: config
-
 select:
   - platform: template
     id: cooling_dew_point_source
@@ -125,7 +76,6 @@ select:
       - "API input"
       - "MQTT"
     initial_option: Auto
-
   - platform: template
     id: cooling_without_dew_point_mode
     name: "Cooling Without Dew Point"
@@ -138,7 +88,6 @@ select:
       - "Allow without dew point, use dew point approximation"
       - "Allow without dew point, user responsibility"
     initial_option: Dew point required
-
 binary_sensor:
   - platform: template
     id: cooling_without_dew_point_enabled
@@ -146,14 +95,12 @@ binary_sensor:
     internal: true
     lambda: |-
       return oq_cooling_safety::runtime().without_dew_point_enabled();
-
   - platform: template
     id: cooling_without_dew_point_user_responsibility_enabled
     name: "Cooling Without Dew Point User Responsibility Enabled"
     internal: true
     lambda: |-
       return oq_cooling_safety::runtime().without_dew_point_user_responsibility_enabled();
-
   - platform: template
     id: cooling_fallback_active
     name: "Cooling Fallback Active"
@@ -162,7 +109,6 @@ binary_sensor:
     device_class: running
     lambda: |-
       return oq_cooling_safety::runtime().fallback_active();
-
   - platform: template
     id: cooling_permitted_core
     name: "Cooling Permitted Core"
@@ -170,7 +116,6 @@ binary_sensor:
     lambda: |-
       // Core cooling preconditions that are independent from the live flow interlock.
       return oq_cooling_safety::runtime().permitted_core();
-
   - platform: template
     id: cooling_request_active
     name: "Cooling Request Active"
@@ -178,7 +123,6 @@ binary_sensor:
     device_class: running
     lambda: |-
       return oq_cooling_safety::runtime().request_active();
-
   - platform: template
     id: cooling_permitted
     name: "Cooling Permitted"
@@ -187,15 +131,13 @@ binary_sensor:
     lambda: |-
       // User-facing permission includes both the core cooling prerequisites and the live flow guard.
       return oq_cooling_safety::runtime().permitted((float) ${oq_cm_min_flow_lph});
-
   - platform: template
     id: cooling_dew_point_available
     name: "Cooling Dew Point Available"
     icon: mdi:water-check
     device_class: connectivity
     lambda: |-
-      return id(cooling_dew_point_selected).has_state() && !isnan(id(cooling_dew_point_selected).state);
-
+      return id(cooling_dew_point_selected).has_state() && isfinite(id(cooling_dew_point_selected).state);
 text_sensor:
   - platform: template
     id: cooling_guard_mode
@@ -204,9 +146,7 @@ text_sensor:
     entity_category: diagnostic
     update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
-      // Summarize which cooling safety route is currently active.
       return {oq_cooling_safety::runtime().guard_mode()};
-
   - platform: template
     id: cooling_block_reason
     name: "Cooling Block Reason"
@@ -214,9 +154,7 @@ text_sensor:
     entity_category: diagnostic
     update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
-      // Report the first blocking condition in operator-friendly terms.
       return {oq_cooling_safety::runtime().block_reason((float) ${oq_cm_min_flow_lph})};
-
 sensor:
   - platform: template
     id: cooling_safety_margin_selected
@@ -227,7 +165,6 @@ sensor:
     update_interval: 10s
     lambda: |-
       return oq_cooling_safety::runtime().safety_margin_selected();
-
   - platform: template
     id: cooling_dew_point_selected
     name: "Cooling Dew Point (Selected)"
@@ -238,19 +175,14 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      // Hold the last valid selected aggregate briefly through source reload gaps.
       const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
       const uint32_t now_ms = (uint32_t) millis();
       return oq_cooling_safety::runtime().selected_dew_point(now_ms, hold_ms);
     filters:
-      # Smooth short dew-point spikes and dips symmetrically before they move
-      # the safe supply floor. Keep this responsive: the user safety margin
-      # remains the real condensation buffer.
       - exponential_moving_average:
           alpha: 0.3
           send_every: 1
           send_first_at: 1
-
   - platform: template
     id: minimum_safe_supply_temp
     name: "Cooling Minimum Safe Supply Temp"
@@ -263,7 +195,6 @@ sensor:
     lambda: |-
       // This is the central cooling guardrail: never target water below dew point + margin.
       return oq_cooling_safety::runtime().minimum_safe_supply();
-
   - platform: template
     id: cooling_fallback_night_min_outdoor_temp
     name: "Cooling Fallback Night Minimum Outdoor Temp"
@@ -277,7 +208,6 @@ sensor:
     update_interval: 60s
     lambda: |-
       return oq_cooling_safety::runtime().fallback_night_min_outdoor_temp();
-
   - platform: template
     id: cooling_fallback_min_supply_temp
     name: "Cooling Fallback Minimum Supply Temp"
@@ -292,7 +222,6 @@ sensor:
     lambda: |-
       // Conservative fallback floor for systems without a dew-point source.
       return oq_cooling_safety::runtime().fallback_min_supply_temp();
-
   - platform: template
     id: cooling_effective_min_supply_temp
     name: "Cooling Effective Minimum Supply Temp"
@@ -305,7 +234,6 @@ sensor:
     lambda: |-
       // Publish the active floor that raises the configured cooling target.
       return oq_cooling_safety::runtime().effective_min_supply_temp();
-
 interval:
   - interval: 60s
     then:

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -2,18 +2,9 @@
 # OpenQuatt - Cooling Safety Entities (policy lives in C++)
 # ==============================================================================
 globals:
-  - id: oq_cooling_fallback_night_min_last_c
-    type: float
-    restore_value: true
-    initial_value: 'NAN'
-  - id: oq_cooling_fallback_night_min_last_day_key
-    type: int
-    restore_value: true
-    initial_value: '-1'
-  - id: oq_cooling_dew_point_selected_hold_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
+  - {id: oq_cooling_fallback_night_min_last_c, type: float, restore_value: true, initial_value: 'NAN'}
+  - {id: oq_cooling_fallback_night_min_last_day_key, type: int, restore_value: true, initial_value: '-1'}
+  - {id: oq_cooling_dew_point_selected_hold_active, type: bool, restore_value: false, initial_value: 'false'}
 switch:
   - platform: template
     id: cooling_room_request_required
@@ -70,11 +61,7 @@ select:
     entity_category: config
     optimistic: true
     restore_value: true
-    options:
-      - "Auto"
-      - "Home Assistant"
-      - "API input"
-      - "MQTT"
+    options: ["Auto", "Home Assistant", "API input", "MQTT"]
     initial_option: Auto
   - platform: template
     id: cooling_without_dew_point_mode
@@ -114,7 +101,6 @@ binary_sensor:
     name: "Cooling Permitted Core"
     internal: true
     lambda: |-
-      // Core cooling preconditions that are independent from the live flow interlock.
       return oq_cooling_safety::runtime().permitted_core();
   - platform: template
     id: cooling_request_active
@@ -129,7 +115,6 @@ binary_sensor:
     icon: mdi:shield-check
     device_class: running
     lambda: |-
-      // User-facing permission includes both the core cooling prerequisites and the live flow guard.
       return oq_cooling_safety::runtime().permitted((float) ${oq_cm_min_flow_lph});
   - platform: template
     id: cooling_dew_point_available
@@ -175,9 +160,7 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
-      const uint32_t now_ms = (uint32_t) millis();
-      return oq_cooling_safety::runtime().selected_dew_point(now_ms, hold_ms);
+      return oq_cooling_safety::runtime().selected_dew_point((uint32_t) millis(), (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL));
     filters:
       - exponential_moving_average:
           alpha: 0.3
@@ -193,7 +176,6 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      // This is the central cooling guardrail: never target water below dew point + margin.
       return oq_cooling_safety::runtime().minimum_safe_supply();
   - platform: template
     id: cooling_fallback_night_min_outdoor_temp
@@ -220,7 +202,6 @@ sensor:
     accuracy_decimals: 1
     update_interval: 10s
     lambda: |-
-      // Conservative fallback floor for systems without a dew-point source.
       return oq_cooling_safety::runtime().fallback_min_supply_temp();
   - platform: template
     id: cooling_effective_min_supply_temp
@@ -232,11 +213,9 @@ sensor:
     accuracy_decimals: 1
     update_interval: 10s
     lambda: |-
-      // Publish the active floor that raises the configured cooling target.
       return oq_cooling_safety::runtime().effective_min_supply_temp();
 interval:
   - interval: 60s
     then:
       - lambda: |-
-          // Track the minimum selected outside temperature during the local 00:00-06:00 window.
           oq_cooling_safety::runtime().update_fallback_night_min();

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -122,7 +122,7 @@ number:
     name: "Cooling Minimum Off Time"
     icon: mdi:timer-pause-outline
     unit_of_measurement: "s"
-    min_value: 240
+    min_value: ${oq_cooling_minimum_off_min_s}
     max_value: 3600
     step: 30
     mode: slider
@@ -404,7 +404,7 @@ sensor:
       const float configured_state = id(cooling_minimum_off_time).state;
       int configured_s =
           !isfinite(configured_state) ? 600 : (int) lroundf(configured_state);
-      configured_s = std::max(240, std::min(3600, configured_s));
+      configured_s = std::max(${oq_cooling_minimum_off_min_s}, std::min(3600, configured_s));
       const uint32_t configured_ms = (uint32_t) configured_s * 1000UL;
       uint32_t remaining_ms = oq_cooling::global_minimum_off_time_remaining_ms(
           true,
@@ -623,11 +623,10 @@ interval:
             id(oq_cooling_request_reason_code) = 0;
             return;
           }
-          const bool restart_by_minimum_off_time = id(cooling_restart_mode).has_state() &&
-                                                   id(cooling_restart_mode).current_option() == "Minimum off time";
+          const bool restart_by_minimum_off_time = id(cooling_restart_mode).has_state() && id(cooling_restart_mode).current_option() == "Minimum off time";
           const float cooling_minimum_off_state = id(cooling_minimum_off_time).state;
           int cooling_minimum_off_s = !isfinite(cooling_minimum_off_state) ? 600 : (int) lroundf(cooling_minimum_off_state);
-          cooling_minimum_off_s = std::max(240, std::min(3600, cooling_minimum_off_s));
+          cooling_minimum_off_s = std::max(${oq_cooling_minimum_off_min_s}, std::min(3600, cooling_minimum_off_s));
           const uint32_t cooling_minimum_off_ms = (uint32_t) cooling_minimum_off_s * 1000UL;
           const uint32_t global_minimum_off_remaining_ms =
               oq_cooling::global_minimum_off_time_remaining_ms(restart_by_minimum_off_time, now_ms,
@@ -666,7 +665,6 @@ interval:
           dispatch.raw_demand = id(oq_cooling_demand_raw); dispatch.demand_max = (int) ${oq_strategy_demand_max_f};
           dispatch.power_cap = id(oq_power_cap_f); dispatch.stored_owner = id(oq_cooling_owner_hp);
           dispatch.cooling_mode = true; dispatch.lead_is_hp1 = lead_is_hp1;
-          dispatch.minimum_off_enabled = restart_by_minimum_off_time;
           dispatch.stop_confirmation_pending = cooling_stop_confirmation_pending;
           dispatch.hp1 = {hp1_candidate, id(hp1_last_start_ms), id(hp1_last_stop_ms), hp_has_any_allowed_level(true)};
           #if OQ_TOPOLOGY_DUO

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -186,6 +186,7 @@ oq_cooling_limiter_stop_confirm_s: "30"               # Confirm time before soft
 oq_cooling_oil_return_hold_s: "1200"                  # Maximum oil-return recovery window; floor-guard modes clear earlier after recovery [s].
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].
 oq_hp_min_off_s: "240"                                # Minimum per-HP off-time before any restart [s].
+oq_hp_min_runtime_min_s: "300"                        # Build-time floor for the user-configurable compressor runtime [s].
 oq_optimizer_penalty_per_w: "5.0"                     # Cost factor above soft limit [cost/W].
 oq_optimizer_topology_power_margin_w: "150.0"         # Required power delta before a single<->duo topology switch counts as a meaningful efficiency gain [W].
 oq_optimizer_topology_heat_advantage_w: "450.0"       # Required heat-match advantage before a less-efficient topology may override the efficiency-first choice [W].

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -181,6 +181,7 @@ oq_outside_temp_stale_s: "1200"                       # Ignore a local outdoor r
 oq_heat_loop_tick_s: "5"                              # Scheduler tick for heat-control loop [s].
 oq_heat_loop_curve_s: "30"                            # Effective heat-control cadence in Heating Curve mode [s].
 oq_heat_loop_powerhouse_s: "60"                       # Effective heat-control cadence in Power House mode [s].
+oq_cooling_minimum_off_min_s: "240"                   # Production floor for the user-configurable cooling restart delay [s].
 oq_cooling_limiter_stop_confirm_s: "30"               # Confirm time before soft-stop and dew hard-stop take effect [s].
 oq_cooling_oil_return_hold_s: "1200"                  # Maximum oil-return recovery window; floor-guard modes clear earlier after recovery [s].
 oq_cop_min_input_w: "10.0"                            # Minimum electrical input for a valid COP calculation [W].

--- a/openquatt/oq_thermal_actuator.yaml
+++ b/openquatt/oq_thermal_actuator.yaml
@@ -1,23 +1,13 @@
 # ==============================================================================
 # OpenQuatt - Thermal Actuator
 # ==============================================================================
-#
-# Contract:
-#   Applies finalized thermal requests through the stateful C++ actuator.
-#   The runtime owns the ordered safety gates, HP writes and bookkeeping.
-#
-# Ownership:
-#   - Consumes `oq_request_mode_code`
-#   - Consumes `oq_actuator_hp1_req` / `oq_actuator_hp2_req`
-#   - Is the only package that writes HP working mode and compressor levels
-# ==============================================================================
-
+# Maps finalized requests to the stateful C++ actuator. The runtime owns ordered
+# safety gates, HP writes and bookkeeping; this is the only HP-commanding package.
 globals:
   - id: oq_thermal_actuator_last_loop_ms
     type: uint32_t
     restore_value: false
     initial_value: '0'
-
 interval:
   - interval: ${oq_heat_loop_tick_s}s
     startup_delay: 4000ms
@@ -25,17 +15,16 @@ interval:
       - lambda: |-
           // Keep elapsed-time accounting in YAML; C++ owns actuation behavior.
           const uint32_t now_ms = (uint32_t) millis();
-          const uint32_t nominal_dt_ms =
-              (uint32_t) ${oq_heat_loop_tick_s} * 1000UL;
+          const uint32_t nominal_dt_ms = (uint32_t) ${oq_heat_loop_tick_s} * 1000UL;
           const uint32_t dt_ms = oq_request::capped_loop_dt_ms(
               now_ms,
               id(oq_thermal_actuator_last_loop_ms),
               nominal_dt_ms);
           id(oq_thermal_actuator_last_loop_ms) = now_ms;
-
           oq_thermal_actuator_runtime::runtime().tick({
               now_ms,
               dt_ms,
               (int) ${oq_hp_min_off_s},
+              (int) ${oq_cooling_minimum_off_min_s},
               (float) ${oq_cm_min_flow_lph},
           });

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -250,7 +250,7 @@ number:
     icon: mdi:timer-cog-outline
     entity_category: config
     unit_of_measurement: "s"
-    min_value: 300
+    min_value: ${oq_hp_min_runtime_min_s}
     max_value: 3600
     step: 30
     mode: slider
@@ -940,7 +940,7 @@ interval:
           // Keep the runtime floor hard in code as well. Older installs may still
           // restore a pre-migration numeric value such as 60, even though the UI
           // slider now starts at 300 s.
-          if (min_rt_s > 0 && min_rt_s < 300) min_rt_s = 300;
+          if (min_rt_s > 0 && min_rt_s < (int) ${oq_hp_min_runtime_min_s}) min_rt_s = (int) ${oq_hp_min_runtime_min_s};
           const uint32_t min_rt_ms = (min_rt_s > 0) ? ((uint32_t) min_rt_s * 1000UL) : 0;
           auto min_runtime_hold_level = [&](bool is_hp1)->int {
             const uint32_t last_real_start_ms = is_hp1 ? id(hp1_last_real_heat_start_ms) : id(hp2_last_real_heat_start_ms);

--- a/scripts/tests/test_cooling_recovery_delegation_contract.py
+++ b/scripts/tests/test_cooling_recovery_delegation_contract.py
@@ -14,7 +14,7 @@ class CoolingRecoveryDelegationContractTest(unittest.TestCase):
         self.assertIn("select_dew_point(", SAFETY_POLICY)
         self.assertNotIn("id(oq_cooling_min_off_stop_pending) = false", YAML)
         self.assertIn("id(oq_cooling_min_off_stop_pending) = false", ACTUATOR_RUNTIME)
-        for marker in ("applied_cooling_[2]", "cycle.cooling.confirmation_pending || cycle.cooling_stop_armed",
+        for marker in ("applied_cooling_[2]", "cooling_stop_confirmation_blocks_start(",
                        "next_applied_cooling("): self.assertIn(marker, ACTUATOR_RUNTIME)
         self.assertIn("(int) ${oq_cooling_minimum_off_min_s}", ACTUATOR_YAML)
         self.assertIn('oq_cooling_minimum_off_min_s: "240"', SUBSTITUTIONS)

--- a/scripts/tests/test_cooling_recovery_delegation_contract.py
+++ b/scripts/tests/test_cooling_recovery_delegation_contract.py
@@ -4,6 +4,7 @@ ROOT = Path(__file__).resolve().parents[2]
 YAML = (ROOT / "openquatt/oq_cooling_strategy.yaml").read_text()
 CORE = (ROOT / "openquatt/includes/control/oq_cooling_demand_logic.h").read_text()
 DISPATCH = (ROOT / "openquatt/includes/control/oq_cooling_dispatch_logic.h").read_text()
+SAFETY_POLICY = (ROOT / "openquatt/includes/control/oq_cooling_safety_policy.h").read_text()
 ACTUATOR_RUNTIME = (ROOT / "openquatt/includes/control/oq_thermal_actuator_runtime.h").read_text()
 DEFROST_TEST = (ROOT / "tests/host/oq_odu_compressor_levels_test.cpp").read_text()
 class CoolingRecoveryDelegationContractTest(unittest.TestCase):
@@ -18,12 +19,14 @@ class CoolingRecoveryDelegationContractTest(unittest.TestCase):
             self.assertIn(marker, CORE)
         for marker in ("update_dispatch(", "recent_activity_owner(", "hp_minimum_off_blocks_start("):
             self.assertIn(marker, DISPATCH)
+        self.assertIn("select_dew_point(", SAFETY_POLICY)
+        self.assertNotIn("id(oq_cooling_min_off_stop_pending) = false", YAML)
         self.assertIn("id(oq_cooling_min_off_stop_pending) = false", ACTUATOR_RUNTIME)
         for marker in ("resolve_retained_level(true, true", "no_cooling_hold.control_level == 0", "no_cooling_hold.physical_level == 0"):
             self.assertIn(marker, DEFROST_TEST)
-        paths = ("openquatt/oq_cooling_strategy.yaml", "openquatt/includes/control/oq_cooling_limiter_logic.h",
-                 "openquatt/includes/control/oq_cooling_demand_logic.h", "openquatt/includes/control/oq_cooling_dispatch_logic.h",
-                 "tests/host/cooling_limiter_logic_test.cpp", "tests/host/cooling_demand_logic_test.cpp", "tests/host/cooling_dispatch_logic_test.cpp",
-                 "tests/host/thermal_request_logic_test.cpp")
+        paths = ("openquatt/oq_cooling_strategy.yaml", "openquatt/oq_cooling_safety.yaml", "openquatt/includes/control/oq_cooling_limiter_logic.h",
+                 "openquatt/includes/control/oq_cooling_demand_logic.h", "openquatt/includes/control/oq_cooling_dispatch_logic.h", "openquatt/includes/control/oq_cooling_safety_logic.h",
+                 "openquatt/includes/control/oq_cooling_safety_policy.h", "tests/host/cooling_limiter_logic_test.cpp", "tests/host/cooling_demand_logic_test.cpp",
+                 "tests/host/cooling_dispatch_logic_test.cpp", "tests/host/cooling_safety_policy_test.cpp", "tests/host/thermal_request_logic_test.cpp")
         files = [ROOT / path for path in paths] + [Path(__file__)]
-        self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in files), 2309)
+        self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in files), 2911)

--- a/scripts/tests/test_cooling_recovery_delegation_contract.py
+++ b/scripts/tests/test_cooling_recovery_delegation_contract.py
@@ -1,32 +1,25 @@
 from pathlib import Path
 import unittest
 ROOT = Path(__file__).resolve().parents[2]
-YAML = (ROOT / "openquatt/oq_cooling_strategy.yaml").read_text()
-CORE = (ROOT / "openquatt/includes/control/oq_cooling_demand_logic.h").read_text()
-DISPATCH = (ROOT / "openquatt/includes/control/oq_cooling_dispatch_logic.h").read_text()
-SAFETY_POLICY = (ROOT / "openquatt/includes/control/oq_cooling_safety_policy.h").read_text()
-ACTUATOR_RUNTIME = (ROOT / "openquatt/includes/control/oq_thermal_actuator_runtime.h").read_text()
-DEFROST_TEST = (ROOT / "tests/host/oq_odu_compressor_levels_test.cpp").read_text()
+YAML, CORE, DISPATCH, SAFETY_POLICY, ACTUATOR_RUNTIME, ACTUATOR_YAML, SUBSTITUTIONS, DEFROST_TEST = (
+    (ROOT / path).read_text() for path in ("openquatt/oq_cooling_strategy.yaml", "openquatt/includes/control/oq_cooling_demand_logic.h", "openquatt/includes/control/oq_cooling_dispatch_logic.h", "openquatt/includes/control/oq_cooling_safety_policy.h", "openquatt/includes/control/oq_thermal_actuator_runtime.h", "openquatt/oq_thermal_actuator.yaml", "openquatt/oq_substitutions_common.yaml", "tests/host/oq_odu_compressor_levels_test.cpp"))
 class CoolingRecoveryDelegationContractTest(unittest.TestCase):
     def test_yaml_delegates_and_live_safety_paths_stay_fail_closed(self) -> None:
         for marker in ("demand_runtime().tick", "DemandInput input", "input.sensor_valid = supply_valid && target_valid",
-                       "dispatch_tick(dispatch)", "DispatchInput dispatch", "publish_cooling_limiter_event"):
-            self.assertIn(marker, YAML)
+                       "dispatch_tick(dispatch)", "DispatchInput dispatch", "publish_cooling_limiter_event"): self.assertIn(marker, YAML)
         for marker in ("update_oil_return(", "evaluate_water_restart(", "oq_cooling_pid_integral", "oq_cooling_last_demand_change_ms",
-                       "hp_can_take_cooling_start", "recent_owner", "id(oq_cooling_min_off_stop_pending) = false"):
-            self.assertNotIn(marker, YAML)
-        for marker in ("update_gap_filter(", "apply_demand_dwell(", "update_demand(", "effective_minimum_off_stop_pending", "isfinite(value)"):
-            self.assertIn(marker, CORE)
-        for marker in ("update_dispatch(", "recent_activity_owner(", "hp_minimum_off_blocks_start("):
-            self.assertIn(marker, DISPATCH)
+                       "hp_can_take_cooling_start", "recent_owner", "id(oq_cooling_min_off_stop_pending) = false"): self.assertNotIn(marker, YAML)
+        for marker in ("update_gap_filter(", "apply_demand_dwell(", "update_demand(", "effective_minimum_off_stop_pending", "isfinite(value)"): self.assertIn(marker, CORE)
+        for marker in ("update_dispatch(", "recent_activity_owner(", "hp_minimum_off_blocks_start("): self.assertIn(marker, DISPATCH)
         self.assertIn("select_dew_point(", SAFETY_POLICY)
         self.assertNotIn("id(oq_cooling_min_off_stop_pending) = false", YAML)
         self.assertIn("id(oq_cooling_min_off_stop_pending) = false", ACTUATOR_RUNTIME)
-        for marker in ("resolve_retained_level(true, true", "no_cooling_hold.control_level == 0", "no_cooling_hold.physical_level == 0"):
-            self.assertIn(marker, DEFROST_TEST)
-        paths = ("openquatt/oq_cooling_strategy.yaml", "openquatt/oq_cooling_safety.yaml", "openquatt/includes/control/oq_cooling_limiter_logic.h",
-                 "openquatt/includes/control/oq_cooling_demand_logic.h", "openquatt/includes/control/oq_cooling_dispatch_logic.h", "openquatt/includes/control/oq_cooling_safety_logic.h",
-                 "openquatt/includes/control/oq_cooling_safety_policy.h", "tests/host/cooling_limiter_logic_test.cpp", "tests/host/cooling_demand_logic_test.cpp",
-                 "tests/host/cooling_dispatch_logic_test.cpp", "tests/host/cooling_safety_policy_test.cpp", "tests/host/thermal_request_logic_test.cpp")
+        for marker in ("applied_cooling_[2]", "cycle.cooling.confirmation_pending || cycle.cooling_stop_armed",
+                       "next_applied_cooling("): self.assertIn(marker, ACTUATOR_RUNTIME)
+        self.assertIn("(int) ${oq_cooling_minimum_off_min_s}", ACTUATOR_YAML)
+        self.assertIn('oq_cooling_minimum_off_min_s: "240"', SUBSTITUTIONS)
+        for marker in ("resolve_retained_level(true, true", "no_cooling_hold.control_level == 0", "no_cooling_hold.physical_level == 0"): self.assertIn(marker, DEFROST_TEST)
+        paths = ("openquatt/oq_cooling_strategy.yaml", "openquatt/oq_cooling_safety.yaml", "openquatt/includes/control/oq_cooling_limiter_logic.h", "openquatt/includes/control/oq_cooling_demand_logic.h", "openquatt/includes/control/oq_cooling_dispatch_logic.h", "openquatt/includes/control/oq_cooling_safety_logic.h",
+                 "openquatt/includes/control/oq_cooling_safety_policy.h", "tests/host/cooling_limiter_logic_test.cpp", "tests/host/cooling_demand_logic_test.cpp", "tests/host/cooling_dispatch_logic_test.cpp", "tests/host/cooling_safety_policy_test.cpp", "tests/host/thermal_request_logic_test.cpp")
         files = [ROOT / path for path in paths] + [Path(__file__)]
         self.assertLessEqual(sum(len(path.read_text().splitlines()) for path in files), 2911)

--- a/tests/host/cooling_dispatch_logic_test.cpp
+++ b/tests/host/cooling_dispatch_logic_test.cpp
@@ -40,7 +40,7 @@ void test_single() {
   in.now_ms++;
   assert(!update_dispatch(in, state).evaluated);
   in.now_ms += in.cadence_ms;
-  in.minimum_off_enabled = in.stop_confirmation_pending = true;
+  in.stop_confirmation_pending = true;
   out = update_dispatch(in, state);
   assert(out.start_blocked && out.owner == 0);
   in.hp1.candidate.previous_applied_level = 2;
@@ -87,6 +87,14 @@ void test_stops() {
   assert(out.owner_before_hold == 2 && out.owner == 2 && out.hp2_request == 4);
   in.now_ms += in.cadence_ms;
   in.hp2.candidate.must_stop = true;
+  out = update_dispatch(in, state);
+  assert(out.owner == 1 && out.hp1_request == 4 && out.hp2_request == 0);
+  in.now_ms += in.cadence_ms;
+  in.stop_confirmation_pending = true;
+  out = update_dispatch(in, state);
+  assert(out.start_blocked && out.owner == 0 && out.hp1_request == 0 && out.hp2_request == 0);
+  in.now_ms += in.cadence_ms;
+  in.stop_confirmation_pending = false;
   out = update_dispatch(in, state);
   assert(out.owner == 1 && out.hp1_request == 4 && out.hp2_request == 0);
   in.now_ms += in.cadence_ms;

--- a/tests/host/cooling_limiter_logic_test.cpp
+++ b/tests/host/cooling_limiter_logic_test.cpp
@@ -48,6 +48,10 @@ void test_existing_water_and_minimum_off_contracts() {
          !apply_hp2_before_hp1_for_cooling_handover(true, false) &&
          !apply_hp2_before_hp1_for_cooling_handover(true, true) &&
          !apply_hp2_before_hp1_for_cooling_handover(false, false));
+  assert(next_applied_cooling(false, 1, 1));
+  assert(next_applied_cooling(true, 1, 0) && !next_applied_cooling(true, 0, 0) && !next_applied_cooling(true, 1, 2));
+  assert(cooling_minimum_off_floor_s(10) == 10 && cooling_minimum_off_floor_s(0) == 1 &&
+         cooling_minimum_off_floor_s(600) == 240);
   uint32_t confirmed_at = 1234;
   bool seen = false;
   assert(!record_confirmed_cooling_stop(false, true, 2000, confirmed_at, seen) && confirmed_at == 1234 && !seen);

--- a/tests/host/cooling_limiter_logic_test.cpp
+++ b/tests/host/cooling_limiter_logic_test.cpp
@@ -51,7 +51,14 @@ void test_existing_water_and_minimum_off_contracts() {
   assert(next_applied_cooling(false, 1, 1));
   assert(next_applied_cooling(true, 1, 0) && !next_applied_cooling(true, 0, 0) && !next_applied_cooling(true, 1, 2));
   assert(cooling_minimum_off_floor_s(10) == 10 && cooling_minimum_off_floor_s(0) == 1 &&
-         cooling_minimum_off_floor_s(600) == 240);
+         cooling_minimum_off_floor_s(600) == 600 && cooling_minimum_off_floor_s(4000) == 3600);
+  assert(cooling_stop_confirmation_blocks_start(true, false, 0) &&
+         cooling_stop_confirmation_blocks_start(false, true, 0) &&
+         !cooling_stop_confirmation_blocks_start(true, true, 1) &&
+         !cooling_stop_confirmation_blocks_start(false, false, 0));
+  assert(
+      cooling_stop_requires_confirmation(true, 0, true, 0) && cooling_stop_requires_confirmation(true, 1, false, 0) &&
+      !cooling_stop_requires_confirmation(false, 1, true, 0) && !cooling_stop_requires_confirmation(true, 0, true, 1));
   uint32_t confirmed_at = 1234;
   bool seen = false;
   assert(!record_confirmed_cooling_stop(false, true, 2000, confirmed_at, seen) && confirmed_at == 1234 && !seen);

--- a/tests/host/cooling_safety_policy_test.cpp
+++ b/tests/host/cooling_safety_policy_test.cpp
@@ -7,9 +7,10 @@ int main() {
   DewPointSources sources{15, 16, 17, true, true, true};
   auto out = select_dew_point(3, sources, 100, 1000, state);
   assert(out.value == 17 && out.route == 2 && !out.held);
+  assert(isnan(select_dew_point(0, sources, 101, 1000, state).value));
   assert(isnan(select_dew_point(3, {}, 150, 1000, state).value));
-  assert(select_dew_point(4, sources, 160, 1000, state).route == 4);
-  assert(select_dew_point(2, sources, 170, 1000, state).route == 2);
+  assert(select_dew_point(4, sources, 160, 1000, state).route == 4 &&
+         select_dew_point(2, sources, 170, 1000, state).route == 2);
   out = select_dew_point(1, sources, 200, 1000, state);
   assert(out.value == 15 && out.route == 1);
   sources.ha = INFINITY;
@@ -20,20 +21,17 @@ int main() {
   assert(select_dew_point(1, sources, 0, 1000, state).value == 15);
   sources.ha_valid = false;
   out = select_dew_point(1, sources, 999, 1000, state);
-  assert(out.value == 15 && out.held);
-  assert(isnan(select_dew_point(1, sources, 1000, 1000, state).value));
+  assert(out.value == 15 && out.held && isnan(select_dew_point(1, sources, 1000, 1000, state).value));
   sources.ha_valid = true;
   select_dew_point(1, sources, UINT32_MAX - 99U, 250, state);
   sources.ha_valid = false;
-  assert(select_dew_point(1, sources, 100, 250, state).held);
-  assert(isnan(select_dew_point(2, sources, 101, 250, state).value));
+  assert(select_dew_point(1, sources, 100, 250, state).held &&
+         isnan(select_dew_point(2, sources, 101, 250, state).value));
   bool latched = false;
   RoomRequestInput in;
   in.room_valid = in.setpoint_valid = true;
-  in.room_c = 20.4f;
-  in.setpoint_c = 20;
-  in.on_delta_c = 0.4f;
-  in.off_delta_c = 0.1f;
+  in.room_c = in.setpoint_c = 20;
+  in.on_delta_c = 0.4f, in.off_delta_c = 0.1f;
   assert(!update_room_request(in, latched));
   in.room_c = 20.41f;
   assert(update_room_request(in, latched) && latched);
@@ -43,19 +41,16 @@ int main() {
   assert(!update_room_request(in, latched) && !latched);
   in.room_c = INFINITY;
   assert(!update_room_request(in, latched));
-  in.room_required = false;
-  in.enabled_valid = in.enabled = true;
+  in.room_required = false, in.enabled_valid = in.enabled = true;
   assert(update_room_request(in, latched) && !latched);
   assert(core_permitted(false, false, true, true, false, false));
-  assert(!core_permitted(true, false, true, true, true, true));
-  assert(core_permitted(true, true, false, false, false, false));
+  assert(!core_permitted(true, false, true, true, true, true) &&
+         core_permitted(true, true, false, false, false, false));
   assert(flow_permitted(true, true, 500, 400, false));
-  assert(!flow_permitted(true, true, INFINITY, 400, false));
-  assert(!flow_permitted(true, true, 500, 400, true));
-  assert(isnan(fallback_minimum_supply(true, 19, false, NAN, false, NAN)));
-  assert(isnan(fallback_minimum_supply(true, INFINITY, false, NAN, false, NAN)));
-  assert(fallback_minimum_supply(true, 24, true, 20, false, NAN) == 21.5f);
-  assert(fallback_minimum_supply(true, 24, true, 20, true, 21) == 20.0f);
-  assert(isnan(clamp_finite(INFINITY, 0, 4)));
+  assert(!flow_permitted(true, true, INFINITY, 400, false) && !flow_permitted(true, true, 500, 400, true));
+  assert(isnan(fallback_minimum_supply(true, 19, false, NAN, false, NAN)) &&
+         isnan(fallback_minimum_supply(true, INFINITY, false, NAN, false, NAN)));
+  assert(fallback_minimum_supply(true, 24, true, 20, false, NAN) == 21.5f &&
+         fallback_minimum_supply(true, 24, true, 20, true, 21) == 20.0f && isnan(clamp_finite(INFINITY, 0, 4)));
   return 0;
 }

--- a/tests/host/cooling_safety_policy_test.cpp
+++ b/tests/host/cooling_safety_policy_test.cpp
@@ -1,0 +1,61 @@
+#include <assert.h>
+#include <math.h>
+#include "../../openquatt/includes/control/oq_cooling_safety_policy.h"
+using namespace oq_cooling_safety;
+int main() {
+  DewPointSelectionState state;
+  DewPointSources sources{15, 16, 17, true, true, true};
+  auto out = select_dew_point(3, sources, 100, 1000, state);
+  assert(out.value == 17 && out.route == 2 && !out.held);
+  assert(isnan(select_dew_point(3, {}, 150, 1000, state).value));
+  assert(select_dew_point(4, sources, 160, 1000, state).route == 4);
+  assert(select_dew_point(2, sources, 170, 1000, state).route == 2);
+  out = select_dew_point(1, sources, 200, 1000, state);
+  assert(out.value == 15 && out.route == 1);
+  sources.ha = INFINITY;
+  out = select_dew_point(1, sources, 1200, 1000, state);
+  assert(isnan(out.value) && !out.held);
+  state = {};
+  sources = {15, NAN, NAN, true, false, false};
+  assert(select_dew_point(1, sources, 0, 1000, state).value == 15);
+  sources.ha_valid = false;
+  out = select_dew_point(1, sources, 999, 1000, state);
+  assert(out.value == 15 && out.held);
+  assert(isnan(select_dew_point(1, sources, 1000, 1000, state).value));
+  sources.ha_valid = true;
+  select_dew_point(1, sources, UINT32_MAX - 99U, 250, state);
+  sources.ha_valid = false;
+  assert(select_dew_point(1, sources, 100, 250, state).held);
+  assert(isnan(select_dew_point(2, sources, 101, 250, state).value));
+  bool latched = false;
+  RoomRequestInput in;
+  in.room_valid = in.setpoint_valid = true;
+  in.room_c = 20.4f;
+  in.setpoint_c = 20;
+  in.on_delta_c = 0.4f;
+  in.off_delta_c = 0.1f;
+  assert(!update_room_request(in, latched));
+  in.room_c = 20.41f;
+  assert(update_room_request(in, latched) && latched);
+  in.room_c = 20.1f;
+  assert(update_room_request(in, latched));
+  in.room_c = 20.09f;
+  assert(!update_room_request(in, latched) && !latched);
+  in.room_c = INFINITY;
+  assert(!update_room_request(in, latched));
+  in.room_required = false;
+  in.enabled_valid = in.enabled = true;
+  assert(update_room_request(in, latched) && !latched);
+  assert(core_permitted(false, false, true, true, false, false));
+  assert(!core_permitted(true, false, true, true, true, true));
+  assert(core_permitted(true, true, false, false, false, false));
+  assert(flow_permitted(true, true, 500, 400, false));
+  assert(!flow_permitted(true, true, INFINITY, 400, false));
+  assert(!flow_permitted(true, true, 500, 400, true));
+  assert(isnan(fallback_minimum_supply(true, 19, false, NAN, false, NAN)));
+  assert(isnan(fallback_minimum_supply(true, INFINITY, false, NAN, false, NAN)));
+  assert(fallback_minimum_supply(true, 24, true, 20, false, NAN) == 21.5f);
+  assert(fallback_minimum_supply(true, 24, true, 20, true, 21) == 20.0f);
+  assert(isnan(clamp_finite(INFINITY, 0, 4)));
+  return 0;
+}

--- a/tests/host/cooling_safety_policy_test.cpp
+++ b/tests/host/cooling_safety_policy_test.cpp
@@ -28,19 +28,12 @@ int main() {
   assert(select_dew_point(1, sources, 100, 250, state).held &&
          isnan(select_dew_point(2, sources, 101, 250, state).value));
   bool latched = false;
-  RoomRequestInput in;
-  in.room_valid = in.setpoint_valid = true;
-  in.room_c = in.setpoint_c = 20;
-  in.on_delta_c = 0.4f, in.off_delta_c = 0.1f;
-  assert(!update_room_request(in, latched));
-  in.room_c = 20.41f;
-  assert(update_room_request(in, latched) && latched);
-  in.room_c = 20.1f;
-  assert(update_room_request(in, latched));
-  in.room_c = 20.09f;
-  assert(!update_room_request(in, latched) && !latched);
-  in.room_c = INFINITY;
-  assert(!update_room_request(in, latched));
+  RoomRequestInput in{true, false, false, true, true, 20, 20, 0.4f, 0.1f};
+  auto demand = [&](float room_c) {
+    in.room_c = room_c;
+    return update_room_request(in, latched);
+  };
+  assert(!demand(20) && demand(20.41f) && latched && demand(20.1f) && !demand(20.09f) && !latched && !demand(INFINITY));
   in.room_required = false, in.enabled_valid = in.enabled = true;
   assert(update_room_request(in, latched) && !latched);
   assert(core_permitted(false, false, true, true, false, false));
@@ -52,5 +45,4 @@ int main() {
          isnan(fallback_minimum_supply(true, INFINITY, false, NAN, false, NAN)));
   assert(fallback_minimum_supply(true, 24, true, 20, false, NAN) == 21.5f &&
          fallback_minimum_supply(true, 24, true, 20, true, 21) == 20.0f && isnan(clamp_finite(INFINITY, 0, 4)));
-  return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst dauwpuntselectie, ruimtevraaghysterese, fallbackvloer en flow-permission uit YAML naar een hosttestbare C++ safety-policy.
- Blokkeert iedere nieuwe HP-start tijdens een onbevestigde Cooling-stop en draagt in Duo pas over nadat de actieve ODU fysiek gestopt is.
- Integreert dit direct met `ThermalActuatorRuntime`; productiegrenzen blijven 240 s Cooling minimum-off en 300 s minimum-runtime, met een expliciete build-time HIL-naad.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Bij linkverlies, een faultstop of een CM-/serviceovergang kan een stilstaande kandidaat niet starten zolang de fysieke stop van een eerder koelende ODU onbevestigd is. De actuator verwerkt de koelende eigenaar eerst, zodat een stop en vervangende start niet in dezelfde tick kunnen passeren. `NaN` en oneindige safety-inputs worden fail-closed afgewezen.

## Achtergrond

Deze PR staat rechtstreeks op actuele `dev`; de eerdere Cooling-, Thermal Actuator-, Heating Curve- en Power House-PR's zijn al geïntegreerd. Er resteert dus geen oude YAML-actuatorintegratie of gestapelde PR-afhankelijkheid.

De private C++-state vervangt alleen `restore_value: false` YAML-globals en start na reboot bewust leeg. Persistente fallbackhistorie blijft in de bestaande herstelbare globals. Incidenttelemetrie herkent een na reboot nog fysiek draaiende Cooling-ODU en registreert eerst een veilige stop.

Volledige diff inclusief tests: 308 toevoegingen / 310 verwijderingen, netto 2 regels kleiner. `openquatt/oq_cooling_safety.yaml` daalt van 314 naar 219 regels.

Cold-review omvatte bronprioriteit en ties, stale-hold/rollover, requesthysterese, fallbacknachtstate, flowverlies, stopregistratie, verloren acknowledgements, reboot, CM5-exit, manual/heating-overgangen, defrost-hold, Single/Duo-volgorde en gelijktijdige owner-overdracht. Geen nieuwe dynamische allocaties, taken, netwerkbuffers, opslagmigraties of credentials.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Er wijzigen geen gebruikersgerichte namen, standaardwaarden of productiegrenzen. De build-time testoverrides zijn intern en behouden zonder override exact het bestaande productiecontract.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

- Geen nieuwe allocaties, taken of buffers; uitsluitend vaste singletonstate en twee booleans voor Cooling-herkomst.
- Q Duo WiFi: DIRAM 210.707 -> 210.619 B (-88 B); image 2.182.807 -> 2.183.131 B (+324 B).
- Q Single WiFi: DIRAM 193.115 -> 193.027 B (-88 B); image 2.137.631 -> 2.138.183 B (+552 B).
- Runtime heap-/stackwatermarks zijn niet opnieuw bemonsterd omdat het allocatie- en taakmodel ongewijzigd is en statische DIRAM afneemt.

Uitgevoerd:

- `./scripts/run_host_regression_tests.sh` — 50/50 geslaagd.
- `npm run check:python-contracts` — 147/147 geslaagd.
- `npm run check:cpp-format` — 182 bestanden geslaagd.
- `python3 scripts/check_style_consistency.py` — geslaagd.
- `python3 scripts/dev.py validate --config-only --config <target>` — alle zes Q-configs geslaagd: Duo/Single × base/Ethernet/WiFi.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd.
- `esphome compile configs/heatpump_controller_q/single_wifi.yaml` — geslaagd.

Q Duo HIL met de ODU-simulator op de uiteindelijke code:

- nominale Cooling-start en modulatie — geslaagd;
- linkverlies actieve eigenaar: vervangende ODU blijft gestopt — geslaagd;
- blokkade blijft actief zonder stopbevestiging — geslaagd;
- overdracht pas na herstel en bevestigde fysieke stop — geslaagd;
- flowverlies op beide ODU's: harde stop — geslaagd;
- flowherstel — geslaagd;
- 10 s-testbuild: countdown start na bevestigde stop en herstart pas na afloop — geslaagd;
- OpenTherm-protocoltellers bleven op nul.

Na HIL is exact de productiebuild teruggezet. Eindcontrole: beide ODU-links gezond en bevestigd gestopt, geen pending stop, requests/accepted levels nul, minimum-runtime 300 s, Cooling minimum-off 600 s, restartmodus `Water temperature` en dauwpuntbron `Home Assistant`.
