### PR TITLE
YAML naar C++: Externe inputs en bronselectie

### DIFF
--- a/docs/yaml-naar-cpp-migratieplan.md
+++ b/docs/yaml-naar-cpp-migratieplan.md
@@ -45,10 +45,60 @@ entities, configuratie, koppelingen en één of enkele runtime-aanroepen.
 | Supervisory state-machine | Resterende hoofdloop naar C++ | Gereed | #583 |
 | Strategy runtimes | Heating Curve, Power House, Cooling en managerbinding | Gereed | #584 |
 | Hydraulics en outputs | Flow Control, Thermal Limits en Auxiliary Relay | Gereed | #589 |
-| Boiler runtime | Commandocapture, outputcontroller en transportbinding | Klaar voor review | #595 |
-| Bronselectie-opruiming | Generieke selectie/freshness waar dit YAML werkelijk verkleint | Beslispunt na bovenstaande blokken | Nog te bepalen |
+| Boiler runtime | Commandocapture, outputcontroller en transportbinding | Gereed | #595 |
+| Externe inputs en bronselectie | API-freshness plus generieke, brongebonden selectie | Go onder harde LOC- en testbaarheidsgrens | Nog te bepalen |
 
-## Actueel werkblok: Boiler runtime
+## Besluit volgend werkblok: externe inputs en bronselectie
+
+De go/no-go-analyse op `dev` commit `1afdf23c` geeft een voorwaardelijke **go**
+voor één gebundeld vervolgblok. De reden is niet alleen YAML-grootte:
+
+- `oq_sensor_sources.yaml` en `oq_api_ingress.yaml` tellen samen 1.461 regels,
+  waarvan 31 inline lambdas samen 815 regels uitvoerbare C++ bevatten;
+- de API-ingress-lifecycle en de bronselectiematrix hebben nog geen directe
+  hostregressies. Alleen de bestaande supply-calibratie- en holdhelpers zijn
+  rechtstreeks afgedekt;
+- de huidige HA-hold voor buiten-, kamer- en setpointtemperatuur onthoudt niet
+  welke bron de cache vulde. Na een bronwissel kan daardoor maximaal 300 s een
+  waarde van bijvoorbeeld Outdoor unit, OpenTherm, CIC, API of MQTT als
+  HA-helde waarde terugkomen;
+- OpenTherm-freshness wordt in Heating Curve aanvullend gecontroleerd, maar niet
+  in het canonieke geselecteerde kamer-/setpointsignaal dat ook Power House en
+  Cooling gebruiken;
+- de API-ingress gebruikt `last_valid_ms == 0` als ontbrekend-sentinel, waardoor
+  een update exact op `millis()`-rollover tijdelijk als ontbrekend geldt. De
+  externe-warmtevraagpublicatie wordt bovendien pas in de 5 s-cadans geldig,
+  anders dan de overige API-inputs.
+
+Scope van één PR:
+
+1. Een pure freshness-/holdkern met bronidentiteit, rolloverveilige tijd en
+   expliciete missing/finite-contracten.
+2. Een API-ingressruntime voor de zeven bestaande inputslots, met behoud van
+   entity-ID's, stale-tijden en reboot-reset.
+3. Een bronselectieruntime voor wateraanvoer, flow, buiten-/kamertemperatuur,
+   kamer-setpoint, externe warmtevraag en heating/cooling enable.
+4. Compacte YAML-binding op de bestaande updatecadans; geen centralisatie die
+   de huidige 5 s/10 s- of eventtiming verandert.
+
+Harde uitvoeringsgrenzen:
+
+- YAML-doel voor de twee hoofdbestanden: maximaal 750 regels samen;
+- totale productiecode van het werkblok groeit niet; tests en dit plan worden
+  afzonderlijk gerapporteerd;
+- entities, opties, standaardwaarden, stale-tijden en HA/MQTT/CIC/OpenTherm-
+  contracten blijven gelijk, behalve expliciet geteste fail-closed correcties;
+- hosttests dekken alle bronmatrices, cross-source hold, stale/NaN/Inf,
+  bronwissels, reboot, timestamp nul en `millis()`-rollover;
+- HIL dekt API-write/expiry/herstel, bronwissels tijdens actieve vraag,
+  heating/cooling-enable fail-closed en reboot zonder stale replay. Niet lokaal
+  injecteerbare PT1000-paden blijven aanvullend hostmatig afgedekt.
+
+Als een compacte pure kern plus runtime deze grenzen niet haalt, stopt dit
+werkblok vóór publicatie. Grote declaratieve YAML, protocolmapping of korte
+bindingslambdas worden niet ter wille van de vorm naar C++ verplaatst.
+
+## Afgerond werkblok: Boiler runtime
 
 Doel: dispatch, outputbeslissingen en de R1/OpenTherm-lifecycle achter één
 transportneutraal C++-contract brengen. YAML blijft eigenaar van entities,

--- a/docs/yaml-naar-cpp-migratieplan.md
+++ b/docs/yaml-naar-cpp-migratieplan.md
@@ -46,14 +46,14 @@ entities, configuratie, koppelingen en één of enkele runtime-aanroepen.
 | Strategy runtimes | Heating Curve, Power House, Cooling en managerbinding | Gereed | #584 |
 | Hydraulics en outputs | Flow Control, Thermal Limits en Auxiliary Relay | Gereed | #589 |
 | Boiler runtime | Commandocapture, outputcontroller en transportbinding | Gereed | #595 |
-| Externe inputs en bronselectie | API-freshness plus generieke, brongebonden selectie | Go onder harde LOC- en testbaarheidsgrens | Nog te bepalen |
+| Externe inputs en bronselectie | API-freshness plus generieke, brongebonden selectie | Gereed; PR volgt | Nog te bepalen |
 
 ## Besluit volgend werkblok: externe inputs en bronselectie
 
-De go/no-go-analyse op `dev` commit `1afdf23c` geeft een voorwaardelijke **go**
+De go/no-go-analyse, herijkt op `dev` commit `3c879b1b`, geeft een voorwaardelijke **go**
 voor één gebundeld vervolgblok. De reden is niet alleen YAML-grootte:
 
-- `oq_sensor_sources.yaml` en `oq_api_ingress.yaml` tellen samen 1.461 regels,
+- `oq_sensor_sources.yaml` en `oq_api_ingress.yaml` tellen samen 1.469 regels,
   waarvan 31 inline lambdas samen 815 regels uitvoerbare C++ bevatten;
 - de API-ingress-lifecycle en de bronselectiematrix hebben nog geen directe
   hostregressies. Alleen de bestaande supply-calibratie- en holdhelpers zijn
@@ -97,6 +97,35 @@ Harde uitvoeringsgrenzen:
 Als een compacte pure kern plus runtime deze grenzen niet haalt, stopt dit
 werkblok vóór publicatie. Grote declaratieve YAML, protocolmapping of korte
 bindingslambdas worden niet ter wille van de vorm naar C++ verplaatst.
+
+Afronding:
+
+- de twee doel-YAML's zijn samen 919 regels kleiner: 1.469 naar 550 regels;
+  inclusief de drie nieuwe C++-modules en de aangepaste supply-holdhelper is de
+  productiecode netto 7 regels kleiner. De 286 regels regressietests en netto
+  79 regels plandocumentatie tellen afzonderlijk; de volledige repositorydelta
+  is daardoor +358 regels;
+- de brongebonden HA-hold kan na een bronwissel geen API-, MQTT-, CIC-,
+  OpenTherm- of outdoorwaarde meer herhalen. OpenTherm- en CIC-kamerinputs
+  vereisen nu expliciete freshness en niet-eindige waarden vallen fail-closed;
+- API-ingress accepteert timestamp nul en `millis()`-rollover, begrenst de
+  seconden-naar-millisecondenconversie en publiceert externe warmtevraag direct
+  geldig. Na reboot blijven alle API-slots ongeldig tot een nieuwe write;
+- de volledige hostset (59), Python-contractset (185), C++-formatcontrole en
+  config-/NVS-validatie voor Q, Waveshare en Listener (Single/Duo) zijn groen;
+- Q Duo en Q Single compileren en gebruiken beide 256 bytes minder statisch
+  DIRAM. Het Q Duo-image is 80 bytes groter; het Q Single-image 76 bytes kleiner
+  dan schone `dev`;
+- HIL is geslaagd voor numerieke API-write/expiry/herstel, brongebonden hold,
+  heating/cooling-enable fail-closed, bronwissel vanuit CM2 en reboot zonder
+  stale replay. Beide ODU-diagnostics bleven op nul protocolfouten; de gemeten
+  `Heap Min Free` was na de run 40.168 B;
+- de HIL-firmware gebruikte lokaal 30 s voor API-stale en 10 s voor hold en
+  minimum-off. Productie behoudt de bestaande 0/600/900/1.800 s-inputgrenzen,
+  300 s hold en 240 s minimum-off;
+- na HIL is de toenmalige schone `dev` (`dcd14503`, config hash `0x49534ec7`)
+  teruggezet. De vastgelegde controller- en simulatorinstellingen zijn na reboot
+  opnieuw gecontroleerd; de latere rebase op `3c879b1b` raakte deze runtime niet.
 
 ## Afgerond werkblok: Boiler runtime
 

