### PR TITLE
YAML naar C++: Supervisory – vermogenslimiet en veiligheidsinterlocks

### DIFF
--- a/openquatt/includes/control/oq_supervisory_power_limiter_logic.h
+++ b/openquatt/includes/control/oq_supervisory_power_limiter_logic.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace oq_supervisory_power {
+
+struct HpMeasurement {
+  bool online = false;
+  bool voltage_valid = false;
+  bool current_valid = false;
+  uint32_t voltage_updated_ms = 0;
+  uint32_t current_updated_ms = 0;
+};
+
+struct Input {
+  uint32_t now_ms = 0;
+  HpMeasurement hp1;
+  HpMeasurement hp2;
+  bool total_power_valid = false;
+  float total_power_w = NAN;
+};
+
+struct Config {
+  bool duo = false;
+  uint32_t tick_s = 0;
+  uint32_t peak_trip_s = 0;
+  uint32_t soft_trip_s = 0;
+  uint32_t recover_s = 0;
+  uint32_t measurement_stale_ms = 0;
+  int fallback_cap_f = 0;
+  int max_cap_f = 0;
+  float soft_limit_w = NAN;
+  float peak_limit_w = NAN;
+  float recover_limit_w = NAN;
+};
+
+struct State {
+  int cap_f = 0;
+  uint32_t over_soft_s = 0;
+  uint32_t over_peak_s = 0;
+  uint32_t under_ok_s = 0;
+};
+
+struct Output {
+  State state;
+  bool measurement_valid = false;
+};
+
+struct Thresholds {
+  float soft_w;
+  float peak_w;
+  float recover_w;
+};
+
+inline float maximum_current_a(bool duo, bool generation_v2, float v1_a, float v2_a) {
+  return duo && generation_v2 ? v2_a : v1_a;
+}
+
+inline float effective_current_a(float configured_a, float minimum_a, float maximum_a) {
+  return std::isnan(configured_a) ? maximum_a : std::min(maximum_a, std::max(minimum_a, configured_a));
+}
+
+inline Thresholds thresholds(float current_a, float mains_voltage_v) {
+  return {
+      current_a * mains_voltage_v * (3400.0f / (16.0f * 230.0f)),
+      current_a * mains_voltage_v * (3650.0f / (16.0f * 230.0f)),
+      current_a * mains_voltage_v * (3300.0f / (16.0f * 230.0f)),
+  };
+}
+
+inline int fallback_cap(bool duo, float current_a, float v1_a, int configured_cap_f, int max_cap_f) {
+  const float scale =
+      std::isfinite(current_a) && std::isfinite(v1_a) && v1_a > 0.0f ? std::min(current_a, v1_a) / v1_a : 0.0f;
+  const float topology_cap = duo ? static_cast<float>(configured_cap_f) : configured_cap_f / 2.0f;
+  return std::clamp(static_cast<int>(std::floor(topology_cap * scale)), 0, std::max(0, max_cap_f));
+}
+
+inline uint32_t seconds_to_ms(uint32_t seconds) {
+  constexpr uint32_t max_seconds = std::numeric_limits<uint32_t>::max() / 1000UL;
+  return std::min(seconds, max_seconds) * 1000UL;
+}
+
+inline bool fresh(uint32_t now_ms, uint32_t updated_ms, uint32_t stale_ms) {
+  return updated_ms != 0 && static_cast<uint32_t>(now_ms - updated_ms) <= stale_ms;
+}
+
+inline bool valid(const HpMeasurement& hp, uint32_t now_ms, uint32_t stale_ms) {
+  return hp.online && hp.voltage_valid && hp.current_valid && fresh(now_ms, hp.voltage_updated_ms, stale_ms) &&
+         fresh(now_ms, hp.current_updated_ms, stale_ms);
+}
+
+inline uint32_t saturated_add(uint32_t value, uint32_t increment) {
+  const uint32_t maximum = std::numeric_limits<uint32_t>::max();
+  return increment > maximum - value ? maximum : value + increment;
+}
+
+inline Output step(const Input& input, const Config& config, State state) {
+  const bool limits_valid = std::isfinite(config.soft_limit_w) && std::isfinite(config.peak_limit_w) &&
+                            std::isfinite(config.recover_limit_w) && config.recover_limit_w >= 0.0f &&
+                            config.recover_limit_w <= config.soft_limit_w && config.soft_limit_w <= config.peak_limit_w;
+  const bool measurement_valid = limits_valid && valid(input.hp1, input.now_ms, config.measurement_stale_ms) &&
+                                 (!config.duo || valid(input.hp2, input.now_ms, config.measurement_stale_ms)) &&
+                                 input.total_power_valid && std::isfinite(input.total_power_w);
+  if (!measurement_valid)
+    return {{std::clamp(config.fallback_cap_f, 0, std::max(0, config.max_cap_f)), 0, 0, 0}, false};
+
+  state.over_peak_s = input.total_power_w > config.peak_limit_w ? saturated_add(state.over_peak_s, config.tick_s) : 0;
+  state.over_soft_s = input.total_power_w > config.soft_limit_w ? saturated_add(state.over_soft_s, config.tick_s) : 0;
+  state.under_ok_s = input.total_power_w < config.recover_limit_w ? saturated_add(state.under_ok_s, config.tick_s) : 0;
+  if (state.over_peak_s >= config.peak_trip_s) {
+    state.cap_f -= 2;
+    state.over_peak_s = state.over_soft_s = state.under_ok_s = 0;
+  } else if (state.over_soft_s >= config.soft_trip_s) {
+    --state.cap_f;
+    state.over_soft_s = state.under_ok_s = 0;
+  }
+  if (state.under_ok_s >= config.recover_s) {
+    ++state.cap_f;
+    state.under_ok_s = 0;
+  }
+  state.cap_f = std::clamp(state.cap_f, 0, std::max(0, config.max_cap_f));
+  return {state, true};
+}
+
+}  // namespace oq_supervisory_power

