### PR TITLE
Herstel captive portal op root-URL van fallback-AP

### DIFF
--- a/components/openquatt_captive_portal_router/OpenQuattCaptivePortalRouter.cpp
+++ b/components/openquatt_captive_portal_router/OpenQuattCaptivePortalRouter.cpp
@@ -1,0 +1,74 @@
+#include "OpenQuattCaptivePortalRouter.h"
+
+#include <lwip/sockets.h>
+
+#include "esphome/components/wifi/wifi_component.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace openquatt_captive_portal_router {
+
+static const char* const TAG = "openquatt.captive_portal_router";
+
+float OpenQuattCaptivePortalRouter::get_setup_priority() const {
+  // CaptivePortal sets up at WIFI + 1.0f; WebServer registers its routes at WIFI - 1.0f.
+  return setup_priority::WIFI + 0.5f;
+}
+
+void OpenQuattCaptivePortalRouter::setup() {
+  if (web_server_base::global_web_server_base == nullptr || captive_portal::global_captive_portal == nullptr) {
+    ESP_LOGE(TAG, "Captive portal or shared web server is unavailable");
+    this->mark_failed();
+    return;
+  }
+
+  // CaptivePortal itself intentionally bypasses web-server auth. Register this
+  // proxy first so the same provisioning routes win while the portal is active.
+  web_server_base::global_web_server_base->add_handler_without_auth(this);
+}
+
+bool OpenQuattCaptivePortalRouter::canHandle(AsyncWebServerRequest* request) const {
+  auto* portal = captive_portal::global_captive_portal;
+  return portal != nullptr && portal->canHandle(request) && this->request_targets_soft_ap_(request);
+}
+
+void OpenQuattCaptivePortalRouter::handleRequest(AsyncWebServerRequest* request) {
+  auto* portal = captive_portal::global_captive_portal;
+  if (portal == nullptr) {
+    request->send(503);
+    return;
+  }
+  portal->handleRequest(request);
+}
+
+bool OpenQuattCaptivePortalRouter::request_targets_soft_ap_(AsyncWebServerRequest* request) const {
+  auto* wifi = wifi::global_wifi_component;
+  if (wifi == nullptr) {
+    return false;
+  }
+
+  const network::IPAddress soft_ap_ip = wifi->wifi_soft_ap_ip();
+  if (!soft_ap_ip.is_set() || !soft_ap_ip.is_ip4()) {
+    return false;
+  }
+
+  httpd_req_t* raw_request = *request;
+  struct sockaddr_storage local_address{};
+  socklen_t address_length = sizeof(local_address);
+  if (getsockname(httpd_req_to_sockfd(raw_request), reinterpret_cast<struct sockaddr*>(&local_address),
+                  &address_length) != 0 ||
+      local_address.ss_family != AF_INET) {
+    return false;
+  }
+
+  const auto* local_ipv4 = reinterpret_cast<const struct sockaddr_in*>(&local_address);
+  const esp_ip4_addr_t soft_ap_ipv4 = soft_ap_ip;
+  return local_ipv4->sin_addr.s_addr == soft_ap_ipv4.addr;
+}
+
+void OpenQuattCaptivePortalRouter::dump_config() {
+  ESP_LOGCONFIG(TAG, "Captive portal routing priority: %s", this->is_failed() ? "unavailable" : "enabled");
+}
+
+}  // namespace openquatt_captive_portal_router
+}  // namespace esphome

--- a/components/openquatt_captive_portal_router/OpenQuattCaptivePortalRouter.cpp
+++ b/components/openquatt_captive_portal_router/OpenQuattCaptivePortalRouter.cpp
@@ -1,8 +1,5 @@
 #include "OpenQuattCaptivePortalRouter.h"
 
-#include <lwip/sockets.h>
-
-#include "esphome/components/wifi/wifi_component.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -29,7 +26,12 @@ void OpenQuattCaptivePortalRouter::setup() {
 
 bool OpenQuattCaptivePortalRouter::canHandle(AsyncWebServerRequest* request) const {
   auto* portal = captive_portal::global_captive_portal;
-  return portal != nullptr && portal->canHandle(request) && this->request_targets_soft_ap_(request);
+  if (portal == nullptr || !portal->canHandle(request)) {
+    return false;
+  }
+
+  char url_buffer[AsyncWebServerRequest::URL_BUF_SIZE];
+  return request->url_to(url_buffer) == "/";
 }
 
 void OpenQuattCaptivePortalRouter::handleRequest(AsyncWebServerRequest* request) {
@@ -39,31 +41,6 @@ void OpenQuattCaptivePortalRouter::handleRequest(AsyncWebServerRequest* request)
     return;
   }
   portal->handleRequest(request);
