### PR TITLE
Maak HIL-tests veilig herhaalbaar

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Run Python contract tests
         run: npm run check:python-contracts
 
+  hil-harness-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Test HIL harness without hardware
+        run: npm run check:hil
+
   validate-web-settings-backup:
     runs-on: ubuntu-latest
     steps:
@@ -91,7 +100,7 @@ jobs:
         run: ./scripts/run_host_regression_tests.sh
 
   validate-and-compile:
-    needs: [cpp-format, docs-consistency, python-contracts, validate-web-settings-backup, host-regression-tests]
+    needs: [cpp-format, docs-consistency, python-contracts, hil-harness-tests, validate-web-settings-backup, host-regression-tests]
     uses: ./.github/workflows/esphome-build.yml
     with:
       artifact_suffix: firmware-${{ github.sha }}

--- a/configs/hil/input_sources_fast_duo_wifi.yaml
+++ b/configs/hil/input_sources_fast_duo_wifi.yaml
@@ -1,0 +1,29 @@
+# ==============================================================================
+# OpenQuatt - HIL TEST ONLY: Fast Input/Source Q Duo WiFi Profile
+# ==============================================================================
+# Shortens only the timers needed by the input/source acceptance scenario.
+# The normal Q Duo WiFi entrypoint remains the complete firmware base.
+
+substitutions:
+  api_input_cooling_dew_point_stale_s: "30"
+  api_input_outside_temperature_stale_s: "30"
+  api_input_room_temperature_stale_s: "30"
+  api_input_room_setpoint_stale_s: "30"
+  api_input_heating_enable_stale_s: "30"
+  api_input_cooling_enable_stale_s: "30"
+  api_input_external_heat_demand_stale_s: "30"
+  oq_selected_input_stale_hold_s: "10"
+  oq_hp_min_off_s: "10"
+
+packages:
+  production_q_duo_wifi: !include ../heatpump_controller_q/duo_wifi.yaml
+
+text_sensor:
+  - platform: template
+    id: oq_hil_test_profile
+    name: "HIL Test Profile"
+    internal: true
+    entity_category: diagnostic
+    update_interval: 5s
+    lambda: |-
+      return {"input-sources-fast-v1"};

--- a/configs/hil/input_sources_fast_duo_wifi.yaml
+++ b/configs/hil/input_sources_fast_duo_wifi.yaml
@@ -5,13 +5,13 @@
 # The normal Q Duo WiFi entrypoint remains the complete firmware base.
 
 substitutions:
-  api_input_cooling_dew_point_stale_s: "30"
-  api_input_outside_temperature_stale_s: "30"
-  api_input_room_temperature_stale_s: "30"
-  api_input_room_setpoint_stale_s: "30"
-  api_input_heating_enable_stale_s: "30"
-  api_input_cooling_enable_stale_s: "30"
-  api_input_external_heat_demand_stale_s: "30"
+  api_input_cooling_dew_point_stale_s: "45"
+  api_input_outside_temperature_stale_s: "45"
+  api_input_room_temperature_stale_s: "45"
+  api_input_room_setpoint_stale_s: "45"
+  api_input_heating_enable_stale_s: "45"
+  api_input_cooling_enable_stale_s: "45"
+  api_input_external_heat_demand_stale_s: "45"
   oq_selected_input_stale_hold_s: "10"
   oq_hp_min_off_s: "10"
 

--- a/docs/hil-testing.md
+++ b/docs/hil-testing.md
@@ -19,6 +19,8 @@ firmware uploadt vereist altijd `--apply`. Verder gelden deze grenzen:
   vastgelegd;
 - testinstellingen worden vóór én na het terugplaatsen van normale firmware
   hersteld en teruggelezen;
+- de herstelde firmwareversie en config-hash moeten exact overeenkomen met de
+  identiteit die vóór de test in het snapshot is opgeslagen;
 - tijdens compileren en terugplaatsen van normale firmware blijft de controller
   geforceerd in CM0; de oorspronkelijke override wordt pas na profielcontrole
   teruggezet;

--- a/docs/hil-testing.md
+++ b/docs/hil-testing.md
@@ -58,7 +58,7 @@ Hij gebruikt de normale Q Duo WiFi-firmware, met alleen deze kortere testtijden:
 
 | Contract | Productie | HIL |
 |---|---:|---:|
-| API-input stale | 0/600/900/1.800 s | 30 s |
+| API-input stale | 0/600/900/1.800 s | 45 s |
 | Geselecteerde-input hold | 300 s | 10 s |
 | HP minimum-off | 240 s | 10 s |
 

--- a/docs/hil-testing.md
+++ b/docs/hil-testing.md
@@ -1,0 +1,138 @@
+# Hardware-in-the-loop-tests
+
+OpenQuatt gebruikt HIL-tests voor wijzigingen waarbij hosttests alleen niet
+bewijzen dat controller, ODU, OpenTherm en timing samen veilig blijven. Een
+volledige HIL-run is bedoeld voor gebundelde control-wijzigingen en
+releasekandidaten, niet voor iedere kleine pull request.
+
+## Veiligheidscontract
+
+De runner is standaard read-only. Een scenario dat instellingen wijzigt of
+firmware uploadt vereist altijd `--apply`. Verder gelden deze grenzen:
+
+- controller- en simulator-URL hebben bewust geen standaardwaarde;
+- alle REST-verzoeken lopen serieel door één begrenzer;
+- controllerstates worden per meetmoment in één read-only bulkverzoek opgehaald;
+- tussen REST-writes zit standaard minimaal 1.500 ms en nooit minder dan
+  1.000 ms;
+- vóór de eerste mutatie wordt `.tmp/hil/<run>/snapshot.json` atomisch
+  vastgelegd;
+- testinstellingen worden vóór én na het terugplaatsen van normale firmware
+  hersteld en teruggelezen;
+- tijdens compileren en terugplaatsen van normale firmware blijft de controller
+  geforceerd in CM0; de oorspronkelijke override wordt pas na profielcontrole
+  teruggezet;
+- de testfirmware moet het verwachte `HIL Test Profile` publiceren;
+- een muterende run vereist een normale restoreconfig en OTA-adres;
+- snapshots en rapporten blijven onder het door Git genegeerde `.tmp/hil/`.
+
+De runner bevat geen IP-adressen, wifi-gegevens, wachtwoorden of lokale
+instellingenback-ups. Gebruik hem alleen wanneer bedrading, hydrauliek en de
+simulator volgens de testerhandleiding veilig zijn aangesloten.
+
+## Read-only rooktest
+
+Controleer bereikbaarheid, firmware, heap en ODU-protocoldiagnostiek zonder
+iets te wijzigen:
+
+```bash
+node scripts/hil/run-input-sources.mjs \
+  --controller http://openquatt.local \
+  --simulator http://SIMULATOR-IP \
+  --stage smoke
+```
+
+Het rapport bevat actuele en minimale interne heap, grootste vrije block,
+fragmentatie, vrije PSRAM en beide ODU-diagnoseregels voor zover de entities
+beschikbaar zijn.
+
+## Volledige input-/bronselectietest
+
+De testconfig is uitsluitend voor HIL en wordt niet als releaseprofiel gebouwd.
+Hij gebruikt de normale Q Duo WiFi-firmware, met alleen deze kortere testtijden:
+
+| Contract | Productie | HIL |
+|---|---:|---:|
+| API-input stale | 0/600/900/1.800 s | 30 s |
+| Geselecteerde-input hold | 300 s | 10 s |
+| HP minimum-off | 240 s | 10 s |
+
+Start de gebundelde run met:
+
+```bash
+node scripts/hil/run-input-sources.mjs \
+  --controller http://openquatt.local \
+  --simulator http://SIMULATOR-IP \
+  --device openquatt.local \
+  --test-config configs/hil/input_sources_fast_duo_wifi.yaml \
+  --restore-config configs/heatpump_controller_q/duo_wifi.yaml \
+  --stage all \
+  --apply
+```
+
+De volgorde is vast:
+
+1. bereikbaarheid en nulmeting controleren;
+2. alle geraakte controller- en simulatorinstellingen opslaan;
+3. testfirmware compileren en via ESPHome-OTA plaatsen;
+4. profielmarker controleren en de gekozen scenario's uitvoeren;
+5. heap- en protocolresultaten vastleggen;
+6. instellingen herstellen;
+7. normale firmware via OTA terugplaatsen;
+8. instellingen na reboot opnieuw herstellen en verifiëren.
+
+Losse scenario's zijn beschikbaar als `inputs`, `enable-expiry`,
+`active-switch` en `reboot-reset`. Ook een losse muterende run herstelt altijd
+de normale firmware. De inputtest raakt alle zeven API-inputslots, inclusief
+het dauwpunt. Met `--min-heap-min-free` en `--min-largest-block` kan een
+vooraf afgesproken profielbudget als harde grens worden meegegeven. Zonder die
+opties rapporteert de runner de waarden, maar noemt hij een geheugentest niet
+automatisch releaseveilig.
+
+## Afbreken en herstellen
+
+Eén keer `Ctrl-C` vraagt recovery aan. Een actieve compile of OTA wordt eerst
+afgerond; REST-wachtlussen stoppen bij hun volgende controle. Een tweede signaal
+breekt direct af en kan daarom handmatig herstel nodig maken. Bij onvolledig
+herstel blijft `.tmp/hil/input-sources.lock` staan
+en toont de runner het snapshotpad. Tegelijk herstel door twee processen wordt
+geblokkeerd; een achtergebleven recovery-processlock wordt alleen opgeruimd als
+de vastgelegde PID niet meer actief is.
+
+Herstel dan met exact dezelfde doelen:
+
+```bash
+node scripts/hil/run-input-sources.mjs \
+  --controller http://openquatt.local \
+  --simulator http://SIMULATOR-IP \
+  --device openquatt.local \
+  --restore-config configs/heatpump_controller_q/duo_wifi.yaml \
+  --restore-snapshot .tmp/hil/RUN/snapshot.json \
+  --apply
+```
+
+Gebruik `--settings-only` alleen wanneer normale firmware aantoonbaar al actief
+is. De herstelopdracht weigert een snapshot voor andere controller- of
+simulator-URL's. In deze modus moeten ook de firmwareversie en config-hash exact
+overeenkomen met de identiteit in het snapshot.
+
+Een herstelpoging overschrijft het oorspronkelijke rapport niet, maar schrijft
+een afzonderlijk `recovery-<tijdstip>.json` in dezelfde runmap.
+
+Kortstondige numerieke API-inputs en API-enablewaarden worden bij herstel bewust
+niet teruggezet; enablewaarden worden expliciet uitgeschakeld. Dat voorkomt dat
+een eerder testcommando na een afgebroken run opnieuw toestemming of vraag geeft
+voor verwarmen of koelen. De oorspronkelijke bronselecties worden wel hersteld,
+waarna de normale integratie nieuwe API-waarden moet aanleveren.
+
+## Lokale validatie zonder hardware
+
+```bash
+npm run check:hil
+python3 scripts/dev.py validate --config-only \
+  --config configs/hil/input_sources_fast_duo_wifi.yaml
+```
+
+De eerste opdracht test write-gating, requestbegrenzing, CLI-veiligheidsregels,
+OTA-commandoconstructie en volledig instellingenherstel met fakes. De tweede
+controleert of de testoverlay met de actuele firmwareconfig blijft compileren.

--- a/docs/hil-testing.md
+++ b/docs/hil-testing.md
@@ -23,12 +23,17 @@ firmware uploadt vereist altijd `--apply`. Verder gelden deze grenzen:
   geforceerd in CM0; de oorspronkelijke override wordt pas na profielcontrole
   teruggezet;
 - de testfirmware moet het verwachte `HIL Test Profile` publiceren;
+- de simulator moet vóór iedere mutatie exact contract
+  `openquatt-modbus-opentherm-v1` publiceren;
 - een muterende run vereist een normale restoreconfig en OTA-adres;
 - snapshots en rapporten blijven onder het door Git genegeerde `.tmp/hil/`.
 
 De runner bevat geen IP-adressen, wifi-gegevens, wachtwoorden of lokale
 instellingenback-ups. Gebruik hem alleen wanneer bedrading, hydrauliek en de
 simulator volgens de testerhandleiding veilig zijn aangesloten.