--- a/openquatt/includes/control/oq_supervisory_power_limiter_runtime.h
+++ b/openquatt/includes/control/oq_supervisory_power_limiter_runtime.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+#include "oq_supervisory_power_limiter_logic.h"
+
+#if defined(OQ_TOPOLOGY_DUO)
+namespace oq_supervisory_power_runtime {
+
+#if OQ_TOPOLOGY_DUO
+#define OQ_POWER_SECONDARY_ID(suffix) id(hp2_##suffix)
+#else
+#define OQ_POWER_SECONDARY_ID(suffix) id(hp1_##suffix)
+#endif
+
+struct TickConfig {
+  uint32_t now_ms;
+  uint32_t tick_s;
+  float v1_current_a;
+  float v2_current_a;
+  float minimum_current_a;
+  float mains_voltage_v;
+  uint32_t peak_trip_s;
+  uint32_t soft_trip_s;
+  uint32_t recover_s;
+  uint32_t measurement_stale_s;
+  int fallback_cap_f;
+  int max_cap_f;
+};
+
+inline bool generation_v2() {
+#if OQ_TOPOLOGY_DUO
+  return id(hp_generation).has_state() && id(hp_generation).current_option() == "V2";
+#else
+  return false;
+#endif
+}
+
+inline float maximum_current_a(float v1_a, float v2_a) {
+  return oq_supervisory_power::maximum_current_a(OQ_TOPOLOGY_DUO, generation_v2(), v1_a, v2_a);
+}
+
+inline float configured_current_a(float minimum_a, float v1_a, float v2_a) {
+  return oq_supervisory_power::effective_current_a(id(oq_electrical_current_limit_configured_a), minimum_a,
+                                                   maximum_current_a(v1_a, v2_a));
+}
+
+class Runtime {
+ public:
+  void tick(const TickConfig& tick) {
+    const float current_a = configured_current_a(tick.minimum_current_a, tick.v1_current_a, tick.v2_current_a);
+    const auto limits = oq_supervisory_power::thresholds(current_a, tick.mains_voltage_v);
+    const oq_supervisory_power::Config config{
+        OQ_TOPOLOGY_DUO,
+        tick.tick_s,
+        tick.peak_trip_s,
+        tick.soft_trip_s,
+        tick.recover_s,
+        oq_supervisory_power::seconds_to_ms(tick.measurement_stale_s),
+        oq_supervisory_power::fallback_cap(OQ_TOPOLOGY_DUO, current_a, tick.v1_current_a, tick.fallback_cap_f,
+                                           tick.max_cap_f),
+        tick.max_cap_f,
+        limits.soft_w,
+        limits.peak_w,
+        limits.recover_w,
+    };
+    const oq_supervisory_power::Input input{
+        tick.now_ms,
+        this->capture_(id(hp1_is_online), id(hp1_voltage).has_state(), id(hp1_voltage).state,
+                       id(hp1_current).has_state(), id(hp1_current).state, id(hp1_voltage_last_update_ms),
+                       id(hp1_current_last_update_ms)),
+        this->capture_(OQ_POWER_SECONDARY_ID(is_online), OQ_POWER_SECONDARY_ID(voltage).has_state(),
+                       OQ_POWER_SECONDARY_ID(voltage).state, OQ_POWER_SECONDARY_ID(current).has_state(),
+                       OQ_POWER_SECONDARY_ID(current).state, OQ_POWER_SECONDARY_ID(voltage_last_update_ms),
+                       OQ_POWER_SECONDARY_ID(current_last_update_ms)),
+        id(oq_total_power_input).has_state(),
+        id(oq_total_power_input).state,
+    };
+    if (!this->initialized_) {
+      this->state_.cap_f = id(oq_power_cap_f);
+      this->initialized_ = true;
+    }
+    const auto output = oq_supervisory_power::step(input, config, this->state_);
+    this->state_ = output.state;
+    id(oq_power_cap_f) = output.state.cap_f;
+    id(oq_power_limit_soft_w) = limits.soft_w;
+    id(oq_power_limit_peak_w) = limits.peak_w;
+    id(oq_power_limit_recover_w) = limits.recover_w;
+  }
+
+ private:
+  static oq_supervisory_power::HpMeasurement capture_(bool online, bool voltage_has_state, float voltage,
+                                                      bool current_has_state, float current,
+                                                      uint32_t voltage_updated_ms, uint32_t current_updated_ms) {
+    return {online, voltage_has_state && std::isfinite(voltage), current_has_state && std::isfinite(current),
+            voltage_updated_ms, current_updated_ms};
+  }
+
+  bool initialized_ = false;
+  oq_supervisory_power::State state_;
+};
+
+inline Runtime& runtime() {
+  static Runtime instance;
+  return instance;
+}
+
+#undef OQ_POWER_SECONDARY_ID
+}  // namespace oq_supervisory_power_runtime
+#endif

--- a/openquatt/includes/control/oq_supervisory_safety_logic.h
+++ b/openquatt/includes/control/oq_supervisory_safety_logic.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace oq_supervisory_safety {
+
+struct Input {
+  uint32_t now_ms = 0;
+  bool thermal_request = false;
+  bool flow_has_state = false;
+  float flow_lph = NAN;
+  bool outside_temperature_has_state = false;
+  float outside_temperature_c = NAN;
+};
+
+struct Config {
+  float minimum_flow_lph = NAN;
+  uint32_t low_flow_fault_ms = 0;
+  uint32_t flow_recover_ms = 0;
+  float frost_on_c = NAN;
+  float frost_off_c = NAN;
+  uint32_t frost_nan_grace_ms = 0;
+};
+
+struct State {
+  bool initialized = false;
+  uint32_t boot_ms = 0;
+  bool low_flow_timing = false;
+  uint32_t low_flow_since_ms = 0;
+  bool flow_recovery_timing = false;
+  uint32_t flow_recovery_since_ms = 0;
+  bool low_flow_fault_active = false;
+  bool frost_active = false;
+};
+
+struct Output {
+  State state;
+  bool flow_valid = false;
+  bool flow_low = true;
+  bool flow_ok = false;
+  bool minimum_flow_ok = false;
+  bool low_flow_fault_started = false;
+  bool low_flow_fault_cleared = false;
+  bool frost_active = false;
+  bool frost_nan_grace_active = false;
+};
+
+inline uint32_t seconds_to_ms(uint32_t seconds) {
+  constexpr uint32_t maximum_seconds = std::numeric_limits<uint32_t>::max() / 1000UL;
+  return (seconds > maximum_seconds ? maximum_seconds : seconds) * 1000UL;
+}
+
+inline bool elapsed(uint32_t now_ms, uint32_t since_ms, uint32_t duration_ms) {
+  return static_cast<uint32_t>(now_ms - since_ms) >= duration_ms;
+}
+
+inline bool force_standby(bool low_flow_fault_active, bool defrost_active, int selected_level, int previous_level) {
+  if (!low_flow_fault_active) return false;
+  return !defrost_active || (selected_level <= 0 && previous_level <= 0);
+}
+
+inline Output step(const Input& input, const Config& config, State state) {
+  if (!state.initialized) {
+    state.initialized = true;
+    state.boot_ms = input.now_ms;
+  }
+
+  const bool previous_fault = state.low_flow_fault_active;
+  const bool minimum_flow_valid = std::isfinite(config.minimum_flow_lph) && config.minimum_flow_lph >= 0.0f;
+  const bool flow_valid = input.flow_has_state && std::isfinite(input.flow_lph);
+  const bool flow_ok = minimum_flow_valid && flow_valid && input.flow_lph >= config.minimum_flow_lph;
+  const bool flow_low = !flow_ok;
+
+  if (!input.thermal_request) {
+    state.low_flow_timing = false;
+    state.flow_recovery_timing = false;
+    state.low_flow_fault_active = false;
+  } else if (flow_low) {
+    if (!state.low_flow_timing) {
+      state.low_flow_timing = true;
+      state.low_flow_since_ms = input.now_ms;
+    }
+    state.flow_recovery_timing = false;
+    if (elapsed(input.now_ms, state.low_flow_since_ms, config.low_flow_fault_ms)) {
+      state.low_flow_fault_active = true;
+    }
+  } else {
+    state.low_flow_timing = false;
+    if (state.low_flow_fault_active) {
+      if (!state.flow_recovery_timing) {
+        state.flow_recovery_timing = true;
+        state.flow_recovery_since_ms = input.now_ms;
+      }
+      if (elapsed(input.now_ms, state.flow_recovery_since_ms, config.flow_recover_ms)) {
+        state.low_flow_fault_active = false;
+        state.flow_recovery_timing = false;
+      }
+    } else {
+      state.flow_recovery_timing = false;
+    }
+  }
+
+  const bool frost_nan_grace_active =
+      config.frost_nan_grace_ms > 0 && !elapsed(input.now_ms, state.boot_ms, config.frost_nan_grace_ms);
+  const bool frost_thresholds_valid =
+      std::isfinite(config.frost_on_c) && std::isfinite(config.frost_off_c) && config.frost_on_c <= config.frost_off_c;
+  const bool outside_temperature_valid =
+      frost_thresholds_valid && input.outside_temperature_has_state && std::isfinite(input.outside_temperature_c);
+  if (input.thermal_request) {
+    state.frost_active = false;
+  } else if (!outside_temperature_valid) {
+    state.frost_active = !frost_nan_grace_active;
+  } else if (state.frost_active) {
+    state.frost_active = input.outside_temperature_c < config.frost_off_c;
+  } else {
+    state.frost_active = input.outside_temperature_c < config.frost_on_c;
+  }
+
+  return {state,
+          flow_valid,
+          flow_low,
+          flow_ok,
+          input.thermal_request ? (!state.low_flow_fault_active && flow_ok) : true,
+          !previous_fault && state.low_flow_fault_active,
+          previous_fault && !state.low_flow_fault_active,
+          state.frost_active,
+          frost_nan_grace_active};
+}
+
+}  // namespace oq_supervisory_safety

