### PR TITLE
Leg ontwikkelafspraken voor de web-app vast

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,9 @@ The checker is intended as a local quality gate. Add new rules only once the cur
 
 ## Generated Web Bundles
 
+Read the [web-app development guide](openquatt/web/README.md) for component reuse,
+styling, lifecycle rules, bundle constraints and the validation/browser checklist.
+
 The files `openquatt/web/js/openquatt-app.js` and `openquatt/web/css/openquatt-app.css` are generated artifacts and are no longer committed. CI and local validate rebuild them before firmware compilation.
 
 When you change web sources, validate the generated output locally with:

--- a/openquatt/web/AGENTS.md
+++ b/openquatt/web/AGENTS.md
@@ -1,7 +1,10 @@
 # Web UI
 
+- Read and follow [README.md](README.md) before web-app development; it is the canonical development guide.
 - Edit source files in `js/src/` and `css/src/`.
-- Do not edit generated bundles directly: `js/openquatt-app.js` and `css/openquatt-app.css`.
-- Rebuild bundles after source changes with `rtk npm run build:web`.
+- Do not edit or commit generated production/preview bundles.
+- Reuse existing field models, controls, tokens and modals; keep service-specific write/safety gates separate.
+- Preserve overview colors and live input/focus/scroll continuity.
 - Keep `dev.html`, `mock-device.js`, and `device-wrapper.js` scoped to local/demo behavior.
-- For UI changes, verify the relevant screen rather than reading all web source files.
+- After web source changes, follow the guide's validation workflow and [browser matrix](BROWSER_SMOKE_MATRIX.md), including production-bundle checks. Verify affected surfaces rather than reading all web source files.
+- For documentation-only changes, check links/commands and docs contracts; no web build or browser run is required.

--- a/openquatt/web/BROWSER_SMOKE_MATRIX.md
+++ b/openquatt/web/BROWSER_SMOKE_MATRIX.md
@@ -1,13 +1,20 @@
 # Web Browser Smoke Matrix
 
-Run this matrix after changes to shared rendering, CSS, state, modals, or entity actions.
-Use `dev.html` with the mock controls and test both light and dark themes.
+Follow the [development guide](README.md). After changes to shared rendering, CSS,
+state, modals, or entity actions, cover all affected consumers in this matrix;
+complete the matrix before release. Record the tested commit/build, browser/version,
+viewport, themes and any skipped checks. Documentation-only changes do not require
+a browser run.
+
+Use `dev.html` with local mock data and test both light and dark themes. Also verify
+the production JS/CSS as described below; the default preview alone is insufficient.
 
 | Surface | Desktop light | Desktop dark | Mobile light | Mobile dark | Required interaction |
 |---|---|---|---|---|---|
 | Overview | Required | Required | Required | Required | Switch overview controls and open silent settings |
 | Energy | Required | Required | Required | Required | Change period and history view |
 | Settings | Required | Required | Required | Required | Change group, select, number, switch, and time controls |
+| Service / experimental controls | Required | Required | Required | Required | Load values, validate input and verify each service's write gates |
 | Firmware modals | Required | Required | Required | Required | Open, close, switch advanced mode, and verify errors |
 | History import/export | Required | Required | Required | Required | Open storage modal, preserve scroll, and validate file state |
 
@@ -16,19 +23,32 @@ For every cell verify:
 - no horizontal page overflow;
 - no overlapping controls or clipped text;
 - visible focus and working close/backdrop behavior;
+- preserved drafts, cursor/selection and native dropdowns during live updates;
 - preserved modal scroll and stick-to-bottom behavior where applicable;
-- no unexpected console errors, extra polling, or repeated requests.
+- no unexpected console errors, extra polling, or repeated requests;
+- explicit busy/error/uncertain states under slow, failed or stale responses; no false success.
 
 Automated prerequisites:
 
 ```sh
-rtk npm run check:web
-rtk npm run smoke:web
-rtk npm run stats:web
+npm run check:web
+npm run smoke:web
+node openquatt/web/build-assets.mjs --check
 ```
 
-`smoke:web` rebuilds the ignored preview assets required by `dev.html`; the
-committed production bundles remain check-only in this flow.
+`check:web` builds production and preview assets; `smoke:web` rebuilds the ignored
+preview assets required by `dev.html` and checks the generated output. Neither
+production nor preview bundles are committed.
+
+For the production check, use an isolated local mock test page based on `dev.html`
+with the same mock scripts, but load `js/openquatt-app.js` and
+`css/openquatt-app.css` instead of the preview pair. Do not mix production JS with
+preview CSS: symbol mappings can differ. Keep the test page temporary and reload
+after every rebuild. Test actual-device writes or OTA only with explicit permission.
+
+For native input, focus, scrolling or mobile layout changes, include Safari/iOS
+checks where applicable. Desktop Safari is not evidence of an iOS test; state any
+coverage limitation explicitly.
 
 The matrix is a release checklist, not a replacement for the automated source,
 bundle, import-boundary, scroll, state, and action contracts in `smoke-web.mjs`.

