### PR TITLE
Ruim metadata van interne entities op

### DIFF
--- a/openquatt/base/common.yaml
+++ b/openquatt/base/common.yaml
@@ -93,7 +93,4 @@ sensor:
     psram:
       name: "PSRAM Free"
       internal: true
-      icon: mdi:memory
-      entity_category: diagnostic
-      disabled_by_default: true
       accuracy_decimals: 0

--- a/openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml
+++ b/openquatt/experimental/oq_odu_runtime_frequency_table_hp.yaml
@@ -28,10 +28,8 @@ switch:
     id: ${hp_id}_odu_runtime_frequency_table_enable
     name: "${prefix}EXPERIMENTAL ODU runtime frequency write enable"
     internal: true
-    icon: mdi:alert-decagram
     optimistic: true
     restore_mode: ALWAYS_OFF
-    entity_category: config
 
 number:
   # RAM-only editor for the ODU-owned runtime table. Defaults only provide a
@@ -41,7 +39,6 @@ number:
     id: ${hp_id}_odu_runtime_cooling_f0
     name: "${prefix}EXPERIMENTAL cooling F0 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -49,13 +46,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f1
     name: "${prefix}EXPERIMENTAL cooling F1 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -63,13 +58,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 30
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f2
     name: "${prefix}EXPERIMENTAL cooling F2 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -77,13 +70,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 36
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f3
     name: "${prefix}EXPERIMENTAL cooling F3 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -91,13 +82,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 42
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f4
     name: "${prefix}EXPERIMENTAL cooling F4 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -105,13 +94,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 47
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f5
     name: "${prefix}EXPERIMENTAL cooling F5 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -119,13 +106,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 52
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f6
     name: "${prefix}EXPERIMENTAL cooling F6 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -133,13 +118,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 56
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f7
     name: "${prefix}EXPERIMENTAL cooling F7 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -147,13 +130,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 61
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f8
     name: "${prefix}EXPERIMENTAL cooling F8 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -161,13 +142,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 66
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f9
     name: "${prefix}EXPERIMENTAL cooling F9 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -175,13 +154,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 71
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f10
     name: "${prefix}EXPERIMENTAL cooling F10 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -189,13 +166,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 74
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f11
     name: "${prefix}EXPERIMENTAL cooling F11 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -203,13 +178,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 48
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f12
     name: "${prefix}EXPERIMENTAL cooling F12 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -217,13 +190,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 52
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f13
     name: "${prefix}EXPERIMENTAL cooling F13 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -231,13 +202,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 54
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f14
     name: "${prefix}EXPERIMENTAL cooling F14 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -245,13 +214,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 56
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f15
     name: "${prefix}EXPERIMENTAL cooling F15 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -259,13 +226,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 58
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f16
     name: "${prefix}EXPERIMENTAL cooling F16 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -273,13 +238,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 60
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f17
     name: "${prefix}EXPERIMENTAL cooling F17 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -287,13 +250,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 64
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f18
     name: "${prefix}EXPERIMENTAL cooling F18 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -301,13 +262,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 66
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f19
     name: "${prefix}EXPERIMENTAL cooling F19 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -315,13 +274,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 68
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_cooling_f20
     name: "${prefix}EXPERIMENTAL cooling F20 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -329,13 +286,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 71
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f0
     name: "${prefix}EXPERIMENTAL heating F0 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -343,13 +298,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f1
     name: "${prefix}EXPERIMENTAL heating F1 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -357,13 +310,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 30
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f2
     name: "${prefix}EXPERIMENTAL heating F2 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -371,13 +322,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 39
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f3
     name: "${prefix}EXPERIMENTAL heating F3 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -385,13 +334,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 49
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f4
     name: "${prefix}EXPERIMENTAL heating F4 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -399,13 +346,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 55
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f5
     name: "${prefix}EXPERIMENTAL heating F5 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -413,13 +358,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 61
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f6
     name: "${prefix}EXPERIMENTAL heating F6 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -427,13 +370,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 67
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f7
     name: "${prefix}EXPERIMENTAL heating F7 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -441,13 +382,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 72
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f8
     name: "${prefix}EXPERIMENTAL heating F8 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -455,13 +394,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 79
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f9
     name: "${prefix}EXPERIMENTAL heating F9 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -469,13 +406,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 85
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f10
     name: "${prefix}EXPERIMENTAL heating F10 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -483,13 +418,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 90
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f11
     name: "${prefix}EXPERIMENTAL heating F11 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -497,13 +430,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 65
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f12
     name: "${prefix}EXPERIMENTAL heating F12 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -511,13 +442,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 68
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f13
     name: "${prefix}EXPERIMENTAL heating F13 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -525,13 +454,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 72
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f14
     name: "${prefix}EXPERIMENTAL heating F14 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -539,13 +466,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 76
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f15
     name: "${prefix}EXPERIMENTAL heating F15 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -553,13 +478,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 82
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f16
     name: "${prefix}EXPERIMENTAL heating F16 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -567,13 +490,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 85
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f17
     name: "${prefix}EXPERIMENTAL heating F17 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -581,13 +502,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 90
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f18
     name: "${prefix}EXPERIMENTAL heating F18 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -595,13 +514,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 95
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f19
     name: "${prefix}EXPERIMENTAL heating F19 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -609,13 +526,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 102
-    entity_category: config
 
   - platform: template
     id: ${hp_id}_odu_runtime_heating_f20
     name: "${prefix}EXPERIMENTAL heating F20 runtime Hz"
     internal: true
-    icon: mdi:sine-wave
     mode: box
     min_value: 0
     max_value: 120
@@ -623,15 +538,12 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 110
-    entity_category: config
 
 button:
   - platform: template
     id: ${hp_id}_odu_runtime_frequency_table_load
     name: "${prefix}EXPERIMENTAL load ODU runtime frequency table"
     internal: true