--- a/openquatt/includes/control/oq_supervisory_safety_runtime.h
+++ b/openquatt/includes/control/oq_supervisory_safety_runtime.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+#include "oq_supervisory_safety_logic.h"
+
+#if defined(OQ_TOPOLOGY_DUO)
+namespace oq_supervisory_safety_runtime {
+
+struct TickConfig {
+  uint32_t now_ms;
+  bool thermal_request;
+  float minimum_flow_lph;
+  uint32_t low_flow_fault_s;
+  uint32_t flow_recover_s;
+  float frost_on_c;
+  float frost_off_c;
+  uint32_t frost_nan_grace_s;
+};
+
+class Runtime {
+ public:
+  oq_supervisory_safety::Output tick(const TickConfig& tick) {
+    if (!this->hydrated_) {
+      this->state_.low_flow_fault_active = id(oq_lowflow_fault_active);
+      this->state_.frost_active = id(oq_cm_frost_prev);
+      this->hydrated_ = true;
+    }
+
+    const oq_supervisory_safety::Input input{
+        tick.now_ms,
+        tick.thermal_request,
+        id(flow_rate_selected).has_state(),
+        id(flow_rate_selected).state,
+        id(outside_temp_selected).has_state(),
+        id(outside_temp_selected).state,
+    };
+    const oq_supervisory_safety::Config config{
+        tick.minimum_flow_lph,
+        oq_supervisory_safety::seconds_to_ms(tick.low_flow_fault_s),
+        oq_supervisory_safety::seconds_to_ms(tick.flow_recover_s),
+        tick.frost_on_c,
+        tick.frost_off_c,
+        oq_supervisory_safety::seconds_to_ms(tick.frost_nan_grace_s),
+    };
+    const auto output = oq_supervisory_safety::step(input, config, this->state_);
+    this->state_ = output.state;
+    id(oq_lowflow_fault_active) = output.state.low_flow_fault_active;
+    id(oq_cm_frost_prev) = output.frost_active;
+    this->publish_binary_if_changed_(id(oq_lowflow_fault_active_bs), output.state.low_flow_fault_active);
+
+    if (output.low_flow_fault_started) {
+      id(oq_decision_log)
+          .emit(openquatt_decision_log::EVENT_DECISION_BLOCKED, openquatt_decision_log::SUBJECT_SYSTEM,
+                openquatt_decision_log::REASON_FLOW_TOO_LOW, openquatt_decision_log::SEVERITY_LIMITED, 1,
+                openquatt_decision_log::STATE_LIMITED, openquatt_decision_log::STATE_BLOCKED,
+                output.flow_valid ? this->int16_limited_(input.flow_lph) : 0, 0,
+                this->int16_limited_(tick.minimum_flow_lph));
+    }
+
+    if (oq_supervisory_safety::force_standby(output.state.low_flow_fault_active, id(hp1_defrost).state,
+                                             this->selected_level_(id(hp1_compressor_level)),
+                                             id(hp1_last_applied_level))) {
+      this->set_select_option_(id(hp1_set_working_mode), "Standby");
+      this->set_select_option_(id(hp1_compressor_level), "0");
+    }
+#if OQ_TOPOLOGY_DUO
+    if (oq_supervisory_safety::force_standby(output.state.low_flow_fault_active, id(hp2_defrost).state,
+                                             this->selected_level_(id(hp2_compressor_level)),
+                                             id(hp2_last_applied_level))) {
+      this->set_select_option_(id(hp2_set_working_mode), "Standby");
+      this->set_select_option_(id(hp2_compressor_level), "0");
+    }
+#endif
+    return output;
+  }
+
+ private:
+  template <typename T>
+  static int selected_level_(T& select) {
+    return select.has_state() ? static_cast<int>(select.active_index().value_or(-1)) : -1;
+  }
+
+  template <typename T>
+  static void set_select_option_(T& select, const char* option) {
+    if (select.has_state() && select.current_option() == option) return;
+    auto call = select.make_call();
+    call.set_option(option);
+    call.perform();
+  }
+
+  template <typename T>
+  static void publish_binary_if_changed_(T& sensor, bool value) {
+    if (!sensor.has_state() || sensor.state != value) sensor.publish_state(value);
+  }
+
+  static int16_t int16_limited_(float value) {
+    if (!std::isfinite(value)) return 0;
+    return static_cast<int16_t>(lroundf(std::max(-32768.0f, std::min(32767.0f, value))));
+  }
+
+  bool hydrated_ = false;
+  oq_supervisory_safety::State state_;
+};
+
+inline Runtime& runtime() {
+  static Runtime instance;
+  return instance;
+}
+
+}  // namespace oq_supervisory_safety_runtime
+#endif

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -48,13 +48,9 @@ esphome:
     - priority: -100
       then:
         - lambda: |-
-            float max_current_a = ${oq_duo_current_limit_v1_a};
-            #if OQ_TOPOLOGY_DUO
-            if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2") {
-              max_current_a = ${oq_duo_current_limit_v2_a};
-            }
-            #endif
-            id(oq_electrical_current_limit_a).traits.set_max_value(max_current_a);
+            id(oq_electrical_current_limit_a).traits.set_max_value(
+                oq_supervisory_power_runtime::maximum_current_a(
+                    ${oq_duo_current_limit_v1_a}, ${oq_duo_current_limit_v2_a}));
     - priority: -100
       then:
         - lambda: |-
@@ -235,18 +231,6 @@ globals:
     restore_value: false
     initial_value: '3300.0'
 
-  - id: oq_power_over_soft_s
-    type: int
-    restore_value: false
-    initial_value: '0'
-  - id: oq_power_over_peak_s
-    type: int
-    restore_value: false
-    initial_value: '0'
-  - id: oq_power_under_ok_s
-    type: int
-    restore_value: false
-    initial_value: '0'
   # DEBUG-RUNTIME START: Power House low-load diagnostics
   # Dynamic low-load diagnostics (Power House)
   - id: oq_low_load_pmin_dyn_w
@@ -406,27 +390,19 @@ number:
     update_interval: ${oq_supervisory_loop_s}s
     entity_category: config
     lambda: |-
-      float max_current_a = ${oq_duo_current_limit_v1_a};
-      #if OQ_TOPOLOGY_DUO
-      if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2") {
-        max_current_a = ${oq_duo_current_limit_v2_a};
-      }
-      #endif
+      const float max_current_a = oq_supervisory_power_runtime::maximum_current_a(
+          ${oq_duo_current_limit_v1_a}, ${oq_duo_current_limit_v2_a});
       id(oq_electrical_current_limit_a).traits.set_max_value(max_current_a);
-      const float configured_a = id(oq_electrical_current_limit_configured_a);
-      if (isnan(configured_a)) return max_current_a;
-      return fminf(max_current_a, fmaxf(${oq_electrical_current_limit_min_a}, configured_a));
+      return oq_supervisory_power_runtime::configured_current_a(
+          ${oq_electrical_current_limit_min_a}, ${oq_duo_current_limit_v1_a}, ${oq_duo_current_limit_v2_a});
     set_action:
       then:
         - lambda: |-
-            float max_current_a = ${oq_duo_current_limit_v1_a};
-            #if OQ_TOPOLOGY_DUO
-            if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2") {
-              max_current_a = ${oq_duo_current_limit_v2_a};
-            }
-            #endif
+            const float max_current_a = oq_supervisory_power_runtime::maximum_current_a(
+                ${oq_duo_current_limit_v1_a}, ${oq_duo_current_limit_v2_a});
             id(oq_electrical_current_limit_a).traits.set_max_value(max_current_a);
