### PR TITLE
Preserve Q debug symbols for dev builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -36,6 +36,7 @@ jobs:
     uses: ./.github/workflows/esphome-build.yml
     with:
       artifact_suffix: dev-release
+      include_debug_symbols: true
       project_version: ${{ needs.compute-meta.outputs.version }}
       release_channel: dev
       release_manifest_tag: dev-latest
@@ -56,6 +57,13 @@ jobs:
           pattern: openquatt-*-dev-release
           path: dist
 
+      - name: Download Q debug symbol staging artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: q-debug-stage-*-dev-release
+          path: q-debug-symbols-staging
+          merge-multiple: true
+
       - name: Prepare dev release assets and manifests
         run: |
           TAG="dev-latest"
@@ -63,6 +71,31 @@ jobs:
           BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
           RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
           ./scripts/prepare_release_assets.sh "${{ needs.compute-meta.outputs.version }}" "${BASE_URL}" "${RELEASE_URL}"
+
+      - name: Prepare Q debug symbol artifact
+        run: |
+          ESPHOME_VERSION="$(sed -n 's/^esphome==//p' .github/requirements-esphome.txt)"
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
+          if [[ -z "${ESPHOME_VERSION}" ]]; then
+            echo "Could not resolve ESPHome version from .github/requirements-esphome.txt" >&2
+            exit 1
+          fi
+          python3 scripts/prepare_q_debug_symbols.py \
+            "${{ needs.compute-meta.outputs.version }}" \
+            "${SOURCE_COMMIT}" \
+            "${ESPHOME_VERSION}" \
+            --artifact-root q-debug-symbols-staging \
+            --output-dir q-debug-symbols
+
+      # Dev builds are frequent, so retain exact symbols for 30 days. The unique
+      # version/SHA name keeps older dev symbol sets available after dev-latest moves.
+      - name: Upload Q debug symbol artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: openquatt-q-debug-symbols-${{ needs.compute-meta.outputs.version }}
+          if-no-files-found: error
+          retention-days: 30
+          path: q-debug-symbols
 
       - name: Move dev release tag
         run: |

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -87,14 +87,14 @@ jobs:
             --artifact-root q-debug-symbols-staging \
             --output-dir q-debug-symbols
 
-      # Dev builds are frequent, so retain exact symbols for 30 days. The unique
+      # Dev builds are frequent, so retain exact symbols for 7 days. The unique
       # version/SHA name keeps older dev symbol sets available after dev-latest moves.
       - name: Upload Q debug symbol artifact
         uses: actions/upload-artifact@v6
         with:
           name: openquatt-q-debug-symbols-${{ needs.compute-meta.outputs.version }}
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 7
           path: q-debug-symbols
 
       - name: Move dev release tag

--- a/docs/crash-telemetry.md
+++ b/docs/crash-telemetry.md
@@ -48,12 +48,16 @@ target, met de opgenomen ESPHome-versie en buildtijd als aanvullende invoer.
 Gebruik dit ELF uitsluitend wanneer zijn SHA256 exact gelijk is aan
 `reporting_build_id`.
 
-Voor getagde Heatpump Controller Q-releases bewaart de releaseworkflow daarom
-90 dagen één GitHub Actions-artifact `openquatt-q-debug-symbols-<tag>`. Dit
-artifact is geen GitHub Release-asset en bevat per Q-target de exacte
-`firmware.elf`, `openquatt.map` en een `index.json`. Het indexbestand koppelt de
-bestanden via de ELF-SHA256 rechtstreeks aan `reporting_build_id`, plus het
-buildtarget, de broncommit en de gebruikte ESPHome-versie. Andere
+Voor Heatpump Controller Q-builds bewaart GitHub Actions de exacte symbolen uit
+dezelfde build als de firmware. Getagde releases krijgen 90 dagen één artifact
+`openquatt-q-debug-symbols-<tag>`. Dev-builds krijgen 30 dagen een uniek artifact
+`openquatt-q-debug-symbols-<dev-versie>`, zodat oudere symbolen beschikbaar
+blijven wanneer `dev-latest` naar een nieuwere build verschuift.
+
+Deze symbolen zijn geen GitHub Release-assets. Ieder artifact bevat per Q-target
+de exacte `firmware.elf`, `openquatt.map` en een `index.json`. Het indexbestand
+koppelt de bestanden via de ELF-SHA256 rechtstreeks aan `reporting_build_id`,
+plus het buildtarget, de broncommit en de gebruikte ESPHome-versie. Andere
 hardwareprofielen krijgen geen debug-symbolenartifact.
 
 Bij opt-out bewaart OpenQuatt alleen een kleine pending-tombstone status en