--- a/openquatt/web/README.md
+++ b/openquatt/web/README.md
@@ -1,0 +1,118 @@
+# Web-appontwikkeling
+
+Dit is de centrale ontwikkelrichtlijn voor de embedded OpenQuatt-web-app, voor
+ontwikkelaars en coding agents. De afspraken gelden bij uitbreidingen en wijzigingen;
+ze zijn geen opdracht om ongerelateerde bestaande code te herschrijven.
+
+## Hergebruik en eigenaarschap
+
+- Gebruik bestaande componenten vóór je een nieuwe variant maakt. Breid een helper
+  uit als gedrag werkelijk overeenkomt; maak geen universele component met allerlei
+  uitzonderingen voor slechts één scherm.
+- Houd waarden, opties, validatie en busy-status in één veldmodel voor initiële
+  rendering én live updates. Laat firmwareopties en lokale drafts niet afzonderlijk
+  door dropdowns en keuzekaarten reconstrueren.
+- Deel presentatie, niet automatisch domeinregels. Entity-controls en servicevelden
+  hebben verschillende eigenaars en schrijfvoorwaarden. Geef servicevelden niet
+  zomaar `data-oq-field` of gedeelde select-markers; behoud hun eigen autorisatie,
+  beschikbaarheids-, identiteits- en schrijfcontroles.
+- Houd domeinspecifieke copy, filters en capability-keuzes bij het domein. Voeg een
+  abstractie pas toe wanneer meerdere gebruikers hetzelfde contract hebben.
+
+Startpunten in de bestaande code:
+
+| Onderdeel | Eigenaar |
+|---|---|
+| Selectwaarden, opties en busy-status | [settings/field-models.js](js/src/settings/field-models.js) |
+| Settings-rendering en live veldpatches | [settings/controls.js](js/src/settings/controls.js) |
+| Numerieke entity-invoer | [core/number-controls.js](js/src/core/number-controls.js) |
+| Modals en behoud van bediening | [core/modal-shell.js](js/src/core/modal-shell.js), [core/modal-continuity.js](js/src/core/modal-continuity.js) |
+| Gedeelde statistiekkaarten | [views/stat-card.js](js/src/views/stat-card.js) |
+| Drafts en rendervergelijking | [core/control-drafts.js](js/src/core/control-drafts.js), [core/render-signatures.js](js/src/core/render-signatures.js) |
+
+De [JS-bronindeling](js/src/README.md) beschrijft de modules en de precieze
+opt-invoorwaarden voor gedeelde select-controls.
+
+## Vormgeving en live bediening
+
+- Gebruik bestaande tokens, spacing, knoppen, velden, kaarten en modalvarianten.
+  Nieuwe CSS hoort bij het kleinste relevante onderdeel; geen globale overrides om
+  één scherm te repareren. Zie de [CSS-bronindeling](css/src/README.md).
+- Behoud de betekenisvolle kleuren van de overview. Uniformering is geen reden om
+  elektrische/thermische waarden, COP, flow of status hun bestaande kleur te ontnemen.
+- Live updates behouden drafts, focus, cursor/selectie, geopende native dropdowns
+  en scrollpositie. Gebruik gerichte patches wanneer dat veilig kan; behoud een
+  volledige render als de structuur of gespecialiseerde bediening die nodig heeft.
+- Vermijd renders bij ongewijzigde data en bouw zware scherminhoud pas wanneer de
+  betreffende view of modal die nodig heeft.
+- Controleer labels, eenheden, toetsenbordbediening, lange teksten en zichtbare
+  sluitknoppen op mobiel én desktop, in licht en donker.
+
+## Requests, bevestiging en compatibiliteit
+
+- Gebruik de bestaande request- en statehelpers. Begrens wachttijden, voorkom
+  dubbele polling en ruim timers/requests op bij het verlaten van een scherm.
+  Een lopende schrijfopdracht mag daarbij niet als geannuleerd worden beschouwd
+  alleen omdat de UI sluit: reconcileer het resultaat bij heropening.
+- Laat late of verouderde antwoorden geen nieuwere keuze, draft of schermstatus
+  overschrijven. Maak retry-, busy-, offline- en foutgedrag expliciet.
+- Een geaccepteerde schrijfopdracht is geen bewezen eindresultaat. Meld succes pas
+  na de bevestiging die het domein vereist; toon een onzekere uitkomst als onzeker.
+  Herhaal niet-idempotente writes niet blind na een timeout.
+- Behoud authenticatie/CSRF en firmware-side veiligheidscontroles. Een disabled
+  knop is geen beveiligingsgrens. Escape onbetrouwbare tekst via de bestaande helpers.
+- Behandel ontbrekende entities, oude firmware en legacy-backups expliciet. Valideer
+  backupwaarden op type en bereik; verzin geen nul/default voor ontbrekende of
+  ongeldige data. Wijzig schema's alleen met een bewuste migratie/restorestrategie.
+
+## Productiebundel en omvang
+
+- De normale bediening blijft lokaal en zelfstandig: geen GitHub Pages, CDN of
+  andere externe hosting voor noodzakelijke UI-assets. Expliciete netwerkfuncties
+  zoals updates staan los van het laden en bedienen van de app.
+- Bewerk `js/src/`, `css/src/` en bronassets, niet de gegenereerde bundles.
+  Productie- en previewbundles zijn gegenereerd en worden niet gecommit.
+  Houd broncode leesbaar; [de build](build-assets.mjs) verzorgt de verkleining.
+- Houd demo/mockgedrag in de preview. Gebruik `__OQ_PREVIEW__` voor code die uit
+  productie moet verdwijnen; `dev.html` laadt standaard de previewbundles.
+- Gebruik volledige, statisch herkenbare CSS-classnamen waar mogelijk. Dynamische
+  namen en externe consumenten moeten passen bij het contract in
+  [bundle-symbols.mjs](bundle-symbols.mjs); gebruik gegenereerde korte namen nooit
+  als bron- of testcontract. Omzeil geen symbol-/dode-CSS-check om een build groen te maken.
+- Hergebruik eerst voordat je nieuwe dependencies, assets of renderpaden toevoegt.
+  Rapporteer raw/gzip-groei tegenover de PR-doelbranch en onderbouw een eventuele
+  wijziging aan [web-budgets.mjs](web-budgets.mjs). Actuele grenswaarden horen daar,
+  niet als tweede kopie in deze richtlijn.
+
+## Validatie en onderhoud
+
+Voer vanuit de repository-root uit na webcodewijzigingen (dependencies installeren
+met `npm ci` indien nodig):
+
+```sh
+npm run check:web
+npm run smoke:web
+node openquatt/web/build-assets.mjs --check
+```
+
+`check:web` bouwt de bundles en controleert tests/kwaliteit/budgetten. `smoke:web`
+bouwt de preview en controleert onder meer importgrenzen. Een lokale budgetcheck
+zonder basisvergelijking bewijst niet dat de PR binnen het relatieve groeibudget valt.
+
+- Voeg gerichte regressietests toe voor de gewijzigde contracten, inclusief relevante
+  fouten, stale responses, dubbele acties, ontbrekende data en herstel na mislukken.
+- Volg de [browsermatrix](BROWSER_SMOKE_MATRIX.md). Test ook de productie-JS en -CSS;
+  een geslaagde preview bewijst niet dat minificatie en symbolcompactie correct zijn.
+- Controleer Safari/iOS waar native invoer, focus, scrolling of mobiele layout wordt
+  geraakt. Vermeld wat werkelijk is getest en wat niet; mocktests vervangen geen
+  hardwaretest wanneer firmwaregedrag verandert. Doe geen echte device-writes/OTA
+  zonder toestemming.
+- Houd de complete PR-diff klein en review die tegen de actuele doelbranch, gevolgd
+  door een afzonderlijke koude nacontrole. Vermeld validatie en resterende risico's.
+- Bij uitsluitend documentatie: controleer links en commando's en voer
+  `npm run check:docs` uit; webbuilds, browserchecks en firmwarecompiles zijn dan
+  niet nodig.
+
+Leg algemene afspraken hier vast, implementatiedetails in de JS/CSS-README's en
+afdwingbare invarianten in tests/checkers. Houd [AGENTS.md](AGENTS.md) kort en
+verwijzend. Gebruikersuitleg blijft in [docs/web-app.md](../../docs/web-app.md).