-            const float configured_a = fminf(max_current_a, fmaxf(${oq_electrical_current_limit_min_a}, x));
+            const float configured_a = oq_supervisory_power::effective_current_a(
+                x, ${oq_electrical_current_limit_min_a}, max_current_a);
             id(oq_electrical_current_limit_configured_a) = configured_a;
             id(oq_electrical_current_limit_a).publish_state(configured_a);
 
@@ -688,111 +664,11 @@ interval:
           if (!id(oq_enabled).state && time_valid && openquatt_resume_scheduled && now_time >= openquatt_resume_at) {
             id(oq_enabled).turn_on();
           }
-          // -------------------------------------------------
-          // -------------------------------------------------
-          // Electrical input limiter - measured safety net for Single and Duo
-          // - Uses oq_total_power_input (W) = HP1+HP2 electrical
-          // - Power House also applies the same thresholds predictively.
-          // - Heating Curve and cooling only use this measured demand cap.
-          //
-          // Targets scale from the configured current limit at 230V:
-          //   V1/V1.5 = 16A -> 3400W / 3650W / 3300W
-          //   V2      = 20A -> 4250W / 4562.5W / 4125W
-          // -------------------------------------------------
-          {
-            const int dt_s = ${oq_supervisory_loop_s};
-            float max_current_a = ${oq_duo_current_limit_v1_a};
-            #if OQ_TOPOLOGY_DUO
-            if (id(hp_generation).has_state() && id(hp_generation).current_option() == "V2") {
-              max_current_a = ${oq_duo_current_limit_v2_a};
-            }
-            #endif
-            const float configured_a = id(oq_electrical_current_limit_configured_a);
-            const float current_limit_a = isnan(configured_a)
-                ? max_current_a
-                : fminf(max_current_a, fmaxf(${oq_electrical_current_limit_min_a}, configured_a));
-            const float mains_voltage_v = ${oq_mains_voltage_v};
-            const float P_SOFT = current_limit_a * mains_voltage_v * (3400.0f / (16.0f * 230.0f));
-            const float P_PEAK = current_limit_a * mains_voltage_v * (3650.0f / (16.0f * 230.0f));
-            const float P_RECOVER = current_limit_a * mains_voltage_v * (3300.0f / (16.0f * 230.0f));
-            id(oq_power_limit_soft_w) = P_SOFT;
-            id(oq_power_limit_peak_w) = P_PEAK;
-            id(oq_power_limit_recover_w) = P_RECOVER;
-
-            // behavior
-            const int PEAK_TRIP_S = ${oq_power_peak_trip_s};
-            const int SOFT_TRIP_S = ${oq_power_soft_trip_s};
-            const int RECOVER_S = ${oq_power_recover_s};
-
-            const uint32_t measurement_stale_ms = (uint32_t)(${oq_power_measurement_stale_s}UL * 1000UL);
-            auto measurement_fresh = [&](uint32_t updated_ms) -> bool {
-              return updated_ms != 0 && (uint32_t)(now_ms - updated_ms) <= measurement_stale_ms;
-            };
-            bool measurement_valid =
-                id(hp1_is_online) &&
-                id(hp1_voltage).has_state() && !isnan(id(hp1_voltage).state) &&
-                id(hp1_current).has_state() && !isnan(id(hp1_current).state) &&
-                measurement_fresh(id(hp1_voltage_last_update_ms)) &&
-                measurement_fresh(id(hp1_current_last_update_ms));
-            #if OQ_TOPOLOGY_DUO
-            measurement_valid = measurement_valid &&
-                id(${secondary_hp_id}_is_online) &&
-                id(${secondary_hp_id}_voltage).has_state() && !isnan(id(${secondary_hp_id}_voltage).state) &&
-                id(${secondary_hp_id}_current).has_state() && !isnan(id(${secondary_hp_id}_current).state) &&
-                measurement_fresh(id(${secondary_hp_id}_voltage_last_update_ms)) &&
-                measurement_fresh(id(${secondary_hp_id}_current_last_update_ms));
-            #endif
-            const float p = id(oq_total_power_input).state;
-            measurement_valid = measurement_valid && id(oq_total_power_input).has_state() && !isnan(p);
-
-            // Fail-safe: unavailable or stale power -> conservative demand cap.
-            if (!measurement_valid) {
-              const float fallback_scale =
-                  fminf(current_limit_a, ${oq_duo_current_limit_v1_a}) / ${oq_duo_current_limit_v1_a};
-              #if OQ_TOPOLOGY_DUO
-              id(oq_power_cap_f) = (int) floorf(${oq_power_cap_nan_f} * fallback_scale);
-              #else
-              id(oq_power_cap_f) = (int) floorf((${oq_power_cap_nan_f} / 2.0f) * fallback_scale);
-              #endif
-              id(oq_power_over_soft_s) = 0;
-              id(oq_power_over_peak_s) = 0;
-              id(oq_power_under_ok_s)  = 0;
-            } else {
-              // Update timers
-              if (p > P_PEAK) id(oq_power_over_peak_s) += dt_s;
-              else id(oq_power_over_peak_s) = 0;
-
-              if (p > P_SOFT) id(oq_power_over_soft_s) += dt_s;
-              else id(oq_power_over_soft_s) = 0;
-
-              if (p < P_RECOVER) id(oq_power_under_ok_s) += dt_s;
-              else id(oq_power_under_ok_s) = 0;
-
-              // Event-based cap down
-              if (id(oq_power_over_peak_s) >= PEAK_TRIP_S) {
-                // fast step down
-                if (id(oq_power_cap_f) > 0) id(oq_power_cap_f) -= 2;
-                id(oq_power_over_peak_s) = 0;
-                id(oq_power_over_soft_s) = 0;
-                id(oq_power_under_ok_s)  = 0;
-              } else if (id(oq_power_over_soft_s) >= SOFT_TRIP_S) {
-                // mild step down
-                if (id(oq_power_cap_f) > 0) id(oq_power_cap_f) -= 1;
-                id(oq_power_over_soft_s) = 0;
-                id(oq_power_under_ok_s)  = 0;
-              }
-
-              // Faster recovery when comfortably below
-              if (id(oq_power_under_ok_s) >= RECOVER_S) {
-                if (id(oq_power_cap_f) < ${oq_power_cap_max_f}) id(oq_power_cap_f) += 1;
-                id(oq_power_under_ok_s) = 0;
-              }
-
-              // Clamp
-              if (id(oq_power_cap_f) < 0) id(oq_power_cap_f) = 0;
-              if (id(oq_power_cap_f) > ${oq_power_cap_max_f}) id(oq_power_cap_f) = ${oq_power_cap_max_f};
-            }
-          }
+          oq_supervisory_power_runtime::runtime().tick(
+              {now_ms, ${oq_supervisory_loop_s}, ${oq_duo_current_limit_v1_a}, ${oq_duo_current_limit_v2_a},
+               ${oq_electrical_current_limit_min_a}, ${oq_mains_voltage_v}, ${oq_power_peak_trip_s},
+               ${oq_power_soft_trip_s}, ${oq_power_recover_s}, ${oq_power_measurement_stale_s},
+               ${oq_power_cap_nan_f}, ${oq_power_cap_max_f}});
 
           const uint32_t prepost_ms = (uint32_t)(${oq_cm_prepost_s}UL * 1000UL);
           const uint32_t frost_nan_grace_ms = (uint32_t)(${oq_cm_frost_nan_grace_s}UL * 1000UL);

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -99,15 +99,7 @@ globals:
     type: int
     restore_value: false
     initial_value: '0'  # 0=CM0, 2=CM2, 4=CM4, 5=CM5, 98=CM98
-  # Flow interlock timers
-  - id: oq_lowflow_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_flow_recover_since_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
+  # Shared flow interlock state; timer ownership lives in the C++ safety runtime.
   - id: oq_lowflow_fault_active
     type: bool
     restore_value: false
@@ -651,8 +643,6 @@ interval:
           // 5) apply_sticky_pump_policy() (CM0 sticky + pump/PWM ownership)
           // -------------------------------------------------
           const uint32_t now_ms = (uint32_t) millis();
