### PR TITLE
Bundel HIL-harnesstests met hostregressies

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -61,15 +61,6 @@ jobs:
       - name: Run Python contract tests
         run: npm run check:python-contracts
 
-  hil-harness-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Test HIL harness without hardware
-        run: npm run check:hil
-
   validate-web-settings-backup:
     runs-on: ubuntu-latest
     steps:
@@ -96,11 +87,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Test HIL harness without hardware
+        run: npm run check:hil
+
       - name: Compile and run host regression tests
         run: ./scripts/run_host_regression_tests.sh
 
   validate-and-compile:
-    needs: [cpp-format, docs-consistency, python-contracts, hil-harness-tests, validate-web-settings-backup, host-regression-tests]
+    needs: [cpp-format, docs-consistency, python-contracts, validate-web-settings-backup, host-regression-tests]
     uses: ./.github/workflows/esphome-build.yml
     with:
       artifact_suffix: firmware-${{ github.sha }}

--- a/scripts/tests/test_hil_harness_contract.py
+++ b/scripts/tests/test_hil_harness_contract.py
@@ -55,8 +55,12 @@ class HilHarnessContractTest(unittest.TestCase):
         self.assertIn("--restore-snapshot", DOCS)
         self.assertIn("OpenQuatt/OpenQuatt-Simulator", DOCS)
         self.assertIn('"check:hil"', PACKAGE)
-        self.assertIn("hil-harness-tests:", WORKFLOW)
-        self.assertIn("npm run check:hil", WORKFLOW)
+        self.assertNotIn("hil-harness-tests:", WORKFLOW)
+        host_job = WORKFLOW.split("  host-regression-tests:", 1)[1].split(
+            "\n  validate-and-compile:", 1
+        )[0]
+        self.assertIn("npm run check:hil", host_job)
+        self.assertIn("./scripts/run_host_regression_tests.sh", host_job)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Wat verandert deze PR?

- Verplaatst `npm run check:hil` van een aparte CI-job naar een eigen stap binnen `host-regression-tests`.
- Behoudt de fake-gebaseerde harness-tests als verplichte blokkade vóór de firmwarematrix.
- Past de contracttest aan zodat de bundeling niet ongemerkt kan worden teruggedraaid.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De echte HIL-run blijft handmatig en vereist nog steeds controller, simulator, OTA en expliciete `--apply`. CI draait uitsluitend de snelle Node-tests met fakes. De dekking en blocking semantics blijven gelijk; alleen de presentatie en jobindeling worden compacter.

## Achtergrond

Volledige diff en afzonderlijke adversarial review uitgevoerd. De gecombineerde job heeft nog steeds afzonderlijke stapnamen, vereist geen `npm install`, en een mislukte harness-test blokkeert zowel de hostjob als de afhankelijke firmwarematrix. De harness-tests duren lokaal circa 0,15 seconde, waardoor de verloren parallelisatie verwaarloosbaar is.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De HIL-handleiding beschrijft al correct dat de echte run handmatig is. Alleen de interne CI-jobindeling verandert.

## Validatie

- `npm run check:hil` — 13/13 groen.
- `npm run check:python-contracts` — 192/192 groen.
- `git diff --check` — groen.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen firmware- of runtimewijziging.
