### PR TITLE
Maak releasebuild cachevrij als compilegate

### DIFF
--- a/.github/workflows/esphome-build.yml
+++ b/.github/workflows/esphome-build.yml
@@ -30,6 +30,10 @@ on:
         required: false
         type: boolean
         default: false
+      enable_ccache:
+        required: false
+        type: boolean
+        default: true
       project_version:
         required: false
         type: string
@@ -124,6 +128,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-esphome-idf-${{ steps.idf_version.outputs.version }}
 
       - name: Make ccache available
+        if: ${{ inputs.enable_ccache }}
         run: |
           if ! command -v ccache >/dev/null 2>&1; then
             sudo apt-get update
@@ -132,7 +137,7 @@ jobs:
           ccache --version
 
       - name: Cache compiler outputs
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ inputs.enable_ccache && github.event_name != 'pull_request' }}
         uses: actions/cache@v5
         with:
           path: ~/.cache/openquatt/ccache/${{ matrix.target.id }}
@@ -141,7 +146,7 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-openquatt-ccache-${{ matrix.target.id }}-${{ steps.idf_version.outputs.version }}-
 
       - name: Restore compiler outputs
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ inputs.enable_ccache && github.event_name == 'pull_request' }}
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/openquatt/ccache/${{ matrix.target.id }}
@@ -152,12 +157,17 @@ jobs:
       - name: Compile firmware
         run: |
           export ESPHOME_ESP_IDF_PREFIX="${HOME}/.cache/esphome/idf"
