### PR TITLE
fix: clarify ODU runtime ready log message

### DIFF
--- a/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
+++ b/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
@@ -396,7 +396,7 @@ void OpenQuattOduRuntimeFrequency::set_extended_layout(bool extended_layout) {
   }
   portEXIT_CRITICAL(&this->state_mux_);
   if (!changed) return;
-  ESP_LOGI(TAG, "HP%u READY: load ODU runtime table", this->hp_index_);
+  ESP_LOGI(TAG, "HP%u runtime frequency editor ready; load the ODU table before editing", this->hp_index_);
   if (reserved_token != 0U) this->eeprom_dump_->end_external_operation();
 }
 

--- a/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
+++ b/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
@@ -396,7 +396,7 @@ void OpenQuattOduRuntimeFrequency::set_extended_layout(bool extended_layout) {
   }
   portEXIT_CRITICAL(&this->state_mux_);
   if (!changed) return;
-  ESP_LOGW(TAG, "HP%u READY: load ODU runtime table", this->hp_index_);
+  ESP_LOGI(TAG, "HP%u READY: load ODU runtime table", this->hp_index_);
   if (reserved_token != 0U) this->eeprom_dump_->end_external_operation();
 }
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Logt de normale initialisatiestatus van de ODU runtime frequency editor als `INFO` in plaats van `WARN`.
- Vervangt de cryptische melding `HPx READY: load ODU runtime table` door `HPx runtime frequency editor ready; load the ODU table before editing`.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen het logniveau en de tekst van één normale initialisatiemelding wijzigen. De statusmachine, API-status en ODU-aansturing blijven ongewijzigd.

## Achtergrond

Na detectie van de ODU-layout zet `set_extended_layout()` de runtime frequency editor terug naar de normale ongeladen beginstatus. Dit is geen afwijking of foutconditie, maar werd door `ESP_LOGW` en de cryptische tekst wel als waarschuwing gepresenteerd.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De wijziging betreft uitsluitend interne logging en verandert geen gebruikersgerichte functionaliteit, entity of configuratie.

## Validatie

- Diff gecontroleerd: uitsluitend de bestaande logaanroep in `set_extended_layout()` wijzigt van `ESP_LOGW` naar `ESP_LOGI` en krijgt een duidelijkere tekst.
- Niet lokaal gecompileerd; er wijzigen geen interfaces, types of controlpaden.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen heap-, PSRAM- of stackimpact; alleen een statische logtekst en het logniveau wijzigen.
