### PR TITLE
Move crash telemetry MQTT lifecycle off the main loop

### DIFF
--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
@@ -398,7 +398,7 @@ void OpenQuattCrashTelemetry::on_setup_complete_(bool complete) {
   this->setup_complete_.store(complete);
   this->unlock_gate_();
   if (complete && this->consent_enabled_.load() && this->record_ && this->record_.data()->pending != 0U) {
-    this->next_attempt_ms_ = millis() + INITIAL_PUBLISH_DELAY_MS;
+    this->next_attempt_ms_ = millis() + CRASH_INITIAL_PUBLISH_DELAY_MS;
   }
 }
 
@@ -450,7 +450,7 @@ void OpenQuattCrashTelemetry::on_consent_state_(bool enabled) {
   }
 
   if (this->setup_complete_.load() && this->record_ && this->record_.data()->pending != 0U) {
-    this->next_attempt_ms_ = millis() + INITIAL_PUBLISH_DELAY_MS;
+    this->next_attempt_ms_ = millis() + CRASH_INITIAL_PUBLISH_DELAY_MS;
   }
 }
 

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
@@ -7,6 +7,7 @@
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
+#include <freertos/task.h>
 
 #include "OpenQuattCrashTelemetryPolicy.h"
 #include "OpenQuattCrashTelemetryRecord.h"
@@ -18,6 +19,7 @@
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
+#include "esphome/core/static_task.h"
 #include "esp_partition.h"
 #include "mqtt_client.h"
 
