### PR TITLE
PR-testfirmware via manifest zonder HCQ Wi-Fi-alias

### DIFF
--- a/.github/workflows/esphome-build.yml
+++ b/.github/workflows/esphome-build.yml
@@ -234,22 +234,3 @@ jobs:
           name: ${{ matrix.target.artifact_name }}-${{ inputs.artifact_suffix }}
           if-no-files-found: error
           path: ${{ matrix.target.build_path }}/build/firmware.ota.bin
-
-      # The privileged PR publisher intentionally runs trusted target-branch
-      # tooling. Keep the old Q artifact inputs available during the staged
-      # matrix migration; all three artifacts contain the same topology binary.
-      - name: Upload WiFi compatibility OTA artifact
-        if: ${{ !inputs.include_firmware_bin && !inputs.include_factory_bin && matrix.target.connection == 'auto' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ matrix.target.artifact_name }}-wifi-${{ inputs.artifact_suffix }}
-          if-no-files-found: error
-          path: ${{ matrix.target.build_path }}/build/firmware.ota.bin
-
-      - name: Upload Ethernet compatibility OTA artifact
-        if: ${{ !inputs.include_firmware_bin && !inputs.include_factory_bin && matrix.target.connection == 'auto' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ matrix.target.artifact_name }}-eth-${{ inputs.artifact_suffix }}
-          if-no-files-found: error
-          path: ${{ matrix.target.build_path }}/build/firmware.ota.bin