--- a/openquatt/includes/control/oq_api_ingress_runtime.h
+++ b/openquatt/includes/control/oq_api_ingress_runtime.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include <array>
+#include <math.h>
+#include <stdint.h>
+
+#include "oq_input_source_logic.h"
+
+namespace oq_api_ingress {
+
+enum class Slot : uint8_t {
+  COOLING_DEW_POINT = 0,
+  OUTSIDE_TEMPERATURE,
+  ROOM_TEMPERATURE,
+  ROOM_SETPOINT,
+  HEATING_ENABLE,
+  COOLING_ENABLE,
+  EXTERNAL_HEAT_DEMAND,
+  COUNT,
+};
+
+struct Config {
+  uint32_t cooling_dew_point_stale_s = 0;
+  uint32_t outside_temperature_stale_s = 0;
+  uint32_t room_temperature_stale_s = 0;
+  uint32_t room_setpoint_stale_s = 0;
+  uint32_t heating_enable_stale_s = 0;
+  uint32_t cooling_enable_stale_s = 0;
+  uint32_t external_heat_demand_stale_s = 0;
+};
+
+class Runtime {
+ public:
+  void reset() {
+    accept_updates_ = false;
+    for (auto& state : states_) state.reset();
+    for (uint8_t index = 0; index < slot_count(); index++) publish(static_cast<Slot>(index), {});
+  }
+
+  void set_accept_updates(bool accept) { accept_updates_ = accept; }
+
+  void observe(Slot slot, uint32_t now_ms) {
+    if (!accept_updates_) return;
+    auto& state = states_[index(slot)];
+    if (!entity_valid(slot)) {
+      state.reset();
+      publish(slot, {});
+      return;
+    }
+    state.observe(now_ms);
+    publish(slot, {0.0f, true});
+  }
+
+  void tick(uint32_t now_ms, const Config& config) {
+    for (uint8_t raw_slot = 0; raw_slot < slot_count(); raw_slot++) {
+      const auto slot = static_cast<Slot>(raw_slot);
+      publish(slot, oq_input_source::evaluate_freshness(states_[raw_slot], now_ms, stale_seconds(slot, config),
+                                                        entity_valid(slot)));
+    }
+  }
+
+ private:
+  static constexpr uint8_t kSlotCount = static_cast<uint8_t>(Slot::COUNT);
+  static constexpr uint8_t slot_count() { return kSlotCount; }
+  static constexpr uint8_t index(Slot slot) { return static_cast<uint8_t>(slot); }
+
+  bool accept_updates_ = false;
+  std::array<oq_input_source::TimedState, kSlotCount> states_{};
+
+  static uint32_t stale_seconds(Slot slot, const Config& config) {
+    switch (slot) {
+      case Slot::COOLING_DEW_POINT:
+        return config.cooling_dew_point_stale_s;
+      case Slot::OUTSIDE_TEMPERATURE:
+        return config.outside_temperature_stale_s;
+      case Slot::ROOM_TEMPERATURE:
+        return config.room_temperature_stale_s;
+      case Slot::ROOM_SETPOINT:
+        return config.room_setpoint_stale_s;
+      case Slot::HEATING_ENABLE:
+        return config.heating_enable_stale_s;
+      case Slot::COOLING_ENABLE:
+        return config.cooling_enable_stale_s;
+      case Slot::EXTERNAL_HEAT_DEMAND:
+        return config.external_heat_demand_stale_s;
+      default:
+        return 0;
+    }
+  }
+
+  static bool entity_valid(Slot slot) {
+    switch (slot) {
+      case Slot::COOLING_DEW_POINT:
+        return id(api_input_cooling_dew_point).has_state() && isfinite(id(api_input_cooling_dew_point).state);
+      case Slot::OUTSIDE_TEMPERATURE:
+        return id(api_input_outside_temperature).has_state() && isfinite(id(api_input_outside_temperature).state);
+      case Slot::ROOM_TEMPERATURE:
+        return id(api_input_room_temperature).has_state() && isfinite(id(api_input_room_temperature).state);
+      case Slot::ROOM_SETPOINT:
+        return id(api_input_room_setpoint).has_state() && isfinite(id(api_input_room_setpoint).state);
+      case Slot::EXTERNAL_HEAT_DEMAND:
+        return id(api_input_external_heat_demand).has_state() && isfinite(id(api_input_external_heat_demand).state);
+      case Slot::HEATING_ENABLE:
+      case Slot::COOLING_ENABLE:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  static void publish(Slot slot, const oq_input_source::Freshness& freshness) {
+    switch (slot) {
+      case Slot::COOLING_DEW_POINT:
+        publish_to(id(api_input_cooling_dew_point_age), id(api_input_cooling_dew_point_valid), freshness);
+        break;
+      case Slot::OUTSIDE_TEMPERATURE:
+        publish_to(id(api_input_outside_temperature_age), id(api_input_outside_temperature_valid), freshness);
+        break;
+      case Slot::ROOM_TEMPERATURE:
+        publish_to(id(api_input_room_temperature_age), id(api_input_room_temperature_valid), freshness);
+        break;
+      case Slot::ROOM_SETPOINT:
+        publish_to(id(api_input_room_setpoint_age), id(api_input_room_setpoint_valid), freshness);
+        break;
+      case Slot::HEATING_ENABLE:
+        publish_to(id(api_input_heating_enable_age), id(api_input_heating_enable_valid), freshness);
+        break;
+      case Slot::COOLING_ENABLE:
+        publish_to(id(api_input_cooling_enable_age), id(api_input_cooling_enable_valid), freshness);
+        break;
+      case Slot::EXTERNAL_HEAT_DEMAND:
+        publish_to(id(api_input_external_heat_demand_age), id(api_input_external_heat_demand_valid), freshness);
+        break;
+      default:
+        break;
+    }
+  }
+
+  template <typename A, typename V>
+  static void publish_to(A& age, V& valid, const oq_input_source::Freshness& freshness) {
+    age.publish_state(freshness.age_s);
+    valid.publish_state(freshness.valid);
+  }
+};
+
+inline Runtime& runtime() {
+  static Runtime instance;
+  return instance;
+}
+
+}  // namespace oq_api_ingress

--- a/openquatt/includes/control/oq_input_source_logic.h
+++ b/openquatt/includes/control/oq_input_source_logic.h
@@ -1,0 +1,257 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+
+namespace oq_input_source {
+
+enum class Source : uint8_t {
+  NONE = 0,
+  AUTO,
+  LOCAL,
+  OUTDOOR,
+  CIC,
+  HA,
+  API,
+  MQTT,
+  OPENTHERM,
+  DISABLED,
+  CIC_OR_HA,
+};
+
+struct NumericSample {
+  float value = NAN;
+  bool valid = false;
+};
+
+inline NumericSample numeric_sample(bool enabled, bool has_state, float value) {
+  return {value, enabled && has_state && isfinite(value)};
+}
+
+struct BinarySample {
+  bool value = false;
+  bool valid = false;
+};
+
+struct TimedState {
+  bool has_value = false;
+  uint32_t last_update_ms = 0;
+
+  void reset() {
+    has_value = false;
+    last_update_ms = 0;
+  }
+
+  void observe(uint32_t now_ms) {
+    has_value = true;
+    last_update_ms = now_ms;
+  }
+};
+
+struct Freshness {
+  float age_s = NAN;
+  bool valid = false;
+};
+
+inline uint32_t seconds_to_millis(uint32_t seconds) {
+  constexpr uint32_t max_seconds = UINT32_MAX / 1000U;
+  return seconds > max_seconds ? UINT32_MAX : seconds * 1000U;
+}
+
+inline Freshness evaluate_freshness(const TimedState& state, uint32_t now_ms, uint32_t stale_s, bool entity_valid) {
+  if (!state.has_value || !entity_valid) return {};
+  const uint32_t age_ms = now_ms - state.last_update_ms;
+  return {static_cast<float>(age_ms) / 1000.0f, stale_s == 0U || age_ms <= seconds_to_millis(stale_s)};
+}
+
+struct NumericSources {
+  NumericSample local;
+  NumericSample outdoor;
+  NumericSample cic;
+  NumericSample ha;
+  NumericSample api;
+  NumericSample mqtt;
+  NumericSample opentherm;
+};
+
+inline NumericSample sample_for(Source source, const NumericSources& sources) {
+  switch (source) {
+    case Source::LOCAL:
+      return sources.local;
+    case Source::OUTDOOR:
+      return sources.outdoor;
+    case Source::CIC:
+      return sources.cic;
+    case Source::HA:
+      return sources.ha;
+    case Source::API:
+      return sources.api;
+    case Source::MQTT:
+      return sources.mqtt;
+    case Source::OPENTHERM:
+      return sources.opentherm;
+    default:
+      return {};
+  }
+}
+
+struct NumericSelection {
+  float value = NAN;
+  Source route = Source::NONE;
+  bool valid = false;
+  bool held = false;
+};
+
+struct HoldState {
+  bool has_value = false;
+  float value = NAN;
+  uint32_t last_valid_ms = 0;
+  Source source = Source::NONE;
+
+  void reset() {
+    has_value = false;
+    value = NAN;
+    last_valid_ms = 0;
+    source = Source::NONE;
+  }
+
+  void remember(float current, uint32_t now_ms, Source current_source) {
+    if (!isfinite(current) || current_source == Source::NONE) {
+      reset();
+      return;
+    }
+    has_value = true;
+    value = current;
+    last_valid_ms = now_ms;
+    source = current_source;
+  }
+
+  bool available(Source current_source, uint32_t now_ms, uint32_t hold_ms) const {
+    return has_value && source == current_source && isfinite(value) && hold_ms > 0U && now_ms - last_valid_ms < hold_ms;
+  }
+};
+
+inline NumericSelection select_direct(Source selected, const NumericSources& sources, bool hold_ha, uint32_t now_ms,
+                                      uint32_t hold_ms, HoldState& hold) {
+  if (!hold_ha || selected != Source::HA) hold.reset();
+  const auto sample = sample_for(selected, sources);
+  if (sample.valid) {
+    if (hold_ha && selected == Source::HA)
+      hold.remember(sample.value, now_ms, selected);
+    else
+      hold.reset();
+    return {sample.value, selected, true, false};
+  }
+  if (hold_ha && selected == Source::HA && hold.available(selected, now_ms, hold_ms)) {
+    return {hold.value, selected, true, true};
+  }
+  return {};
+}
+
+inline NumericSelection select_lowest_outside(const NumericSources& sources) {
+  NumericSelection selected;
+  const auto take = [&](Source route, const NumericSample& sample) {
+    if (sample.valid && (!selected.valid || sample.value < selected.value)) {
+      selected = {sample.value, route, true, false};
+    }
+  };
+  take(Source::HA, sources.ha);
+  take(Source::OUTDOOR, sources.outdoor);
+  take(Source::API, sources.api);
+  take(Source::MQTT, sources.mqtt);
+  return selected;
+}
+
+inline NumericSelection select_outside(Source selected, const NumericSources& sources, uint32_t now_ms,
+                                       uint32_t hold_ms, HoldState& hold) {
+  if (selected == Source::AUTO) {
+    hold.reset();
+    return select_lowest_outside(sources);
+  }
+  return select_direct(selected, sources, true, now_ms, hold_ms, hold);
+}
+
+struct EnableSources {
+  BinarySample opentherm;
+  BinarySample cic;
+  BinarySample ha;
+  BinarySample api;
+  BinarySample mqtt;
+};
+
+inline BinarySample valid_binary(const BinarySample& sample) { return {sample.valid && sample.value, sample.valid}; }
+
+inline BinarySample binary_for(Source source, const EnableSources& sources) {
+  switch (source) {
+    case Source::OPENTHERM:
+      return valid_binary(sources.opentherm);
+    case Source::CIC:
+      return valid_binary(sources.cic);
+    case Source::HA:
+      return valid_binary(sources.ha);
+    case Source::API:
+      return valid_binary(sources.api);
+    case Source::MQTT:
+      return valid_binary(sources.mqtt);
+    case Source::CIC_OR_HA:
+      return {(sources.cic.valid && sources.cic.value) || (sources.ha.valid && sources.ha.value),
+              sources.cic.valid || sources.ha.valid};
+    default:
+      return {};
+  }
+}
+
+inline BinarySample select_heating_enable(Source selected, const EnableSources& sources) {
+  if (selected == Source::DISABLED) return {true, true};
+  return binary_for(selected, sources);
+}
+
+inline BinarySample select_cooling_enable(Source selected, const EnableSources& sources, bool manual_enabled) {
+  if (manual_enabled) return {true, true};
+  if (selected == Source::DISABLED) return {false, true};
+  return binary_for(selected, sources);
+}
+
+enum class FlowRoute : uint8_t { NONE = 0, CIC, CONTROLLER, HP1, HP2, AGGREGATE, PUMPS_STOPPED };
+enum class ControllerFlowMode : uint8_t { OTHER = 0, LOCAL, AUTO };
+enum class OutdoorFlowMode : uint8_t { AGGREGATE = 0, HP1, HP2 };
+
+struct FlowInputs {
+  Source selected = Source::NONE;
+  bool q_hardware = false;
+  bool duo = false;
+  bool hp_generation_v1 = false;
+  bool all_relevant_pumps_stopped = false;
+  ControllerFlowMode controller_mode = ControllerFlowMode::OTHER;
+  OutdoorFlowMode outdoor_mode = OutdoorFlowMode::AGGREGATE;
+  NumericSample cic;
+  NumericSample controller;
+  NumericSample hp1;
+  NumericSample hp2;
+  NumericSample aggregate;
+};
+
+struct FlowSelection {
+  float value = NAN;
+  FlowRoute route = FlowRoute::NONE;
+  bool valid = false;
+};
+
+inline FlowSelection flow_sample(const NumericSample& sample, FlowRoute route) {
+  return sample.valid ? FlowSelection{sample.value, route, true} : FlowSelection{};
+}
+
+inline FlowSelection select_flow(const FlowInputs& input) {
+  if (input.selected == Source::CIC) return flow_sample(input.cic, FlowRoute::CIC);
+  if (input.selected != Source::OUTDOOR) return {};
+  const bool controller_only =
+      input.q_hardware && (input.controller_mode == ControllerFlowMode::LOCAL ||
+                           (!input.duo && input.controller_mode == ControllerFlowMode::AUTO && input.hp_generation_v1));
+  if (controller_only) return flow_sample(input.controller, FlowRoute::CONTROLLER);
+  if (input.all_relevant_pumps_stopped) return {0.0f, FlowRoute::PUMPS_STOPPED, true};
+  if (input.duo && input.outdoor_mode == OutdoorFlowMode::HP1) return flow_sample(input.hp1, FlowRoute::HP1);
+  if (input.duo && input.outdoor_mode == OutdoorFlowMode::HP2) return flow_sample(input.hp2, FlowRoute::HP2);
+  return flow_sample(input.aggregate, FlowRoute::AGGREGATE);
+}
+
+}  // namespace oq_input_source

--- a/openquatt/includes/control/oq_sensor_source_runtime.h
+++ b/openquatt/includes/control/oq_sensor_source_runtime.h
@@ -1,0 +1,500 @@
+#pragma once
+
+#include <math.h>
+#include <stdint.h>
+#include <string>
+
+#include "oq_flow_pump_logic.h"
+#include "oq_input_source_logic.h"
+#include "oq_supply_calibration_logic.h"
+#include "oq_supply_hold_logic.h"
+
+namespace oq_sensor_source {
+
+class Runtime {
+ public:
+  void water_source_changed(const std::string& option) {
+    if (!id(oq_water_supply_temp_current_source_ready)) return;
+    const int32_t current = id(oq_water_supply_temp_current_source_code);
+    const bool unchanged = (option == "Local" && (current == oq_supply_calibration::SOURCE_LOCAL_PT1000 ||
+                                                  current == oq_supply_calibration::SOURCE_LOCAL_DS18B20)) ||
+                           (option == "CIC" && current == oq_supply_calibration::SOURCE_CIC) ||
+                           (option == "HA input" && current == oq_supply_calibration::SOURCE_HA_INPUT);
+    if (unchanged) return;
+    id(oq_water_supply_temp_current_source_ready) = false;
+    if (id(oq_hp_water_calibration_active)) id(oq_hp_water_calibration_abort) = true;
+    id(water_supply_temp_selected).update();
+  }
+
+  bool heating_enable_valid() const {
+    if (!id(heating_enable_source).has_state()) return false;
+    return oq_input_source::select_heating_enable(parse_source(id(heating_enable_source).current_option()),
+                                                  heating_enable_sources())
+        .valid;
+  }
+
+  bool heating_enable_value() const {
+    if (!id(heating_enable_source).has_state()) return false;
+    return oq_input_source::select_heating_enable(parse_source(id(heating_enable_source).current_option()),
+                                                  heating_enable_sources())
+        .value;
+  }
+
+  bool cooling_enable_valid() const {
+    if (!id(cooling_enable_source).has_state()) return false;
+    return oq_input_source::select_cooling_enable(parse_source(id(cooling_enable_source).current_option()),
+                                                  cooling_enable_sources(), false)
+        .valid;
+  }
+
+  bool cooling_enable_selected() const {
+    if (!id(cooling_enable_source).has_state()) return false;
+    return oq_input_source::select_cooling_enable(parse_source(id(cooling_enable_source).current_option()),
+                                                  cooling_enable_sources(), id(oq_manual_cooling_enable).state)
+        .value;
+  }
+
+  bool heating_blocked_by_thermostat() const {
+    if (!id(heating_enable_source).has_state() ||
+        parse_source(id(heating_enable_source).current_option()) == oq_input_source::Source::DISABLED) {
+      return false;
+    }
+    return id(oq_enabled).state && id(oq_strategy_heat_request_active) && !id(heating_enable_selected).state;
+  }
+
+  std::string calibration_status() const {
+    if (!id(oq_water_supply_temp_current_source_ready)) return "Calibration inactive: source not ready";
+    const auto source = current_calibration_source();
+    const auto record = calibration_record(source.code);
+    if (!oq_supply_calibration::record_present(record)) return "Not calibrated";
+    if (!oq_supply_calibration::record_matches(record, source)) {
+      return std::string("Recalibration required: ") +
+             oq_supply_calibration::source_label(static_cast<int32_t>(source.code));
+    }
+    return std::string("Calibrated: ") + oq_supply_calibration::source_label(static_cast<int32_t>(source.code));
+  }
+
+  std::string heating_effective_source() const {
+    if (!id(heating_enable_source).has_state()) return "Unknown";
+    const std::string option = id(heating_enable_source).current_option();
+    if (parse_source(option) == oq_input_source::Source::DISABLED) return "None";
+    return heating_enable_valid() ? option : "None";
+  }
+
+  std::string configured_room_source() const {
+    return id(room_temp_source).has_state() ? std::string(id(room_temp_source).current_option()) : "Unknown";
+  }
+
+  std::string configured_setpoint_source() const {
+    return id(room_setpoint_source).has_state() ? std::string(id(room_setpoint_source).current_option()) : "Unknown";
+  }
+
+  std::string cooling_effective_source() const {
+    if (!id(cooling_enable_source).has_state()) return "Unknown";
+    const std::string option = id(cooling_enable_source).current_option();
+    const auto selected = parse_source(option);
+    const bool manual = id(oq_manual_cooling_enable).state;
+    const auto sources = cooling_enable_sources();
+    std::string automatic = "None";
+    if (selected == oq_input_source::Source::CIC_OR_HA) {
+      const bool cic = sources.cic.valid && sources.cic.value;
+      const bool ha = sources.ha.valid && sources.ha.value;
+      automatic = cic && ha ? "CIC + HA input" : (cic ? "CIC" : (ha ? "HA input" : "None"));
+    } else if (selected != oq_input_source::Source::DISABLED) {
+      const auto value = oq_input_source::binary_for(selected, sources);
+      if (value.valid && value.value) automatic = option;
+    }
+    if (!manual) return automatic;
+    return automatic == "None" ? "Manual" : automatic + " + Manual";
+  }
+
+  std::string selected_hold_status() const {
+    std::string active;
+    add_hold(active, id(oq_water_supply_temp_selected_hold_active), "Water supply");
+    add_hold(active, id(oq_outside_temp_selected_hold_active), "Outside temp");
+    add_hold(active, id(oq_room_temp_selected_hold_active), "Room temp");
+    add_hold(active, id(oq_room_setpoint_selected_hold_active), "Room setpoint");
+    add_hold(active, id(oq_external_heat_demand_selected_hold_active), "External heat demand");
+    add_hold(active, id(oq_cooling_dew_point_selected_hold_active), "Cooling dew point");
+    return active.empty() ? "None" : active;
+  }
+
+  float water_supply(uint32_t now_ms, uint32_t local_cic_hold_ms, uint32_t ha_hold_ms, uint32_t fallback_stale_ms,
+                     const char* ha_entity_id) {
+    const std::string option =
+        id(water_supply_source).has_state() ? id(water_supply_source).current_option() : std::string();
+    const auto source = supply_source(option, ha_entity_id);
+    migrate_legacy_calibration();
+    if (selected_supply_hold_.has_value() && !selected_supply_hold_.matches_source(source)) clear_supply_hold();
+
+    bool calibration_required = false;
+    if (source.ready) {
+      const auto record = calibration_record(source.code);
+      calibration_required = oq_supply_calibration::calibration_required(record, source);
+      if (calibration_required) clear_supply_hold();
+      id(oq_water_supply_temp_current_source_code) = static_cast<int32_t>(source.code);
+      id(oq_water_supply_temp_current_source_fingerprint) = source.fingerprint;
+      id(oq_water_supply_temp_current_source_ready) = true;
+      const float offset = oq_supply_calibration::record_matches(record, source) ? record.offset_c : 0.0f;
+      if (!id(water_supply_temp_calibration_offset).has_state() ||
+          fabsf(id(water_supply_temp_calibration_offset).state - offset) > 0.0001f) {
+        id(water_supply_temp_calibration_offset).publish_state(offset);
+      }
+    } else {
+      id(oq_water_supply_temp_current_source_code) = 0;
+      id(oq_water_supply_temp_current_source_fingerprint) = 0;
+      id(oq_water_supply_temp_current_source_ready) = false;
+    }
+    id(oq_water_supply_temp_calibration_required).publish_state(calibration_required);
+    id(oq_water_supply_temp_calibration_status).update();
+
+    float selected_c = NAN;
+    if (option == "CIC" && cic_feed_valid() && id(water_supply_temp_cic).has_state())
+      selected_c = id(water_supply_temp_cic).state;
+    else if (option == "HA input" && ha_valid(id(water_supply_temp_valid_ha), id(water_supply_temp_ha)))
+      selected_c = id(water_supply_temp_ha).state;
+    else if (option == "Local" && id(water_supply_temp_esp).has_state())
+      selected_c = id(water_supply_temp_esp).state;
+
+    if (isfinite(selected_c)) {
+      const auto record = calibration_record(source.code);
+      if (oq_supply_calibration::record_matches(record, source)) selected_c += record.offset_c;
+      if (source.ready)
+        selected_supply_hold_.remember(selected_c, now_ms, source);
+      else
+        clear_supply_hold();
+      id(oq_water_supply_temp_selected_hold_active) = false;
+      id(oq_water_supply_temp_fallback_runtime_active) = false;
+      publish_supply_source(local_supply_label(option));
+      return selected_c;
+    }
+
+    id(oq_water_supply_temp_selected_hold_active) = false;
+    const uint32_t hold_ms = oq_supply_hold::timeout_ms(source, local_cic_hold_ms, ha_hold_ms);
+    const bool may_hold = selected_supply_hold_.available(source, now_ms, hold_ms);
+    if (!may_hold) clear_supply_hold();
+    const auto fallback = fallback_supply(now_ms, fallback_stale_ms);
+    if (fallback.valid) {
+      id(oq_water_supply_temp_fallback_runtime_active) = true;
+      publish_supply_source(fallback.label);
+      return fallback.value;
+    }
+    id(oq_water_supply_temp_fallback_runtime_active) = false;
+    if (may_hold) {
+      id(oq_water_supply_temp_selected_hold_active) = true;
+      publish_supply_source(std::string(oq_supply_calibration::source_label(selected_supply_hold_.source_code)) +
+                            " (held)");
+      return selected_supply_hold_.last_valid_c;
+    }
+    publish_supply_source("Unavailable");
+    return NAN;
+  }
+
+  float flow() const {
+    if (!id(flow_source).has_state()) return NAN;
+    oq_input_source::FlowInputs input;
+    input.selected = parse_source(id(flow_source).current_option());
+    input.cic = sample(cic_feed_valid(), id(flow_rate_cic));
+    input.aggregate = sample(true, id(flow_rate_hp_avg));
+    input.q_hardware = OQ_HARDWARE_HEATPUMP_CONTROLLER_Q;
+    input.duo = OQ_TOPOLOGY_DUO;
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+    if (id(oq_q_flow_source).has_state()) {
+      const auto option = id(oq_q_flow_source).current_option();
+      input.controller_mode = option == "Local"  ? oq_input_source::ControllerFlowMode::LOCAL
+                              : option == "Auto" ? oq_input_source::ControllerFlowMode::AUTO
+                                                 : oq_input_source::ControllerFlowMode::OTHER;
+    }
+    input.hp_generation_v1 = id(hp_generation).has_state() && id(hp_generation).current_option() == "V1";
+    input.controller = sample(true, id(flow_rate_controller));
+#endif
+    const oq_flow::PumpRelayState hp1{id(hp1_is_online) && id(hp1_pump_relay).has_state(), id(hp1_pump_relay).state};
+#if OQ_TOPOLOGY_DUO
+    const oq_flow::PumpRelayState hp2{id(hp2_is_online) && id(hp2_pump_relay).has_state(), id(hp2_pump_relay).state};
+    input.hp1 = sample(true, id(hp1_flow));
+    input.hp2 = sample(true, id(hp2_flow));
+    if (id(oq_duo_outdoor_flow_mode).has_state()) {
+      const auto mode = id(oq_duo_outdoor_flow_mode).current_option();
+      input.outdoor_mode = mode == "Flowmeter HP1"   ? oq_input_source::OutdoorFlowMode::HP1
+                           : mode == "Flowmeter HP2" ? oq_input_source::OutdoorFlowMode::HP2
+                                                     : oq_input_source::OutdoorFlowMode::AGGREGATE;
+    }
+#else
+    const oq_flow::PumpRelayState hp2{};
+#endif
+    input.all_relevant_pumps_stopped = oq_flow::all_relevant_pumps_stopped(OQ_TOPOLOGY_DUO, hp1, hp2);
+    const auto selected = oq_input_source::select_flow(input);
+    return selected.valid ? selected.value : NAN;
+  }
+
+  float outside(uint32_t now_ms, uint32_t hold_ms) {
+    if (!id(outside_temp_source).has_state()) return NAN;
+    oq_input_source::NumericSources sources;
+    sources.outdoor = sample(true, id(outside_temp_hp_avg));
+    sources.ha = sample(ha_valid(id(outside_temp_valid_ha), id(outside_temp_ha)), id(outside_temp_ha));
+    sources.api = sample(api_valid(id(api_input_outside_temperature_valid), id(api_input_outside_temperature)),
+                         id(api_input_outside_temperature));
+    sources.mqtt = sample(mqtt_valid(id(mqtt_outside_temperature_valid), id(mqtt_outside_temperature)),
+                          id(mqtt_outside_temperature));
+    const auto selected = oq_input_source::select_outside(parse_source(id(outside_temp_source).current_option()),
+                                                          sources, now_ms, hold_ms, outside_hold_);
+    id(oq_outside_temp_selected_hold_active) = selected.held;
+    return selected.valid ? selected.value : NAN;
+  }
+
+  float room_temperature(uint32_t now_ms, uint32_t hold_ms, bool opentherm_fresh) {
+    if (!id(room_temp_source).has_state()) return NAN;
+    const auto sources = room_sources(opentherm_fresh, false);
+    const auto selected = oq_input_source::select_direct(parse_source(id(room_temp_source).current_option()), sources,
+                                                         true, now_ms, hold_ms, room_hold_);
+    id(oq_room_temp_selected_hold_active) = selected.held;
+    return selected.valid ? selected.value : NAN;
+  }
+
+  float room_setpoint(uint32_t now_ms, uint32_t hold_ms, bool opentherm_fresh) {
+    if (!id(room_setpoint_source).has_state()) return NAN;
+    const auto sources = room_sources(opentherm_fresh, true);
+    const auto selected = oq_input_source::select_direct(parse_source(id(room_setpoint_source).current_option()),
+                                                         sources, true, now_ms, hold_ms, setpoint_hold_);
+    id(oq_room_setpoint_selected_hold_active) = selected.held;
+    return selected.valid ? selected.value : NAN;
+  }
+
+  float external_heat_demand(uint32_t now_ms, uint32_t hold_ms) {
+    if (!id(external_heat_demand_source).has_state()) return NAN;
+    oq_input_source::NumericSources sources;
+    sources.ha =
+        sample(ha_valid(id(external_heat_demand_valid_ha), id(external_heat_demand_ha)), id(external_heat_demand_ha));
+    sources.api = sample(api_valid(id(api_input_external_heat_demand_valid), id(api_input_external_heat_demand)),
+                         id(api_input_external_heat_demand));
+    const auto selected = oq_input_source::select_direct(parse_source(id(external_heat_demand_source).current_option()),
+                                                         sources, true, now_ms, hold_ms, demand_hold_);
+    id(oq_external_heat_demand_selected_hold_active) = selected.held;
+    return selected.valid ? selected.value : NAN;
+  }
+
+ private:
+  struct SupplyFallback {
+    bool valid = false;
+    float value = NAN;
+    const char* label = "Unavailable";
+  };
+
+  oq_supply_hold::State selected_supply_hold_;
+  oq_input_source::HoldState outside_hold_;
+  oq_input_source::HoldState room_hold_;
+  oq_input_source::HoldState setpoint_hold_;
+  oq_input_source::HoldState demand_hold_;
+
+  template <typename T>
+  static oq_input_source::Source parse_source(const T& option) {
+    if (option == "Auto" || option == "Lowest valid") return oq_input_source::Source::AUTO;
+    if (option == "Local") return oq_input_source::Source::LOCAL;
+    if (option == "Outdoor unit") return oq_input_source::Source::OUTDOOR;
+    if (option == "CIC") return oq_input_source::Source::CIC;
+    if (option == "HA input") return oq_input_source::Source::HA;
+    if (option == "API input") return oq_input_source::Source::API;
+    if (option == "MQTT") return oq_input_source::Source::MQTT;
+    if (option == "OT thermostat") return oq_input_source::Source::OPENTHERM;
+    if (option == "Disabled") return oq_input_source::Source::DISABLED;
+    if (option == "CIC or HA input") return oq_input_source::Source::CIC_OR_HA;
+    return oq_input_source::Source::NONE;
+  }
+
+  template <typename T>
+  static oq_input_source::NumericSample sample(bool enabled, const T& entity) {
+    return oq_input_source::numeric_sample(enabled, entity.has_state(), entity.state);
+  }
+
+  template <typename B, typename S>
+  static bool ha_valid(const B& valid, const S& value) {
+    return valid.has_state() && valid.state && value.has_state() && isfinite(value.state);
+  }
+
+  template <typename B, typename S>
+  static bool api_valid(const B& valid, const S& value) {
+    return valid.has_state() && valid.state && value.has_state() && isfinite(value.state);
+  }
+
+  template <typename B, typename S>
+  static bool mqtt_valid(const B& valid, const S& value) {
+    return valid.has_state() && valid.state && value.has_state() && isfinite(value.state);
+  }
+
+  static bool cic_feed_valid() {
+    return id(feed_ok).has_state() && id(feed_ok).state && id(cic_data_stale).has_state() && !id(cic_data_stale).state;
+  }
+
+  static oq_input_source::EnableSources heating_enable_sources() {
+    return {{id(ot_thermostat_status_valid).has_state() && id(ot_thermostat_status_valid).state &&
+                 id(ot_thermostat_ch_enable).has_state() && id(ot_thermostat_ch_enable).state,
+             id(ot_thermostat_status_valid).has_state() && id(ot_thermostat_status_valid).state &&
+                 id(ot_thermostat_ch_enable).has_state()},
+            {id(cic_ch_enabled).has_state() && id(cic_ch_enabled).state,
+             cic_feed_valid() && id(cic_ch_enable_valid).has_state() && id(cic_ch_enable_valid).state &&
+                 id(cic_ch_enabled).has_state()},
+            {id(heating_enable_ha).has_state() && id(heating_enable_ha).state,
+             id(heating_enable_valid_ha).has_state() && id(heating_enable_valid_ha).state &&
+                 id(heating_enable_ha).has_state()},
+            {id(api_input_heating_enable).state,
+             id(api_input_heating_enable_valid).has_state() && id(api_input_heating_enable_valid).state},
+            {id(mqtt_heating_enable).has_state() && id(mqtt_heating_enable).state,
+             id(mqtt_heating_enable_valid).has_state() && id(mqtt_heating_enable_valid).state &&
+                 id(mqtt_heating_enable).has_state()}};
+  }
+
+  static oq_input_source::EnableSources cooling_enable_sources() {
+    return {{id(ot_thermostat_status_valid).has_state() && id(ot_thermostat_status_valid).state &&
+                 id(ot_thermostat_cooling_enable).has_state() && id(ot_thermostat_cooling_enable).state,
+             id(ot_thermostat_status_valid).has_state() && id(ot_thermostat_status_valid).state &&
+                 id(ot_thermostat_cooling_enable).has_state()},
+            {id(cic_cooling_enabled).has_state() && id(cic_cooling_enabled).state,
+             cic_feed_valid() && id(cic_cooling_enabled).has_state()},
+            {id(cooling_enable_ha).has_state() && id(cooling_enable_ha).state,
+             id(cooling_enable_valid_ha).has_state() && id(cooling_enable_valid_ha).state &&
+                 id(cooling_enable_ha).has_state()},
+            {id(api_input_cooling_enable).state,
+             id(api_input_cooling_enable_valid).has_state() && id(api_input_cooling_enable_valid).state},
+            {id(mqtt_cooling_enable).has_state() && id(mqtt_cooling_enable).state,
+             id(mqtt_cooling_enable_valid).has_state() && id(mqtt_cooling_enable_valid).state &&
+                 id(mqtt_cooling_enable).has_state()}};
+  }
+
+  static oq_input_source::NumericSources room_sources(bool opentherm_fresh, bool setpoint) {
+    oq_input_source::NumericSources sources;
+    if (setpoint) {
+      sources.ha = sample(ha_valid(id(room_setpoint_valid_ha), id(thermostat_setpoint_ha)), id(thermostat_setpoint_ha));
+      sources.opentherm = sample(opentherm_fresh, id(ot_thermostat_room_setpoint));
+      sources.cic = sample(cic_feed_valid(), id(cic_room_setpoint));
+      sources.api = sample(api_valid(id(api_input_room_setpoint_valid), id(api_input_room_setpoint)),
+                           id(api_input_room_setpoint));
+      sources.mqtt = sample(mqtt_valid(id(mqtt_room_setpoint_valid), id(mqtt_room_setpoint)), id(mqtt_room_setpoint));
+    } else {
+      sources.ha = sample(ha_valid(id(room_temp_valid_ha), id(thermostat_room_temp_ha)), id(thermostat_room_temp_ha));
+      sources.opentherm = sample(opentherm_fresh, id(ot_thermostat_room_temp));
+      sources.cic = sample(cic_feed_valid(), id(cic_room_temp));
+      sources.api = sample(api_valid(id(api_input_room_temperature_valid), id(api_input_room_temperature)),
+                           id(api_input_room_temperature));
+      sources.mqtt =
+          sample(mqtt_valid(id(mqtt_room_temperature_valid), id(mqtt_room_temperature)), id(mqtt_room_temperature));
+    }
+    return sources;
+  }
+
+  static oq_supply_calibration::SourceIdentity current_calibration_source() {
+    return {static_cast<oq_supply_calibration::SourceCode>(id(oq_water_supply_temp_current_source_code)),
+            id(oq_water_supply_temp_current_source_fingerprint), true};
+  }
+
+  static oq_supply_calibration::CalibrationRecord calibration_record(oq_supply_calibration::SourceCode code) {
+    switch (code) {
+      case oq_supply_calibration::SOURCE_LOCAL_PT1000:
+        return oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_pt1000_record));
+      case oq_supply_calibration::SOURCE_LOCAL_DS18B20:
+        return oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_ds18b20_record));
+      case oq_supply_calibration::SOURCE_CIC:
+        return oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_cic_record));
+      case oq_supply_calibration::SOURCE_HA_INPUT:
+        return oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_ha_input_record));
+      default:
+        return {};
+    }
+  }
+
+  static void migrate_legacy_calibration() {
+    if (!id(water_supply_temp_calibration_offset).has_state()) return;
+    const int32_t code = id(oq_water_supply_temp_calibration_source_code);
+    switch (code) {
+      case oq_supply_calibration::SOURCE_LOCAL_PT1000:
+        oq_supply_calibration::migrate_legacy_record(id(oq_water_supply_temp_calibration_pt1000_record), code,
+                                                     id(oq_water_supply_temp_calibration_source_fingerprint),
+                                                     id(oq_water_supply_temp_calibration_checksum),
+                                                     id(water_supply_temp_calibration_offset).state);
+        break;
+      case oq_supply_calibration::SOURCE_LOCAL_DS18B20:
+        oq_supply_calibration::migrate_legacy_record(id(oq_water_supply_temp_calibration_ds18b20_record), code,
+                                                     id(oq_water_supply_temp_calibration_source_fingerprint),
+                                                     id(oq_water_supply_temp_calibration_checksum),
+                                                     id(water_supply_temp_calibration_offset).state);
+        break;
+      case oq_supply_calibration::SOURCE_CIC:
+        oq_supply_calibration::migrate_legacy_record(id(oq_water_supply_temp_calibration_cic_record), code,
+                                                     id(oq_water_supply_temp_calibration_source_fingerprint),
+                                                     id(oq_water_supply_temp_calibration_checksum),
+                                                     id(water_supply_temp_calibration_offset).state);
+        break;
+      case oq_supply_calibration::SOURCE_HA_INPUT:
+        oq_supply_calibration::migrate_legacy_record(id(oq_water_supply_temp_calibration_ha_input_record), code,
+                                                     id(oq_water_supply_temp_calibration_source_fingerprint),
+                                                     id(oq_water_supply_temp_calibration_checksum),
+                                                     id(water_supply_temp_calibration_offset).state);
+        break;
+      default:
+        break;
+    }
+  }
+
+  static oq_supply_calibration::SourceIdentity supply_source(const std::string& option, const char* ha_entity_id) {
+    std::string local_source;
+    bool local_ready = false;
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+    local_ready = id(oq_local_supply_temp_source).has_state();
+    if (local_ready) local_source = id(oq_local_supply_temp_source).current_option();
+#endif
+    const bool cic_configured = id(cic_feed_url).has_state();
+    const std::string cic_url = cic_configured ? id(cic_feed_url).state : std::string();
+    return oq_supply_calibration::source_identity(
+        option.c_str(), OQ_HARDWARE_HEATPUMP_CONTROLLER_Q, local_source.c_str(), local_ready, cic_url.c_str(),
+        cic_configured && id(cic_component).is_url_ready(cic_url), ha_entity_id);
+  }
+
+  static std::string local_supply_label(const std::string& option) {
+    if (option != "Local") return option;
+#if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
+    return id(oq_local_supply_temp_source).has_state()
+               ? std::string("Local - ") + id(oq_local_supply_temp_source).current_option()
+               : "Local";
+#else
+    return "Local - DS18B20";
+#endif
+  }
+
+  static SupplyFallback fallback_supply(uint32_t now_ms, uint32_t stale_ms) {
+#if OQ_TOPOLOGY_DUO
+    const uint32_t last_update_ms = id(hp2_water_out_temp_last_update_ms);
+    const bool valid = id(hp2_is_online) && last_update_ms > 0 && now_ms - last_update_ms <= stale_ms &&
+                       id(hp2_water_out_temp).has_state() && isfinite(id(hp2_water_out_temp).state);
+    return {valid, valid ? id(hp2_water_out_temp).state : NAN, "hp2 water out (fallback)"};
+#else
+    const uint32_t last_update_ms = id(hp1_water_out_temp_last_update_ms);
+    const bool valid = id(hp1_is_online) && last_update_ms > 0 && now_ms - last_update_ms <= stale_ms &&
+                       id(hp1_water_out_temp).has_state() && isfinite(id(hp1_water_out_temp).state);
+    return {valid, valid ? id(hp1_water_out_temp).state : NAN, "hp1 water out (fallback)"};
+#endif
+  }
+
+  void clear_supply_hold() {
+    selected_supply_hold_.reset();
+    id(oq_water_supply_temp_selected_hold_active) = false;
+  }
+
+  static void publish_supply_source(const std::string& source) {
+    if (!id(oq_water_supply_temp_effective_source).has_state() ||
+        id(oq_water_supply_temp_effective_source).state != source) {
+      id(oq_water_supply_temp_effective_source).publish_state(source);
+    }
+  }
+
+  static void add_hold(std::string& active, bool enabled, const char* label) {
+    if (!enabled) return;
+    if (!active.empty()) active += ", ";
+    active += label;
+  }
+};
+
+inline Runtime& runtime() {
+  static Runtime instance;
+  return instance;
+}
+
+}  // namespace oq_sensor_source

