### PR TITLE
Herstel legacy OTA-aliases voor Q-releases

### DIFF
--- a/scripts/build_targets.py
+++ b/scripts/build_targets.py
@@ -109,7 +109,10 @@ def release_asset_names(target: dict[str, str]) -> list[str]:
         f"{artifact_name}.firmware.ota.bin",
         f"{artifact_name}.firmware.factory.bin",
     ]
-    names.extend(manifest_name_for_artifact(target, published_name) for published_name in artifact_names(target))
+    for published_name in artifact_names(target):
+        if published_name != artifact_name:
+            names.append(f"{published_name}.firmware.ota.bin")
+        names.append(manifest_name_for_artifact(target, published_name))
     return names
 
 
@@ -201,13 +204,18 @@ def prepare_release_assets(version: str, base_url: str, release_url: str) -> Non
         ota_md5 = md5sum(ota_dest)
 
         for published_name in artifact_names(target):
+            published_ota_name = f"{published_name}.firmware.ota.bin"
+            if published_name != artifact_name:
+                # Legacy firmware validates the OTA filename suffix before install.
+                # Keep byte-identical alias binaries beside compatibility manifests.
+                shutil.copy2(ota_dest, dist_dir / published_ota_name)
             manifest = build_ota_manifest(
                 target,
                 published_name,
                 version,
                 base_url,
                 release_url,
-                ota_name,
+                published_ota_name,
                 ota_md5,
             )
             manifest_path = REPO_ROOT / manifest_name_for_artifact(target, published_name)

--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -189,7 +189,7 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
                 manifest["builds"][0]["ota"]["path"],
             )
 
-    def test_release_aliases_get_compatibility_manifests_without_duplicate_binaries(self) -> None:
+    def test_release_aliases_are_byte_identical_and_get_matching_manifests(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)
             artifact_dir = repo_root / "dist/openquatt-test"
@@ -222,7 +222,9 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
                         "openquatt-test.firmware.ota.bin",
                         "openquatt-test.firmware.factory.bin",
                         "openquatt-test-ota.manifest.json",
+                        "openquatt-test-wifi.firmware.ota.bin",
                         "openquatt-test-wifi-ota.manifest.json",
+                        "openquatt-test-eth.firmware.ota.bin",
                         "openquatt-test-eth-ota.manifest.json",
                     ],
                     build_targets.release_asset_names(target),
@@ -238,28 +240,28 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
             self.assertEqual(b"ota-firmware", canonical_ota.read_bytes())
             self.assertEqual(b"factory-firmware", canonical_factory.read_bytes())
 
-            manifests = {
-                name: json.loads((repo_root / name).read_text(encoding="utf-8"))
-                for name in (
-                    "openquatt-test-ota.manifest.json",
-                    "openquatt-test-wifi-ota.manifest.json",
-                    "openquatt-test-eth-ota.manifest.json",
-                )
-            }
-            expected_ota_path = "https://example.invalid/download/openquatt-test.firmware.ota.bin"
             expected_ota_md5 = build_targets.md5sum(canonical_ota)
-            for manifest in manifests.values():
-                self.assertEqual(expected_ota_path, manifest["builds"][0]["ota"]["path"])
+            for published_name in ("openquatt-test", "openquatt-test-wifi", "openquatt-test-eth"):
+                published_ota = repo_root / f"dist/{published_name}.firmware.ota.bin"
+                self.assertEqual(canonical_ota.read_bytes(), published_ota.read_bytes())
+                manifest = json.loads(
+                    (repo_root / f"{published_name}-ota.manifest.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(
+                    f"https://example.invalid/download/{published_name}.firmware.ota.bin",
+                    manifest["builds"][0]["ota"]["path"],
+                )
                 self.assertEqual(expected_ota_md5, manifest["builds"][0]["ota"]["md5"])
 
-            self.assertEqual("Test target", manifests["openquatt-test-ota.manifest.json"]["name"])
             for alias in ("openquatt-test-wifi", "openquatt-test-eth"):
-                self.assertFalse((repo_root / f"dist/{alias}.firmware.ota.bin").exists())
                 self.assertFalse((repo_root / f"dist/{alias}.firmware.factory.bin").exists())
                 expected_connection = "Wi-Fi" if alias.endswith("-wifi") else "Ethernet"
+                manifest = json.loads(
+                    (repo_root / f"{alias}-ota.manifest.json").read_text(encoding="utf-8")
+                )
                 self.assertEqual(
                     f"Test target {expected_connection}",
-                    manifests[f"{alias}-ota.manifest.json"]["name"],
+                    manifest["name"],
                 )
 
     def test_pr_aliases_publish_canonical_bin_with_compatibility_manifests(self) -> None:


### PR DESCRIPTION
# Wat verandert deze PR?

- Publiceer voor Q-releases byte-identieke `-wifi`- en `-eth`-OTA-aliases naast de canonieke binary.
- Laat ieder compatibility-manifest verwijzen naar de bijbehorende alias, zodat firmware tot en met v0.48 de target-suffix accepteert.
- Neem de aliasbinaries op in de verwachte release-assets, zodat de dev-releasepruner ze behoudt.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de releaseverpakking wijzigt. De aliasbestanden bevatten exact dezelfde bytes en MD5 als de canonieke Q-binary. De canonieke manifests en factory-binaries blijven ongewijzigd.

## Achtergrond

v0.48 valideert vóór OTA dat de firmware-URL eindigt op de verbindingsspecifieke targetnaam, bijvoorbeeld `openquatt-heatpump-controller-q-duo-wifi.firmware.ota.bin`. Vanaf v0.49.1 wees het legacy compatibility-manifest naar de nieuwe canonieke `...-duo.firmware.ota.bin`, waardoor de upgrade met `target mismatch` werd geblokkeerd.

Audit van de volledige diff tegen `main` omvatte release- en dev-publicatie, pruning, canonical/alias-scheidingen, MD5-consistentie, gedeeltelijke fouten en compatibiliteit met bestaande installaties. De uploadglobs nemen de nieuwe binaries automatisch mee; `release-files` voorkomt dat de dev-pruner ze verwijdert. Andere hardwareprofielen en fresh-install factory-assets blijven ongewijzigd.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt het bestaande OTA-upgradecontract zonder gebruikersflow, configuratie of bediening te wijzigen.

## Validatie

- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; alleen Python-releaseverpakking en contracttests wijzigen.

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 211 tests geslaagd.
- `python3 scripts/build_targets.py release-files --status enabled` — vier Q OTA-aliases staan in de verwachte assets.
- `git diff --check origin/main...HEAD` — geslaagd.
- Handmatige v0.49.1-hotfixvoorbereiding: canonieke Single/Duo OTA-binaries gecontroleerd tegen gepubliceerde SHA-256 en manifest-MD5; alle vier aliasbinaries zijn byte-identiek en elk compatibility-manifest verwijst naar zijn eigen suffix.