-    icon: mdi:download-alert-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_odu_runtime_frequency::RuntimeFrequencyTableRefs refs = {
@@ -704,8 +616,6 @@ button:
     id: ${hp_id}_odu_runtime_frequency_table_apply
     name: "${prefix}EXPERIMENTAL apply ODU runtime frequency table"
     internal: true
-    icon: mdi:alert-circle-check-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_odu_runtime_frequency::RuntimeFrequencyTableRefs refs = {
@@ -781,8 +691,6 @@ text_sensor:
     id: ${hp_id}_odu_runtime_frequency_table_status
     name: "${prefix}EXPERIMENTAL ODU runtime frequency status"
     internal: true
-    icon: mdi:alert-decagram-outline
-    entity_category: diagnostic
     update_interval: never
     on_value:
       then:

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -588,9 +588,6 @@ button:
     id: ${hp_id}_detect_odu_generation
     name: "${prefix}Detect ODU generation"
     internal: true
-    disabled_by_default: true
-    icon: mdi:refresh
-    entity_category: diagnostic
     on_press:
       - if:
           condition:
@@ -608,8 +605,6 @@ select:
     id: ${hp_id}_set_working_mode
     name: "${prefix}Set Working Mode"
     internal: true
-    disabled_by_default: true
-    icon: "mdi:heat-pump-outline"
     address: 3999
     value_type: U_WORD
     optimistic: true
@@ -624,8 +619,6 @@ select:
     id: ${hp_id}_compressor_level
     name: "${prefix}Set Compressor Level"
     internal: true
-    disabled_by_default: true
-    icon: "mdi:sine-wave"
     address: 1999
     value_type: U_WORD
     optimistic: true
@@ -658,8 +651,6 @@ select:
     id: ${hp_id}_low_noise_mode
     name: "${prefix}Silent Mode"
     internal: true
-    disabled_by_default: true
-    icon: mdi:weather-night
     address: 2006
     value_type: U_WORD
     optimistic: true
@@ -673,8 +664,6 @@ select:
     id: ${hp_id}_set_pump_mode
     name: "${prefix}Set Pump Mode"
     internal: true
-    disabled_by_default: true
-    icon: "mdi:pump"
     address: 2010
     value_type: U_WORD
     optimistic: true
@@ -721,7 +710,6 @@ number:
     id: ${hp_id}_pump_speed
     name: "${prefix}Set Pump Speed"
     internal: true
-    icon: "mdi:speedometer"
     register_type: holding
     address: 2015
     value_type: U_WORD
@@ -1056,8 +1044,6 @@ sensor:
     modbus_controller_id: ${hp_id}
     name: "${prefix}Firmware EEPROM"
     internal: true
-    disabled_by_default: true
-    icon: mdi:memory
     register_type: holding
     register_count: 4  # 2123 - 2127
     address: 2123
@@ -1068,8 +1054,6 @@ sensor:
     id: ${hp_id}_control_board_item
     name: "${prefix}Control board item number"
     internal: true
-    disabled_by_default: true
-    icon: mdi:identifier
     register_type: holding
     # Read span 2127-2130 to keep the Modbus range contiguous with 2131.
     # Only register 2127 is decoded as this U_WORD diagnostic value.
@@ -1124,16 +1108,12 @@ sensor:
     id: ${hp_id}_water_in_temp_raw
     name: "${prefix}Water in temperature raw"
     internal: true
-    disabled_by_default: true
-    icon: mdi:thermometer-water
     register_type: holding
     address: 2133
     #skip_updates: 0
     unit_of_measurement: "°C"
-    device_class: "temperature"
     state_class: "measurement"
     accuracy_decimals: 2
-    entity_category: diagnostic
     filters:
       - offset: -3000
       - multiply: 0.01
@@ -1148,16 +1128,12 @@ sensor:
     id: ${hp_id}_water_out_temp_raw
     name: "${prefix}Water out temperature raw"
     internal: true
-    disabled_by_default: true
-    icon: mdi:thermometer-water
     register_type: holding
     address: 2134
     #skip_updates: 0
     unit_of_measurement: "°C"
-    device_class: "temperature"
     state_class: "measurement"
     accuracy_decimals: 2
-    entity_category: diagnostic
     filters:
       - offset: -3000
       - multiply: 0.01
@@ -1227,9 +1203,6 @@ sensor:
     id: ${hp_id}_pump_ipwm_feedback_raw
     name: "${prefix}Pump iPWM feedback raw"
     internal: true
-    icon: mdi:pump
-    disabled_by_default: true
-    entity_category: diagnostic
     register_type: holding
     address: 2137
     value_type: U_WORD
@@ -1464,9 +1437,6 @@ binary_sensor:
     id: ${hp_id}_fan_low_speed_mode
     name: "${prefix}Fan Low Speed Mode"
     internal: true
-    disabled_by_default: true
-    icon: mdi:fan-speed-1
-    device_class: running
 
   - platform: template
     id: ${hp_id}_bottom_plate_heater
@@ -1485,17 +1455,11 @@ binary_sensor:
     id: ${hp_id}_fan_defrost_mode
     name: "${prefix}Fan Defrost Mode"
     internal: true
-    disabled_by_default: true
-    icon: mdi:snowflake-melt
-    device_class: running
 
   - platform: template
     id: ${hp_id}_fan_high_speed_mode
     name: "${prefix}Fan High Speed Mode"
     internal: true
-    disabled_by_default: true
-    icon: mdi:fan-speed-3
-    device_class: running
 
   - platform: template
     id: ${hp_id}_4_way_valve
@@ -1548,7 +1512,6 @@ binary_sensor:
     id: ${hp_id}_ot_fault_active
     name: "${prefix}OT fault active"
     internal: true
-    device_class: problem
     lambda: |-
       // OT fault should only reflect explicit failure bits, not protection or cycle states.
       auto has_bit = [](float raw, uint16_t bitmask) -> bool {
@@ -1596,8 +1559,6 @@ text_sensor:
     id: ${hp_id}_generation
     name: "${prefix}ODU generation"
     internal: true
-    icon: mdi:heat-pump-outline
-    entity_category: diagnostic
     update_interval: never
 
   - platform: template
@@ -1611,16 +1572,12 @@ text_sensor:
     id: ${hp_id}_generation_variant
     name: "${prefix}ODU generation variant"
     internal: true
-    icon: mdi:identifier
-    entity_category: diagnostic
     update_interval: never
 
   - platform: template
     id: ${hp_id}_customer_model_code
     name: "${prefix}ODU customer model code"
     internal: true
-    icon: mdi:identifier
-    entity_category: diagnostic
     update_interval: never
 
   - platform: template
@@ -1765,9 +1722,6 @@ text_sensor:
     id: ${hp_id}_pcb_firmware_version
     name: "${prefix}ODU PCB firmware version"
     internal: true
-    icon: mdi:chip
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       if (!id(${hp_id}_pcb_firmware_raw).has_state()) {
         return {};

--- a/openquatt/oq_air_purge.yaml
+++ b/openquatt/oq_air_purge.yaml
@@ -60,8 +60,6 @@ button:
     id: oq_air_purge_start
     name: "Air Purge Start"
     internal: true
-    icon: mdi:water-pump
-    entity_category: config
     on_press:
       - lambda: |-
           oq_air_purge::runtime().start(
@@ -72,8 +70,6 @@ button:
     id: oq_air_purge_abort_btn
     name: "Air Purge Abort"
     internal: true
-    icon: mdi:stop-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_air_purge::runtime().abort_or_clear();
@@ -83,8 +79,6 @@ switch:
     id: oq_air_purge_return_to_auto
     name: "Air purge return to Auto"
     internal: true
-    icon: mdi:backup-restore
-    entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
 

--- a/openquatt/oq_api_ingress.yaml
+++ b/openquatt/oq_api_ingress.yaml
@@ -126,57 +126,42 @@ binary_sensor:
   - platform: template
     id: api_input_cooling_dew_point_valid
     name: "API Input Cooling Dew Point Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: api_input_outside_temperature_valid
     name: "API Input Outside Temperature Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: api_input_room_temperature_valid
     name: "API Input Room Temperature Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: api_input_room_setpoint_valid
     name: "API Input Room Setpoint Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: api_input_heating_enable_valid
     name: "API Input Heating Enable Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: api_input_cooling_enable_valid
     name: "API Input Cooling Enable Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: api_input_external_heat_demand_valid
     name: "API Input External Heat Demand Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
 sensor:
   - platform: template
     id: api_input_cooling_dew_point_age
     name: "API Input Cooling Dew Point Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -185,7 +170,6 @@ sensor:
   - platform: template
     id: api_input_outside_temperature_age
     name: "API Input Outside Temperature Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -194,7 +178,6 @@ sensor:
   - platform: template
     id: api_input_room_temperature_age
     name: "API Input Room Temperature Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -203,7 +186,6 @@ sensor:
   - platform: template
     id: api_input_room_setpoint_age
     name: "API Input Room Setpoint Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -212,7 +194,6 @@ sensor:
   - platform: template
     id: api_input_heating_enable_age
     name: "API Input Heating Enable Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -221,7 +202,6 @@ sensor:
   - platform: template
     id: api_input_cooling_enable_age
     name: "API Input Cooling Enable Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -230,7 +210,6 @@ sensor:
   - platform: template
     id: api_input_external_heat_demand_age
     name: "API Input External Heat Demand Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0

--- a/openquatt/oq_aux_relay_control.yaml
+++ b/openquatt/oq_aux_relay_control.yaml
@@ -84,19 +84,15 @@ switch:
   - platform: template
     id: oq_aux_wait_for_supply_temp
     name: "Aux Relay Wait For Supply Temp"
-    icon: mdi:thermometer-check
     internal: true
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true
-    entity_category: config
 
 select:
   - platform: template
     id: oq_aux_relay_function
     name: "Aux Relay Function"
-    icon: mdi:electric-switch
     internal: true
-    entity_category: config
     optimistic: true
     restore_value: true
     options:
@@ -111,7 +107,6 @@ number:
   - platform: template
     id: oq_aux_heat_start_c
     name: "Aux Relay Heating Start Temp"
-    icon: mdi:thermometer-chevron-up
     internal: true
     unit_of_measurement: "°C"
     min_value: 20
@@ -121,12 +116,10 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 30
-    entity_category: config
 
   - platform: template
     id: oq_aux_cool_start_c
     name: "Aux Relay Cooling Start Temp"
-    icon: mdi:thermometer-chevron-down
     internal: true
     unit_of_measurement: "°C"
     min_value: 8
@@ -136,12 +129,10 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 18
-    entity_category: config
 
   - platform: template
     id: oq_aux_temp_hysteresis_c
     name: "Aux Relay Temp Hysteresis"
-    icon: mdi:swap-vertical
     internal: true
     unit_of_measurement: "°C"
     min_value: 0.5
@@ -151,7 +142,6 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 2
-    entity_category: config
 
 # ----------------------------
 # DIAGNOSTICS

--- a/openquatt/oq_boiler_control.yaml
+++ b/openquatt/oq_boiler_control.yaml
@@ -182,11 +182,8 @@ switch:
     id: boiler_relay
     name: "Boiler relay"
     internal: true
-    disabled_by_default: true
     output: boiler_relay_out
-    icon: mdi:water-boiler
     restore_mode: ALWAYS_OFF
-    entity_category: diagnostic
 
 binary_sensor:
   - platform: template
@@ -248,12 +245,9 @@ sensor:
   - platform: template
     id: boiler_start_thermal_safe_ceiling
     name: "Boiler warm-start safe ceiling"
-    icon: mdi:thermometer-check
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 1
-    entity_category: diagnostic
     internal: true
     update_interval: 1s
     lambda: |-
@@ -262,10 +256,8 @@ sensor:
   - platform: template
     id: boiler_command_age
     name: "Boiler command age"
-    icon: mdi:timer-outline
     unit_of_measurement: "s"
     accuracy_decimals: 1
-    entity_category: diagnostic
     internal: true
     update_interval: 1s
     lambda: |-
@@ -313,8 +305,6 @@ text_sensor:
   - platform: template
     id: boiler_start_thermal_guard
     name: "Boiler warm-start guard"
-    icon: mdi:thermometer-alert
-    entity_category: diagnostic
     internal: true
     update_interval: 1s
     lambda: |-

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -335,8 +335,6 @@ number:
       id: oq_otb_t_set_command
       name: "OTB - Control Setpoint Command"
       internal: true
-      entity_category: diagnostic
-      icon: mdi:thermostat
       min_value: 0
       max_value: 90
       step: 0.1
@@ -350,9 +348,7 @@ switch:
       id: oq_otb_ch_enable
       name: "OTB - Central Heating Command"
       internal: true
-      entity_category: diagnostic
       restore_mode: ALWAYS_OFF
-      icon: mdi:radiator
 
 # Keep Home Assistant lean: expose primary operational values by default,
 # publish secondary status as disabled-by-default, and keep service/protocol
@@ -363,8 +359,6 @@ binary_sensor:
     id: oq_boiler_connection_auto_selected
     name: "OTB - Boiler Connection Auto-selected"
     internal: true
-    entity_category: diagnostic
-    icon: mdi:auto-fix
     lambda: |-
       return id(oq_boiler_connection_auto_selected_state);
 
@@ -372,9 +366,6 @@ binary_sensor:
     id: oq_boiler_connection_mismatch
     name: "OTB - Boiler Connection Mismatch"
     internal: true
-    device_class: problem
-    entity_category: diagnostic
-    icon: mdi:connection
     lambda: |-
       return id(oq_boiler_connection_mismatch_state);
 
@@ -411,7 +402,6 @@ binary_sensor:
       id: otb_dhw_present
       name: "OTB - DHW Present"
       internal: true
-      entity_category: diagnostic
     service_request:
       id: otb_service_request
       name: "OTB - Service Required"
@@ -421,7 +411,6 @@ binary_sensor:
       id: otb_lockout_reset
       name: "OTB - Lockout Reset"
       internal: true
-      entity_category: diagnostic
     low_water_pressure:
       id: otb_low_water_pressure
       name: "OTB - Low Water Pressure"
@@ -466,51 +455,37 @@ sensor:
       id: otb_oem_fault_code
       name: "OTB - OEM Fault Code"
       internal: true
-      entity_category: diagnostic
     oem_diagnostic_code:
       id: otb_oem_diagnostic_code
       name: "OTB - OEM Diagnostic Code"
       internal: true
-      entity_category: diagnostic
     max_capacity:
       id: otb_max_capacity
       name: "OTB - Maximum Boiler Capacity"
       internal: true
-      entity_category: diagnostic
-      disabled_by_default: true
     min_mod_level:
       id: otb_min_modulation
       name: "OTB - Minimum Modulation"
       internal: true
-      entity_category: diagnostic
-      disabled_by_default: true
     opentherm_version_device:
       id: otb_opentherm_version
       name: "OTB - OpenTherm Device Version"
       internal: true
-      entity_category: diagnostic
-      disabled_by_default: true
     device_type:
       id: otb_device_type
       name: "OTB - Device Type"
       internal: true
-      entity_category: diagnostic
-      disabled_by_default: true
     device_version:
       id: otb_device_version
       name: "OTB - Device Product Version"
       internal: true
-      entity_category: diagnostic
-      disabled_by_default: true
 
   - platform: template
     id: otb_last_response_age
     name: "OTB - Last Response Age"
     internal: true
-    icon: mdi:timer-outline
     unit_of_measurement: "s"
     accuracy_decimals: 1
-    entity_category: diagnostic
     update_interval: ${oq_otb_link_watch_s}s
     lambda: |-
       if (!oq_otb::telemetry_state.session_has_response()) return NAN;
@@ -521,10 +496,8 @@ sensor:
     id: otb_response_count
     name: "OTB - Valid Response Count"
     internal: true
-    icon: mdi:counter
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.acknowledged_response_count();
@@ -533,11 +506,8 @@ sensor:
     id: otb_complete_response_count
     name: "OTB - Complete Response Count"
     internal: true
-    icon: mdi:counter
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.accepted_response_count();
@@ -546,11 +516,8 @@ sensor:
     id: otb_data_invalid_response_count
     name: "OTB - DATA_INVALID Response Count"
     internal: true
-    icon: mdi:alert-circle-outline
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.data_invalid_response_count();
@@ -559,11 +526,8 @@ sensor:
     id: otb_unknown_data_id_response_count
     name: "OTB - UNKNOWN_DATAID Response Count"
     internal: true
-    icon: mdi:help-circle-outline
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.unknown_data_id_response_count();
@@ -572,11 +536,8 @@ sensor:
     id: otb_unexpected_response_type_count
     name: "OTB - Unexpected Response Type Count"
     internal: true
-    icon: mdi:message-alert-outline
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.unexpected_response_type_count();
@@ -585,11 +546,8 @@ sensor:
     id: otb_response_id_mismatch_count
     name: "OTB - Response ID Mismatch Count"
     internal: true
-    icon: mdi:identifier
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.response_id_mismatch_count();
@@ -598,11 +556,8 @@ sensor:
     id: otb_response_type_mismatch_count
     name: "OTB - Response Type Mismatch Count"
     internal: true
-    icon: mdi:message-alert-outline
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.response_type_mismatch_count();
@@ -611,11 +566,8 @@ sensor:
     id: otb_transport_error_count
     name: "OTB - Transport Error Count"
     internal: true
-    icon: mdi:alert-octagon-outline
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.transport_error_count();
@@ -624,11 +576,8 @@ sensor:
     id: otb_protocol_error_count
     name: "OTB - Protocol Error Count"
     internal: true
-    icon: mdi:pulse
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.protocol_error_count();
@@ -637,11 +586,8 @@ sensor:
     id: otb_response_timeout_count
     name: "OTB - Response Timeout Count"
     internal: true
-    icon: mdi:timer-alert-outline
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.response_timeout_count();
@@ -650,11 +596,8 @@ sensor:
     id: otb_no_transition_count
     name: "OTB - NO_TRANSITION Count"
     internal: true
-    icon: mdi:chart-timeline-variant-shimmer
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.no_transition_count();
@@ -663,11 +606,8 @@ sensor:
     id: otb_no_change_too_long_count
     name: "OTB - NO_CHANGE_TOO_LONG Count"
     internal: true
-    icon: mdi:chart-timeline-variant-shimmer
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) oq_otb::telemetry_state.no_change_too_long_count();
@@ -676,11 +616,8 @@ sensor:
     id: otb_last_transport_error_age
     name: "OTB - Last Transport Error Age"
     internal: true
-    icon: mdi:timer-alert-outline
     unit_of_measurement: "s"
     accuracy_decimals: 1
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       if (oq_otb::telemetry_state.transport_error_count() == 0) return NAN;
@@ -692,9 +629,7 @@ sensor:
     id: otb_last_response_id
     name: "OTB - Last Response Message ID"
     internal: true
-    icon: mdi:identifier
     accuracy_decimals: 0
-    entity_category: diagnostic
     update_interval: 5s
     lambda: |-
       const int message_id = oq_otb::telemetry_state.last_response_id();
@@ -704,11 +639,8 @@ sensor:
     id: otb_start_tset_requested
     name: "OTB - Start TSet Requested"
     internal: true
-    icon: mdi:thermometer-chevron-up
     unit_of_measurement: "°C"
     accuracy_decimals: 1
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 1s
     lambda: |-
       if (!oq_otb::start_handshake_state.tset_request_seen()) return NAN;
@@ -718,11 +650,8 @@ sensor:
     id: otb_start_tset_accepted
     name: "OTB - Start TSet Accepted"
     internal: true
-    icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     accuracy_decimals: 1
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 1s
     lambda: |-
       if (!oq_otb::start_handshake_state.tset_ack_seen()) return NAN;
@@ -733,9 +662,6 @@ text_sensor:
     id: otb_last_response_type
     name: "OTB - Last Response Type"
     internal: true
-    icon: mdi:message-text-outline
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return {oq_otb::telemetry_state.last_response_type_name()};
@@ -744,9 +670,6 @@ text_sensor:
     id: otb_last_transport_error
     name: "OTB - Last Transport Error"
     internal: true
-    icon: mdi:alert-decagram-outline
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return {oq_otb::telemetry_state.last_transport_error_name()};
@@ -755,9 +678,6 @@ text_sensor:
     id: otb_start_handshake_state
     name: "OTB - Start Handshake State"
     internal: true
-    icon: mdi:message-check-outline
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 1s
     lambda: |-
       return {oq_otb::start_handshake_state.result_name()};
@@ -766,9 +686,6 @@ text_sensor:
     id: otb_start_handshake_detail
     name: "OTB - Start Handshake Detail"
     internal: true
-    icon: mdi:message-text-fast-outline
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 1s
     lambda: |-
       char detail[128];

--- a/openquatt/oq_boiler_test.yaml
+++ b/openquatt/oq_boiler_test.yaml
@@ -65,8 +65,6 @@ button:
     id: oq_boiler_power_test_start
     name: "Boiler Power Test Start"
     internal: true
-    icon: mdi:play-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_boiler_task::runtime().start(oq_boiler_task::default_config(), (uint32_t) millis());
@@ -75,8 +73,6 @@ button:
     id: oq_boiler_power_test_abort
     name: "Boiler Power Test Abort"
     internal: true
-    icon: mdi:stop-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_boiler_task::runtime().abort_or_clear();
@@ -85,8 +81,6 @@ button:
     id: oq_boiler_power_test_apply
     name: "Boiler Power Test Apply"
     internal: true
-    icon: mdi:check-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_boiler_task::runtime().apply_result((uint32_t) millis());
@@ -96,7 +90,6 @@ text_sensor:
     id: oq_boiler_power_test_status
     name: "Boiler power test status"
     internal: true
-    entity_category: diagnostic
     update_interval: 1s
     lambda: |-
       return {id(oq_boiler_power_test_status_value)};
@@ -105,7 +98,6 @@ text_sensor:
     id: oq_boiler_power_test_result_quality
     name: "Boiler power test result quality"
     internal: true
-    entity_category: diagnostic
     update_interval: 1s
     lambda: |-
       return {id(oq_boiler_power_test_result_quality_value)};

--- a/openquatt/oq_cic.yaml
+++ b/openquatt/oq_cic.yaml
@@ -131,11 +131,8 @@ sensor:
     name: "CIC - Polling interval"
     internal: true
     unit_of_measurement: "s"
-    device_class: duration
     state_class: measurement
     accuracy_decimals: 0
-    icon: mdi:timer-sand
-    disabled_by_default: true
     update_interval: never
 
   - platform: template
@@ -143,11 +140,8 @@ sensor:
     name: "CIC - Last success age"
     internal: true
     unit_of_measurement: "s"
-    device_class: duration
     state_class: measurement
     accuracy_decimals: 0
-    disabled_by_default: true
-    icon: mdi:timeline-clock-outline
     update_interval: never
 
 binary_sensor:
@@ -161,8 +155,6 @@ binary_sensor:
   - platform: template
     id: cic_ch_enable_valid
     name: "CIC - CH enable valid"
-    icon: mdi:check-decagram
-    entity_category: diagnostic
     internal: true
 
   - platform: template

--- a/openquatt/oq_commissioning.yaml
+++ b/openquatt/oq_commissioning.yaml
@@ -71,8 +71,6 @@ button:
     id: oq_commissioning_cm100_start
     name: "CM100 Start"
     internal: true
-    icon: mdi:play-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           // Request CM100 as a neutral service state with no task yet.
@@ -99,8 +97,6 @@ button:
     id: oq_commissioning_cm100_stop
     name: "CM100 Stop"
     internal: true
-    icon: mdi:stop-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           // Stop CM100 immediately when no task is active; otherwise abort the running task.
@@ -112,7 +108,6 @@ text_sensor:
     id: oq_commissioning_status
     name: "Commissioning status"
     internal: true
-    entity_category: diagnostic
     update_interval: 1s
     lambda: |-
       return {id(oq_commissioning_status_value)};

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -637,25 +637,19 @@ text:
     name: "Firmware Test OTA URL"
     id: oq_firmware_test_ota_url
     internal: true
-    icon: mdi:link-variant
     mode: text
     optimistic: true
     restore_value: false
     max_length: 255
-    disabled_by_default: true
-    entity_category: config
 
   - platform: template
     name: "Firmware Test OTA MD5 URL"
     id: oq_firmware_test_ota_md5_url
     internal: true
-    icon: mdi:link-variant
     mode: text
     optimistic: true
     restore_value: false
     max_length: 255
-    disabled_by_default: true
-    entity_category: config
 
 # ==============================================================================
 # DIAGNOSTIC ENTITIES
@@ -733,10 +727,7 @@ select:
   - platform: template
     name: "Firmware Update Target"
     id: oq_firmware_update_target
-    icon: mdi:swap-horizontal
     internal: true
-    disabled_by_default: true
-    entity_category: config
     optimistic: true
     restore_value: false
     options: ["current build", "alternate connection", "alternate topology", "alternate topology and connection"]
@@ -812,9 +803,6 @@ select:
     name: "Debug Level"
     id: debug_level_select
     internal: true
-    disabled_by_default: true
-    icon: mdi:lan
-    entity_category: diagnostic
     optimistic: true
     # Always recover to INFO after a reboot; DEBUG can overwhelm busy Duo installations.
     restore_value: false
@@ -853,9 +841,6 @@ button:
     name: "Install Firmware Test OTA"
     id: oq_install_firmware_test_ota
     internal: true
-    icon: mdi:test-tube
-    disabled_by_default: true
-    entity_category: config
     on_press:
       then:
         - if:
@@ -930,9 +915,6 @@ button:
     id: oq_trend_history_flush_button
     name: Trendhistorie nu opslaan
     internal: true
-    disabled_by_default: true
-    icon: mdi:content-save
-    entity_category: config
     on_press:
       - lambda: |-
           id(oq_trend_capture_force_once) = true;
@@ -945,9 +927,6 @@ button:
     id: oq_decision_log_flush_button
     name: Beslisloghistorie nu opslaan
     internal: true
-    disabled_by_default: true
-    icon: mdi:content-save
-    entity_category: config
     on_press:
       - lambda: |-
           id(oq_decision_log).force_flush();
@@ -956,9 +935,6 @@ button:
     id: oq_decision_log_clear_button
     name: Beslisloghistorie wissen
     internal: true
-    disabled_by_default: true
-    icon: mdi:delete-clock
-    entity_category: config
     on_press:
       - lambda: |-
           id(oq_decision_log).clear_flash_history();
@@ -967,9 +943,6 @@ button:
     id: oq_lifetime_energy_history_clear_button
     name: Lifetime energiehistorie wissen
     internal: true
-    disabled_by_default: true
-    icon: mdi:delete-clock
-    entity_category: config
     on_press:
       - lambda: |-
           id(oq_energy_history_endpoint).clear_history();
@@ -978,9 +951,6 @@ button:
     id: oq_lifetime_energy_history_capture_button
     name: Lifetime energiehistorie nu opslaan
     internal: true
-    disabled_by_default: true
-    icon: mdi:content-save
-    entity_category: config
     on_press:
       - script.execute: oq_capture_energy_history_sample
       - script.wait: oq_capture_energy_history_sample
@@ -1019,9 +989,6 @@ button:
     id: oq_install_firmware_update_target
     name: Install Firmware Update Target
     internal: true
-    disabled_by_default: true
-    icon: mdi:swap-horizontal-bold
-    entity_category: diagnostic
     on_press:
       - if:
           condition:
@@ -1039,9 +1006,6 @@ switch:
     id: oq_trend_history_enabled_switch
     name: Trendopslag
     internal: true
-    disabled_by_default: true
-    icon: mdi:chart-line
-    entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
     turn_on_action:
@@ -1054,8 +1018,6 @@ switch:
     id: oq_trend_history_flash_switch
     name: Trendhistorie opslaan in flash
     internal: true
-    icon: mdi:database
-    entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
     turn_on_action:
@@ -1069,8 +1031,6 @@ switch:
     id: oq_decision_log_flash_switch
     name: Beslisloghistorie bewaren
     internal: true
-    icon: mdi:timeline-clock-outline
-    entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
     turn_on_action:
@@ -1084,8 +1044,6 @@ switch:
     id: oq_lifetime_energy_history_switch
     name: Lifetime energiehistorie opslaan
     internal: true
-    icon: mdi:database-clock
-    entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
     turn_on_action:
@@ -1100,7 +1058,6 @@ binary_sensor:
     id: oq_runtime_polling_paused
     name: Runtime polling paused
     internal: true
-    entity_category: diagnostic
     on_state:
       then:
         - lambda: |-
@@ -1143,20 +1100,15 @@ sensor:
       id: oq_loop_time
       name: "Loop Time"
       internal: true
-      icon: mdi:timer-outline
-      entity_category: diagnostic
-      disabled_by_default: true
       accuracy_decimals: 0
 
   - platform: template
     name: Firmware Update Progress
     id: oq_firmware_update_progress
     internal: true
-    icon: mdi:progress-upload
     unit_of_measurement: "%"
     accuracy_decimals: 0
     update_interval: 1s
-    entity_category: diagnostic
     lambda: |-
       return id(oq_ota_progress_pct);
 
@@ -1164,11 +1116,8 @@ sensor:
     name: Uptime raw
     id: uptime_sensor
     internal: true
-    icon: mdi:timer-outline
     update_interval: 60s
-    device_class: duration
     unit_of_measurement: s
-    entity_category: diagnostic
 
   - platform: template
     name: Uptime
@@ -1198,8 +1147,6 @@ text_sensor:
     id: oq_firmware_update_status
     name: Firmware Update Status
     internal: true
-    icon: mdi:upload-network-outline
-    entity_category: diagnostic
     update_interval: never
     lambda: |-
       // Expose a compact OTA phase label for dashboards and the local web UI.
@@ -1234,8 +1181,6 @@ text_sensor:
     id: oq_installation_topology_text
     name: OpenQuatt Installation Topology
     internal: true
-    icon: mdi:home-analytics
-    entity_category: diagnostic
     update_interval: never
     lambda: |-
       #if OQ_TOPOLOGY_DUO
@@ -1247,8 +1192,6 @@ text_sensor:
     id: oq_hardware_profile_text
     name: OpenQuatt Hardware Profile
     internal: true
-    icon: mdi:developer-board
-    entity_category: diagnostic
     update_interval: never
     lambda: |-
       return {"${oq_hardware_profile}"};
@@ -1279,8 +1222,6 @@ text_sensor:
     id: uptime_readable_text
     name: Uptime readable
     internal: true
-    icon: mdi:timer-outline
-    entity_category: diagnostic
     update_interval: 60s
     lambda: |-
       // Read the raw uptime and bail out early when the source is unavailable.

--- a/openquatt/oq_cooling_safety.yaml
+++ b/openquatt/oq_cooling_safety.yaml
@@ -89,8 +89,6 @@ binary_sensor:
     id: cooling_fallback_active
     name: "Cooling Fallback Active"
     internal: true
-    icon: mdi:water-alert
-    device_class: running
     lambda: |-
       return oq_cooling_safety::runtime().fallback_active();
   - platform: template
@@ -179,10 +177,7 @@ sensor:
     id: cooling_fallback_night_min_outdoor_temp
     name: "Cooling Fallback Night Minimum Outdoor Temp"
     internal: true
-    disabled_by_default: true
-    icon: mdi:weather-night
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 1
     update_interval: 60s
@@ -192,10 +187,7 @@ sensor:
     id: cooling_fallback_min_supply_temp
     name: "Cooling Fallback Minimum Supply Temp"
     internal: true
-    disabled_by_default: true
-    icon: mdi:thermometer-chevron-down
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 1
     update_interval: 10s

--- a/openquatt/oq_cooling_strategy.yaml
+++ b/openquatt/oq_cooling_strategy.yaml
@@ -205,191 +205,155 @@ sensor:
     id: oq_cooling_base_demand_raw_sensor
     name: "Cooling base demand raw"
     internal: true
-    icon: mdi:speedometer
     unit_of_measurement: "step"
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) oq_cooling::demand_runtime().state().base_demand;
   - platform: template
     id: oq_cooling_limited_demand_sensor
     name: "Cooling limited demand"
     internal: true
-    icon: mdi:speedometer-slow
     unit_of_measurement: "step"
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) oq_cooling::demand_runtime().state().limited_demand;
   - platform: template
     id: oq_cooling_limiter_allowed_max_sensor
     name: "Cooling limiter allowed max"
     internal: true
-    icon: mdi:speedometer-medium
     unit_of_measurement: "step"
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) oq_cooling::demand_runtime().state().allowed_max;
   - platform: template
     id: oq_cooling_buffer_gap_filtered_sensor
     name: "Cooling buffer gap filtered"
     internal: true
-    icon: mdi:delta
     unit_of_measurement: "°C"
     accuracy_decimals: 2
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return oq_cooling::demand_runtime().state().filter.filtered_gap_c;
   - platform: template
     id: oq_cooling_buffer_gap_rate_sensor
     name: "Cooling buffer gap rate"
     internal: true
-    icon: mdi:chart-line
     unit_of_measurement: "°C/min"
     accuracy_decimals: 2
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return oq_cooling::demand_runtime().state().filter.rate_c_per_min;
   - platform: template
     id: oq_cooling_projected_gap_sensor
     name: "Cooling projected gap"
     internal: true
-    icon: mdi:chart-bell-curve
     unit_of_measurement: "°C"
     accuracy_decimals: 2
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return oq_cooling::demand_runtime().state().projected_gap_c;
   - platform: template
     id: oq_cooling_projection_brake_active_sensor
     name: "Cooling projection brake active"
     internal: true
-    icon: mdi:car-brake-alert
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return oq_cooling::demand_runtime().state().limiter.projection_brake_active ? 1.0f : 0.0f;
   - platform: template
     id: oq_cooling_dew_gap_sensor
     name: "Cooling dew gap"
     internal: true
-    icon: mdi:water-thermometer
     unit_of_measurement: "°C"
     accuracy_decimals: 2
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return oq_cooling::demand_runtime().state().dew_gap_c;
   - platform: template
     id: oq_cooling_stop_buffer_gap_sensor
     name: "Cooling stop buffer gap"
     internal: true
-    icon: mdi:stop-circle-outline
     unit_of_measurement: "°C"
     accuracy_decimals: 2
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return oq_cooling::demand_runtime().state().water_cycle.stop_buffer_gap_c;
   - platform: template
     id: oq_cooling_limiter_reason_code_sensor
     name: "Cooling limiter reason code"
     internal: true
-    icon: mdi:counter
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) oq_cooling::demand_runtime().state().limiter_reason_code;
   - platform: template
     id: oq_cooling_stop_reason_code_sensor
     name: "Cooling stop reason code"
     internal: true