--- a/openquatt/includes/control/oq_supply_hold_logic.h
+++ b/openquatt/includes/control/oq_supply_hold_logic.h
@@ -26,18 +26,20 @@ inline bool can_hold(float last_valid_c, uint32_t last_valid_ms, int32_t source_
 }
 
 struct State {
+  bool remembered = false;
   float last_valid_c = NAN;
   uint32_t last_valid_ms = 0;
   int32_t source_code = 0;
   uint32_t source_fingerprint = 0;
 
-  bool has_value() const { return isfinite(last_valid_c) && last_valid_ms > 0 && source_code != 0; }
+  bool has_value() const { return remembered && isfinite(last_valid_c) && source_code != 0; }
 
   bool matches_source(const oq_supply_calibration::SourceIdentity& current) const {
     return source_matches(source_code, source_fingerprint, current);
   }
 
   void reset() {
+    remembered = false;
     last_valid_c = NAN;
     last_valid_ms = 0;
     source_code = 0;
@@ -49,6 +51,7 @@ struct State {
       reset();
       return;
     }
+    remembered = true;
     last_valid_c = value_c;
     last_valid_ms = now_ms;
     source_code = static_cast<int32_t>(current.code);
@@ -56,7 +59,8 @@ struct State {
   }
 
   bool available(const oq_supply_calibration::SourceIdentity& current, uint32_t now_ms, uint32_t hold_ms) const {
-    return can_hold(last_valid_c, last_valid_ms, source_code, source_fingerprint, current, now_ms, hold_ms);
+    return has_value() && hold_ms > 0 && matches_source(current) &&
+           static_cast<uint32_t>(now_ms - last_valid_ms) < hold_ms;
   }
 };
 

--- a/openquatt/oq_api_ingress.yaml
+++ b/openquatt/oq_api_ingress.yaml
@@ -13,82 +13,6 @@
 #
 # ==============================================================================
 
-globals:
-  - id: api_input_accept_updates
-    type: bool
-    restore_value: no
-    initial_value: "false"
-
-  - id: api_input_cooling_dew_point_last_valid_ms
-    type: uint32_t
-    restore_value: no
-    initial_value: "0"
-
-  - id: api_input_outside_temperature_last_valid_ms
-    type: uint32_t
-    restore_value: no
-    initial_value: "0"
-
-  - id: api_input_room_temperature_last_valid_ms
-    type: uint32_t
-    restore_value: no
-    initial_value: "0"
-
-  - id: api_input_room_setpoint_last_valid_ms
-    type: uint32_t
-    restore_value: no
-    initial_value: "0"
-
-  - id: api_input_heating_enable_last_valid_ms
-    type: uint32_t
-    restore_value: no
-    initial_value: "0"
-
-  - id: api_input_cooling_enable_last_valid_ms
-    type: uint32_t
-    restore_value: no
-    initial_value: "0"
-
-  - id: api_input_external_heat_demand_last_valid_ms
-    type: uint32_t
-    restore_value: no
-    initial_value: "0"
-
-  - id: api_input_cooling_dew_point_has_value
-    type: bool
-    restore_value: no
-    initial_value: "false"
-
-  - id: api_input_outside_temperature_has_value
-    type: bool
-    restore_value: no
-    initial_value: "false"
-
-  - id: api_input_room_temperature_has_value
-    type: bool
-    restore_value: no
-    initial_value: "false"
-
-  - id: api_input_room_setpoint_has_value
-    type: bool
-    restore_value: no
-    initial_value: "false"
-
-  - id: api_input_heating_enable_has_value
-    type: bool
-    restore_value: no
-    initial_value: "false"
-
-  - id: api_input_cooling_enable_has_value
-    type: bool
-    restore_value: no
-    initial_value: "false"
-
-  - id: api_input_external_heat_demand_has_value
-    type: bool
-    restore_value: no
-    initial_value: "false"
-
 number:
   - platform: template
     id: api_input_cooling_dew_point
@@ -99,13 +23,7 @@ number:
     optimistic: true
     on_value:
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_cooling_dew_point_has_value) = true;
-          id(api_input_cooling_dew_point_last_valid_ms) = (uint32_t) millis();
-          id(api_input_cooling_dew_point_age).publish_state(0);
-          id(api_input_cooling_dew_point_valid).publish_state(true);
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::COOLING_DEW_POINT, (uint32_t) millis());
 
   - platform: template
     id: api_input_outside_temperature