-          export IDF_CCACHE_ENABLE=1
-          export CCACHE_DIR="${HOME}/.cache/openquatt/ccache/${{ matrix.target.id }}"
-          export CCACHE_MAXSIZE=2G
-          export CCACHE_NOHASHDIR=true
-          export CCACHE_DEPEND=1
-          export CCACHE_BASEDIR="${GITHUB_WORKSPACE}/${{ matrix.target.build_path }}"
+          if [[ "${{ inputs.enable_ccache }}" == "true" ]]; then
+            export IDF_CCACHE_ENABLE=1
+            export CCACHE_DIR="${HOME}/.cache/openquatt/ccache/${{ matrix.target.id }}"
+            export CCACHE_MAXSIZE=2G
+            export CCACHE_NOHASHDIR=true
+            export CCACHE_DEPEND=1
+            export CCACHE_BASEDIR="${GITHUB_WORKSPACE}/${{ matrix.target.build_path }}"
+          else
+            unset IDF_CCACHE_ENABLE
+            export CCACHE_DISABLE=1
+          fi
           SOURCE_REPOSITORY="${{ inputs.checkout_repository || github.repository }}"
           SOURCE_COMMIT="$(git rev-parse HEAD)"
           EXTRA_ARGS=(
@@ -178,7 +188,7 @@ jobs:
           esphome "${EXTRA_ARGS[@]}" compile "${{ matrix.target.config }}"
 
       - name: Show ccache statistics
-        if: ${{ always() }}
+        if: ${{ always() && inputs.enable_ccache }}
         run: |
           export CCACHE_DIR="${HOME}/.cache/openquatt/ccache/${{ matrix.target.id }}"
           export CCACHE_MAXSIZE=2G

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -16,6 +16,8 @@ jobs:
     with:
       artifact_suffix: release
       include_debug_symbols: true
+      # Release artifacts must come from a compiler-cache-free matrix.
+      enable_ccache: false
 
   publish-release:
     runs-on: ubuntu-latest

--- a/scripts/tests/test_release_build_workflows.py
+++ b/scripts/tests/test_release_build_workflows.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REUSABLE_BUILD_WORKFLOW = (ROOT / ".github/workflows/esphome-build.yml").read_text(encoding="utf-8")
+RELEASE_WORKFLOW = (ROOT / ".github/workflows/release-build.yml").read_text(encoding="utf-8")
+DEV_WORKFLOW = (ROOT / ".github/workflows/dev-build.yml").read_text(encoding="utf-8")
+
+
+class ReleaseBuildWorkflowTests(unittest.TestCase):
+    def test_ccache_is_enabled_by_default_for_reusable_builds(self) -> None:
+        self.assertIn(
+            """      enable_ccache:
+        required: false
+        type: boolean
+        default: true
+""",
+            REUSABLE_BUILD_WORKFLOW,
+        )
+        self.assertNotIn("enable_ccache: false", DEV_WORKFLOW)
+
+    def test_release_uses_cache_free_enabled_target_matrix_as_publish_gate(self) -> None:
+        self.assertIn(
+            'MATRIX="$(python3 scripts/build_targets.py github-matrix --status enabled)"',
+            REUSABLE_BUILD_WORKFLOW,
+        )
+        self.assertIn("enable_ccache: false", RELEASE_WORKFLOW)
+        self.assertIn("needs: compile-profiles", RELEASE_WORKFLOW)
+        self.assertIn(
+            'if [[ "${{ inputs.enable_ccache }}" == "true" ]]; then',
+            REUSABLE_BUILD_WORKFLOW,
+        )
+        self.assertIn("unset IDF_CCACHE_ENABLE", REUSABLE_BUILD_WORKFLOW)
+        self.assertIn("export CCACHE_DISABLE=1", REUSABLE_BUILD_WORKFLOW)
+
+    def test_disabled_ccache_skips_setup_restore_and_statistics(self) -> None:
+        self.assertIn(
+            "name: Make ccache available\n        if: ${{ inputs.enable_ccache }}",
+            REUSABLE_BUILD_WORKFLOW,
+        )
+        self.assertIn(
+            "inputs.enable_ccache && github.event_name != 'pull_request'",
+            REUSABLE_BUILD_WORKFLOW,
+        )
+        self.assertIn(
+            "inputs.enable_ccache && github.event_name == 'pull_request'",
+            REUSABLE_BUILD_WORKFLOW,
+        )
+        self.assertIn(
+            "name: Show ccache statistics\n        if: ${{ always() && inputs.enable_ccache }}",
+            REUSABLE_BUILD_WORKFLOW,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt een `enable_ccache`-input toe aan de herbruikbare ESPHome-buildworkflow; bestaande PR-, CI- en dev-builds houden standaard ccache.
- Laat de volledige release-matrix alle enabled firmwareprofielen bouwen met `CCACHE_DISABLE=1` en zonder `IDF_CCACHE_ENABLE`, voordat publicatie kan starten.
- Borgt het cachevrije releasepad en de publicatiegate met workflow-contracttests.

Closes #611

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de GitHub Actions-buildstrategie verandert. De geproduceerde releasefirmware gebruikt dezelfde broncode en buildmatrix, maar compilerobjecten worden niet uit ccache hergebruikt.

## Achtergrond

De ontbrekende directe includes uit #611 zijn de bewezen codefout; dat ccache een foutieve hit gaf is nog niet definitief aangetoond. Deze wijziging maakt de release daarom fail-safe zonder die hypothese als bewezen aan te nemen: release-artifacts komen uit een volledige compiler-cachevrije matrix en `publish-release` blijft afhankelijk van `compile-profiles`.

De native ESP-IDF-toolchaincache en dependencycaches blijven intact; alleen hergebruik van gecompileerde objecten wordt voor releases uitgesloten. De standaard `enable_ccache: true` voorkomt timingregressies voor PR-, CI- en dev-builds.

Volledige diff-audit uitgevoerd op correctheid, fail-closed publicatie, overige workflow-callers, compatibiliteit en regressiedekking. Geen runtime-, migratie-, upgrade-, backup/restore- of fresh-installpaden worden geraakt.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne CI/release-hardening zonder wijziging aan gebruikersconfiguratie, firmwaregedrag of publieke interfaces.

## Validatie

- [x] `npm run check:python-contracts` — 211 tests geslaagd.
- [x] Beide gewijzigde workflows syntactisch geparseerd met Ruby/Psych.
- [x] `git diff --check` — geslaagd.
- [x] [GitHub CI #1977](https://github.com/OpenQuatt/OpenQuatt/actions/runs/33889934017) — geslaagd; alle zes enabled firmwareprofielen compileerden via het standaard gecachete PR-pad.
- [ ] Cachevrije release-matrix end-to-end uitgevoerd; dit pad wordt alleen door `Release Build` geactiveerd en is in deze PR met contracttests afgedekt.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; alleen GitHub Actions-workflows en contracttests wijzigen.