-    icon: mdi:counter
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_stop_reason_code);
   - platform: template
     id: oq_cooling_request_reason_code_sensor
     name: "Cooling request reason code"
     internal: true
-    icon: mdi:counter
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_request_reason_code);
   - platform: template
     id: oq_cooling_request_hp1_level_sensor
     name: "Cooling request HP1 level"
     internal: true
-    icon: mdi:numeric-1-box-outline
     unit_of_measurement: "step"
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_request_hp1_level);
   - platform: template
     id: oq_cooling_request_hp2_level_sensor
     name: "Cooling request HP2 level"
     internal: true
-    icon: mdi:numeric-2-box-outline
     unit_of_measurement: "step"
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_request_hp2_level);
   - platform: template
     id: oq_cooling_request_owner_hp_sensor
     name: "Cooling request owner HP"
     internal: true
-    icon: mdi:source-branch
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_request_owner_hp);
   - platform: template
     id: oq_cooling_owner_hp_sensor
     name: "Cooling owner HP"
     internal: true
-    icon: mdi:source-branch
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_cooling_owner_hp);
   - platform: template
     id: oq_cooling_water_cycle_active_sensor
     name: "Cooling water cycle active"
     internal: true
-    icon: mdi:water-sync
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return oq_cooling::demand_runtime().state().water_cycle.active ? 1.0f : 0.0f;
   - platform: template
     id: oq_cooling_minimum_off_time_remaining_sensor
     name: "Cooling Minimum Off Time Remaining"
     internal: true