-}
-
-bool OpenQuattCaptivePortalRouter::request_targets_soft_ap_(AsyncWebServerRequest* request) const {
-  auto* wifi = wifi::global_wifi_component;
-  if (wifi == nullptr) {
-    return false;
-  }
-
-  const network::IPAddress soft_ap_ip = wifi->wifi_soft_ap_ip();
-  if (!soft_ap_ip.is_set() || !soft_ap_ip.is_ip4()) {
-    return false;
-  }
-
-  httpd_req_t* raw_request = *request;
-  struct sockaddr_storage local_address{};
-  socklen_t address_length = sizeof(local_address);
-  if (getsockname(httpd_req_to_sockfd(raw_request), reinterpret_cast<struct sockaddr*>(&local_address),
-                  &address_length) != 0 ||
-      local_address.ss_family != AF_INET) {
-    return false;
-  }
-
-  const auto* local_ipv4 = reinterpret_cast<const struct sockaddr_in*>(&local_address);
-  const esp_ip4_addr_t soft_ap_ipv4 = soft_ap_ip;
-  return local_ipv4->sin_addr.s_addr == soft_ap_ipv4.addr;
 }
 
 void OpenQuattCaptivePortalRouter::dump_config() {

--- a/components/openquatt_captive_portal_router/OpenQuattCaptivePortalRouter.h
+++ b/components/openquatt_captive_portal_router/OpenQuattCaptivePortalRouter.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/components/captive_portal/captive_portal.h"
+#include "esphome/components/web_server_base/web_server_base.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace openquatt_captive_portal_router {
+
+class OpenQuattCaptivePortalRouter final : public AsyncWebHandler, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+  bool canHandle(AsyncWebServerRequest* request) const override;
+  void handleRequest(AsyncWebServerRequest* request) override;
+
+ protected:
+  bool request_targets_soft_ap_(AsyncWebServerRequest* request) const;
+};
+
+}  // namespace openquatt_captive_portal_router
+}  // namespace esphome

--- a/components/openquatt_captive_portal_router/OpenQuattCaptivePortalRouter.h
+++ b/components/openquatt_captive_portal_router/OpenQuattCaptivePortalRouter.h
@@ -15,9 +15,6 @@ class OpenQuattCaptivePortalRouter final : public AsyncWebHandler, public Compon
 
   bool canHandle(AsyncWebServerRequest* request) const override;
   void handleRequest(AsyncWebServerRequest* request) override;
-
- protected:
-  bool request_targets_soft_ap_(AsyncWebServerRequest* request) const;
 };
 
 }  // namespace openquatt_captive_portal_router

--- a/components/openquatt_captive_portal_router/__init__.py
+++ b/components/openquatt_captive_portal_router/__init__.py
@@ -1,0 +1,23 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["web_server_base"]
+DEPENDENCIES = ["captive_portal", "web_server", "wifi"]
+
+openquatt_captive_portal_router_ns = cg.esphome_ns.namespace(
+    "openquatt_captive_portal_router"
+)
+OpenQuattCaptivePortalRouter = openquatt_captive_portal_router_ns.class_(
+    "OpenQuattCaptivePortalRouter", cg.Component
+)
+
+CONFIG_SCHEMA = cv.Schema(
+    {cv.GenerateID(): cv.declare_id(OpenQuattCaptivePortalRouter)}
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    cg.add_global(openquatt_captive_portal_router_ns.using)
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)