@@ -69,8 +73,8 @@ server-side afgehandeld.
   gepubliceerde oudere crash.
 - Een pending tombstone gebruikt de op dat moment geconfigureerde broker en
   topicbasis. Migratie over meerdere oude endpoints valt buiten deze versie.
-- Voor Q-releasebuilds zijn de exacte symbolen 90 dagen beschikbaar; buiten die
-  termijn en voor andere buildsoorten blijft reconstructie afhankelijk van de
-  opgenomen buildmetadata.
+- Voor Q-releasebuilds zijn de exacte symbolen 90 dagen beschikbaar en voor
+  Q-dev-builds 30 dagen; daarna blijft reconstructie afhankelijk van de opgenomen
+  buildmetadata.
 - Wanneer een opnieuw gebouwd ELF niet exact dezelfde SHA256 heeft, blijven de
   adressen ruwe diagnose-informatie en worden ze niet gesymboliseerd.

--- a/docs/crash-telemetry.md
+++ b/docs/crash-telemetry.md
@@ -50,7 +50,7 @@ Gebruik dit ELF uitsluitend wanneer zijn SHA256 exact gelijk is aan
 
 Voor Heatpump Controller Q-builds bewaart GitHub Actions de exacte symbolen uit
 dezelfde build als de firmware. Getagde releases krijgen 90 dagen één artifact
-`openquatt-q-debug-symbols-<tag>`. Dev-builds krijgen 30 dagen een uniek artifact
+`openquatt-q-debug-symbols-<tag>`. Dev-builds krijgen 7 dagen een uniek artifact
 `openquatt-q-debug-symbols-<dev-versie>`, zodat oudere symbolen beschikbaar
 blijven wanneer `dev-latest` naar een nieuwere build verschuift.
 
@@ -74,7 +74,7 @@ server-side afgehandeld.
 - Een pending tombstone gebruikt de op dat moment geconfigureerde broker en
   topicbasis. Migratie over meerdere oude endpoints valt buiten deze versie.
 - Voor Q-releasebuilds zijn de exacte symbolen 90 dagen beschikbaar en voor
-  Q-dev-builds 30 dagen; daarna blijft reconstructie afhankelijk van de opgenomen
+  Q-dev-builds 7 dagen; daarna blijft reconstructie afhankelijk van de opgenomen
   buildmetadata.
 - Wanneer een opnieuw gebouwd ELF niet exact dezelfde SHA256 heeft, blijven de
   adressen ruwe diagnose-informatie en worden ze niet gesymboliseerd.

--- a/scripts/tests/test_release_debug_symbols.py
+++ b/scripts/tests/test_release_debug_symbols.py
@@ -14,10 +14,11 @@ from scripts import prepare_q_debug_symbols as debug_symbols
 ROOT = Path(__file__).resolve().parents[2]
 REUSABLE_BUILD_WORKFLOW = (ROOT / ".github/workflows/esphome-build.yml").read_text(encoding="utf-8")
 RELEASE_WORKFLOW = (ROOT / ".github/workflows/release-build.yml").read_text(encoding="utf-8")
+DEV_WORKFLOW = (ROOT / ".github/workflows/dev-build.yml").read_text(encoding="utf-8")
 
 
 class ReleaseDebugSymbolsTests(unittest.TestCase):