+De zelfstandige simulatorbron en testerhandleiding staan in
+[`OpenQuatt-Simulator`](https://github.com/OpenQuatt/OpenQuatt-Simulator). Gebruik
+voor dit contract minimaal simulatorrelease `v0.1.0`.
 
 ## Read-only rooktest
 
@@ -44,7 +49,7 @@ node scripts/hil/run-input-sources.mjs \
 
 Het rapport bevat actuele en minimale interne heap, grootste vrije block,
 fragmentatie, vrije PSRAM en beide ODU-diagnoseregels voor zover de entities
-beschikbaar zijn.
+beschikbaar zijn. Ook simulatorcontract en -versie worden vastgelegd.
 
 ## Volledige input-/bronselectietest
 

--- a/docs/yaml-naar-cpp-migratieplan.md
+++ b/docs/yaml-naar-cpp-migratieplan.md
@@ -46,7 +46,13 @@ entities, configuratie, koppelingen en één of enkele runtime-aanroepen.
 | Strategy runtimes | Heating Curve, Power House, Cooling en managerbinding | Gereed | #584 |
 | Hydraulics en outputs | Flow Control, Thermal Limits en Auxiliary Relay | Gereed | #589 |
 | Boiler runtime | Commandocapture, outputcontroller en transportbinding | Gereed | #595 |
-| Externe inputs en bronselectie | API-freshness plus generieke, brongebonden selectie | Gereed; PR volgt | Nog te bepalen |
+| Externe inputs en bronselectie | API-freshness plus generieke, brongebonden selectie | Gereed | #599 |
+
+Vervolg ligt niet automatisch in nog een YAML-migratie. Eerst wordt de
+herhaalbaarheid van de acceptatietests verbeterd met de veilige, repositorylokale
+[HIL-runner](hil-testing.md). Een volgend migratieblok krijgt opnieuw een
+go/no-go op testwaarde, contractgrens en netto productiecode; regelaantal alleen
+is geen reden om declaratieve YAML te verplaatsen.
 
 ## Besluit volgend werkblok: externe inputs en bronselectie
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:web:preview": "node openquatt/web/build-assets.mjs --preview",
     "check:docs": "npm run check:docs:contracts",
     "check:docs:contracts": "python3 scripts/check_docs_consistency.py && node scripts/check_web_docs_sync.mjs",
+    "check:hil": "node --test tests/hil/*.test.mjs",
     "check:python-contracts": "python3 -m unittest discover -s scripts/tests -p \"test_*.py\"",
     "check:cpp-format": "python3 scripts/cpp_format.py check",
     "check:web": "npm run build:web && node openquatt/web/run-web-tests.mjs && node openquatt/web/check-web-quality.mjs",

--- a/scripts/hil/firmware.mjs
+++ b/scripts/hil/firmware.mjs
@@ -1,0 +1,46 @@
+import { spawn } from 'node:child_process';
+
+export function firmwareCommand({
+  esphome = process.env.OQ_ESPHOME_BIN || 'esphome',
+  config,
+  device,
+}) {
+  if (!config) throw new Error('firmware config is required');
+  if (!device) throw new Error('OTA device address is required');
+  return {
+    executable: esphome,
+    args: [
+      'run',
+      '--device',
+      device,
+      '--ota-platform',
+      'esphome',
+      '--no-logs',
+      config,
+    ],
+  };
+}
+
+export async function flashFirmware(options, { spawnImpl = spawn, cwd = process.cwd() } = {}) {
+  const command = firmwareCommand(options);
+  await new Promise((resolve, reject) => {
+    const child = spawnImpl(command.executable, command.args, {
+      cwd,
+      env: process.env,
+      stdio: 'inherit',
+      shell: false,
+    });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `firmware command failed${signal ? ` with signal ${signal}` : ` with exit code ${code}`}`,
+        ),
+      );
+    });
+  });
+}

