### PR TITLE
Maak interne flow-PWM-waarden vast

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -131,12 +131,12 @@ Belangrijke instellingen:
 - `Cooling Flow Setpoint`
 - `Flow Control Mode`
 - `Manual iPWM`
-- `Frost Circulation iPWM`
-- `Flow AUTO start iPWM`
 - `Flow PI Kp`
 - `Flow PI Ki`
 
 `Flow Setpoint` geldt voor verwarmen en normaal automatisch bedrijf. `Cooling Flow Setpoint` geldt alleen tijdens koelen, zodat koeling een eigen hydraulisch werkpunt kan hebben zonder de verwarmingsflow te veranderen.
+
+CM98 gebruikt een vaste pompregeling van iPWM 800. AUTO start met de laatst bekende goede iPWM voor verwarmen of koelen en valt bij een ongeldige waarde terug op iPWM 440.
 
 Gebruik deze groep voorzichtig. Bij verkeerde bronwaarden of hydraulische problemen maak je hier snel meer ruis dan winst.
 

--- a/openquatt/includes/control/oq_flow_control_logic.h
+++ b/openquatt/includes/control/oq_flow_control_logic.h
@@ -10,6 +10,8 @@
 
 namespace oq_flow_control {
 
+constexpr int kAutoStartFallbackIpwm = 440;
+
 // iPWM limits shared with YAML.
 inline int clamp_ipwm(int value) {
   constexpr int kMin = 50;
@@ -19,12 +21,12 @@ inline int clamp_ipwm(int value) {
   return value;
 }
 
-inline int compute_start_pwm(bool commissioning_start, int commissioning_start_pwm, int last_good_pwm, int fallback_pwm,
+inline int compute_start_pwm(bool commissioning_start, int commissioning_start_pwm, int last_good_pwm,
                              bool cooling_target, int last_good_pwm_cooling) {
   if (commissioning_start) return clamp_ipwm(commissioning_start_pwm);
   const int candidate = cooling_target ? last_good_pwm_cooling : last_good_pwm;
   if (candidate >= 50 && candidate <= 850) return clamp_ipwm(candidate);
-  return clamp_ipwm(fallback_pwm);
+  return clamp_ipwm(kAutoStartFallbackIpwm);
 }
 
 inline float select_local_flow(bool secondary_enabled, float hp1_flow_lph, float hp2_flow_lph,

--- a/openquatt/includes/control/oq_flow_runtime.h
+++ b/openquatt/includes/control/oq_flow_runtime.h
@@ -10,6 +10,7 @@ namespace oq_flow_runtime {
 struct TickConfig {
   float dt_s = 10.0f;
   int startup_hold_s = 20;
+  int frost_ipwm = 800;
 };
 
 class Runtime {
@@ -143,7 +144,7 @@ class Runtime {
       pi_.pi_failsafe = false;
       mode = oq_flow_control::ExecutionMode::MANUAL;
     } else if (frost) {
-      pwm = oq_flow_control::clamp_ipwm((int)roundf(id(oq_flow_frost_pwm).state));
+      pwm = oq_flow_control::clamp_ipwm(config.frost_ipwm);
       pi_.stable_cnt = 0;
       pi_.pi_failsafe = false;
       pi_.last_e = 0.0f;
@@ -194,15 +195,14 @@ class Runtime {
   }
 
   void start_auto_(const TickConfig& config, const char* reason) {
-    const int fallback = oq_flow_control::clamp_ipwm((int)roundf(id(oq_flow_auto_start_pwm).state));
     const int cm_code = id(oq_control_mode_code);
     const bool cooling_target = cm_code == 5;
     const bool commissioning_start = cm_code == 100 && id(oq_commissioning_task_code) != oq_commissioning::TASK_NONE;
     const int last_good = cooling_target ? id(oq_flow_last_good_pwm_cooling) : id(oq_flow_last_good_pwm);
-    const int pwm = oq_flow_control::compute_start_pwm(commissioning_start, 400, id(oq_flow_last_good_pwm), fallback,
+    const int pwm = oq_flow_control::compute_start_pwm(commissioning_start, 400, id(oq_flow_last_good_pwm),
                                                        cooling_target, id(oq_flow_last_good_pwm_cooling));
     ESP_LOGI("flow", "AUTO start(%s): iPWM=%d (last_good=%d bank=%s fallback=%d commissioning=%s hold %ds, fixed iPWM)",
-             reason, pwm, last_good, cooling_target ? "cooling" : "normal", fallback,
+             reason, pwm, last_good, cooling_target ? "cooling" : "normal", oq_flow_control::kAutoStartFallbackIpwm,
              commissioning_start ? "yes" : "no", config.startup_hold_s);
     set_output_pwm_(pwm);
     pi_ = {};

--- a/openquatt/oq_flow_control.yaml
+++ b/openquatt/oq_flow_control.yaml
@@ -33,6 +33,18 @@
 #
 # ==============================================================================
 
+esphome:
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          constexpr std::array<uint32_t, 2> retired_flow_pwm_preferences{{
+              435184091U,
+              3242211636U,
+          }};
+          oq_nvs_cleanup::erase_esphome_preferences(
+              retired_flow_pwm_preferences, "retired flow PWM entities");
+
 # ----------------------------
 # INTERNAL STATE (PI)
 # ----------------------------
@@ -107,32 +119,6 @@ number:
     initial_value: 400
     restore_value: true
     optimistic: true
-
-  - platform: template
-    id: oq_flow_frost_pwm
-    name: "Frost Circulation iPWM"
-    internal: true
-    unit_of_measurement: "iPWM"
-    mode: slider
-    min_value: 50
-    max_value: 850
-    step: 10
-    restore_value: true
-    optimistic: true
-    initial_value: 800
-
-  - platform: template
-    id: oq_flow_auto_start_pwm
-    name: "Flow AUTO start iPWM"
-    internal: true
-    unit_of_measurement: "iPWM"
-    mode: slider
-    min_value: 50
-    max_value: 850
-    step: 1
-    restore_value: true
-    optimistic: true
-    initial_value: 440
 
   - platform: template
     id: oq_flow_kp
@@ -241,4 +227,4 @@ interval:
     startup_delay: ${oq_flow_loop_startup_delay_ms}ms
     then:
       - lambda: |-
-          oq_flow_runtime::runtime().tick({${oq_flow_loop_s}, 20});
+          oq_flow_runtime::runtime().tick({${oq_flow_loop_s}, 20, ${oq_cm98_pump_ipwm}});

--- a/openquatt/oq_substitutions_common.yaml
+++ b/openquatt/oq_substitutions_common.yaml
@@ -162,6 +162,7 @@ oq_cm0_sticky_wait_s: "86400"                         # Wait time in CM0 before 
 oq_cm0_sticky_run_s: "60"                             # Duration of sticky-pump run in CM0 [s].
 oq_cm0_pump_stop_ipwm: "1000.0"                       # iPWM setpoint that forces pump off in CM0.
 oq_sticky_pwm: "800"                                  # Fixed iPWM fallback used during CM0 sticky circulation.
+oq_cm98_pump_ipwm: "800"                              # Fixed pump iPWM used during CM98 frost circulation.
 
 # ----------------------------
 # HEATING STRATEGY

--- a/scripts/tests/test_hydraulics_outputs_runtime_contract.py
+++ b/scripts/tests/test_hydraulics_outputs_runtime_contract.py
@@ -7,6 +7,8 @@ FLOW_YAML = (ROOT / "openquatt/oq_flow_control.yaml").read_text()
 THERMAL_YAML = (ROOT / "openquatt/oq_thermal_limits.yaml").read_text()
 AUX_YAML = (ROOT / "openquatt/oq_aux_relay_control.yaml").read_text()
 FLOW_RUNTIME = (ROOT / "openquatt/includes/control/oq_flow_runtime.h").read_text()
+FLOW_LOGIC = (ROOT / "openquatt/includes/control/oq_flow_control_logic.h").read_text()
+SUBSTITUTIONS = (ROOT / "openquatt/oq_substitutions_common.yaml").read_text()
 THERMAL_RUNTIME = (ROOT / "openquatt/includes/control/oq_thermal_limits_runtime.h").read_text()
 AUX_RUNTIME = (ROOT / "openquatt/includes/control/oq_aux_relay_runtime.h").read_text()
 
@@ -41,6 +43,14 @@ class HydraulicsOutputsRuntimeContractTest(unittest.TestCase):
         self.assertIn("oq_flow_control::update_pi", FLOW_RUNTIME)
         self.assertIn("oq_thermal_limits::update", THERMAL_RUNTIME)
         self.assertIn("oq_aux_relay::update", AUX_RUNTIME)
+
+    def test_hidden_flow_pwm_entities_are_fixed_build_contracts(self) -> None:
+        for retired_id in ("oq_flow_frost_pwm", "oq_flow_auto_start_pwm"):
+            self.assertNotIn(f"id: {retired_id}", FLOW_YAML)
+            self.assertNotIn(f"id({retired_id})", FLOW_RUNTIME)
+        self.assertIn('oq_cm98_pump_ipwm: "800"', SUBSTITUTIONS)
+        self.assertIn("config.frost_ipwm", FLOW_RUNTIME)
+        self.assertIn("constexpr int kAutoStartFallbackIpwm = 440;", FLOW_LOGIC)
 
     def test_host_regressions_cover_failure_boundaries(self) -> None:
         flow_test = (ROOT / "tests/host/flow_control_logic_test.cpp").read_text()

--- a/scripts/tests/test_nvs_persistence_contract.py
+++ b/scripts/tests/test_nvs_persistence_contract.py
@@ -13,6 +13,7 @@ ODU_EDITOR = (ROOT / "openquatt/experimental/oq_odu_runtime_frequency_table_hp.y
 ODU_RUNTIME = (ROOT / "openquatt/includes/experimental/oq_odu_runtime_frequency_table.h").read_text()
 HP_IO = (ROOT / "openquatt/oq_HP_io.yaml").read_text()
 API_INGRESS = (ROOT / "openquatt/oq_api_ingress.yaml").read_text()
+FLOW_CONTROL = (ROOT / "openquatt/oq_flow_control.yaml").read_text()
 NVS_CLEANUP = (ROOT / "openquatt/includes/storage/oq_nvs_cleanup.h").read_text()
 DEV = (ROOT / "scripts/dev.py").read_text()
 CRASH_HEADER = (ROOT / "components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h").read_text()
@@ -31,6 +32,11 @@ class NvsPersistenceContractTest(unittest.TestCase):
         self.assertEqual(API_INGRESS.count("restore_mode: ALWAYS_OFF"), 2)
         self.assertNotIn("restore_mode: RESTORE_DEFAULT_OFF", API_INGRESS)
         self.assertIn('"API ingress enable state"', API_INGRESS)
+
+    def test_retired_flow_pwm_preferences_are_cleaned_up(self) -> None:
+        self.assertIn("435184091U", FLOW_CONTROL)
+        self.assertIn("3242211636U", FLOW_CONTROL)
+        self.assertIn('"retired flow PWM entities"', FLOW_CONTROL)
 
     def test_cleanup_is_targeted_and_never_erases_the_partition(self) -> None:
         self.assertIn('nvs_open(ESPHOME_NAMESPACE, NVS_READWRITE', NVS_CLEANUP)

--- a/tests/host/flow_control_logic_test.cpp
+++ b/tests/host/flow_control_logic_test.cpp
@@ -118,19 +118,21 @@ void test_nan_flow_failsafe() {
 
 void test_compute_start_pwm() {
   // CM100 commissioning always uses commissioning PWM (400), not last_good
-  int start = compute_start_pwm(true, 400, 440, 440, false, 460);
+  int start = compute_start_pwm(true, 400, 440, false, 460);
   assert(start == 400);
-  int start_cooling = compute_start_pwm(true, 400, 440, 440, true, 460);
+  int start_cooling = compute_start_pwm(true, 400, 440, true, 460);
   assert(start_cooling == 400);
   // Outside CM100 uses last_good per bank
-  int start_auto = compute_start_pwm(false, 400, 440, 440, false, 460);
+  int start_auto = compute_start_pwm(false, 400, 440, false, 460);
   assert(start_auto == 440);
-  int start_auto_cooling = compute_start_pwm(false, 400, 440, 440, true, 460);
+  int start_auto_cooling = compute_start_pwm(false, 400, 440, true, 460);
   assert(start_auto_cooling == 460);
-  // Invalid last_good falls back to fallback
-  int start_fallback = compute_start_pwm(false, 400, 0, 440, false, 460);
-  assert(start_fallback == 440);
-  int start_fallback_comm = compute_start_pwm(true, 400, 0, 440, false, 460);
+  // Invalid last_good falls back to the fixed C++ default.
+  int start_fallback = compute_start_pwm(false, 400, 0, false, 460);
+  assert(start_fallback == kAutoStartFallbackIpwm);
+  int start_fallback_cooling = compute_start_pwm(false, 400, 440, true, 900);
+  assert(start_fallback_cooling == kAutoStartFallbackIpwm);
+  int start_fallback_comm = compute_start_pwm(true, 400, 0, false, 460);
   assert(start_fallback_comm == 400);
 }
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert de interne template-numbers `oq_flow_frost_pwm` en `oq_flow_auto_start_pwm`.
- Zet CM98 vast op build-time `oq_cm98_pump_ipwm: 800` en maakt de AUTO-fallback een vaste C++-waarde van 440; geldige `last_good`-waarden per verwarmings-/koelbank blijven leidend.
- Ruimt de twee achtergebleven ESPHome-voorkeuren gericht uit NVS op en werkt documentatie en regressiecontracten bij.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

- CM98 schrijft voortaan altijd de geclampte build-time iPWM 800 in dezelfde flow-tick naar de relevante pomp(en).
- AUTO start nog steeds op 400 bij CM100 commissioning en anders op de geldige `last_good`-waarde van de actieve verwarmings- of koelbank. Alleen een ongeldige bankwaarde valt terug op de geclampte C++-constante 440.
- De NVS-opruiming is best effort; een opruimfout wordt gelogd maar kan het vaste runtimegedrag niet beïnvloeden. Een downgrade initialiseert de oude entities weer met dezelfde waarden 800 en 440.

## Achtergrond

Beide entities waren `internal: true`, niet zinvol instelbaar, maar wel persistent. Daardoor droegen ze componentgeheugen en NVS-kosten terwijl een oude verborgen waarde veiligheids- of startgedrag kon beïnvloeden.

De volledige diff tegen `dev` is beoordeeld op control-correctheid, actuatorgrenzen, boot/upgrade/downgrade, verse installatie, mislukte NVS-opruiming en normale/koel/commissioning-paden. Een aparte koude review vond geen resterende bevindingen.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De twee niet-bestaande instellingen zijn uit het instellingenoverzicht verwijderd; de vaste CM98- en AUTO-waarden zijn expliciet beschreven.

## Validatie

- [x] `./scripts/run_host_regression_tests.sh` — 59 hosttests geslaagd
- [x] `npm run check:python-contracts` — 194 contracttests geslaagd
- [x] `npm run check:cpp-format`
- [x] `python3 scripts/check_nvs_budget.py configs/heatpump_controller_q/duo.yaml` — 144 entries beschikbaar, minimum 126
- [x] `esphome compile configs/heatpump_controller_q/duo.yaml`
- [ ] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo.yaml` — repo-brede stylefase wordt op actuele `dev` geblokkeerd door bestaande metadata in `configs/hil/input_sources_fast_duo_wifi.yaml`; dit bestand valt buiten deze diff. De Q Duo-configuratie, NVS-check en volledige compile zijn afzonderlijk geslaagd.

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- Q Duo static DIRAM: 210223 -> 210063 bytes (-160 bytes)
- Q Duo image: 2187283 -> 2187147 bytes (-136 bytes)
- NVS: twee float-preferences vervallen; maximaal 6 entries worden bij upgrade teruggewonnen
- Geen nieuwe dynamische allocaties of taken; runtime heap-, fragmentatie- en stackwatermarks zijn niet op HIL gemeten