-    def test_release_only_enables_q_debug_symbols(self) -> None:
+    def test_release_enables_q_debug_symbols(self) -> None:
         self.assertIn("include_debug_symbols:", REUSABLE_BUILD_WORKFLOW)
         self.assertIn("include_debug_symbols: true", RELEASE_WORKFLOW)
         self.assertIn(
@@ -28,6 +29,20 @@ class ReleaseDebugSymbolsTests(unittest.TestCase):
         self.assertIn("merge-multiple: true", RELEASE_WORKFLOW)
         self.assertIn("name: openquatt-q-debug-symbols-${{ github.ref_name }}", RELEASE_WORKFLOW)
         self.assertIn("retention-days: 90", RELEASE_WORKFLOW)
+
+    def test_dev_enables_unique_q_debug_symbol_artifacts(self) -> None:
+        self.assertIn("include_debug_symbols: true", DEV_WORKFLOW)
+        self.assertIn("pattern: q-debug-stage-*-dev-release", DEV_WORKFLOW)
+        self.assertIn("merge-multiple: true", DEV_WORKFLOW)
+        self.assertIn(
+            "name: openquatt-q-debug-symbols-${{ needs.compute-meta.outputs.version }}",
+            DEV_WORKFLOW,
+        )
+        self.assertIn("retention-days: 30", DEV_WORKFLOW)
+        self.assertIn(
+            '"${{ needs.compute-meta.outputs.version }}"',
+            DEV_WORKFLOW,
+        )
 
     def test_prepare_q_debug_symbols_indexes_only_q_targets(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/tests/test_release_debug_symbols.py
+++ b/scripts/tests/test_release_debug_symbols.py
@@ -38,7 +38,7 @@ class ReleaseDebugSymbolsTests(unittest.TestCase):
             "name: openquatt-q-debug-symbols-${{ needs.compute-meta.outputs.version }}",
             DEV_WORKFLOW,
         )
-        self.assertIn("retention-days: 30", DEV_WORKFLOW)
+        self.assertIn("retention-days: 7", DEV_WORKFLOW)
         self.assertIn(
             '"${{ needs.compute-meta.outputs.version }}"',
             DEV_WORKFLOW,


### PR DESCRIPTION
# Wat verandert deze PR?

- Bewaart ook voor iedere `dev`-build de exacte Q `firmware.elf` en `openquatt.map` uit dezelfde build als de firmware.
- Maakt per dev-build één uniek `openquatt-q-debug-symbols-<dev-versie>` Actions-artifact met 7 dagen retentie.
- Laat `dev-latest` release-assets ongewijzigd; symbolen blijven uitsluitend Actions-artifacts.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alle wijzigingen zitten in GitHub Actions/release-tooling en documentatie. Firmwarecode en runtimegedrag veranderen niet.

## Achtergrond

Vervolg op #609 / #612. De eerste implementatie activeerde Q-debugsymbolen alleen voor getagde releases. Daardoor leverde `dev-latest` nog geen exact ELF/map-set op, terwijl dev-firmware juist vaak wordt gebruikt bij het onderzoeken van veldcrashes.

Dev-builds zijn frequent, daarom gebruikt deze PR 7 dagen retentie in plaats van 90 dagen. De artifactnaam bevat de unieke dev-versie (`<base>-dev.<run>+<sha>`), zodat symbolen van recente oudere dev-builds beschikbaar blijven nadat `dev-latest` doorschuift.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/crash-telemetry.md` beschrijft nu zowel 90-daagse release-symbolen als 7-daagse unieke dev-symbolen en waar deze worden bewaard.

## Validatie

- Bestaande `prepare_q_debug_symbols.py` wordt hergebruikt; geen nieuwe packaginglogica.
- Contracttest controleert dat dev `include_debug_symbols: true` activeert, Q staging-artifacts samenvoegt, een unieke versiegebonden artifactnaam gebruikt en 7 dagen retentie instelt.
- De bestaande releasecontracten voor 90 dagen blijven ongewijzigd.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; uitsluitend CI/release-tooling en documentatie.