@@ -116,13 +34,7 @@ number:
     optimistic: true
     on_value:
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_outside_temperature_has_value) = true;
-          id(api_input_outside_temperature_last_valid_ms) = (uint32_t) millis();
-          id(api_input_outside_temperature_age).publish_state(0);
-          id(api_input_outside_temperature_valid).publish_state(true);
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::OUTSIDE_TEMPERATURE, (uint32_t) millis());
 
   - platform: template
     id: api_input_room_temperature
@@ -133,13 +45,7 @@ number:
     optimistic: true
     on_value:
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_room_temperature_has_value) = true;
-          id(api_input_room_temperature_last_valid_ms) = (uint32_t) millis();
-          id(api_input_room_temperature_age).publish_state(0);
-          id(api_input_room_temperature_valid).publish_state(true);
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::ROOM_TEMPERATURE, (uint32_t) millis());
 
   - platform: template
     id: api_input_room_setpoint
@@ -150,13 +56,7 @@ number:
     optimistic: true
     on_value:
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_room_setpoint_has_value) = true;
-          id(api_input_room_setpoint_last_valid_ms) = (uint32_t) millis();
-          id(api_input_room_setpoint_age).publish_state(0);
-          id(api_input_room_setpoint_valid).publish_state(true);
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::ROOM_SETPOINT, (uint32_t) millis());
 
   - platform: template
     id: api_input_external_heat_demand
@@ -167,11 +67,7 @@ number:
     optimistic: true
     on_value:
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_external_heat_demand_has_value) = true;
-          id(api_input_external_heat_demand_last_valid_ms) = (uint32_t) millis();
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::EXTERNAL_HEAT_DEMAND, (uint32_t) millis());
 
 switch:
   - platform: template
@@ -183,25 +79,13 @@ switch:
           id: api_input_heating_enable
           state: ON
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_heating_enable_has_value) = true;
-          id(api_input_heating_enable_last_valid_ms) = (uint32_t) millis();
-          id(api_input_heating_enable_age).publish_state(0);
-          id(api_input_heating_enable_valid).publish_state(true);
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::HEATING_ENABLE, (uint32_t) millis());
     turn_off_action:
       - switch.template.publish:
           id: api_input_heating_enable
           state: OFF
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_heating_enable_has_value) = true;
-          id(api_input_heating_enable_last_valid_ms) = (uint32_t) millis();
-          id(api_input_heating_enable_age).publish_state(0);
-          id(api_input_heating_enable_valid).publish_state(true);
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::HEATING_ENABLE, (uint32_t) millis());
 
   - platform: template
     id: api_input_cooling_enable
@@ -212,25 +96,13 @@ switch:
           id: api_input_cooling_enable
           state: ON
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_cooling_enable_has_value) = true;
-          id(api_input_cooling_enable_last_valid_ms) = (uint32_t) millis();
-          id(api_input_cooling_enable_age).publish_state(0);
-          id(api_input_cooling_enable_valid).publish_state(true);
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::COOLING_ENABLE, (uint32_t) millis());
     turn_off_action:
       - switch.template.publish:
           id: api_input_cooling_enable
           state: OFF
       - lambda: |-
-          if (!id(api_input_accept_updates)) {
-            return;
-          }
-          id(api_input_cooling_enable_has_value) = true;
-          id(api_input_cooling_enable_last_valid_ms) = (uint32_t) millis();
-          id(api_input_cooling_enable_age).publish_state(0);
-          id(api_input_cooling_enable_valid).publish_state(true);
+          oq_api_ingress::runtime().observe(oq_api_ingress::Slot::COOLING_ENABLE, (uint32_t) millis());
 
 esphome:
   on_boot:
@@ -245,38 +117,10 @@ esphome:
               retired_api_preferences, "API ingress enable state");
       - lambda: |-
           // Ignore template component startup state until real API writes can arrive.
-          id(api_input_accept_updates) = false;
-          id(api_input_cooling_dew_point_has_value) = false;
-          id(api_input_outside_temperature_has_value) = false;
-          id(api_input_room_temperature_has_value) = false;
-          id(api_input_room_setpoint_has_value) = false;
-          id(api_input_heating_enable_has_value) = false;
-          id(api_input_cooling_enable_has_value) = false;
-          id(api_input_external_heat_demand_has_value) = false;
-          id(api_input_cooling_dew_point_last_valid_ms) = 0U;
-          id(api_input_outside_temperature_last_valid_ms) = 0U;
-          id(api_input_room_temperature_last_valid_ms) = 0U;
-          id(api_input_room_setpoint_last_valid_ms) = 0U;
-          id(api_input_heating_enable_last_valid_ms) = 0U;
-          id(api_input_cooling_enable_last_valid_ms) = 0U;
-          id(api_input_external_heat_demand_last_valid_ms) = 0U;
-          id(api_input_cooling_dew_point_age).publish_state(NAN);
-          id(api_input_outside_temperature_age).publish_state(NAN);
-          id(api_input_room_temperature_age).publish_state(NAN);
-          id(api_input_room_setpoint_age).publish_state(NAN);
-          id(api_input_heating_enable_age).publish_state(NAN);
-          id(api_input_cooling_enable_age).publish_state(NAN);
-          id(api_input_external_heat_demand_age).publish_state(NAN);
-          id(api_input_cooling_dew_point_valid).publish_state(false);
-          id(api_input_outside_temperature_valid).publish_state(false);
-          id(api_input_room_temperature_valid).publish_state(false);
-          id(api_input_room_setpoint_valid).publish_state(false);
-          id(api_input_heating_enable_valid).publish_state(false);
-          id(api_input_cooling_enable_valid).publish_state(false);
-          id(api_input_external_heat_demand_valid).publish_state(false);
+          oq_api_ingress::runtime().reset();
       - delay: 1s
       - lambda: |-
-          id(api_input_accept_updates) = true;
+          oq_api_ingress::runtime().set_accept_updates(true);
 
 binary_sensor:
   - platform: template
@@ -396,86 +240,12 @@ interval:
   - interval: 5s
     then:
       - lambda: |-