-          static uint32_t boot_ms = 0;
-          if (boot_ms == 0) boot_ms = now_ms;
 
           auto now_time = id(oq_time).now();
           const bool time_valid = now_time.is_valid();
@@ -671,12 +661,7 @@ interval:
                ${oq_power_cap_nan_f}, ${oq_power_cap_max_f}});
 
           const uint32_t prepost_ms = (uint32_t)(${oq_cm_prepost_s}UL * 1000UL);
-          const uint32_t frost_nan_grace_ms = (uint32_t)(${oq_cm_frost_nan_grace_s}UL * 1000UL);
-          const bool frost_nan_grace_active =
-              (frost_nan_grace_ms > 0) && ((uint32_t)(now_ms - boot_ms) < frost_nan_grace_ms);
           const float min_flow_lph = ${oq_cm_min_flow_lph};
-          const uint32_t flow_fault_ms = (uint32_t)(${oq_cm_flow_fault_s}UL * 1000UL);
-          const uint32_t flow_recover_ms = (uint32_t)(${oq_cm_flow_recover_s}UL * 1000UL);
           // -------------------------------------------------
           // Helpers: minimize Modbus writes (write-on-change)
           // -------------------------------------------------
@@ -818,18 +803,6 @@ interval:
           const bool any_hp_compressor_active =
               hp1_lvl > 0 || hp1_cmd_lvl > 0;
           #endif
-          auto defrost_stop_hold_level = [&](bool is_hp1)->int {
-            const bool defrost_active = is_hp1 ? id(hp1_defrost).state : id(${secondary_defrost_id}).state;
-            if (!defrost_active) return 0;
-
-            const int selected_level = is_hp1 ? hp1_cmd_lvl : hp2_cmd_lvl;
-            if (selected_level > 0) return selected_level;
-
-            const int prev_level = is_hp1 ? hp1_lvl : hp2_lvl;
-            if (prev_level > 0) return prev_level;
-
-            return 0;
-          };
           const bool both_units_idle = !any_hp_active_guard;
 
           bool heating_req = heating_req_raw && openquatt_enabled;
@@ -1013,86 +986,13 @@ interval:
           // -------------------------------------------------
           // 2) Flow interlock status + timers
           // -------------------------------------------------
-          const float flow = id(flow_rate_selected).state;
-          const bool flow_valid = !isnan(flow);
-          const bool flow_low = (!flow_valid) || (flow < min_flow_lph);
-          const bool lowflow_fault_was_active = id(oq_lowflow_fault_active);
-
-          if (!thermal_req) {
-            // No active thermal request: reset flow interlock state
-            id(oq_lowflow_since_ms) = 0;
-            id(oq_flow_recover_since_ms) = 0;
-            id(oq_lowflow_fault_active) = false;
-          } else {
-            if (flow_low) {
-              // Start/continue low-flow timer
-              if (id(oq_lowflow_since_ms) == 0) id(oq_lowflow_since_ms) = now_ms;
-              id(oq_flow_recover_since_ms) = 0;
-
-              // Declare fault if low flow persists >= flow_fault_ms
-              const uint32_t dt = (uint32_t)(now_ms - id(oq_lowflow_since_ms));
-              if (dt >= flow_fault_ms) id(oq_lowflow_fault_active) = true;
-            } else {
-              // Flow OK: start/continue recovery timer if we were in fault
-              id(oq_lowflow_since_ms) = 0;
-              if (id(oq_lowflow_fault_active)) {
-                if (id(oq_flow_recover_since_ms) == 0) id(oq_flow_recover_since_ms) = now_ms;
-                const uint32_t dt = (uint32_t)(now_ms - id(oq_flow_recover_since_ms));
-                if (dt >= flow_recover_ms) {
-                  id(oq_lowflow_fault_active) = false;
-                  id(oq_flow_recover_since_ms) = 0;
-                }
-              } else {
-                id(oq_flow_recover_since_ms) = 0;
-              }
-            }
-          }
-
-          // Normal pump startup may begin below the flow threshold. Only log a
-          // blocked start when that condition survives the configured fault delay.
-          if (!lowflow_fault_was_active && id(oq_lowflow_fault_active)) {
-            const int16_t measured_flow_lph = flow_valid
-                ? (int16_t) std::max(-32768L, std::min(32767L, lroundf(flow)))
-                : 0;
-            const int16_t required_flow_lph =
-                (int16_t) std::max(-32768L, std::min(32767L, lroundf(min_flow_lph)));
-            id(oq_decision_log).emit(
-              openquatt_decision_log::EVENT_DECISION_BLOCKED,
-              openquatt_decision_log::SUBJECT_SYSTEM,
-              openquatt_decision_log::REASON_FLOW_TOO_LOW,
-              openquatt_decision_log::SEVERITY_LIMITED,
-              1,
-              openquatt_decision_log::STATE_LIMITED,
-              openquatt_decision_log::STATE_BLOCKED,
-              measured_flow_lph,
-              0,
-              required_flow_lph);
-          }
-
-          // Flow OK definition for diagnostics: NaN is NOT OK.
-          const bool flow_ok = flow_valid && (flow >= min_flow_lph);
-
-          // Internal interlock: only enforced when heating is requested.
-          const bool min_flow_ok = thermal_req ? (!id(oq_lowflow_fault_active) && flow_ok) : true;
-
-          // Publish lowflow fault status (writes-only-on-change)
-          publish_binary_if_changed(id(oq_lowflow_fault_active_bs), id(oq_lowflow_fault_active));
-
-          // Hard safety path: persistent low-flow fault must force both HPs to Standby + level 0.
-          // Never issue that stop command to a unit that is actively defrosting; let heat-control
-          // keep its last non-zero command until defrost clears.
-          if (id(oq_lowflow_fault_active)) {
-            if (defrost_stop_hold_level(true) <= 0) {
-              set_select_option(id(hp1_set_working_mode), "Standby");
-              set_select_option(id(hp1_compressor_level), "0");
-            }
-            #if OQ_TOPOLOGY_DUO
-            if (defrost_stop_hold_level(false) <= 0) {
-              set_select_option(id(${secondary_set_working_mode_id}), "Standby");
-              set_select_option(id(${secondary_compressor_level_id}), "0");
-            }
-            #endif
-          }
+          const auto safety = oq_supervisory_safety_runtime::runtime().tick(
+              {now_ms, thermal_req, min_flow_lph, ${oq_cm_flow_fault_s}, ${oq_cm_flow_recover_s},
+               ${oq_cm_frost_on_c}, ${oq_cm_frost_off_c}, ${oq_cm_frost_nan_grace_s}});
+          const bool flow_valid = safety.flow_valid;
+          const bool flow_low = safety.flow_low;
+          const bool flow_ok = safety.flow_ok;
+          const bool frost = safety.frost_active;
 
           // -------------------------------------------------
           // 2b) Cold water start
@@ -1166,30 +1066,6 @@ interval:
             }
             id(oq_cold_start_hp_blocked) = cold_start_blocked;
           }
-          // -------------------------------------------------
-          // 3) Frost condition (hysteresis + fail-safe) [CM98]
-          //    Relevant only when there is no heat demand.
-          //    Uses selected outside source to stay aligned with active source selection.
-          //    - ON: <5°C
-          //    - OFF: >6°C
-          //    - FAIL-SAFE: NaN -> frost ON (after startup grace)
-          // -------------------------------------------------
-          const float outside_c = id(outside_temp_selected).state;
-
-          bool frost = false;
-          if (!thermal_req) {
-            if (isnan(outside_c)) {
-              frost = !frost_nan_grace_active; // fail-safe after startup grace
-            } else {
-              if (id(oq_cm_frost_prev)) {
-                frost = (outside_c < ${oq_cm_frost_off_c});
-              } else {
-                frost = (outside_c < ${oq_cm_frost_on_c});
-              }
-            }
-          }
-          id(oq_cm_frost_prev) = frost;
-
           // -------------------------------------------------
           // 4) CM selection with CM1 timer (pre/postflow) + flow interlock
           // -------------------------------------------------