--- a/components/openquatt_captive_portal_router/__init__.py
+++ b/components/openquatt_captive_portal_router/__init__.py
@@ -3,7 +3,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 AUTO_LOAD = ["web_server_base"]
-DEPENDENCIES = ["captive_portal", "web_server", "wifi"]
+DEPENDENCIES = ["captive_portal", "web_server"]
 
 openquatt_captive_portal_router_ns = cg.esphome_ns.namespace(
     "openquatt_captive_portal_router"

--- a/openquatt/connection/wifi.yaml
+++ b/openquatt/connection/wifi.yaml
@@ -7,6 +7,12 @@
 substitutions:
   oq_connection: "wifi"
 
+external_components:
+  - source:
+      type: local
+      path: ${external_components_path}
+    components: [openquatt_captive_portal_router]
+
 wifi:
   power_save_mode: none
   min_auth_mode: wpa2
@@ -15,6 +21,9 @@ wifi:
     password: "openquatt"
 
 captive_portal:
+
+# Keep captive provisioning ahead of the normal web app while fallback AP mode is active.
+openquatt_captive_portal_router:
 
 # Enable ESP Web Tools Wi-Fi provisioning while keeping AP fallback available.
 improv_serial:

--- a/openquatt/connection/wifi_eth.yaml
+++ b/openquatt/connection/wifi_eth.yaml
@@ -30,6 +30,9 @@ ethernet:
 
 captive_portal:
 
+# Keep captive provisioning ahead of the normal web app on the fallback AP.
+openquatt_captive_portal_router:
+
 # Enable ESP Web Tools WiFi provisioning while keeping AP fallback available.
 improv_serial:
   next_url: "http://{{ip_address}}/"
@@ -38,7 +41,7 @@ external_components:
   - source:
       type: local
       path: ${external_components_path}
-    components: [openquatt_network]
+    components: [openquatt_network, openquatt_captive_portal_router]
 
 openquatt_network:
   id: oq_network_manager

--- a/scripts/tests/test_esphome_compatibility_contract.py
+++ b/scripts/tests/test_esphome_compatibility_contract.py
@@ -68,10 +68,9 @@ class ESPHomeCompatibilityContractTest(unittest.TestCase):
         self.assertIn("portal->canHandle(request)", CAPTIVE_PORTAL_ROUTER_CPP)
         self.assertIn("portal->handleRequest(request)", CAPTIVE_PORTAL_ROUTER_CPP)
 
-    def test_captive_portal_router_only_handles_soft_ap_requests(self) -> None:
-        self.assertIn("wifi->wifi_soft_ap_ip()", CAPTIVE_PORTAL_ROUTER_CPP)
-        self.assertIn("getsockname(httpd_req_to_sockfd", CAPTIVE_PORTAL_ROUTER_CPP)
-        self.assertIn("local_address.ss_family != AF_INET", CAPTIVE_PORTAL_ROUTER_CPP)
+    def test_captive_portal_router_only_handles_root_requests(self) -> None:
+        self.assertIn("request->url_to(url_buffer)", CAPTIVE_PORTAL_ROUTER_CPP)
+        self.assertIn('== "/";', CAPTIVE_PORTAL_ROUTER_CPP)
 
     def test_web_auth_credentials_have_component_lifetime(self) -> None:
         self.assertIn("AuthStorage runtime_storage_{};", WEB_AUTH_HEADER)

--- a/scripts/tests/test_esphome_compatibility_contract.py
+++ b/scripts/tests/test_esphome_compatibility_contract.py
@@ -27,9 +27,52 @@ ODU_RUNTIME_TABLE = (
 ODU_RUNTIME_TABLE_YAML = (
     ROOT / "openquatt" / "experimental" / "oq_odu_runtime_frequency_table_hp.yaml"
 ).read_text()
+CAPTIVE_PORTAL_ROUTER_CPP = (
+    ROOT
+    / "components"
+    / "openquatt_captive_portal_router"
+    / "OpenQuattCaptivePortalRouter.cpp"
+).read_text()
+WIFI_PROFILE = (ROOT / "openquatt" / "connection" / "wifi.yaml").read_text()
+WIFI_ETH_PROFILE = (
+    ROOT / "openquatt" / "connection" / "wifi_eth.yaml"
+).read_text()
 
 
 class ESPHomeCompatibilityContractTest(unittest.TestCase):
+    def test_captive_portal_router_registers_before_web_server(self) -> None:
+        self.assertIn(
+            "return setup_priority::WIFI + 0.5f;", CAPTIVE_PORTAL_ROUTER_CPP
+        )
+        self.assertIn(
+            "add_handler_without_auth(this);", CAPTIVE_PORTAL_ROUTER_CPP
+        )
+        profiles = (
+            (
+                "wifi",
+                WIFI_PROFILE,
+                "components: [openquatt_captive_portal_router]",
+            ),
+            (
+                "wifi_eth",
+                WIFI_ETH_PROFILE,
+                "components: [openquatt_network, openquatt_captive_portal_router]",
+            ),
+        )
+        for profile_name, profile, component_declaration in profiles:
+            with self.subTest(profile=profile_name):
+                self.assertIn(component_declaration, profile)
+                self.assertIn("openquatt_captive_portal_router:", profile)
+
+    def test_captive_portal_router_delegates_existing_portal_routes(self) -> None:
+        self.assertIn("portal->canHandle(request)", CAPTIVE_PORTAL_ROUTER_CPP)
+        self.assertIn("portal->handleRequest(request)", CAPTIVE_PORTAL_ROUTER_CPP)
+
+    def test_captive_portal_router_only_handles_soft_ap_requests(self) -> None:
+        self.assertIn("wifi->wifi_soft_ap_ip()", CAPTIVE_PORTAL_ROUTER_CPP)
+        self.assertIn("getsockname(httpd_req_to_sockfd", CAPTIVE_PORTAL_ROUTER_CPP)
+        self.assertIn("local_address.ss_family != AF_INET", CAPTIVE_PORTAL_ROUTER_CPP)
+
     def test_web_auth_credentials_have_component_lifetime(self) -> None:
         self.assertIn("AuthStorage runtime_storage_{};", WEB_AUTH_HEADER)
         self.assertIn(


### PR DESCRIPTION
# Wat verandert deze PR?

- Registreert een kleine captive-portalproxy vóór de ESPHome-webserver, zodat `http://192.168.4.1/` tijdens fallback-AP-modus weer de WiFi-configuratiepagina toont.
- De proxy claimt uitsluitend `GET /` zolang ESPHome's captive portal actief is en delegeert de response aan de bestaande captive-portalimplementatie.
- Activeert de fix in zowel `wifi.yaml` als `wifi_eth.yaml` en borgt de routeringscontracten in de algemene ESPHome-compatibiliteitstest.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de root-HTTP-route tijdens actieve fallback-AP-modus wijzigt. Zodra de captive portal stopt, behandelt de normale webserver `/` weer. Overige routes, webauthenticatie en regelgedrag blijven ongewijzigd. De proxy gebruikt geen buffers of eigen task en voegt alleen een componentinstantie en handlerregistratie toe.

## Achtergrond

ESPHome 2026.8 registreert de normale webserverhandler tijdens setup, terwijl de captive-portalhandler pas bij het starten van het fallback-AP wordt toegevoegd. Omdat handlers op registratievolgorde worden gekozen, claimt de webserver daardoor `/` eerder.

De proxy wordt tussen beide setup-prioriteiten geregistreerd en gebruikt de bestaande `CaptivePortal::canHandle()` en `handleRequest()`. Een eerste kandidaat filterde daarnaast op het lokale socketadres. Een hardwaretest reproduceerde dat het fallback-AP actief was maar die ESP-IDF-filter de request niet betrouwbaar herkende. De vervolgcommit verwijdert die platformafhankelijke filter en beperkt de proxy in plaats daarvan deterministisch tot de conflicterende rootroute.

Volledige diff-audit en afzonderlijke cold review omvatten setupvolgorde, authenticatiegrens, AP/Ethernet-overlap, start/stop/herstart, herhaalde portalactivatie, foutpaden en request-races. Geen aanvullende bevindingen.

Closes #586

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt de bedoelde bestaande captive-portalroute; er komt geen nieuwe gebruikershandeling of URL bij. De documentatie blijft daarom bewust ongewijzigd.

## Validatie

- `python3 -m unittest discover -s scripts/tests -p "test_*.py"` — 170 tests geslaagd.
- `python3 scripts/cpp_format.py check` — 209 C/C++-bestanden conform.
- `esphome config configs/heatpump_controller_q/duo_wifi.yaml` — geldig met ESPHome 2026.8.2.
- `esphome config configs/waveshare/duo_wifi.yaml` — geldig met ESPHome 2026.8.2.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd; gecorrigeerde routercomponent meegecompileerd, 58% app-partitie vrij.
- HIL eerste kandidaat — fallback-AP aantoonbaar actief, maar socketadresfilter blokkeerde de proxy; verwerkt in vervolgcommit `2aef95ad`.
- HIL gecorrigeerde root-only kandidaat — geslaagd op Q Duo WiFi (`config hash 0x7f5caacd`): na blokkeren van de WiFi-verbinding startte het fallback-AP en toonde `http://192.168.4.1/` de WiFi-configuratiepagina in plaats van de webapp.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe runtimebuffer, allocatielus of task. Kandidaatbuild: 210.511 bytes DIRAM (61,6%) en 2.186.043 bytes image. Geen HIL heap/stack-meting uitgevoerd.