### PR TITLE
Sta terugkeer van PR-testfirmware naar dev toe

### DIFF
--- a/openquatt/web/js/src/features/firmware-update.js
+++ b/openquatt/web/js/src/features/firmware-update.js
@@ -759,6 +759,9 @@ import { render } from "../core/render-scheduler.js";
     if (!isFirmwareEntityAlignedWithChannel()) {
       return false;
     }
+    if (isFirmwarePrToDevTransition()) {
+      return true;
+    }
     const relation = getFirmwareVersionRelation();
     if (relation !== null) {
       return relation > 0;
@@ -795,7 +798,13 @@ import { render } from "../core/render-scheduler.js";
     const current = getFirmwareCurrentVersion(entity) || "—";
     let latest = isFirmwareEntityAlignedWithChannel(entity) ? getFirmwareLatestVersion(entity) : "";
     const relation = getFirmwareVersionRelation(entity);
-    if (!isFirmwareUpdateChecking() && relation !== null && relation <= 0 && !isFirmwareDowngradeAvailable(entity)) {
+    if (
+      !isFirmwareUpdateChecking()
+      && relation !== null
+      && relation <= 0
+      && !isFirmwareDowngradeAvailable(entity)
+      && !isFirmwarePrToDevTransition(entity)
+    ) {
       latest = "";
     }
     return {
@@ -811,6 +820,15 @@ import { render } from "../core/render-scheduler.js";
       return null;
     }
     return compareFirmwareVersions(latest, current);
+  }
+
+  function isFirmwarePrToDevTransition(entity = getFirmwareUpdateEntity() || {}) {
+    const current = parseFirmwareVersion(getFirmwareCurrentVersion(entity));
+    const latest = parseFirmwareVersion(getFirmwareLatestVersion(entity));
+    return getFirmwareChannelLabel().toLowerCase() === "dev"
+      && isFirmwareEntityAlignedWithChannel(entity, "dev")
+      && current?.prereleaseTag.toLowerCase() === "pr"
+      && latest?.prereleaseTag.toLowerCase() === "dev";
   }
 
   export function getFirmwareReleaseUrlFallback(channel = getFirmwareChannelLabel()) {
@@ -1098,6 +1116,9 @@ import { render } from "../core/render-scheduler.js";
     if (isFirmwareDowngradeAvailable()) {
       const { current, latest } = getFirmwareUpdateVersions();
       return `De stabiele main-release ${latest} is ouder dan de draaiende dev-build ${current}. Je kunt bewust teruggaan naar main.`;
+    }
+    if (isFirmwarePrToDevTransition()) {
+      return "Dev-firmware kan de PR-testfirmware vervangen.";
     }
     if (isFirmwareUpdateAvailable()) {
       return "Er staat een nieuwere firmware klaar.";

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -55,6 +55,33 @@ function setDevToMainDowngradeState() {
   state.updateModalOpen = true;
 }
 
+function setPrToDevState() {
+  state.drafts = {};
+  state.entities = {
+    firmwareUpdate: {
+      state: "UPDATE AVAILABLE",
+      value: "v0.49.0-dev.740+2f65a08",
+      current_version: "v0.49.0-pr.555.1321+222bde1",
+      latest_version: "v0.49.0-dev.740+2f65a08",
+      release_url: "https://github.com/OpenQuatt/OpenQuatt/releases/tag/dev-latest",
+    },
+    firmwareUpdateChannel: { state: "dev", value: "dev", option: ["main", "dev"] },
+    projectVersionText: { state: "v0.49.0-pr.555.1321+222bde1", value: "v0.49.0-pr.555.1321+222bde1" },
+    releaseChannelText: { state: "dev", value: "dev" },
+  };
+  state.updateCheckBusy = false;
+  state.updateInstallBusy = false;
+  state.updateInstallCompleted = false;
+  state.updateInstallCompletedVersion = "";
+  state.updateInstallMode = "";
+  state.updateInstallTargetVersion = "";
+  state.updateInstallPhaseHint = "";
+  state.updateInstallProgressHint = Number.NaN;
+  state.updateInstallStatusPollObserved = false;
+  state.firmwareDowngradeConfirmedVersion = "";
+  state.updateModalOpen = true;
+}
+
 test("PR firmware uses deterministic release URLs without the GitHub REST API", () => {
   const target = {
     available: true,
@@ -68,6 +95,22 @@ test("PR firmware uses deterministic release URLs without the GitHub REST API", 
     label: "PR 395 · Heatpump Controller Q Duo Wi-Fi",
   });
   assert.equal(getFirmwareTestAssetUrls("395/../../dev-latest", target), null);
+});
+
+test("PR test firmware can return to the dev channel", () => {
+  setPrToDevState();
+
+  assert.equal(isFirmwareUpdateAvailable(), true);
+  assert.deepEqual(getFirmwareUpdateVersions(), {
+    current: "v0.49.0-pr.555.1321+222bde1",
+    latest: "v0.49.0-dev.740+2f65a08",
+  });
+  assert.equal(getUpdateStatus(), "Beschikbaar");
+  assert.match(getFirmwareModalCopy(), /Dev-firmware kan de PR-testfirmware vervangen/);
+
+  const modal = renderUpdateModal();
+  const installButton = modal.match(/<button class="oq-helper-button[^"]*" type="button" data-oq-action="install-firmware-update"[^>]*>/)?.[0] || "";
+  assert.doesNotMatch(installButton, /disabled/);
 });
 
 test("PR firmware starts with one complete render before the first device write", async (t) => {


### PR DESCRIPTION
# Wat verandert deze PR?

- Herkent een overgang van PR-testfirmware naar het geselecteerde dev-kanaal als beschikbare firmwarewissel.
- Houdt de dev-doelversie zichtbaar en activeert `Nu bijwerken`.
- Voegt regressiedekking toe met het gemelde PR- en dev-versieformaat.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de web-UI-classificatie van een expliciete PR→dev-firmwarewissel verandert. De OTA-uitvoering, doelmanifestvalidatie en dev→main-downgradebeveiliging blijven ongewijzigd.

## Achtergrond

Een PR-versie zoals `v0.49.0-pr.555.1321+...` werd door de bestaande prereleasevergelijking hoger geordend dan `v0.49.0-dev.740+...`. Daardoor verdween de gevonden dev-versie na de controle en bleef `Nu bijwerken` uitgeschakeld.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt bestaande OTA-bediening voor een testfirmware-terugkeerpad; er worden geen nieuwe gebruikersstappen, configuratieopties of entities toegevoegd.

## Validatie

- `npm run check:web` — 309 tests geslaagd; webbundle- en kwaliteitscontroles geslaagd.
- Browsercontrole met de gemelde PR-versie en actuele dev-doelversie — versies en overgangstekst zichtbaar; `Nu bijwerken` actief.
- `git diff --check` — geslaagd.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen web-UI-logica en tests wijzigen; firmware-runtime, heap, PSRAM en task-stacks zijn niet geraakt.