--- a/scripts/tests/test_electrical_input_limit_contract.py
+++ b/scripts/tests/test_electrical_input_limit_contract.py
@@ -3,6 +3,9 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
 SUPERVISOR = (ROOT / "openquatt" / "oq_supervisory_controlmode.yaml").read_text()
+LIMITER_LOGIC = (ROOT / "openquatt" / "includes" / "control" / "oq_supervisory_power_limiter_logic.h").read_text()
+LIMITER_RUNTIME = (ROOT / "openquatt" / "includes" / "control" / "oq_supervisory_power_limiter_runtime.h").read_text()
+LIMITER_TEST = (ROOT / "tests" / "host" / "supervisory_power_limiter_logic_test.cpp").read_text()
 POWER_HOUSE = (ROOT / "openquatt" / "oq_power_house_strategy.yaml").read_text()
 DISPATCH = (ROOT / "openquatt" / "includes" / "control" / "oq_power_house_dispatch_logic.h").read_text()
 HEATING_CURVE = (ROOT / "openquatt" / "oq_heating_curve_strategy.yaml").read_text()
@@ -14,38 +17,32 @@ class ElectricalInputLimitContractTest(unittest.TestCase):
         self.assertIn("id: oq_electrical_current_limit_configured_a", SUPERVISOR)
         self.assertIn("restore_value: true\n    initial_value: 'NAN'", SUPERVISOR)
         self.assertIn("id: oq_electrical_current_limit_a", SUPERVISOR)
-        self.assertIn("id(hp_generation).current_option() == \"V2\"", SUPERVISOR)
-        self.assertIn("max_current_a = ${oq_duo_current_limit_v2_a}", SUPERVISOR)
-        self.assertIn("fmaxf(${oq_electrical_current_limit_min_a}, x)", SUPERVISOR)
-        self.assertGreaterEqual(
-            SUPERVISOR.count(
-                "id(oq_electrical_current_limit_a).traits.set_max_value(max_current_a)"
-            ),
-            3,
-        )
+        self.assertIn("id(hp_generation).current_option() == \"V2\"", LIMITER_RUNTIME)
+        self.assertIn("maximum_current_a(", LIMITER_LOGIC)
+        self.assertIn("effective_current_a(", LIMITER_LOGIC)
+        self.assertGreaterEqual(SUPERVISOR.count("traits.set_max_value"), 3)
 
     def test_single_and_duo_share_measured_feedback_limiter(self) -> None:
-        limiter = SUPERVISOR.split(
-            "// Electrical input limiter - measured safety net for Single and Duo",
-            maxsplit=1,
-        )[1].split("const uint32_t prepost_ms", maxsplit=1)[0]
-        self.assertIn("id(hp1_is_online)", limiter)
-        self.assertIn("id(${secondary_hp_id}_is_online)", limiter)
-        self.assertIn("if (!measurement_valid)", limiter)
-        self.assertNotIn("id(oq_power_cap_f) = (int) ${oq_power_cap_max_f}", limiter)
+        self.assertEqual(SUPERVISOR.count("oq_supervisory_power_runtime::runtime().tick"), 1)
+        self.assertNotIn("if (!measurement_valid)", SUPERVISOR)
+        self.assertIn("id(hp1_is_online)", LIMITER_RUNTIME)
+        self.assertIn("OQ_POWER_SECONDARY_ID(is_online)", LIMITER_RUNTIME)
+        self.assertIn("!config.duo || valid(input.hp2", LIMITER_LOGIC)
 
     def test_missing_or_stale_measurements_fail_conservatively(self) -> None:
         self.assertIn("${hp_id}_voltage_last_update_ms", HP_IO)
         self.assertIn("${hp_id}_current_last_update_ms", HP_IO)
         self.assertIn("${oq_power_measurement_stale_s}", SUPERVISOR)
-        self.assertIn("fminf(current_limit_a, ${oq_duo_current_limit_v1_a})", SUPERVISOR)
-        self.assertIn(
-            "floorf(${oq_power_cap_nan_f} * fallback_scale)", SUPERVISOR
-        )
-        self.assertIn(
-            "floorf((${oq_power_cap_nan_f} / 2.0f) * fallback_scale)",
-            SUPERVISOR,
-        )
+        for marker in ("fresh(", "fallback_cap(", "saturated_add("):
+            self.assertIn(marker, LIMITER_LOGIC)
+            self.assertIn(marker, LIMITER_TEST)
+        self.assertIn("std::isfinite(input.total_power_w)", LIMITER_LOGIC)
+        self.assertIn("std::numeric_limits<float>::infinity()", LIMITER_TEST)
+
+    def test_yaml_is_a_compact_contract_and_extracted_sources_stay_bounded(self) -> None:
+        self.assertLessEqual(len(SUPERVISOR.splitlines()), 2050)
+        total = sum(len(source.splitlines()) for source in (SUPERVISOR, LIMITER_LOGIC, LIMITER_RUNTIME, LIMITER_TEST))
+        self.assertLessEqual(total, 2360)
 
     def test_power_house_alone_uses_predictive_thresholds(self) -> None:
         self.assertEqual(POWER_HOUSE.count("id(oq_power_limit_soft_w)"), 1)

