### PR TITLE
Herstel Quick Start na factory reset

### DIFF
--- a/openquatt/web/js/src/features/quickstart.js
+++ b/openquatt/web/js/src/features/quickstart.js
@@ -26,6 +26,7 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
     const switchModel = getFirmwareBuildSwitchModel(targetTopology, targetConnection);
     return {
       ...switchModel,
+      currentConnection,
       currentKey,
       selectedKey,
       changes: selectedKey !== currentKey,
@@ -51,7 +52,7 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
         ["single:eth", "Single · Ethernet", "Eén warmtepomp via een vaste netwerkkabel."],
         ["duo:wifi", "Duo · Wi-Fi", "Twee warmtepompen via het draadloze netwerk."],
         ["duo:eth", "Duo · Ethernet", "Twee warmtepompen via een vaste netwerkkabel."],
-      ].filter(([key]) => !unifiedNetworkBuild || key.endsWith(`:${currentConnection}`));
+      ].filter(([key]) => !unifiedNetworkBuild || key.endsWith(`:${model.currentConnection}`));
     const requirements = [
       model.targetIsDuo ? "De tweede warmtepomp is aangesloten en hoort bij deze controller." : "Deze controller wordt voor één warmtepomp gebruikt.",
       model.targetIsEthernet ? "De netwerkkabel is aangesloten." : "De Wi-Fi-gegevens zijn beschikbaar op de controller.",

--- a/openquatt/web/tests/quickstart-setup-update.test.mjs
+++ b/openquatt/web/tests/quickstart-setup-update.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { build } from "esbuild";
 
 globalThis.__OQ_PREVIEW__ = false;
 const storage = new Map();
@@ -36,13 +40,55 @@ const {
   isQuickStartSetupInstallCompletionConfirmed,
   isQuickStartSetupFirmwareCurrent,
 } = await import("../js/src/features/firmware-update.js");
+const quickStartBundle = await build({
+  bundle: true,
+  define: { __OQ_PREVIEW__: "false" },
+  format: "esm",
+  platform: "node",
+  stdin: {
+    contents: `
+      export { renderQuickStartModal, renderSetupWorkspace } from "../js/src/features/quickstart.js";
+      export { state } from "../js/src/core/state.js";
+    `,
+    loader: "js",
+    resolveDir: fileURLToPath(new URL(".", import.meta.url)),
+  },
+  plugins: [{
+    name: "quickstart-test-assets",
+    setup(pluginBuild) {
+      pluginBuild.onResolve({ filter: /^virtual:embedded-assets$/ }, () => ({
+        path: "embedded-assets",
+        namespace: "quickstart-test-assets",
+      }));
+      pluginBuild.onLoad({ filter: /.*/, namespace: "quickstart-test-assets" }, () => ({
+        contents: 'export const HP_GENERATION_IMAGE_V1 = ""; export const HP_GENERATION_IMAGE_V2 = ""; export const LOGO_MARKUP = "";',
+        loader: "js",
+      }));
+    },
+  }],
+  write: false,
+});
+const quickStartBundleDirectory = await mkdtemp(join(tmpdir(), "openquatt-quickstart-test-"));
+const quickStartBundlePath = join(quickStartBundleDirectory, "quickstart.mjs");
+let quickStartModule;
+try {
+  await writeFile(quickStartBundlePath, quickStartBundle.outputFiles[0].text);
+  quickStartModule = await import(pathToFileURL(quickStartBundlePath).href);
+} finally {
+  await rm(quickStartBundleDirectory, { force: true, recursive: true });
+}
+const {
+  renderQuickStartModal,
+  renderSetupWorkspace,
+  state: quickStartState,
+} = quickStartModule;
 
 function textEntity(value) {
   return { state: value, value };
 }
 
-function resetSetupState() {
-  state.entities = {
+function resetSetupState(targetState = state) {
+  targetState.entities = {
     connectionText: textEntity("wifi"),
     firmwareUpdate: {
       current_version: "v0.48.0",
@@ -63,24 +109,29 @@ function resetSetupState() {
     installationTopology: textEntity("single"),
     projectVersionText: textEntity("v0.48.0"),
     releaseChannelText: textEntity("main"),
+    setupComplete: textEntity(false),
   };
-  state.quickStartSetupDraft = "";
-  state.quickStartSetupConfirmed = false;
-  state.quickStartSetupUpdateComplete = false;
-  state.complete = false;
-  state.updateInstallBusy = false;
-  state.updateInstallMode = "";
-  state.updateInstallPhaseHint = "";
-  state.updateInstallProgressHint = Number.NaN;
-  state.updateInstallStatusPollObserved = false;
-  state.updateInstallSuccessfulPhaseObserved = false;
-  state.updateInstallResumedAfterReload = false;
-  state.updateInstallTargetConnection = "";
-  state.updateInstallTargetTopology = "";
-  state.updateInstallTargetVersion = "";
-  state.ota = { on: false, ok: 0, id: null, wait: false, base: null };
-  state.controlError = "";
-  state.controlNotice = "";
+  targetState.currentStep = "setup";
+  targetState.quickStartSetupDraft = "";
+  targetState.quickStartSetupConfirmed = false;
+  targetState.quickStartSetupUpdateComplete = false;
+  targetState.quickStartModalMode = "wizard";
+  targetState.quickStartModalOpen = true;
+  targetState.complete = false;
+  targetState.loadingEntities = false;
+  targetState.updateInstallBusy = false;
+  targetState.updateInstallMode = "";
+  targetState.updateInstallPhaseHint = "";
+  targetState.updateInstallProgressHint = Number.NaN;
+  targetState.updateInstallStatusPollObserved = false;
+  targetState.updateInstallSuccessfulPhaseObserved = false;
+  targetState.updateInstallResumedAfterReload = false;
+  targetState.updateInstallTargetConnection = "";
+  targetState.updateInstallTargetTopology = "";
+  targetState.updateInstallTargetVersion = "";
+  targetState.ota = { on: false, ok: 0, id: null, wait: false, base: null };
+  targetState.controlError = "";
+  targetState.controlNotice = "";
 }
 
 test("de actuele main-versie en configuratie hebben geen OTA nodig", () => {
@@ -145,6 +196,54 @@ test("de uniforme Q-firmware beheert verbinding los van OTA", () => {
   assert.equal(topologyModel.targetOption, "alternate topology");
   assert.equal(topologyModel.canSwitch, true);
   assert.equal(topologyModel.targetBuildLabel, "Heatpump Controller Q Duo");
+});
+
+test("Quick Start rendert alleen setups voor de verbinding van uniforme Q-firmware", () => {
+  resetSetupState(quickStartState);
+  quickStartState.entities.preferredConnection = {
+    ...textEntity("Automatic"),
+    option: ["Automatic", "WiFi", "Ethernet"],
+  };
+  quickStartState.entities.firmwareUpdate.title = "Heatpump Controller Q Single";
+
+  let setupHtml = "";
+  assert.doesNotThrow(() => {
+    setupHtml = renderSetupWorkspace();
+  });
+  assert.deepEqual(
+    [...setupHtml.matchAll(/data-setup-target="([^"]+)"/g)].map((match) => match[1]),
+    ["single:wifi", "duo:wifi"],
+  );
+
+  quickStartState.entities.installationTopology = textEntity("duo");
+  quickStartState.entities.preferredConnection = {
+    ...textEntity("Ethernet"),
+    option: ["Automatic", "WiFi", "Ethernet"],
+  };
+  quickStartState.entities.connectionText = textEntity("eth");
+  quickStartState.entities.firmwareUpdate.title = "Heatpump Controller Q Duo";
+  setupHtml = renderSetupWorkspace();
+  assert.deepEqual(
+    [...setupHtml.matchAll(/data-setup-target="([^"]+)"/g)].map((match) => match[1]),
+    ["single:eth", "duo:eth"],
+  );
+});
+
+test("Quick Start opent na eerste synchronisatie voor een factory-resetstatus", () => {
+  resetSetupState(quickStartState);
+  quickStartState.entities.preferredConnection = {
+    ...textEntity("Automatic"),
+    option: ["Automatic", "WiFi", "Ethernet"],
+  };
+  quickStartState.entities.firmwareUpdate.title = "Heatpump Controller Q Single";
+  quickStartState.loadingEntities = true;
+  assert.equal(renderQuickStartModal(), "");
+
+  quickStartState.loadingEntities = false;
+  const modalHtml = renderQuickStartModal();
+  assert.match(modalHtml, /Rond eerst de Quick Start af/);
+  assert.match(modalHtml, /data-setup-target="single:wifi"/);
+  assert.doesNotMatch(modalHtml, /Eerste synchronisatie/);
 });
 
 test("Quick Start staat de expliciet bevestigde overstap van dev naar main toe", () => {


### PR DESCRIPTION
# Wat verandert deze PR?

- Herstelt de Quick Start-rendering na een factory reset op uniforme Q-firmware.
- Gebruikt de genormaliseerde actuele verbinding uit het setupmodel om alleen Wi-Fi- of Ethernetopties te tonen.
- Voegt regressietests toe voor Wi-Fi, Ethernet en de eerste synchronisatie na factory reset.

Fixes #587

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de web-UI-rendering van Quick Start wijzigt. De regeling, firmwareconfiguratie en persistente status blijven ongewijzigd.

## Achtergrond

De renderer verwees naar een variabele die alleen binnen `getQuickStartSetupModel()` bestond. Daardoor ontstond na de eerste synchronisatie een `ReferenceError` en bleef de interface op “Eerste synchronisatie” staan.

De complete diff tegen de actuele `dev` is afzonderlijk gecontroleerd op correctheid, security/privacy, lifecycle/timing, foutafhandeling, compatibiliteit en factory-reset/fresh-installgedrag. Legacy netwerkbuilds houden hun bestaande opties; uniforme builds filteren uitsluitend op de reeds genormaliseerde actuele verbinding.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt het al bedoelde Quick Start-gedrag en verandert geen gebruikersflow of configuratiecontract.

## Validatie

- `node --test openquatt/web/tests/quickstart-setup-update.test.mjs` — 12/12 geslaagd
- `npm run check:web` — 311/311 geslaagd; build- en kwaliteitscontroles geslaagd
- `npm run smoke:web` — geslaagd
- Browsercheck op de actuele commit: factory-resetstatus opent Quick Start met alleen `single:wifi` en `duo:wifi`; de synchronisatie-overlay verdwijnt.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; alleen webbroncode en webtests zijn gewijzigd.
