### PR TITLE
Rond YAML-naar-C++-migratie af

### DIFF
--- a/docs/yaml-naar-cpp-migratieplan.md
+++ b/docs/yaml-naar-cpp-migratieplan.md
@@ -48,11 +48,76 @@ entities, configuratie, koppelingen en één of enkele runtime-aanroepen.
 | Boiler runtime | Commandocapture, outputcontroller en transportbinding | Gereed | #595 |
 | Externe inputs en bronselectie | API-freshness plus generieke, brongebonden selectie | Gereed | #599 |
 
-Vervolg ligt niet automatisch in nog een YAML-migratie. Eerst wordt de
-herhaalbaarheid van de acceptatietests verbeterd met de veilige, repositorylokale
-[HIL-runner](hil-testing.md). Een volgend migratieblok krijgt opnieuw een
-go/no-go op testwaarde, contractgrens en netto productiecode; regelaantal alleen
-is geen reden om declaratieve YAML te verplaatsen.
+## Eindconclusie
+
+De migratie is afgerond. De zestien functionele migratie-PR's hebben 9.030
+YAML-regels verwijderd. Inclusief de nieuwe C++-runtimes is de productiecode
+netto 620 regels kleiner. Daartegenover staan 2.630 regels regressietests, 340
+regels documentatie en 7 overige regels; de volledige repository groeide dus
+bewust met 2.357 regels. De winst zit vooral in rechtstreeks hosttestbare
+besliskernen, expliciete runtimecontracten en compactere YAML-binding, niet in
+een zo klein mogelijke repository.
+
+Voorbereidende contract-PR's: [#562](https://github.com/OpenQuatt/OpenQuatt/pull/562)
+en [#563](https://github.com/OpenQuatt/OpenQuatt/pull/563).
+
+Functionele migratie-PR's:
+[#564](https://github.com/OpenQuatt/OpenQuatt/pull/564),
+[#566](https://github.com/OpenQuatt/OpenQuatt/pull/566),
+[#567](https://github.com/OpenQuatt/OpenQuatt/pull/567),
+[#568](https://github.com/OpenQuatt/OpenQuatt/pull/568),
+[#570](https://github.com/OpenQuatt/OpenQuatt/pull/570),
+[#571](https://github.com/OpenQuatt/OpenQuatt/pull/571),
+[#573](https://github.com/OpenQuatt/OpenQuatt/pull/573),
+[#577](https://github.com/OpenQuatt/OpenQuatt/pull/577),
+[#578](https://github.com/OpenQuatt/OpenQuatt/pull/578),
+[#581](https://github.com/OpenQuatt/OpenQuatt/pull/581),
+[#582](https://github.com/OpenQuatt/OpenQuatt/pull/582),
+[#583](https://github.com/OpenQuatt/OpenQuatt/pull/583),
+[#584](https://github.com/OpenQuatt/OpenQuatt/pull/584),
+[#589](https://github.com/OpenQuatt/OpenQuatt/pull/589),
+[#595](https://github.com/OpenQuatt/OpenQuatt/pull/595) en
+[#599](https://github.com/OpenQuatt/OpenQuatt/pull/599).
+
+De acceptatie is herhaalbaar gemaakt in
+[#600](https://github.com/OpenQuatt/OpenQuatt/pull/600). De gecombineerde
+Modbus/OpenTherm-simulator, het versiecontract en de testerhandleiding staan
+zelfstandig in [OpenQuatt-Simulator](https://github.com/OpenQuatt/OpenQuatt-Simulator),
+release [v0.1.0](https://github.com/OpenQuatt/OpenQuatt-Simulator/releases/tag/v0.1.0).
+
+## Laatste go/no-go-audit
+
+Een hernieuwde scan van actuele `dev` geeft **no-go** voor verdere migratie
+binnen dit project. De grootste resterende YAML is groot om declaratieve redenen:
+
+- `oq_HP_io.yaml` bevat vooral Modbus-registers, entities en transportbinding.
+  De ODU-detectie en frequentietabel hebben al pure C++-parsers en hosttests;
+  het verplaatsen van de asynchrone ESPHome-callbacks zou nu meer adaptercode en
+  integratierisico dan testwinst opleveren.
+- `oq_boiler_opentherm.yaml` en `oq_ot_slave.yaml` blijven het protocol- en
+  entitycontract. Dispatch, outputbeslissingen, freshness en transportpolicy
+  zijn al naar C++ verplaatst en getest.
+- Heating Curve, Power House, Cooling, Supervisory, Thermal Request, flow,
+  actuator, boiler en service-YAML bevatten hoofdzakelijk entities,
+  configuratie, publicatie en compacte `runtime().tick()`-binding.
+- `oq_hp_water_calibration.yaml` bestaat grotendeels uit instellingen en
+  backupbridges; de state-machine draait al in C++.
+- `experimental/oq_odu_runtime_frequency_table_hp.yaml` blijft bewust
+  experimenteel en is geen productie-migratiekandidaat.
+
+Twee blokken kunnen later een eigen reliability-project rechtvaardigen:
+firmware-update/OTA-orchestratie in `oq_common.yaml` en de asynchrone
+ODU-detectie/table-load in `oq_HP_io.yaml`. Daarvoor is eerst een concreet
+probleem, expliciet componentcontract en aantoonbare netto test- of
+betrouwbaarheidswinst nodig. Regelaantal alleen is geen reden om ze te
+verplaatsen.
+
+Resterende risico's zijn vooral integratierisico's: hosttests simuleren geen
+ESPHome-scheduler of elektrische bus, de simulator is geen volledig fysiek
+hydraulisch systeem en versnelde HIL-timers bewijzen niet iedere lange
+productieduur in realtime. Daarom blijven firmwarecompilatie voor alle profielen,
+gerichte HIL bij safety-/timingwijzigingen en een schone firmware-/settingsrestore
+onderdeel van de acceptatiecriteria.
 
 ## Besluit volgend werkblok: externe inputs en bronselectie
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Legt de eindconclusie en meetresultaten van de YAML-naar-C++-migratie vast.
- Verwijst naar alle voorbereidende, functionele en HIL-PR's plus de zelfstandige Modbus/OpenTherm-simulator.
- Sluit na een hernieuwde go/no-go-audit verdere migratie om alleen regelaantal af.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Dit is uitsluitend de afsluitende projectadministratie; productiecode, configuratie en firmware wijzigen niet.

## Achtergrond

Resultaat van de zestien functionele migratie-PR's:

- YAML: netto 9.030 regels kleiner;
- totale productiecode inclusief C++: netto 620 regels kleiner;
- regressietests: +2.630 regels;
- documentatie: +340 regels;
- overig: +7 regels;
- volledige repository: netto +2.357 regels.

Voorbereidende contracten: #562 en #563.

Functionele migraties: #564, #566, #567, #568, #570, #571, #573, #577, #578, #581, #582, #583, #584, #589, #595 en #599.

Herhaalbare acceptatie: #600. De gecombineerde simulator en testerhandleiding staan in [OpenQuatt-Simulator](https://github.com/OpenQuatt/OpenQuatt-Simulator), release [v0.1.0](https://github.com/OpenQuatt/OpenQuatt-Simulator/releases/tag/v0.1.0).

De koude eindaudit bekeek de grootste resterende YAML en stateful lambdas. `oq_HP_io.yaml`, `oq_boiler_opentherm.yaml` en `oq_ot_slave.yaml` zijn nu vooral protocol-/entitycontract en transportbinding; de besliskernen zijn al naar C++ verplaatst. De strategy-, supervisory-, flow-, actuator-, boiler- en servicelagen bestaan hoofdzakelijk uit entities, configuratie, publicatie en compacte runtimebinding. Verdere migratie levert daarom nu onvoldoende test- of betrouwbaarheidswinst op.

Firmware-update/OTA-orchestratie in `oq_common.yaml` en asynchrone ODU-detectie/table-load in `oq_HP_io.yaml` blijven mogelijke zelfstandige reliability-projecten, maar alleen bij een concreet probleem en een vooraf aantoonbaar beter componentcontract.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/yaml-naar-cpp-migratieplan.md` bevat nu de duurzame eindconclusie, PR-links, laatste go/no-go-audit en resterende integratierisico's.

## Validatie

- `npm run check:docs` — groen.
- Volledige diff tegen actuele `dev` gecontroleerd: alleen het migratieplan wijzigt.
- Afzonderlijke adversarial review uitgevoerd op volledigheid van PR-links, meetdefinities, resterende migratiekandidaten en risicoformulering.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen firmware- of runtimewijziging.
