### PR TITLE
Publish PR manifests when present

### DIFF
--- a/.github/workflows/pr-test-firmware-publish.yml
+++ b/.github/workflows/pr-test-firmware-publish.yml
@@ -261,14 +261,23 @@ jobs:
             --notes "${NOTES}" \
             --prerelease
 
+          # Backward-compatible: oudere builds genereren nog geen manifesten.
+          # Upload ze alleen indien aanwezig, zodat deze publisher zowel op
+          # main (oude generator) als op dev (nieuwe generator) werkt.
+          MANIFEST_ARGS=()
+          if compgen -G "dist/*-ota.manifest.json" > /dev/null; then
+            MANIFEST_ARGS=(dist/*-ota.manifest.json)
+          fi
+
           gh release upload "${TAG}" \
             dist/*.firmware.ota.bin \
             dist/*.firmware.ota.bin.md5 \
+            "${MANIFEST_ARGS[@]}" \
             dist/pr-firmware.json \
             --clobber
 
           EXPECTED_ASSET_COUNT="$(find dist -maxdepth 1 -type f \
-            \( -name '*.firmware.ota.bin' -o -name '*.firmware.ota.bin.md5' -o -name 'pr-firmware.json' \) \
+            \( -name '*.firmware.ota.bin' -o -name '*.firmware.ota.bin.md5' -o -name '*-ota.manifest.json' -o -name 'pr-firmware.json' \) \
             | wc -l | tr -d ' ')"
           PUBLISHED_ASSET_COUNT="$(gh release view "${TAG}" --json assets --jq '.assets | length')"
           if [[ "${PUBLISHED_ASSET_COUNT}" != "${EXPECTED_ASSET_COUNT}" ]]; then


### PR DESCRIPTION
# Wat verandert deze PR?

- `pr-test-firmware-publish.yml` uploadt `dist/*-ota.manifest.json` indien aanwezig, zodat oude builds zonder manifesten blijven werken en nieuwe builds met manifesten worden gepubliceerd.
- Staging voor #607 / #616: deze publisher moet eerst op `main` staan omdat `workflow_run` met de default branch draait; daarna pas kan de dev-generator (#616) manifesten aanleveren zonder 404.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen CI-publicatie; `find`-telling telt manifesten mee indien aanwezig.

## Achtergrond

Review op #616 blocker 1: na merge naar `dev` zou de actieve publisher op `main` manifesten laten liggen (404 op elke manifest-URL). Eerst deze backward-compatibele publisher naar `main`, daarna #616 naar `dev`.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

CI-only; geen gebruikersgerichte functionaliteit.

## Validatie

- `bash -n .github/workflows/pr-test-firmware-publish.yml` (YAML bevat shell; visueel gecontroleerd op lege-array-expansie)
- Bestaande `scripts/tests/test_pr_test_firmware_workflows.py` dekt manifestgeneratie; publisher-telling via `find` werkt met en zonder manifesten.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen firmwarewijziging.