-          const uint32_t now_ms = (uint32_t) millis();
-
-          auto update_numeric = [&](bool has_value,
-                                    uint32_t last_valid_ms,
-                                    uint32_t stale_s,
-                                    bool entity_has_state,
-                                    sensor::Sensor *age_sensor,
-                                    binary_sensor::BinarySensor *valid_sensor) {
-            // Recompute age/validity exactly like the MQTT ingress model.
-            if (!has_value || !entity_has_state || last_valid_ms == 0U) {
-              age_sensor->publish_state(NAN);
-              valid_sensor->publish_state(false);
-              return;
-            }
-            const uint32_t age_ms = (uint32_t) (now_ms - last_valid_ms);
-            age_sensor->publish_state((float) age_ms / 1000.0f);
-            const bool valid = stale_s == 0U || age_ms <= (stale_s * 1000UL);
-            valid_sensor->publish_state(valid);
-          };
-
-          auto update_binary = [&](bool has_value,
-                                   uint32_t last_valid_ms,
-                                   uint32_t stale_s,
-                                   sensor::Sensor *age_sensor,
-                                   binary_sensor::BinarySensor *valid_sensor) {
-            if (!has_value || last_valid_ms == 0U) {
-              age_sensor->publish_state(NAN);
-              valid_sensor->publish_state(false);
-              return;
-            }
-            const uint32_t age_ms = (uint32_t) (now_ms - last_valid_ms);
-            age_sensor->publish_state((float) age_ms / 1000.0f);
-            const bool valid = stale_s == 0U || age_ms <= (stale_s * 1000UL);
-            valid_sensor->publish_state(valid);
-          };
-
-          update_numeric(
-              id(api_input_cooling_dew_point_has_value),
-              id(api_input_cooling_dew_point_last_valid_ms),
-              (uint32_t) ${api_input_cooling_dew_point_stale_s}UL,
-              id(api_input_cooling_dew_point).has_state(),
-              id(api_input_cooling_dew_point_age),
-              id(api_input_cooling_dew_point_valid));
-          update_numeric(
-              id(api_input_outside_temperature_has_value),
-              id(api_input_outside_temperature_last_valid_ms),
-              (uint32_t) ${api_input_outside_temperature_stale_s}UL,
-              id(api_input_outside_temperature).has_state(),
-              id(api_input_outside_temperature_age),
-              id(api_input_outside_temperature_valid));
-          update_numeric(
-              id(api_input_room_temperature_has_value),
-              id(api_input_room_temperature_last_valid_ms),
-              (uint32_t) ${api_input_room_temperature_stale_s}UL,
-              id(api_input_room_temperature).has_state(),
-              id(api_input_room_temperature_age),
-              id(api_input_room_temperature_valid));
-          update_numeric(
-              id(api_input_room_setpoint_has_value),
-              id(api_input_room_setpoint_last_valid_ms),
-              (uint32_t) ${api_input_room_setpoint_stale_s}UL,
-              id(api_input_room_setpoint).has_state(),
-              id(api_input_room_setpoint_age),
-              id(api_input_room_setpoint_valid));
-          update_binary(
-              id(api_input_heating_enable_has_value),
-              id(api_input_heating_enable_last_valid_ms),
-              (uint32_t) ${api_input_heating_enable_stale_s}UL,
-              id(api_input_heating_enable_age),
-              id(api_input_heating_enable_valid));
-          update_binary(
-              id(api_input_cooling_enable_has_value),
-              id(api_input_cooling_enable_last_valid_ms),
-              (uint32_t) ${api_input_cooling_enable_stale_s}UL,
-              id(api_input_cooling_enable_age),
-              id(api_input_cooling_enable_valid));
-          update_numeric(
-              id(api_input_external_heat_demand_has_value),
-              id(api_input_external_heat_demand_last_valid_ms),
-              (uint32_t) ${api_input_external_heat_demand_stale_s}UL,
-              id(api_input_external_heat_demand).has_state(),
-              id(api_input_external_heat_demand_age),
-              id(api_input_external_heat_demand_valid));
+          oq_api_ingress::runtime().tick(
+              (uint32_t) millis(),
+              {(uint32_t) ${api_input_cooling_dew_point_stale_s}UL,
+               (uint32_t) ${api_input_outside_temperature_stale_s}UL,
+               (uint32_t) ${api_input_room_temperature_stale_s}UL,
+               (uint32_t) ${api_input_room_setpoint_stale_s}UL,
+               (uint32_t) ${api_input_heating_enable_stale_s}UL,
+               (uint32_t) ${api_input_cooling_enable_stale_s}UL,
+               (uint32_t) ${api_input_external_heat_demand_stale_s}UL});

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -15,115 +15,26 @@ packages:
   oq_cooling_safety: !include oq_cooling_safety.yaml
 
 globals:
-  - id: oq_water_supply_temp_selected_hold_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-  - id: oq_water_supply_temp_fallback_runtime_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_water_supply_temp_current_source_code
-    type: int32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_water_supply_temp_current_source_fingerprint
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_water_supply_temp_current_source_ready
-    type: bool
-    restore_value: false
-    initial_value: 'false'
+  - {id: oq_water_supply_temp_selected_hold_active, type: bool, restore_value: false, initial_value: 'false'}
+  - {id: oq_water_supply_temp_fallback_runtime_active, type: bool, restore_value: false, initial_value: 'false'}
+  - {id: oq_water_supply_temp_current_source_code, type: int32_t, restore_value: false, initial_value: '0'}
+  - {id: oq_water_supply_temp_current_source_fingerprint, type: uint32_t, restore_value: false, initial_value: '0'}
+  - {id: oq_water_supply_temp_current_source_ready, type: bool, restore_value: false, initial_value: 'false'}
 
   # Legacy single-record storage retained for one-time migration and safe downgrade.
-  - id: oq_water_supply_temp_calibration_source_code
-    type: int32_t
-    restore_value: true
-    initial_value: '0'
-  - id: oq_water_supply_temp_calibration_source_fingerprint
-    type: uint32_t
-    restore_value: true
-    initial_value: '0'
-  - id: oq_water_supply_temp_calibration_checksum
-    type: uint32_t
-    restore_value: true
-    initial_value: '0'
+  - {id: oq_water_supply_temp_calibration_source_code, type: int32_t, restore_value: true, initial_value: '0'}
+  - {id: oq_water_supply_temp_calibration_source_fingerprint, type: uint32_t, restore_value: true, initial_value: '0'}
+  - {id: oq_water_supply_temp_calibration_checksum, type: uint32_t, restore_value: true, initial_value: '0'}
 
   # Each physical/configured source has an independent fail-closed record.
-  - id: oq_water_supply_temp_calibration_pt1000_record
-    type: uint32_t[3]
-    restore_value: true
-    initial_value: '{0, 0, 0}'
-  - id: oq_water_supply_temp_calibration_ds18b20_record
-    type: uint32_t[3]
-    restore_value: true
-    initial_value: '{0, 0, 0}'
-  - id: oq_water_supply_temp_calibration_cic_record
-    type: uint32_t[3]
-    restore_value: true
-    initial_value: '{0, 0, 0}'
-  - id: oq_water_supply_temp_calibration_ha_input_record
-    type: uint32_t[3]
-    restore_value: true
-    initial_value: '{0, 0, 0}'
-
-  - id: oq_outside_temp_selected_last_valid_c
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-  - id: oq_outside_temp_selected_last_valid_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_outside_temp_selected_hold_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_room_temp_selected_last_valid_c
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-  - id: oq_room_temp_selected_last_valid_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_room_temp_selected_hold_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_room_setpoint_selected_last_valid_c
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-  - id: oq_room_setpoint_selected_last_valid_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_room_setpoint_selected_hold_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-
-  - id: oq_external_heat_demand_selected_last_valid_w
-    type: float
-    restore_value: false
-    initial_value: 'NAN'
-  - id: oq_external_heat_demand_selected_last_valid_ms
-    type: uint32_t
-    restore_value: false
-    initial_value: '0'
-  - id: oq_external_heat_demand_selected_hold_active
-    type: bool
-    restore_value: false
-    initial_value: 'false'
-  - id: oq_external_heat_demand_selected_last_valid_source
-    type: uint8_t
-    restore_value: false
-    initial_value: '0'
+  - {id: oq_water_supply_temp_calibration_pt1000_record, type: 'uint32_t[3]', restore_value: true, initial_value: '{0, 0, 0}'}
+  - {id: oq_water_supply_temp_calibration_ds18b20_record, type: 'uint32_t[3]', restore_value: true, initial_value: '{0, 0, 0}'}
+  - {id: oq_water_supply_temp_calibration_cic_record, type: 'uint32_t[3]', restore_value: true, initial_value: '{0, 0, 0}'}
+  - {id: oq_water_supply_temp_calibration_ha_input_record, type: 'uint32_t[3]', restore_value: true, initial_value: '{0, 0, 0}'}
+  - {id: oq_outside_temp_selected_hold_active, type: bool, restore_value: false, initial_value: 'false'}
+  - {id: oq_room_temp_selected_hold_active, type: bool, restore_value: false, initial_value: 'false'}
+  - {id: oq_room_setpoint_selected_hold_active, type: bool, restore_value: false, initial_value: 'false'}
+  - {id: oq_external_heat_demand_selected_hold_active, type: bool, restore_value: false, initial_value: 'false'}
 
 select:
   - platform: template
@@ -133,27 +44,11 @@ select:
     entity_category: config
     optimistic: true
     restore_value: true
-    options:
-      - Local
-      - CIC
-      - HA input
+    options: [Local, CIC, HA input]
     initial_option: Local
     on_value:
       - lambda: |-
-          // Stop using the old runtime identity before the newly selected source can enter control.
-          if (!id(oq_water_supply_temp_current_source_ready)) return;
-          const int32_t current = id(oq_water_supply_temp_current_source_code);
-          const bool same_source =
-              (x == "Local" &&
-               (current == oq_supply_calibration::SOURCE_LOCAL_PT1000 ||
-                current == oq_supply_calibration::SOURCE_LOCAL_DS18B20)) ||
-              (x == "CIC" && current == oq_supply_calibration::SOURCE_CIC) ||
-              (x == "HA input" && current == oq_supply_calibration::SOURCE_HA_INPUT);
-          if (same_source) return;
-
-          id(oq_water_supply_temp_current_source_ready) = false;
-          if (id(oq_hp_water_calibration_active)) id(oq_hp_water_calibration_abort) = true;
-          id(water_supply_temp_selected).update();
+          oq_sensor_source::runtime().water_source_changed(x);
 
   - platform: template
     name: "Flow Source"
@@ -162,9 +57,7 @@ select:
     entity_category: config
     optimistic: true
     restore_value: true
-    options:
-      - Outdoor unit
-      - CIC
+    options: [Outdoor unit, CIC]
     initial_option: Outdoor unit
 
   - platform: template
@@ -175,10 +68,7 @@ select:
     entity_category: config
     optimistic: true
     restore_value: true
-    options:
-      - Flowmeter HP1
-      - Flowmeter HP2
-      - Local aggregate HP1/HP2
+    options: [Flowmeter HP1, Flowmeter HP2, Local aggregate HP1/HP2]
     initial_option: Local aggregate HP1/HP2
 
   - platform: template
@@ -188,12 +78,7 @@ select:
     entity_category: config
     optimistic: true
     restore_value: true
-    options:
-      - Auto
-      - Outdoor unit
-      - HA input
-      - API input
-      - MQTT
+    options: [Auto, Outdoor unit, HA input, API input, MQTT]
     initial_option: Auto
 
 switch:
@@ -230,23 +115,7 @@ binary_sensor:
     icon: mdi:check-decagram
     entity_category: diagnostic
     lambda: |-
-      // Validate only the currently selected heating enable source.
-      if (!id(heating_enable_source).has_state()) return false;
-      const auto source = id(heating_enable_source).current_option();
-      if (source == "Disabled") return true;
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (source == "OT thermostat") return id(ot_thermostat_status_valid).has_state() && id(ot_thermostat_status_valid).state;
-      #endif
-      if (source == "CIC") {
-        return id(feed_ok).has_state() && id(feed_ok).state &&
-               id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
-               id(cic_ch_enable_valid).has_state() && id(cic_ch_enable_valid).state;
-      }
-      if (source == "HA input") return id(heating_enable_valid_ha).state && id(heating_enable_ha).has_state();
-      if (source == "API input") return id(api_input_heating_enable_valid).has_state() && id(api_input_heating_enable_valid).state;
-      if (source == "MQTT") return id(mqtt_heating_enable_valid).has_state() && id(mqtt_heating_enable_valid).state &&
-                                  id(mqtt_heating_enable).has_state();
-      return false;
+      return oq_sensor_source::runtime().heating_enable_valid();
 
   - platform: template
     id: heating_enable_selected
@@ -254,19 +123,7 @@ binary_sensor:
     icon: mdi:radiator
     device_class: heat
     lambda: |-
-      // Resolve selected source only when the active source is valid.
-      if (!id(heating_enable_source).has_state()) return false;
-      const auto source = id(heating_enable_source).current_option();
-      if (source == "Disabled") return true;
-      if (!id(heating_enable_valid).state) return false;
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (source == "OT thermostat") return id(ot_thermostat_ch_enable).state;
-      #endif
-      if (source == "CIC") return id(cic_ch_enabled).state;
-      if (source == "HA input") return id(heating_enable_ha).state;
-      if (source == "API input") return id(api_input_heating_enable).state;
-      if (source == "MQTT") return id(mqtt_heating_enable).state;
-      return false;
+      return oq_sensor_source::runtime().heating_enable_value();
 
   - platform: template
     id: cooling_enable_valid
@@ -274,24 +131,7 @@ binary_sensor:
     icon: mdi:check-decagram
     entity_category: diagnostic
     lambda: |-
-      // Validate only the currently selected automatic cooling enable source.
-      if (!id(cooling_enable_source).has_state()) return false;
-      const auto source = id(cooling_enable_source).current_option();
-      if (source == "Disabled") return true;
-      const bool cic_valid = id(feed_ok).has_state() && id(feed_ok).state &&
-                             id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
-                             id(cic_cooling_enabled).has_state();
-      const bool ha_valid = id(cooling_enable_valid_ha).state && id(cooling_enable_ha).has_state();
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (source == "OT thermostat") return id(ot_thermostat_status_valid).has_state() && id(ot_thermostat_status_valid).state;
-      #endif
-      if (source == "CIC") return cic_valid;
-      if (source == "CIC or HA input") return cic_valid || ha_valid;
-      if (source == "HA input") return ha_valid;
-      if (source == "API input") return id(api_input_cooling_enable_valid).has_state() && id(api_input_cooling_enable_valid).state;
-      if (source == "MQTT") return id(mqtt_cooling_enable_valid).has_state() && id(mqtt_cooling_enable_valid).state &&
-                                  id(mqtt_cooling_enable).has_state();
-      return false;
+      return oq_sensor_source::runtime().cooling_enable_valid();
 
   - platform: template
     id: heating_blocked_by_thermostat
@@ -300,8 +140,7 @@ binary_sensor:
     device_class: problem
     entity_category: diagnostic
     lambda: |-
-      if (!id(heating_enable_source).has_state() || id(heating_enable_source).current_option() == "Disabled") return false;
-      return id(oq_enabled).state && id(oq_strategy_heat_request_active) && !id(heating_enable_selected).state;
+      return oq_sensor_source::runtime().heating_blocked_by_thermostat();
 
   - platform: template
     id: cooling_enable_selected
@@ -309,26 +148,7 @@ binary_sensor:
     icon: mdi:snowflake-check
     device_class: cold
     lambda: |-
-      // Cooling may be enabled by the selected automatic source or by the manual override.
-      if (!id(cooling_enable_source).has_state()) return false;
-      const auto source = id(cooling_enable_source).current_option();
-      const bool manual_enabled = id(oq_manual_cooling_enable).state;
-      if (manual_enabled) return true;
-      if (source == "Disabled") return false;
-      if (!id(cooling_enable_valid).state) return false;
-      const bool cic_enabled = id(feed_ok).has_state() && id(feed_ok).state &&
-                               id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
-                               id(cic_cooling_enabled).has_state() && id(cic_cooling_enabled).state;
-      const bool ha_enabled = id(cooling_enable_valid_ha).state && id(cooling_enable_ha).has_state() && id(cooling_enable_ha).state;
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (source == "OT thermostat") return id(ot_thermostat_cooling_enable).state;
-      #endif
-      if (source == "CIC") return cic_enabled;
-      if (source == "CIC or HA input") return cic_enabled || ha_enabled;
-      if (source == "HA input") return id(cooling_enable_ha).state;
-      if (source == "API input") return id(api_input_cooling_enable).state;
-      if (source == "MQTT") return id(mqtt_cooling_enable).state;
-      return false;
+      return oq_sensor_source::runtime().cooling_enable_selected();
 
 text_sensor:
   - platform: template
@@ -338,36 +158,7 @@ text_sensor:
     entity_category: diagnostic
     update_interval: 5s
     lambda: |-