-    icon: mdi:timer-sand
     unit_of_measurement: "s"
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return oq_cooling_runtime::runtime().minimum_off_remaining_s(
           ${oq_cooling_minimum_off_min_s});

--- a/openquatt/oq_flow_autotune.yaml
+++ b/openquatt/oq_flow_autotune.yaml
@@ -70,8 +70,6 @@ button:
     id: oq_flow_autotune_start
     name: "Flow Autotune Start"
     internal: true
-    icon: mdi:play-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           const auto cfg = oq_flow_autotune::make_runtime_config(
@@ -86,8 +84,6 @@ button:
     id: oq_flow_autotune_abort_btn
     name: "Flow Autotune Abort"
     internal: true
-    icon: mdi:stop-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           id(oq_flow_autotune_abort) = true;
@@ -96,8 +92,6 @@ button:
     id: oq_flow_autotune_apply
     name: "Apply Flow Autotune Kp-Ki"
     internal: true
-    icon: mdi:check-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           // Read the suggested gains and apply them only when both are valid.

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -112,8 +112,6 @@ number:
     id: oq_flow_frost_pwm
     name: "Frost Circulation iPWM"
     internal: true
-    disabled_by_default: true
-    icon: mdi:snowflake
     unit_of_measurement: "iPWM"
     mode: slider
     min_value: 50
@@ -127,8 +125,6 @@ number:
     id: oq_flow_auto_start_pwm
     name: "Flow AUTO start iPWM"
     internal: true
-    disabled_by_default: true
-    icon: mdi:rocket-launch-outline
     unit_of_measurement: "iPWM"
     mode: slider
     min_value: 50
@@ -137,7 +133,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 440
-    entity_category: config
 
   - platform: template
     id: oq_flow_kp
@@ -191,9 +186,7 @@ sensor:
     id: oq_flow_output_ipwm
     name: "Flow Output iPWM"
     internal: true
-    icon: mdi:fan-speed-3
     unit_of_measurement: "iPWM"
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: never
 

--- a/openquatt/oq_ha_inputs.yaml
+++ b/openquatt/oq_ha_inputs.yaml
@@ -67,9 +67,7 @@ sensor:
     name: "HA - Cooling Dew Point"
     entity_id: ${ha_cooling_dew_point_entity_id}
     internal: true
-    icon: mdi:water-thermometer
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
 
@@ -109,53 +107,45 @@ binary_sensor:
     name: "HA - Outside Temperature Valid"
     entity_id: ${ha_outside_temp_valid_entity_id}
     internal: true
-    icon: mdi:check-decagram
 
   - platform: homeassistant
     id: water_supply_temp_valid_ha
     name: "HA - Water Supply Temperature Valid"
     entity_id: ${ha_water_supply_temp_valid_entity_id}
     internal: true
-    icon: mdi:check-decagram
 
   - platform: homeassistant
     id: room_setpoint_valid_ha
     name: "HA - Room Setpoint Valid"
     entity_id: ${ha_room_setpoint_valid_entity_id}
     internal: true
-    icon: mdi:check-decagram
 
   - platform: homeassistant
     id: room_temp_valid_ha
     name: "HA - Room Temperature Valid"
     entity_id: ${ha_room_temp_valid_entity_id}
     internal: true
-    icon: mdi:check-decagram
 
   - platform: homeassistant
     id: heating_enable_valid_ha
     name: "HA - Heating Enable Valid"
     entity_id: ${ha_heating_enable_valid_entity_id}
     internal: true
-    icon: mdi:check-decagram
 
   - platform: homeassistant
     id: cooling_enable_valid_ha
     name: "HA - Cooling Enable Valid"
     entity_id: ${ha_cooling_enable_valid_entity_id}
     internal: true
-    icon: mdi:check-decagram
 
   - platform: homeassistant
     id: cooling_dew_point_valid_ha
     name: "HA - Cooling Dew Point Valid"
     entity_id: ${ha_cooling_dew_point_valid_entity_id}
     internal: true
-    icon: mdi:check-decagram
 
   - platform: homeassistant
     id: external_heat_demand_valid_ha
     name: "HA - External Heat Demand Valid"
     entity_id: ${ha_external_heat_demand_valid_entity_id}
     internal: true
-    icon: mdi:check-decagram

--- a/openquatt/oq_heating_curve_strategy.yaml
+++ b/openquatt/oq_heating_curve_strategy.yaml
@@ -285,9 +285,6 @@ button:
     id: reset_heating_curve_pid_integral
     name: "Reset Heating Curve PID integral"
     internal: true
-    disabled_by_default: true
-    icon: mdi:restart
-    entity_category: config
     on_press:
       then:
         - climate.pid.reset_integral_term: oq_heating_curve_pid
@@ -297,7 +294,6 @@ climate:
     id: oq_heating_curve_pid
     name: "Heating Curve PID"
     internal: true
-    icon: mdi:thermostat
     sensor: oq_system_supply_temp
     default_target_temperature: 35 °C
     heat_output: heating_curve_pid_out
@@ -330,10 +326,8 @@ sensor:
   - platform: template
     id: oq_curve_outside_temp_filtered
     name: "Outside Temperature (Curve filtered)"
-    icon: mdi:thermometer-lines
     internal: true
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 10s
@@ -356,13 +350,10 @@ sensor:
     id: oq_curve_demand_continuous_sensor
     name: "Curve demand (effective)"
     internal: true
-    disabled_by_default: true
-    icon: mdi:sine-wave
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return id(oq_curve_demand_continuous);
 
@@ -370,13 +361,10 @@ sensor:
     id: oq_curve_demand_post_guardrail_sensor
     name: "Curve demand (discrete)"
     internal: true
-    disabled_by_default: true
-    icon: mdi:counter
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_demand_curve);
 
