### PR TITLE
Reconstructeer frost-hysteresis na warmtevraag

### DIFF
--- a/openquatt/includes/control/oq_supervisory_safety_logic.h
+++ b/openquatt/includes/control/oq_supervisory_safety_logic.h
@@ -111,7 +111,6 @@ inline Output step(const Input& input, const Config& config, State state) {
       frost_thresholds_valid && input.outside_temperature_has_state && std::isfinite(input.outside_temperature_c);
   if (input.thermal_request) {
     state.frost_active = false;
-    state.frost_initialized = true;
   } else if (!outside_temperature_valid) {
     state.frost_active = !frost_nan_grace_active;
     if (!frost_nan_grace_active) state.frost_initialized = true;

--- a/tests/host/supervisory_safety_logic_test.cpp
+++ b/tests/host/supervisory_safety_logic_test.cpp
@@ -91,7 +91,7 @@ int main() {
   output = step(input(400, false, 300.0f, 5.0f), config(), output.state);
   assert(!output.frost_active);
   output = step(input(500, true, 300.0f, 0.0f), config(), output.state);
-  assert(!output.frost_active);
+  assert(!output.frost_active && output.state.frost_initialized);
 
   // On a cold boot, the gap between the on/off thresholds must fail safe.
   output = step(input(100, false, 300.0f, 5.5f), config(), {});
@@ -100,6 +100,12 @@ int main() {
   assert(!output.frost_active);
   output = step(input(300, false, 300.0f, 5.5f), config(), output.state);
   assert(!output.frost_active);
+
+  // Thermal demand suppresses frost but cannot initialize a cold-boot state.
+  output = step(input(100, true, 300.0f, 5.5f), config(), {});
+  assert(!output.frost_active && !output.state.frost_initialized);
+  output = step(input(200, false, 300.0f, 5.5f), config(), output.state);
+  assert(output.frost_active && output.state.frost_initialized);
 
   auto missing_outside = input(1000, false, 300.0f, NAN);
   missing_outside.outside_temperature_has_state = false;


### PR DESCRIPTION
# Wat verandert deze PR?

- Laat een cold-boot frost-hysteresis tijdens actieve warmtevraag ongeïnitialiseerd.
- Reconstructeert de hysteresis bij het einde van de warmtevraag conservatief via `frost_off_c`.
- Voegt een hostregressietest toe voor reboot → warmtevraag → 5,5 °C zonder warmtevraag.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Na een reboot tijdens warmtevraag wordt frost nog steeds onderdrukt. Zodra de warmtevraag eindigt, wordt een nog onbekende hysteresisstand nu conservatief gereconstrueerd. Een al geïnitialiseerde hysteresis blijft tijdens warmtevraag behouden.

## Achtergrond

Aanvullende fix op #597 naar aanleiding van [reviewcommentaar](https://github.com/OpenQuatt/OpenQuatt/pull/597#discussion_r3902806687). Zonder deze fix markeerde warmtevraag de niet-persistente hysteresis als geïnitialiseerd; bij 5,5 °C kon frost daardoor na het einde van de warmtevraag uit blijven.

De complete diff tegen `dev` is gecontroleerd op reboot/fresh-install, overgang tijdens en na warmtevraag, ongeldige buitentemperatuur en NaN-grace, bestaande hysteresis, NVS/migratie, flowbeveiliging en geheugenimpact. Een aparte koude review leverde geen aanvullende bevindingen op.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne correctie van transient control-state; geen entities, configuratie of gebruikersflow wijzigt.

## Validatie

- `npm run check:python-contracts` — 177 tests geslaagd
- `./scripts/run_host_regression_tests.sh` — 58 tests geslaagd
- `npm run check:cpp-format` — geslaagd
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd, inclusief ESPHome-config en NVS-budget
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd
- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen een bestaande boolean-stateovergang en hosttest wijzigen; geen allocaties, objectgroottes, buffers of task-stacks gewijzigd.