-      // Report whether this source's persisted record is applicable to the current source.
-      if (!id(oq_water_supply_temp_current_source_ready)) return {"Calibration inactive: source not ready"};
-
-      const oq_supply_calibration::SourceIdentity current{
-          static_cast<oq_supply_calibration::SourceCode>(id(oq_water_supply_temp_current_source_code)),
-          id(oq_water_supply_temp_current_source_fingerprint), true};
-      oq_supply_calibration::CalibrationRecord record;
-      switch (current.code) {
-        case oq_supply_calibration::SOURCE_LOCAL_PT1000:
-          record = oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_pt1000_record));
-          break;
-        case oq_supply_calibration::SOURCE_LOCAL_DS18B20:
-          record = oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_ds18b20_record));
-          break;
-        case oq_supply_calibration::SOURCE_CIC:
-          record = oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_cic_record));
-          break;
-        case oq_supply_calibration::SOURCE_HA_INPUT:
-          record = oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_ha_input_record));
-          break;
-        default:
-          break;
-      }
-      if (!oq_supply_calibration::record_present(record)) return {"Not calibrated"};
-      if (!oq_supply_calibration::record_matches(record, current)) {
-        return {std::string("Recalibration required: ") +
-                oq_supply_calibration::source_label(static_cast<int32_t>(current.code))};
-      }
-      return {std::string("Calibrated: ") +
-              oq_supply_calibration::source_label(static_cast<int32_t>(current.code))};
+      return {oq_sensor_source::runtime().calibration_status()};
 
   - platform: template
     id: oq_water_supply_temp_effective_source
@@ -383,31 +174,25 @@ text_sensor:
     entity_category: diagnostic
     update_interval: 5s
     lambda: |-
-      if (!id(heating_enable_source).has_state()) return {"Unknown"};
-      const auto source = id(heating_enable_source).current_option();
-      if (source == "Disabled") return {"None"};
-      if (!id(heating_enable_valid).state) return {"None"};
-      return {source.c_str()};
+      return {oq_sensor_source::runtime().heating_effective_source()};
 
   - platform: template
     id: oq_room_temperature_effective_source
     name: "Room Temperature Effective Source"
     icon: mdi:source-branch
+    entity_category: diagnostic
     update_interval: 5s
     lambda: |-
-      if (!id(room_temp_source).has_state()) return {"Unknown"};
-      return {id(room_temp_source).current_option().c_str()};
-    entity_category: diagnostic
+      return {oq_sensor_source::runtime().configured_room_source()};
 
   - platform: template
     id: oq_room_setpoint_effective_source
     name: "Room Setpoint Effective Source"
     icon: mdi:source-branch
+    entity_category: diagnostic
     update_interval: 5s
     lambda: |-
-      if (!id(room_setpoint_source).has_state()) return {"Unknown"};
-      return {id(room_setpoint_source).current_option().c_str()};
-    entity_category: diagnostic
+      return {oq_sensor_source::runtime().configured_setpoint_source()};
 
   - platform: template
     id: oq_cooling_enable_effective_source
@@ -416,38 +201,7 @@ text_sensor:
     entity_category: diagnostic
     update_interval: 5s
     lambda: |-
-      // Report which raw source is currently granting cooling enable.
-      if (!id(cooling_enable_source).has_state()) return {"Unknown"};
-
-      const auto source = id(cooling_enable_source).current_option();
-      const bool manual_enabled = id(oq_manual_cooling_enable).state;
-      const bool valid = id(cooling_enable_valid).has_state() && id(cooling_enable_valid).state;
-      const bool cic_enabled = id(feed_ok).has_state() && id(feed_ok).state &&
-                               id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
-                               id(cic_cooling_enabled).has_state() && id(cic_cooling_enabled).state;
-      const bool ha_enabled = id(cooling_enable_valid_ha).state && id(cooling_enable_ha).has_state() && id(cooling_enable_ha).state;
-
-      auto with_manual = [&](const std::string &base) -> std::string {
-        if (!manual_enabled) return base;
-        if (base == "None") return "Manual";
-        return base + " + Manual";
-      };
-
-      if (source == "Disabled") return {with_manual("None")};
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (source == "OT thermostat") return {with_manual(valid && id(ot_thermostat_cooling_enable).state ? "OT thermostat" : "None")};
-      #endif
-      if (source == "CIC") return {with_manual(cic_enabled ? "CIC" : "None")};
-      if (source == "CIC or HA input") {
-        if (cic_enabled && ha_enabled) return {with_manual("CIC + HA input")};
-        if (cic_enabled) return {with_manual("CIC")};
-        if (ha_enabled) return {with_manual("HA input")};
-        return {with_manual("None")};
-      }
-      if (source == "HA input") return {with_manual(valid && id(cooling_enable_ha).state ? "HA input" : "None")};
-      if (source == "API input") return {with_manual(valid && id(api_input_cooling_enable).state ? "API input" : "None")};
-      if (source == "MQTT") return {with_manual(valid && id(mqtt_cooling_enable).state ? "MQTT" : "None")};
-      return {"Unknown"};
+      return {oq_sensor_source::runtime().cooling_effective_source()};
 
   - platform: template
     id: oq_selected_input_hold_active
@@ -458,22 +212,7 @@ text_sensor:
     entity_category: diagnostic
     update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
-      // Report which selected-source inputs are currently being held through source dropouts.
-      std::string active;
-      auto add = [&](const char *label) {
-        if (!active.empty()) active += ", ";
-        active += label;
-      };
-
-      if (id(oq_water_supply_temp_selected_hold_active)) add("Water supply");
-      if (id(oq_outside_temp_selected_hold_active)) add("Outside temp");
-      if (id(oq_room_temp_selected_hold_active)) add("Room temp");
-      if (id(oq_room_setpoint_selected_hold_active)) add("Room setpoint");
-      if (id(oq_external_heat_demand_selected_hold_active)) add("External heat demand");
-      if (id(oq_cooling_dew_point_selected_hold_active)) add("Cooling dew point");
-
-      if (active.empty()) active = "None";
-      return {active};
+      return {oq_sensor_source::runtime().selected_hold_status()};
 
 sensor:
   - platform: template
@@ -486,191 +225,12 @@ sensor:
     accuracy_decimals: 2
     update_interval: 5s
     lambda: |-
-      // Prefer the configured source, then the topology's last heat-pump outlet.
-      // If both are unavailable, briefly hold the last value from the exact same source.
-      const bool source_available = id(water_supply_source).has_state();
-      const std::string source = source_available
-          ? id(water_supply_source).current_option()
-          : std::string();
-      const uint32_t local_cic_hold_ms = (uint32_t)(${oq_water_supply_temp_local_cic_hold_s}UL * 1000UL);
-      const uint32_t ha_hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
-      const uint32_t fallback_stale_ms = (uint32_t)(${oq_hp_water_temp_stale_s}UL * 1000UL);
-      const uint32_t now_ms = (uint32_t) millis();
-      static oq_supply_hold::State selected_hold;
-
-      std::string local_source;
-      bool local_source_ready = false;
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      local_source_ready = id(${oq_local_supply_temp_selector_id}).has_state();
-      if (local_source_ready) local_source = id(${oq_local_supply_temp_selector_id}).current_option();
-      #endif
-      const bool cic_url_configured = id(cic_feed_url).has_state();
-      const std::string cic_url = cic_url_configured ? id(cic_feed_url).state : std::string();
-      const bool cic_url_ready = cic_url_configured && id(cic_component).is_url_ready(cic_url);
-      const auto source_identity = oq_supply_calibration::source_identity(
-          source.c_str(), OQ_HARDWARE_HEATPUMP_CONTROLLER_Q, local_source.c_str(), local_source_ready,
-          cic_url.c_str(), cic_url_ready, "${ha_water_supply_temp_entity_id}");
-
-      auto calibration_record_for = [&](oq_supply_calibration::SourceCode source_code) {
-        switch (source_code) {
-          case oq_supply_calibration::SOURCE_LOCAL_PT1000:
-            return oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_pt1000_record));
-          case oq_supply_calibration::SOURCE_LOCAL_DS18B20:
-            return oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_ds18b20_record));
-          case oq_supply_calibration::SOURCE_CIC:
-            return oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_cic_record));
-          case oq_supply_calibration::SOURCE_HA_INPUT:
-            return oq_supply_calibration::load_record(id(oq_water_supply_temp_calibration_ha_input_record));
-          default:
-            return oq_supply_calibration::CalibrationRecord{};
-        }
-      };
-
-      if (id(water_supply_temp_calibration_offset).has_state()) {
-        const int32_t legacy_source = id(oq_water_supply_temp_calibration_source_code);
-        const uint32_t legacy_fingerprint = id(oq_water_supply_temp_calibration_source_fingerprint);
-        const uint32_t legacy_checksum = id(oq_water_supply_temp_calibration_checksum);
-        const float legacy_offset = id(water_supply_temp_calibration_offset).state;
-        switch (legacy_source) {
-          case oq_supply_calibration::SOURCE_LOCAL_PT1000:
-            oq_supply_calibration::migrate_legacy_record(
-                id(oq_water_supply_temp_calibration_pt1000_record), legacy_source, legacy_fingerprint,
-                legacy_checksum, legacy_offset);
-            break;
-          case oq_supply_calibration::SOURCE_LOCAL_DS18B20:
-            oq_supply_calibration::migrate_legacy_record(
-                id(oq_water_supply_temp_calibration_ds18b20_record), legacy_source, legacy_fingerprint,
-                legacy_checksum, legacy_offset);
-            break;
-          case oq_supply_calibration::SOURCE_CIC:
-            oq_supply_calibration::migrate_legacy_record(
-                id(oq_water_supply_temp_calibration_cic_record), legacy_source, legacy_fingerprint,
-                legacy_checksum, legacy_offset);
-            break;
-          case oq_supply_calibration::SOURCE_HA_INPUT:
-            oq_supply_calibration::migrate_legacy_record(
-                id(oq_water_supply_temp_calibration_ha_input_record), legacy_source, legacy_fingerprint,
-                legacy_checksum, legacy_offset);
-            break;
-          default:
-            break;
-        }
-      }
-
-      auto clear_selected_hold = [&]() {
-        selected_hold.reset();
-        id(oq_water_supply_temp_selected_hold_active) = false;
-      };
-      const bool cached_source_changed = selected_hold.has_value() && !selected_hold.matches_source(source_identity);
-      if (cached_source_changed) clear_selected_hold();
-
-      bool source_calibration_required = false;
-      if (source_identity.ready) {
-        const auto record = calibration_record_for(source_identity.code);
-        const bool record_invalid = oq_supply_calibration::calibration_required(record, source_identity);
-        source_calibration_required = record_invalid;
-        if (record_invalid) clear_selected_hold();
-        id(oq_water_supply_temp_current_source_code) = static_cast<int32_t>(source_identity.code);
-        id(oq_water_supply_temp_current_source_fingerprint) = source_identity.fingerprint;
-        id(oq_water_supply_temp_current_source_ready) = true;
-
-        const float active_offset = oq_supply_calibration::record_matches(record, source_identity)
-            ? record.offset_c
-            : 0.0f;
-        if (!id(water_supply_temp_calibration_offset).has_state() ||
-            fabsf(id(water_supply_temp_calibration_offset).state - active_offset) > 0.0001f) {
-          // Mirror the selected slot for diagnostics; control reads the validated source record directly.
-          id(water_supply_temp_calibration_offset).publish_state(active_offset);
-        }
-      } else {
-        id(oq_water_supply_temp_current_source_code) = 0;
-        id(oq_water_supply_temp_current_source_fingerprint) = 0;
-        id(oq_water_supply_temp_current_source_ready) = false;
-      }
-      // Publish diagnostics with the runtime identity so a source switch is fail-closed immediately.
-      id(oq_water_supply_temp_calibration_required).publish_state(source_calibration_required);
-      id(oq_water_supply_temp_calibration_status).update();
-
-      auto publish_effective_source = [&](const std::string &value) {
-        if (!id(oq_water_supply_temp_effective_source).has_state() ||
-            id(oq_water_supply_temp_effective_source).state != value) {
-          id(oq_water_supply_temp_effective_source).publish_state(value);
-        }
-      };
-
-      float selected_c = NAN;
-      if (source == "CIC") {
-        if (id(feed_ok).has_state() && id(feed_ok).state &&
-            id(cic_data_stale).has_state() && !id(cic_data_stale).state &&
-            id(water_supply_temp_cic).has_state()) {
-          selected_c = id(water_supply_temp_cic).state;
-        }
-      }
-      if (source == "HA input") {
-        if (id(water_supply_temp_valid_ha).state && id(water_supply_temp_ha).has_state()) selected_c = id(water_supply_temp_ha).state;
-      }
-      if (source == "Local") {
-        if (id(water_supply_temp_esp).has_state()) selected_c = id(water_supply_temp_esp).state;
-      }
-
-      const bool selected_valid = !isnan(selected_c);
-      if (selected_valid) {
-        const auto record = calibration_record_for(source_identity.code);
-        if (oq_supply_calibration::record_matches(record, source_identity)) {
-          selected_c += record.offset_c;
-        }
-        if (source_identity.ready) {
-          selected_hold.remember(selected_c, now_ms, source_identity);
-        } else {
-          clear_selected_hold();
-        }
-        id(oq_water_supply_temp_selected_hold_active) = false;
-        id(oq_water_supply_temp_fallback_runtime_active) = false;
-
-        std::string effective_source = source;
-        if (source == "Local") {
-          #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-          if (id(${oq_local_supply_temp_selector_id}).has_state()) {
-            effective_source += " - ";
-            effective_source += id(${oq_local_supply_temp_selector_id}).current_option();
-          }
-          #else
-          effective_source = "Local - DS18B20";
-          #endif
-        }
-        publish_effective_source(effective_source);
-        return selected_c;
-      }
-
-      id(oq_water_supply_temp_selected_hold_active) = false;
-      const uint32_t hold_ms = oq_supply_hold::timeout_ms(source_identity, local_cic_hold_ms, ha_hold_ms);
-      const bool selected_hold_available = selected_hold.available(source_identity, now_ms, hold_ms);
-      if (!selected_hold_available) clear_selected_hold();
-
-      const uint32_t fallback_last_update_ms = id(${secondary_water_out_last_update_ms_id});
-      const bool fallback_fresh =
-          fallback_last_update_ms > 0 &&
-          (uint32_t)(now_ms - fallback_last_update_ms) <= fallback_stale_ms;
-      if (id(${secondary_hp_id}_is_online) &&
-          fallback_fresh &&
-          id(${secondary_water_out_temp_id}).has_state() &&
-          !isnan(id(${secondary_water_out_temp_id}).state)) {
-        id(oq_water_supply_temp_fallback_runtime_active) = true;
-        publish_effective_source("${secondary_hp_id} water out (fallback)");
-        return id(${secondary_water_out_temp_id}).state;
-      }
-
-      id(oq_water_supply_temp_fallback_runtime_active) = false;
-      if (selected_hold_available) {
-        id(oq_water_supply_temp_selected_hold_active) = true;
-        publish_effective_source(
-            std::string(oq_supply_calibration::source_label(selected_hold.source_code)) + " (held)");
-        return selected_hold.last_valid_c;
-      }
-
-      clear_selected_hold();
-      publish_effective_source("Unavailable");
-      return NAN;
+      return oq_sensor_source::runtime().water_supply(
+          (uint32_t) millis(),
+          (uint32_t) (${oq_water_supply_temp_local_cic_hold_s}UL * 1000UL),
+          (uint32_t) (${oq_selected_input_stale_hold_s}UL * 1000UL),
+          (uint32_t) (${oq_hp_water_temp_stale_s}UL * 1000UL),
+          "${ha_water_supply_temp_entity_id}");
 
   - platform: template
     id: flow_rate_selected
@@ -682,60 +242,7 @@ sensor:
     accuracy_decimals: 1
     update_interval: 5s
     lambda: |-