--- a/.github/workflows/pr-test-firmware-publish.yml
+++ b/.github/workflows/pr-test-firmware-publish.yml
@@ -264,11 +264,12 @@ jobs:
           gh release upload "${TAG}" \
             dist/*.firmware.ota.bin \
             dist/*.firmware.ota.bin.md5 \
+            dist/*-ota.manifest.json \
             dist/pr-firmware.json \
             --clobber
 
           EXPECTED_ASSET_COUNT="$(find dist -maxdepth 1 -type f \
-            \( -name '*.firmware.ota.bin' -o -name '*.firmware.ota.bin.md5' -o -name 'pr-firmware.json' \) \
+            \( -name '*.firmware.ota.bin' -o -name '*.firmware.ota.bin.md5' -o -name '*-ota.manifest.json' -o -name 'pr-firmware.json' \) \
             | wc -l | tr -d ' ')"
           PUBLISHED_ASSET_COUNT="$(gh release view "${TAG}" --json assets --jq '.assets | length')"
           if [[ "${PUBLISHED_ASSET_COUNT}" != "${EXPECTED_ASSET_COUNT}" ]]; then

--- a/.github/workflows/pr-test-firmware-publish.yml
+++ b/.github/workflows/pr-test-firmware-publish.yml
@@ -261,10 +261,18 @@ jobs:
             --notes "${NOTES}" \
             --prerelease
 
+          # Backward-compatible: oudere builds genereren nog geen manifesten.
+          # Upload ze alleen indien aanwezig, zodat deze publisher zowel op
+          # main (oude generator) als op dev (nieuwe generator) werkt.
+          MANIFEST_ARGS=()
+          if compgen -G "dist/*-ota.manifest.json" > /dev/null; then
+            MANIFEST_ARGS=(dist/*-ota.manifest.json)
+          fi
+
           gh release upload "${TAG}" \
             dist/*.firmware.ota.bin \
             dist/*.firmware.ota.bin.md5 \
-            dist/*-ota.manifest.json \
+            "${MANIFEST_ARGS[@]}" \
             dist/pr-firmware.json \
             --clobber
 

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -932,7 +932,7 @@ openquatt_energy_history:
   clock: oq_time
 
 # ==============================================================================
-# PR TEST FIRMWARE VIA OTA-MANIFEST (optie A: geen oude directe OTA-compat)
+# PR TEST FIRMWARE VIA OTA-MANIFEST (manifest preferred, directe OTA+MD5 als fallback)
 # ==============================================================================
 text:
   - platform: template

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -558,6 +558,9 @@ script:
           id(oq_ota_phase_code) = 1;
           id(oq_firmware_update_status).publish_state("Starting");
           id(oq_firmware_update_progress).publish_state(0.0f);
+          // Claim de installatie vroeg, zodat periodieke main/dev-checks de
+          // PR-source niet kunnen overschrijven terwijl de PR-check loopt.
+          id(oq_firmware_target_install_active) = true;
       - delay: 1500ms
       - lambda: |-
           // Fail-closed validatie van de PR-manifest-URL. Alleen exact
@@ -577,6 +580,7 @@ script:
             hardware_slug = "heatpump-controller-q";
           } else {
             ESP_LOGW("oq_fw", "Test firmware rejected: unsupported hardware profile.");
+            id(oq_firmware_target_install_active) = false;
             id(oq_ota_phase_code) = 5;
             id(oq_firmware_update_status).publish_state("Error");
             return;
@@ -614,6 +618,7 @@ script:
           }
           if (!valid) {
             ESP_LOGW("oq_fw", "Test firmware rejected: invalid PR manifest URL for this build.");
+            id(oq_firmware_target_install_active) = false;
             id(oq_ota_phase_code) = 5;
             id(oq_firmware_update_status).publish_state("Error");
             return;
@@ -639,6 +644,56 @@ script:
               return id(oq_fw_check_completed_generation) == id(oq_fw_check_request_generation)
                   || id(oq_ota_phase_code) == 5;
           timeout: 20s
+      - lambda: |-
+          // PR-specifieke exact-URL-validatie: een reeds lopende normale
+          // manifestcheck kan een stale resultaat publiceren. De generieke
+          // target_ready controleert slechts het suffix van de firmware-
+          // bestandsnaam, die voor main/dev en PR gelijk is. Wijs daarom
+          // alles af wat niet exact naar deze PR-release en asset wijst.
+          if (id(oq_ota_phase_code) == 5) {
+            return;
+          }
+          if (id(oq_fw_check_completed_generation) != id(oq_fw_check_request_generation)) {
+            return;
+          }
+          const std::string manifest_url = id(oq_firmware_test_manifest_url).state;
+          const std::string prefix =
+              "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-";
+          if (manifest_url.rfind(prefix, 0) != 0) {
+            id(oq_ota_phase_code) = 5;
+            id(oq_firmware_update_status).publish_state("Error");
+            ESP_LOGW("oq_fw", "PR test install blocked: manifest URL changed mid-flight.");
+            return;
+          }
+          std::string rest = manifest_url.substr(prefix.size());
+          auto slash = rest.find('/');
+          if (slash == std::string::npos) {
+            id(oq_ota_phase_code) = 5;
+            id(oq_firmware_update_status).publish_state("Error");
+            return;
+          }
+          std::string pr = rest.substr(0, slash);
+          std::string manifest_file = rest.substr(slash + 1);
+          const std::string manifest_suffix = "-ota.manifest.json";
+          if (manifest_file.size() <= manifest_suffix.size()
+              || manifest_file.compare(
+                     manifest_file.size() - manifest_suffix.size(),
+                     manifest_suffix.size(), manifest_suffix) != 0) {
+            id(oq_ota_phase_code) = 5;
+            id(oq_firmware_update_status).publish_state("Error");
+            return;
+          }
+          std::string ota_file = manifest_file.substr(
+                  0, manifest_file.size() - manifest_suffix.size())
+              + ".firmware.ota.bin";
+          const std::string expected_firmware_url = prefix + pr + "/" + ota_file;
+          const std::string actual_firmware_url =
+              id(oq_firmware_update).update_info.firmware_url;
+          if (actual_firmware_url != expected_firmware_url) {
+            ESP_LOGW("oq_fw", "PR test manifest check rejected stale result for this install.");
+            return;
+          }
+          id(oq_fw_check_target_ready) = true;
       - if:
           condition:
             lambda: |-
@@ -647,6 +702,10 @@ script:
                       || !id(oq_fw_check_target_ready));
           then:
             - lambda: |-
+                // Herstel de PR-source voor de retry: een stale normale check
+                // kan de source hebben laten staan op main/dev.
+                const std::string url = id(oq_firmware_test_manifest_url).state;
+                id(oq_firmware_update).set_source_url(url.c_str());
                 id(oq_fw_check_request_generation) += 1;
                 if (id(oq_fw_check_request_generation) == 0) {
                   id(oq_fw_check_request_generation) = 1;
@@ -661,6 +720,47 @@ script:
                   lambda: |-
                     return id(oq_fw_check_completed_generation) == id(oq_fw_check_request_generation);
                 timeout: 20s
+            - lambda: |-
+                if (id(oq_fw_check_completed_generation) != id(oq_fw_check_request_generation)) {
+                  return;
+                }
+                const std::string manifest_url = id(oq_firmware_test_manifest_url).state;
+                const std::string prefix =
+                    "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-";
+                if (manifest_url.rfind(prefix, 0) != 0) {
+                  id(oq_ota_phase_code) = 5;
+                  id(oq_firmware_update_status).publish_state("Error");
+                  return;
+                }
+                std::string rest = manifest_url.substr(prefix.size());
+                auto slash = rest.find('/');
+                if (slash == std::string::npos) {
+                  id(oq_ota_phase_code) = 5;
+                  id(oq_firmware_update_status).publish_state("Error");
+                  return;
+                }
+                std::string pr = rest.substr(0, slash);
+                std::string manifest_file = rest.substr(slash + 1);
+                const std::string manifest_suffix = "-ota.manifest.json";
+                if (manifest_file.size() <= manifest_suffix.size()
+                    || manifest_file.compare(
+                           manifest_file.size() - manifest_suffix.size(),
+                           manifest_suffix.size(), manifest_suffix) != 0) {
+                  id(oq_ota_phase_code) = 5;
+                  id(oq_firmware_update_status).publish_state("Error");
+                  return;
+                }
+                std::string ota_file = manifest_file.substr(
+                        0, manifest_file.size() - manifest_suffix.size())
+                    + ".firmware.ota.bin";
+                const std::string expected_firmware_url = prefix + pr + "/" + ota_file;
+                const std::string actual_firmware_url =
+                    id(oq_firmware_update).update_info.firmware_url;
+                if (actual_firmware_url != expected_firmware_url) {
+                  ESP_LOGW("oq_fw", "PR test manifest retry rejected stale result.");
+                  return;
+                }
+                id(oq_fw_check_target_ready) = true;
       - if:
           condition:
             lambda: |-
@@ -668,10 +768,13 @@ script:
                   && id(oq_fw_check_completed_generation) == id(oq_fw_check_request_generation)
                   && id(oq_fw_check_target_ready)
                   && !id(oq_runtime_polling_paused).state
-                  && !id(oq_firmware_target_install_active);
+                  && id(oq_firmware_target_install_active);
           then:
             - lambda: |-
-                id(oq_firmware_target_install_active) = true;
+                // Bevestig de PR-source nogmaals vlak voor perform, zodat een
+                // tussentijdse kanaal/target-wissel geen main/dev installeert.
+                const std::string url = id(oq_firmware_test_manifest_url).state;
+                id(oq_firmware_update).set_source_url(url.c_str());
                 id(oq_firmware_target_install_attempt) = 1;
                 id(oq_http_ota_begin_observed) = false;
                 id(oq_runtime_polling_paused).publish_state(true);
@@ -686,6 +789,7 @@ script:
           else:
             - lambda: |-
                 if (id(oq_ota_phase_code) == 5) {
+                  id(oq_firmware_target_install_active) = false;
                   return;
                 }
                 if (id(oq_runtime_polling_paused).state) {
@@ -695,6 +799,7 @@ script:
                   id(oq_firmware_update_status).publish_state("Error");
                   ESP_LOGE("oq_fw", "PR test install blocked: target manifest check failed twice.");
                 }
+                id(oq_firmware_target_install_active) = false;
 
   - id: oq_capture_overview_trend_sample
     mode: single

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -782,10 +782,59 @@ script:
                 id(oq_firmware_update_status).publish_state("Starting");
                 id(oq_firmware_update_progress).publish_state(0.0f);
             - delay: 1500ms
-            - script.execute: oq_watch_http_ota_start
-            - update.perform:
-                id: oq_firmware_update
-                force_update: true
+            - lambda: |-
+                // Laatste gordel vlak voor perform: set_source_url() geldt
+                // pas voor een volgende check, perform() flasht uit het al
+                // aanwezige update_info. Weiger alles wat niet exact naar
+                // deze PR-release en asset wijst.
+                const std::string manifest_url = id(oq_firmware_test_manifest_url).state;
+                const std::string prefix =
+                    "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-";
+                bool valid = manifest_url.rfind(prefix, 0) == 0;
+                if (valid) {
+                  std::string rest = manifest_url.substr(prefix.size());
+                  auto slash = rest.find('/');
+                  if (slash == std::string::npos) {
+                    valid = false;
+                  } else {
+                    std::string pr = rest.substr(0, slash);
+                    std::string manifest_file = rest.substr(slash + 1);
+                    const std::string manifest_suffix = "-ota.manifest.json";
+                    if (manifest_file.size() <= manifest_suffix.size()
+                        || manifest_file.compare(
+                               manifest_file.size() - manifest_suffix.size(),
+                               manifest_suffix.size(), manifest_suffix) != 0) {
+                      valid = false;
+                    } else {
+                      std::string ota_file = manifest_file.substr(
+                              0, manifest_file.size() - manifest_suffix.size())
+                          + ".firmware.ota.bin";
+                      const std::string expected_firmware_url = prefix + pr + "/" + ota_file;
+                      valid = id(oq_firmware_update).update_info.firmware_url
+                          == expected_firmware_url;
+                    }
+                  }
+                }
+                if (!valid) {
+                  ESP_LOGE("oq_fw", "PR test install blocked: firmware info no longer matches this PR.");
+                  id(oq_ota_phase_code) = 5;
+                  id(oq_firmware_update_status).publish_state("Error");
+                  id(oq_firmware_target_install_active) = false;
+                  return;
+                }
+            - if:
+                condition:
+                  lambda: |-
+                    return id(oq_ota_phase_code) != 5
+                        && id(oq_firmware_target_install_active);
+                then:
+                  - script.execute: oq_watch_http_ota_start
+                  - update.perform:
+                      id: oq_firmware_update
+                      force_update: true
+                else:
+                  - lambda: |-
+                      id(oq_firmware_target_install_active) = false;
           else:
             - lambda: |-
                 if (id(oq_ota_phase_code) == 5) {
@@ -911,6 +960,11 @@ select:
       then:
         - lambda: |-
             // Keep the update source aligned with the selected channel and target.
+            // No source changes while a firmware install owns the update slot.
+            if (id(oq_firmware_target_install_active)) {
+              ESP_LOGW("oq_fw", "Firmware source change ignored during active install.");
+              return;
+            }
             const bool alternate_connection_update_target =
               id(oq_firmware_update_target).current_option() == "alternate connection";
             const bool alternate_topology_update_target =
@@ -950,6 +1004,10 @@ select:
                 if (!id(oq_fw_select_callbacks_runtime_ready)) {
                   return false;
                 }
+                if (id(oq_firmware_target_install_active)) {
+                  ESP_LOGI("oq_fw", "Firmware update check skipped: install active.");
+                  return false;
+                }
                 // A real runtime selection supersedes the deferred boot check.
                 id(oq_fw_boot_check_pending) = false;
                 // Prevent duplicate update checks when the channel changes repeatedly.
@@ -979,6 +1037,11 @@ select:
       then:
         - lambda: |-
             // Switch between the current-build manifest and alternate target manifests.
+            // No source changes while a firmware install owns the update slot.
+            if (id(oq_firmware_target_install_active)) {
+              ESP_LOGW("oq_fw", "Firmware source change ignored during active install.");
+              return;
+            }
             const bool alternate_connection_update_target = x == "alternate connection";
             const bool alternate_topology_update_target = x == "alternate topology";
             const bool alternate_build_update_target = x == "alternate topology and connection";
@@ -1013,6 +1076,10 @@ select:
             condition:
               lambda: |-
                 if (!id(oq_fw_select_callbacks_runtime_ready)) {
+                  return false;
+                }
+                if (id(oq_firmware_target_install_active)) {
+                  ESP_LOGI("oq_fw", "Firmware update check skipped: install active.");
                   return false;
                 }
                 // A real runtime selection supersedes the deferred boot check.
@@ -1215,27 +1282,36 @@ button:
     icon: mdi:update
     entity_category: diagnostic
     on_press:
-      - script.execute: oq_apply_firmware_update_source
-      - script.wait: oq_apply_firmware_update_source
       - if:
           condition:
             lambda: |-
-              // A manual request supersedes the deferred boot check.
-              id(oq_fw_boot_check_pending) = false;
-              // Prevent duplicate update checks after repeated manual requests.
-              constexpr uint32_t fw_check_cooldown_ms = 1000UL;
-              const uint32_t now_ms = (uint32_t) millis();
-              const uint32_t last_request_ms = id(oq_fw_check_last_request_ms);
-              if (last_request_ms > 0 && now_ms >= last_request_ms &&
-                  (now_ms - last_request_ms) < fw_check_cooldown_ms) {
-                ESP_LOGI("oq_fw", "Firmware update check skipped: cooldown active after a recent request.");
+              if (id(oq_firmware_target_install_active)) {
+                ESP_LOGW("oq_fw", "Firmware update check ignored because an install is active.");
                 return false;
               }
-              id(oq_fw_check_last_request_ms) = now_ms;
               return true;
           then:
-            - update.check:
-                id: oq_firmware_update
+            - script.execute: oq_apply_firmware_update_source
+            - script.wait: oq_apply_firmware_update_source
+            - if:
+                condition:
+                  lambda: |-
+                    // A manual request supersedes the deferred boot check.
+                    id(oq_fw_boot_check_pending) = false;
+                    // Prevent duplicate update checks after repeated manual requests.
+                    constexpr uint32_t fw_check_cooldown_ms = 1000UL;
+                    const uint32_t now_ms = (uint32_t) millis();
+                    const uint32_t last_request_ms = id(oq_fw_check_last_request_ms);
+                    if (last_request_ms > 0 && now_ms >= last_request_ms &&
+                        (now_ms - last_request_ms) < fw_check_cooldown_ms) {
+                      ESP_LOGI("oq_fw", "Firmware update check skipped: cooldown active after a recent request.");
+                      return false;
+                    }
+                    id(oq_fw_check_last_request_ms) = now_ms;
+                    return true;
+                then:
+                  - update.check:
+                      id: oq_firmware_update
 
   - platform: template
     id: oq_install_firmware_update_target

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -549,6 +549,153 @@ script:
                   ESP_LOGE("oq_fw", "Firmware install blocked: target manifest check failed twice.");
                 }
 
+  - id: oq_install_firmware_test_manifest_deferred
+    mode: single
+    then:
+      - lambda: |-
+          id(oq_fw_boot_check_pending) = false;
+          id(oq_http_ota_begin_observed) = false;
+          id(oq_ota_phase_code) = 1;
+          id(oq_firmware_update_status).publish_state("Starting");
+          id(oq_firmware_update_progress).publish_state(0.0f);
+      - delay: 1500ms
+      - lambda: |-
+          // Fail-closed validatie van de PR-manifest-URL. Alleen exact
+          // OpenQuatt/OpenQuatt/releases/download/pr-<nr>/<manifest> voor
+          // dit hardware/topology-target wordt geaccepteerd. Voor uniforme
+          // HCQ is dat de canonieke naam zonder verbindingssuffix.
+          const std::string url = id(oq_firmware_test_manifest_url).state;
+          const std::string prefix =
+              "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-";
+          std::string hardware_slug;
+          const std::string hardware = "${oq_hardware_profile}";
+          if (hardware == "waveshare") {
+            hardware_slug = "waveshare";
+          } else if (hardware == "heatpump_listener") {
+            hardware_slug = "heatpump-listener";
+          } else if (hardware == "heatpump_controller_q") {
+            hardware_slug = "heatpump-controller-q";
+          } else {
+            ESP_LOGW("oq_fw", "Test firmware rejected: unsupported hardware profile.");
+            id(oq_ota_phase_code) = 5;
+            id(oq_firmware_update_status).publish_state("Error");
+            return;
+          }
+          #if OQ_TOPOLOGY_DUO
+          const std::string topology = "duo";
+          #else
+          const std::string topology = "single";
+          #endif
+          const std::string artifact_base = "openquatt-" + hardware_slug + "-" + topology;
+          const std::string expected_manifest =
+              artifact_base + "${oq_artifact_connection_suffix}-ota.manifest.json";
+          bool valid = url.rfind(prefix, 0) == 0;
+          if (valid) {
+            std::string rest = url.substr(prefix.size());
+            auto slash = rest.find('/');
+            std::string pr;
+            std::string file;
+            if (slash != std::string::npos) {
+              pr = rest.substr(0, slash);
+              file = rest.substr(slash + 1);
+            }
+            valid = !pr.empty() && pr.size() <= 6 && file == expected_manifest;
+            if (valid) {
+              for (char c : pr) {
+                if (c < '0' || c > '9') {
+                  valid = false;
+                  break;
+                }
+              }
+              if (valid && pr[0] == '0') {
+                valid = false;
+              }
+            }
+          }
+          if (!valid) {
+            ESP_LOGW("oq_fw", "Test firmware rejected: invalid PR manifest URL for this build.");
+            id(oq_ota_phase_code) = 5;
+            id(oq_firmware_update_status).publish_state("Error");
+            return;
+          }
+          ESP_LOGI("oq_fw", "PR test manifest uses manifest: %s", url.c_str());
+          id(oq_firmware_update).set_source_url(url.c_str());
+      - lambda: |-
+          if (id(oq_ota_phase_code) == 5) {
+            return;
+          }
+          id(oq_fw_check_request_generation) += 1;
+          if (id(oq_fw_check_request_generation) == 0) {
+            id(oq_fw_check_request_generation) = 1;
+          }
+          id(oq_fw_check_target_ready) = false;
+          ESP_LOGI("oq_fw", "Waiting for PR test manifest check %lu before install.",
+                   (unsigned long) id(oq_fw_check_request_generation));
+      - update.check:
+          id: oq_firmware_update
+      - wait_until:
+          condition:
+            lambda: |-
+              return id(oq_fw_check_completed_generation) == id(oq_fw_check_request_generation)
+                  || id(oq_ota_phase_code) == 5;
+          timeout: 20s
+      - if:
+          condition:
+            lambda: |-
+              return id(oq_ota_phase_code) != 5
+                  && (id(oq_fw_check_completed_generation) != id(oq_fw_check_request_generation)
+                      || !id(oq_fw_check_target_ready));
+          then:
+            - lambda: |-
+                id(oq_fw_check_request_generation) += 1;
+                if (id(oq_fw_check_request_generation) == 0) {
+                  id(oq_fw_check_request_generation) = 1;
+                }
+                id(oq_fw_check_target_ready) = false;
+                ESP_LOGW("oq_fw", "PR test manifest check did not complete; retrying check %lu once.",
+                         (unsigned long) id(oq_fw_check_request_generation));
+            - update.check:
+                id: oq_firmware_update
+            - wait_until:
+                condition:
+                  lambda: |-
+                    return id(oq_fw_check_completed_generation) == id(oq_fw_check_request_generation);
+                timeout: 20s
+      - if:
+          condition:
+            lambda: |-
+              return id(oq_ota_phase_code) != 5
+                  && id(oq_fw_check_completed_generation) == id(oq_fw_check_request_generation)
+                  && id(oq_fw_check_target_ready)
+                  && !id(oq_runtime_polling_paused).state
+                  && !id(oq_firmware_target_install_active);
+          then:
+            - lambda: |-
+                id(oq_firmware_target_install_active) = true;
+                id(oq_firmware_target_install_attempt) = 1;
+                id(oq_http_ota_begin_observed) = false;
+                id(oq_runtime_polling_paused).publish_state(true);
+                ESP_LOGI("oq_fw", "Runtime polling paused before deferred PR test OTA.");
+                id(oq_firmware_update_status).publish_state("Starting");
+                id(oq_firmware_update_progress).publish_state(0.0f);
+            - delay: 1500ms
+            - script.execute: oq_watch_http_ota_start
+            - update.perform:
+                id: oq_firmware_update
+                force_update: true
+          else:
+            - lambda: |-
+                if (id(oq_ota_phase_code) == 5) {
+                  return;
+                }
+                if (id(oq_runtime_polling_paused).state) {
+                  ESP_LOGW("oq_fw", "PR test install request cancelled because another OTA became active.");
+                } else {
+                  id(oq_ota_phase_code) = 5;
+                  id(oq_firmware_update_status).publish_state("Error");
+                  ESP_LOGE("oq_fw", "PR test install blocked: target manifest check failed twice.");
+                }
+
   - id: oq_capture_overview_trend_sample
     mode: single
     then:
@@ -630,21 +777,12 @@ openquatt_energy_history:
   clock: oq_time
 
 # ==============================================================================
-# PR TEST FIRMWARE OTA
+# PR TEST FIRMWARE VIA OTA-MANIFEST (optie A: geen oude directe OTA-compat)
 # ==============================================================================
 text:
   - platform: template
-    name: "Firmware Test OTA URL"
-    id: oq_firmware_test_ota_url
-    internal: true
-    mode: text
-    optimistic: true
-    restore_value: false
-    max_length: 255
-
-  - platform: template
-    name: "Firmware Test OTA MD5 URL"
-    id: oq_firmware_test_ota_md5_url
+    name: "Firmware Test Manifest URL"
+    id: oq_firmware_test_manifest_url
     internal: true
     mode: text
     optimistic: true
@@ -838,17 +976,18 @@ select:
 
 button:
   - platform: template
-    name: "Install Firmware Test OTA"
-    id: oq_install_firmware_test_ota
+    name: "Install Firmware Test Manifest"
+    id: oq_install_firmware_test_manifest
     internal: true
     on_press:
       then:
         - if:
             condition:
               lambda: |-
-                // Accept only OpenQuatt PR-release assets for this exact build target.
-                const std::string url = id(oq_firmware_test_ota_url).state;
-                const std::string md5_url = id(oq_firmware_test_ota_md5_url).state;
+                // Fail-closed: alleen exact OpenQuatt/OpenQuatt/releases/download/pr-<nr>/
+                // met exact de manifestnaam voor hardware en topologie. Voor
+                // uniforme HCQ de canonieke naam zonder verbindingssuffix.
+                const std::string url = id(oq_firmware_test_manifest_url).state;
                 const std::string prefix =
                     "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-";
                 std::string hardware_slug;
@@ -860,7 +999,8 @@ button:
                 } else if (hardware == "heatpump_controller_q") {
                   hardware_slug = "heatpump-controller-q";
                 } else {
-                  ESP_LOGW("oq_fw", "Test firmware rejected: unsupported hardware profile '%s'.", hardware.c_str());
+                  ESP_LOGW("oq_fw", "Test firmware rejected: unsupported hardware profile.");
+                  id(oq_firmware_update_status).publish_state("Error");
                   return false;
                 }
                 #if OQ_TOPOLOGY_DUO
@@ -870,36 +1010,43 @@ button:
                 #endif
                 const std::string artifact_base =
                     "openquatt-" + hardware_slug + "-" + topology;
-                const std::string expected_file =
-                    artifact_base + "${oq_artifact_connection_suffix}.firmware.ota.bin";
-                const bool valid_prefix = url.rfind(prefix, 0) == 0;
-                bool valid_file =
-                    url.size() >= expected_file.size() &&
-                    url.compare(url.size() - expected_file.size(), expected_file.size(), expected_file) == 0;
-                #ifdef USE_OPENQUATT_NETWORK
-                // Stage-one WiFi/Ethernet names remain byte-identical aliases so
-                // trusted PR publishing also works before this tooling reaches dev.
-                for (const char *connection_suffix : {"-wifi", "-eth"}) {
-                  const std::string alias_file =
-                      artifact_base + connection_suffix + ".firmware.ota.bin";
-                  valid_file = valid_file ||
-                      (url.size() >= alias_file.size() &&
-                       url.compare(url.size() - alias_file.size(), alias_file.size(), alias_file) == 0);
-                }
-                #endif
-                const bool valid_md5 = md5_url == (url + ".md5");
-                if (!valid_prefix || !valid_file || !valid_md5) {
-                  ESP_LOGW("oq_fw", "Test firmware rejected: invalid OTA URL for this build.");
+                const std::string expected_manifest =
+                    artifact_base + "${oq_artifact_connection_suffix}-ota.manifest.json";
+                if (url.rfind(prefix, 0) != 0) {
+                  ESP_LOGW("oq_fw", "Test firmware rejected: invalid PR manifest prefix.");
                   id(oq_firmware_update_status).publish_state("Error");
                   return false;
                 }
-                return true;
+                std::string rest = url.substr(prefix.size());
+                auto slash = rest.find('/');
+                if (slash == std::string::npos) {
+                  ESP_LOGW("oq_fw", "Test firmware rejected: invalid PR manifest URL.");
+                  id(oq_firmware_update_status).publish_state("Error");
+                  return false;
+                }
+                std::string pr = rest.substr(0, slash);
+                std::string file = rest.substr(slash + 1);
+                bool valid = !pr.empty() && pr.size() <= 6 && file == expected_manifest;
+                if (valid) {
+                  for (char c : pr) {
+                    if (c < '0' || c > '9') {
+                      valid = false;
+                      break;
+                    }
+                  }
+                  if (valid && pr[0] == '0') {
+                    valid = false;
+                  }
+                }
+                if (!valid) {
+                  ESP_LOGW("oq_fw", "Test firmware rejected: invalid PR manifest URL for this build.");
+                  id(oq_firmware_update_status).publish_state("Error");
+                  return false;
+                }
+                return !id(oq_runtime_polling_paused).state
+                    && !id(oq_firmware_target_install_active);
             then:
-              - ota.http_request.flash:
-                  url: !lambda |-
-                    return id(oq_firmware_test_ota_url).state;
-                  md5_url: !lambda |-
-                    return id(oq_firmware_test_ota_md5_url).state;
+              - script.execute: oq_install_firmware_test_manifest_deferred
 
   - platform: restart
     name: Restart

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -816,10 +816,11 @@ script:
                   }
                 }
                 if (!valid) {
-                  ESP_LOGE("oq_fw", "PR test install blocked: firmware info no longer matches this PR.");
+                  ESP_LOGE("oq_fw", "PR test install blocked before OTA start; runtime polling resumed.");
+                  id(oq_firmware_target_install_active) = false;
+                  id(oq_runtime_polling_paused).publish_state(false);
                   id(oq_ota_phase_code) = 5;
                   id(oq_firmware_update_status).publish_state("Error");
-                  id(oq_firmware_target_install_active) = false;
                   return;
                 }
             - if:

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -4763,8 +4763,8 @@
       }
     } else if (name === "Install Firmware Update Target") {
       handleUpdateInstall("Firmware Update");
-    } else if (name === "Install Firmware Test OTA") {
-      handleUpdateInstall("Firmware Test OTA");
+    } else if (name === "Install Firmware Test OTA" || name === "Install Firmware Test Manifest") {
+      handleUpdateInstall(name === "Install Firmware Test Manifest" ? "Firmware Test Manifest" : "Firmware Test OTA");
     } else if (name === "Trendhistorie nu opslaan") {
       state.trendFlashLastFlushAt = Date.now();
       state.trendFlashNewestAt = Date.now() - (2 * 60 * 1000);
@@ -4786,10 +4786,10 @@
   }
 
   function handleUpdateInstall(name) {
-    if (name !== "Firmware Update" && name !== "Firmware Test OTA") {
+    if (name !== "Firmware Update" && name !== "Firmware Test OTA" && name !== "Firmware Test Manifest") {
       return;
     }
-    const testFirmware = name === "Firmware Test OTA";
+    const testFirmware = name === "Firmware Test OTA" || name === "Firmware Test Manifest";
     const updateEntity = getEntity("update", "Firmware Update");
     if (!updateEntity) {
       return;

--- a/openquatt/web/js/src/core/config.js
+++ b/openquatt/web/js/src/core/config.js
@@ -34,8 +34,10 @@
     firmwareUpdateStatus: { domain: "text_sensor", name: "Firmware Update Status", optional: true },
     firmwareTestOtaUrl: { domain: "text", name: "Firmware Test OTA URL", optional: true },
     firmwareTestOtaMd5Url: { domain: "text", name: "Firmware Test OTA MD5 URL", optional: true },
+    firmwareTestManifestUrl: { domain: "text", name: "Firmware Test Manifest URL", optional: true },
     checkFirmwareUpdates: { domain: "button", name: "Check Firmware Updates", optional: true },
     installFirmwareTestOta: { domain: "button", name: "Install Firmware Test OTA", optional: true },
+    installFirmwareTestManifest: { domain: "button", name: "Install Firmware Test Manifest", optional: true },
     installFirmwareUpdateTarget: { domain: "button", name: "Install Firmware Update Target", optional: true },
     restartAction: { domain: "button", name: "Restart", optional: true },
     uptime: { domain: "sensor", name: "Uptime", optional: true },
@@ -1429,7 +1431,7 @@
     "boilerPowerTestResultQuality",
   ];
   export const FIRMWARE_ENTITY_KEYS = ["firmwareUpdate", "firmwareUpdateChannel", "firmwareUpdateTarget", "firmwareUpdateProgress", "firmwareUpdateStatus"];
-  export const FIRMWARE_TEST_ENTITY_KEYS = ["firmwareTestOtaUrl", "firmwareTestOtaMd5Url", "installFirmwareTestOta"];
+  export const FIRMWARE_TEST_ENTITY_KEYS = ["firmwareTestManifestUrl", "installFirmwareTestManifest"];
   export const FIRMWARE_MODAL_KEYS = [...FIRMWARE_ENTITY_KEYS, ...FIRMWARE_TEST_ENTITY_KEYS, "installFirmwareUpdateTarget", "projectVersionText", "releaseChannelText", "installationTopology", "hardwareProfileText", "connectionText", "preferredConnection"];
   export const TOPOLOGY_HINT_KEYS = ["hp2ExcludeMinHz", "hp2Power", "hp2WaterOut"];
   export const HEADER_ENTITY_KEYS = [

--- a/openquatt/web/js/src/core/config.js
+++ b/openquatt/web/js/src/core/config.js
@@ -1432,7 +1432,8 @@
   ];
   export const FIRMWARE_ENTITY_KEYS = ["firmwareUpdate", "firmwareUpdateChannel", "firmwareUpdateTarget", "firmwareUpdateProgress", "firmwareUpdateStatus"];
   export const FIRMWARE_TEST_ENTITY_KEYS = ["firmwareTestManifestUrl", "installFirmwareTestManifest"];
-  export const FIRMWARE_MODAL_KEYS = [...FIRMWARE_ENTITY_KEYS, ...FIRMWARE_TEST_ENTITY_KEYS, "installFirmwareUpdateTarget", "projectVersionText", "releaseChannelText", "installationTopology", "hardwareProfileText", "connectionText", "preferredConnection"];
+  export const FIRMWARE_TEST_LEGACY_ENTITY_KEYS = ["firmwareTestOtaUrl", "firmwareTestOtaMd5Url", "installFirmwareTestOta"];
+  export const FIRMWARE_MODAL_KEYS = [...FIRMWARE_ENTITY_KEYS, ...FIRMWARE_TEST_ENTITY_KEYS, ...FIRMWARE_TEST_LEGACY_ENTITY_KEYS, "installFirmwareUpdateTarget", "projectVersionText", "releaseChannelText", "installationTopology", "hardwareProfileText", "connectionText", "preferredConnection"];
   export const TOPOLOGY_HINT_KEYS = ["hp2ExcludeMinHz", "hp2Power", "hp2WaterOut"];
   export const HEADER_ENTITY_KEYS = [
     "status",

--- a/openquatt/web/js/src/features/firmware-actions.js
+++ b/openquatt/web/js/src/features/firmware-actions.js
@@ -8,7 +8,7 @@ import { isLikelyDeviceConnectionError, refreshEntities } from "../core/entity-s
 import { armOtaRefresh, awaitOtaEvidence, beginDeviceReconnect, clearOtaRefresh } from "../core/device-reconnect.js";
 import { clearQuickStartSetupInstall, state, storeQuickStartSetupInstall } from "../core/state.js";
 import { getFirmwareConnectionLabel, getFirmwareTopologyLabel, getInstallationTopology } from "./device-context.js";
-import { beginFirmwareOtaQuietWindow, clearFirmwareOtaQuietWindow, getFirmwareBuildSwitchModel, getFirmwareConnectionSwitchModel, getFirmwareCurrentVersion, getFirmwareLatestVersion, getFirmwareRunningChannelLabel, getFirmwareTestAssetUrls, getFirmwareTestPrNumber, getFirmwareTestTargetModel, getFirmwareTopologySwitchModel, getFirmwareUpdateEntity, hasKnownFirmwareTargetVersion, isFirmwareDowngradeAvailable, isFirmwareEntityAlignedWithChannel, isFirmwareUpdateEntityForBuild, isQuickStartSetupFirmwareCurrent, pollFirmwareInstallState, pollFirmwareUpdateState, primeFirmwareInstallProgressHints, primeFirmwareUpdateState, resetFirmwareInstallUiState, resetFirmwareManualUploadSelection, resetFirmwareTestSelection, wait } from "./firmware-update.js";
+import { beginFirmwareOtaQuietWindow, clearFirmwareOtaQuietWindow, getFirmwareBuildSwitchModel, getFirmwareConnectionSwitchModel, getFirmwareCurrentVersion, getFirmwareLatestVersion, getFirmwareRunningChannelLabel, getFirmwareTestAssetUrls, getFirmwareTestPrNumber, getFirmwareTestTargetModel, getFirmwareTopologySwitchModel, getFirmwareUpdateEntity, hasFirmwareTestLegacyCapability, hasFirmwareTestManifestCapability, hasKnownFirmwareTargetVersion, isFirmwareDowngradeAvailable, isFirmwareEntityAlignedWithChannel, isFirmwareUpdateEntityForBuild, isQuickStartSetupFirmwareCurrent, pollFirmwareInstallState, pollFirmwareUpdateState, primeFirmwareInstallProgressHints, primeFirmwareUpdateState, resetFirmwareInstallUiState, resetFirmwareManualUploadSelection, resetFirmwareTestSelection, wait } from "./firmware-update.js";
 import { render } from "../core/render-scheduler.js";
 
   export async function requestFirmwareOta(path, options) {
@@ -524,7 +524,11 @@ import { render } from "../core/render-scheduler.js";
   export async function installFirmwareTestUpdate() {
     const prNumber = getFirmwareTestPrNumber();
     const target = getFirmwareTestTargetModel();
-    const buttonEntity = ENTITY_DEFS.installFirmwareTestManifest;
+    const useManifest = hasFirmwareTestManifestCapability();
+    const useLegacy = !useManifest && hasFirmwareTestLegacyCapability();
+    const buttonEntity = useManifest
+      ? ENTITY_DEFS.installFirmwareTestManifest
+      : useLegacy ? ENTITY_DEFS.installFirmwareTestOta : null;
     if (!prNumber) {
       state.updateTestFirmwareError = "Vul een geldig PR-nummer in.";
       render();
@@ -540,7 +544,7 @@ import { render } from "../core/render-scheduler.js";
       render();
       return;
     }
-    if (!buttonEntity || !hasEntity("firmwareTestManifestUrl") || !hasEntity("installFirmwareTestManifest")) {
+    if (!buttonEntity || (!useManifest && !useLegacy)) {
       state.updateTestFirmwareError = "Deze firmware bevat de testfirmware-installatieknop nog niet. Installeer eerst een nieuwere build.";
       render();
       return;
@@ -567,17 +571,24 @@ import { render } from "../core/render-scheduler.js";
 
     let flashRequested = false;
     try {
-      // PR-manifest-URL is deterministisch. Het device valideert fail-closed
-      // op repository, PR-tag en exact target en gebruikt daarna dezelfde
-      // bewaakte update.check → update.perform-lifecycle als main/dev.
       const testAsset = getFirmwareTestAssetUrls(prNumber, target);
-      if (!testAsset?.manifestUrl) {
+      if (!testAsset || (useManifest && !testAsset.manifestUrl) || (useLegacy && !testAsset.otaUrl)) {
         throw new Error("Geen geldig PR-target gevonden.");
       }
       state.updateTestFirmwareBuild = testAsset.label;
       render();
 
-      await setFirmwareTestTextEntity("firmwareTestManifestUrl", testAsset.manifestUrl);
+      if (useManifest) {
+        // PR-manifest-URL is deterministisch. Het device valideert fail-closed
+        // op repository, PR-tag en exact target en gebruikt daarna dezelfde
+        // bewaakte update.check → update.perform-lifecycle als main/dev.
+        await setFirmwareTestTextEntity("firmwareTestManifestUrl", testAsset.manifestUrl);
+      } else {
+        // Legacy fallback voor firmware zonder manifest-capability (#607).
+        // Let op: voor oude uniforme HCQ bestaan geen wifi/eth bins meer.
+        await setFirmwareTestTextEntity("firmwareTestOtaUrl", testAsset.otaUrl);
+        await setFirmwareTestTextEntity("firmwareTestOtaMd5Url", testAsset.md5Url);
+      }
 
       flashRequested = true;
       beginFirmwareOtaQuietWindow();

--- a/openquatt/web/js/src/features/firmware-actions.js
+++ b/openquatt/web/js/src/features/firmware-actions.js
@@ -524,7 +524,7 @@ import { render } from "../core/render-scheduler.js";
   export async function installFirmwareTestUpdate() {
     const prNumber = getFirmwareTestPrNumber();
     const target = getFirmwareTestTargetModel();
-    const buttonEntity = ENTITY_DEFS.installFirmwareTestOta;
+    const buttonEntity = ENTITY_DEFS.installFirmwareTestManifest;
     if (!prNumber) {
       state.updateTestFirmwareError = "Vul een geldig PR-nummer in.";
       render();
@@ -540,8 +540,8 @@ import { render } from "../core/render-scheduler.js";
       render();
       return;
     }
-    if (!buttonEntity || !hasEntity("installFirmwareTestOta")) {
-      state.updateTestFirmwareError = "Deze firmware bevat de testfirmware-installatieknop nog niet.";
+    if (!buttonEntity || !hasEntity("firmwareTestManifestUrl") || !hasEntity("installFirmwareTestManifest")) {
+      state.updateTestFirmwareError = "Deze firmware bevat de testfirmware-installatieknop nog niet. Installeer eerst een nieuwere build.";
       render();
       return;
     }
@@ -567,17 +567,17 @@ import { render } from "../core/render-scheduler.js";
 
     let flashRequested = false;
     try {
-      // PR release asset URLs are deterministic. The device reports download
-      // and checksum failures, so the webapp does not need GitHub's rate-limited API.
+      // PR-manifest-URL is deterministisch. Het device valideert fail-closed
+      // op repository, PR-tag en exact target en gebruikt daarna dezelfde
+      // bewaakte update.check → update.perform-lifecycle als main/dev.
       const testAsset = getFirmwareTestAssetUrls(prNumber, target);
-      if (!testAsset) {
+      if (!testAsset?.manifestUrl) {
         throw new Error("Geen geldig PR-target gevonden.");
       }
       state.updateTestFirmwareBuild = testAsset.label;
       render();
 
-      await setFirmwareTestTextEntity("firmwareTestOtaUrl", testAsset.otaUrl);
-      await setFirmwareTestTextEntity("firmwareTestOtaMd5Url", testAsset.md5Url);
+      await setFirmwareTestTextEntity("firmwareTestManifestUrl", testAsset.manifestUrl);
 
       flashRequested = true;
       beginFirmwareOtaQuietWindow();

--- a/openquatt/web/js/src/features/firmware-update.js
+++ b/openquatt/web/js/src/features/firmware-update.js
@@ -181,10 +181,12 @@ import { render } from "../core/render-scheduler.js";
     }
     const topologyLabel = topology === "duo" ? "Duo" : "Single";
 
-    // Optie A: uniforme HCQ-build gebruikt altijd het canonieke
-    // topologie-artifact zonder verbindingssuffix. preferredConnection is
-    // een runtimevoorkeur en geen buildvariant.
-    if (hardware === "heatpump_controller_q") {
+    // Uniforme HCQ-build (herkenbaar aan preferredConnection) gebruikt het
+    // canonieke topologie-artifact zonder verbindingssuffix.
+    // preferredConnection is een runtimevoorkeur en geen buildvariant.
+    // Oudere HCQ-firmware zonder preferredConnection valt terug op het
+    // verbindingsspecifieke artifact voor de legacy OTA+MD5-route.
+    if (hardware === "heatpump_controller_q" && hasEntity("preferredConnection")) {
       const artifactName = `openquatt-heatpump-controller-q-${topology}`;
       return {
         available: true,
@@ -196,6 +198,23 @@ import { render } from "../core/render-scheduler.js";
     }
 
     const connection = getFirmwareBuildConnection();
+    if (hardware === "heatpump_controller_q") {
+      if (connection !== "wifi" && connection !== "eth") {
+        return {
+          available: false,
+          label: "Onbekend target",
+          error: "Deze firmware meldt geen herkenbaar hardware-, opstelling- of verbindingsprofiel.",
+        };
+      }
+      const artifactName = `openquatt-heatpump-controller-q-${topology}-${connection}`;
+      return {
+        available: true,
+        artifactName,
+        otaFileName: `${artifactName}.firmware.ota.bin`,
+        manifestFileName: `${artifactName}-ota.manifest.json`,
+        label: `Heatpump Controller Q ${topologyLabel} ${getFirmwareConnectionLabel(connection)}`,
+      };
+    }
     const hardwareMap = {
       waveshare: {
         slug: "waveshare",
@@ -241,6 +260,14 @@ import { render } from "../core/render-scheduler.js";
       manifestFileName,
       label: `PR ${normalizedPrNumber} · ${target.label}`,
     };
+  }
+
+  export function hasFirmwareTestManifestCapability() {
+    return Boolean(hasEntity("firmwareTestManifestUrl") && hasEntity("installFirmwareTestManifest"));
+  }
+
+  export function hasFirmwareTestLegacyCapability() {
+    return Boolean(hasEntity("firmwareTestOtaUrl") && hasEntity("firmwareTestOtaMd5Url") && hasEntity("installFirmwareTestOta"));
   }
 
   export function getUpdateStatus() {
@@ -1339,7 +1366,7 @@ import { render } from "../core/render-scheduler.js";
     const prNumber = getFirmwareTestPrNumber();
     const target = getFirmwareTestTargetModel();
     const urls = getFirmwareTestAssetUrls(prNumber, target);
-    const controlsAvailable = Boolean(target.available && hasEntity("firmwareTestManifestUrl") && hasEntity("installFirmwareTestManifest"));
+    const controlsAvailable = Boolean(target.available && (hasFirmwareTestManifestCapability() || hasFirmwareTestLegacyCapability()));
     const ready = Boolean(prNumber && controlsAvailable);
     const build = state.updateTestFirmwareBuild || null;
     const targetLabel = target.available ? target.label : target.error;

--- a/openquatt/web/js/src/features/firmware-update.js
+++ b/openquatt/web/js/src/features/firmware-update.js
@@ -172,26 +172,42 @@ import { render } from "../core/render-scheduler.js";
   export function getFirmwareTestTargetModel() {
     const hardware = getFirmwareHardwareProfile();
     const topology = getInstallationTopology();
+    if (topology !== "single" && topology !== "duo") {
+      return {
+        available: false,
+        label: "Onbekend target",
+        error: "Deze firmware meldt geen herkenbaar hardware- of opstellingsprofiel.",
+      };
+    }
+    const topologyLabel = topology === "duo" ? "Duo" : "Single";
+
+    // Optie A: uniforme HCQ-build gebruikt altijd het canonieke
+    // topologie-artifact zonder verbindingssuffix. preferredConnection is
+    // een runtimevoorkeur en geen buildvariant.
+    if (hardware === "heatpump_controller_q") {
+      const artifactName = `openquatt-heatpump-controller-q-${topology}`;
+      return {
+        available: true,
+        artifactName,
+        otaFileName: `${artifactName}.firmware.ota.bin`,
+        manifestFileName: `${artifactName}-ota.manifest.json`,
+        label: `Heatpump Controller Q ${topologyLabel}`,
+      };
+    }
+
     const connection = getFirmwareBuildConnection();
     const hardwareMap = {
       waveshare: {
         slug: "waveshare",
         label: "Waveshare",
-        connections: ["wifi"],
       },
       heatpump_listener: {
         slug: "heatpump-listener",
         label: "Heatpump Listener",
-        connections: ["wifi"],
-      },
-      heatpump_controller_q: {
-        slug: "heatpump-controller-q",
-        label: "Heatpump Controller Q",
-        connections: ["wifi", "eth"],
       },
     };
     const profile = hardwareMap[hardware];
-    if (!profile || (topology !== "single" && topology !== "duo") || !profile.connections.includes(connection)) {
+    if (!profile || connection !== "wifi") {
       return {
         available: false,
         label: "Onbekend target",
@@ -199,13 +215,13 @@ import { render } from "../core/render-scheduler.js";
       };
     }
 
-    const artifactName = `openquatt-${profile.slug}-${topology}-${connection}`;
-    const topologyLabel = topology === "duo" ? "Duo" : "Single";
+    const artifactName = `openquatt-${profile.slug}-${topology}-wifi`;
     return {
       available: true,
       artifactName,
       otaFileName: `${artifactName}.firmware.ota.bin`,
-      label: `${profile.label} ${topologyLabel} ${getFirmwareConnectionLabel(connection)}`,
+      manifestFileName: `${artifactName}-ota.manifest.json`,
+      label: `${profile.label} ${topologyLabel} Wi-Fi`,
     };
   }
 
@@ -215,10 +231,14 @@ import { render } from "../core/render-scheduler.js";
       return null;
     }
     const baseUrl = `https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-${normalizedPrNumber}`;
+    const manifestFileName = target.manifestFileName || `${target.artifactName}-ota.manifest.json`;
+    const manifestUrl = `${baseUrl}/${manifestFileName}`;
     const otaUrl = `${baseUrl}/${target.otaFileName}`;
     return {
       otaUrl,
       md5Url: `${otaUrl}.md5`,
+      manifestUrl,
+      manifestFileName,
       label: `PR ${normalizedPrNumber} · ${target.label}`,
     };
   }
@@ -1319,7 +1339,7 @@ import { render } from "../core/render-scheduler.js";
     const prNumber = getFirmwareTestPrNumber();
     const target = getFirmwareTestTargetModel();
     const urls = getFirmwareTestAssetUrls(prNumber, target);
-    const controlsAvailable = Boolean(target.available && hasEntity("firmwareTestOtaUrl") && hasEntity("firmwareTestOtaMd5Url") && hasEntity("installFirmwareTestOta"));
+    const controlsAvailable = Boolean(target.available && hasEntity("firmwareTestManifestUrl") && hasEntity("installFirmwareTestManifest"));
     const ready = Boolean(prNumber && controlsAvailable);
     const build = state.updateTestFirmwareBuild || null;
     const targetLabel = target.available ? target.label : target.error;

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -142,6 +142,7 @@ test("PR firmware starts with one complete render before the first device write"
     hardwareProfileText: { state: "heatpump_controller_q" },
     installationTopology: { state: "duo" },
     connectionText: { state: "wifi" },
+    preferredConnection: { state: "Automatic", value: "Automatic", option: ["Automatic", "WiFi", "Ethernet"] },
     installFirmwareTestManifest: { state: "" },
     firmwareTestManifestUrl: { state: "" },
   };

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -85,14 +85,18 @@ function setPrToDevState() {
 test("PR firmware uses deterministic release URLs without the GitHub REST API", () => {
   const target = {
     available: true,
-    label: "Heatpump Controller Q Duo Wi-Fi",
-    otaFileName: "openquatt-heatpump-controller-q-duo-wifi.firmware.ota.bin",
+    label: "Heatpump Controller Q Duo",
+    artifactName: "openquatt-heatpump-controller-q-duo",
+    otaFileName: "openquatt-heatpump-controller-q-duo.firmware.ota.bin",
+    manifestFileName: "openquatt-heatpump-controller-q-duo-ota.manifest.json",
   };
 
   assert.deepEqual(getFirmwareTestAssetUrls(395, target), {
-    otaUrl: "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-395/openquatt-heatpump-controller-q-duo-wifi.firmware.ota.bin",
-    md5Url: "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-395/openquatt-heatpump-controller-q-duo-wifi.firmware.ota.bin.md5",
-    label: "PR 395 · Heatpump Controller Q Duo Wi-Fi",
+    otaUrl: "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-395/openquatt-heatpump-controller-q-duo.firmware.ota.bin",
+    md5Url: "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-395/openquatt-heatpump-controller-q-duo.firmware.ota.bin.md5",
+    manifestUrl: "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-395/openquatt-heatpump-controller-q-duo-ota.manifest.json",
+    manifestFileName: "openquatt-heatpump-controller-q-duo-ota.manifest.json",
+    label: "PR 395 · Heatpump Controller Q Duo",
   });
   assert.equal(getFirmwareTestAssetUrls("395/../../dev-latest", target), null);
 });
@@ -138,9 +142,8 @@ test("PR firmware starts with one complete render before the first device write"
     hardwareProfileText: { state: "heatpump_controller_q" },
     installationTopology: { state: "duo" },
     connectionText: { state: "wifi" },
-    installFirmwareTestOta: { state: "" },
-    firmwareTestOtaUrl: { state: "" },
-    firmwareTestOtaMd5Url: { state: "" },
+    installFirmwareTestManifest: { state: "" },
+    firmwareTestManifestUrl: { state: "" },
   };
   state.updateTestFirmwarePr = "528";
   state.updateTestFirmwareConfirmed = true;
@@ -167,13 +170,13 @@ test("PR firmware starts with one complete render before the first device write"
     {
       type: "render",
       busy: true,
-      build: "PR 528 · Heatpump Controller Q Duo Wi-Fi",
+      build: "PR 528 · Heatpump Controller Q Duo",
     },
     { type: "fetch" },
     {
       type: "render",
       busy: false,
-      build: "PR 528 · Heatpump Controller Q Duo Wi-Fi",
+      build: "PR 528 · Heatpump Controller Q Duo",
     },
   ]);
 });

--- a/openquatt/web/tests/quickstart-setup-update.test.mjs
+++ b/openquatt/web/tests/quickstart-setup-update.test.mjs
@@ -187,9 +187,10 @@ test("de uniforme Q-firmware beheert verbinding los van OTA", () => {
   assert.equal(getFirmwareConnectionSwitchModel(), null);
   assert.deepEqual(getFirmwareTestTargetModel(), {
     available: true,
-    artifactName: "openquatt-heatpump-controller-q-single-wifi",
-    otaFileName: "openquatt-heatpump-controller-q-single-wifi.firmware.ota.bin",
-    label: "Heatpump Controller Q Single Wi-Fi",
+    artifactName: "openquatt-heatpump-controller-q-single",
+    otaFileName: "openquatt-heatpump-controller-q-single.firmware.ota.bin",
+    manifestFileName: "openquatt-heatpump-controller-q-single-ota.manifest.json",
+    label: "Heatpump Controller Q Single",
   });
 
   const topologyModel = getFirmwareBuildSwitchModel("duo", "eth");

--- a/scripts/build_targets.py
+++ b/scripts/build_targets.py
@@ -81,7 +81,7 @@ def artifact_names(target: dict[str, str]) -> list[str]:
 
 def manifest_name_for_artifact(target: dict[str, str], artifact_name: str) -> str:
     if artifact_name == target["artifact_name"]:
-        return target["manifest_name"]
+        return target.get("manifest_name") or f"{artifact_name}-ota.manifest.json"
     return f"{artifact_name}-ota.manifest.json"
 
 
@@ -150,6 +150,35 @@ def find_artifact_dir(
     raise SystemExit(f"Ambiguous artifact directories for {artifact_name}: {names}")
 
 
+def build_ota_manifest(
+    target: dict[str, str],
+    published_name: str,
+    version: str,
+    base_url: str,
+    release_url: str,
+    ota_name: str,
+    ota_md5: str,
+) -> dict:
+    """Build a standard ESPHome OTA manifest with the main/dev schema."""
+    published_display_name = display_name_for_artifact(target, published_name)
+    chip_family = target.get("chip_family") or "ESP32-S3"
+    return {
+        "name": published_display_name,
+        "version": version,
+        "builds": [
+            {
+                "chipFamily": chip_family,
+                "ota": {
+                    "path": f"{base_url}/{ota_name}",
+                    "md5": ota_md5,
+                    "release_url": release_url,
+                    "summary": f"{published_display_name} firmware {version}",
+                },
+            },
+        ],
+    }
+
+
 def prepare_release_assets(version: str, base_url: str, release_url: str) -> None:
     dist_dir = REPO_ROOT / "dist"
     dist_dir.mkdir(parents=True, exist_ok=True)
@@ -172,22 +201,15 @@ def prepare_release_assets(version: str, base_url: str, release_url: str) -> Non
         ota_md5 = md5sum(ota_dest)
 
         for published_name in artifact_names(target):
-            published_display_name = display_name_for_artifact(target, published_name)
-            manifest = {
-                "name": published_display_name,
-                "version": version,
-                "builds": [
-                    {
-                        "chipFamily": target["chip_family"],
-                        "ota": {
-                            "path": f"{base_url}/{ota_name}",
-                            "md5": ota_md5,
-                            "release_url": release_url,
-                            "summary": f"{published_display_name} firmware {version}",
-                        },
-                    },
-                ],
-            }
+            manifest = build_ota_manifest(
+                target,
+                published_name,
+                version,
+                base_url,
+                release_url,
+                ota_name,
+                ota_md5,
+            )
             manifest_path = REPO_ROOT / manifest_name_for_artifact(target, published_name)
             manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
@@ -213,29 +235,46 @@ def prepare_pr_test_assets(
         if ota_source.is_symlink() or not ota_source.is_file():
             raise SystemExit(f"Artifact {artifact_name} is missing firmware.ota.bin")
 
-        for published_name in artifact_names(target):
-            published_display_name = display_name_for_artifact(target, published_name)
-            ota_name = f"{published_name}.firmware.ota.bin"
-            ota_dest = dist_dir / ota_name
-            shutil.copy2(ota_source, ota_dest)
-            digest = md5sum(ota_dest)
-            md5_name = f"{ota_name}.md5"
-            (dist_dir / md5_name).write_text(f"{digest}\n", encoding="utf-8")
+        # Optie A: alleen de canonieke OTA-binary publiceren. Voor uniforme
+        # HCQ betekent dit géén aparte wifi/eth bins meer; compatibiliteit
+        # wordt via manifesten (zelfde schema als main/dev) geboden.
+        ota_name = f"{artifact_name}.firmware.ota.bin"
+        ota_dest = dist_dir / ota_name
+        shutil.copy2(ota_source, ota_dest)
+        digest = md5sum(ota_dest)
+        md5_name = f"{ota_name}.md5"
+        (dist_dir / md5_name).write_text(f"{digest}\n", encoding="utf-8")
 
-            assets.append(
-                {
-                    "target": target["id"],
-                    "hardware": target["hardware"],
-                    "topology": target["topology"],
-                    "connection": connection_for_artifact(target, published_name),
-                    "display_name": published_display_name,
-                    "ota_file": ota_name,
-                    "ota_url": f"{base_url}/{ota_name}",
-                    "md5_file": md5_name,
-                    "md5_url": f"{base_url}/{md5_name}",
-                    "md5": digest,
-                }
+        for published_name in artifact_names(target):
+            manifest = build_ota_manifest(
+                target,
+                published_name,
+                version,
+                base_url,
+                release_url,
+                ota_name,
+                digest,
             )
+            manifest_name = manifest_name_for_artifact(target, published_name)
+            (dist_dir / manifest_name).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+        published_display_name = display_name_for_artifact(target, artifact_name)
+        assets.append(
+            {
+                "target": target["id"],
+                "hardware": target["hardware"],
+                "topology": target["topology"],
+                "connection": target["connection"],
+                "display_name": published_display_name,
+                "ota_file": ota_name,
+                "ota_url": f"{base_url}/{ota_name}",
+                "md5_file": md5_name,
+                "md5_url": f"{base_url}/{md5_name}",
+                "md5": digest,
+                "manifest_file": manifest_name_for_artifact(target, artifact_name),
+                "manifest_url": f"{base_url}/{manifest_name_for_artifact(target, artifact_name)}",
+            }
+        )
 
     catalog = {
         "pr": str(pr_number),

--- a/scripts/build_targets.py
+++ b/scripts/build_targets.py
@@ -235,9 +235,9 @@ def prepare_pr_test_assets(
         if ota_source.is_symlink() or not ota_source.is_file():
             raise SystemExit(f"Artifact {artifact_name} is missing firmware.ota.bin")
 
-        # Optie A: alleen de canonieke OTA-binary publiceren. Voor uniforme
-        # HCQ betekent dit géén aparte wifi/eth bins meer; compatibiliteit
-        # wordt via manifesten (zelfde schema als main/dev) geboden.
+        # Eén keer canoniek bouwen; voor legacy-firmware zonder
+        # manifest-capability ook wifi/eth copies met MD5 publiceren.
+        # Alle manifesten (canoniek + alias) wijzen naar de canonieke binary.
         ota_name = f"{artifact_name}.firmware.ota.bin"
         ota_dest = dist_dir / ota_name
         shutil.copy2(ota_source, ota_dest)
@@ -258,23 +258,32 @@ def prepare_pr_test_assets(
             manifest_name = manifest_name_for_artifact(target, published_name)
             (dist_dir / manifest_name).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
-        published_display_name = display_name_for_artifact(target, artifact_name)
-        assets.append(
-            {
-                "target": target["id"],
-                "hardware": target["hardware"],
-                "topology": target["topology"],
-                "connection": target["connection"],
-                "display_name": published_display_name,
-                "ota_file": ota_name,
-                "ota_url": f"{base_url}/{ota_name}",
-                "md5_file": md5_name,
-                "md5_url": f"{base_url}/{md5_name}",
-                "md5": digest,
-                "manifest_file": manifest_name_for_artifact(target, artifact_name),
-                "manifest_url": f"{base_url}/{manifest_name_for_artifact(target, artifact_name)}",
-            }
-        )
+            if published_name != artifact_name:
+                alias_ota_name = f"{published_name}.firmware.ota.bin"
+                shutil.copy2(ota_dest, dist_dir / alias_ota_name)
+                (dist_dir / f"{alias_ota_name}.md5").write_text(f"{digest}\n", encoding="utf-8")
+
+            published_display_name = display_name_for_artifact(target, published_name)
+            alias_ota_file = (
+                ota_name if published_name == artifact_name
+                else f"{published_name}.firmware.ota.bin"
+            )
+            assets.append(
+                {
+                    "target": target["id"],
+                    "hardware": target["hardware"],
+                    "topology": target["topology"],
+                    "connection": connection_for_artifact(target, published_name),
+                    "display_name": published_display_name,
+                    "ota_file": alias_ota_file,
+                    "ota_url": f"{base_url}/{alias_ota_file}",
+                    "md5_file": f"{alias_ota_file}.md5",
+                    "md5_url": f"{base_url}/{alias_ota_file}.md5",
+                    "md5": digest,
+                    "manifest_file": manifest_name_for_artifact(target, published_name),
+                    "manifest_url": f"{base_url}/{manifest_name_for_artifact(target, published_name)}",
+                }
+            )
 
     catalog = {
         "pr": str(pr_number),

--- a/scripts/tests/test_pr_manifest_install_contract.py
+++ b/scripts/tests/test_pr_manifest_install_contract.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMON_PACKAGE = (ROOT / "openquatt" / "oq_common.yaml").read_text()
+WEB_UPDATE = (ROOT / "openquatt" / "web" / "js" / "src" / "features" / "firmware-update.js").read_text()
+WEB_ACTIONS = (ROOT / "openquatt" / "web" / "js" / "src" / "features" / "firmware-actions.js").read_text()
+
+
+def _script_block(script_id: str) -> str:
+    start = COMMON_PACKAGE.index(f"  - id: {script_id}\n")
+    end = COMMON_PACKAGE.index("\n  - id:", start + 1)
+    return COMMON_PACKAGE[start:end]
+
+
+class PrManifestInstallContractTest(unittest.TestCase):
+    def test_manifest_button_validates_exact_pr_manifest(self) -> None:
+        self.assertIn("id: oq_install_firmware_test_manifest", COMMON_PACKAGE)
+        self.assertIn('name: "Install Firmware Test Manifest"', COMMON_PACKAGE)
+        self.assertIn(
+            "https://github.com/OpenQuatt/OpenQuatt/releases/download/pr-",
+            COMMON_PACKAGE,
+        )
+        # Canonical HCQ manifest without connection suffix via substitution.
+        self.assertIn(
+            'artifact_base + "${oq_artifact_connection_suffix}-ota.manifest.json"',
+            COMMON_PACKAGE,
+        )
+        # PR number 1-6 digits, no leading zero, exact manifest filename.
+        self.assertIn("pr.size() <= 6", COMMON_PACKAGE)
+        self.assertIn('pr[0] == \'0\'', COMMON_PACKAGE)
+        self.assertIn("file == expected_manifest", COMMON_PACKAGE)
+
+    def test_manifest_install_rejects_stale_checks_with_exact_url(self) -> None:
+        install_script = _script_block("oq_install_firmware_test_manifest_deferred")
+
+        # Claims install early so periodic main/dev checks cannot overwrite source.
+        self.assertLess(
+            install_script.index("id(oq_firmware_target_install_active) = true;"),
+            install_script.index("- update.check:"),
+        )
+        # Exact firmware URL derived from manifest, not generic suffix match.
+        self.assertIn("expected_firmware_url", install_script)
+        self.assertIn("actual_firmware_url", install_script)
+        self.assertIn(
+            "id(oq_firmware_update).update_info.firmware_url",
+            install_script,
+        )
+        self.assertIn("stale", install_script)
+        # Source re-asserted before retry and before perform.
+        self.assertGreaterEqual(
+            install_script.count('id(oq_firmware_update).set_source_url(url.c_str());'),
+            3,
+        )
+        self.assertIn("- update.perform:\n                id: oq_firmware_update", install_script)
+        self.assertIn("force_update: true", install_script)
+        self.assertLess(
+            install_script.index("- update.check:"),
+            install_script.index("- update.perform:"),
+        )
+
+    def test_webapp_uniform_selection_uses_preferred_connection(self) -> None:
+        self.assertIn(
+            'hardware === "heatpump_controller_q" && hasEntity("preferredConnection")',
+            WEB_UPDATE,
+        )
+        self.assertIn("hasFirmwareTestManifestCapability", WEB_UPDATE)
+        self.assertIn("hasFirmwareTestLegacyCapability", WEB_UPDATE)
+
+    def test_webapp_keeps_legacy_fallback(self) -> None:
+        self.assertIn("useLegacy", WEB_ACTIONS)
+        self.assertIn('setFirmwareTestTextEntity("firmwareTestOtaUrl"', WEB_ACTIONS)
+        self.assertIn('setFirmwareTestTextEntity("firmwareTestManifestUrl"', WEB_ACTIONS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_pr_manifest_install_contract.py
+++ b/scripts/tests/test_pr_manifest_install_contract.py
@@ -61,6 +61,25 @@ class PrManifestInstallContractTest(unittest.TestCase):
             install_script.index("- update.perform:"),
         )
 
+    def test_failed_pre_perform_check_resumes_runtime_polling(self) -> None:
+        install_script = _script_block("oq_install_firmware_test_manifest_deferred")
+        pause_index = install_script.index(
+            "Runtime polling paused before deferred PR test OTA."
+        )
+        resume_index = install_script.index(
+            "PR test install blocked before OTA start; runtime polling resumed."
+        )
+        self.assertLess(pause_index, resume_index)
+        tail = install_script[resume_index:]
+        self.assertIn(
+            "id(oq_runtime_polling_paused).publish_state(false);",
+            tail,
+        )
+        self.assertIn(
+            "id(oq_firmware_target_install_active) = false;",
+            tail,
+        )
+
     def test_update_lifecycle_is_exclusive_during_install(self) -> None:
         self.assertIn(
             "Firmware source change ignored during active install.",
@@ -75,7 +94,7 @@ class PrManifestInstallContractTest(unittest.TestCase):
             COMMON_PACKAGE,
         )
         self.assertIn(
-            "firmware info no longer matches this PR",
+            "PR test install blocked before OTA start; runtime polling resumed.",
             COMMON_PACKAGE,
         )
 

--- a/scripts/tests/test_pr_manifest_install_contract.py
+++ b/scripts/tests/test_pr_manifest_install_contract.py
@@ -53,11 +53,30 @@ class PrManifestInstallContractTest(unittest.TestCase):
             install_script.count('id(oq_firmware_update).set_source_url(url.c_str());'),
             3,
         )
-        self.assertIn("- update.perform:\n                id: oq_firmware_update", install_script)
+        self.assertIn("- update.perform:", install_script)
+        self.assertIn("id: oq_firmware_update", install_script)
         self.assertIn("force_update: true", install_script)
         self.assertLess(
             install_script.index("- update.check:"),
             install_script.index("- update.perform:"),
+        )
+
+    def test_update_lifecycle_is_exclusive_during_install(self) -> None:
+        self.assertIn(
+            "Firmware source change ignored during active install.",
+            COMMON_PACKAGE,
+        )
+        self.assertIn(
+            "Firmware update check skipped: install active.",
+            COMMON_PACKAGE,
+        )
+        self.assertIn(
+            "Firmware update check ignored because an install is active.",
+            COMMON_PACKAGE,
+        )
+        self.assertIn(
+            "firmware info no longer matches this PR",
+            COMMON_PACKAGE,
         )
 
     def test_webapp_uniform_selection_uses_preferred_connection(self) -> None:

--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -300,10 +300,17 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
             catalog = json.loads(
                 (repo_root / "dist/pr-firmware.json").read_text(encoding="utf-8")
             )
-            # Optie A: één canoniek asset, géén wifi/eth bins meer.
-            self.assertEqual(1, len(catalog["assets"]))
-            self.assertEqual("auto", catalog["assets"][0]["connection"])
-            self.assertEqual("Test target", catalog["assets"][0]["display_name"])
+            # Legacy-firmware zonder manifest-capability gebruikt de
+            # verbindingsspecifieke bins; daarom bestaan de alias-copies
+            # naast de canonieke binary.
+            self.assertEqual(
+                ["auto", "wifi", "eth"],
+                [asset["connection"] for asset in catalog["assets"]],
+            )
+            self.assertEqual(
+                ["Test target", "Test target Wi-Fi", "Test target Ethernet"],
+                [asset["display_name"] for asset in catalog["assets"]],
+            )
             self.assertEqual(
                 "openquatt-test.firmware.ota.bin",
                 catalog["assets"][0]["ota_file"],
@@ -313,7 +320,11 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
                 catalog["assets"][0]["manifest_file"],
             )
             for alias in ("openquatt-test-wifi", "openquatt-test-eth"):
-                self.assertFalse((repo_root / f"dist/{alias}.firmware.ota.bin").exists())
+                self.assertEqual(
+                    b"ota-firmware",
+                    (repo_root / f"dist/{alias}.firmware.ota.bin").read_bytes(),
+                )
+                self.assertTrue((repo_root / f"dist/{alias}.firmware.ota.bin.md5").is_file())
 
             manifests = {
                 name: json.loads((repo_root / f"dist/{name}").read_text(encoding="utf-8"))

--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -106,13 +106,14 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
 
         self.assertEqual(Path("/tmp/firmware"), args.artifact_root)
 
-    def test_unified_q_uploads_trusted_publisher_compatibility_artifacts(self) -> None:
-        self.assertIn("Upload WiFi compatibility OTA artifact", REUSABLE_BUILD_WORKFLOW)
-        self.assertIn("Upload Ethernet compatibility OTA artifact", REUSABLE_BUILD_WORKFLOW)
+    def test_unified_q_has_no_compatibility_artifact_uploads(self) -> None:
+        self.assertNotIn("Upload WiFi compatibility OTA artifact", REUSABLE_BUILD_WORKFLOW)
+        self.assertNotIn("Upload Ethernet compatibility OTA artifact", REUSABLE_BUILD_WORKFLOW)
         self.assertEqual(
-            2,
+            0,
             REUSABLE_BUILD_WORKFLOW.count("matrix.target.connection == 'auto'"),
         )
+        self.assertIn("dist/*-ota.manifest.json", PUBLISH_WORKFLOW)
 
     def test_symlinked_artifact_directory_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -181,6 +182,12 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
             self.assertEqual(b"firmware", (repo_root / "dist/openquatt-test.firmware.ota.bin").read_bytes())
             self.assertTrue((repo_root / "dist/openquatt-test.firmware.ota.bin.md5").is_file())
             self.assertTrue((repo_root / "dist/pr-firmware.json").is_file())
+            manifest = json.loads((repo_root / "dist/openquatt-test-ota.manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual("v1.2.3-pr.423.1+1234567", manifest["version"])
+            self.assertEqual(
+                "https://example.invalid/download/openquatt-test.firmware.ota.bin",
+                manifest["builds"][0]["ota"]["path"],
+            )
 
     def test_release_aliases_get_compatibility_manifests_without_duplicate_binaries(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -255,7 +262,7 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
                     manifests[f"{alias}-ota.manifest.json"]["name"],
                 )
 
-    def test_pr_aliases_keep_legacy_connection_catalog_entries(self) -> None:
+    def test_pr_aliases_publish_canonical_bin_with_compatibility_manifests(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)
             artifact_dir = repo_root / "dist/openquatt-test"
@@ -268,6 +275,8 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
     status: enabled
     artifact_name: openquatt-test
     artifact_aliases: openquatt-test-wifi,openquatt-test-eth
+    manifest_name: openquatt-test-ota.manifest.json
+    chip_family: ESP32-S3
     hardware: heatpump_controller_q
     topology: duo
     connection: auto
@@ -291,19 +300,33 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
             catalog = json.loads(
                 (repo_root / "dist/pr-firmware.json").read_text(encoding="utf-8")
             )
+            # Optie A: één canoniek asset, géén wifi/eth bins meer.
+            self.assertEqual(1, len(catalog["assets"]))
+            self.assertEqual("auto", catalog["assets"][0]["connection"])
+            self.assertEqual("Test target", catalog["assets"][0]["display_name"])
             self.assertEqual(
-                ["auto", "wifi", "eth"],
-                [asset["connection"] for asset in catalog["assets"]],
+                "openquatt-test.firmware.ota.bin",
+                catalog["assets"][0]["ota_file"],
             )
             self.assertEqual(
-                ["Test target", "Test target Wi-Fi", "Test target Ethernet"],
-                [asset["display_name"] for asset in catalog["assets"]],
+                "openquatt-test-ota.manifest.json",
+                catalog["assets"][0]["manifest_file"],
             )
             for alias in ("openquatt-test-wifi", "openquatt-test-eth"):
-                self.assertEqual(
-                    b"ota-firmware",
-                    (repo_root / f"dist/{alias}.firmware.ota.bin").read_bytes(),
+                self.assertFalse((repo_root / f"dist/{alias}.firmware.ota.bin").exists())
+
+            manifests = {
+                name: json.loads((repo_root / f"dist/{name}").read_text(encoding="utf-8"))
+                for name in (
+                    "openquatt-test-ota.manifest.json",
+                    "openquatt-test-wifi-ota.manifest.json",
+                    "openquatt-test-eth-ota.manifest.json",
                 )
+            }
+            expected_ota_path = "https://example.invalid/download/openquatt-test.firmware.ota.bin"
+            for manifest in manifests.values():
+                self.assertEqual("v1.2.3-pr.476.1+1234567", manifest["version"])
+                self.assertEqual(expected_ota_path, manifest["builds"][0]["ota"]["path"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Wat verandert deze PR?

- PR-testfirmware gebruikt per target een standaard OTA-manifest met hetzelfde schema als main/dev; HCQ gebruikt het canonieke topologie-manifest zonder `-wifi`/`-eth` suffix.
- Testfirmware-UI toont voor uniforme HCQ alleen `Heatpump Controller Q Single/Duo` en het canonieke OTA-bestand; device valideert de PR-manifest-URL fail-closed en installeert via de bewaakte `update.check → update.perform`-lifecycle.
- HCQ wordt een keer canoniek gebouwd; de packager publiceert daarnaast wifi/eth copies met MD5 voor legacy-firmware zonder manifest-ondersteuning. Alle manifesten wijzen naar de canonieke binary.
- Update-lifecycle is exclusief tijdens installatie: channel/target-callbacks en handmatige checks wijzigen geen source en starten geen check zolang `oq_firmware_target_install_active` true is; vlak voor `update.perform` volgt een laatste exact-URL-check.
- 
<img width="743" height="334" alt="image" src="https://github.com/user-attachments/assets/ace4eae4-8122-473f-beb8-fed123a25545" />


## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Nieuwe entities `Firmware Test Manifest URL` + `Install Firmware Test Manifest` als voorkeursroute; bestaande OTA-URL/MD5-route blijft als fallback voor firmware zonder manifest-bediening. Installatie hergebruikt bestaande update-lifecycle.

## Achtergrond

Fixes #607. Uniforme HCQ herkenbaar aan `preferredConnection` (runtimevoorkeur, geen buildvariant); oudere HCQ zonder `preferredConnection` gebruikt het verbindingsspecifieke artifact via de fallback. PR-release wordt opgebouwd als `dev-latest` met gedeelde manifesthelper in `scripts/build_targets.py`. `pr-firmware.json` blijft diagnose-index met canoniek asset + manifest-URL. Staging: #618 (publisher, naar `main`) eerst, daarna deze PR naar `dev`.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

`docs/handmatige-installatie.md` beschrijft al canonieke Q Single/Duo binaries zonder aparte Wi-Fi/Ethernet binaries; PR-testflow is interne testfunctionaliteit zonder gebruikershandleiding.

## Validatie

- `python3 -m unittest discover -s scripts/tests -p "test_*.py"` → 205 tests OK
- `node openquatt/web/run-web-tests.mjs` → 327 tests OK
- `npm run build:web` + `npm run check:web` → OK

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen een extra interne tekst-entity (255 chars) en een deferred install-script dat de bestaande update-lifecycle hergebruikt; geen grote buffers of nieuwe taken.