--- a/openquatt/web/css/src/README.md
+++ b/openquatt/web/css/src/README.md
@@ -1,13 +1,18 @@
 `openquatt/web/css/src/` contains the source fragments for the bundled stylesheet.
 Bundle order is defined in `openquatt/web/css-source-list.mjs`.
 
+See the [web-app development guide](../../README.md) for styling, bundle and validation rules.
+
 Current split:
+
 - `00-tokens.css`: shared CSS custom properties
 - `01-shell.css`: page surface, app shell, header and footer
-- `02-devtools.css`: helper hub, dev dock, native surface and status tiles
+- `02-interface-panel.css`: interface panel and display controls
+- `02-devtools.css`: preview-only development controls; excluded from production
 - `03-modals.css`: shared modal, firmware modal and button styling
 - `04-debug-recording.css`: debug recording modal styling
 - `05-layout-controls.css`: shared grids, panels, helper fields and curve controls
+- `06-shared-stats.css`: shared statistics grids and cards
 - `10-settings-layout.css`: settings sections, navigation, callouts and rule tables
 - `11-settings-climate.css`: climate strategy, response, cooling and generation blocks
 - `12-settings-service.css`: service, ODU runtime, monitoring, commissioning and boiler blocks
@@ -17,12 +22,10 @@ Current split:
 - `16-settings-storage.css`: storage history summary and storage modal
 - `17-settings-integrations-controls.css`: integrations, source selection, switches, time controls and curve fallbacks
 - `20-overview.css`: overview summary, control and temperature styling