-      if (!id(flow_source).has_state()) return NAN;
-      const auto source = id(flow_source).current_option();
-      if (source == "CIC") {
-        if (id(flow_rate_cic).has_state()) return id(flow_rate_cic).state;
-        return NAN;
-      }
-      if (source == "Outdoor unit") {
-        #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-        const auto q_flow_source = id(${oq_q_flow_source_selector_id}).current_option();
-        bool q_uses_exclusively_local_flow = q_flow_source == "Local";
-        #if !OQ_TOPOLOGY_DUO
-        // Q V1 Auto resolves to the local controller meter in a single topology.
-        q_uses_exclusively_local_flow =
-          q_uses_exclusively_local_flow ||
-          (q_flow_source == "Auto" &&
-           id(hp_generation).has_state() &&
-           id(hp_generation).current_option() == "V1");
-        #endif
-        if (q_uses_exclusively_local_flow) {
-          if (id(${oq_controller_flow_sensor_id}).has_state()) return id(${oq_controller_flow_sensor_id}).state;
-          return NAN;
-        }
-        #endif
-        const oq_flow::PumpRelayState hp1_pump{
-          id(hp1_is_online) && id(hp1_pump_relay).has_state(), id(hp1_pump_relay).state
-        };
-        const oq_flow::PumpRelayState hp2_pump{
-          id(${secondary_hp_id}_is_online) && id(${secondary_hp_id}_pump_relay).has_state(),
-          id(${secondary_hp_id}_pump_relay).state
-        };
-        if (oq_flow::all_relevant_pumps_stopped(
-              (${flow_secondary_enabled} != 0), hp1_pump, hp2_pump)) {
-          return 0.0f;
-        }
-        #if OQ_TOPOLOGY_DUO
-        // Duo-only outdoor-unit flow selector:
-        // - HP1/HP2 = direct individual outdoor-unit flowmeter
-        // - Local aggregate HP1/HP2 = existing combined HP1/HP2 flow signal
-        //   (normally average, but with mismatch guard inside flow_rate_hp_avg)
-        // Q-edition local controller flow is selected explicitly above.
-        const auto local_mode = id(oq_duo_outdoor_flow_mode).current_option();
-        if (local_mode == "Flowmeter HP1") {
-          if (id(hp1_flow).has_state()) return id(hp1_flow).state;
-          return NAN;
-        }
-        if (local_mode == "Flowmeter HP2") {
-          if (id(${secondary_flow_id}).has_state()) return id(${secondary_flow_id}).state;
-          return NAN;
-        }
-        #endif
-        if (id(flow_rate_hp_avg).has_state()) return id(flow_rate_hp_avg).state;
-        return NAN;
-      }
-      return NAN;
+      return oq_sensor_source::runtime().flow();
 
   - platform: template
     id: outside_temp_selected
@@ -747,63 +254,8 @@ sensor:
     accuracy_decimals: 1
     update_interval: 10s
     lambda: |-
-      // Auto uses the lowest currently valid outside temperature source.
-      if (!id(outside_temp_source).has_state()) return NAN;
-      const auto source = id(outside_temp_source).current_option();
-      const uint32_t now_ms = (uint32_t) millis();
-      const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
-      const bool hp_valid = id(outside_temp_hp_avg).has_state() && !isnan(id(outside_temp_hp_avg).state);
-      const bool ha_valid = id(outside_temp_valid_ha).state && id(outside_temp_ha).has_state() && !isnan(id(outside_temp_ha).state);
-      const bool mqtt_valid =
-          id(mqtt_outside_temperature_valid).has_state() && id(mqtt_outside_temperature_valid).state &&
-          id(mqtt_outside_temperature).has_state() && !isnan(id(mqtt_outside_temperature).state);
-        const bool api_valid =
-          id(api_input_outside_temperature_valid).has_state() && id(api_input_outside_temperature_valid).state &&
-          id(api_input_outside_temperature).has_state() && !isnan(id(api_input_outside_temperature).state);
-      const bool hold_enabled = source == "HA input";
-
-      float selected_c = NAN;
-      auto take_lowest = [&](float value) {
-        if (isnan(selected_c) || value < selected_c) selected_c = value;
-      };
-      if (source == "Auto" || source == "Lowest valid") {
-        if (ha_valid) take_lowest(id(outside_temp_ha).state);
-        if (hp_valid) take_lowest(id(outside_temp_hp_avg).state);
-        if (api_valid) take_lowest(id(api_input_outside_temperature).state);
-        if (mqtt_valid) take_lowest(id(mqtt_outside_temperature).state);
-      }
-      if (source == "HA input") {
-        if (ha_valid) selected_c = id(outside_temp_ha).state;
-      }
-      if (source == "Outdoor unit") {
-        if (hp_valid) selected_c = id(outside_temp_hp_avg).state;
-      }
-      if (source == "API input") {
-        if (api_valid) selected_c = id(api_input_outside_temperature).state;
-      }
-      if (source == "MQTT") {
-        if (mqtt_valid) selected_c = id(mqtt_outside_temperature).state;
-      }
-
-      const bool selected_valid = !isnan(selected_c);
-      if (selected_valid) {
-        id(oq_outside_temp_selected_last_valid_c) = selected_c;
-        id(oq_outside_temp_selected_last_valid_ms) = now_ms;
-        id(oq_outside_temp_selected_hold_active) = false;
-        return selected_c;
-      }
-
-      id(oq_outside_temp_selected_hold_active) = false;
-      if (hold_enabled &&
-          hold_ms > 0 &&
-          id(oq_outside_temp_selected_last_valid_ms) > 0 &&
-          (uint32_t)(now_ms - id(oq_outside_temp_selected_last_valid_ms)) < hold_ms &&
-          !isnan(id(oq_outside_temp_selected_last_valid_c))) {
-        id(oq_outside_temp_selected_hold_active) = true;
-        return id(oq_outside_temp_selected_last_valid_c);
-      }
-
-      return NAN;
+      return oq_sensor_source::runtime().outside(
+          (uint32_t) millis(), (uint32_t) (${oq_selected_input_stale_hold_s}UL * 1000UL));
 
   - platform: template
     id: room_temp_selected
@@ -815,57 +267,9 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      // Hold the selected HA room temperature briefly through HA reload gaps.
-      if (!id(room_temp_source).has_state()) return NAN;
-      const auto source = id(room_temp_source).current_option();
-      const bool hold_enabled = source == "HA input";
-      const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
-      const uint32_t now_ms = (uint32_t) millis();
-      const bool mqtt_valid =
-          id(mqtt_room_temperature_valid).has_state() && id(mqtt_room_temperature_valid).state &&
-          id(mqtt_room_temperature).has_state() && !isnan(id(mqtt_room_temperature).state);
-        const bool api_valid =
-          id(api_input_room_temperature_valid).has_state() && id(api_input_room_temperature_valid).state &&
-          id(api_input_room_temperature).has_state() && !isnan(id(api_input_room_temperature).state);
-
-      float selected_c = NAN;
-      if (source == "HA input") {
-        if (id(room_temp_valid_ha).state && id(thermostat_room_temp_ha).has_state()) selected_c = id(thermostat_room_temp_ha).state;
-      }
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (source == "OT thermostat") {
-        if (id(ot_thermostat_room_temp).has_state()) selected_c = id(ot_thermostat_room_temp).state;
-      }
-      #endif
-      if (source == "CIC") {
-        if (id(cic_room_temp).has_state()) selected_c = id(cic_room_temp).state;
-      }
-      if (source == "API input") {
-        if (api_valid) selected_c = id(api_input_room_temperature).state;
-      }
-      if (source == "MQTT") {
-        if (mqtt_valid) selected_c = id(mqtt_room_temperature).state;
-      }
-
-      const bool selected_valid = !isnan(selected_c);
-      if (selected_valid) {
-        id(oq_room_temp_selected_last_valid_c) = selected_c;
-        id(oq_room_temp_selected_last_valid_ms) = now_ms;
-        id(oq_room_temp_selected_hold_active) = false;
-        return selected_c;
-      }
-
-      id(oq_room_temp_selected_hold_active) = false;
-      if (hold_enabled &&
-          hold_ms > 0 &&
-          id(oq_room_temp_selected_last_valid_ms) > 0 &&
-          (uint32_t)(now_ms - id(oq_room_temp_selected_last_valid_ms)) < hold_ms &&
-          !isnan(id(oq_room_temp_selected_last_valid_c))) {
-        id(oq_room_temp_selected_hold_active) = true;
-        return id(oq_room_temp_selected_last_valid_c);
-      }
-
-      return NAN;
+      return oq_sensor_source::runtime().room_temperature(
+          (uint32_t) millis(), (uint32_t) (${oq_selected_input_stale_hold_s}UL * 1000UL),
+          (${oq_ot_room_temperature_fresh_expr}));
 
   - platform: template
     id: room_setpoint_selected
@@ -877,57 +281,9 @@ sensor:
     accuracy_decimals: 2
     update_interval: 10s
     lambda: |-
-      // Hold the selected HA room setpoint briefly through HA reload gaps.
-      if (!id(room_setpoint_source).has_state()) return NAN;
-      const auto source = id(room_setpoint_source).current_option();
-      const bool hold_enabled = source == "HA input";
-      const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
-      const uint32_t now_ms = (uint32_t) millis();
-      const bool mqtt_valid =
-          id(mqtt_room_setpoint_valid).has_state() && id(mqtt_room_setpoint_valid).state &&
-          id(mqtt_room_setpoint).has_state() && !isnan(id(mqtt_room_setpoint).state);
-        const bool api_valid =
-          id(api_input_room_setpoint_valid).has_state() && id(api_input_room_setpoint_valid).state &&
-          id(api_input_room_setpoint).has_state() && !isnan(id(api_input_room_setpoint).state);
-
-      float selected_c = NAN;
-      if (source == "HA input") {
-        if (id(room_setpoint_valid_ha).state && id(thermostat_setpoint_ha).has_state()) selected_c = id(thermostat_setpoint_ha).state;
-      }
-      #if OQ_HARDWARE_HEATPUMP_CONTROLLER_Q
-      if (source == "OT thermostat") {
-        if (id(ot_thermostat_room_setpoint).has_state()) selected_c = id(ot_thermostat_room_setpoint).state;
-      }
-      #endif
-      if (source == "CIC") {
-        if (id(cic_room_setpoint).has_state()) selected_c = id(cic_room_setpoint).state;
-      }
-      if (source == "API input") {
-        if (api_valid) selected_c = id(api_input_room_setpoint).state;
-      }
-      if (source == "MQTT") {
-        if (mqtt_valid) selected_c = id(mqtt_room_setpoint).state;
-      }
-
-      const bool selected_valid = !isnan(selected_c);
-      if (selected_valid) {
-        id(oq_room_setpoint_selected_last_valid_c) = selected_c;
-        id(oq_room_setpoint_selected_last_valid_ms) = now_ms;
-        id(oq_room_setpoint_selected_hold_active) = false;
-        return selected_c;
-      }
-
-      id(oq_room_setpoint_selected_hold_active) = false;
-      if (hold_enabled &&
-          hold_ms > 0 &&
-          id(oq_room_setpoint_selected_last_valid_ms) > 0 &&
-          (uint32_t)(now_ms - id(oq_room_setpoint_selected_last_valid_ms)) < hold_ms &&
-          !isnan(id(oq_room_setpoint_selected_last_valid_c))) {
-        id(oq_room_setpoint_selected_hold_active) = true;
-        return id(oq_room_setpoint_selected_last_valid_c);
-      }
-
-      return NAN;
+      return oq_sensor_source::runtime().room_setpoint(
+          (uint32_t) millis(), (uint32_t) (${oq_selected_input_stale_hold_s}UL * 1000UL),
+          (${oq_ot_room_setpoint_fresh_expr}));
 
   - platform: template
     id: external_heat_demand_selected
@@ -939,50 +295,5 @@ sensor:
     accuracy_decimals: 0
     update_interval: 10s
     lambda: |-
-      // Optional external Power House feedforward. NAN is the normal state and
-      // leaves the modelled house power in charge, so an absent or stale
-      // planner degrades to firmware behaviour instead of to no heat.
-      if (!id(external_heat_demand_source).has_state()) return NAN;
-      const auto source = id(external_heat_demand_source).current_option();
-      const bool hold_enabled = source == "HA input";
-      const uint8_t source_code = (source == "HA input")
-          ? oq_power_house::kDemandSourceHaInput
-          : (source == "API input") ? oq_power_house::kDemandSourceApiInput
-                                    : oq_power_house::kDemandSourceNone;
-      const uint32_t hold_ms = (uint32_t)(${oq_selected_input_stale_hold_s}UL * 1000UL);
-      const uint32_t now_ms = (uint32_t) millis();
-      const bool api_valid =
-          id(api_input_external_heat_demand_valid).has_state() && id(api_input_external_heat_demand_valid).state &&
-          id(api_input_external_heat_demand).has_state() && !isnan(id(api_input_external_heat_demand).state);
-
-      float selected_w = NAN;
-      if (source == "HA input") {
-        if (id(external_heat_demand_valid_ha).state && id(external_heat_demand_ha).has_state()) selected_w = id(external_heat_demand_ha).state;
-      }
-      if (source == "API input") {
-        if (api_valid) selected_w = id(api_input_external_heat_demand).state;
-      }
-
-      const bool selected_valid = !isnan(selected_w);
-      if (selected_valid) {
-        id(oq_external_heat_demand_selected_last_valid_w) = selected_w;
-        id(oq_external_heat_demand_selected_last_valid_ms) = now_ms;
-        id(oq_external_heat_demand_selected_last_valid_source) = source_code;
-        id(oq_external_heat_demand_selected_hold_active) = false;
-        return selected_w;
-      }
-
-      id(oq_external_heat_demand_selected_hold_active) = false;
-      if (hold_enabled &&
-          oq_power_house::hold_cached_demand(
-              id(oq_external_heat_demand_selected_last_valid_source),
-              source_code,
-              id(oq_external_heat_demand_selected_last_valid_w),
-              id(oq_external_heat_demand_selected_last_valid_ms),
-              now_ms,
-              hold_ms)) {
-        id(oq_external_heat_demand_selected_hold_active) = true;
-        return id(oq_external_heat_demand_selected_last_valid_w);
-      }
-
-      return NAN;
+      return oq_sensor_source::runtime().external_heat_demand(
+          (uint32_t) millis(), (uint32_t) (${oq_selected_input_stale_hold_s}UL * 1000UL));