--- a/scripts/tests/test_supervisory_safety_contract.py
+++ b/scripts/tests/test_supervisory_safety_contract.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SUPERVISOR = (ROOT / "openquatt/oq_supervisory_controlmode.yaml").read_text()
+LOGIC = (ROOT / "openquatt/includes/control/oq_supervisory_safety_logic.h").read_text()
+RUNTIME = (ROOT / "openquatt/includes/control/oq_supervisory_safety_runtime.h").read_text()
+HOST_TEST = (ROOT / "tests/host/supervisory_safety_logic_test.cpp").read_text()
+
+
+class SupervisorySafetyContractTest(unittest.TestCase):
+    def test_yaml_delegates_flow_and_frost_decisions_once(self) -> None:
+        self.assertEqual(SUPERVISOR.count("oq_supervisory_safety_runtime::runtime().tick"), 1)
+        for removed_inline_state in ("oq_lowflow_since_ms", "oq_flow_recover_since_ms", "frost_nan_grace_active"):
+            self.assertNotIn(removed_inline_state, SUPERVISOR)
+        self.assertIn("const bool flow_low = safety.flow_low;", SUPERVISOR)
+        self.assertIn("const bool frost = safety.frost_active;", SUPERVISOR)
+
+    def test_runtime_owns_side_effects_and_preserves_shared_contracts(self) -> None:
+        for marker in (
+            "id(oq_lowflow_fault_active) =",
+            "id(oq_cm_frost_prev) =",
+            "id(oq_lowflow_fault_active_bs)",
+            "REASON_FLOW_TOO_LOW",
+            "id(hp1_set_working_mode)",
+            "id(hp1_compressor_level)",
+            "#if OQ_TOPOLOGY_DUO",
+            "id(hp2_set_working_mode)",
+            "id(hp2_compressor_level)",
+        ):
+            self.assertIn(marker, RUNTIME)
+        self.assertIn("restore_value: true\n    initial_value: 'false'", SUPERVISOR)
+        self.assertIn("id: oq_lowflow_fault_active", SUPERVISOR)
+
+    def test_logic_covers_failure_boundaries(self) -> None:
+        for marker in (
+            "std::isfinite(input.flow_lph)",
+            "std::isfinite(input.outside_temperature_c)",
+            "low_flow_fault_started",
+            "flow_recovery_timing",
+            "frost_nan_grace_active",
+            "force_standby(",
+            "seconds_to_ms(",
+        ):
+            self.assertIn(marker, LOGIC)
+        for marker in (
+            "low_flow_fault_started",
+            "flow_recovery_timing",
+            "frost_nan_grace_active",
+            "force_standby(",
+            "seconds_to_ms(",
+        ):
+            self.assertIn(marker, HOST_TEST)
+        self.assertIn("UINT32_MAX - 20", HOST_TEST)
+        self.assertIn("std::numeric_limits<float>::infinity()", HOST_TEST)
+
+    def test_supervisory_yaml_is_smaller_than_the_electrical_only_stage(self) -> None:
+        self.assertLess(len(SUPERVISOR.splitlines()), 2039)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host/supervisory_power_limiter_logic_test.cpp
+++ b/tests/host/supervisory_power_limiter_logic_test.cpp
@@ -1,0 +1,79 @@
+#include <assert.h>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include "../../openquatt/includes/control/oq_supervisory_power_limiter_logic.h"
+
+namespace {
+oq_supervisory_power::HpMeasurement hp(uint32_t updated_ms = 1000) {
+  return {true, true, true, updated_ms, updated_ms};
+}
+
+oq_supervisory_power::Input input(uint32_t now_ms, float power_w) { return {now_ms, hp(), hp(), true, power_w}; }
+
+oq_supervisory_power::Config config(bool duo = true) {
+  return {duo, 5, 15, 30, 10, 60000, duo ? 16 : 8, 20, 3400.0f, 3650.0f, 3300.0f};
+}
+}  // namespace
+
+int main() {
+  using namespace oq_supervisory_power;
+  assert(maximum_current_a(true, false, 16.0f, 20.0f) == 16.0f);
+  assert(maximum_current_a(true, true, 16.0f, 20.0f) == 20.0f);
+  assert(maximum_current_a(false, true, 16.0f, 20.0f) == 16.0f);
+  assert(effective_current_a(NAN, 10.0f, 16.0f) == 16.0f);
+  assert(effective_current_a(4.0f, 10.0f, 16.0f) == 10.0f);
+  assert(effective_current_a(18.0f, 10.0f, 16.0f) == 16.0f);
+  const auto v2 = thresholds(20.0f, 230.0f);
+  assert(v2.soft_w == 4250.0f && v2.peak_w == 4562.5f && v2.recover_w == 4125.0f);
+  assert(fallback_cap(true, 16.0f, 16.0f, 16, 20) == 16);
+  assert(fallback_cap(false, 16.0f, 16.0f, 16, 20) == 8);
+  assert(fallback_cap(true, 10.0f, 16.0f, 16, 20) == 10);
+  assert(fallback_cap(true, 16.0f, 0.0f, 16, 20) == 0);
+
+  assert(fresh(1500, 1000, 500));
+  assert(!fresh(1501, 1000, 500));
+  assert(fresh(250, UINT32_MAX - 249, 500));
+  assert(seconds_to_ms(UINT32_MAX) == (UINT32_MAX / 1000UL) * 1000UL);
+
+  State state{20, 0, 0, 0};
+  auto out = step(input(2000, 3700.0f), config(), state);
+  out = step(input(7000, 3700.0f), config(), out.state);
+  out = step(input(12000, 3700.0f), config(), out.state);
+  assert(out.measurement_valid && out.state.cap_f == 18);
+  assert(out.state.over_peak_s == 0 && out.state.over_soft_s == 0);
+  out = step(input(17000, 3650.0f), config(), out.state);
+  assert(out.state.over_peak_s == 0);
+
+  auto soft_config = config();
+  soft_config.soft_trip_s = 10;
+  out = step(input(2000, 3500.0f), soft_config, {20, 0, 0, 0});
+  out = step(input(7000, 3500.0f), soft_config, out.state);
+  assert(out.state.cap_f == 19 && out.state.over_soft_s == 0);
+  out = step(input(12000, 3200.0f), soft_config, out.state);
+  out = step(input(17000, 3200.0f), soft_config, out.state);
+  assert(out.state.cap_f == 20 && out.state.under_ok_s == 0);
+
+  auto invalid = input(2000, 3000.0f);
+  invalid.hp1.online = false;
+  out = step(invalid, config(), {20, 10, 10, 10});
+  assert(!out.measurement_valid && out.state.cap_f == 16);
+  assert(out.state.over_soft_s == 0 && out.state.over_peak_s == 0 && out.state.under_ok_s == 0);
+  invalid = input(70000, 3000.0f);
+  assert(!step(invalid, config(), state).measurement_valid);
+  invalid = input(2000, std::numeric_limits<float>::infinity());
+  assert(!step(invalid, config(), state).measurement_valid);
+  invalid = input(2000, NAN);
+  assert(!step(invalid, config(), state).measurement_valid);
+  invalid = input(2000, 3000.0f);
+  invalid.hp2.current_valid = false;
+  assert(!step(invalid, config(true), state).measurement_valid);
+  assert(step(invalid, config(false), state).measurement_valid);
+  auto invalid_config = config();
+  invalid_config.peak_limit_w = 3000.0f;
+  assert(!step(input(2000, 3000.0f), invalid_config, state).measurement_valid);
+
+  assert(saturated_add(UINT32_MAX - 2, 5) == UINT32_MAX);
+  return 0;
+}