@@ -63,9 +65,26 @@ class OpenQuattCrashTelemetry : public Component {
   static constexpr size_t CRASH_PAYLOAD_CAPACITY = 4096U;
   static constexpr uint32_t SESSION_TIMEOUT_MS = 30000UL;
   static constexpr uint32_t INITIAL_RETRY_MS = 5UL * 60UL * 1000UL;
-  static constexpr uint32_t INITIAL_PUBLISH_DELAY_MS = 15000UL;
   static constexpr uint32_t TIME_SYNC_WAIT_MS = 60000UL;
+  static constexpr uint32_t WORKER_STALL_LOG_MS = 30UL * 1000UL;
+  static constexpr uint32_t WORKER_CLEANUP_RETRY_MS = 1000UL;
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+  // PSRAM-backed worker stack, mirroring usage telemetry. Sizes stay
+  // conservative until HIL watermarks prove they can shrink.
+  static constexpr uint32_t MQTT_WORKER_TASK_STACK_SIZE = 16384U;
+  static constexpr bool MQTT_WORKER_STACK_IN_PSRAM = true;
+#else
+  // Classic ESP32 cannot safely run Wi-Fi/ROM-using tasks from a PSRAM stack.
+  static constexpr uint32_t MQTT_WORKER_TASK_STACK_SIZE = 8192U;
+  static constexpr bool MQTT_WORKER_STACK_IN_PSRAM = false;
+#endif
   static constexpr int MQTT_TASK_STACK_SIZE = 12288;
+  static_assert(sizeof(StackType_t) == 1U, "ESP-IDF StaticTask stack sizes are configured in bytes");
+
+  enum class WorkerCommand : uint32_t {
+    START = 1U,
+    CLEANUP = 2U,
+  };
 
   using CrashRecord = detail::CrashRecord;
 
@@ -97,9 +116,15 @@ class OpenQuattCrashTelemetry : public Component {
   bool save_state_();
   bool build_topic_();
   bool build_crash_payload_();
-  bool start_session_(CrashPublishKind kind);
-  void complete_session_(bool succeeded);
-  bool stop_client_();
+  void start_publish_session_(CrashPublishKind kind);
+  bool ensure_worker_task_();
+  bool notify_worker_(WorkerCommand command);
+  bool start_client_();
+  bool cleanup_client_();
+  void request_session_finish_(bool publication_succeeded);
+  void finalize_session_();
+  static bool time_reached_(uint32_t now_ms, uint32_t target_ms);
+  static void worker_task_(void* arg);
   void schedule_retry_();
   void schedule_immediate_();
   bool lock_gate_() const;
@@ -139,6 +164,19 @@ class OpenQuattCrashTelemetry : public Component {
   ESPPreferenceObject state_pref_{};
   const esp_partition_t* flash_partition_{nullptr};
   int8_t active_record_slot_{-1};
+  StaticTask worker_task_state_{};
+  bool worker_task_region_valid_{false};
+  std::atomic<bool> start_task_running_{false};
+  std::atomic<bool> start_task_complete_{false};
+  std::atomic<bool> finishing_session_{false};
+  std::atomic<bool> cleanup_task_complete_{false};
+  std::atomic<bool> mqtt_connected_seen_{false};
+  std::atomic<bool> mqtt_disconnected_seen_{false};
+  bool publication_result_succeeded_{false};
+  bool cleanup_disconnect_requested_{false};
+  uint8_t cleanup_stop_failures_{0U};
+  uint32_t worker_operation_started_ms_{0U};
+  bool worker_stall_logged_{false};
   openquatt_common::PsramBuffer<CrashRecord> record_{};
   openquatt_common::PsramBuffer<StateStorage> state_{};
   openquatt_common::PsramBuffer<char> topic_buffer_{};
@@ -155,7 +193,6 @@ class OpenQuattCrashTelemetry : public Component {
   uint32_t next_attempt_ms_{0U};
   uint32_t time_sync_deadline_ms_{0U};
   uint32_t session_started_ms_{0U};
-  uint8_t cleanup_attempts_{0U};
 
   esp_mqtt_client_handle_t mqtt_client_{nullptr};
   bool mqtt_client_started_{false};

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
@@ -2,10 +2,12 @@
 #include "OpenQuattCrashTelemetryHelpers.h"
 
 #include "esp_crt_bundle.h"
+#include "esp_memory_utils.h"
 #include "esphome/components/network/util.h"
 #include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include <freertos/task.h>
 
 namespace esphome::openquatt_crash_telemetry {
 namespace {
@@ -124,15 +126,104 @@ bool OpenQuattCrashTelemetry::build_crash_payload_() {
   return true;
 }
 
-bool OpenQuattCrashTelemetry::start_session_(CrashPublishKind kind) {
-  if (kind == CrashPublishKind::NONE || this->session_active_.load() || !this->build_topic_()) return false;
+void OpenQuattCrashTelemetry::start_publish_session_(CrashPublishKind kind) {
+  // Main-loop only: bounded preparation, then hand off to the worker. The
+  // loopTask must never run esp_mqtt_client_init/start/stop/destroy itself.
+  if (kind == CrashPublishKind::NONE || this->session_active_.load() || this->finishing_session_.load()) {
+    return;
+  }
+  if (!this->build_topic_()) {
+    this->schedule_retry_();
+    return;
+  }
   if (kind == CrashPublishKind::CRASH && !this->build_crash_payload_()) {
     this->topic_buffer_.release();
-    return false;
+    this->schedule_retry_();
+    return;
   }
   if (kind == CrashPublishKind::TOMBSTONE) {
     this->payload_buffer_.release();
     this->payload_size_ = 0U;
+  }
+  if (!this->ensure_worker_task_()) {
+    this->topic_buffer_.release();
+    this->payload_buffer_.release();
+    this->payload_size_ = 0U;
+    this->schedule_retry_();
+    return;
+  }
+
+  this->session_succeeded_.store(false);
+  this->session_failed_.store(false);
+  this->pending_message_id_.store(-1);
+  this->active_kind_.store(kind);
+  this->start_task_running_.store(true);
+  this->start_task_complete_.store(false);
+  this->finishing_session_.store(false);
+  this->cleanup_task_complete_.store(false);
+  this->mqtt_connected_seen_.store(false);
+  this->mqtt_disconnected_seen_.store(false);
+  this->publication_result_succeeded_ = false;
+  this->cleanup_disconnect_requested_ = false;
+  this->cleanup_stop_failures_ = 0U;
+  this->session_started_ms_ = millis();
+  this->worker_operation_started_ms_ = millis();
+  this->worker_stall_logged_ = false;
+  this->session_active_.store(true);
+
+  if (!this->notify_worker_(WorkerCommand::START)) {
+    // No client was started: reset state directly, never touch MQTT handles
+    // from the main loop.
+    this->session_active_.store(false);
+    this->start_task_running_.store(false);
+    this->active_kind_.store(CrashPublishKind::NONE);
+    this->topic_buffer_.release();
+    this->payload_buffer_.release();
+    this->payload_size_ = 0U;
+    this->schedule_retry_();
+    ESP_LOGE(TAG, "Failed to notify crash telemetry MQTT worker");
+  }
+}
+
+bool OpenQuattCrashTelemetry::ensure_worker_task_() {
+  if (this->worker_task_state_.is_created()) {
+    return this->worker_task_region_valid_;
+  }
+  this->worker_task_region_valid_ = false;
+  if (!this->worker_task_state_.create(&OpenQuattCrashTelemetry::worker_task_, "oq_crash_mqtt",
+                                       MQTT_WORKER_TASK_STACK_SIZE, this, 4, MQTT_WORKER_STACK_IN_PSRAM)) {
+    ESP_LOGE(TAG, "Failed to create %u-byte crash telemetry worker in %s",
+             static_cast<unsigned>(MQTT_WORKER_TASK_STACK_SIZE), MQTT_WORKER_STACK_IN_PSRAM ? "PSRAM" : "internal RAM");
+    return false;
+  }
+
+  const bool stack_is_external = esp_ptr_external_ram(pxTaskGetStackStart(this->worker_task_state_.get_handle()));
+  if (stack_is_external != MQTT_WORKER_STACK_IN_PSRAM) {
+    ESP_LOGE(TAG, "Crash telemetry worker stack was allocated in the wrong memory region; worker remains parked");
+    // StaticTask owns a static stack. It must not free that stack while the
+    // freshly created task may still be entering its notification wait on the
+    // other core. Treat this impossible allocator-contract violation as a
+    // permanent telemetry failure and leave the parked task intact.
+    this->mark_failed();
+    return false;
+  }
+  this->worker_task_region_valid_ = true;
+  ESP_LOGD(TAG, "Crash telemetry worker stack: %u bytes in %s", static_cast<unsigned>(MQTT_WORKER_TASK_STACK_SIZE),
+           stack_is_external ? "PSRAM" : "internal RAM");
+  return true;
+}
+
+bool OpenQuattCrashTelemetry::notify_worker_(WorkerCommand command) {
+  const TaskHandle_t handle = this->worker_task_state_.get_handle();
+  if (handle == nullptr) return false;
+  return xTaskNotify(handle, static_cast<uint32_t>(command), eSetValueWithOverwrite) == pdPASS;
+}
+
+bool OpenQuattCrashTelemetry::start_client_() {
+  // Worker only. Payload and topic were built by the main loop beforehand.
+  if (!this->session_active_.load() || this->active_kind_.load() == CrashPublishKind::NONE ||
+      this->mqtt_client_ != nullptr) {
+    return false;
   }
 
   this->client_id_ = this->state_.data()->installation_id;
@@ -154,70 +245,161 @@ bool OpenQuattCrashTelemetry::start_session_(CrashPublishKind kind) {
   if (!this->username_.empty()) config.credentials.username = this->username_.c_str();
   if (!this->password_.empty()) config.credentials.authentication.password = this->password_.c_str();
 
-  this->session_succeeded_.store(false);
-  this->session_failed_.store(false);
-  this->pending_message_id_.store(-1);
-  this->active_kind_.store(kind);
-  this->cleanup_attempts_ = 0U;
-  this->session_started_ms_ = millis();
-  this->session_active_.store(true);
-
   this->mqtt_client_ = esp_mqtt_client_init(&config);
   if (this->mqtt_client_ == nullptr) {
-    this->session_active_.store(false);
-    this->active_kind_.store(CrashPublishKind::NONE);
     return false;
   }
+  // On partial initialization the handle is kept for the central worker
+  // cleanup; never destroy from multiple places.
   esp_err_t error = esp_mqtt_client_register_event(this->mqtt_client_, MQTT_EVENT_ANY, mqtt_event_handler_, this);
-  if (error == ESP_OK) error = esp_mqtt_client_start(this->mqtt_client_);
+  if (error == ESP_OK) {
+    error = esp_mqtt_client_start(this->mqtt_client_);
+  }
   if (error != ESP_OK) {
     ESP_LOGW(TAG, "Could not start crash MQTT client: %s", esp_err_to_name(error));
-    esp_mqtt_client_destroy(this->mqtt_client_);
-    this->mqtt_client_ = nullptr;
-    this->session_active_.store(false);
-    this->active_kind_.store(CrashPublishKind::NONE);
     return false;
   }
   this->mqtt_client_started_ = true;
-  ESP_LOGD(TAG, "Started %s publication", kind == CrashPublishKind::CRASH ? "crash" : "retained tombstone");
+  ESP_LOGD(TAG, "Started %s publication",
+           this->active_kind_.load() == CrashPublishKind::CRASH ? "crash" : "retained tombstone");
   return true;
 }
 
-bool OpenQuattCrashTelemetry::stop_client_() {
-  if (this->mqtt_client_ == nullptr) return true;
-  if (this->mqtt_client_started_) {
-    const esp_err_t stop_error = esp_mqtt_client_stop(this->mqtt_client_);
-    if (stop_error != ESP_OK) {
-      ++this->cleanup_attempts_;
-      if (this->cleanup_attempts_ == 1U) esp_mqtt_client_disconnect(this->mqtt_client_);
-      if (this->cleanup_attempts_ < 3U) return false;
-      ESP_LOGW(TAG, "Crash MQTT stop did not confirm; releasing the one-shot client");
+void OpenQuattCrashTelemetry::worker_task_(void* arg) {
+  auto* self = static_cast<OpenQuattCrashTelemetry*>(arg);
+  if (self == nullptr) {
+    while (true) {
+      vTaskSuspend(nullptr);
     }
   }
-  const esp_err_t destroy_error = esp_mqtt_client_destroy(this->mqtt_client_);
-  if (destroy_error != ESP_OK) return false;
+
+  while (true) {
+    uint32_t command_value = 0U;
+    if (xTaskNotifyWait(0U, UINT32_MAX, &command_value, portMAX_DELAY) != pdTRUE) {
+      continue;
+    }
+
+    const WorkerCommand command = static_cast<WorkerCommand>(command_value);
+    if (command == WorkerCommand::START) {
+      if (!self->start_client_()) {
+        self->session_failed_.store(true);
+      }
+      self->start_task_complete_.store(true);
+      ESP_LOGD(TAG, "Crash telemetry worker stack free after start: %u bytes",
+               static_cast<unsigned>(uxTaskGetStackHighWaterMark(nullptr)));
+      App.wake_loop_threadsafe();
+      continue;
+    }
+
+    if (command == WorkerCommand::CLEANUP) {
+      while (!self->cleanup_client_()) {
+        vTaskDelay(pdMS_TO_TICKS(WORKER_CLEANUP_RETRY_MS));
+      }
+      ESP_LOGD(TAG, "Crash telemetry worker stack free after cleanup: %u bytes",
+               static_cast<unsigned>(uxTaskGetStackHighWaterMark(nullptr)));
+      self->cleanup_task_complete_.store(true);
+      App.wake_loop_threadsafe();
+      if (!MQTT_WORKER_STACK_IN_PSRAM) {
+        vTaskSuspend(nullptr);
+      }
+      continue;
+    }
+
+    ESP_LOGE(TAG, "Crash telemetry worker received invalid command: %u", static_cast<unsigned>(command_value));
+  }
+}
+
+bool OpenQuattCrashTelemetry::cleanup_client_() {
+  // Worker only. Never delete the worker while it may still run inside
+  // ESP-IDF code; a permanently stuck stop just parks this boot's session.
+  esp_mqtt_client_handle_t client = this->mqtt_client_;
+  if (client == nullptr) return true;
+
+  if (this->mqtt_client_started_) {
+    const esp_err_t error = esp_mqtt_client_stop(client);
+    if (error != ESP_OK && error != ESP_FAIL) {
+      ESP_LOGE(TAG, "Unexpected crash telemetry MQTT stop error: %s", esp_err_to_name(error));
+      return false;
+    }
+    if (error != ESP_OK) {
+      ++this->cleanup_stop_failures_;
+      const CrashCleanupDecision decision = select_crash_cleanup_decision(
+          false, this->mqtt_connected_seen_.load(), this->mqtt_disconnected_seen_.load(), this->cleanup_stop_failures_);
+      if (decision == CrashCleanupDecision::FORCE_DISCONNECT) {
+        // A connected client may fail to construct its graceful DISCONNECT
+        // packet under memory pressure. Its own task handles the disconnect by
+        // aborting the transport without allocating that packet.
+        if (!this->cleanup_disconnect_requested_) {
+          ESP_LOGW(TAG, "Crash telemetry MQTT stop failed (%s); forcing disconnect before retry",
+                   esp_err_to_name(error));
+        }
+        esp_mqtt_client_disconnect(client);
+        this->cleanup_disconnect_requested_ = true;
+        return false;
+      }
+
+      // ESP-IDF also returns ESP_FAIL when the mqtt task has already stopped
+      // itself (for example after a transport-allocation failure). Allow one
+      // full worker interval for its STOPPED tail to finish before destroy.
+      if (decision == CrashCleanupDecision::RETRY_STOP) {
+        ESP_LOGD(TAG, "Crash telemetry MQTT task may already be stopped; verifying before destroy");
+        return false;
+      }
+      ESP_LOGW(TAG, "Crash telemetry MQTT task stopped before cleanup; releasing its client resources");
+    }
+  }
+
+  const esp_err_t error = esp_mqtt_client_destroy(client);
+  if (error != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to destroy crash telemetry MQTT client: %s", esp_err_to_name(error));
+    return false;
+  }
   this->mqtt_client_ = nullptr;
   this->mqtt_client_started_ = false;
-  this->cleanup_attempts_ = 0U;
+  this->cleanup_stop_failures_ = 0U;
+  this->cleanup_disconnect_requested_ = false;
   return true;
 }
 
-void OpenQuattCrashTelemetry::complete_session_(bool succeeded) {
-  if (!this->stop_client_()) return;
+void OpenQuattCrashTelemetry::request_session_finish_(bool publication_succeeded) {
+  // Main loop only: request worker cleanup, never perform it. Cleanup is sent
+  // only after the start worker completed, so a pending START notification
+  // cannot be overwritten by CLEANUP.
+  if (!this->session_active_.load() || this->start_task_running_.load() || this->finishing_session_.exchange(true)) {
+    return;
+  }
+  this->publication_result_succeeded_ = publication_succeeded;
+  this->worker_operation_started_ms_ = millis();
+  this->worker_stall_logged_ = false;
+  if (!this->notify_worker_(WorkerCommand::CLEANUP)) {
+    this->finishing_session_.store(false);
+    this->session_failed_.store(true);
+    ESP_LOGE(TAG, "Failed to notify crash telemetry MQTT cleanup");
+  }
+}
+
+void OpenQuattCrashTelemetry::finalize_session_() {
+  // Main loop only, after the worker confirmed full client destruction.
+  // PUBACK alone is not enough to release buffers: the MQTT task may still
+  // reference them until destroy completed.
   const CrashPublishKind kind = this->active_kind_.load();
+  const bool succeeded = this->publication_result_succeeded_;
+  bool finalized = true;
 
   if (succeeded && kind == CrashPublishKind::CRASH) {
     if (!this->clear_record_()) {
-      succeeded = false;
+      finalized = false;
       ESP_LOGW(TAG, "Crash was acknowledged, but local record clearing failed; retrying is harmless");
     }
   } else if (succeeded && kind == CrashPublishKind::TOMBSTONE) {
     this->state_.data()->tombstone_pending = 0U;
     if (!this->save_state_()) {
       this->state_.data()->tombstone_pending = 1U;
-      succeeded = false;
+      finalized = false;
       ESP_LOGW(TAG, "Retained tombstone was acknowledged, but pending state clearing failed");
     }
+  } else {
+    finalized = false;
   }
 
   this->session_active_.store(false);
@@ -225,16 +407,24 @@ void OpenQuattCrashTelemetry::complete_session_(bool succeeded) {
   this->session_failed_.store(false);
   this->pending_message_id_.store(-1);
   this->active_kind_.store(CrashPublishKind::NONE);
+  this->finishing_session_.store(false);
+  this->publication_result_succeeded_ = false;
   this->topic_buffer_.release();
   this->payload_buffer_.release();
   this->payload_size_ = 0U;
 
-  if (succeeded) {
+  if (finalized) {
     this->next_attempt_ms_ = 0U;
     ESP_LOGI(TAG, "%s published successfully", kind == CrashPublishKind::CRASH ? "Crash" : "Crash tombstone");
   } else {
+    // Record/tombstone stays intact for retry under the same message ID, so a
+    // lost QoS 1 PUBACK remains idempotent for ingestion.
     this->schedule_retry_();
   }
+}
+
+bool OpenQuattCrashTelemetry::time_reached_(uint32_t now_ms, uint32_t target_ms) {
+  return static_cast<int32_t>(now_ms - target_ms) >= 0;
 }
 
 void OpenQuattCrashTelemetry::schedule_retry_() { this->next_attempt_ms_ = millis() + INITIAL_RETRY_MS; }
@@ -242,15 +432,54 @@ void OpenQuattCrashTelemetry::schedule_retry_() { this->next_attempt_ms_ = milli
 void OpenQuattCrashTelemetry::schedule_immediate_() { this->next_attempt_ms_ = millis() + 1U; }
 
 void OpenQuattCrashTelemetry::loop() {
+  // The loopTask only observes worker completions and asks for cleanup. It
+  // never runs MQTT lifecycle calls or waits on network I/O itself.
+  if (this->start_task_complete_.exchange(false)) {
+    this->start_task_running_.store(false);
+  }
+  if (this->cleanup_task_complete_.exchange(false)) {
+    if (!MQTT_WORKER_STACK_IN_PSRAM) {
+      const TaskHandle_t handle = this->worker_task_state_.get_handle();
+      if (handle != nullptr && eTaskGetState(handle) != eSuspended) {
+        // The classic-ESP32 worker publishes completion immediately before it
+        // parks itself. Do not free a static stack that may still be executing
+        // on the other core.
+        this->cleanup_task_complete_.store(true);
+        return;
+      }
+      this->worker_task_state_.deallocate();
+      this->worker_task_region_valid_ = false;
+    }
+    this->finalize_session_();
+  }
+  if (this->start_task_running_.load() || this->finishing_session_.load()) {
+    // Signal only: a stuck worker must never stall the controller loop or
+    // trigger a second session while the first is unresolved.
+    if (!this->worker_stall_logged_ &&
+        time_reached_(millis(), this->worker_operation_started_ms_ + WORKER_STALL_LOG_MS)) {
+      ESP_LOGW(TAG, "Crash telemetry MQTT worker has not completed within %u ms; controller loop remains active",
+               static_cast<unsigned>(WORKER_STALL_LOG_MS));
+      this->worker_stall_logged_ = true;
+    }
+    return;
+  }
+
   if (this->session_active_.load()) {
-    const bool timed_out = static_cast<int32_t>(millis() - (this->session_started_ms_ + SESSION_TIMEOUT_MS)) >= 0;
     if (this->active_kind_.load() == CrashPublishKind::CRASH && !this->consent_enabled_.load()) {
       this->session_failed_.store(true);
     }
-    if (this->session_succeeded_.load()) {
-      this->complete_session_(true);
-    } else if (this->session_failed_.load() || timed_out) {
-      this->complete_session_(false);
+    const bool timed_out = time_reached_(millis(), this->session_started_ms_ + SESSION_TIMEOUT_MS);
+    switch (select_crash_session_action(this->session_active_.load(), this->start_task_running_.load(),
+                                        this->finishing_session_.load(), this->session_succeeded_.load(),
+                                        this->session_failed_.load(), timed_out)) {
+      case CrashSessionAction::FINISH_SUCCESS:
+        this->request_session_finish_(true);
+        break;
+      case CrashSessionAction::FINISH_FAILURE:
+        this->request_session_finish_(false);
+        break;
+      case CrashSessionAction::NONE:
+        break;
     }
     return;
   }
@@ -261,15 +490,17 @@ void OpenQuattCrashTelemetry::loop() {
       select_crash_publish_kind(this->state_.data()->tombstone_pending != 0U, this->consent_enabled_.load(),
                                 this->setup_complete_.load(), this->record_.data()->pending != 0U);
   if (kind == CrashPublishKind::NONE || !valid_installation_id(this->state_.data()->installation_id)) return;
-  if (this->next_attempt_ms_ == 0U) this->next_attempt_ms_ = millis() + INITIAL_PUBLISH_DELAY_MS;
-  if (static_cast<int32_t>(millis() - this->next_attempt_ms_) < 0) return;
+  if (this->next_attempt_ms_ == 0U) this->next_attempt_ms_ = millis() + initial_publish_delay_ms(kind);
+  if (!time_reached_(millis(), this->next_attempt_ms_)) return;
   if (should_wait_for_time_sync(kind, this->time_synchronized_.load(), millis(), this->time_sync_deadline_ms_)) return;
-  if (!this->start_session_(kind)) this->schedule_retry_();
+  this->start_publish_session_(kind);
 }
 
 void OpenQuattCrashTelemetry::dump_config() {
   ESP_LOGCONFIG(TAG, "OpenQuatt crash telemetry:");
   ESP_LOGCONFIG(TAG, "  Broker configured: %s", YESNO(this->is_configured()));
+  ESP_LOGCONFIG(TAG, "  Worker stack: %u bytes in %s", static_cast<unsigned>(MQTT_WORKER_TASK_STACK_SIZE),
+                MQTT_WORKER_STACK_IN_PSRAM ? "PSRAM" : "internal RAM");
   ESP_LOGCONFIG(TAG, "  Pending crash: %s", YESNO(this->record_ && this->record_.data()->pending != 0U));
   ESP_LOGCONFIG(TAG, "  Tombstone pending: %s", YESNO(this->state_ && this->state_.data()->tombstone_pending != 0U));
   ESP_LOGCONFIG(TAG, "  Consent observed: %s", YESNO(this->consent_seen_));
@@ -281,7 +512,19 @@ void OpenQuattCrashTelemetry::mqtt_event_handler_(void* handler_args, esp_event_
   (void)base;
   auto* self = static_cast<OpenQuattCrashTelemetry*>(handler_args);
   auto* event = static_cast<esp_mqtt_event_handle_t>(event_data);
-  if (self == nullptr || event == nullptr || !self->session_active_.load()) return;
+  if (self == nullptr || event == nullptr) return;
+
+  // Connection tracking always runs first: the worker needs the disconnect
+  // signal during cleanup, while publish callbacks must no longer touch the
+  // session once finishing started.
+  if (event_id == MQTT_EVENT_CONNECTED) {
+    self->mqtt_connected_seen_.store(true);
+  } else if (event_id == MQTT_EVENT_DISCONNECTED) {
+    self->mqtt_disconnected_seen_.store(true);
+  }
+  if (!self->session_active_.load() || self->finishing_session_.load()) {
+    return;
+  }
 
   switch (event_id) {
     case MQTT_EVENT_CONNECTED: {

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
@@ -292,6 +292,17 @@ void OpenQuattCrashTelemetry::worker_task_(void* arg) {
     }
 
     if (command == WorkerCommand::CLEANUP) {
+#ifdef OQ_CRASH_TELEMETRY_CLEANUP_STALL_TEST_MS
+      // HIL-only fault injection: stall the isolated worker before MQTT
+      // cleanup to prove the controller loop stays responsive (HIL 9.4).
+      // Pass -DOQ_CRASH_TELEMETRY_CLEANUP_STALL_TEST_MS=<ms> as an extra
+      // build flag in a temporary local HIL config. Never enable in release
+      // firmware.
+      ESP_LOGW(TAG,
+               "HIL fault injection active: stalling crash worker cleanup by %u ms; never enable in release builds",
+               static_cast<unsigned>(OQ_CRASH_TELEMETRY_CLEANUP_STALL_TEST_MS));
+      vTaskDelay(pdMS_TO_TICKS(OQ_CRASH_TELEMETRY_CLEANUP_STALL_TEST_MS));
+#endif
       while (!self->cleanup_client_()) {
         vTaskDelay(pdMS_TO_TICKS(WORKER_CLEANUP_RETRY_MS));
       }
@@ -323,8 +334,9 @@ bool OpenQuattCrashTelemetry::cleanup_client_() {
     }
     if (error != ESP_OK) {
       ++this->cleanup_stop_failures_;
-      const CrashCleanupDecision decision = select_crash_cleanup_decision(
-          false, this->mqtt_connected_seen_.load(), this->mqtt_disconnected_seen_.load(), this->cleanup_stop_failures_);
+      const CrashCleanupDecision decision =
+          select_crash_cleanup_decision(false, this->mqtt_connected_seen_.load(), this->mqtt_disconnected_seen_.load(),
+                                        this->cleanup_stop_failures_, this->cleanup_disconnect_requested_);
       if (decision == CrashCleanupDecision::FORCE_DISCONNECT) {
         // A connected client may fail to construct its graceful DISCONNECT
         // packet under memory pressure. Its own task handles the disconnect by

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
@@ -292,17 +292,6 @@ void OpenQuattCrashTelemetry::worker_task_(void* arg) {
     }
 
     if (command == WorkerCommand::CLEANUP) {
-#ifdef OQ_CRASH_TELEMETRY_CLEANUP_STALL_TEST_MS
-      // HIL-only fault injection: stall the isolated worker before MQTT
-      // cleanup to prove the controller loop stays responsive (HIL 9.4).
-      // Pass -DOQ_CRASH_TELEMETRY_CLEANUP_STALL_TEST_MS=<ms> as an extra
-      // build flag in a temporary local HIL config. Never enable in release
-      // firmware.
-      ESP_LOGW(TAG,
-               "HIL fault injection active: stalling crash worker cleanup by %u ms; never enable in release builds",
-               static_cast<unsigned>(OQ_CRASH_TELEMETRY_CLEANUP_STALL_TEST_MS));
-      vTaskDelay(pdMS_TO_TICKS(OQ_CRASH_TELEMETRY_CLEANUP_STALL_TEST_MS));
-#endif
       while (!self->cleanup_client_()) {
         vTaskDelay(pdMS_TO_TICKS(WORKER_CLEANUP_RETRY_MS));
       }

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
@@ -89,13 +89,19 @@ enum class CrashCleanupDecision : uint8_t {
 
 // Crash-specific cleanup decision for the worker task. Kept local to this
 // component so the already-working usage telemetry helper stays untouched.
+//
+// The disconnect request is an input: esp_mqtt_client_disconnect() only sets
+// DISCONNECT_BIT, which a no-longer-running MQTT task never processes. So at
+// most one FORCE_DISCONNECT is allowed; a repeated ESP_FAIL afterwards means
+// the task is gone and destroy becomes safe.
 inline constexpr CrashCleanupDecision select_crash_cleanup_decision(bool stop_succeeded, bool connected_seen,
                                                                     bool disconnected_seen,
-                                                                    uint8_t consecutive_stop_failures) {
+                                                                    uint8_t consecutive_stop_failures,
+                                                                    bool disconnect_requested) {
   if (stop_succeeded) {
     return CrashCleanupDecision::DESTROY;
   }
-  if (connected_seen && !disconnected_seen) {
+  if (connected_seen && !disconnected_seen && !disconnect_requested) {
     return CrashCleanupDecision::FORCE_DISCONNECT;
   }
   if (consecutive_stop_failures < 2U) {

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
@@ -55,4 +55,62 @@ inline constexpr bool reported_at_is_usable(bool time_synchronized, bool timesta
   return time_synchronized && timestamp_is_sane && (!crash_time_valid || reported_at >= crash_timestamp);
 }
 
+enum class CrashSessionAction : uint8_t {
+  NONE = 0U,
+  FINISH_SUCCESS = 1U,
+  FINISH_FAILURE = 2U,
+};
+
+// Pure main-loop decision for an active publish session. The ESPHome loopTask
+// must never block on MQTT lifecycle calls; it only observes these flags and
+// asks the worker to start cleanup. A simultaneous success and failure keeps
+// the historical priority of success.
+inline constexpr CrashSessionAction select_crash_session_action(bool session_active, bool start_task_running,
+                                                                bool finishing_session, bool succeeded, bool failed,
+                                                                bool timed_out) {
+  if (!session_active || start_task_running || finishing_session) {
+    return CrashSessionAction::NONE;
+  }
+  if (succeeded) {
+    return CrashSessionAction::FINISH_SUCCESS;
+  }
+  if (failed || timed_out) {
+    return CrashSessionAction::FINISH_FAILURE;
+  }
+  return CrashSessionAction::NONE;
+}
+
+enum class CrashCleanupDecision : uint8_t {
+  DESTROY = 0U,
+  FORCE_DISCONNECT = 1U,
+  RETRY_STOP = 2U,
+  DESTROY_ALREADY_STOPPED = 3U,
+};
+
+// Crash-specific cleanup decision for the worker task. Kept local to this
+// component so the already-working usage telemetry helper stays untouched.
+inline constexpr CrashCleanupDecision select_crash_cleanup_decision(bool stop_succeeded, bool connected_seen,
+                                                                    bool disconnected_seen,
+                                                                    uint8_t consecutive_stop_failures) {
+  if (stop_succeeded) {
+    return CrashCleanupDecision::DESTROY;
+  }
+  if (connected_seen && !disconnected_seen) {
+    return CrashCleanupDecision::FORCE_DISCONNECT;
+  }
+  if (consecutive_stop_failures < 2U) {
+    return CrashCleanupDecision::RETRY_STOP;
+  }
+  return CrashCleanupDecision::DESTROY_ALREADY_STOPPED;
+}
+
+inline constexpr uint32_t CRASH_INITIAL_PUBLISH_DELAY_MS = 15UL * 1000UL;
+inline constexpr uint32_t TOMBSTONE_INITIAL_PUBLISH_DELAY_MS = 1U;
+
+// A crash publication waits out the early boot activity wave; an opt-out
+// tombstone takes effect immediately.
+inline constexpr uint32_t initial_publish_delay_ms(CrashPublishKind kind) {
+  return kind == CrashPublishKind::TOMBSTONE ? TOMBSTONE_INITIAL_PUBLISH_DELAY_MS : CRASH_INITIAL_PUBLISH_DELAY_MS;
+}
+
 }  // namespace esphome::openquatt_crash_telemetry

--- a/components/openquatt_crash_telemetry/__init__.py
+++ b/components/openquatt_crash_telemetry/__init__.py
@@ -1,8 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, socket, switch, text_sensor, time
-from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.components import binary_sensor, psram, socket, switch, text_sensor, time
+from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
+from esphome.components.esp32.const import VARIANT_ESP32S3
 from esphome.const import CONF_ID
+from esphome.core import CORE
 
 DEPENDENCIES = [
     "logger",
@@ -97,6 +99,8 @@ CONFIG_SCHEMA = cv.All(
 
 async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_APP_RETRIEVE_LEN_ELF_SHA", 64)
+    if CORE.is_esp32 and get_esp32_variant() == VARIANT_ESP32S3:
+        psram.request_external_task_stack()
 
     cg.add_global(openquatt_crash_telemetry_ns.using)
     var = cg.new_Pvariable(config[CONF_ID])

--- a/docs/crash-telemetry.md
+++ b/docs/crash-telemetry.md
@@ -13,6 +13,14 @@ begrensde record in flash beschikbaar voor een retry. MQTT QoS 1 kan dezelfde
 crash opnieuw afleveren wanneer een acknowledgement verloren gaat. Een ontvanger
 moet daarom dedupliceren op de combinatie van `installation_id` en `message_id`.
 
+De MQTT-client voor crashpublicatie wordt door een geïsoleerde worker beheerd.
+De normale ESPHome-hoofdloop bouwt alleen de begrensde payload op en verwerkt
+het resultaat. Een trage of vastlopende MQTT-start of -cleanup mag daardoor de
+verwarmingsregeling of controllerhoofdloop niet blokkeren. Het lokale
+crashrecord wordt pas gewist nadat de PUBACK is ontvangen én de client volledig
+is opgeruimd; blijft de cleanup hangen, dan blijft het record behouden voor een
+retry onder hetzelfde `message_id`.
+
 De payload bevat geen gewone runtime-logs, metingen of regelwaarden. Wel bevat
 hij de regels uit het ESPHome-crashrapport, het resettype, firmwareversie,
 releasekanaal, ESPHome-versie, bronrepository, volledige commit-SHA, exact

--- a/scripts/tests/test_internal_heap_contract.py
+++ b/scripts/tests/test_internal_heap_contract.py
@@ -39,6 +39,21 @@ TELEMETRY_POLICY = (
     / "openquatt_usage_telemetry"
     / "OpenQuattUsageTelemetryPolicy.h"
 ).read_text()
+CRASH_TELEMETRY_HEADER = (
+    ROOT
+    / "components"
+    / "openquatt_crash_telemetry"
+    / "OpenQuattCrashTelemetry.h"
+).read_text()
+CRASH_TELEMETRY_CPP = (
+    ROOT
+    / "components"
+    / "openquatt_crash_telemetry"
+    / "OpenQuattCrashTelemetryMqtt.cpp"
+).read_text()
+CRASH_TELEMETRY_CODEGEN = (
+    ROOT / "components" / "openquatt_crash_telemetry" / "__init__.py"
+).read_text()
 LOG_HISTORY_CPP = (
     ROOT
     / "components"
@@ -149,6 +164,43 @@ class InternalHeapPlacementContractTest(unittest.TestCase):
         )
         self.assertIn("eSetValueWithOverwrite", TELEMETRY_CPP)
         self.assertNotIn("eSetValueWithoutOverwrite", TELEMETRY_CPP)
+
+    def test_crash_telemetry_worker_owns_mqtt_lifecycle(self) -> None:
+        self.assertIn("StaticTask worker_task_state_", CRASH_TELEMETRY_HEADER)
+        self.assertIn(
+            "MQTT_WORKER_STACK_IN_PSRAM = true",
+            CRASH_TELEMETRY_HEADER,
+        )
+        self.assertIn(
+            "MQTT_WORKER_STACK_IN_PSRAM = false",
+            CRASH_TELEMETRY_HEADER,
+        )
+        self.assertIn("psram.request_external_task_stack()", CRASH_TELEMETRY_CODEGEN)
+        self.assertIn(
+            "get_esp32_variant() == VARIANT_ESP32S3",
+            CRASH_TELEMETRY_CODEGEN,
+        )
+        self.assertNotIn("xTaskCreatePinnedToCore(", CRASH_TELEMETRY_CPP)
+        self.assertNotIn("vTaskDelete(", CRASH_TELEMETRY_CPP)
+        self.assertIn(
+            "this->worker_task_state_.deallocate();",
+            CRASH_TELEMETRY_CPP,
+        )
+        self.assertIn("eTaskGetState(handle) != eSuspended", CRASH_TELEMETRY_CPP)
+        # Every MQTT lifecycle call exists exactly once, inside the worker
+        # start/cleanup path. The main loop only notifies the worker.
+        for lifecycle_call in (
+            "esp_mqtt_client_init(",
+            "esp_mqtt_client_start(",
+            "esp_mqtt_client_stop(",
+            "esp_mqtt_client_destroy(",
+        ):
+            self.assertEqual(CRASH_TELEMETRY_CPP.count(lifecycle_call), 1)
+        self.assertIn("void OpenQuattCrashTelemetry::finalize_session_()", CRASH_TELEMETRY_CPP)
+        self.assertIn("this->finalize_session_();", CRASH_TELEMETRY_CPP)
+        self.assertIn("request_session_finish_(", CRASH_TELEMETRY_CPP)
+        self.assertIn("select_crash_session_action(", CRASH_TELEMETRY_CPP)
+        self.assertIn("select_crash_cleanup_decision(", CRASH_TELEMETRY_CPP)
 
     def test_large_diagnostic_buffers_never_fall_back_to_internal_heap(self) -> None:
         self.assertIn(

--- a/tests/host/openquatt_crash_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_crash_telemetry_policy_test.cpp
@@ -4,11 +4,16 @@
 
 using esphome::openquatt_crash_telemetry::crash_data_may_be_published;
 using esphome::openquatt_crash_telemetry::crash_publication_is_retained;
+using esphome::openquatt_crash_telemetry::CrashCleanupDecision;
 using esphome::openquatt_crash_telemetry::CrashPublishKind;
+using esphome::openquatt_crash_telemetry::CrashSessionAction;
 using esphome::openquatt_crash_telemetry::flash_sequence_is_newer;
+using esphome::openquatt_crash_telemetry::initial_publish_delay_ms;
 using esphome::openquatt_crash_telemetry::persisted_consent_blocks_crash;
 using esphome::openquatt_crash_telemetry::reported_at_is_usable;
+using esphome::openquatt_crash_telemetry::select_crash_cleanup_decision;
 using esphome::openquatt_crash_telemetry::select_crash_publish_kind;
+using esphome::openquatt_crash_telemetry::select_crash_session_action;
 using esphome::openquatt_crash_telemetry::should_request_tombstone;
 using esphome::openquatt_crash_telemetry::should_wait_for_time_sync;
 
@@ -59,6 +64,27 @@ int main() {
   assert(!reported_at_is_usable(false, true, true, 201U, 200U));
   assert(!reported_at_is_usable(true, false, true, 201U, 200U));
   assert(!reported_at_is_usable(true, true, true, 199U, 200U));
+
+  assert(select_crash_session_action(false, false, false, false, false, false) == CrashSessionAction::NONE);
+  assert(select_crash_session_action(true, true, false, true, false, false) == CrashSessionAction::NONE);
+  assert(select_crash_session_action(true, false, true, true, false, false) == CrashSessionAction::NONE);
+  assert(select_crash_session_action(true, false, false, true, false, false) == CrashSessionAction::FINISH_SUCCESS);
+  assert(select_crash_session_action(true, false, false, false, true, false) == CrashSessionAction::FINISH_FAILURE);
+  assert(select_crash_session_action(true, false, false, false, false, true) == CrashSessionAction::FINISH_FAILURE);
+  assert(select_crash_session_action(true, false, false, false, false, false) == CrashSessionAction::NONE);
+  assert(select_crash_session_action(true, false, false, true, true, true) == CrashSessionAction::FINISH_SUCCESS);
+
+  assert(select_crash_cleanup_decision(true, false, false, 0U) == CrashCleanupDecision::DESTROY);
+  assert(select_crash_cleanup_decision(false, true, false, 0U) == CrashCleanupDecision::FORCE_DISCONNECT);
+  assert(select_crash_cleanup_decision(false, true, true, 0U) == CrashCleanupDecision::RETRY_STOP);
+  assert(select_crash_cleanup_decision(false, false, false, 0U) == CrashCleanupDecision::RETRY_STOP);
+  assert(select_crash_cleanup_decision(false, false, false, 1U) == CrashCleanupDecision::RETRY_STOP);
+  assert(select_crash_cleanup_decision(false, false, false, 2U) == CrashCleanupDecision::DESTROY_ALREADY_STOPPED);
+  assert(select_crash_cleanup_decision(false, true, true, 9U) == CrashCleanupDecision::DESTROY_ALREADY_STOPPED);
+
+  assert(initial_publish_delay_ms(CrashPublishKind::CRASH) == 15UL * 1000UL);
+  assert(initial_publish_delay_ms(CrashPublishKind::NONE) == 15UL * 1000UL);
+  assert(initial_publish_delay_ms(CrashPublishKind::TOMBSTONE) < initial_publish_delay_ms(CrashPublishKind::CRASH));
 
   return 0;
 }

--- a/tests/host/openquatt_crash_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_crash_telemetry_policy_test.cpp
@@ -74,13 +74,25 @@ int main() {
   assert(select_crash_session_action(true, false, false, false, false, false) == CrashSessionAction::NONE);
   assert(select_crash_session_action(true, false, false, true, true, true) == CrashSessionAction::FINISH_SUCCESS);
 
-  assert(select_crash_cleanup_decision(true, false, false, 0U) == CrashCleanupDecision::DESTROY);
-  assert(select_crash_cleanup_decision(false, true, false, 0U) == CrashCleanupDecision::FORCE_DISCONNECT);
-  assert(select_crash_cleanup_decision(false, true, true, 0U) == CrashCleanupDecision::RETRY_STOP);
-  assert(select_crash_cleanup_decision(false, false, false, 0U) == CrashCleanupDecision::RETRY_STOP);
-  assert(select_crash_cleanup_decision(false, false, false, 1U) == CrashCleanupDecision::RETRY_STOP);
-  assert(select_crash_cleanup_decision(false, false, false, 2U) == CrashCleanupDecision::DESTROY_ALREADY_STOPPED);
-  assert(select_crash_cleanup_decision(false, true, true, 9U) == CrashCleanupDecision::DESTROY_ALREADY_STOPPED);
+  assert(select_crash_cleanup_decision(true, false, false, 0U, false) == CrashCleanupDecision::DESTROY);
+  assert(select_crash_cleanup_decision(false, true, false, 0U, false) == CrashCleanupDecision::FORCE_DISCONNECT);
+  assert(select_crash_cleanup_decision(false, true, true, 0U, false) == CrashCleanupDecision::RETRY_STOP);
+  assert(select_crash_cleanup_decision(false, false, false, 0U, false) == CrashCleanupDecision::RETRY_STOP);
+  assert(select_crash_cleanup_decision(false, false, false, 1U, false) == CrashCleanupDecision::RETRY_STOP);
+  assert(select_crash_cleanup_decision(false, false, false, 2U, false) ==
+         CrashCleanupDecision::DESTROY_ALREADY_STOPPED);
+  assert(select_crash_cleanup_decision(false, true, true, 9U, false) == CrashCleanupDecision::DESTROY_ALREADY_STOPPED);
+  // No second FORCE_DISCONNECT once a disconnect was requested: without a
+  // running MQTT task the disconnect bit is never processed, so retrying it
+  // would loop forever instead of reaching destroy. One verification retry
+  // is allowed then destroy follows.
+  assert(select_crash_cleanup_decision(false, true, false, 1U, true) == CrashCleanupDecision::RETRY_STOP);
+  assert(select_crash_cleanup_decision(false, true, false, 2U, true) == CrashCleanupDecision::DESTROY_ALREADY_STOPPED);
+  // Start race: first ESP_FAIL before the MQTT task set run=true gets one
+  // verification retry, then cleanup must progress to destroy.
+  assert(select_crash_cleanup_decision(false, false, false, 1U, false) == CrashCleanupDecision::RETRY_STOP);
+  assert(select_crash_cleanup_decision(false, false, false, 2U, false) ==
+         CrashCleanupDecision::DESTROY_ALREADY_STOPPED);
 
   assert(initial_publish_delay_ms(CrashPublishKind::CRASH) == 15UL * 1000UL);
   assert(initial_publish_delay_ms(CrashPublishKind::NONE) == 15UL * 1000UL);


### PR DESCRIPTION
# Wat verandert deze PR?

- Start en cleanup van de one-shot crash-MQTT-client draaien op een aparte worker (`oq_crash_mqtt`, prio 4), niet meer in de watchdog-bewaakte ESPHome-hoofdloop.
- Voorkomt dat `esp_mqtt_client_stop()` of `destroy()` (netwerk-timeout 10s vs Task-WDT 5s) zelf een Task-WDT veroorzaakt.
- Behoudt bestaande consent-, QoS-, retry-, flash- en deduplicatiesemantiek.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De regeling verandert niet. Alleen de lifecycle van de afzonderlijke crashtelemetrie-MQTT-client verhuist uit `loopTask`. Workerstack: 16KB PSRAM op ESP32-S3 (persistent), 8KB intern op classic ESP32 (alleen tijdens sessie). Een vastlopende netwerkcleanup parkeert alleen die boot zijn crashsessie; record blijft pending voor retry onder hetzelfde `message_id`. Bewust geen 15s->30s bootvertraging meegenomen: een crash-loop-device (16s uptime in de echte logs) zou publicatie dan nooit halen.

## Achtergrond

Aanleiding was een Task-WDT-crashreeks (v0.48.0, duo-wifi) waarbij `core 1` in de FreeRTOS idle-task stond (`prvIdleTask -> esp_vApplicationIdleHook -> esp_cpu_wait_for_intr`, gedecodeerd tegen een lokaal gebouwde v0.48.0-ELF). De dader-task staat niet in de ingekorte backtrace; dit is een hardening-PR, geen root-cause-fix. Ontwerp volgt het bewezen `StaticTask`-patroon van usage telemetry; geen gedeelde worker (scope beperkt).

Merge-voorwaarde: backend-dedup op `installation_id + message_id` bevestigen, omdat na PUBACK + hangende cleanup hetzelfde bericht opnieuw verstuurd kan worden.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging

Docs-impact motivatie:

N.v.t. (bovenstaande optie gekozen): paragraaf over workerisolatie toegevoegd aan `docs/crash-telemetry.md`; geen schema- of privacywijziging.

## Validatie

- `./scripts/run_host_regression_tests.sh` (59 tests, incl. nieuwe sessie-/cleanup-policytests)
- `python3 -m unittest discover -s scripts/tests -p "test_*.py"` (207 tests, incl. nieuw crashworker-contract)
- `npm run check:cpp-format`
- `esphome config configs/heatpump_controller_q/duo.yaml` en `esphome config configs/heatpump_listener/single_wifi.yaml`
- `esphome compile configs/heatpump_controller_q/duo.yaml` en `esphome compile configs/heatpump_listener/single_wifi.yaml` (beide geslaagd)

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Nog te meten op hardware (HIL): static RAM-delta baseline vs kandidaat op Q Duo/S3, interne heap (current/minimum/largest block/fragmentatie), crashworker- en ESP-MQTT-stackwatermarks onder HA+web+Modbus+OpenTherm+crashpublicatie. Belangrijkste bewijsproef: 10s-cleanupstall zonder Task-WDT (HIL 9.4 uit het plan). Classic ESP32: minimaal één fysieke run i.v.m. tijdelijke interne workerstack.