### PR TITLE
Preserve Q release debug symbols

### DIFF
--- a/.github/workflows/esphome-build.yml
+++ b/.github/workflows/esphome-build.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: boolean
         default: true
+      include_debug_symbols:
+        required: false
+        type: boolean
+        default: false
       project_version:
         required: false
         type: string
@@ -182,6 +186,25 @@ jobs:
 
       - name: Validate and normalize firmware artifacts
         run: python3 scripts/repair_factory_bin.py "${{ matrix.target.build_path }}/build" --normalize-app
+
+      - name: Stage Q debug symbols
+        if: ${{ inputs.include_debug_symbols && matrix.target.hardware == 'heatpump_controller_q' }}
+        run: |
+          SYMBOL_ROOT="${RUNNER_TEMP}/q-debug-symbols/${{ matrix.target.id }}"
+          mkdir -p "${SYMBOL_ROOT}"
+          cp "${{ matrix.target.build_path }}/build/firmware.elf" "${SYMBOL_ROOT}/firmware.elf"
+          cp "${{ matrix.target.build_path }}/build/openquatt.map" "${SYMBOL_ROOT}/openquatt.map"
+
+      # Matrix jobs cannot share files directly. Keep these fan-in artifacts for
+      # one day only; the release workflow consolidates them into one 90-day artifact.
+      - name: Upload Q debug symbol staging artifact
+        if: ${{ inputs.include_debug_symbols && matrix.target.hardware == 'heatpump_controller_q' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: q-debug-stage-${{ matrix.target.id }}-${{ inputs.artifact_suffix }}
+          if-no-files-found: error
+          retention-days: 1
+          path: ${{ runner.temp }}/q-debug-symbols
 
       - name: Upload firmware artifacts
         if: ${{ inputs.include_firmware_bin }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -14,6 +14,7 @@ jobs:
     uses: ./.github/workflows/esphome-build.yml
     with:
       artifact_suffix: release
+      include_debug_symbols: true
 
   publish-release:
     runs-on: ubuntu-latest
@@ -29,6 +30,13 @@ jobs:
           pattern: openquatt-*-release
           path: dist
 
+      - name: Download Q debug symbol staging artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: q-debug-stage-*-release
+          path: q-debug-symbols-staging
+          merge-multiple: true
+
       - name: Prepare release assets and manifests
         run: |
           TAG="${GITHUB_REF_NAME}"
@@ -36,6 +44,31 @@ jobs:
           BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
           RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
           ./scripts/prepare_release_assets.sh "${TAG}" "${BASE_URL}" "${RELEASE_URL}"
+
+      - name: Prepare Q debug symbol artifact
+        run: |
+          ESPHOME_VERSION="$(sed -n 's/^esphome==//p' .github/requirements-esphome.txt)"
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
+          if [[ -z "${ESPHOME_VERSION}" ]]; then
+            echo "Could not resolve ESPHome version from .github/requirements-esphome.txt" >&2
+            exit 1
+          fi
+          python3 scripts/prepare_q_debug_symbols.py \
+            "${GITHUB_REF_NAME}" \
+            "${SOURCE_COMMIT}" \
+            "${ESPHOME_VERSION}" \
+            --artifact-root q-debug-symbols-staging \
+            --output-dir q-debug-symbols
+
+      # Keep symbols out of GitHub Release assets. This Actions artifact is retained
+      # for 90 days so field crashes can be decoded against the exact release ELF.
+      - name: Upload Q debug symbol artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: openquatt-q-debug-symbols-${{ github.ref_name }}
+          if-no-files-found: error
+          retention-days: 90
+          path: q-debug-symbols
 
       - name: Create release if needed
         env:

--- a/docs/crash-telemetry.md
+++ b/docs/crash-telemetry.md
@@ -46,8 +46,15 @@ Voor normale crashes na een herstart in dezelfde firmware kan een kandidaat-ELF
 opnieuw worden gebouwd vanuit de opgenomen bronrepository, commit en het exacte
 target, met de opgenomen ESPHome-versie en buildtijd als aanvullende invoer.
 Gebruik dit ELF uitsluitend wanneer zijn SHA256 exact gelijk is aan
-`reporting_build_id`. De firmware bewaart of publiceert niet standaard bij
-iedere build een ELF-bestand.
+`reporting_build_id`.
+
+Voor getagde Heatpump Controller Q-releases bewaart de releaseworkflow daarom
+90 dagen één GitHub Actions-artifact `openquatt-q-debug-symbols-<tag>`. Dit
+artifact is geen GitHub Release-asset en bevat per Q-target de exacte
+`firmware.elf`, `openquatt.map` en een `index.json`. Het indexbestand koppelt de
+bestanden via de ELF-SHA256 rechtstreeks aan `reporting_build_id`, plus het
+buildtarget, de broncommit en de gebruikte ESPHome-versie. Andere
+hardwareprofielen krijgen geen debug-symbolenartifact.
 
 Bij opt-out bewaart OpenQuatt alleen een kleine pending-tombstone status en
 publiceert het een lege retained payload zodra de broker bereikbaar is. Deze
@@ -62,8 +69,8 @@ server-side afgehandeld.
   gepubliceerde oudere crash.
 - Een pending tombstone gebruikt de op dat moment geconfigureerde broker en
   topicbasis. Migratie over meerdere oude endpoints valt buiten deze versie.
-- De opgenomen buildvelden maken een gerichte rebuild en SHA-controle mogelijk,
-  maar vormen geen garantie dat iedere oude toolchain later nog byte-identiek
-  beschikbaar is.
+- Voor Q-releasebuilds zijn de exacte symbolen 90 dagen beschikbaar; buiten die
+  termijn en voor andere buildsoorten blijft reconstructie afhankelijk van de
+  opgenomen buildmetadata.
 - Wanneer een opnieuw gebouwd ELF niet exact dezelfde SHA256 heeft, blijven de
   adressen ruwe diagnose-informatie en worden ze niet gesymboliseerd.

--- a/scripts/prepare_q_debug_symbols.py
+++ b/scripts/prepare_q_debug_symbols.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Package exact Q release ELF/map files for crash symbolication."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import build_targets  # noqa: E402
+
+
+Q_HARDWARE = "heatpump_controller_q"
+
+
+def sha256sum(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def prepare_q_debug_symbols(
+    version: str,
+    source_commit: str,
+    esphome_version: str,
+    artifact_root: Path,
+    output_dir: Path,
+) -> None:
+    """Build one indexed Q debug-symbol directory from release staging artifacts."""
+    if artifact_root.is_symlink():
+        raise SystemExit(f"Q debug symbol staging root must not be a symlink: {artifact_root}")
+    if output_dir.is_symlink():
+        raise SystemExit(f"Q debug symbol output must not be a symlink: {output_dir}")
+
+    q_targets = [
+        target
+        for target in build_targets.filter_targets(build_targets.load_targets(), "enabled")
+        if target.get("hardware") == Q_HARDWARE
+    ]
+    if not q_targets:
+        raise SystemExit("No enabled Q build targets found")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    records: list[dict[str, object]] = []
+
+    for target in q_targets:
+        target_id = target["id"]
+        source_dir = artifact_root / target_id
+        if source_dir.is_symlink() or not source_dir.is_dir():
+            raise SystemExit(f"Missing Q debug symbol directory for target {target_id}: {source_dir}")
+
+        elf_source = source_dir / "firmware.elf"
+        map_source = source_dir / "openquatt.map"
+        for required_path in (elf_source, map_source):
+            if required_path.is_symlink() or not required_path.is_file():
+                raise SystemExit(f"Missing Q debug symbol file for target {target_id}: {required_path}")
+
+        target_output = output_dir / target_id
+        target_output.mkdir(parents=True, exist_ok=True)
+        elf_dest = target_output / "firmware.elf"
+        map_dest = target_output / "openquatt.map"
+        shutil.copy2(elf_source, elf_dest)
+        shutil.copy2(map_source, map_dest)
+
+        records.append(
+            {
+                "target_id": target_id,
+                "build_target": target["config"],
+                "source_commit": source_commit,
+                "reporting_build_id": sha256sum(elf_dest),
+                "esphome_version": esphome_version,
+                "files": {
+                    "elf": f"{target_id}/firmware.elf",
+                    "map": f"{target_id}/openquatt.map",
+                },
+            }
+        )
+
+    index = {
+        "schema_version": 1,
+        "release": version,
+        "targets": records,
+    }
+    (output_dir / "index.json").write_text(json.dumps(index, indent=2) + "\n", encoding="utf-8")
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Package Q release debug symbols.")
+    parser.add_argument("version")
+    parser.add_argument("source_commit")
+    parser.add_argument("esphome_version")
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = create_parser().parse_args(argv)
+    prepare_q_debug_symbols(
+        args.version,
+        args.source_commit,
+        args.esphome_version,
+        args.artifact_root,
+        args.output_dir,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_release_debug_symbols.py
+++ b/scripts/tests/test_release_debug_symbols.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import build_targets
+from scripts import prepare_q_debug_symbols as debug_symbols
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REUSABLE_BUILD_WORKFLOW = (ROOT / ".github/workflows/esphome-build.yml").read_text(encoding="utf-8")
+RELEASE_WORKFLOW = (ROOT / ".github/workflows/release-build.yml").read_text(encoding="utf-8")
+
+
+class ReleaseDebugSymbolsTests(unittest.TestCase):
+    def test_release_only_enables_q_debug_symbols(self) -> None:
+        self.assertIn("include_debug_symbols:", REUSABLE_BUILD_WORKFLOW)
+        self.assertIn("include_debug_symbols: true", RELEASE_WORKFLOW)
+        self.assertIn(
+            "inputs.include_debug_symbols && matrix.target.hardware == 'heatpump_controller_q'",
+            REUSABLE_BUILD_WORKFLOW,
+        )
+        self.assertIn("retention-days: 1", REUSABLE_BUILD_WORKFLOW)
+        self.assertIn("merge-multiple: true", RELEASE_WORKFLOW)
+        self.assertIn("name: openquatt-q-debug-symbols-${{ github.ref_name }}", RELEASE_WORKFLOW)
+        self.assertIn("retention-days: 90", RELEASE_WORKFLOW)
+
+    def test_prepare_q_debug_symbols_indexes_only_q_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "staging"
+            output_dir = root / "output"
+            targets_file = root / "build_targets.yaml"
+            targets_file.write_text(
+                """targets:
+  - id: q_single
+    status: enabled
+    hardware: heatpump_controller_q
+    config: configs/heatpump_controller_q/single.yaml
+  - id: q_duo
+    status: enabled
+    hardware: heatpump_controller_q
+    config: configs/heatpump_controller_q/duo.yaml
+  - id: waveshare_single
+    status: enabled
+    hardware: waveshare
+    config: configs/waveshare/single_wifi.yaml
+""",
+                encoding="utf-8",
+            )
+
+            expected_hashes: dict[str, str] = {}
+            for target_id in ("q_single", "q_duo"):
+                target_dir = artifact_root / target_id
+                target_dir.mkdir(parents=True)
+                elf_bytes = f"elf-{target_id}".encode()
+                (target_dir / "firmware.elf").write_bytes(elf_bytes)
+                (target_dir / "openquatt.map").write_text(f"map-{target_id}\n", encoding="utf-8")
+                expected_hashes[target_id] = hashlib.sha256(elf_bytes).hexdigest()
+
+            with mock.patch.object(build_targets, "TARGETS_FILE", targets_file):
+                debug_symbols.prepare_q_debug_symbols(
+                    "v1.2.3",
+                    "1234567890abcdef1234567890abcdef12345678",
+                    "2026.8.2",
+                    artifact_root,
+                    output_dir,
+                )
+
+            index = json.loads((output_dir / "index.json").read_text(encoding="utf-8"))
+            self.assertEqual(1, index["schema_version"])
+            self.assertEqual("v1.2.3", index["release"])
+            self.assertEqual(["q_single", "q_duo"], [record["target_id"] for record in index["targets"]])
+
+            for record in index["targets"]:
+                target_id = record["target_id"]
+                self.assertEqual(expected_hashes[target_id], record["reporting_build_id"])
+                self.assertEqual(
+                    "1234567890abcdef1234567890abcdef12345678",
+                    record["source_commit"],
+                )
+                self.assertEqual("2026.8.2", record["esphome_version"])
+                self.assertEqual(f"{target_id}/firmware.elf", record["files"]["elf"])
+                self.assertEqual(f"{target_id}/openquatt.map", record["files"]["map"])
+                self.assertTrue((output_dir / record["files"]["elf"]).is_file())
+                self.assertTrue((output_dir / record["files"]["map"]).is_file())
+
+            self.assertFalse((output_dir / "waveshare_single").exists())
+
+    def test_missing_q_mapfile_fails_packaging(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            artifact_root = root / "staging"
+            target_dir = artifact_root / "q_single"
+            target_dir.mkdir(parents=True)
+            (target_dir / "firmware.elf").write_bytes(b"elf")
+
+            targets_file = root / "build_targets.yaml"
+            targets_file.write_text(
+                """targets:
+  - id: q_single
+    status: enabled
+    hardware: heatpump_controller_q
+    config: configs/heatpump_controller_q/single.yaml
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(build_targets, "TARGETS_FILE", targets_file):
+                with self.assertRaisesRegex(SystemExit, "openquatt.map"):
+                    debug_symbols.prepare_q_debug_symbols(
+                        "v1.2.3",
+                        "1234567890abcdef1234567890abcdef12345678",
+                        "2026.8.2",
+                        artifact_root,
+                        root / "output",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Bewaart voor getagde Heatpump Controller Q-releases de exacte `firmware.elf` en `openquatt.map` uit dezelfde CI-build als de gepubliceerde firmware.
- Bundelt Q single/duo in één 90-daags GitHub Actions-artifact met `index.json` en koppeling via `reporting_build_id`.
- Laat publieke OTA-, factory- en manifest-release-assets ongewijzigd.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alle wijzigingen zitten in release/build-tooling en documentatie. De firmwarelogica zelf verandert niet.

## Achtergrond

Implementeert #609. Crashtelemetrie bevat al de volledige ELF-SHA256 als `reporting_build_id`; zonder het exacte release-ELF blijft symbolisatie afhankelijk van een mogelijk niet-byte-identieke rebuild.

De matrixjobs gebruiken per Q-target een 1-daags staging-artifact voor fan-in. De releasejob maakt daar één `openquatt-q-debug-symbols-<tag>` artifact van met 90 dagen retentie. Dit artifact wordt niet als GitHub Release-asset gepubliceerd.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/crash-telemetry.md` beschrijft nu beschikbaarheid, retentie, Q-only scope en de koppeling met `reporting_build_id`.

## Validatie

- CI `python-contracts`: 198 tests geslaagd, inclusief de nieuwe debug-symbol packagingtests.
- Packagingtest controleert Q-only indexing en exacte SHA-256-koppeling van `firmware.elf` naar `reporting_build_id`.
- Packaging faalt hard als een Q-target `firmware.elf` of `openquatt.map` mist.
- Workflow-contracttest bewaakt release-only activatie, 1-daagse staging en 90-daagse eindretentie.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; alleen GitHub Actions/release-tooling en documentatie wijzigen.

Closes #609