--- a/scripts/hil/rest-client.mjs
+++ b/scripts/hil/rest-client.mjs
@@ -1,0 +1,206 @@
+const defaultSleep = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export function normalizeBaseUrl(value, label = "target") {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${label} must be an absolute http(s) URL`);
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`${label} must use http or https`);
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error(`${label} must not contain credentials, query parameters, or a fragment`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+  return parsed.toString().replace(/\/$/, '');
+}
+
+export class RequestGate {
+  constructor({
+    readIntervalMs = 250,
+    writeIntervalMs = 1500,
+    now = () => Date.now(),
+    sleep = defaultSleep,
+  } = {}) {
+    if (!Number.isFinite(readIntervalMs) || readIntervalMs < 0) {
+      throw new Error('readIntervalMs must be a non-negative number');
+    }
+    if (!Number.isFinite(writeIntervalMs) || writeIntervalMs < 1000) {
+      throw new Error('writeIntervalMs must be at least 1000 ms');
+    }
+    this.readIntervalMs = readIntervalMs;
+    this.writeIntervalMs = writeIntervalMs;
+    this.now = now;
+    this.sleep = sleep;
+    this.nextRequestAt = 0;
+    this.counts = { read: 0, write: 0 };
+    this.queue = Promise.resolve();
+  }
+
+  async enter({ write = false } = {}) {
+    const waitMs = Math.max(0, this.nextRequestAt - this.now());
+    if (waitMs > 0) await this.sleep(waitMs);
+    this.counts[write ? 'write' : 'read'] += 1;
+    this.nextRequestAt = this.now() + (write ? this.writeIntervalMs : this.readIntervalMs);
+  }
+
+  async run(options, operation) {
+    const previous = this.queue;
+    let release;
+    this.queue = new Promise((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      await this.enter(options);
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
+export function entityPath(domain, name, action = '') {
+  return `/${domain}/${encodeURIComponent(name)}${action ? `/${action}` : ''}`;
+}
+
+export function asFiniteNumber(value) {
+  if (value === null || value === undefined || value === '' || value === 'nan' || value === 'NaN') {
+    return null;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+export function asBoolean(value) {
+  if (value === true || value === 1 || value === '1' || value === 'ON' || value === 'on' || value === 'true') {
+    return true;
+  }
+  if (value === false || value === 0 || value === '0' || value === 'OFF' || value === 'off' || value === 'false') {
+    return false;
+  }
+  throw new Error(`cannot convert ${JSON.stringify(value)} to a boolean`);
+}
+
+export class HilRestClient {
+  constructor({
+    baseUrl,
+    allowWrites = false,
+    gate = new RequestGate(),
+    fetchImpl = globalThis.fetch,
+    timeoutMs = 12000,
+    onRequest = () => {},
+    bulkReads = false,
+  }) {
+    if (typeof fetchImpl !== 'function') throw new Error('fetch is unavailable');
+    this.baseUrl = normalizeBaseUrl(baseUrl);
+    this.allowWrites = allowWrites;
+    this.gate = gate;
+    this.fetchImpl = fetchImpl;
+    this.timeoutMs = timeoutMs;
+    this.onRequest = onRequest;
+    this.bulkReads = bulkReads;
+  }
+
+  async request(endpoint, {
+    method = 'GET',
+    optional = false,
+    readOnly = false,
+    body,
+    headers = {},
+  } = {}) {
+    const normalizedMethod = method.toUpperCase();
+    const write = normalizedMethod !== 'GET' && !readOnly;
+    if (write && !this.allowWrites) {
+      throw new Error('REST writes require the explicit --apply flag');
+    }
+    return this.gate.run({ write }, async () => {
+      this.onRequest({ baseUrl: this.baseUrl, endpoint, method: normalizedMethod, readOnly });
+      const response = await this.fetchImpl(`${this.baseUrl}${endpoint}`, {
+        method: normalizedMethod,
+        body: body ?? (normalizedMethod === 'POST' ? '' : undefined),
+        signal: AbortSignal.timeout(this.timeoutMs),
+        headers: { 'Cache-Control': 'no-store', ...headers },
+      });
+      if (optional && response.status === 404) return null;
+      if (!response.ok) {
+        throw new Error(`${normalizedMethod} ${endpoint}: ${response.status} ${response.statusText}`);
+      }
+      const text = await response.text();
+      if (!text) return null;
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new Error(`${normalizedMethod} ${endpoint}: response is not valid JSON`);
+      }
+    });
+  }
+
+  async value(domain, name, { optional = false } = {}) {
+    if (this.bulkReads) {
+      const values = await this.values([{ key: 'value', domain, name, optional }]);
+      return values.value;
+    }
+    const response = await this.request(entityPath(domain, name), { optional });
+    return response?.value ?? null;
+  }
+
+  async values(entities) {
+    if (!this.bulkReads) {
+      const result = {};
+      for (const entity of entities) {
+        result[entity.key] = await this.value(entity.domain, entity.name, {
+          optional: entity.optional === true,
+        });
+      }
+      return result;
+    }
+    const lines = entities.map((entity) => `${entity.key}\t${entity.domain}\t${entity.name}`);
+    const form = new URLSearchParams({ detail: 'state', entities: lines.join('\n') });
+    const payload = await this.request('/openquatt/entities', {
+      method: 'POST',
+      readOnly: true,
+      body: form.toString(),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+    const missing = new Set(Array.isArray(payload?.missing) ? payload.missing : []);
+    const result = {};
+    for (const entity of entities) {
+      const item = payload?.entities?.[entity.key];
+      if (!item || missing.has(entity.key)) {
+        if (entity.optional) {
+          result[entity.key] = null;
+          continue;
+        }
+        throw new Error(`bulk entity response is missing ${entity.domain}/${entity.name}`);
+      }
+      result[entity.key] = item.value ?? item.state ?? null;
+    }
+    return result;
+  }
+
+  async post(domain, name, action, query = {}) {
+    const search = new URLSearchParams(query).toString();
+    const suffix = search ? `?${search}` : '';
+    return this.request(`${entityPath(domain, name, action)}${suffix}`, { method: 'POST' });
+  }
+
+  setNumber(name, value) {
+    return this.post('number', name, 'set', { value: String(value) });
+  }
+
+  setSelect(name, option) {
+    return this.post('select', name, 'set', { option });
+  }
+
+  setSwitch(name, enabled) {
+    return this.post('switch', name, enabled ? 'turn_on' : 'turn_off');
+  }
+
+  press(name) {
+    return this.post('button', name, 'press');
+  }
+}

--- a/scripts/hil/run-input-sources.mjs
+++ b/scripts/hil/run-input-sources.mjs
@@ -162,14 +162,23 @@ async function waitProfile(controller, expectedProfile, interrupted) {
   }, `HIL profile ${expectedProfile}`, { timeoutMs: 180000, intervalMs: 1500, interrupted });
 }
 
-async function waitNormalFirmware(controller, interrupted) {
-  return waitFor(async () => {
+export function verifyRestoredFirmware(actual, expected) {
+  assert(
+    actual === expected,
+    `restored firmware differs: expected ${expected}, received ${actual ?? 'missing'}`,
+  );
+  return actual;
+}
+
+async function waitNormalFirmware(controller, expectedFirmware, interrupted) {
+  const actualFirmware = await waitFor(async () => {
     const values = await controller.values([
       { key: 'version', domain: 'text_sensor', name: 'ESPHome Version' },
       { key: 'profile', domain: 'text_sensor', name: 'HIL Test Profile', optional: true },
     ]);
     return values.version && values.profile === null ? values.version : false;
   }, 'normal firmware after OTA restore', { timeoutMs: 180000, intervalMs: 1500, interrupted });
+  return verifyRestoredFirmware(actualFirmware, expectedFirmware);
 }
 
 async function diagnostics(controller, simulator) {
@@ -269,7 +278,7 @@ async function restoreFirmwareAndSettings({
     );
     const normalFirmwareConfirmed = firmwareRestored
       ? await attempt('wait for normal firmware', async () => {
-          restoredFirmware = await waitNormalFirmware(controller, interrupted);
+          restoredFirmware = await waitNormalFirmware(controller, snapshot.firmware, interrupted);
         })
       : false;
     if (normalFirmwareConfirmed) {

--- a/scripts/hil/run-input-sources.mjs
+++ b/scripts/hil/run-input-sources.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+
+import { mkdir, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { flashFirmware } from './firmware.mjs';
+import {
+  HilRestClient,
+  RequestGate,
+  asFiniteNumber,
+  normalizeBaseUrl,
+} from './rest-client.mjs';
+import {
+  acquireLock,
+  acquireRecoveryLock,
+  readSnapshot,
+  restoreSettings,
+  runDirectory,
+  snapshotSettings,
+  writeJsonAtomic,
+} from './session.mjs';
+import { waitFor } from './wait.mjs';
+import {
+  prepareInputSourceScenario,
+  runInputSourceScenarios,
+} from '../../tests/hil/scenarios/input-sources.mjs';
+
+const HIL_PROFILE = 'input-sources-fast-v1';
+const VALID_STAGES = new Set([
+  'smoke',
+  'inputs',
+  'enable-expiry',
+  'active-switch',
+  'reboot-reset',
+  'all',
+]);
+
+function usage() {
+  return `Usage:
+  node scripts/hil/run-input-sources.mjs --controller URL --simulator URL [--stage smoke]
+
+Mutating run:
+  node scripts/hil/run-input-sources.mjs --controller URL --simulator URL \\
+    --device HOST --test-config configs/hil/input_sources_fast_duo_wifi.yaml \\
+    --restore-config configs/heatpump_controller_q/duo_wifi.yaml --stage all --apply
+
+Recovery:
+  node scripts/hil/run-input-sources.mjs --controller URL --simulator URL \\
+    --device HOST --restore-config configs/heatpump_controller_q/duo_wifi.yaml \\
+    --restore-snapshot .tmp/hil/<run>/snapshot.json --apply
+
+Options:
+  --controller URL          Controller web-server URL; no default.
+  --simulator URL           ODU simulator web-server URL; no default.
+  --stage NAME              smoke, inputs, enable-expiry, active-switch,
+                            reboot-reset, or all (default: smoke).
+  --apply                   Explicitly allow REST writes and OTA uploads.
+  --device HOST             ESPHome OTA device address.
+  --test-config PATH        Optional test profile to compile and upload first.
+  --restore-config PATH     Normal firmware config uploaded in finally/recovery.
+  --expected-profile NAME   Required HIL marker (default: ${HIL_PROFILE}).
+  --write-interval-ms N     Global REST-write spacing, minimum 1000 (default: 1500).
+  --output-root PATH        Run artifacts (default: .tmp/hil).
+  --restore-snapshot PATH   Recover settings from an earlier snapshot.
+  --settings-only           Recovery only: do not restore firmware.
+  --min-heap-min-free N     Optional failure threshold in bytes.
+  --min-largest-block N     Optional failure threshold in bytes.
+  --help                    Show this help.
+`;
+}
+
+function requiredValue(argv, index, option) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`${option} requires a value`);
+  return value;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    stage: 'smoke',
+    apply: false,
+    expectedProfile: HIL_PROFILE,
+    writeIntervalMs: 1500,
+    outputRoot: '.tmp/hil',
+    settingsOnly: false,
+    minHeapMinFree: 0,
+    minLargestBlock: 0,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (option === '--apply') options.apply = true;
+    else if (option === '--settings-only') options.settingsOnly = true;
+    else if (option === '--help') options.help = true;
+    else if (option === '--controller') options.controller = requiredValue(argv, index++, option);
+    else if (option === '--simulator') options.simulator = requiredValue(argv, index++, option);
+    else if (option === '--stage') options.stage = requiredValue(argv, index++, option);
+    else if (option === '--device') options.device = requiredValue(argv, index++, option);
+    else if (option === '--test-config') options.testConfig = requiredValue(argv, index++, option);
+    else if (option === '--restore-config') options.restoreConfig = requiredValue(argv, index++, option);
+    else if (option === '--expected-profile') options.expectedProfile = requiredValue(argv, index++, option);
+    else if (option === '--output-root') options.outputRoot = requiredValue(argv, index++, option);
+    else if (option === '--restore-snapshot') options.restoreSnapshot = requiredValue(argv, index++, option);
+    else if (option === '--write-interval-ms') {
+      options.writeIntervalMs = Number(requiredValue(argv, index++, option));
+    } else if (option === '--min-heap-min-free') {
+      options.minHeapMinFree = Number(requiredValue(argv, index++, option));
+    } else if (option === '--min-largest-block') {
+      options.minLargestBlock = Number(requiredValue(argv, index++, option));
+    } else {
+      throw new Error(`unknown option: ${option}`);
+    }
+  }
+  if (options.help) return options;
+  if (!options.controller || !options.simulator) {
+    throw new Error('--controller and --simulator are required');
+  }
+  options.controller = normalizeBaseUrl(options.controller, 'controller');
+  options.simulator = normalizeBaseUrl(options.simulator, 'simulator');
+  if (!VALID_STAGES.has(options.stage)) throw new Error(`unsupported stage: ${options.stage}`);
+  if (!Number.isFinite(options.writeIntervalMs) || options.writeIntervalMs < 1000) {
+    throw new Error('--write-interval-ms must be at least 1000');
+  }
+  for (const key of ['minHeapMinFree', 'minLargestBlock']) {
+    if (!Number.isFinite(options[key]) || options[key] < 0) {
+      throw new Error(`${key} must be a non-negative number`);
+    }
+  }
+  const mutating = options.stage !== 'smoke' || Boolean(options.restoreSnapshot);
+  if (mutating && !options.apply) throw new Error('mutating HIL runs require --apply');
+  if (options.testConfig && options.stage === 'smoke') {
+    throw new Error('--test-config is only valid for a mutating stage');
+  }
+  if (options.testConfig && !options.restoreConfig) {
+    throw new Error('--test-config requires --restore-config');
+  }
+  if (mutating && !options.settingsOnly && (!options.restoreConfig || !options.device)) {
+    throw new Error('mutating HIL runs require --device and --restore-config');
+  }
+  if (options.settingsOnly && !options.restoreSnapshot) {
+    throw new Error('--settings-only is only valid with --restore-snapshot');
+  }
+  return options;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function waitProfile(controller, expectedProfile, interrupted) {
+  return waitFor(async () => {
+    const profile = await controller.value('text_sensor', 'HIL Test Profile', { optional: true });
+    return profile === expectedProfile ? profile : false;
+  }, `HIL profile ${expectedProfile}`, { timeoutMs: 180000, intervalMs: 1500, interrupted });
+}
+
+async function waitNormalFirmware(controller, interrupted) {
+  return waitFor(async () => {
+    const values = await controller.values([
+      { key: 'version', domain: 'text_sensor', name: 'ESPHome Version' },
+      { key: 'profile', domain: 'text_sensor', name: 'HIL Test Profile', optional: true },
+    ]);
+    return values.version && values.profile === null ? values.version : false;
+  }, 'normal firmware after OTA restore', { timeoutMs: 180000, intervalMs: 1500, interrupted });
+}
+
+async function diagnostics(controller, simulator) {
+  const controllerValues = await controller.values([
+    { key: 'firmware', domain: 'text_sensor', name: 'ESPHome Version' },
+    { key: 'profile', domain: 'text_sensor', name: 'HIL Test Profile', optional: true },
+    { key: 'heapFree', domain: 'sensor', name: 'Heap Free', optional: true },
+    { key: 'heapMinFree', domain: 'sensor', name: 'Heap Min Free', optional: true },
+    { key: 'largestBlock', domain: 'sensor', name: 'Heap Max Block', optional: true },
+    { key: 'fragmentationPercent', domain: 'sensor', name: 'Heap Fragmentation', optional: true },
+    { key: 'psramFree', domain: 'sensor', name: 'PSRAM Free', optional: true },
+  ]);
+  return {
+    capturedAt: new Date().toISOString(),
+    firmware: controllerValues.firmware,
+    profile: controllerValues.profile,
+    memory: {
+      heapFree: asFiniteNumber(controllerValues.heapFree),
+      heapMinFree: asFiniteNumber(controllerValues.heapMinFree),
+      largestBlock: asFiniteNumber(controllerValues.largestBlock),
+      fragmentationPercent: asFiniteNumber(controllerValues.fragmentationPercent),
+      psramFree: asFiniteNumber(controllerValues.psramFree),
+    },
+    hp1: await simulator.value('text_sensor', 'ODU 1 diagnostics'),
+    hp2: await simulator.value('text_sensor', 'ODU 2 diagnostics'),
+  };
+}
+
+function verifyDiagnostics(result, options) {
+  for (const [name, text] of [['HP1', result.hp1], ['HP2', result.hp2]]) {
+    for (const field of ['exc', 'bad_addr', 'bad_write', 'cap']) {
+      const match = String(text).match(new RegExp(`${field}=(\\d+)`));
+      assert(match && Number(match[1]) === 0, `${name} ${field} nonzero: ${text}`);
+    }
+  }
+  if (options.minHeapMinFree > 0) {
+    assert(
+      result.memory.heapMinFree !== null && result.memory.heapMinFree >= options.minHeapMinFree,
+      `Heap Min Free ${result.memory.heapMinFree} is below ${options.minHeapMinFree}`,
+    );
+  }
+  if (options.minLargestBlock > 0) {
+    assert(
+      result.memory.largestBlock !== null && result.memory.largestBlock >= options.minLargestBlock,
+      `Heap Max Block ${result.memory.largestBlock} is below ${options.minLargestBlock}`,
+    );
+  }
+}
+
+function assertSnapshotTargets(snapshot, options) {
+  assert(snapshot.targets?.controller === options.controller, 'snapshot controller URL differs');
+  assert(snapshot.targets?.simulator === options.simulator, 'snapshot simulator URL differs');
+}
+
+async function restoreFirmwareAndSettings({
+  options,
+  controller,
+  simulator,
+  snapshot,
+  interrupted,
+}) {
+  const errors = [];
+  let restoredFirmware = null;
+  const attempt = async (label, operation) => {
+    try {
+      await operation();
+      return true;
+    } catch (error) {
+      errors.push(new Error(`${label}: ${error.message}`));
+      return false;
+    }
+  };
+  if (options.settingsOnly) {
+    await attempt('restore settings', () => restoreSettings({ controller, simulator, snapshot }));
+    restoredFirmware = snapshot.firmware;
+  } else {
+    await attempt('restore settings in safe CM0 before firmware OTA', () =>
+      restoreSettings({ controller, simulator, snapshot, restoreCmOverride: false }),
+    );
+    const firmwareRestored = await attempt('restore normal firmware', () =>
+      flashFirmware({ config: options.restoreConfig, device: options.device }),
+    );
+    const normalFirmwareConfirmed = firmwareRestored
+      ? await attempt('wait for normal firmware', async () => {
+          restoredFirmware = await waitNormalFirmware(controller, interrupted);
+        })
+      : false;
+    if (normalFirmwareConfirmed) {
+      await attempt('verify settings after normal firmware reboot', () =>
+        restoreSettings({ controller, simulator, snapshot }),
+      );
+    }
+  }
+  if (errors.length > 0) throw new AggregateError(errors, 'HIL recovery incomplete');
+  return restoredFirmware;
+}
+
+async function verifySettingsOnlyFirmware(controller, snapshot) {
+  const values = await controller.values([
+    { key: 'firmware', domain: 'text_sensor', name: 'ESPHome Version' },
+    { key: 'profile', domain: 'text_sensor', name: 'HIL Test Profile', optional: true },
+  ]);
+  assert(values.profile === null, '--settings-only requires normal firmware without HIL profile');
+  assert(
+    values.firmware === snapshot.firmware,
+    `--settings-only firmware differs: expected ${snapshot.firmware}, received ${values.firmware}`,
+  );
+}
+
+async function run(options) {
+  const startedAt = new Date();
+  const outputRoot = path.resolve(options.outputRoot);
+  const runDir = options.restoreSnapshot
+    ? path.dirname(path.resolve(options.restoreSnapshot))
+    : runDirectory(outputRoot, startedAt);
+  const reportPath = options.restoreSnapshot
+    ? path.join(runDir, `recovery-${startedAt.toISOString().replace(/[:.]/g, '-')}.json`)
+    : path.join(runDir, 'report.json');
+  await mkdir(runDir, { recursive: true });
+  const requests = [];
+  const gate = new RequestGate({ writeIntervalMs: options.writeIntervalMs });
+  const clientOptions = {
+    allowWrites: options.apply,
+    gate,
+    onRequest: (request) => requests.push({ at: new Date().toISOString(), ...request }),
+  };
+  const controller = new HilRestClient({
+    baseUrl: options.controller,
+    bulkReads: true,
+    ...clientOptions,
+  });
+  const simulator = new HilRestClient({ baseUrl: options.simulator, ...clientOptions });
+  let interruptedFlag = false;
+  const interrupt = () => {
+    if (interruptedFlag) process.exit(130);
+    interruptedFlag = true;
+    console.error('Interrupt received; recovery will run after the current operation yields.');
+  };
+  process.on('SIGINT', interrupt);
+  process.on('SIGTERM', interrupt);
+  const interrupted = () => interruptedFlag;
+  let lock;
+  let recoveryLock;
+  let snapshot;
+  let success = false;
+  let failure;
+  let mutationStarted = false;
+  let recoverySucceeded = false;
+  let before;
+  let after;
+  let restoredFirmware;
+  try {
+    if (options.restoreSnapshot) {
+      recoveryLock = await acquireRecoveryLock(path.dirname(runDir), runDir);
+      snapshot = await readSnapshot(path.resolve(options.restoreSnapshot));
+      assertSnapshotTargets(snapshot, options);
+      if (options.settingsOnly) await verifySettingsOnlyFirmware(controller, snapshot);
+      mutationStarted = true;
+      restoredFirmware = await restoreFirmwareAndSettings({
+        options,
+        controller,
+        simulator,
+        snapshot,
+        interrupted,
+      });
+      recoverySucceeded = true;
+      success = true;
+    } else {
+      before = await diagnostics(controller, simulator);
+      console.log(`BASELINE ${JSON.stringify(before)}`);
+      verifyDiagnostics(before, options);
+      if (options.stage === 'smoke') {
+        success = true;
+      } else {
+        lock = await acquireLock(outputRoot, runDir);
+        snapshot = await snapshotSettings({
+          controller,
+          simulator,
+          targets: { controller: options.controller, simulator: options.simulator },
+          firmware: before.firmware,
+        });
+        await writeJsonAtomic(path.join(runDir, 'snapshot.json'), snapshot);
+        console.log(`SNAPSHOT ${path.join(runDir, 'snapshot.json')}`);
+
+        if (options.testConfig) {
+          mutationStarted = true;
+          await flashFirmware({ config: options.testConfig, device: options.device });
+        }
+        await waitProfile(controller, options.expectedProfile, interrupted);
+        mutationStarted = true;
+        await prepareInputSourceScenario(controller, simulator, interrupted);
+        await runInputSourceScenarios({
+          stage: options.stage,
+          controller,
+          interrupted,
+          waitForProfile: () => waitProfile(controller, options.expectedProfile, interrupted),
+        });
+        after = await diagnostics(controller, simulator);
+        verifyDiagnostics(after, options);
+        console.log(`DIAGNOSTICS ${JSON.stringify(after)}`);
+        success = true;
+      }
+    }
+  } catch (error) {
+    failure = error;
+  } finally {
+    if (snapshot && mutationStarted && !options.restoreSnapshot) {
+      try {
+        restoredFirmware = await restoreFirmwareAndSettings({
+          options,
+          controller,
+          simulator,
+          snapshot,
+          interrupted: () => false,
+        });
+        recoverySucceeded = true;
+      } catch (restoreError) {
+        failure = failure
+          ? new AggregateError([failure, restoreError], 'HIL run and recovery failed')
+          : restoreError;
+        success = false;
+      }
+    }
+    const recoveryComplete = !mutationStarted || recoverySucceeded;
+    const recordCleanupFailure = (cleanupError) => {
+      failure = failure
+        ? new AggregateError([failure, cleanupError], 'HIL run and lock cleanup failed')
+        : cleanupError;
+      success = false;
+    };
+    let recoveryLockReleased = !recoveryLock;
+    if (recoveryLock) {
+      try {
+        await recoveryLock.release();
+        recoveryLockReleased = true;
+      } catch (cleanupError) {
+        recordCleanupFailure(cleanupError);
+      }
+    }
+    if (lock && recoveryComplete) {
+      await lock.release().catch(recordCleanupFailure);
+    }
+    if (options.restoreSnapshot && recoverySucceeded && recoveryLockReleased) {
+      await unlink(path.join(path.dirname(runDir), 'input-sources.lock')).catch((error) => {
+        if (error.code !== 'ENOENT') recordCleanupFailure(error);
+      });
+    }
+    if (snapshot && !recoveryComplete) {
+      console.error(`RECOVERY REQUIRED: ${path.join(runDir, 'snapshot.json')}`);
+    }
+    const report = {
+      schema: 1,
+      scenario: 'input-sources',
+      stage: options.stage,
+      startedAt: startedAt.toISOString(),
+      finishedAt: new Date().toISOString(),
+      success: success && !failure,
+      failure: failure ? String(failure.stack || failure) : null,
+      requestCounts: gate.counts,
+      requestIntervalMs: {
+        read: gate.readIntervalMs,
+        write: gate.writeIntervalMs,
+      },
+      diagnostics: { before, after },
+      restoredFirmware,
+      requests,
+    };
+    try {
+      await writeJsonAtomic(reportPath, report);
+    } catch (reportError) {
+      failure = failure
+        ? new AggregateError([failure, reportError], 'HIL run and report write failed')
+        : reportError;
+      success = false;
+    }
+    process.off('SIGINT', interrupt);
+    process.off('SIGTERM', interrupt);
+  }
+  if (failure) throw failure;
+  if (options.restoreSnapshot) {
+    console.log(`PASS HIL recovery; report: ${reportPath}`);
+  } else if (options.stage === 'smoke') {
+    console.log(`PASS read-only HIL smoke; report: ${reportPath}`);
+  } else {
+    console.log(`PASS input/source HIL ${options.stage}; report: ${reportPath}`);
+  }
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      console.log(usage());
+    } else {
+      await run(options);
+    }
+  } catch (error) {
+    console.error(`FAIL ${error.stack || error}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/hil/run-input-sources.mjs
+++ b/scripts/hil/run-input-sources.mjs
@@ -27,6 +27,7 @@ import {
 } from '../../tests/hil/scenarios/input-sources.mjs';
 
 const HIL_PROFILE = 'input-sources-fast-v1';
+const SIMULATOR_CONTRACT = 'openquatt-modbus-opentherm-v1';
 const VALID_STAGES = new Set([
   'smoke',
   'inputs',
@@ -60,6 +61,8 @@ Options:
   --test-config PATH        Optional test profile to compile and upload first.
   --restore-config PATH     Normal firmware config uploaded in finally/recovery.
   --expected-profile NAME   Required HIL marker (default: ${HIL_PROFILE}).
+  --expected-simulator-contract NAME
+                            Required simulator contract (default: ${SIMULATOR_CONTRACT}).
   --write-interval-ms N     Global REST-write spacing, minimum 1000 (default: 1500).
   --output-root PATH        Run artifacts (default: .tmp/hil).
   --restore-snapshot PATH   Recover settings from an earlier snapshot.
@@ -81,6 +84,7 @@ export function parseArgs(argv) {
     stage: 'smoke',
     apply: false,
     expectedProfile: HIL_PROFILE,
+    expectedSimulatorContract: SIMULATOR_CONTRACT,
     writeIntervalMs: 1500,
     outputRoot: '.tmp/hil',
     settingsOnly: false,
@@ -100,6 +104,9 @@ export function parseArgs(argv) {
     else if (option === '--test-config') options.testConfig = requiredValue(argv, index++, option);
     else if (option === '--restore-config') options.restoreConfig = requiredValue(argv, index++, option);
     else if (option === '--expected-profile') options.expectedProfile = requiredValue(argv, index++, option);
+    else if (option === '--expected-simulator-contract') {
+      options.expectedSimulatorContract = requiredValue(argv, index++, option);
+    }
     else if (option === '--output-root') options.outputRoot = requiredValue(argv, index++, option);
     else if (option === '--restore-snapshot') options.restoreSnapshot = requiredValue(argv, index++, option);
     else if (option === '--write-interval-ms') {
@@ -175,6 +182,12 @@ async function diagnostics(controller, simulator) {
     { key: 'fragmentationPercent', domain: 'sensor', name: 'Heap Fragmentation', optional: true },
     { key: 'psramFree', domain: 'sensor', name: 'PSRAM Free', optional: true },
   ]);
+  const simulatorValues = await simulator.values([
+    { key: 'contract', domain: 'text_sensor', name: 'OpenQuatt Simulator Contract', optional: true },
+    { key: 'version', domain: 'text_sensor', name: 'OpenQuatt Simulator Version', optional: true },
+    { key: 'hp1', domain: 'text_sensor', name: 'ODU 1 diagnostics' },
+    { key: 'hp2', domain: 'text_sensor', name: 'ODU 2 diagnostics' },
+  ]);
   return {
     capturedAt: new Date().toISOString(),
     firmware: controllerValues.firmware,
@@ -186,12 +199,21 @@ async function diagnostics(controller, simulator) {
       fragmentationPercent: asFiniteNumber(controllerValues.fragmentationPercent),
       psramFree: asFiniteNumber(controllerValues.psramFree),
     },
-    hp1: await simulator.value('text_sensor', 'ODU 1 diagnostics'),
-    hp2: await simulator.value('text_sensor', 'ODU 2 diagnostics'),
+    simulator: {
+      contract: simulatorValues.contract,
+      version: simulatorValues.version,
+    },
+    hp1: simulatorValues.hp1,
+    hp2: simulatorValues.hp2,
   };
 }
 
-function verifyDiagnostics(result, options) {
+export function verifyDiagnostics(result, options) {
+  assert(
+    result.simulator?.contract === options.expectedSimulatorContract,
+    `simulator contract differs: expected ${options.expectedSimulatorContract}, received ${result.simulator?.contract ?? 'missing'}`,
+  );
+  assert(result.simulator.version, 'simulator version is missing');
   for (const [name, text] of [['HP1', result.hp1], ['HP2', result.hp2]]) {
     for (const field of ['exc', 'bad_addr', 'bad_write', 'cap']) {
       const match = String(text).match(new RegExp(`${field}=(\\d+)`));

--- a/scripts/hil/session.mjs
+++ b/scripts/hil/session.mjs
@@ -1,0 +1,281 @@
+import { mkdir, open, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { asBoolean, asFiniteNumber } from './rest-client.mjs';
+import { waitValue } from './wait.mjs';
+
+export const SNAPSHOT_SCHEMA = 1;
+
+export const controllerSettings = [
+  { key: 'cmOverride', domain: 'select', name: 'CM Override', kind: 'select' },
+  { key: 'outsideSource', domain: 'select', name: 'Outside Temperature Source', kind: 'select' },
+  { key: 'roomSource', domain: 'select', name: 'Room Temperature Source', kind: 'select' },
+  { key: 'setpointSource', domain: 'select', name: 'Room Setpoint Source', kind: 'select' },
+  { key: 'externalSource', domain: 'select', name: 'External Heat Demand Source', kind: 'select' },
+  { key: 'heatingEnableSource', domain: 'select', name: 'Heating Enable Source', kind: 'select' },
+  { key: 'coolingEnableSource', domain: 'select', name: 'Cooling Enable Source', kind: 'select' },
+  { key: 'coolingDewPointSource', domain: 'select', name: 'Cooling Dew Point Source', kind: 'select' },
+  { key: 'manualCooling', domain: 'switch', name: 'Manual Cooling Enable', kind: 'switch' },
+  { key: 'heatingMode', domain: 'select', name: 'Heating Control Mode', kind: 'select' },
+  { key: 'phReaction', domain: 'number', name: 'Power House temperature reaction', kind: 'number' },
+  { key: 'phRise', domain: 'number', name: 'Power House demand rise time', kind: 'number' },
+  { key: 'demandRamp', domain: 'number', name: 'Demand filter ramp up', kind: 'number' },
+  { key: 'flowSource', domain: 'select', name: 'Flow Source', kind: 'select' },
+  { key: 'outdoorFlowMode', domain: 'select', name: 'Outdoor Unit Flow Mode', kind: 'select' },
+  { key: 'flowMode', domain: 'select', name: 'Flow Control Mode', kind: 'select' },
+  { key: 'flowSetpoint', domain: 'number', name: 'Flow Setpoint', kind: 'number' },
+];
+
+export const simulatorSettings = [
+  { key: 'externalFlow', domain: 'switch', name: 'ODU external system pump flow', kind: 'switch' },
+  { key: 'hp1NoFlow', domain: 'switch', name: 'ODU 1 force no flow', kind: 'switch' },
+  { key: 'hp2NoFlow', domain: 'switch', name: 'ODU 2 force no flow', kind: 'switch' },
+];
+
+function normalizeSettingValue(setting, value) {
+  if (setting.kind === 'number') {
+    const number = asFiniteNumber(value);
+    if (number === null) throw new Error(`${setting.name} is unavailable or non-finite`);
+    return number;
+  }
+  if (setting.kind === 'switch') return asBoolean(value);
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${setting.name} has no selected option`);
+  }
+  return value;
+}
+
+async function readSettings(client, settings) {
+  const values = await client.values(settings);
+  const result = {};
+  for (const setting of settings) {
+    result[setting.key] = normalizeSettingValue(setting, values[setting.key]);
+  }
+  return result;
+}
+
+export async function snapshotSettings({ controller, simulator, targets, firmware }) {
+  if (typeof firmware !== 'string' || firmware.length === 0) {
+    throw new Error('firmware identity is required for a HIL snapshot');
+  }
+  return {
+    schema: SNAPSHOT_SCHEMA,
+    capturedAt: new Date().toISOString(),
+    targets,
+    firmware,
+    controller: await readSettings(controller, controllerSettings),
+    simulator: await readSettings(simulator, simulatorSettings),
+  };
+}
+
+async function applySetting(client, setting, value) {
+  if (setting.kind === 'number') return client.setNumber(setting.name, value);
+  if (setting.kind === 'switch') return client.setSwitch(setting.name, value);
+  return client.setSelect(setting.name, value);
+}
+
+function valuesMatch(setting, actual, expected) {
+  try {
+    const normalized = normalizeSettingValue(setting, actual);
+    if (setting.kind === 'number') return Math.abs(normalized - expected) < 0.011;
+    return normalized === expected;
+  } catch {
+    return false;
+  }
+}
+
+export function validateSnapshot(snapshot) {
+  if (!snapshot || snapshot.schema !== SNAPSHOT_SCHEMA) {
+    throw new Error(`unsupported HIL snapshot schema: ${snapshot?.schema ?? 'missing'}`);
+  }
+  if (typeof snapshot.firmware !== 'string' || snapshot.firmware.length === 0) {
+    throw new Error('HIL snapshot has no firmware identity');
+  }
+  for (const setting of controllerSettings) {
+    normalizeSettingValue(setting, snapshot.controller?.[setting.key]);
+  }
+  for (const setting of simulatorSettings) {
+    normalizeSettingValue(setting, snapshot.simulator?.[setting.key]);
+  }
+  return snapshot;
+}
+
+export async function restoreSettings({
+  controller,
+  simulator,
+  snapshot,
+  restoreCmOverride = true,
+  log = console.log,
+}) {
+  validateSnapshot(snapshot);
+  const errors = [];
+  const attempt = async (label, operation) => {
+    try {
+      await operation();
+    } catch (error) {
+      errors.push(new Error(`${label}: ${error.message}`));
+    }
+  };
+
+  await attempt('force safe CM0', () => controller.setSelect('CM Override', 'Force CM0'));
+  await attempt('disable API heating input', () =>
+    controller.setSwitch('api_input_heating_enable', false),
+  );
+  await attempt('disable API cooling input', () =>
+    controller.setSwitch('api_input_cooling_enable', false),
+  );
+  await attempt('clear HP1 no-flow injection', () =>
+    simulator.setSwitch('ODU 1 force no flow', false),
+  );
+  await attempt('clear HP2 no-flow injection', () =>
+    simulator.setSwitch('ODU 2 force no flow', false),
+  );
+  await attempt('wait for safe CM0', () =>
+    waitValue(controller, 'text_sensor', 'Control Mode', 'CM0', 'safe CM0 before restore', {
+      timeoutMs: 50000,
+    }),
+  );
+
+  const restoreGroup = async (client, settings, expectedValues, label) => {
+    let currentValues;
+    await attempt(`read ${label} before restore`, async () => {
+      currentValues = await client.values(settings);
+    });
+    for (const setting of settings) {
+      const expected = expectedValues[setting.key];
+      if (currentValues && valuesMatch(setting, currentValues[setting.key], expected)) continue;
+      await attempt(`restore ${setting.name}`, () => applySetting(client, setting, expected));
+    }
+    let verifiedValues;
+    await attempt(`read ${label} after restore`, async () => {
+      verifiedValues = await client.values(settings);
+    });
+    if (!verifiedValues) return;
+    for (const setting of settings) {
+      const expected = expectedValues[setting.key];
+      if (!valuesMatch(setting, verifiedValues[setting.key], expected)) {
+        errors.push(
+          new Error(
+            `${setting.name} restore verification failed: expected ${JSON.stringify(expected)}, ` +
+              `received ${JSON.stringify(verifiedValues[setting.key])}`,
+          ),
+        );
+        continue;
+      }
+      log(`RESTORED ${setting.name}=${JSON.stringify(expected)}`);
+    }
+  };
+
+  await restoreGroup(
+    controller,
+    controllerSettings.filter((item) => item.key !== 'cmOverride'),
+    snapshot.controller,
+    'controller settings',
+  );
+  await restoreGroup(simulator, simulatorSettings, snapshot.simulator, 'simulator settings');
+  if (restoreCmOverride && errors.length === 0) {
+    const cmOverride = controllerSettings.find((item) => item.key === 'cmOverride');
+    await restoreGroup(
+      controller,
+      [cmOverride],
+      snapshot.controller,
+      'CM Override',
+    );
+  } else if (restoreCmOverride) {
+    errors.push(new Error('CM Override remains Force CM0 because earlier restore steps failed'));
+  }
+
+  if (errors.length > 0) throw new AggregateError(errors, 'one or more HIL settings could not be restored');
+}
+
+export async function writeJsonAtomic(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  await rename(temporaryPath, filePath);
+}
+
+export async function readSnapshot(filePath) {
+  return validateSnapshot(JSON.parse(await readFile(filePath, 'utf8')));
+}
+
+export function runDirectory(rootDirectory, now = new Date()) {
+  const timestamp = now.toISOString().replace(/[:.]/g, '-');
+  return path.join(rootDirectory, `${timestamp}-input-sources`);
+}
+
+export async function acquireLock(rootDirectory, runDir) {
+  await mkdir(rootDirectory, { recursive: true });
+  const lockPath = path.join(rootDirectory, 'input-sources.lock');
+  let handle;
+  try {
+    handle = await open(lockPath, 'wx', 0o600);
+  } catch (error) {
+    if (error.code !== 'EEXIST') throw error;
+    const current = await readFile(lockPath, 'utf8').catch(() => 'unknown run');
+    throw new Error(
+      `another HIL run or recovery is active (${current.trim()}); restore it before continuing`,
+    );
+  }
+  await handle.writeFile(`${runDir}\n`);
+  await handle.close();
+  return {
+    path: lockPath,
+    async release() {
+      await unlink(lockPath).catch((error) => {
+        if (error.code !== 'ENOENT') throw error;
+      });
+    },
+  };
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error.code === 'EPERM') return true;
+    if (error.code === 'ESRCH') return false;
+    throw error;
+  }
+}
+
+export async function acquireRecoveryLock(rootDirectory, runDir) {
+  await mkdir(rootDirectory, { recursive: true });
+  const lockPath = path.join(rootDirectory, 'input-sources-recovery.lock');
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let handle;
+    try {
+      handle = await open(lockPath, 'wx', 0o600);
+      await handle.writeFile(`${JSON.stringify({ pid: process.pid, runDir })}\n`);
+      await handle.close();
+      return {
+        path: lockPath,
+        async release() {
+          await unlink(lockPath).catch((error) => {
+            if (error.code !== 'ENOENT') throw error;
+          });
+        },
+      };
+    } catch (error) {
+      await handle?.close().catch(() => {});
+      if (error.code !== 'EEXIST') throw error;
+      let owner;
+      try {
+        owner = JSON.parse(await readFile(lockPath, 'utf8'));
+      } catch {
+        throw new Error(`HIL recovery lock is unreadable: ${lockPath}`);
+      }
+      if (!Number.isSafeInteger(owner.pid) || owner.pid <= 0) {
+        throw new Error(`HIL recovery lock has no valid owner: ${lockPath}`);
+      }
+      if (processIsAlive(owner.pid)) {
+        throw new Error(`another HIL recovery is active (pid ${owner.pid})`);
+      }
+      await unlink(lockPath).catch((unlinkError) => {
+        if (unlinkError.code !== 'ENOENT') throw unlinkError;
+      });
+    }
+  }
+  throw new Error(`could not acquire HIL recovery lock: ${lockPath}`);
+}

--- a/scripts/hil/wait.mjs
+++ b/scripts/hil/wait.mjs
@@ -1,0 +1,46 @@
+import { asFiniteNumber } from './rest-client.mjs';
+
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export async function waitFor(check, label, {
+  timeoutMs = 90000,
+  intervalMs = 1000,
+  interrupted = () => false,
+} = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (interrupted()) throw new Error('HIL run interrupted; starting recovery');
+    try {
+      const result = await check();
+      if (result) return result;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`${label} timed out${lastError ? `: ${lastError.message}` : ''}`);
+}
+
+export function waitValue(client, domain, name, expected, label, options = {}) {
+  return waitFor(
+    async () => String(await client.value(domain, name)) === String(expected),
+    label,
+    options,
+  );
+}
+
+export function waitNumber(controller, name, predicate, label, options = {}) {
+  return waitFor(async () => {
+    const current = asFiniteNumber(await controller.value('sensor', name));
+    return current !== null && predicate(current) ? current : false;
+  }, label, options);
+}
+
+export function waitUnavailable(controller, name, label, options = {}) {
+  return waitFor(
+    async () => asFiniteNumber(await controller.value('sensor', name)) === null,
+    label,
+    options,
+  );
+}

--- a/scripts/tests/test_hil_harness_contract.py
+++ b/scripts/tests/test_hil_harness_contract.py
@@ -44,6 +44,8 @@ class HilHarnessContractTest(unittest.TestCase):
     def test_mutations_are_gated_and_targets_have_no_defaults(self):
         self.assertIn("mutating HIL runs require --apply", RUNNER)
         self.assertIn("--device and --restore-config", RUNNER)
+        self.assertIn("openquatt-modbus-opentherm-v1", RUNNER)
+        self.assertIn("simulator contract differs", RUNNER)
         self.assertIn("writeIntervalMs < 1000", REST_CLIENT)
         self.assertNotIn("192.168.", RUNNER)
         self.assertNotIn("192.168.", REST_CLIENT)
@@ -51,6 +53,7 @@ class HilHarnessContractTest(unittest.TestCase):
     def test_harness_is_documented_and_checked_in_ci(self):
         self.assertIn("snapshot.json", DOCS)
         self.assertIn("--restore-snapshot", DOCS)
+        self.assertIn("OpenQuatt/OpenQuatt-Simulator", DOCS)
         self.assertIn('"check:hil"', PACKAGE)
         self.assertIn("hil-harness-tests:", WORKFLOW)
         self.assertIn("npm run check:hil", WORKFLOW)

--- a/scripts/tests/test_hil_harness_contract.py
+++ b/scripts/tests/test_hil_harness_contract.py
@@ -1,0 +1,60 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+PROFILE = (ROOT / "configs/hil/input_sources_fast_duo_wifi.yaml").read_text()
+RUNNER = (ROOT / "scripts/hil/run-input-sources.mjs").read_text()
+REST_CLIENT = (ROOT / "scripts/hil/rest-client.mjs").read_text()
+SUBSTITUTIONS = (ROOT / "openquatt/oq_substitutions_common.yaml").read_text()
+TARGETS = (ROOT / "build_targets.yaml").read_text()
+DOCS = (ROOT / "docs/hil-testing.md").read_text()
+PACKAGE = (ROOT / "package.json").read_text()
+WORKFLOW = (ROOT / ".github/workflows/ci-build.yml").read_text()
+
+
+class HilHarnessContractTest(unittest.TestCase):
+    def test_fast_profile_is_explicitly_test_only(self):
+        self.assertIn("HIL TEST ONLY", PROFILE)
+        self.assertIn(
+            "!include ../heatpump_controller_q/duo_wifi.yaml", PROFILE
+        )
+        self.assertIn('name: "HIL Test Profile"', PROFILE)
+        self.assertIn('return {"input-sources-fast-v1"};', PROFILE)
+        self.assertNotIn("input_sources_fast_duo_wifi.yaml", TARGETS)
+
+    def test_fast_profile_does_not_change_production_floors(self):
+        for marker in (
+            'api_input_room_temperature_stale_s: "30"',
+            'api_input_heating_enable_stale_s: "30"',
+            'oq_selected_input_stale_hold_s: "10"',
+            'oq_hp_min_off_s: "10"',
+        ):
+            self.assertIn(marker, PROFILE)
+        for marker in (
+            'api_input_room_temperature_stale_s: "600"',
+            'api_input_heating_enable_stale_s: "0"',
+            'oq_selected_input_stale_hold_s: "300"',
+            'oq_cooling_minimum_off_min_s: "240"',
+            'oq_hp_min_off_s: "240"',
+        ):
+            self.assertIn(marker, SUBSTITUTIONS)
+        self.assertNotIn("oq_cooling_minimum_off_min_s", PROFILE)
+
+    def test_mutations_are_gated_and_targets_have_no_defaults(self):
+        self.assertIn("mutating HIL runs require --apply", RUNNER)
+        self.assertIn("--device and --restore-config", RUNNER)
+        self.assertIn("writeIntervalMs < 1000", REST_CLIENT)
+        self.assertNotIn("192.168.", RUNNER)
+        self.assertNotIn("192.168.", REST_CLIENT)
+
+    def test_harness_is_documented_and_checked_in_ci(self):
+        self.assertIn("snapshot.json", DOCS)
+        self.assertIn("--restore-snapshot", DOCS)
+        self.assertIn('"check:hil"', PACKAGE)
+        self.assertIn("hil-harness-tests:", WORKFLOW)
+        self.assertIn("npm run check:hil", WORKFLOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_hil_harness_contract.py
+++ b/scripts/tests/test_hil_harness_contract.py
@@ -25,8 +25,8 @@ class HilHarnessContractTest(unittest.TestCase):
 
     def test_fast_profile_does_not_change_production_floors(self):
         for marker in (
-            'api_input_room_temperature_stale_s: "30"',
-            'api_input_heating_enable_stale_s: "30"',
+            'api_input_room_temperature_stale_s: "45"',
+            'api_input_heating_enable_stale_s: "45"',
             'oq_selected_input_stale_hold_s: "10"',
             'oq_hp_min_off_s: "10"',
         ):

--- a/tests/hil/harness.test.mjs
+++ b/tests/hil/harness.test.mjs
@@ -5,7 +5,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { firmwareCommand } from '../../scripts/hil/firmware.mjs';
-import { parseArgs } from '../../scripts/hil/run-input-sources.mjs';
+import { parseArgs, verifyDiagnostics } from '../../scripts/hil/run-input-sources.mjs';
 import {
   HilRestClient,
   RequestGate,
@@ -179,9 +179,37 @@ test('mutating CLI modes require apply plus an automatic firmware restore', () =
   ]);
   assert.equal(parsed.apply, true);
   assert.equal(parsed.writeIntervalMs, 1500);
+  assert.equal(parsed.expectedSimulatorContract, 'openquatt-modbus-opentherm-v1');
+  assert.equal(
+    parseArgs([...targets, '--expected-simulator-contract', 'next-contract']).expectedSimulatorContract,
+    'next-contract',
+  );
   assert.throws(
     () => parseArgs([...targets, '--stage', 'all', '--apply', '--settings-only']),
     /--device and --restore-config|--settings-only/,
+  );
+});
+
+test('diagnostics reject an absent or incompatible simulator contract', () => {
+  const result = {
+    simulator: { contract: 'openquatt-modbus-opentherm-v1', version: 'v0.1.0' },
+    memory: { heapMinFree: 40000, largestBlock: 50000 },
+    hp1: 'exc=0 bad_addr=0 bad_write=0 cap=0',
+    hp2: 'exc=0 bad_addr=0 bad_write=0 cap=0',
+  };
+  const options = {
+    expectedSimulatorContract: 'openquatt-modbus-opentherm-v1',
+    minHeapMinFree: 0,
+    minLargestBlock: 0,
+  };
+  assert.doesNotThrow(() => verifyDiagnostics(result, options));
+  assert.throws(
+    () => verifyDiagnostics({ ...result, simulator: { contract: null, version: null } }, options),
+    /simulator contract differs/,
+  );
+  assert.throws(
+    () => verifyDiagnostics(result, { ...options, expectedSimulatorContract: 'next-contract' }),
+    /simulator contract differs/,
   );
 });
 

--- a/tests/hil/harness.test.mjs
+++ b/tests/hil/harness.test.mjs
@@ -5,7 +5,11 @@ import path from 'node:path';
 import test from 'node:test';
 
 import { firmwareCommand } from '../../scripts/hil/firmware.mjs';
-import { parseArgs, verifyDiagnostics } from '../../scripts/hil/run-input-sources.mjs';
+import {
+  parseArgs,
+  verifyDiagnostics,
+  verifyRestoredFirmware,
+} from '../../scripts/hil/run-input-sources.mjs';
 import {
   HilRestClient,
   RequestGate,
@@ -155,6 +159,20 @@ test('target URLs reject credentials and non-HTTP protocols', () => {
 
 test('snapshots require the exact pre-test firmware identity', () => {
   assert.throws(() => validateSnapshot({ schema: 1 }), /firmware identity/);
+  assert.equal(
+    verifyRestoredFirmware(
+      '2026.8.2 (config hash 0x12345678)',
+      '2026.8.2 (config hash 0x12345678)',
+    ),
+    '2026.8.2 (config hash 0x12345678)',
+  );
+  assert.throws(
+    () => verifyRestoredFirmware(
+      '2026.8.2 (config hash 0x87654321)',
+      '2026.8.2 (config hash 0x12345678)',
+    ),
+    /restored firmware differs/,
+  );
 });
 
 test('mutating CLI modes require apply plus an automatic firmware restore', () => {

--- a/tests/hil/harness.test.mjs
+++ b/tests/hil/harness.test.mjs
@@ -1,0 +1,337 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { firmwareCommand } from '../../scripts/hil/firmware.mjs';
+import { parseArgs } from '../../scripts/hil/run-input-sources.mjs';
+import {
+  HilRestClient,
+  RequestGate,
+  normalizeBaseUrl,
+} from '../../scripts/hil/rest-client.mjs';
+import {
+  acquireRecoveryLock,
+  controllerSettings,
+  restoreSettings,
+  simulatorSettings,
+  snapshotSettings,
+  validateSnapshot,
+} from '../../scripts/hil/session.mjs';
+
+test('recovery lock blocks concurrent recovery and reclaims a dead owner', async (context) => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'openquatt-hil-lock-'));
+  context.after(() => rm(directory, { recursive: true, force: true }));
+  const first = await acquireRecoveryLock(directory, '/run/first');
+  await assert.rejects(
+    () => acquireRecoveryLock(directory, '/run/second'),
+    /another HIL recovery is active/,
+  );
+  await first.release();
+
+  await writeFile(
+    path.join(directory, 'input-sources-recovery.lock'),
+    `${JSON.stringify({ pid: 99_999_999, runDir: '/run/stale' })}\n`,
+  );
+  const reclaimed = await acquireRecoveryLock(directory, '/run/reclaimed');
+  await reclaimed.release();
+});
+
+test('REST client is read-only unless writes are explicitly enabled', async () => {
+  let called = false;
+  const client = new HilRestClient({
+    baseUrl: 'http://controller.local',
+    fetchImpl: async () => {
+      called = true;
+      return new Response('', { status: 200 });
+    },
+  });
+  await assert.rejects(() => client.setSwitch('test', true), /--apply/);
+  assert.equal(called, false);
+});
+
+test('one shared request gate enforces the global write interval', async () => {
+  let now = 0;
+  const waits = [];
+  const gate = new RequestGate({
+    now: () => now,
+    sleep: async (milliseconds) => {
+      waits.push(milliseconds);
+      now += milliseconds;
+    },
+    writeIntervalMs: 1500,
+  });
+  const fetchImpl = async () => new Response('', { status: 200 });
+  const controller = new HilRestClient({
+    baseUrl: 'http://controller.local',
+    allowWrites: true,
+    fetchImpl,
+    gate,
+  });
+  const simulator = new HilRestClient({
+    baseUrl: 'http://simulator.local',
+    allowWrites: true,
+    fetchImpl,
+    gate,
+  });
+  await controller.setSwitch('first', true);
+  await simulator.setSwitch('second', false);
+  assert.deepEqual(waits, [1500]);
+  assert.deepEqual(gate.counts, { read: 0, write: 2 });
+});
+
+test('one shared request gate prevents concurrent controller and simulator calls', async () => {
+  let releaseFirst;
+  const firstBlocked = new Promise((resolve) => {
+    releaseFirst = resolve;
+  });
+  let active = 0;
+  let maximumActive = 0;
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    active += 1;
+    maximumActive = Math.max(maximumActive, active);
+    if (calls === 1) await firstBlocked;
+    active -= 1;
+    return new Response(JSON.stringify({ value: calls }), { status: 200 });
+  };
+  const gate = new RequestGate({ readIntervalMs: 0 });
+  const controller = new HilRestClient({
+    baseUrl: 'http://controller.local',
+    fetchImpl,
+    gate,
+  });
+  const simulator = new HilRestClient({
+    baseUrl: 'http://simulator.local',
+    fetchImpl,
+    gate,
+  });
+  const first = controller.value('sensor', 'first');
+  const second = simulator.value('sensor', 'second');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(calls, 1);
+  releaseFirst();
+  await Promise.all([first, second]);
+  assert.equal(maximumActive, 1);
+});
+
+test('controller bulk reads use one read-only POST without enabling writes', async () => {
+  const gate = new RequestGate();
+  let receivedBody = '';
+  const client = new HilRestClient({
+    baseUrl: 'http://controller.local',
+    bulkReads: true,
+    gate,
+    fetchImpl: async (_url, options) => {
+      receivedBody = options.body;
+      return new Response(
+        JSON.stringify({
+          entities: {
+            heap: { value: 42000 },
+            profile: { value: 'input-sources-fast-v1' },
+          },
+          missing: [],
+        }),
+        { status: 200 },
+      );
+    },
+  });
+  const values = await client.values([
+    { key: 'heap', domain: 'sensor', name: 'Heap Min Free' },
+    { key: 'profile', domain: 'text_sensor', name: 'HIL Test Profile' },
+  ]);
+  assert.deepEqual(values, { heap: 42000, profile: 'input-sources-fast-v1' });
+  assert.match(receivedBody, /entities=heap%09sensor%09Heap\+Min\+Free/);
+  assert.deepEqual(gate.counts, { read: 1, write: 0 });
+});
+
+test('target URLs reject credentials and non-HTTP protocols', () => {
+  assert.equal(normalizeBaseUrl('http://controller.local/'), 'http://controller.local');
+  assert.throws(() => normalizeBaseUrl('ftp://controller.local'), /http or https/);
+  assert.throws(() => normalizeBaseUrl('http://user:secret@controller.local'), /credentials/);
+});
+
+test('snapshots require the exact pre-test firmware identity', () => {
+  assert.throws(() => validateSnapshot({ schema: 1 }), /firmware identity/);
+});
+
+test('mutating CLI modes require apply plus an automatic firmware restore', () => {
+  const targets = ['--controller', 'http://controller.local', '--simulator', 'http://simulator.local'];
+  assert.equal(parseArgs(targets).stage, 'smoke');
+  assert.throws(() => parseArgs([...targets, '--stage', 'all']), /--apply/);
+  assert.throws(
+    () => parseArgs([...targets, '--stage', 'all', '--apply']),
+    /--device and --restore-config/,
+  );
+  const parsed = parseArgs([
+    ...targets,
+    '--stage',
+    'all',
+    '--apply',
+    '--device',
+    'controller.local',
+    '--test-config',
+    'test.yaml',
+    '--restore-config',
+    'production.yaml',
+  ]);
+  assert.equal(parsed.apply, true);
+  assert.equal(parsed.writeIntervalMs, 1500);
+  assert.throws(
+    () => parseArgs([...targets, '--stage', 'all', '--apply', '--settings-only']),
+    /--device and --restore-config|--settings-only/,
+  );
+});
+
+test('firmware upload uses argument arrays without a shell', () => {
+  assert.deepEqual(
+    firmwareCommand({ config: 'test profile.yaml', device: 'controller.local', esphome: '/bin/esphome' }),
+    {
+      executable: '/bin/esphome',
+      args: [
+        'run',
+        '--device',
+        'controller.local',
+        '--ota-platform',
+        'esphome',
+        '--no-logs',
+        'test profile.yaml',
+      ],
+    },
+  );
+});
+
+class FakeClient {
+  constructor(settings) {
+    this.state = new Map(settings.map((setting, index) => [
+      `${setting.domain}:${setting.name}`,
+      setting.kind === 'number'
+        ? index + 0.5
+        : setting.kind === 'switch'
+          ? index % 2 === 0
+          : `option-${index}`,
+    ]));
+  }
+
+  async value(domain, name) {
+    return this.state.get(`${domain}:${name}`);
+  }
+
+  async values(settings) {
+    return Object.fromEntries(
+      settings.map((setting) => [setting.key, this.state.get(`${setting.domain}:${setting.name}`)]),
+    );
+  }
+
+  async setNumber(name, value) {
+    this.state.set(`number:${name}`, Number(value));
+  }
+
+  async setSelect(name, value) {
+    this.state.set(`select:${name}`, value);
+    if (name === 'CM Override' && value === 'Force CM0') {
+      this.state.set('text_sensor:Control Mode', 'CM0');
+    }
+  }
+
+  async setSwitch(name, value) {
+    this.state.set(`switch:${name}`, Boolean(value));
+  }
+}
+
+test('snapshot restore reinstates every captured setting after a failed scenario', async () => {
+  const controller = new FakeClient(controllerSettings);
+  const simulator = new FakeClient(simulatorSettings);
+  const targets = {
+    controller: 'http://controller.local',
+    simulator: 'http://simulator.local',
+  };
+  const snapshot = await snapshotSettings({
+    controller,
+    simulator,
+    targets,
+    firmware: '2026.8.2 (config hash 0x12345678)',
+  });
+  for (const setting of controllerSettings) {
+    controller.state.set(`${setting.domain}:${setting.name}`, setting.kind === 'number' ? 999 : 'changed');
+  }
+  for (const setting of simulatorSettings) {
+    simulator.state.set(`${setting.domain}:${setting.name}`, true);
+  }
+  await restoreSettings({ controller, simulator, snapshot, log: () => {} });
+  for (const setting of controllerSettings) {
+    assert.equal(
+      await controller.value(setting.domain, setting.name),
+      snapshot.controller[setting.key],
+      setting.name,
+    );
+  }
+  for (const setting of simulatorSettings) {
+    assert.equal(
+      await simulator.value(setting.domain, setting.name),
+      snapshot.simulator[setting.key],
+      setting.name,
+    );
+  }
+});
+
+test('pre-OTA restore keeps CM0 until normal firmware is confirmed', async () => {
+  const controller = new FakeClient(controllerSettings);
+  const simulator = new FakeClient(simulatorSettings);
+  const snapshot = await snapshotSettings({
+    controller,
+    simulator,
+    targets: {
+      controller: 'http://controller.local',
+      simulator: 'http://simulator.local',
+    },
+    firmware: '2026.8.2 (config hash 0x12345678)',
+  });
+  controller.state.set('select:Room Temperature Source', 'changed');
+  await restoreSettings({
+    controller,
+    simulator,
+    snapshot,
+    restoreCmOverride: false,
+    log: () => {},
+  });
+  assert.equal(await controller.value('select', 'CM Override'), 'Force CM0');
+  assert.equal(
+    await controller.value('select', 'Room Temperature Source'),
+    snapshot.controller.roomSource,
+  );
+});
+
+test('restore failures remain blocking while other settings are still attempted', async () => {
+  class FailingClient extends FakeClient {
+    async setNumber(name, value) {
+      if (name === 'Power House temperature reaction') throw new Error('injected write failure');
+      await super.setNumber(name, value);
+    }
+  }
+
+  const controller = new FailingClient(controllerSettings);
+  const simulator = new FakeClient(simulatorSettings);
+  const snapshot = await snapshotSettings({
+    controller,
+    simulator,
+    targets: {
+      controller: 'http://controller.local',
+      simulator: 'http://simulator.local',
+    },
+    firmware: '2026.8.2 (config hash 0x12345678)',
+  });
+  controller.state.set('number:Power House temperature reaction', 999);
+  controller.state.set('select:Room Temperature Source', 'changed');
+  await assert.rejects(
+    () => restoreSettings({ controller, simulator, snapshot, log: () => {} }),
+    /one or more HIL settings could not be restored/,
+  );
+  assert.equal(
+    await controller.value('select', 'Room Temperature Source'),
+    snapshot.controller.roomSource,
+  );
+  assert.equal(await controller.value('select', 'CM Override'), 'Force CM0');
+});

--- a/tests/hil/scenarios/input-sources.mjs
+++ b/tests/hil/scenarios/input-sources.mjs
@@ -16,6 +16,25 @@ function closeEnough(actual, expected, tolerance = 0.11) {
   return actual !== null && Math.abs(actual - expected) <= tolerance;
 }
 
+function waitDewPointApiState(controller, expected, label, options = {}) {
+  return waitFor(async () => {
+    const values = await controller.values([
+      { key: 'raw', domain: 'number', name: 'api_input_cooling_dew_point' },
+      { key: 'available', domain: 'binary_sensor', name: 'Cooling Dew Point Available' },
+      { key: 'guard', domain: 'text_sensor', name: 'Cooling Guard Mode' },
+      { key: 'selected', domain: 'sensor', name: 'Cooling Dew Point (Selected)' },
+    ]);
+    const raw = asFiniteNumber(values.raw);
+    const selected = asFiniteNumber(values.selected);
+    const accepted =
+      closeEnough(raw, expected) &&
+      String(values.available) === 'true' &&
+      values.guard === 'Dew point (API input)' &&
+      selected !== null;
+    return accepted ? values : false;
+  }, label, options);
+}
+
 export async function prepareInputSourceScenario(controller, simulator, interrupted) {
   await controller.setSelect('CM Override', 'Force CM0');
   await controller.setSwitch('Manual Cooling Enable', false);
@@ -42,7 +61,7 @@ async function testNumericIngress(controller, interrupted) {
     { interrupted },
   );
   await waitUnavailable(controller, 'External Heat Demand (Selected)', 'external demand expired', {
-    timeoutMs: 55000,
+    timeoutMs: 75000,
     interrupted,
   });
   await controller.setNumber('api_input_external_heat_demand', 6400);
@@ -64,7 +83,7 @@ async function testNumericIngress(controller, interrupted) {
     { interrupted },
   );
   await waitUnavailable(controller, 'Outside Temperature (Selected)', 'outside API expired', {
-    timeoutMs: 55000,
+    timeoutMs: 75000,
     interrupted,
   });
   await controller.setNumber('api_input_outside_temperature', 11.7);
@@ -78,25 +97,13 @@ async function testNumericIngress(controller, interrupted) {
 
   await controller.setSelect('Cooling Dew Point Source', 'API input');
   await controller.setNumber('api_input_cooling_dew_point', 16.2);
-  await waitNumber(
-    controller,
-    'Cooling Dew Point (Selected)',
-    (value) => closeEnough(value, 16.2),
-    'cooling dew point API accepted',
-    { interrupted },
-  );
+  await waitDewPointApiState(controller, 16.2, 'cooling dew point API accepted', { interrupted });
   await waitUnavailable(controller, 'Cooling Dew Point (Selected)', 'cooling dew point expired', {
-    timeoutMs: 55000,
+    timeoutMs: 75000,
     interrupted,
   });
   await controller.setNumber('api_input_cooling_dew_point', 15.8);
-  await waitNumber(
-    controller,
-    'Cooling Dew Point (Selected)',
-    (value) => closeEnough(value, 15.8),
-    'cooling dew point API recovered',
-    { interrupted },
-  );
+  await waitDewPointApiState(controller, 15.8, 'cooling dew point API recovered', { interrupted });
 
   await controller.setSelect('Room Temperature Source', 'API input');
   await controller.setSelect('Room Setpoint Source', 'API input');
@@ -195,12 +202,21 @@ async function testActiveSourceSwitch(controller, interrupted) {
     await controller.setNumber('api_input_room_temperature', 19);
     await controller.setNumber('api_input_room_setpoint', 21);
     await controller.setSwitch('api_input_heating_enable', true);
-    const mode = String(await controller.value('text_sensor', 'Control Mode'));
+    const status = await controller.values([
+      { key: 'mode', domain: 'text_sensor', name: 'Control Mode' },
+      { key: 'enabled', domain: 'binary_sensor', name: 'Heating Enable (Selected)' },
+      { key: 'external', domain: 'sensor', name: 'External Heat Demand (Selected)' },
+      { key: 'outside', domain: 'sensor', name: 'Outside Temperature (Selected)' },
+      { key: 'room', domain: 'sensor', name: 'Room Temperature (Selected)' },
+      { key: 'setpoint', domain: 'sensor', name: 'Room Setpoint (Selected)' },
+      { key: 'flow', domain: 'sensor', name: 'Flow average (Selected)' },
+    ]);
+    console.log(`STATE active source switch ${JSON.stringify(status)}`);
+    const mode = String(status.mode);
     if (['CM2', 'CM3', 'CM4'].includes(mode)) {
       activeMode = mode;
       break;
     }
-    await sleep(10000);
   }
   assert(activeMode, 'heating request never became active');
   await controller.setSelect('Heating Enable Source', 'MQTT');

--- a/tests/hil/scenarios/input-sources.mjs
+++ b/tests/hil/scenarios/input-sources.mjs
@@ -1,0 +1,286 @@
+import { asFiniteNumber } from '../../../scripts/hil/rest-client.mjs';
+import {
+  waitFor,
+  waitNumber,
+  waitUnavailable,
+  waitValue,
+} from '../../../scripts/hil/wait.mjs';
+
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function closeEnough(actual, expected, tolerance = 0.11) {
+  return actual !== null && Math.abs(actual - expected) <= tolerance;
+}
+
+export async function prepareInputSourceScenario(controller, simulator, interrupted) {
+  await controller.setSelect('CM Override', 'Force CM0');
+  await controller.setSwitch('Manual Cooling Enable', false);
+  await controller.setSwitch('api_input_heating_enable', false);
+  await controller.setSwitch('api_input_cooling_enable', false);
+  await simulator.setSwitch('ODU 1 force no flow', false);
+  await simulator.setSwitch('ODU 2 force no flow', false);
+  await simulator.setSwitch('ODU external system pump flow', true);
+  await waitValue(controller, 'text_sensor', 'Control Mode', 'CM0', 'safe CM0 start', {
+    timeoutMs: 50000,
+    interrupted,
+  });
+}
+
+async function testNumericIngress(controller, interrupted) {
+  console.log('TEST numeric API ingress, expiry, recovery, and source-bound hold');
+  await controller.setSelect('External Heat Demand Source', 'API input');
+  await controller.setNumber('api_input_external_heat_demand', 7300);
+  await waitNumber(
+    controller,
+    'External Heat Demand (Selected)',
+    (value) => closeEnough(value, 7300, 1),
+    'external demand accepted',
+    { interrupted },
+  );
+  await waitUnavailable(controller, 'External Heat Demand (Selected)', 'external demand expired', {
+    timeoutMs: 55000,
+    interrupted,
+  });
+  await controller.setNumber('api_input_external_heat_demand', 6400);
+  await waitNumber(
+    controller,
+    'External Heat Demand (Selected)',
+    (value) => closeEnough(value, 6400, 1),
+    'external demand recovered',
+    { interrupted },
+  );
+
+  await controller.setSelect('Outside Temperature Source', 'API input');
+  await controller.setNumber('api_input_outside_temperature', 12.3);
+  await waitNumber(
+    controller,
+    'Outside Temperature (Selected)',
+    (value) => closeEnough(value, 12.3),
+    'outside API accepted',
+    { interrupted },
+  );
+  await waitUnavailable(controller, 'Outside Temperature (Selected)', 'outside API expired', {
+    timeoutMs: 55000,
+    interrupted,
+  });
+  await controller.setNumber('api_input_outside_temperature', 11.7);
+  await waitNumber(
+    controller,
+    'Outside Temperature (Selected)',
+    (value) => closeEnough(value, 11.7),
+    'outside API recovered',
+    { interrupted },
+  );
+
+  await controller.setSelect('Cooling Dew Point Source', 'API input');
+  await controller.setNumber('api_input_cooling_dew_point', 16.2);
+  await waitNumber(
+    controller,
+    'Cooling Dew Point (Selected)',
+    (value) => closeEnough(value, 16.2),
+    'cooling dew point API accepted',
+    { interrupted },
+  );
+  await waitUnavailable(controller, 'Cooling Dew Point (Selected)', 'cooling dew point expired', {
+    timeoutMs: 55000,
+    interrupted,
+  });
+  await controller.setNumber('api_input_cooling_dew_point', 15.8);
+  await waitNumber(
+    controller,
+    'Cooling Dew Point (Selected)',
+    (value) => closeEnough(value, 15.8),
+    'cooling dew point API recovered',
+    { interrupted },
+  );
+
+  await controller.setSelect('Room Temperature Source', 'API input');
+  await controller.setSelect('Room Setpoint Source', 'API input');
+  await controller.setNumber('api_input_room_temperature', 33.7);
+  await controller.setNumber('api_input_room_setpoint', 24.1);
+  await waitNumber(
+    controller,
+    'Room Temperature (Selected)',
+    (value) => closeEnough(value, 33.7),
+    'room API accepted',
+    { interrupted },
+  );
+  await waitNumber(
+    controller,
+    'Room Setpoint (Selected)',
+    (value) => closeEnough(value, 24.1),
+    'setpoint API accepted',
+    { interrupted },
+  );
+  await controller.setSelect('Room Temperature Source', 'HA input');
+  await sleep(11000);
+  const switched = asFiniteNumber(
+    await controller.value('sensor', 'Room Temperature (Selected)'),
+  );
+  assert(
+    switched === null || !closeEnough(switched, 33.7),
+    `cross-source hold replayed API room value: ${switched}`,
+  );
+  console.log('PASS numeric API ingress and source-bound hold');
+}
+
+async function testEnableExpiry(controller, interrupted) {
+  console.log('TEST heating/cooling enable expiry is fail-closed');
+  await controller.setSelect('Heating Enable Source', 'API input');
+  await controller.setSelect('Cooling Enable Source', 'API input');
+  await controller.setSwitch('api_input_heating_enable', true);
+  await controller.setSwitch('api_input_cooling_enable', true);
+  for (const [name, label] of [
+    ['Heating Enable Valid', 'heating API valid'],
+    ['Heating Enable (Selected)', 'heating API selected'],
+    ['Cooling Enable Valid', 'cooling API valid'],
+    ['Cooling Enable (Selected)', 'cooling API selected'],
+  ]) {
+    await waitValue(controller, 'binary_sensor', name, true, label, {
+      timeoutMs: 70000,
+      interrupted,
+    });
+  }
+  for (const [name, label] of [
+    ['Heating Enable Valid', 'heating API expiry'],
+    ['Heating Enable (Selected)', 'heating fails closed'],
+    ['Cooling Enable Valid', 'cooling API expiry'],
+    ['Cooling Enable (Selected)', 'cooling fails closed'],
+  ]) {
+    await waitValue(controller, 'binary_sensor', name, false, label, {
+      timeoutMs: 85000,
+      interrupted,
+    });
+  }
+  console.log('PASS heating/cooling enable expiry');
+}
+
+async function testActiveSourceSwitch(controller, interrupted) {
+  console.log('TEST active heating request loses permission on source switch');
+  await controller.setSelect('Heating Enable Source', 'MQTT');
+  await waitValue(
+    controller,
+    'binary_sensor',
+    'Heating Enable (Selected)',
+    false,
+    'MQTT route is non-granting',
+    { timeoutMs: 70000, interrupted },
+  );
+  await controller.setSelect('Heating Enable Source', 'API input');
+  await controller.setSwitch('api_input_heating_enable', true);
+  await controller.setSelect('Heating Control Mode', 'Power House');
+  await controller.setNumber('Power House temperature reaction', 0);
+  await controller.setNumber('Power House demand rise time', 2);
+  await controller.setNumber('Demand filter ramp up', 20);
+  await controller.setSelect('External Heat Demand Source', 'API input');
+  await controller.setSelect('Outside Temperature Source', 'API input');
+  await controller.setSelect('Room Temperature Source', 'API input');
+  await controller.setSelect('Room Setpoint Source', 'API input');
+  await controller.setSelect('Flow Source', 'Outdoor unit');
+  await controller.setSelect('Outdoor Unit Flow Mode', 'Flowmeter HP1');
+  await controller.setNumber('Flow Setpoint', 800);
+  await controller.setSelect('Flow Control Mode', 'Flow Setpoint');
+  await controller.setSelect('CM Override', 'Auto');
+
+  const deadline = Date.now() + 240000;
+  let activeMode;
+  while (Date.now() < deadline) {
+    if (interrupted()) throw new Error('HIL run interrupted; starting recovery');
+    await controller.setNumber('api_input_external_heat_demand', 8000);
+    await controller.setNumber('api_input_outside_temperature', 8);
+    await controller.setNumber('api_input_room_temperature', 19);
+    await controller.setNumber('api_input_room_setpoint', 21);
+    await controller.setSwitch('api_input_heating_enable', true);
+    const mode = String(await controller.value('text_sensor', 'Control Mode'));
+    if (['CM2', 'CM3', 'CM4'].includes(mode)) {
+      activeMode = mode;
+      break;
+    }
+    await sleep(10000);
+  }
+  assert(activeMode, 'heating request never became active');
+  await controller.setSelect('Heating Enable Source', 'MQTT');
+  await waitValue(
+    controller,
+    'binary_sensor',
+    'Heating Enable (Selected)',
+    false,
+    'active source switch withdraws grant',
+    { timeoutMs: 70000, interrupted },
+  );
+  await waitFor(async () => {
+    const mode = String(await controller.value('text_sensor', 'Control Mode'));
+    return mode === 'CM1' || mode === 'CM0' ? mode : false;
+  }, 'active request leaves heating mode', {
+    timeoutMs: 100000,
+    intervalMs: 1500,
+    interrupted,
+  });
+  console.log(`PASS active source switch from ${activeMode}`);
+}
+
+async function testRebootReset(controller, waitForProfile, interrupted) {
+  console.log('TEST reboot does not replay API state');
+  await controller.setSelect('CM Override', 'Force CM0');
+  await waitValue(controller, 'text_sensor', 'Control Mode', 'CM0', 'CM0 before reboot', {
+    timeoutMs: 50000,
+    interrupted,
+  });
+  await controller.setSelect('Heating Enable Source', 'API input');
+  await controller.setSelect('Cooling Enable Source', 'API input');
+  await controller.setSelect('External Heat Demand Source', 'API input');
+  await controller.setSwitch('api_input_heating_enable', true);
+  await controller.setSwitch('api_input_cooling_enable', true);
+  await controller.setNumber('api_input_external_heat_demand', 5000);
+  await waitValue(
+    controller,
+    'binary_sensor',
+    'Heating Enable (Selected)',
+    true,
+    'heating set before reboot',
+    { timeoutMs: 70000, interrupted },
+  );
+  await controller.press('Restart');
+  await sleep(6000);
+  await waitForProfile();
+  for (const [domain, name, expected, label] of [
+    ['switch', 'api_input_heating_enable', false, 'heating API state reset'],
+    ['switch', 'api_input_cooling_enable', false, 'cooling API state reset'],
+    ['binary_sensor', 'Heating Enable Valid', false, 'heating validity reset'],
+    ['binary_sensor', 'Cooling Enable Valid', false, 'cooling validity reset'],
+  ]) {
+    await waitValue(controller, domain, name, expected, label, {
+      timeoutMs: 70000,
+      interrupted,
+    });
+  }
+  await waitUnavailable(controller, 'External Heat Demand (Selected)', 'external demand reset', {
+    timeoutMs: 70000,
+    interrupted,
+  });
+  console.log('PASS reboot reset without stale replay');
+}
+
+export async function runInputSourceScenarios({
+  stage,
+  controller,
+  interrupted,
+  waitForProfile,
+}) {
+  if (stage === 'all' || stage === 'inputs') {
+    await testNumericIngress(controller, interrupted);
+  }
+  if (stage === 'all' || stage === 'enable-expiry') {
+    await testEnableExpiry(controller, interrupted);
+  }
+  if (stage === 'all' || stage === 'active-switch') {
+    await testActiveSourceSwitch(controller, interrupted);
+  }
+  if (stage === 'all' || stage === 'reboot-reset') {
+    await testRebootReset(controller, waitForProfile, interrupted);
+  }
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt een repositorylokale HIL-runner toe voor de zeven API-inputs, bronwissels, fail-closed enable-expiry en reboot-reset.
- Maakt muterende runs fail-closed met expliciete `--apply`, seriële REST-begrenzing, een atomisch instellingensnapshot, CM0 tijdens herstel en verplichte terugplaatsing van exact dezelfde normale firmware.
- Voegt een uitsluitend lokale Q Duo WiFi-testoverlay, herstelhandleiding, hosttests en een afzonderlijke CI-job voor het harness toe.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De productie-entrypoints en controlcode wijzigen niet. De HIL-overlay staat niet in `build_targets.yaml` en verkort alleen tijdens een expliciete testupload API-stale naar 45 s, geselecteerde-input-hold naar 10 s en HP minimum-off naar 10 s. Normale firmware behoudt alle bestaande waarden.

## Achtergrond

PR #599 is hostmatig en handmatig op controller/simulator geaccepteerd. Deze PR legt dat acceptatiepad veilig en herhaalbaar vast. De runner vereist simulatorcontract `openquatt-modbus-opentherm-v1`; bron en testerhandleiding staan in [OpenQuatt-Simulator](https://github.com/OpenQuatt/OpenQuatt-Simulator), release `v0.1.0`.

Safety-, lifecycle- en koude adversarial audit van de volledige diff:

- controller- en simulatordoelen hebben geen standaard-IP en URL's met credentials worden geweigerd;
- REST-writes en OTA zijn alleen bereikbaar met `--apply`; alle controller- en simulatorcalls delen één seriële gate met minimaal 1.000 ms tussen writes;
- vóór de eerste mutatie worden alle geraakte persistente instellingen en de exacte firmware/config-hash atomisch vastgelegd;
- simulatorcontract, protocolstatus en optionele heapgrenzen worden vóór de eerste mutatie gecontroleerd;
- de testprofielmarker wordt vóór scenario-writes bevestigd;
- herstel schakelt transient API-enablewaarden en faultinjecties eerst uit, houdt CM0 actief tijdens compile/OTA en herstelt de oorspronkelijke CM-override pas als alle overige waarden zijn teruggelezen;
- normale firmware geldt pas als hersteld wanneer versie én config-hash exact overeenkomen met het snapshot;
- gedeeltelijk herstel, OTA-falen, profiel-timeout en verificatiefouten blijven blocking en laten snapshot plus hoofdlock staan;
- gelijktijdige runs en recovery worden geblokkeerd; een recovery-processlock wordt alleen voor een aantoonbaar beëindigde PID hergebruikt;
- snapshots en rapporten zijn mode `0600`; herstel weigert andere doelen en `--settings-only` vereist exact de oorspronkelijke firmware-identiteit;
- numerieke API-inputs en API-enablewaarden worden niet gereplayed na reboot; bronselecties worden wel hersteld.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/hil-testing.md` beschrijft veiligheidscontract, read-only rooktest, volledige run, timingoverlay, artifacts, afbreken en handmatig herstel. Het YAML-naar-C++-migratieplan verwijst naar dit vervolg en markeert #599 afgerond.

## Validatie

- `npm run check:hil` — 13/13 groen, inclusief write-gating, serialisatie, simulatorcontract, recovery-lock, exacte firmware-identiteit, CM0-hold en failure injection.
- `python3 -m unittest scripts.tests.test_hil_harness_contract` — 4/4 groen.
- `npm run check:python-contracts` — 189/189 groen.
- `npm run check:docs` — groen.
- `CXX=g++-15 ./scripts/run_host_regression_tests.sh` — 59/59 groen.
- `python3 scripts/dev.py validate --config-only --config configs/hil/input_sources_fast_duo_wifi.yaml` — config en NVS-budget groen.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` — normale Q Duo WiFi-config en NVS-budget groen.
- `esphome compile configs/hil/input_sources_fast_duo_wifi.yaml` — groen.
- Volledige HIL-run tegen controller en gecombineerde Modbus/OpenTherm-simulator `v0.1.0` — alle vier scenario's groen: numerieke ingress/expiry/recovery, enable-expiry fail-closed, actieve bronwissel en reboot zonder stale replay.
- De run deed 307 reads en 159 begrensde writes. Normale firmware `2026.8.2 (config hash 0x51134a5d)` en alle instellingen zijn automatisch teruggezet en teruggelezen; `CM Override=Auto` en de HIL-profielentity is daarna afwezig.
- ODU1/ODU2 hielden `exc=0`, `bad_addr=0`, `bad_write=0`, `cap=0`.

- [x] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen productiecode of productieconfig gewijzigd. Voor de HIL-run rapporteerde normale firmware 99.679 B actuele interne heap, 39.828 B minimum-sinds-boot, 53.248 B grootste block, 46,58% fragmentatie en 6.874.900 B vrije PSRAM. Na alle scenario's op testfirmware: 103.479 B, 39.828 B, 63.488 B, 38,65% en 6.874.928 B. Dit is diagnostiek van bestaande firmware en geen nieuwe geheugenbudgetclaim.
