### PR TITLE
Remove Q debug staging artifacts after consolidation

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: dev-release
@@ -96,6 +97,19 @@ jobs:
           if-no-files-found: error
           retention-days: 7
           path: q-debug-symbols
+
+      - name: Delete Q debug symbol staging artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -t artifact_ids < <(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+              --paginate \
+              --jq '.artifacts[] | select(.name | startswith("q-debug-stage-")) | .id'
+          )
+          for artifact_id in "${artifact_ids[@]}"; do
+            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}"
+          done
 
       - name: Move dev release tag
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   compile-profiles:
@@ -69,6 +70,19 @@ jobs:
           if-no-files-found: error
           retention-days: 90
           path: q-debug-symbols
+
+      - name: Delete Q debug symbol staging artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -t artifact_ids < <(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+              --paginate \
+              --jq '.artifacts[] | select(.name | startswith("q-debug-stage-")) | .id'
+          )
+          for artifact_id in "${artifact_ids[@]}"; do
+            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}"
+          done
 
       - name: Create release if needed
         env:

--- a/scripts/tests/test_release_debug_symbols.py
+++ b/scripts/tests/test_release_debug_symbols.py
@@ -44,6 +44,18 @@ class ReleaseDebugSymbolsTests(unittest.TestCase):
             DEV_WORKFLOW,
         )
 
+    def test_staging_artifacts_are_deleted_after_consolidation(self) -> None:
+        for workflow in (RELEASE_WORKFLOW, DEV_WORKFLOW):
+            self.assertIn("actions: write", workflow)
+            self.assertIn("Delete Q debug symbol staging artifacts", workflow)
+            self.assertIn("actions/runs/${GITHUB_RUN_ID}/artifacts", workflow)
+            self.assertIn('startswith("q-debug-stage-")', workflow)
+            self.assertIn("actions/artifacts/${artifact_id}", workflow)
+
+            upload_position = workflow.index("Upload Q debug symbol artifact")
+            delete_position = workflow.index("Delete Q debug symbol staging artifacts")
+            self.assertLess(upload_position, delete_position)
+
     def test_prepare_q_debug_symbols_indexes_only_q_targets(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
# Wat verandert deze PR?

- Verwijdert de tijdelijke Q single/duo debug-symbol staging-artifacts direct nadat de gecombineerde bundel succesvol is geüpload.
- Past dit toe op zowel `dev`-builds als getagde release-builds.
- Laat alleen het definitieve `openquatt-q-debug-symbols-*` artifact achter.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen GitHub Actions artifact-opslag verandert. Firmware en release-assets blijven ongewijzigd.

## Achtergrond

Na #612 en #613 bestond één build tijdelijk uit twee staging-artifacts van circa 16 MB plus één gecombineerde bundel van circa 32 MB. De twee staging-artifacts zijn na de fan-in niet meer nodig.

Deze PR geeft de workflows expliciet `actions: write` en verwijdert na succesvolle upload van de definitieve bundel uitsluitend artifacts uit dezelfde workflow-run waarvan de naam met `q-debug-stage-` begint. Daardoor blijft per build alleen de gecombineerde bundel over.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit wijzigt alleen de levensduur van interne staging-artifacts. De gedocumenteerde definitieve Q-symbolenartifacts, inhoud en retentietermijnen veranderen niet.

## Validatie

- Contracttest controleert `actions: write` voor dev en release.
- Contracttest controleert selectie op `q-debug-stage-` binnen de huidige `GITHUB_RUN_ID`.
- Contracttest controleert dat cleanup pas na `Upload Q debug symbol artifact` plaatsvindt.
- Definitieve dev-retentie blijft 7 dagen; getagde releases blijven 90 dagen.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; uitsluitend CI/tooling.