### PR TITLE
Vermijd SHOW-macroconflict in OpenQuattOTSlave

### DIFF
--- a/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
+++ b/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
@@ -238,9 +238,9 @@ OpenQuattOTSlave::~OpenQuattOTSlave() {
 }
 
 void OpenQuattOTSlave::dump_config() {
-#define ID(x) x
-#define SHOW2(x) #x
-#define SHOW(x) SHOW2(x)
+#define OQ_OT_SLAVE_ID(x) x
+#define OQ_OT_SLAVE_SHOW_INNER(x) #x
+#define OQ_OT_SLAVE_SHOW(x) OQ_OT_SLAVE_SHOW_INNER(x)
 
   ESP_LOGCONFIG(TAG, "OpenQuatt OT Slave:");
   ESP_LOGCONFIG(TAG, "  Thermostat In: GPIO%d", m_pinThermostatIn);
@@ -249,12 +249,15 @@ void OpenQuattOTSlave::dump_config() {
   ESP_LOGCONFIG(TAG, "  Default Tret: %.1f C", m_slave_state.t_ret);
   ESP_LOGCONFIG(TAG, "  Default MaxTSet: %.1f C", m_slave_state.max_t_set);
   ESP_LOGCONFIG(TAG, "  Response enabled: %s", YESNO(m_response_enabled));
-  ESP_LOGCONFIG(TAG, "  Sensors: %s", SHOW(OPENQUATT_OT_SLAVE_SENSOR_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Binary sensors: %s", SHOW(OPENQUATT_OT_SLAVE_BINARY_SENSOR_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Switches: %s", SHOW(OPENQUATT_OT_SLAVE_SWITCH_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Input sensors: %s", SHOW(OPENQUATT_OT_SLAVE_INPUT_SENSOR_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Outputs: %s", SHOW(OPENQUATT_OT_SLAVE_OUTPUT_LIST(ID, )));
+  ESP_LOGCONFIG(TAG, "  Sensors: %s", OQ_OT_SLAVE_SHOW(OPENQUATT_OT_SLAVE_SENSOR_LIST(OQ_OT_SLAVE_ID, )));
+  ESP_LOGCONFIG(TAG, "  Binary sensors: %s", OQ_OT_SLAVE_SHOW(OPENQUATT_OT_SLAVE_BINARY_SENSOR_LIST(OQ_OT_SLAVE_ID, )));
+  ESP_LOGCONFIG(TAG, "  Switches: %s", OQ_OT_SLAVE_SHOW(OPENQUATT_OT_SLAVE_SWITCH_LIST(OQ_OT_SLAVE_ID, )));
+  ESP_LOGCONFIG(TAG, "  Input sensors: %s", OQ_OT_SLAVE_SHOW(OPENQUATT_OT_SLAVE_INPUT_SENSOR_LIST(OQ_OT_SLAVE_ID, )));
+  ESP_LOGCONFIG(TAG, "  Outputs: %s", OQ_OT_SLAVE_SHOW(OPENQUATT_OT_SLAVE_OUTPUT_LIST(OQ_OT_SLAVE_ID, )));
 }
+#undef OQ_OT_SLAVE_SHOW
+#undef OQ_OT_SLAVE_SHOW_INNER
+#undef OQ_OT_SLAVE_ID
 
 void OpenQuattOTSlave::setup() {
   m_ot_thermostat_ = new OpenTherm(m_pinThermostatIn, m_pinThermostatOut, true);


### PR DESCRIPTION
# Wat verandert deze PR?

- Vervangt de generieke `ID`-, `SHOW2`- en `SHOW`-helpermacro's in `OpenQuattOTSlave::dump_config()` door component-specifieke namen.
- Ruimt de helpermacro's direct na `dump_config()` op met `#undef`, zodat ze niet verder door de translation unit lekken.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen preprocessor-identifiers en hun levensduur wijzigen. De tweestaps-stringificatie en de resulterende sensor-, binary-sensor- en switchlijsten blijven gelijk; input- en outputlijsten blijven leeg voor deze target.

## Achtergrond

Closes #585.

ESPHome 2026.8.2 brengt via `opentherm_macros.h` al een generieke `SHOW`-macro binnen. De lokale definitie gebruikte een andere replacement-list en veroorzaakte daardoor een redefinition-warning.

De volledige diff tegen `dev` is apart gecontroleerd op correcte macro-expansie, naamconflicten, macrolekkage, runtimegedrag, compatibiliteit en geheugenimpact. Er zijn geen auditbevindingen overgebleven.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is een interne compile-waarschuwing zonder gebruikersgerichte configuratie- of gedragswijziging.

## Validatie

- [x] `npm run check:cpp-format`
- [x] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`
- [x] `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` met ESPHome 2026.8.2; geen `SHOW redefined`-warning
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen preprocessormacro's zijn hernoemd en na gebruik opgeruimd; gegenereerde runtimecode, state en allocaties wijzigen niet.

Opmerking: de volledige `scripts/dev.py validate`-run compileerde de firmware succesvol, maar de helper gaf daarna een bestaande artifactpadfout omdat hij `.esphome/build/duo_wifi/build/flasher_args.json` verwacht terwijl deze target onder `.esphome/build/heatpump_controller_q_duo/` bouwt. De rechtstreekse ESPHome-compile is volledig geslaagd.