### PR TITLE
Voorkom NVS-uitputting door runtimevoorkeuren op te ruimen

### DIFF
--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
@@ -80,7 +80,7 @@ class OpenQuattCrashTelemetry : public Component {
     uint32_t checksum;
   };
 
-  static_assert(sizeof(StateStorage) < 64U, "Crash telemetry state should remain small");
+  static_assert(sizeof(StateStorage) == 56U, "Crash telemetry NVS budget changed");
 
   void capture_pending_crash_();
   void on_log_(const char* tag, const char* message, size_t message_len);

--- a/components/openquatt_network/OpenQuattNetworkManager.cpp
+++ b/components/openquatt_network/OpenQuattNetworkManager.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "includes/storage/oq_nvs_cleanup.h"
 
 namespace esphome {
 namespace openquatt_network {
@@ -508,7 +509,21 @@ bool OpenQuattNetworkManager::save_preference_(Preference preference) {
   stored.magic = PREFERENCE_MAGIC;
   stored.preference = static_cast<uint8_t>(preference);
   if (!this->preference_store_.save(&stored)) {
+    oq_nvs_cleanup::log_stats("network-preference-queue-failed");
     return false;
+  }
+
+  const bool synced = global_preferences != nullptr && global_preferences->sync();
+  PreferenceStorage verified{};
+  const bool persisted = this->preference_store_.load(&verified) && verified.magic == PREFERENCE_MAGIC &&
+                         verified.preference == stored.preference;
+  if (!persisted) {
+    ESP_LOGE(TAG, "Preferred connection was not persisted (sync=%s)", YESNO(synced));
+    oq_nvs_cleanup::log_stats("network-preference-write-failed");
+    return false;
+  }
+  if (!synced) {
+    ESP_LOGW(TAG, "Preference sync reported a failure, but readback verified this connection preference");
   }
 
   this->preference_ = preference;

--- a/components/openquatt_network/OpenQuattNetworkManager.h
+++ b/components/openquatt_network/OpenQuattNetworkManager.h
@@ -69,6 +69,8 @@ class OpenQuattNetworkManager : public Component {
     uint8_t reserved[3];
   };
 
+  static_assert(sizeof(PreferenceStorage) == 8U, "Network preference NVS budget changed");
+
   static constexpr uint32_t PREFERENCE_MAGIC = 0x4F514E32UL;
   static constexpr uint32_t W5500_PHYCFGR_REGISTER = 0x002E0000UL;
   static constexpr uint8_t W5500_PHYCFGR_POWER_DOWN = 0xF0;

--- a/components/openquatt_web_auth/OpenQuattWebAuth.h
+++ b/components/openquatt_web_auth/OpenQuattWebAuth.h
@@ -51,6 +51,8 @@ class OpenQuattWebAuth : public Component {
     char password[PASSWORD_MAX_LEN + 1];
   };
 
+  static_assert(sizeof(AuthStorage) == 104U, "Web authentication NVS budget changed");
+
   bool load_storage_(AuthStorage* storage);
   bool save_storage_(const AuthStorage& storage);
   bool apply_storage_(const AuthStorage& storage, const char* source);

--- a/openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml
+++ b/openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml
@@ -34,8 +34,9 @@ switch:
     entity_category: config
 
 number:
-  # Editable desired runtime table. Defaults mirror the known ODU factory table;
-  # use Load before applying to confirm the current runtime values.
+  # RAM-only editor for the ODU-owned runtime table. Defaults only provide a
+  # bounded initial display; a successful Load in the current boot is required
+  # before Apply can write anything.
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f0
     name: "${prefix}EXPERIMENTAL cooling F0 runtime Hz"
@@ -45,7 +46,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 0
     entity_category: config
@@ -59,7 +60,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 30
     entity_category: config
@@ -73,7 +74,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 36
     entity_category: config
@@ -87,7 +88,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 42
     entity_category: config
@@ -101,7 +102,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 47
     entity_category: config
@@ -115,7 +116,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 52
     entity_category: config
@@ -129,7 +130,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 56
     entity_category: config
@@ -143,7 +144,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 61
     entity_category: config
@@ -157,7 +158,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 66
     entity_category: config
@@ -171,7 +172,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 71
     entity_category: config
@@ -185,7 +186,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 74
     entity_category: config
@@ -199,7 +200,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 48
     entity_category: config
@@ -213,7 +214,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 52
     entity_category: config
@@ -227,7 +228,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 54
     entity_category: config
@@ -241,7 +242,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 56
     entity_category: config
@@ -255,7 +256,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 58
     entity_category: config
@@ -269,7 +270,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 60
     entity_category: config
@@ -283,7 +284,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 64
     entity_category: config
@@ -297,7 +298,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 66
     entity_category: config
@@ -311,7 +312,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 68
     entity_category: config
@@ -325,7 +326,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 71
     entity_category: config
@@ -339,7 +340,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 0
     entity_category: config
@@ -353,7 +354,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 30
     entity_category: config
@@ -367,7 +368,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 39
     entity_category: config
@@ -381,7 +382,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 49
     entity_category: config
@@ -395,7 +396,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 55
     entity_category: config
@@ -409,7 +410,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 61
     entity_category: config
@@ -423,7 +424,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 67
     entity_category: config
@@ -437,7 +438,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 72
     entity_category: config
@@ -451,7 +452,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 79
     entity_category: config
@@ -465,7 +466,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 85
     entity_category: config
@@ -479,7 +480,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 90
     entity_category: config
@@ -493,7 +494,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 65
     entity_category: config
@@ -507,7 +508,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 68
     entity_category: config
@@ -521,7 +522,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 72
     entity_category: config
@@ -535,7 +536,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 76
     entity_category: config
@@ -549,7 +550,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 82
     entity_category: config
@@ -563,7 +564,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 85
     entity_category: config
@@ -577,7 +578,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 90
     entity_category: config
@@ -591,7 +592,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 95
     entity_category: config
@@ -605,7 +606,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 102
     entity_category: config
@@ -619,7 +620,7 @@ number:
     min_value: 0
     max_value: 120
     step: 1
-    restore_value: true
+    restore_value: false
     optimistic: true
     initial_value: 110
     entity_category: config
@@ -689,6 +690,7 @@ button:
                   id(${hp_id}_odu_runtime_heating_f19),
                   id(${hp_id}_odu_runtime_heating_f20),
               },
+              &id(${hp_id}_runtime_frequency_table_loaded),
               &id(${hp_id}_runtime_frequency_write_operation_token),
           };
           if (id(${hp_id}_runtime_frequency_write_verification_pending)) {
@@ -762,6 +764,7 @@ button:
                   id(${hp_id}_odu_runtime_heating_f19),
                   id(${hp_id}_odu_runtime_heating_f20),
               },
+              &id(${hp_id}_runtime_frequency_table_loaded),
               &id(${hp_id}_runtime_frequency_write_operation_token),
           };
           if (id(${hp_id}_runtime_frequency_write_verification_pending)) {

--- a/openquatt/includes/control/oq_supervisory_safety_logic.h
+++ b/openquatt/includes/control/oq_supervisory_safety_logic.h
@@ -32,6 +32,7 @@ struct State {
   bool flow_recovery_timing = false;
   uint32_t flow_recovery_since_ms = 0;
   bool low_flow_fault_active = false;
+  bool frost_initialized = false;
   bool frost_active = false;
 };
 
@@ -110,8 +111,14 @@ inline Output step(const Input& input, const Config& config, State state) {
       frost_thresholds_valid && input.outside_temperature_has_state && std::isfinite(input.outside_temperature_c);
   if (input.thermal_request) {
     state.frost_active = false;
+    state.frost_initialized = true;
   } else if (!outside_temperature_valid) {
     state.frost_active = !frost_nan_grace_active;
+    if (!frost_nan_grace_active) state.frost_initialized = true;
+  } else if (!state.frost_initialized) {
+    // Reconstruct the non-persistent hysteresis conservatively after boot.
+    state.frost_active = input.outside_temperature_c < config.frost_off_c;
+    state.frost_initialized = true;
   } else if (state.frost_active) {
     state.frost_active = input.outside_temperature_c < config.frost_off_c;
   } else {

--- a/openquatt/includes/control/oq_supervisory_safety_runtime.h
+++ b/openquatt/includes/control/oq_supervisory_safety_runtime.h
@@ -25,7 +25,7 @@ class Runtime {
   oq_supervisory_safety::Output tick(const TickConfig& tick) {
     if (!this->hydrated_) {
       this->state_.low_flow_fault_active = id(oq_lowflow_fault_active);
-      this->state_.frost_active = id(oq_cm_frost_prev);
+      // Frost hysteresis is reconstructed conservatively on the first step.
       this->hydrated_ = true;
     }
 

--- a/openquatt/includes/experimental/oq_odu_runtime_frequency_table.h
+++ b/openquatt/includes/experimental/oq_odu_runtime_frequency_table.h
@@ -34,6 +34,7 @@ struct RuntimeFrequencyTableRefs {
   bool extended_layout;
   std::array<esphome::number::Number*, EXTENDED_LEVEL_COUNT> cooling_desired;
   std::array<esphome::number::Number*, EXTENDED_LEVEL_COUNT> heating_desired;
+  bool* table_loaded;
   uint32_t* write_operation_token;
 };
 
@@ -130,6 +131,7 @@ inline void finish_apply_readback(const RuntimeFrequencyTableRefs& refs, const R
     publish_status(refs, "VERIFY_FAILED: readback mismatch");
     return;
   }
+  *refs.table_loaded = true;
   publish_runtime_table(refs, actual);
   publish_status(refs, "APPLIED: runtime table written and read back");
 }
@@ -176,6 +178,7 @@ inline void queue_apply_readback(RuntimeFrequencyTableRefs refs, RuntimeFrequenc
 }
 
 inline void finish_load(const RuntimeFrequencyTableRefs& refs, const RuntimeFrequencyTables& tables) {
+  *refs.table_loaded = true;
   publish_runtime_table(refs, tables);
   publish_register_progress(refs, "LOADED", runtime_register_count(tables.level_count),
                             runtime_register_count(tables.level_count));
@@ -204,6 +207,7 @@ inline void load_runtime_table(RuntimeFrequencyTableRefs refs) {
     publish_status(refs, "BLOCKED: EEPROM dump active");
     return;
   }
+  *refs.table_loaded = false;
   publish_status(refs, "LOAD_REQUESTED");
   const uint32_t operation_token = ++*refs.write_operation_token;
   auto cmd = esphome::modbus_controller::ModbusCommandItem::create_read_command(
@@ -239,6 +243,10 @@ inline void apply_runtime_table(RuntimeFrequencyTableRefs refs, bool enabled) {
   }
   if (!enabled) {
     publish_status(refs, "BLOCKED: enable switch is off");
+    return;
+  }
+  if (!*refs.table_loaded) {
+    publish_status(refs, "BLOCKED: load ODU runtime table first");
     return;
   }
 

--- a/openquatt/includes/storage/oq_nvs_cleanup.h
+++ b/openquatt/includes/storage/oq_nvs_cleanup.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <array>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <span>
+
+#include "nvs.h"
+#include "nvs_flash.h"
+#include "esphome/core/entity_base.h"
+#include "esphome/core/log.h"
+
+namespace oq_nvs_cleanup {
+
+static constexpr const char* TAG = "openquatt.nvs";
+static constexpr const char* ESPHOME_NAMESPACE = "esphome";
+
+inline void log_stats(const char* phase) {
+  nvs_stats_t stats{};
+  const esp_err_t err = nvs_get_stats(nullptr, &stats);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "NVS stats unavailable at %s: %s", phase, esp_err_to_name(err));
+    return;
+  }
+  ESP_LOGI(TAG, "NVS %s: used=%u free=%u available=%u total=%u namespaces=%u", phase,
+           static_cast<unsigned>(stats.used_entries), static_cast<unsigned>(stats.free_entries),
+           static_cast<unsigned>(stats.available_entries), static_cast<unsigned>(stats.total_entries),
+           static_cast<unsigned>(stats.namespace_count));
+}
+
+inline bool erase_esphome_preferences(std::span<const uint32_t> keys, const char* reason) {
+  nvs_handle_t handle{};
+  const esp_err_t open_err = nvs_open(ESPHOME_NAMESPACE, NVS_READWRITE, &handle);
+  if (open_err != ESP_OK) {
+    ESP_LOGE(TAG, "Could not open retired preferences for %s: %s", reason, esp_err_to_name(open_err));
+    log_stats("cleanup-open-failed");
+    return false;
+  }
+
+  size_t erased = 0U;
+  size_t failed = 0U;
+  for (const uint32_t key : keys) {
+    char key_text[12];
+    std::snprintf(key_text, sizeof(key_text), "%" PRIu32, key);
+    const esp_err_t erase_err = nvs_erase_key(handle, key_text);
+    if (erase_err == ESP_OK) {
+      ++erased;
+    } else if (erase_err != ESP_ERR_NVS_NOT_FOUND) {
+      ++failed;
+      ESP_LOGE(TAG, "Could not retire preference key %s for %s: %s", key_text, reason, esp_err_to_name(erase_err));
+    }
+  }
+
+  esp_err_t commit_err = ESP_OK;
+  if (erased > 0U) commit_err = nvs_commit(handle);
+  nvs_close(handle);
+
+  if (commit_err != ESP_OK) {
+    ESP_LOGE(TAG, "Could not commit retired preferences for %s: %s", reason, esp_err_to_name(commit_err));
+    ++failed;
+  }
+  if (erased > 0U || failed > 0U) {
+    ESP_LOGI(TAG, "Retired preferences for %s: erased=%u failed=%u", reason, static_cast<unsigned>(erased),
+             static_cast<unsigned>(failed));
+    log_stats("after-cleanup");
+  }
+  return failed == 0U;
+}
+
+inline uint32_t legacy_entity_preference_key(esphome::EntityBase* entity) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const uint32_t key = entity->get_preference_hash();
+#pragma GCC diagnostic pop
+  return key;
+}
+
+template <size_t N>
+inline bool erase_entity_preferences(const std::array<esphome::EntityBase*, N>& entities, const char* reason) {
+  std::array<uint32_t, N> keys{};
+  for (size_t index = 0; index < N; ++index) keys[index] = legacy_entity_preference_key(entities[index]);
+  return erase_esphome_preferences(keys, reason);
+}
+
+}  // namespace oq_nvs_cleanup

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -31,6 +31,55 @@ esphome:
     priority: -100
     then:
       - lambda: |-
+          // Retire only the former RAM-editor preferences; ODU registers remain authoritative.
+          const std::array<esphome::EntityBase*, 42> retired_runtime_editor_preferences{{
+              id(${hp_id}_odu_runtime_cooling_f0),
+              id(${hp_id}_odu_runtime_cooling_f1),
+              id(${hp_id}_odu_runtime_cooling_f2),
+              id(${hp_id}_odu_runtime_cooling_f3),
+              id(${hp_id}_odu_runtime_cooling_f4),
+              id(${hp_id}_odu_runtime_cooling_f5),
+              id(${hp_id}_odu_runtime_cooling_f6),
+              id(${hp_id}_odu_runtime_cooling_f7),
+              id(${hp_id}_odu_runtime_cooling_f8),
+              id(${hp_id}_odu_runtime_cooling_f9),
+              id(${hp_id}_odu_runtime_cooling_f10),
+              id(${hp_id}_odu_runtime_cooling_f11),
+              id(${hp_id}_odu_runtime_cooling_f12),
+              id(${hp_id}_odu_runtime_cooling_f13),
+              id(${hp_id}_odu_runtime_cooling_f14),
+              id(${hp_id}_odu_runtime_cooling_f15),
+              id(${hp_id}_odu_runtime_cooling_f16),
+              id(${hp_id}_odu_runtime_cooling_f17),
+              id(${hp_id}_odu_runtime_cooling_f18),
+              id(${hp_id}_odu_runtime_cooling_f19),
+              id(${hp_id}_odu_runtime_cooling_f20),
+              id(${hp_id}_odu_runtime_heating_f0),
+              id(${hp_id}_odu_runtime_heating_f1),
+              id(${hp_id}_odu_runtime_heating_f2),
+              id(${hp_id}_odu_runtime_heating_f3),
+              id(${hp_id}_odu_runtime_heating_f4),
+              id(${hp_id}_odu_runtime_heating_f5),
+              id(${hp_id}_odu_runtime_heating_f6),
+              id(${hp_id}_odu_runtime_heating_f7),
+              id(${hp_id}_odu_runtime_heating_f8),
+              id(${hp_id}_odu_runtime_heating_f9),
+              id(${hp_id}_odu_runtime_heating_f10),
+              id(${hp_id}_odu_runtime_heating_f11),
+              id(${hp_id}_odu_runtime_heating_f12),
+              id(${hp_id}_odu_runtime_heating_f13),
+              id(${hp_id}_odu_runtime_heating_f14),
+              id(${hp_id}_odu_runtime_heating_f15),
+              id(${hp_id}_odu_runtime_heating_f16),
+              id(${hp_id}_odu_runtime_heating_f17),
+              id(${hp_id}_odu_runtime_heating_f18),
+              id(${hp_id}_odu_runtime_heating_f19),
+              id(${hp_id}_odu_runtime_heating_f20),
+          }};
+          oq_nvs_cleanup::erase_entity_preferences(
+              retired_runtime_editor_preferences,
+              "${hp_id} ODU runtime frequency editor");
+      - lambda: |-
           // Runtime identity is deliberately not restored across boots.
           id(${hp_id}_odu_generation_detection_complete) = false;
           id(${hp_id}_odu_generation_request_pending) = false;
@@ -39,6 +88,7 @@ esphome:
           id(${hp_id}_generation_variant_code) =
               static_cast<int>(oq_odu::Variant::UNKNOWN);
           id(${hp_id}_runtime_frequency_snapshot_storage) = {};
+          id(${hp_id}_runtime_frequency_table_loaded) = false;
           id(${hp_id}_compressor_level_profile_request_pending) = false;
           id(${hp_id}_compressor_level_profile_request_token) = 0U;
           id(${hp_id}_runtime_frequency_retry_ms) = 0U;
@@ -73,6 +123,7 @@ modbus_controller:
             id(${hp_id}_generation_variant_code) =
                 static_cast<int>(oq_odu::Variant::UNKNOWN);
             id(${hp_id}_runtime_frequency_snapshot_storage) = {};
+            id(${hp_id}_runtime_frequency_table_loaded) = false;
             id(${hp_id}_compressor_level_profile_request_token) =
                 oq_odu::next_request_token(
                     id(${hp_id}_compressor_level_profile_request_token));
@@ -211,6 +262,12 @@ globals:
     restore_value: no
     initial_value: 'std::array<uint8_t, 46>{}'
 
+  # The editor is writable only after a successful explicit Load in this boot.
+  - id: ${hp_id}_runtime_frequency_table_loaded
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
   - id: ${hp_id}_compressor_level_profile_request_pending
     type: bool
     restore_value: no
@@ -259,6 +316,7 @@ script:
               millis() == 0U ? 1U : millis();
           id(${hp_id}_odu_generation_detection_complete) = false;
           id(${hp_id}_odu_generation_request_pending) = true;
+          id(${hp_id}_runtime_frequency_table_loaded) = false;
           id(${hp_id}_generation).publish_state("Unknown");
           id(${hp_id}_generation_variant_code) =
               static_cast<int>(oq_odu::Variant::UNKNOWN);

--- a/openquatt/oq_api_ingress.yaml
+++ b/openquatt/oq_api_ingress.yaml
@@ -176,7 +176,7 @@ number:
 switch:
   - platform: template
     id: api_input_heating_enable
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ALWAYS_OFF
     optimistic: true
     turn_on_action:
       - switch.template.publish:
@@ -205,7 +205,7 @@ switch:
 
   - platform: template
     id: api_input_cooling_enable
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ALWAYS_OFF
     optimistic: true
     turn_on_action:
       - switch.template.publish:
@@ -236,6 +236,13 @@ esphome:
   on_boot:
     priority: -100
     then:
+      - lambda: |-
+          const std::array<esphome::EntityBase*, 2> retired_api_preferences{{
+              id(api_input_heating_enable),
+              id(api_input_cooling_enable),
+          }};
+          oq_nvs_cleanup::erase_entity_preferences(
+              retired_api_preferences, "API ingress enable state");
       - lambda: |-
           // Ignore template component startup state until real API writes can arrive.
           id(api_input_accept_updates) = false;

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -17,6 +17,7 @@ esphome:
     priority: -100
     then:
       - lambda: |-
+          oq_nvs_cleanup::log_stats("boot");
           // Always start from a clean paused state after reboot or OTA.
           id(oq_runtime_polling_paused).publish_state(false);
           id(oq_http_ota_begin_observed) = false;

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -48,6 +48,12 @@ esphome:
     - priority: -100
       then:
         - lambda: |-
+            constexpr std::array<uint32_t, 1> retired_frost_preferences{{
+                2881445393U,
+            }};
+            oq_nvs_cleanup::erase_esphome_preferences(
+                retired_frost_preferences, "legacy frost hysteresis");
+        - lambda: |-
             id(oq_electrical_current_limit_a).traits.set_max_value(
                 oq_supervisory_power_runtime::maximum_current_a(
                     ${oq_duo_current_limit_v1_a}, ${oq_duo_current_limit_v2_a}));
@@ -84,10 +90,11 @@ globals:
     restore_value: true
     initial_value: 'false'
 
-  # Frost hysteresis state for CM98 selection
+  # Runtime-only frost hysteresis. The first evaluation starts conservatively
+  # at the off-threshold, so a reboot cannot weaken frost protection.
   - id: oq_cm_frost_prev
     type: bool
-    restore_value: true
+    restore_value: false
     initial_value: 'false'
 
   # Pre/Postflow timer (CM1)

--- a/scripts/check_nvs_budget.py
+++ b/scripts/check_nvs_budget.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Fail when a validated ESPHome config leaves too little usable NVS space.
+
+ESP-IDF NVS stores ESPHome preferences as blobs. A blob consumes two metadata
+entries plus one 32-byte entry per payload chunk. One page is kept available
+for garbage collection, so it is excluded from the usable capacity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+NVS_PAGE_SIZE = 4096
+NVS_ENTRIES_PER_PAGE = 126
+NVS_GC_RESERVED_PAGES = 1
+REQUIRED_AVAILABLE_ENTRIES = 126
+
+# Custom OpenQuatt preferences: MQTT config 11, web auth 6, crash state 4,
+# usage telemetry 3, network preference 3 and incident reset journal 9.
+CUSTOM_PREFERENCE_ENTRIES = 36
+# Namespace records, ESPHome safe-mode/WiFi/PHY state and estimation margin.
+ESP_SYSTEM_RESERVE_ENTRIES = 14
+
+CPP_SCALAR_BYTES = {
+    "bool": 1,
+    "float": 4,
+    "int": 4,
+    "int32_t": 4,
+    "uint32_t": 4,
+}
+
+
+def blob_entries(payload_bytes: int) -> int:
+    if payload_bytes < 0:
+        raise ValueError("NVS payload size cannot be negative")
+    return 2 + math.ceil(payload_bytes / 32)
+
+
+def cpp_type_bytes(type_name: str) -> int:
+    type_name = type_name.strip()
+    if type_name in CPP_SCALAR_BYTES:
+        return CPP_SCALAR_BYTES[type_name]
+    array_match = re.fullmatch(r"(.+?)\[(\d+)]", type_name)
+    if array_match:
+        return cpp_type_bytes(array_match.group(1)) * int(array_match.group(2))
+    raise ValueError(f"Unknown restored global type {type_name!r}; extend the NVS estimator")
+
+
+def parse_nvs_partition_size(partition_path: Path) -> int:
+    with partition_path.open(encoding="utf-8", newline="") as partition_file:
+        for row in csv.reader(partition_file):
+            fields = [field.strip() for field in row]
+            if not fields or fields[0].startswith("#") or fields[0] != "nvs":
+                continue
+            if len(fields) < 5:
+                raise ValueError(f"Malformed NVS partition row in {partition_path}")
+            return int(fields[4], 0)
+    raise ValueError(f"No NVS partition found in {partition_path}")
+
+
+def _add(category_entries: dict[str, int], category_keys: dict[str, int], category: str, payload_bytes: int) -> None:
+    category_entries[category] += blob_entries(payload_bytes)
+    category_keys[category] += 1
+
+
+def estimate_entity_preferences(config: Any) -> tuple[dict[str, int], dict[str, int]]:
+    entries: dict[str, int] = defaultdict(int)
+    keys: dict[str, int] = defaultdict(int)
+
+    for item in config.get("globals", []):
+        if item.get("restore_value") is True:
+            _add(entries, keys, "globals", cpp_type_bytes(str(item["type"])))
+
+    for item in config.get("number", []):
+        if item.get("restore_value") is True:
+            _add(entries, keys, "numbers", 4)
+
+    for item in config.get("select", []):
+        if item.get("restore_value") is True:
+            _add(entries, keys, "selects", 4)
+
+    for item in config.get("switch", []):
+        if str(item.get("restore_mode", "")).startswith("RESTORE"):
+            _add(entries, keys, "switches", 1)
+
+    for item in config.get("datetime", []):
+        if item.get("restore_value") is True:
+            _add(entries, keys, "datetimes", 16)
+
+    for item in config.get("text", []):
+        if item.get("restore_value") is True:
+            _add(entries, keys, "texts", int(item["max_length"]) + 1)
+
+    for item in config.get("sensor", []):
+        if item.get("restore") is True:
+            _add(entries, keys, "restored sensors", 4)
+
+    for item in config.get("climate", []):
+        if item.get("platform") == "pid":
+            _add(entries, keys, "PID climates", 16)
+
+    return dict(entries), dict(keys)
+
+
+def load_validated_config(config_path: Path) -> Any:
+    from esphome.config import read_config
+    from esphome.core import CORE
+
+    CORE.config_path = config_path
+    return read_config({}, skip_external_update=True)
+
+
+def check_config(config_path: Path) -> int:
+    config = load_validated_config(config_path)
+    partition_path = Path(config["esp32"]["partitions"])
+    partition_size = parse_nvs_partition_size(partition_path)
+    pages = partition_size // NVS_PAGE_SIZE
+    if partition_size % NVS_PAGE_SIZE or pages <= NVS_GC_RESERVED_PAGES:
+        raise ValueError(f"Unsupported NVS partition size: 0x{partition_size:X}")
+
+    entity_entries, entity_keys = estimate_entity_preferences(config)
+    usable_entries = (pages - NVS_GC_RESERVED_PAGES) * NVS_ENTRIES_PER_PAGE
+    reserved_entries = CUSTOM_PREFERENCE_ENTRIES + ESP_SYSTEM_RESERVE_ENTRIES
+    estimated_entries = sum(entity_entries.values()) + reserved_entries
+    available_entries = usable_entries - estimated_entries
+
+    for category in sorted(entity_entries):
+        print(f"{category:18} keys={entity_keys[category]:3} entries={entity_entries[category]:3}")
+    print(f"{'OpenQuatt/system':18} keys={'-':>3} entries={reserved_entries:3}")
+    print(
+        f"NVS budget: partition=0x{partition_size:X} usable={usable_entries} "
+        f"estimated={estimated_entries} available={available_entries} "
+        f"required={REQUIRED_AVAILABLE_ENTRIES}"
+    )
+    if available_entries < REQUIRED_AVAILABLE_ENTRIES:
+        print("NVS budget: FAIL")
+        return 1
+    print("NVS budget: PASS")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", type=Path, help="Validated ESPHome config to inspect")
+    args = parser.parse_args()
+    return check_config(args.config.resolve())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -505,6 +505,13 @@ def validate_command(args: argparse.Namespace) -> int:
             log_path=log_dir / f"{stem}.config.log",
             label=f"config {config}",
         )
+        run_logged(
+            [*helper_python, str(command_scripts_dir / "check_nvs_budget.py"), config],
+            cwd=command_root,
+            env=env,
+            log_path=log_dir / f"{stem}.nvs-budget.log",
+            label=f"NVS budget {config}",
+        )
 
     if args.config_only:
         print()

--- a/scripts/tests/test_nvs_persistence_contract.py
+++ b/scripts/tests/test_nvs_persistence_contract.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_nvs_budget  # noqa: E402
+
+
+ODU_EDITOR = (ROOT / "openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml").read_text()
+ODU_RUNTIME = (ROOT / "openquatt/includes/experimental/oq_odu_runtime_frequency_table.h").read_text()
+HP_IO = (ROOT / "openquatt/oq_HP_io.yaml").read_text()
+API_INGRESS = (ROOT / "openquatt/oq_api_ingress.yaml").read_text()
+NVS_CLEANUP = (ROOT / "openquatt/includes/storage/oq_nvs_cleanup.h").read_text()
+DEV = (ROOT / "scripts/dev.py").read_text()
+CRASH_HEADER = (ROOT / "components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h").read_text()
+AUTH_HEADER = (ROOT / "components/openquatt_web_auth/OpenQuattWebAuth.h").read_text()
+
+
+class NvsPersistenceContractTest(unittest.TestCase):
+    def test_odu_editor_is_ram_only_and_requires_a_current_boot_load(self) -> None:
+        self.assertEqual(ODU_EDITOR.count("restore_value: false"), 42)
+        self.assertNotIn("restore_value: true", ODU_EDITOR)
+        self.assertIn("runtime_frequency_table_loaded", HP_IO)
+        self.assertIn("BLOCKED: load ODU runtime table first", ODU_RUNTIME)
+        self.assertIn("erase_entity_preferences", HP_IO)
+
+    def test_api_enable_inputs_are_session_state(self) -> None:
+        self.assertEqual(API_INGRESS.count("restore_mode: ALWAYS_OFF"), 2)
+        self.assertNotIn("restore_mode: RESTORE_DEFAULT_OFF", API_INGRESS)
+        self.assertIn('"API ingress enable state"', API_INGRESS)
+
+    def test_cleanup_is_targeted_and_never_erases_the_partition(self) -> None:
+        self.assertIn('nvs_open(ESPHOME_NAMESPACE, NVS_READWRITE', NVS_CLEANUP)
+        self.assertIn("nvs_erase_key", NVS_CLEANUP)
+        self.assertNotIn("nvs_flash_erase", NVS_CLEANUP)
+
+    def test_budget_math_and_validation_integration(self) -> None:
+        self.assertEqual(check_nvs_budget.blob_entries(1), 3)
+        self.assertEqual(check_nvs_budget.blob_entries(32), 3)
+        self.assertEqual(check_nvs_budget.blob_entries(33), 4)
+        self.assertEqual(check_nvs_budget.blob_entries(256), 10)
+        self.assertEqual(check_nvs_budget.cpp_type_bytes("uint32_t[3]"), 12)
+        self.assertEqual(check_nvs_budget.REQUIRED_AVAILABLE_ENTRIES, 126)
+        self.assertIn("check_nvs_budget.py", DEV)
+
+    def test_custom_blob_sizes_are_compile_time_budget_contracts(self) -> None:
+        self.assertIn("sizeof(StateStorage) == 56U", CRASH_HEADER)
+        self.assertIn("sizeof(AuthStorage) == 104U", AUTH_HEADER)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_openquatt_network_contract.py
+++ b/scripts/tests/test_openquatt_network_contract.py
@@ -74,6 +74,13 @@ class OpenQuattNetworkContractTest(unittest.TestCase):
         self.assertIn('active_connection == "Ethernet"', USAGE_TELEMETRY_CPP)
         self.assertIn('connection_preference == "Automatic"', USAGE_TELEMETRY_CPP)
 
+    def test_preference_change_is_published_only_after_nvs_readback(self) -> None:
+        save = function_body("save_preference_(Preference preference)", "publish_preference_()")
+        self.assertLess(save.index("global_preferences->sync()"), save.index("preference_store_.load"))
+        self.assertLess(save.index("preference_store_.load"), save.index("this->preference_ = preference"))
+        self.assertIn('log_stats("network-preference-write-failed")', save)
+        self.assertIn("sizeof(PreferenceStorage) == 8U", NETWORK_HEADER)
+
     def test_q_installer_uses_canonical_automatic_builds_with_wifi_provisioning(self) -> None:
         self.assertIn(
             'fileName: "openquatt-heatpump-controller-q-single.firmware.factory.bin"',

--- a/scripts/tests/test_supervisory_safety_contract.py
+++ b/scripts/tests/test_supervisory_safety_contract.py
@@ -31,7 +31,11 @@ class SupervisorySafetyContractTest(unittest.TestCase):
             "id(hp2_compressor_level)",
         ):
             self.assertIn(marker, RUNTIME)
-        self.assertIn("restore_value: true\n    initial_value: 'false'", SUPERVISOR)
+        frost_global = SUPERVISOR.split("id: oq_cm_frost_prev", 1)[1].split("# Pre/Postflow", 1)[0]
+        self.assertIn("restore_value: false", frost_global)
+        self.assertIn("2881445393U", SUPERVISOR)
+        self.assertIn("frost_initialized", LOGIC)
+        self.assertIn("config.frost_off_c", LOGIC)
         self.assertIn("id: oq_lowflow_fault_active", SUPERVISOR)
 
     def test_logic_covers_failure_boundaries(self) -> None:

--- a/tests/host/supervisory_safety_logic_test.cpp
+++ b/tests/host/supervisory_safety_logic_test.cpp
@@ -93,10 +93,22 @@ int main() {
   output = step(input(500, true, 300.0f, 0.0f), config(), output.state);
   assert(!output.frost_active);
 
+  // On a cold boot, the gap between the on/off thresholds must fail safe.
+  output = step(input(100, false, 300.0f, 5.5f), config(), {});
+  assert(output.frost_active);
+  output = step(input(200, false, 300.0f, 6.0f), config(), {});
+  assert(!output.frost_active);
+  output = step(input(300, false, 300.0f, 5.5f), config(), output.state);
+  assert(!output.frost_active);
+
   auto missing_outside = input(1000, false, 300.0f, NAN);
   missing_outside.outside_temperature_has_state = false;
   output = step(missing_outside, config(), {});
   assert(output.frost_nan_grace_active && !output.frost_active);
+  auto delayed_outside = input(2000, false, 300.0f, 5.5f);
+  output = step(delayed_outside, config(), output.state);
+  assert(output.frost_active && output.state.frost_initialized);
+  output = step(missing_outside, config(), {});
   missing_outside.now_ms = 30999;
   output = step(missing_outside, config(), output.state);
   assert(output.frost_nan_grace_active && !output.frost_active);
@@ -108,9 +120,11 @@ int main() {
   output = step(missing_outside, config(), output.state);
   assert(output.frost_active);
 
-  State restored_frost;
-  restored_frost.frost_active = true;
-  output = step(input(1000, false, 300.0f, 5.5f), config(), restored_frost);
+  State active_frost_hysteresis;
+  active_frost_hysteresis.initialized = true;
+  active_frost_hysteresis.frost_initialized = true;
+  active_frost_hysteresis.frost_active = true;
+  output = step(input(1000, false, 300.0f, 5.5f), config(), active_frost_hysteresis);
   assert(output.frost_active);
   auto invalid_frost_config = config();
   invalid_frost_config.frost_on_c = 7.0f;


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert onnodige NVS-persistence van 84 ODU-runtimefrequentievelden, de twee API-enable-ingangen en de frost-hysteresisstate; de ODU-editor vereist voortaan een succesvolle Load in dezelfde boot vóór Apply.
- Ruimt uitsluitend de bekende retired preferencekeys op en logt NVS-capaciteit bij boot en schrijffouten; er vindt nooit een volledige NVS-erase plaats.
- Voegt een build-time NVS-budgetcheck en duurzame sync/readback voor de netwerkvoorkeur toe.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Entity-ID's en instelbereiken blijven gelijk. De ODU blijft bron van waarheid voor de experimentele frequentietabel; RAM-editorwaarden worden niet meer over boots hersteld. Frost-hysteresis wordt bij de eerste geldige meting conservatief gereconstrueerd. API-enable-ingangen starten na iedere boot uit en wachten op nieuwe API-data. Er zijn geen nieuwe diagnostische sensoren toegevoegd.

## Achtergrond

Closes #588.

De Q Duo-config komt statisch uit op 492 geschatte gebruikte entries en 138 beschikbare entries, bij een vereiste marge van 126. Gerichte cleanup migreert bestaande installaties zonder WiFi, authenticatie, MQTT of gebruikersinstellingen te wissen.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen entity-ID's of ondersteunde installatiestappen wijzigen. Het aangepaste Load-vóór-Apply-contract betreft interne experimentele ODU-controls en is in de bronbeschrijving vastgelegd.

## Validatie

- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe dynamische allocaties, taken of buffers. Alleen begrensde bool-state en tijdelijke boot-cleanuparrays; de definitieve Q Duo WiFi-build gebruikt 210527 bytes DIRAM (61,6%).

Uitgevoerd:

- `npm run check:python-contracts` — 177 tests geslaagd.
- `./scripts/run_host_regression_tests.sh` — 58 hosttests geslaagd. De lokale Apple CLT-installatie vereiste een expliciete SDK C++-include-path.
- `npm run check:cpp-format` — geslaagd.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — inclusief NVS-budgetcheck geslaagd.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd; firmware 2188511 bytes, flash 41,7%, DIRAM 61,6%.
- Q Duo WiFi upgrade-/reboot-HIL vanaf v0.49.0:
  - OTA zonder NVS-erase of verlies van instellingen;
  - 2 retired API-ingresskeys verwijderd;
  - `available_entries` steeg van 298 naar 304;
  - tweede boot bleef exact stabiel op `used=326`, `available=304`;
  - netwerkvoorkeur `Automatic`, actieve WiFi, safe-mode bootbevestiging en 240s startup-inhibit herstelden correct.

Resterende HIL-beperking: deze installatie bevatte geen oude ODU-editor- of frost-key. Volledige synthetische NVS-populatie en geforceerde page rotation zijn niet op de productie-installatie uitgevoerd.