--- a/scripts/tests/test_input_source_runtime_contract.py
+++ b/scripts/tests/test_input_source_runtime_contract.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_YAML = (ROOT / "openquatt/oq_sensor_sources.yaml").read_text()
+API_YAML = (ROOT / "openquatt/oq_api_ingress.yaml").read_text()
+SOURCE_RUNTIME = (ROOT / "openquatt/includes/control/oq_sensor_source_runtime.h").read_text()
+API_RUNTIME = (ROOT / "openquatt/includes/control/oq_api_ingress_runtime.h").read_text()
+SOURCE_LOGIC = (ROOT / "openquatt/includes/control/oq_input_source_logic.h").read_text()
+
+
+def entity_block(source: str, entity_id: str) -> str:
+    start = source.index(f"    id: {entity_id}")
+    end = source.find("\n  - platform:", start + 1)
+    return source[start:] if end < 0 else source[start:end]
+
+
+class InputSourceRuntimeContractTest(unittest.TestCase):
+    def test_entity_options_defaults_and_ranges_are_preserved(self) -> None:
+        source_contracts = {
+            "water_supply_source": ("options: [Local, CIC, HA input]", "initial_option: Local"),
+            "flow_source": ("options: [Outdoor unit, CIC]", "initial_option: Outdoor unit"),
+            "oq_duo_outdoor_flow_mode": (
+                "options: [Flowmeter HP1, Flowmeter HP2, Local aggregate HP1/HP2]",
+                "initial_option: Local aggregate HP1/HP2",
+            ),
+            "outside_temp_source": (
+                "options: [Auto, Outdoor unit, HA input, API input, MQTT]",
+                "initial_option: Auto",
+            ),
+        }
+        for entity_id, snippets in source_contracts.items():
+            block = entity_block(SOURCE_YAML, entity_id)
+            for snippet in snippets:
+                self.assertIn(snippet, block)
+
+        api_ranges = {
+            "api_input_cooling_dew_point": (-20, 35, 0.1),
+            "api_input_outside_temperature": (-40, 60, 0.1),
+            "api_input_room_temperature": (0, 50, 0.1),
+            "api_input_room_setpoint": (5, 35, 0.1),
+            "api_input_external_heat_demand": (0, 15000, 10),
+        }
+        for entity_id, (minimum, maximum, step) in api_ranges.items():
+            block = entity_block(API_YAML, entity_id)
+            self.assertIn(f"min_value: {minimum}", block)
+            self.assertIn(f"max_value: {maximum}", block)
+            self.assertIn(f"step: {step}", block)
+            self.assertIn("restore_value: false", block)
+            self.assertIn("optimistic: true", block)
+
+        self.assertIn("restore_mode: RESTORE_DEFAULT_OFF", entity_block(SOURCE_YAML, "oq_manual_cooling_enable"))
+        for entity_id in ("water_supply_temp_selected", "flow_rate_selected"):
+            self.assertIn("update_interval: 5s", entity_block(SOURCE_YAML, entity_id))
+        for entity_id in (
+            "outside_temp_selected",
+            "room_temp_selected",
+            "room_setpoint_selected",
+            "external_heat_demand_selected",
+        ):
+            self.assertIn("update_interval: 10s", entity_block(SOURCE_YAML, entity_id))
+
+    def test_yaml_is_a_compact_runtime_contract(self) -> None:
+        self.assertLessEqual(len(SOURCE_YAML.splitlines()) + len(API_YAML.splitlines()), 750)
+        for call in (
+            "oq_sensor_source::runtime().water_supply(",
+            "oq_sensor_source::runtime().flow()",
+            "oq_sensor_source::runtime().outside(",
+            "oq_sensor_source::runtime().room_temperature(",
+            "oq_sensor_source::runtime().room_setpoint(",
+            "oq_sensor_source::runtime().external_heat_demand(",
+        ):
+            self.assertIn(call, SOURCE_YAML)
+        self.assertEqual(API_YAML.count("oq_api_ingress::runtime().observe("), 9)
+        self.assertIn("oq_api_ingress::runtime().tick(", API_YAML)
+
+    def test_stateful_decisions_live_in_cpp(self) -> None:
+        for removed in (
+            "_has_value",
+            "_last_valid_ms",
+            "auto update_numeric",
+            "auto update_binary",
+            "static float last_valid",
+        ):
+            self.assertNotIn(removed, API_YAML)
+        for removed in (
+            "static float last_valid",
+            "auto source_valid",
+            "auto source_value",
+            "auto source_name",
+        ):
+            self.assertNotIn(removed, SOURCE_YAML)
+        self.assertIn("oq_input_source::evaluate_freshness", API_RUNTIME)
+        self.assertIn("oq_input_source::select_outside", SOURCE_RUNTIME)
+        self.assertIn("oq_input_source::select_direct", SOURCE_RUNTIME)
+
+    def test_safety_and_upgrade_contracts_remain_explicit(self) -> None:
+        self.assertEqual(API_YAML.count("restore_mode: ALWAYS_OFF"), 2)
+        self.assertIn("oq_nvs_cleanup::erase_entity_preferences(", API_YAML)
+        self.assertIn("oq_api_ingress::runtime().reset()", API_YAML)
+        self.assertIn("oq_ot_room_temperature_fresh_expr", SOURCE_YAML)
+        self.assertIn("oq_ot_room_setpoint_fresh_expr", SOURCE_YAML)
+        self.assertIn("isfinite", API_RUNTIME)
+        self.assertIn("isfinite", SOURCE_LOGIC)
+        for runtime in (SOURCE_RUNTIME, API_RUNTIME, SOURCE_LOGIC):
+            self.assertNotIn("${", runtime)
+
+    def test_host_regressions_cover_failure_boundaries(self) -> None:
+        host_test = (ROOT / "tests/host/input_source_logic_test.cpp").read_text()
+        for test_name in (
+            "test_freshness_accepts_timestamp_zero_and_rollover",
+            "test_hold_is_bound_to_selected_source",
+            "test_non_finite_samples_fail_closed",
+            "test_outside_lowest_valid_selection",
+            "test_enable_source_selection",
+            "test_flow_source_routes",
+        ):
+            self.assertIn(test_name, host_test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host/input_source_logic_test.cpp
+++ b/tests/host/input_source_logic_test.cpp
@@ -1,0 +1,158 @@
+#include <assert.h>
+#include <limits.h>
+#include <math.h>
+
+#include "../../openquatt/includes/control/oq_input_source_logic.h"
+
+using namespace oq_input_source;
+
+void test_freshness_accepts_timestamp_zero_and_rollover() {
+  TimedState state;
+  assert(!evaluate_freshness(state, 1000, 10, true).valid);
+
+  state.observe(0);
+  auto result = evaluate_freshness(state, 0, 10, true);
+  assert(result.valid);
+  assert(result.age_s == 0.0f);
+  assert(evaluate_freshness(state, 10000, 10, true).valid);
+  assert(!evaluate_freshness(state, 10001, 10, true).valid);
+  assert(evaluate_freshness(state, 100000, 0, true).valid);
+  result = evaluate_freshness(state, 1000, 10, false);
+  assert(!result.valid && isnan(result.age_s));
+
+  state.observe(UINT32_MAX - 4U);
+  result = evaluate_freshness(state, 5, 10, true);
+  assert(result.valid);
+  assert(result.age_s == 0.010f);
+  assert(seconds_to_millis(UINT32_MAX / 1000U) == (UINT32_MAX / 1000U) * 1000U);
+  assert(seconds_to_millis(UINT32_MAX) == UINT32_MAX);
+}
+
+void test_hold_is_bound_to_selected_source() {
+  NumericSources sources;
+  HoldState hold;
+
+  sources.ha = numeric_sample(true, true, 20.0f);
+  auto selected = select_direct(Source::HA, sources, true, 0, 300000, hold);
+  assert(selected.valid && !selected.held && selected.value == 20.0f);
+
+  sources.ha = {};
+  selected = select_direct(Source::HA, sources, true, 1000, 300000, hold);
+  assert(selected.valid && selected.held && selected.value == 20.0f);
+  selected = select_direct(Source::HA, sources, true, 300000, 300000, hold);
+  assert(!selected.valid);
+
+  // Switching away clears the HA cache, so switching back cannot replay another source.
+  sources.ha = numeric_sample(true, true, 21.0f);
+  assert(select_direct(Source::HA, sources, true, 400000, 300000, hold).valid);
+  sources.opentherm = numeric_sample(true, true, 19.0f);
+  assert(select_direct(Source::OPENTHERM, sources, true, 401000, 300000, hold).value == 19.0f);
+  sources.ha = {};
+  assert(!select_direct(Source::HA, sources, true, 402000, 300000, hold).valid);
+
+  // API inputs expire instead of inheriting the HA-only reload hold.
+  sources.api = numeric_sample(true, true, 22.0f);
+  assert(select_direct(Source::API, sources, true, 500000, 300000, hold).valid);
+  sources.api = {};
+  assert(!select_direct(Source::API, sources, true, 501000, 300000, hold).valid);
+}
+
+void test_non_finite_samples_fail_closed() {
+  assert(!numeric_sample(true, true, INFINITY).valid);
+  assert(!numeric_sample(true, true, NAN).valid);
+  assert(!numeric_sample(false, true, 20.0f).valid);
+}
+
+void test_outside_lowest_valid_selection() {
+  NumericSources sources;
+  sources.ha = numeric_sample(true, true, 8.0f);
+  sources.outdoor = numeric_sample(true, true, 5.0f);
+  sources.api = numeric_sample(true, true, 6.0f);
+  sources.mqtt = numeric_sample(true, true, 7.0f);
+
+  HoldState hold;
+  auto selected = select_outside(Source::AUTO, sources, 1000, 300000, hold);
+  assert(selected.valid && selected.route == Source::OUTDOOR && selected.value == 5.0f);
+  sources.outdoor = {};
+  selected = select_outside(Source::AUTO, sources, 2000, 300000, hold);
+  assert(selected.valid && selected.route == Source::API && selected.value == 6.0f);
+}
+
+void test_enable_source_selection() {
+  EnableSources sources;
+  sources.cic = {false, true};
+  sources.ha = {true, true};
+  sources.api = {true, false};
+
+  auto heating = select_heating_enable(Source::DISABLED, sources);
+  assert(heating.valid && heating.value);
+  heating = select_heating_enable(Source::CIC, sources);
+  assert(heating.valid && !heating.value);
+  heating = select_heating_enable(Source::API, sources);
+  assert(!heating.valid && !heating.value);
+
+  auto cooling = select_cooling_enable(Source::CIC_OR_HA, sources, false);
+  assert(cooling.valid && cooling.value);
+  cooling = select_cooling_enable(Source::DISABLED, sources, false);
+  assert(cooling.valid && !cooling.value);
+  cooling = select_cooling_enable(Source::API, sources, true);
+  assert(cooling.valid && cooling.value);
+  sources.ha = {false, false};
+  cooling = select_cooling_enable(Source::CIC_OR_HA, sources, false);
+  assert(cooling.valid && !cooling.value);
+  sources.cic = {false, false};
+  cooling = select_cooling_enable(Source::CIC_OR_HA, sources, false);
+  assert(!cooling.valid && !cooling.value);
+}
+
+void test_flow_source_routes() {
+  FlowInputs input;
+  input.selected = Source::OUTDOOR;
+  input.aggregate = numeric_sample(true, true, 900.0f);
+  auto selected = select_flow(input);
+  assert(selected.valid && selected.route == FlowRoute::AGGREGATE && selected.value == 900.0f);
+
+  input.all_relevant_pumps_stopped = true;
+  selected = select_flow(input);
+  assert(selected.valid && selected.route == FlowRoute::PUMPS_STOPPED && selected.value == 0.0f);
+
+  input.q_hardware = true;
+  input.controller_mode = ControllerFlowMode::LOCAL;
+  input.controller = numeric_sample(true, true, 850.0f);
+  selected = select_flow(input);
+  assert(selected.valid && selected.route == FlowRoute::CONTROLLER && selected.value == 850.0f);
+
+  // Q Single V1 Auto also resolves exclusively to the controller flowmeter.
+  input.controller_mode = ControllerFlowMode::AUTO;
+  input.hp_generation_v1 = true;
+  selected = select_flow(input);
+  assert(selected.valid && selected.route == FlowRoute::CONTROLLER && selected.value == 850.0f);
+
+  // Duo Auto keeps using the selected outdoor-unit route.
+  input.duo = true;
+  input.all_relevant_pumps_stopped = false;
+  selected = select_flow(input);
+  assert(selected.valid && selected.route == FlowRoute::AGGREGATE && selected.value == 900.0f);
+
+  input.q_hardware = false;
+  input.all_relevant_pumps_stopped = false;
+  input.outdoor_mode = OutdoorFlowMode::HP2;
+  input.hp2 = numeric_sample(true, true, 700.0f);
+  selected = select_flow(input);
+  assert(selected.valid && selected.route == FlowRoute::HP2 && selected.value == 700.0f);
+
+  input.selected = Source::CIC;
+  input.cic = numeric_sample(true, true, 600.0f);
+  selected = select_flow(input);
+  assert(selected.valid && selected.route == FlowRoute::CIC && selected.value == 600.0f);
+}
+
+int main() {
+  test_freshness_accepts_timestamp_zero_and_rollover();
+  test_hold_is_bound_to_selected_source();
+  test_non_finite_samples_fail_closed();
+  test_outside_lowest_valid_selection();
+  test_enable_source_selection();
+  test_flow_source_routes();
+  return 0;
+}

--- a/tests/host/oq_supply_hold_logic_test.cpp
+++ b/tests/host/oq_supply_hold_logic_test.cpp
@@ -61,5 +61,10 @@ int main() {
   assert(!state.available(ha, 301000, ha_hold_ms));
   state.remember(NAN, 302000, ha);
   assert(!state.has_value());
+
+  // Timestamp zero is a valid observation at millis() rollover.
+  state.remember(30.0f, 0, pt1000);
+  assert(state.has_value());
+  assert(state.available(pt1000, 10, short_hold_ms));
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst de uitvoerbare logica voor zeven API-inputs en de generieke bronselectie naar drie compacte C++-runtimes; entities, opties, defaults en productietiming blijven YAML-contract.
- Verkleint `oq_sensor_sources.yaml` en `oq_api_ingress.yaml` samen van 1.469 naar 550 regels. Inclusief C++ is productie netto 7 regels kleiner; regressietests zijn apart toegevoegd.
- Laat stale/missing/NaN/Inf en bronwissels fail-closed verlopen, bindt HA-hold aan de geselecteerde bron en maakt timestamp nul plus `millis()`-rollover expliciet veilig.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De bronselectie en input-freshness sturen verwarming, koeling en flow. Bestaande geldige paden blijven semantisch gelijk. Bewuste correcties zijn fail-closed CIC/OpenTherm-freshness, brongebonden HA-hold, finite-validatie, onmiddellijke geldigheid van externe warmtevraag en rolloverveilige timestamps. De runtime introduceert geen taken, protocolverkeer of langdurige dynamische buffers.

## Achtergrond

De twee YAML-bestanden bevatten 31 lambdas en 815 regels inline C++. Deze logica was daardoor moeilijk rechtstreeks hostmatig te testen. De migratie is als één functioneel blok uitgevoerd en stopt hier: declaratieve entities, protocolmapping en korte bindingslambdas blijven in YAML.

De volledige diff is na implementatie opnieuw adversarial beoordeeld op boot/reset, bronwissels, ontbrekende en stale inputs, NaN/Inf, timestamp nul, `millis()`-rollover, legacy calibratie/NVS, herstel na reboot en callback-interleavings. Geen openstaande bevindingen.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Er wijzigen geen gebruikersgerichte entities, opties, defaults of instellingen. Het lokale migratie- en acceptatieplan is wel bijgewerkt met scope, grenzen en meetresultaten.

## Validatie

- [x] `CXX=/opt/homebrew/bin/g++-15 ./scripts/run_host_regression_tests.sh` — 59 hosttests groen.
- [x] `npm run check:python-contracts` — 185 contracttests groen.
- [x] `npm run check:cpp-format` — 219 C/C++-bestanden groen.
- [x] `python3 scripts/dev.py validate --config-only` voor Q, Waveshare en Listener, telkens Single/Duo — configuratie en NVS-budget groen.
- [x] `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` en `single_wifi.yaml` — beide firmwarebuilds groen.
- [x] HIL op Q Duo met ODU- en OpenTherm-simulator: API-write/expiry/herstel, brongebonden hold, heating/cooling-enable fail-closed, actieve bronwissel vanuit CM2 en reboot zonder stale replay groen. HP1/HP2 bleven op nul protocolfouten.

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- Q Duo statisch DIRAM: 210.543 -> 210.287 B (-256 B); image: 2.189.239 -> 2.189.319 B (+80 B).
- Q Single statisch DIRAM: 192.983 -> 192.727 B (-256 B); image: 2.144.319 -> 2.144.243 B (-76 B).
- HIL-kandidaat `Heap Min Free`: 40.168 B; geen allocatie- of protocolfouten tijdens de acceptatierun.
- Geen nieuwe task-stack, PSRAM-eigenaar of netwerkbuffer. Largest-block/fragmentatie en een identieke baseline-HIL zijn in dit werkblok niet afzonderlijk gelogd.

Na HIL zijn de toenmalige schone `dev`-firmware en de vastgelegde controller- en simulatorinstellingen teruggezet en na reboot gecontroleerd. De branch is daarna conflictvrij herbaseerd op `dev` `3c879b1b`; de toegevoegde upstream-wijzigingen raken deze runtimes niet.