@@ -384,13 +372,10 @@ sensor:
     id: oq_curve_request_total_level_sensor
     name: "Curve dispatch total level"
     internal: true
-    disabled_by_default: true
-    icon: mdi:counter
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_curve_request_total_level);
 
@@ -398,13 +383,10 @@ sensor:
     id: oq_curve_dispatch_hp1_level_sensor
     name: "Curve target HP1 level"
     internal: true
-    disabled_by_default: true
-    icon: mdi:counter
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_curve_dispatch_hp1_level);
 
@@ -412,13 +394,10 @@ sensor:
     id: oq_curve_dispatch_hp2_level_sensor
     name: "Curve target HP2 level"
     internal: true
-    disabled_by_default: true
-    icon: mdi:counter
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return (float) id(oq_curve_dispatch_hp2_level);
 
@@ -426,11 +405,8 @@ sensor:
     id: oq_curve_restart_inhibit_sensor
     name: "Curve restart inhibit"
     internal: true
-    disabled_by_default: true
-    icon: mdi:timer-sand-paused
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return id(oq_curve_restart_inhibit_active) ? 1.0f : 0.0f;
 
@@ -438,11 +414,8 @@ sensor:
     id: oq_curve_restart_blocked_by_room_sensor
     name: "Curve restart blocked by room"
     internal: true
-    disabled_by_default: true
-    icon: mdi:home-thermometer-outline
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
     lambda: |-
       return id(oq_curve_restart_blocked_by_room) ? 1.0f : 0.0f;
 
@@ -451,10 +424,7 @@ text_sensor:
     id: oq_curve_phase_sensor
     name: "Curve Phase"
     internal: true
-    icon: mdi:state-machine
     update_interval: ${oq_diagnostic_update_interval_s}s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       if (!id(oq_curve_heat_request_active)) return std::string("OFF");
       return (id(oq_curve_regime_code) == 1) ? std::string("HEAT") : std::string("COAST");
@@ -463,10 +433,7 @@ text_sensor:
     id: oq_curve_regime_sensor
     name: "Curve operating regime"
     internal: true