+- `21-control-replay.css`: control replay view
 - `30-energy.css`: energy board styling
 - `40-heatpump.css`: heat pump cards, schematic and tooltips
 - `90-responsive.css`: responsive overrides and compact breakpoints
 
-The deployed/runtime file remains:
-- `openquatt/web/css/openquatt-app.css`
-
-Rebuild the bundle with:
-- `rtk npm run build:web`
+The deployed/runtime file is `openquatt/web/css/openquatt-app.css`; it is generated
+and not committed. Build commands live in the development guide.

--- a/openquatt/web/js/src/README.md
+++ b/openquatt/web/js/src/README.md
@@ -1,20 +1,17 @@
 `openquatt/web/js/src/` contains the ES module source for the bundled web app.
 
+See the [web-app development guide](../../README.md) for shared rules and validation.
+
 Current split:
+
 - `app.js`: bundle entrypoint; imports and starts `boot()`
 - `core/`: shared config, state/runtime, entity store, sync, actions, browser helpers and small formatting/domain helpers
 - `features/`: feature flows such as firmware update, header status, security, MQTT, quickstart, storage/history, webserver logs and debug recording
 - `settings/`: settings shell helpers and domain renderers for storage, heating, water, installation, integrations, security, service, silent mode and cooling
 - `views/`: overview, energy, heat pump and root shell rendering
 
-The deployed/runtime file remains:
-- `openquatt/web/js/openquatt-app.js`
-
-Rebuild the bundle with:
-- `rtk npm run build:web`
-
-Run the local web smoke checks with:
-- `rtk npm run smoke:web`
+The deployed/runtime file is `openquatt/web/js/openquatt-app.js`; it is generated
+and not committed. Build and smoke commands live in the development guide.
 
 Settings select controls use `settings/field-models.js` for entity availability,
 draft-aware values, firmware options (`option` or `options`) and busy state.


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt `openquatt/web/README.md` toe als centrale ontwikkelrichtlijn: hergebruik/veldmodellen, uniforme stijl, behoud van overviewkleuren en live invoer, request- en schrijfveiligheid, lokale assets, bundelomvang en validatie.
- Houdt `openquatt/web/AGENTS.md` kort en verwijzend; verbindt de technische JS/CSS-README's en `CONTRIBUTING.md` met de centrale richtlijn.
- Actualiseert de CSS-bestandsindeling en browsermatrix, inclusief productie versus preview, mobiel/Safari, foutpaden en de afspraak dat gegenereerde bundles niet worden gecommit.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Uitsluitend zes Markdown-bestanden. Geen JS/CSS-code, firmware, dependencies, bundels of budgetwaarden gewijzigd.

## Achtergrond

Kleine opvolg-PR bij de webrefactor #630 en de afspraken rond #625. Zelfstandig gebaseerd op actuele `dev` (`0282c2e9`); verwijzingen gebruiken alleen helpers die daar al bestaan. De richtlijn geldt bij toekomstige wijzigingen en geeft geen opdracht tot ongerelateerde refactors.

De complete diff tegen `dev` is gecontroleerd, gevolgd door een afzonderlijke koude nacontrole op tegenstrijdige instructies, scope, linkdoelen, beschikbare commando's, bronindeling en correcte productie-/previewclaims. Geen open bevindingen. Runtime-, migratie-, persistence- en HIL-tests zijn voor deze documentatiewijziging niet van toepassing.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

Deze PR is ontwikkelaarsdocumentatie. Algemene afspraken staan centraal, implementatiedetails blijven in de bron-README's; gebruikersdocs hoeven niet te wijzigen.

## Validatie

- `npm run check:docs` — geslaagd: docs-consistentie en web/docs-contracten.
- Lokale Markdown-links gecontroleerd: 22 geldige doelen; npm-commandoverwijzingen getoetst aan `package.json`.
- CSS-README gecontroleerd tegen `css-source-list.mjs`: alle 21 bronfragmenten in de juiste volgorde.
- `git diff --check origin/dev` — geslaagd.
- Webtests/builds, browserchecks en firmwarecompile bewust niet uitgevoerd: uitsluitend documentatie, geen runtimewijziging.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; geen uitvoerbare code gewijzigd.
