### PR TITLE
Bound usage telemetry cleanup disconnect retries

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -670,8 +670,9 @@ bool OpenQuattUsageTelemetry::cleanup_client_() {
     }
     if (error != ESP_OK) {
       ++this->cleanup_stop_failures_;
-      const MqttCleanupDecision decision = mqtt_cleanup_decision(
-          false, this->mqtt_connected_seen_.load(), this->mqtt_disconnected_seen_.load(), this->cleanup_stop_failures_);
+      const MqttCleanupDecision decision =
+          mqtt_cleanup_decision(false, this->mqtt_connected_seen_.load(), this->mqtt_disconnected_seen_.load(),
+                                this->cleanup_stop_failures_, this->cleanup_disconnect_requested_);
       if (decision == MqttCleanupDecision::FORCE_DISCONNECT) {
         // A connected client may fail to construct its graceful DISCONNECT
         // packet under memory pressure. Its own task handles DISCONNECT_BIT by

--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetryPolicy.h
@@ -191,11 +191,15 @@ inline const char* flow_source_config_wire_value(const std::string& flow_source,
 }
 
 inline MqttCleanupDecision mqtt_cleanup_decision(bool stop_succeeded, bool connected_seen, bool disconnected_seen,
-                                                 uint8_t consecutive_stop_failures) {
+                                                 uint8_t consecutive_stop_failures, bool disconnect_requested) {
   if (stop_succeeded) {
     return MqttCleanupDecision::DESTROY;
   }
-  if (connected_seen && !disconnected_seen) {
+  // esp_mqtt_client_disconnect() only sets DISCONNECT_BIT, which a
+  // no-longer-running MQTT task never processes. Allow at most one
+  // FORCE_DISCONNECT; a repeated ESP_FAIL afterwards means the task is gone
+  // and destroy becomes safe.
+  if (connected_seen && !disconnected_seen && !disconnect_requested) {
     return MqttCleanupDecision::FORCE_DISCONNECT;
   }
   if (consecutive_stop_failures < 2U) {

--- a/scripts/tests/test_internal_heap_contract.py
+++ b/scripts/tests/test_internal_heap_contract.py
@@ -151,6 +151,7 @@ class InternalHeapPlacementContractTest(unittest.TestCase):
     def test_telemetry_cleanup_and_consent_fail_closed(self) -> None:
         self.assertIn("mqtt_cleanup_decision(", TELEMETRY_POLICY)
         self.assertIn("DESTROY_ALREADY_STOPPED", TELEMETRY_POLICY)
+        self.assertIn("disconnect_requested", TELEMETRY_POLICY)
         self.assertIn("xSemaphoreCreateMutexStatic", TELEMETRY_CPP)
         self.assertIn("consent_mutex_", TELEMETRY_HEADER)
         self.assertIn("consent_publish_blocked_", TELEMETRY_HEADER)

--- a/tests/host/openquatt_usage_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_usage_telemetry_policy_test.cpp
@@ -18,11 +18,16 @@ using esphome::openquatt_usage_telemetry::quatt_hybrid_generation_wire_value;
 int main() {
   assert(MQTT_PUBLISH_RETAIN == 0);
 
-  assert(mqtt_cleanup_decision(true, false, false, 0U) == MqttCleanupDecision::DESTROY);
-  assert(mqtt_cleanup_decision(false, true, false, 1U) == MqttCleanupDecision::FORCE_DISCONNECT);
-  assert(mqtt_cleanup_decision(false, false, false, 1U) == MqttCleanupDecision::RETRY_STOP);
-  assert(mqtt_cleanup_decision(false, false, false, 2U) == MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
-  assert(mqtt_cleanup_decision(false, true, true, 2U) == MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
+  assert(mqtt_cleanup_decision(true, false, false, 0U, false) == MqttCleanupDecision::DESTROY);
+  assert(mqtt_cleanup_decision(false, true, false, 1U, false) == MqttCleanupDecision::FORCE_DISCONNECT);
+  assert(mqtt_cleanup_decision(false, false, false, 1U, false) == MqttCleanupDecision::RETRY_STOP);
+  assert(mqtt_cleanup_decision(false, false, false, 2U, false) == MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
+  assert(mqtt_cleanup_decision(false, true, true, 2U, false) == MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
+  // No second FORCE_DISCONNECT once a disconnect was requested: without a
+  // running MQTT task the disconnect bit is never processed, so retrying it
+  // would loop forever instead of reaching destroy.
+  assert(mqtt_cleanup_decision(false, true, false, 1U, true) == MqttCleanupDecision::RETRY_STOP);
+  assert(mqtt_cleanup_decision(false, true, false, 2U, true) == MqttCleanupDecision::DESTROY_ALREADY_STOPPED);
 
   assert(std::strcmp(quatt_hybrid_generation_wire_value("V1"), "v1") == 0);
   assert(std::strcmp(quatt_hybrid_generation_wire_value("V1.5"), "v1_5") == 0);


### PR DESCRIPTION
# Wat verandert deze PR?

- Zelfde fix als #619 voor usage telemetry: hooguit één `FORCE_DISCONNECT` bij falende MQTT-stop, daarna valt een herhaalde `ESP_FAIL` door naar `DESTROY_ALREADY_STOPPED` zodat destroy altijd bereikt wordt.
- `mqtt_cleanup_decision()` neemt `disconnect_requested` mee; call site en policytests bijgewerkt.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de cleanup-beslisboom van de usage-telemetryworker; geen stack-, buffer- of publicatiesemantiek gewijzigd. Gestapeld op #619 omdat het dezelfde beslisvorm betreft; inhoudelijk onafhankelijk mergebaar zodra de basis erin zit.

## Achtergrond

Follow-up op reviewbevinding bij #619: zonder deze begrenzing kan de worker bij een reeds gestopte MQTT-task blijven hangen in `stop -> ESP_FAIL -> FORCE_DISCONNECT` (disconnect-bit wordt dan nooit verwerkt), waardoor die boot geen verdere telemetriesessies meer start en de classic-ESP32-stack niet wordt vrijgegeven.

## Documentatie

- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne cleanup-beslisboom zonder user-facing of payloadwijziging; bestaand telemetriegedrag blijft gelijk.

## Validatie

- `./scripts/run_host_regression_tests.sh` (59 tests, incl. uitgebreide cleanup-beslistests)
- `python3 -m unittest discover -s scripts/tests -p "test_*.py"` (208 tests)
- `npm run check:cpp-format`
- `esphome compile configs/heatpump_controller_q/duo.yaml` (geslaagd)

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen: geen nieuwe stacks, buffers of taken; uitsluitend een extra parameter in een pure beslisfunctie.