-    icon: mdi:state-machine
     update_interval: ${oq_diagnostic_update_interval_s}s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       switch (id(oq_curve_regime_code)) {
         case 1: return std::string("RECOVERY");
@@ -478,10 +445,7 @@ text_sensor:
     id: oq_curve_capacity_mode_sensor
     name: "Curve capacity mode"
     internal: true
-    icon: mdi:state-machine
     update_interval: ${oq_diagnostic_update_interval_s}s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       const char *mode_name = oq_curve::capacity_mode_name(id(oq_curve_capacity_mode_code));
       return std::string(mode_name);

--- a/openquatt/oq_hp_water_calibration.yaml
+++ b/openquatt/oq_hp_water_calibration.yaml
@@ -161,7 +161,6 @@ number:
     id: water_supply_temp_calibration_offset
     name: "Water Supply Temperature Calibration Offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -170,8 +169,6 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0
-    entity_category: config
-    disabled_by_default: true
 
   # Read/write backup bridges for the four source-bound records. Firmware
   # reconstructs each checksum; HA also carries its anonymous fingerprint.
@@ -179,15 +176,12 @@ number:
     id: oq_water_supply_temp_calibration_pt1000_backup
     name: "Water Supply PT1000 Calibration Offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: box
     min_value: -2
     max_value: 2
     step: 0.01
     update_interval: 5s
-    entity_category: config
-    disabled_by_default: true
     lambda: |-
       const oq_supply_calibration::SourceIdentity source{
           oq_supply_calibration::SOURCE_LOCAL_PT1000,
@@ -214,15 +208,12 @@ number:
     id: oq_water_supply_temp_calibration_ds18b20_backup
     name: "Water Supply DS18B20 Calibration Offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: box
     min_value: -2
     max_value: 2
     step: 0.01
     update_interval: 5s
-    entity_category: config
-    disabled_by_default: true
     lambda: |-
       const oq_supply_calibration::SourceIdentity source{
           oq_supply_calibration::SOURCE_LOCAL_DS18B20,
@@ -249,15 +240,12 @@ number:
     id: oq_water_supply_temp_calibration_cic_backup
     name: "Water Supply CIC Calibration Offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: box
     min_value: -2
     max_value: 2
     step: 0.01
     update_interval: 5s
-    entity_category: config
-    disabled_by_default: true
     lambda: |-
       const auto record = oq_supply_calibration::load_record(
           id(oq_water_supply_temp_calibration_cic_record));
@@ -281,15 +269,12 @@ number:
     id: oq_water_supply_temp_calibration_ha_input_backup
     name: "Water Supply HA Input Calibration Offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: box
     min_value: -2
     max_value: 2
     step: 0.01
     update_interval: 5s
-    entity_category: config
-    disabled_by_default: true
     lambda: |-
       const oq_supply_calibration::SourceIdentity source{
           oq_supply_calibration::SOURCE_HA_INPUT,
@@ -339,7 +324,6 @@ number:
     id: hp1_water_in_temp_offset
     name: "HP1 water in temperature offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -348,14 +332,11 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0
-    entity_category: config
-    disabled_by_default: true
 
   - platform: template
     id: hp1_water_out_temp_offset
     name: "HP1 water out temperature offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -364,14 +345,11 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0
-    entity_category: config
-    disabled_by_default: true
 
   - platform: template
     id: hp2_water_in_temp_offset
     name: "HP2 water in temperature offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -380,14 +358,11 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0
-    entity_category: config
-    disabled_by_default: true
 
   - platform: template
     id: hp2_water_out_temp_offset
     name: "HP2 water out temperature offset"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -396,14 +371,11 @@ number:
     restore_value: true
     optimistic: true
     initial_value: 0
-    entity_category: config
-    disabled_by_default: true
 
   - platform: template
     id: oq_hp_calibration_hp1_water_in_offset_suggested
     name: "HP calibration HP1 water in offset suggested"
     internal: true
-    icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -412,14 +384,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: diagnostic
-    disabled_by_default: true
 
   - platform: template
     id: oq_hp_calibration_supply_offset_suggested
     name: "HP calibration supply temperature offset suggested"
     internal: true
-    icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -428,14 +397,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: diagnostic
-    disabled_by_default: true
 
   - platform: template
     id: oq_hp_calibration_hp1_water_out_offset_suggested
     name: "HP calibration HP1 water out offset suggested"
     internal: true
-    icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -444,14 +410,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: diagnostic
-    disabled_by_default: true
 
   - platform: template
     id: oq_hp_calibration_hp2_water_in_offset_suggested
     name: "HP calibration HP2 water in offset suggested"
     internal: true
-    icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -460,14 +423,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: diagnostic
-    disabled_by_default: true
 
   - platform: template
     id: oq_hp_calibration_hp2_water_out_offset_suggested
     name: "HP calibration HP2 water out offset suggested"
     internal: true
-    icon: mdi:thermometer-check
     unit_of_measurement: "°C"
     mode: slider
     min_value: -2
@@ -476,30 +436,22 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: diagnostic
-    disabled_by_default: true
 
 text:
   - platform: template
     id: oq_water_supply_temp_calibration_ha_input_identity_backup
     name: "Water Supply HA Input Calibration Identity"
     internal: true
-    icon: mdi:fingerprint
     mode: text
     optimistic: true
     restore_value: false
     initial_value: ""
-    entity_category: config
-    disabled_by_default: true
 
 button:
   - platform: template
     id: oq_hp_water_calibration_start
     name: "HP Water Calibration Start"
     internal: true
-    icon: mdi:thermometer-sync
-    entity_category: config
-    disabled_by_default: true
     on_press:
       - lambda: |-
           oq_hp_water_calibration::runtime().start(
@@ -510,9 +462,6 @@ button:
     id: oq_hp_water_calibration_abort_btn
     name: "HP Water Calibration Abort"
     internal: true
-    icon: mdi:stop-circle-outline
-    entity_category: config
-    disabled_by_default: true
     on_press:
       - lambda: |-
           oq_hp_water_calibration::runtime().abort_or_clear();
@@ -521,9 +470,6 @@ button:
     id: oq_hp_water_calibration_apply
     name: "Apply HP Water Calibration Offsets"
     internal: true
-    icon: mdi:check-circle-outline
-    entity_category: config
-    disabled_by_default: true
     on_press:
       - lambda: |-
           oq_hp_water_calibration::runtime().apply(

--- a/openquatt/oq_installation_monitoring.yaml
+++ b/openquatt/oq_installation_monitoring.yaml
@@ -60,8 +60,6 @@ button:
     id: oq_acknowledge_compressor_cycling_alert
     name: "Acknowledge compressor cycling alert"
     internal: true
-    icon: mdi:check-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_diagnostics::acknowledge_compressor_cycling_alert();
@@ -70,8 +68,6 @@ button:
     id: oq_acknowledge_recovered_hp_incidents
     name: "Acknowledge recovered HP incidents"
     internal: true
-    icon: mdi:check-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           id(oq_incident_manager).acknowledge_all_cleared();
@@ -81,8 +77,6 @@ number:
     id: oq_compressor_starts_warning_limit_2h
     name: "Compressor starts 2h warning limit"
     internal: true
-    icon: mdi:alert-decagram-outline
-    entity_category: config
     optimistic: true
     restore_value: true
     initial_value: 6
@@ -95,8 +89,6 @@ number:
     id: oq_compressor_starts_warning_limit_72h
     name: "Compressor starts 72h warning limit"
     internal: true
-    icon: mdi:calendar-clock-outline
-    entity_category: config
     optimistic: true
     restore_value: true
     initial_value: 40
@@ -110,8 +102,6 @@ sensor:
     id: oq_hp1_compressor_starts_2h
     name: "HP1 - Compressor starts 2h"
     internal: true
-    icon: mdi:counter
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -122,8 +112,6 @@ sensor:
     id: oq_hp1_compressor_starts_6h
     name: "HP1 - Compressor starts 6h"
     internal: true
-    icon: mdi:counter
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -134,8 +122,6 @@ sensor:
     id: oq_hp1_compressor_starts_24h
     name: "HP1 - Compressor starts 24h"
     internal: true
-    icon: mdi:counter
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -146,8 +132,6 @@ sensor:
     id: oq_hp1_compressor_starts_72h
     name: "HP1 - Compressor starts 72h"
     internal: true
-    icon: mdi:counter
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -158,8 +142,6 @@ sensor:
     id: oq_hp1_compressor_last_start_age
     name: "HP1 - Compressor last start age"
     internal: true
-    icon: mdi:clock-outline
-    entity_category: diagnostic
     unit_of_measurement: min
     accuracy_decimals: 0
     update_interval: 60s
@@ -170,9 +152,7 @@ sensor:
   - platform: template
     id: oq_hp2_compressor_starts_2h
     name: "HP2 - Compressor starts 2h"
-    icon: mdi:counter
     internal: true
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -182,9 +162,7 @@ sensor:
   - platform: template
     id: oq_hp2_compressor_starts_6h
     name: "HP2 - Compressor starts 6h"
-    icon: mdi:counter
     internal: true
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -194,9 +172,7 @@ sensor:
   - platform: template
     id: oq_hp2_compressor_starts_24h
     name: "HP2 - Compressor starts 24h"
-    icon: mdi:counter
     internal: true
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -206,9 +182,7 @@ sensor:
   - platform: template
     id: oq_hp2_compressor_starts_72h
     name: "HP2 - Compressor starts 72h"
-    icon: mdi:counter
     internal: true
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -218,9 +192,7 @@ sensor:
   - platform: template
     id: oq_hp2_compressor_last_start_age
     name: "HP2 - Compressor last start age"
-    icon: mdi:clock-outline
     internal: true
-    entity_category: diagnostic
     unit_of_measurement: min
     accuracy_decimals: 0
     update_interval: 60s
@@ -232,8 +204,6 @@ sensor:
     id: oq_compressor_cycling_alert_first_seen
     name: "Compressor cycling alert first seen"
     internal: true
-    icon: mdi:clock-start
-    entity_category: diagnostic
     unit_of_measurement: s
     accuracy_decimals: 0
     update_interval: 60s
@@ -246,8 +216,6 @@ sensor:
     id: oq_compressor_cycling_alert_last_seen
     name: "Compressor cycling alert last seen"
     internal: true
-    icon: mdi:clock-end
-    entity_category: diagnostic
     unit_of_measurement: s
     accuracy_decimals: 0
     update_interval: 60s
@@ -260,8 +228,6 @@ sensor:
     id: oq_compressor_cycling_alert_hp1_peak_2h
     name: "Compressor cycling alert HP1 peak 2h"
     internal: true
-    icon: mdi:chart-line
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -271,8 +237,6 @@ sensor:
     id: oq_compressor_cycling_alert_hp1_peak_72h
     name: "Compressor cycling alert HP1 peak 72h"
     internal: true
-    icon: mdi:chart-line
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -281,9 +245,7 @@ sensor:
   - platform: template
     id: oq_compressor_cycling_alert_hp2_peak_2h
     name: "Compressor cycling alert HP2 peak 2h"
-    icon: mdi:chart-line
     internal: true
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -292,9 +254,7 @@ sensor:
   - platform: template
     id: oq_compressor_cycling_alert_hp2_peak_72h
     name: "Compressor cycling alert HP2 peak 72h"
-    icon: mdi:chart-line
     internal: true
-    entity_category: diagnostic
     accuracy_decimals: 0
     update_interval: 60s
     lambda: |-
@@ -305,18 +265,13 @@ binary_sensor:
     id: oq_compressor_cycling_alert_latched_sensor
     name: "Compressor cycling alert latched"
     internal: true
-    icon: mdi:alert-circle-check-outline
-    device_class: problem
-    entity_category: diagnostic
     lambda: |-
       return id(oq_compressor_cycling_alert_latched);
 
   - platform: template
     id: oq_compressor_cycling_alert_alternating_sensor
     name: "Compressor cycling alert alternating"
-    icon: mdi:swap-horizontal-bold
     internal: true
-    entity_category: diagnostic
     lambda: |-
       return id(oq_compressor_cycling_alert_alternating);
 

--- a/openquatt/oq_manual_flow.yaml
+++ b/openquatt/oq_manual_flow.yaml
@@ -44,7 +44,6 @@ number:
     id: oq_manual_flow_setpoint_lph
     name: "Manual flow service setpoint"
     internal: true
-    icon: mdi:waves-arrow-right
     unit_of_measurement: "L/h"
     mode: slider
     min_value: 0
@@ -53,15 +52,12 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 800
-    entity_category: config
 
 button:
   - platform: template
     id: oq_manual_flow_start
     name: "Manual Flow Start"
     internal: true
-    icon: mdi:water-pump
-    entity_category: config
     on_press:
       - lambda: |-
           oq_manual_flow::runtime().start();
@@ -70,8 +66,6 @@ button:
     id: oq_manual_flow_abort
     name: "Manual Flow Abort"
     internal: true
-    icon: mdi:stop-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_manual_flow::runtime().abort_or_clear();
@@ -80,8 +74,6 @@ button:
     id: oq_manual_flow_apply_heating
     name: "Apply Manual Flow To Heating"
     internal: true
-    icon: mdi:radiator
-    entity_category: config
     on_press:
       - lambda: |-
           oq_manual_flow::runtime().apply_to_heating();
@@ -90,8 +82,6 @@ button:
     id: oq_manual_flow_apply_cooling
     name: "Apply Manual Flow To Cooling"
     internal: true
-    icon: mdi:snowflake
-    entity_category: config
     on_press:
       - lambda: |-
           oq_manual_flow::runtime().apply_to_cooling();
@@ -101,8 +91,6 @@ switch:
     id: oq_quick_flow_test_switch
     name: "Quick flow test"
     internal: true
-    icon: mdi:water-pump
-    entity_category: config
     lambda: |-
       return id(oq_quick_flow_test_active);
     turn_on_action:

--- a/openquatt/oq_manual_hp.yaml
+++ b/openquatt/oq_manual_hp.yaml
@@ -49,7 +49,6 @@ select:
     id: oq_manual_hp1_mode
     name: "Manual HP1 service mode"
     internal: true
-    icon: mdi:heat-pump
     optimistic: false
     restore_value: false
     initial_option: "Standby"
@@ -57,7 +56,6 @@ select:
       - "Standby"
       - "Heating"
       - "Cooling"
-    entity_category: config
     set_action:
       - lambda: |-
           oq_manual_hp::runtime().set_mode(1, x.str(), (float) ${oq_cm_min_flow_lph});
@@ -66,7 +64,6 @@ select:
     id: oq_manual_hp2_mode
     name: "Manual HP2 service mode"
     internal: true
-    icon: mdi:heat-pump
     optimistic: false
     restore_value: false
     initial_option: "Standby"
@@ -74,7 +71,6 @@ select:
       - "Standby"
       - "Heating"
       - "Cooling"
-    entity_category: config
     set_action:
       - lambda: |-
           oq_manual_hp::runtime().set_mode(2, x.str(), (float) ${oq_cm_min_flow_lph});
@@ -84,7 +80,6 @@ number:
     id: oq_manual_hp1_level
     name: "Manual HP1 compressor level"
     internal: true
-    icon: mdi:speedometer
     mode: slider
     min_value: 0
     max_value: 20
@@ -92,13 +87,11 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: config
 
   - platform: template
     id: oq_manual_hp2_level
     name: "Manual HP2 compressor level"
     internal: true
-    icon: mdi:speedometer
     mode: slider
     min_value: 0
     max_value: 20
@@ -106,15 +99,12 @@ number:
     restore_value: false
     optimistic: true
     initial_value: 0
-    entity_category: config
 
 button:
   - platform: template
     id: oq_manual_hp_start
     name: "Manual HP Start"
     internal: true
-    icon: mdi:heat-pump-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_manual_hp::runtime().start();
@@ -123,8 +113,6 @@ button:
     id: oq_manual_hp_abort
     name: "Manual HP Abort"
     internal: true
-    icon: mdi:stop-circle-outline
-    entity_category: config
     on_press:
       - lambda: |-
           oq_manual_hp::runtime().abort_or_clear();

--- a/openquatt/oq_mqtt_ingress.yaml
+++ b/openquatt/oq_mqtt_ingress.yaml
@@ -72,7 +72,6 @@ sensor:
   - platform: template
     id: mqtt_cooling_dew_point_age
     name: "MQTT Cooling Dew Point Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -92,7 +91,6 @@ sensor:
   - platform: template
     id: mqtt_outside_temperature_age
     name: "MQTT Outside Temperature Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -112,7 +110,6 @@ sensor:
   - platform: template
     id: mqtt_room_temperature_age
     name: "MQTT Room Temperature Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -132,7 +129,6 @@ sensor:
   - platform: template
     id: mqtt_room_setpoint_age
     name: "MQTT Room Setpoint Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -141,7 +137,6 @@ sensor:
   - platform: template
     id: mqtt_heating_enable_age
     name: "MQTT Heating Enable Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -150,7 +145,6 @@ sensor:
   - platform: template
     id: mqtt_cooling_enable_age
     name: "MQTT Cooling Enable Age"
-    icon: mdi:timer-outline
     internal: true
     unit_of_measurement: "s"
     accuracy_decimals: 0
@@ -160,30 +154,22 @@ binary_sensor:
   - platform: template
     id: mqtt_cooling_dew_point_valid
     name: "MQTT Cooling Dew Point Valid"
-    icon: mdi:water-check
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: mqtt_outside_temperature_valid
     name: "MQTT Outside Temperature Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: mqtt_room_temperature_valid
     name: "MQTT Room Temperature Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: mqtt_room_setpoint_valid
     name: "MQTT Room Setpoint Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: mqtt_heating_enable
@@ -195,9 +181,7 @@ binary_sensor:
   - platform: template
     id: mqtt_heating_enable_valid
     name: "MQTT Heating Enable Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity
 
   - platform: template
     id: mqtt_cooling_enable
@@ -209,6 +193,4 @@ binary_sensor:
   - platform: template
     id: mqtt_cooling_enable_valid
     name: "MQTT Cooling Enable Valid"
-    icon: mdi:check-decagram
     internal: true
-    device_class: connectivity

--- a/openquatt/oq_ot_slave.yaml
+++ b/openquatt/oq_ot_slave.yaml
@@ -87,11 +87,8 @@ sensor:
     id: ot_thermostat_successful_frame_count
     name: "OT - Successful Frame Count"
     internal: true
-    icon: mdi:counter
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) id(oq_ot_slave_hub).successful_frame_count();
@@ -100,11 +97,8 @@ sensor:
     id: ot_thermostat_invalid_frame_count
     name: "OT - Invalid Frame Count"
     internal: true
-    icon: mdi:message-alert-outline
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) id(oq_ot_slave_hub).invalid_frame_count();
@@ -113,11 +107,8 @@ sensor:
     id: ot_thermostat_timeout_frame_count
     name: "OT - Timeout Frame Count"
     internal: true
-    icon: mdi:timer-alert-outline
     accuracy_decimals: 0
     state_class: total_increasing
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: 5s
     lambda: |-
       return (float) id(oq_ot_slave_hub).timeout_frame_count();

--- a/openquatt/oq_power_house_strategy.yaml
+++ b/openquatt/oq_power_house_strategy.yaml
@@ -201,9 +201,6 @@ text_sensor:
     id: oq_duo_optimizer_reason
     name: "Duo optimizer reason"
     internal: true
-    icon: mdi:swap-horizontal
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: never
     lambda: |-
       #if OQ_TOPOLOGY_DUO
@@ -257,14 +254,10 @@ sensor:
     id: oq_phouse_comfort_memory_c_sensor
     name: "Power House – comfort memory"
     internal: true
-    icon: mdi:thermometer-plus
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 3
     update_interval: 5s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return id(oq_phouse_comfort_memory_c);
 
@@ -272,14 +265,10 @@ sensor:
     id: oq_phouse_effective_room_target_c_sensor
     name: "Power House – effective room target"
     internal: true
-    icon: mdi:target
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 2
     update_interval: 5s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return id(room_setpoint_selected).state + id(oq_phouse_comfort_memory_c);
 

--- a/openquatt/oq_sensor_sources.yaml
+++ b/openquatt/oq_sensor_sources.yaml
@@ -207,9 +207,6 @@ text_sensor:
     id: oq_selected_input_hold_active
     name: "Selected Input Hold Active"
     internal: true
-    disabled_by_default: true
-    icon: mdi:timer-sand
-    entity_category: diagnostic
     update_interval: ${oq_diagnostic_update_interval_s}s
     lambda: |-
       return {oq_sensor_source::runtime().selected_hold_status()};

--- a/openquatt/oq_setup_status.yaml
+++ b/openquatt/oq_setup_status.yaml
@@ -23,9 +23,6 @@ button:
     id: oq_setup_complete_button
     name: "Complete setup"
     internal: true
-    disabled_by_default: true
-    icon: mdi:check-bold
-    entity_category: config
     on_press:
       - lambda: |-
           id(oq_setup_complete) = true;
@@ -34,9 +31,6 @@ button:
     id: oq_setup_reset_button
     name: "Reset setup state"
     internal: true
-    disabled_by_default: true
-    icon: mdi:restart
-    entity_category: config
     on_press:
       - lambda: |-
           id(oq_setup_complete) = false;
@@ -46,8 +40,5 @@ binary_sensor:
     id: oq_setup_complete_sensor
     name: "Setup Complete"
     internal: true
-    icon: mdi:check-circle-outline
-    device_class: running
-    entity_category: diagnostic
     lambda: |-
       return id(oq_setup_complete);

--- a/openquatt/oq_strategy_manager.yaml
+++ b/openquatt/oq_strategy_manager.yaml
@@ -124,10 +124,7 @@ text_sensor:
     id: oq_strategy_phase_text
     name: "Strategy phase"
     internal: true
-    icon: mdi:state-machine
     update_interval: never
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return std::string("idle");
 
@@ -150,11 +147,8 @@ sensor:
     id: oq_strategy_active_code_sensor
     name: "Strategy active code"
     internal: true
-    icon: mdi:counter
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return (float) id(oq_strategy_active_code);
 
@@ -162,11 +156,8 @@ sensor:
     id: oq_strategy_phase_code_sensor
     name: "Strategy phase code"
     internal: true
-    icon: mdi:counter
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return (float) id(oq_strategy_phase_code);
 
@@ -174,13 +165,10 @@ sensor:
     id: oq_strategy_requested_power_w_sensor
     name: "Strategy requested power"
     internal: true
-    icon: mdi:flash-outline
     unit_of_measurement: "W"
     state_class: measurement
     accuracy_decimals: 0
     update_interval: 5s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return id(oq_strategy_requested_power_w);
 
@@ -188,14 +176,10 @@ sensor:
     id: oq_strategy_supply_target_temp_sensor
     name: "Strategy supply target"
     internal: true
-    icon: mdi:target
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 1
     update_interval: 5s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return id(oq_strategy_supply_target_temp);
 
@@ -203,11 +187,8 @@ sensor:
     id: oq_strategy_water_limit_factor_sensor
     name: "Strategy water limit factor"
     internal: true
-    icon: mdi:water-percent-alert
     accuracy_decimals: 2
     update_interval: 5s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return id(oq_strategy_water_limit_factor);
 
@@ -216,9 +197,6 @@ binary_sensor:
     id: oq_strategy_heat_request_active_sensor
     name: "Strategy request active"
     internal: true
-    device_class: heat
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return id(oq_strategy_heat_request_active);
 
@@ -226,8 +204,6 @@ binary_sensor:
     id: oq_strategy_water_trip_active_sensor
     name: "Strategy water trip active"
     internal: true
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return id(oq_strategy_water_trip_active);
 
@@ -235,8 +211,6 @@ binary_sensor:
     id: oq_strategy_water_hard_trip_active_sensor
     name: "Strategy water hard trip active"
     internal: true
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       return id(oq_strategy_water_hard_trip_active);
 

--- a/openquatt/oq_supervisory_controlmode.yaml
+++ b/openquatt/oq_supervisory_controlmode.yaml
@@ -435,36 +435,28 @@ number:
     id: oq_low_load_dyn_off_factor
     name: "Low-load dynamic OFF factor"
     internal: true
-    icon: mdi:percent-outline
-    disabled_by_default: true
     min_value: 0.60
     max_value: 0.90
     step: 0.05
     optimistic: true
     restore_value: true
     initial_value: 0.75
-    entity_category: config
 
   - platform: template
     id: oq_low_load_dyn_on_factor
     name: "Low-load dynamic ON factor"
     internal: true
-    icon: mdi:percent-outline
-    disabled_by_default: true
     min_value: 0.85
     max_value: 1.10
     step: 0.05
     optimistic: true
     restore_value: true
     initial_value: 1.0
-    entity_category: config
 
   - platform: template
     id: oq_low_load_min_hysteresis_w
     name: "Low-load minimum hysteresis"
     internal: true
-    icon: mdi:arrow-expand-vertical
-    disabled_by_default: true
     unit_of_measurement: "W"
     min_value: 100
     max_value: 400
@@ -472,14 +464,11 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 200
-    entity_category: config
 
   - platform: template
     id: oq_low_load_reentry_block_s
     name: "Low-load CM2 re-entry block"
     internal: true
-    icon: mdi:timer-lock-outline
-    disabled_by_default: true
     unit_of_measurement: "s"
     min_value: 0
     max_value: 900
@@ -487,7 +476,6 @@ number:
     optimistic: true
     restore_value: true
     initial_value: 300
-    entity_category: config
 # ----------------------------
 # SCHEDULE INPUTS
 # ----------------------------
@@ -547,10 +535,6 @@ binary_sensor:
     id: oq_time_valid
     name: "Time valid"
     internal: true
-    disabled_by_default: true
-    icon: mdi:clock-check
-    device_class: connectivity
-    entity_category: diagnostic
 
 text_sensor:
   - platform: template
@@ -569,37 +553,26 @@ text_sensor:
     id: oq_time_now_hhmm
     name: "Time now (HH:MM)"
     internal: true
-    icon: mdi:clock-outline
     update_interval: never
-    entity_category: diagnostic
 
   - platform: template
     id: oq_silent_window_hhmm
     name: "Silent window (start-end)"
     internal: true
-    disabled_by_default: true
-    icon: mdi:calendar-clock
     update_interval: never
-    entity_category: diagnostic
 
   - platform: template
     id: oq_silent_status
     name: "Silent status"
     internal: true
-    disabled_by_default: true
-    icon: mdi:information-outline
     update_interval: never
-    entity_category: diagnostic
 
   # DEBUG-RUNTIME START: Power House low-load diagnostics
   - platform: template
     id: oq_low_load_dyn_status
     name: "Low-load dynamic thresholds"
     internal: true
-    icon: mdi:chart-bell-curve
     update_interval: ${oq_diagnostic_update_interval_s}s
-    entity_category: diagnostic
-    disabled_by_default: true
     lambda: |-
       // Read the active threshold set from diagnostics.
       const float pmin = id(oq_low_load_pmin_dyn_w);
@@ -625,7 +598,6 @@ sensor:
     id: power_cap_level
     name: "Power cap demand"
     internal: true
-    icon: mdi:speedometer
     unit_of_measurement: "step"
     state_class: measurement
     accuracy_decimals: 0

--- a/openquatt/oq_thermal_limits.yaml
+++ b/openquatt/oq_thermal_limits.yaml
@@ -61,10 +61,8 @@ sensor:
   - platform: template
     id: oq_system_supply_temp
     name: "System Supply Temp (abstraction)"
-    icon: mdi:water-thermometer
     internal: true
     unit_of_measurement: "°C"
-    device_class: temperature
     state_class: measurement
     accuracy_decimals: 1
     update_interval: 5s

--- a/openquatt/oq_thermal_request_control.yaml
+++ b/openquatt/oq_thermal_request_control.yaml
@@ -491,9 +491,6 @@ text_sensor:
     id: oq_request_reason
     name: "Request Reason"
     internal: true
-    icon: mdi:source-branch
-    entity_category: diagnostic
-    disabled_by_default: true
     update_interval: never
     lambda: |-
       return std::string("inactive");

--- a/openquatt/oq_usage_telemetry.yaml
+++ b/openquatt/oq_usage_telemetry.yaml
@@ -31,13 +31,11 @@ openquatt_usage_telemetry:
     id: oq_usage_telemetry_installation_id
     name: "Usage statistics installation ID"
     internal: true
-    entity_category: diagnostic
   setup_complete_sensor: oq_setup_complete_sensor
   choice_configured:
     id: oq_usage_telemetry_choice_configured
     name: "Usage statistics choice configured"
     internal: true
-    entity_category: diagnostic
   interval: 1h
   firmware_version: "${project_version}"
   release_channel: "${release_channel}"

--- a/openquatt/profiles/heatpump_controller_q_hardware_revision.yaml
+++ b/openquatt/profiles/heatpump_controller_q_hardware_revision.yaml
@@ -46,6 +46,4 @@ text_sensor:
     id: oq_hardware_revision_text
     name: "OpenQuatt Hardware Revision"
     internal: true
-    icon: mdi:developer-board
-    entity_category: diagnostic
     update_interval: never

--- a/openquatt/profiles/heatpump_controller_q_status_leds.yaml
+++ b/openquatt/profiles/heatpump_controller_q_status_leds.yaml
@@ -31,8 +31,6 @@ switch:
     id: oq_q_status_leds_enabled
     name: "Status LEDs enabled"
     internal: true
-    icon: mdi:led-on
-    entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
 

--- a/scripts/check_style_consistency.py
+++ b/scripts/check_style_consistency.py
@@ -52,9 +52,22 @@ BUILTIN_YAML_PATTERNS = (
     "docs/templates/**/*.yaml",
     "openquatt/**/*.yaml",
 )
+ENTITY_YAML_PATTERNS = (
+    "components/**/*.yaml",
+    "configs/**/*.yaml",
+    "openquatt/**/*.yaml",
+)
 BUILTIN_WEB_SORTING_KEY_RE = re.compile(
     r"""(?:^|[,{]\s*)["']?(?:sorting_groups|sorting_group_id|sorting_weight)["']?\s*:"""
 )
+INTERNAL_TRUE_RE = re.compile(r"^(?P<indent>\s*)internal:\s*true\s*(?:#.*)?$")
+YAML_MAPPING_KEY_RE = re.compile(r"^(?P<indent>\s*)(?P<key>[A-Za-z_][\w]*):")
+INTERNAL_ENTITY_PRESENTATION_KEYS = {
+    "device_class",
+    "disabled_by_default",
+    "entity_category",
+    "icon",
+}
 
 STRICT_TOP_LEVEL_ORDER_RULES = {
     "configs/waveshare/single_wifi.yaml": (
@@ -416,6 +429,60 @@ def check_no_builtin_web_sorting(path: Path, findings: list[Finding]) -> None:
             )
 
 
+def check_no_internal_entity_presentation_metadata(path: Path, findings: list[Finding]) -> None:
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    lines = read_lines(path)
+    reported_lines: set[int] = set()
+
+    for marker_index, line in enumerate(lines):
+        internal_match = INTERNAL_TRUE_RE.match(line)
+        if not internal_match:
+            continue
+
+        property_indent = len(internal_match.group("indent"))
+        mapping_start = marker_index
+        while mapping_start > 0:
+            candidate = lines[mapping_start - 1]
+            if not candidate.strip():
+                mapping_start -= 1
+                continue
+            candidate_indent = len(candidate) - len(candidate.lstrip())
+            if candidate_indent < property_indent or (
+                candidate_indent == property_indent and candidate.lstrip().startswith("- ")
+            ):
+                break
+            mapping_start -= 1
+
+        mapping_end = marker_index + 1
+        while mapping_end < len(lines):
+            candidate = lines[mapping_end]
+            if not candidate.strip():
+                mapping_end += 1
+                continue
+            candidate_indent = len(candidate) - len(candidate.lstrip())
+            if candidate_indent < property_indent or (
+                candidate_indent == property_indent and candidate.lstrip().startswith("- ")
+            ):
+                break
+            mapping_end += 1
+
+        for sibling_index in range(mapping_start, mapping_end):
+            sibling_match = YAML_MAPPING_KEY_RE.match(lines[sibling_index])
+            if not sibling_match or len(sibling_match.group("indent")) != property_indent:
+                continue
+            key = sibling_match.group("key")
+            line_number = sibling_index + 1
+            if key not in INTERNAL_ENTITY_PRESENTATION_KEYS or line_number in reported_lines:
+                continue
+            reported_lines.add(line_number)
+            add(
+                findings,
+                rel,
+                line_number,
+                f"`{key}:` is unused presentation metadata on a literal `internal: true` entity.",
+            )
+
+
 def check_yaml_banner(path: Path, findings: list[Finding]) -> None:
     rel = path.relative_to(REPO_ROOT).as_posix()
     nonempty = [(idx, line) for idx, line in enumerate(read_lines(path), start=1) if line.strip()]
@@ -691,6 +758,9 @@ def main() -> int:
 
     for path in expand_patterns(BUILTIN_YAML_PATTERNS):
         check_no_builtin_web_sorting(path, findings)
+
+    for path in expand_patterns(ENTITY_YAML_PATTERNS):
+        check_no_internal_entity_presentation_metadata(path, findings)
 
     for path in expand_patterns(YAML_BANNER_PATTERNS):
         check_yaml_banner(path, findings)

--- a/scripts/tests/test_style_consistency.py
+++ b/scripts/tests/test_style_consistency.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import check_style_consistency
+
+
+class InternalEntityPresentationMetadataTests(unittest.TestCase):
+    def run_check(self, yaml: str) -> list[check_style_consistency.Finding]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            path = root / "entities.yaml"
+            path.write_text(yaml, encoding="utf-8")
+            findings: list[check_style_consistency.Finding] = []
+            with mock.patch.object(check_style_consistency, "REPO_ROOT", root):
+                check_style_consistency.check_no_internal_entity_presentation_metadata(path, findings)
+            return findings
+
+    def test_reports_presentation_metadata_before_and_after_internal_flag(self) -> None:
+        findings = self.run_check(
+            """binary_sensor:
+  - platform: template
+    id: clock_valid
+    icon: mdi:clock-check
+    internal: true
+    disabled_by_default: true
+    device_class: connectivity
+    entity_category: diagnostic
+"""
+        )
+
+        self.assertEqual(
+            {"device_class", "disabled_by_default", "entity_category", "icon"},
+            {finding.message.split(":", 1)[0].strip("`") for finding in findings},
+        )
+
+    def test_does_not_cross_into_the_next_entity_mapping(self) -> None:
+        findings = self.run_check(
+            """binary_sensor:
+  - platform: template
+    id: internal_helper
+    internal: true
+
+  - platform: template
+    id: public_diagnostic
+    icon: mdi:check
+    device_class: connectivity
+    entity_category: diagnostic
+"""
+        )
+
+        self.assertEqual([], findings)
+
+    def test_checks_nested_custom_component_entities(self) -> None:
+        findings = self.run_check(
+            """custom_component:
+  installation_id:
+    id: installation_id
+    name: Installation ID
+    internal: true
+    entity_category: diagnostic
+"""
+        )
+
+        self.assertEqual(1, len(findings))
+        self.assertIn("`entity_category:`", findings[0].message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert 692 ongebruikte `disabled_by_default`-, `icon`-, `device_class`- en `entity_category`-regels van entities met letterlijk `internal: true`.
- Voegt een stylecheck en regressietests toe zodat deze presentatie-metadata niet terugkomt.
- Bespaart op de Q Duo-build 1.928 bytes flash; de statische RAM-delta is 0 bytes.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alle entity-ID's, registraties, states, traits en restore-instellingen blijven gelijk. Alleen presentatievelden van compile-time interne entities verdwijnen; zij blijven verborgen voor Home Assistant. Componentdefaults voor publieke entities en configureerbare `internal:`-substituties blijven ongemoeid.

## Achtergrond

De repository bevat 323 entities met letterlijk `internal: true`; 308 daarvan hadden samen 692 presentatievelden die ESPHome wel in de firmware opnam maar die voor een interne entity niet worden gebruikt.

De volledige YAML-diff is mechanisch tegen `origin/dev` gecontroleerd: 34 bestanden zijn exact gelijk aan de baseline na uitsluitend deze 692 velden te verwijderen. Een koude audit bevestigde daarnaast dat alle 1.787 `App.register_*`-calls in de representatieve build behouden blijven. Er wijzigen geen persistence-, migratie-, setup-, restore- of controlpaden.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit is cleanup van firmware-interne presentatie-metadata zonder wijziging van publieke entities of gebruikersgedrag.

## Validatie

- `python3 scripts/check_style_consistency.py`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (188 tests)
- `npm run build:web`
- `esphome config` voor alle zes firmware-entrypoints:
  - `configs/waveshare/single_wifi.yaml`
  - `configs/waveshare/duo_wifi.yaml`
  - `configs/heatpump_listener/single_wifi.yaml`
  - `configs/heatpump_listener/duo_wifi.yaml`
  - `configs/heatpump_controller_q/single.yaml`
  - `configs/heatpump_controller_q/duo.yaml`
- A/B-compile met ESPHome 2026.8.2: `esphome compile configs/heatpump_controller_q/duo.yaml`
- `git diff origin/dev...HEAD --check`

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

- static RAM: baseline 210.287 bytes, candidate 210.287 bytes (delta 0)
- total image: baseline 2.189.319 bytes, candidate 2.187.391 bytes (delta −1.928)
- runtime heap, PSRAM en task-stack-watermarks niet opnieuw gemeten: entity-objecten, allocaties en lifecycle blijven ongewijzigd