--- a/tests/host/supervisory_safety_logic_test.cpp
+++ b/tests/host/supervisory_safety_logic_test.cpp
@@ -1,0 +1,139 @@
+#include <assert.h>
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+#include "../../openquatt/includes/control/oq_supervisory_safety_logic.h"
+
+namespace {
+oq_supervisory_safety::Config config() { return {250.0f, 60000, 30000, 5.0f, 6.0f, 30000}; }
+
+oq_supervisory_safety::Input input(uint32_t now_ms, bool thermal_request, float flow_lph, float outside_c = 10.0f) {
+  return {now_ms, thermal_request, true, flow_lph, true, outside_c};
+}
+}  // namespace
+
+int main() {
+  using namespace oq_supervisory_safety;
+
+  State state;
+  auto output = step(input(1000, true, 249.0f), config(), state);
+  assert(output.flow_valid && output.flow_low && !output.flow_ok && !output.minimum_flow_ok);
+  assert(!output.state.low_flow_fault_active && !output.low_flow_fault_started);
+  output = step(input(60999, true, 249.0f), config(), output.state);
+  assert(!output.state.low_flow_fault_active);
+  output = step(input(61000, true, 249.0f), config(), output.state);
+  assert(output.state.low_flow_fault_active && output.low_flow_fault_started);
+
+  output = step(input(62000, true, 250.0f), config(), output.state);
+  assert(output.flow_ok && output.state.low_flow_fault_active && !output.minimum_flow_ok);
+  output = step(input(91999, true, 400.0f), config(), output.state);
+  assert(output.state.low_flow_fault_active);
+  output = step(input(92000, true, 400.0f), config(), output.state);
+  assert(!output.state.low_flow_fault_active && output.low_flow_fault_cleared && output.minimum_flow_ok);
+
+  output = step(input(93000, true, 100.0f), config(), output.state);
+  output = step(input(153000, true, 100.0f), config(), output.state);
+  assert(output.state.low_flow_fault_active);
+  output = step(input(153001, false, 100.0f), config(), output.state);
+  assert(!output.state.low_flow_fault_active && output.low_flow_fault_cleared && output.minimum_flow_ok);
+  assert(!output.state.low_flow_timing && !output.state.flow_recovery_timing);
+
+  output = step(input(1000, true, 100.0f), config(), {});
+  output = step(input(30000, true, 300.0f), config(), output.state);
+  output = step(input(90000, true, 100.0f), config(), output.state);
+  output = step(input(149999, true, 100.0f), config(), output.state);
+  assert(!output.state.low_flow_fault_active);
+  output.state.low_flow_fault_active = true;
+  output = step(input(150000, true, 300.0f), config(), output.state);
+  output = step(input(160000, true, 100.0f), config(), output.state);
+  assert(output.state.low_flow_fault_active && !output.state.flow_recovery_timing);
+  output = step(input(170000, true, 300.0f), config(), output.state);
+  output = step(input(199999, true, 300.0f), config(), output.state);
+  assert(output.state.low_flow_fault_active);
+
+  auto invalid_flow = input(2000, true, NAN);
+  invalid_flow.flow_has_state = false;
+  output = step(invalid_flow, config(), {});
+  assert(!output.flow_valid && output.flow_low && !output.flow_ok);
+  invalid_flow.flow_has_state = true;
+  invalid_flow.flow_lph = std::numeric_limits<float>::infinity();
+  output = step(invalid_flow, config(), {});
+  assert(!output.flow_valid && output.flow_low);
+  auto invalid_flow_config = config();
+  invalid_flow_config.minimum_flow_lph = NAN;
+  output = step(input(2000, true, 1000.0f), invalid_flow_config, {});
+  assert(output.flow_valid && output.flow_low && !output.flow_ok);
+
+  auto immediate_config = config();
+  immediate_config.low_flow_fault_ms = 0;
+  immediate_config.flow_recover_ms = 0;
+  output = step(input(0, true, 100.0f), immediate_config, {});
+  assert(output.state.low_flow_fault_active);
+  output = step(input(0, true, 300.0f), immediate_config, output.state);
+  assert(!output.state.low_flow_fault_active);
+
+  State rollover_state;
+  output = step(input(UINT32_MAX - 20, true, 100.0f), config(), rollover_state);
+  auto rollover_config = config();
+  rollover_config.low_flow_fault_ms = 60;
+  output = step(input(39, true, 100.0f), rollover_config, output.state);
+  assert(output.state.low_flow_fault_active);
+  assert(seconds_to_ms(UINT32_MAX) == (UINT32_MAX / 1000UL) * 1000UL);
+
+  output = step(input(100, false, 300.0f, 4.9f), config(), {});
+  assert(output.frost_active);
+  output = step(input(200, false, 300.0f, 5.5f), config(), output.state);
+  assert(output.frost_active);
+  output = step(input(300, false, 300.0f, 6.0f), config(), output.state);
+  assert(!output.frost_active);
+  output = step(input(400, false, 300.0f, 5.0f), config(), output.state);
+  assert(!output.frost_active);
+  output = step(input(500, true, 300.0f, 0.0f), config(), output.state);
+  assert(!output.frost_active);
+
+  auto missing_outside = input(1000, false, 300.0f, NAN);
+  missing_outside.outside_temperature_has_state = false;
+  output = step(missing_outside, config(), {});
+  assert(output.frost_nan_grace_active && !output.frost_active);
+  missing_outside.now_ms = 30999;
+  output = step(missing_outside, config(), output.state);
+  assert(output.frost_nan_grace_active && !output.frost_active);
+  missing_outside.now_ms = 31000;
+  output = step(missing_outside, config(), output.state);
+  assert(!output.frost_nan_grace_active && output.frost_active);
+  missing_outside.outside_temperature_has_state = true;
+  missing_outside.outside_temperature_c = std::numeric_limits<float>::infinity();
+  output = step(missing_outside, config(), output.state);
+  assert(output.frost_active);
+
+  State restored_frost;
+  restored_frost.frost_active = true;
+  output = step(input(1000, false, 300.0f, 5.5f), config(), restored_frost);
+  assert(output.frost_active);
+  auto invalid_frost_config = config();
+  invalid_frost_config.frost_on_c = 7.0f;
+  invalid_frost_config.frost_off_c = 6.0f;
+  invalid_frost_config.frost_nan_grace_ms = 0;
+  output = step(input(1000, false, 300.0f, 10.0f), invalid_frost_config, {});
+  assert(output.frost_active);
+
+  auto rollover_frost_config = config();
+  rollover_frost_config.frost_nan_grace_ms = 30;
+  missing_outside.now_ms = UINT32_MAX - 10;
+  output = step(missing_outside, rollover_frost_config, {});
+  missing_outside.now_ms = 18;
+  output = step(missing_outside, rollover_frost_config, output.state);
+  assert(output.frost_nan_grace_active && !output.frost_active);
+  missing_outside.now_ms = 19;
+  output = step(missing_outside, rollover_frost_config, output.state);
+  assert(!output.frost_nan_grace_active && output.frost_active);
+
+  assert(!force_standby(false, false, 5, 5));
+  assert(force_standby(true, false, 5, 5));
+  assert(!force_standby(true, true, 5, 0));
+  assert(!force_standby(true, true, 0, 5));
+  assert(force_standby(true, true, 0, 0));
+  return 0;
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst de gemeten elektrische vermogensbegrenzing én de Supervisory-flow-/vorstbeveiliging uit `oq_supervisory_controlmode.yaml` naar pure C++-besliskernen met dunne ESPHome-runtimes.
- Behoudt drempels, hysterese, defrost-hold, Single/Duo-gedrag en gedeelde entitycontracten; ontbrekende, stale, NaN-, oneindige of intern ongeldige meetcontext gaat fail-closed.
- Voegt deterministische hostregressies toe voor vermogensstappen, flowtrip/herstel, frost-hysterese, rebootinitialisatie, `millis()`-rollover en timerverzadiging.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De normale regelvolgorde en grenswaarden blijven gelijk. Bewuste aanscherpingen zijn fail-closed behandeling van ontbrekende state, oneindige waarden, een ongeldige flowdrempel of ongeldige frost-drempelvolgorde. Flowtimers en powertimers hebben dezelfde niet-gerestaureerde rebootlevenscyclus; de gerestaureerde frost-hysterese blijft behouden. Een low-flowstop respecteert nog steeds een actieve defrost en stopt die ODU zodra defrost eindigt.

## Achtergrond

Dit bundelt twee nauw gekoppelde Supervisory-stappen tot één functionele PR. `oq_supervisory_controlmode.yaml` daalt van 2163 naar 1915 regels (-248). Productiecode groeit netto 237 regels door vier expliciete C++-contract/runtimeheaders; host- en contracttests voegen netto 278 regels toe. De volledige PR is daardoor netto +515 regels, met aanzienlijk compactere YAML en rechtstreeks testbare veiligheidslogica.

De volledige diff is afzonderlijk geaudit op numerieke pariteit, Single/Duo-compilatie, restore/reboot, stale/offline/NaN/inf, rollover, timinggrenzen, defrost-interleaving, gedeelde stateconsumenten en afwezigheid van dynamische allocaties, taken of netwerkpaden.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne implementatie en safety-hardening; entity-ID's, instellingen, standaardwaarden en gebruikersbediening wijzigen niet.

## Validatie

- [x] `./scripts/run_host_regression_tests.sh` — 53 C++-hosttests groen
- [x] `npm run check:python-contracts` — 155 contracttests groen
- [x] `npm run check:cpp-format`
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- [x] `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` met ESPHome 2026.8.2
- [x] `esphome compile configs/heatpump_controller_q/single_wifi.yaml` met ESPHome 2026.8.2
- [x] Q-Duo HIL tegen de ODU-simulator: CM98 aan/hold/uit, ontbrekende buitentemperatuur fail-safe, vertraagde low-flowtrip, herstelhysterese, reset zonder warmtevraag en defrost-hold gevolgd door veilige stop
- [x] Q-Duo HIL vermogenslimiet: 10 A met circa 3,7 kW verlaagt de cap, lage belasting herstelt de cap, ontbrekende HP2-metingen kiezen de berekende fail-safe cap en herstel van de meting hervat de regeling
- [x] Controller na HIL teruggezet naar schone `origin/dev`-firmware (`v0.49.0`, kanaal `dev`); simulator teruggezet naar normale uitgangsinstellingen
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

- Q-Duo statische DIRAM op identieke `origin/dev`-baseline: 210695 B → 210663 B (-32 B).
- Flash: 2183943 B → 2184347 B (+404 B).
- Geen heapallocaties, PSRAM-eigenaarschap, taken, stacks of netwerkpaden toegevoegd.
