### PR TITLE
Neem bevestigde HP-uit-tijd mee bij gecontroleerde herstart

### DIFF
--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
@@ -10,6 +10,7 @@
 #include "esphome/components/web_server/web_server.h"
 #include "esphome/components/web_server_base/web_server_base.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include "includes/incidents/oq_hp_incident_sources.h"
 
 namespace esphome {
@@ -521,8 +522,11 @@ void OpenQuattIncidentManager::setup() {
   this->units_()[1].configured = OQ_TOPOLOGY_DUO != 0;
   const uint32_t now_ms = millis();
   this->rotate_action_csrf_token_();
-  for (UnitState& unit : this->units_()) {
+  for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
+    UnitState& unit = this->units_()[slot];
     unit.last_link_round_ms = now_ms;
+    unit.restart_guard.configure(this->minimum_off_ms_, LINK_ROUND_TIMEOUT_MS);
+    unit.restart_guard.restore_credit(restored_off_credit_ms(static_cast<uint8_t>(slot + 1U)), true);
   }
   this->setup_manual_reset_persistence_(now_ms);
   for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
@@ -535,6 +539,10 @@ void OpenQuattIncidentManager::setup() {
 }
 
 void OpenQuattIncidentManager::loop() {
+  if (this->restart_requested_.exchange(false)) {
+    this->perform_restart_(millis());
+    return;
+  }
   if (!this->storage_ready_()) return;
   const uint32_t now_ms = millis();
   if (elapsed_ms_(now_ms, this->last_loop_ms_) < 1000U) return;
@@ -554,13 +562,57 @@ void OpenQuattIncidentManager::loop() {
     }
 
     if (link_round_timeout_elapsed(now_ms, unit.last_link_round_ms, LINK_ROUND_TIMEOUT_MS)) {
+      unit.restart_guard.invalidate();
       unit.engine.observe_link_round(now_ms, false);
       unit.last_link_round_ms = now_ms;
     }
     unit.engine.tick(now_ms);
+    if (!unit.startup_released && unit.restart_guard.can_start(now_ms)) {
+      unit.startup_released = true;
+      ESP_LOGI(TAG, "HP%u startup minimum off-time confirmed", static_cast<unsigned>(slot + 1U));
+    }
     this->publish_transitions_(unit, slot, now_ms);
   }
   this->publish_snapshot_(now_ms);
+}
+
+bool OpenQuattIncidentManager::startup_inhibited(uint8_t hp_index) const {
+  const UnitState* unit = this->unit_(hp_index);
+  return unit == nullptr || !unit->startup_released;
+}
+
+uint32_t OpenQuattIncidentManager::minimum_off_remaining_ms(uint8_t hp_index, uint32_t now_ms) const {
+  const UnitState* unit = this->unit_(hp_index);
+  return unit == nullptr ? this->minimum_off_ms_ : unit->restart_guard.remaining_ms(now_ms);
+}
+
+void OpenQuattIncidentManager::perform_restart_(uint32_t now_ms) {
+  // Runs synchronously on the ESPHome loop. No controller/strategy loop can
+  // enqueue another start between this snapshot and safe_reboot().
+  this->restarting_ = true;
+  std::array<uint32_t, 2U> credit{};
+  for (uint8_t hp = 1U; hp <= this->configured_hp_count(); ++hp) {
+    if (this->polling_paused_ == nullptr || !this->polling_paused_->has_state() || this->polling_paused_->state) break;
+    const UnitState* unit = this->unit_(hp);
+    auto* controller = this->controllers_[hp - 1U];
+    // ESPHome 2026.8 submits one-shots directly to the hub; the controller's
+    // ownership list is not a second transmit queue. Continuous reads are safe.
+    if (unit == nullptr || controller == nullptr || controller->hub() == nullptr ||
+        !controller->hub()->tx_buffer_empty() || controller->hub()->tx_blocked())
+      continue;
+    const auto outputs = this->get_outputs(hp);
+    if (outputs.link_state == oq_incidents::LinkState::HEALTHY && outputs.stop_confirmed &&
+        !outputs.stop_confirmation_pending && !unit->start_feedback_armed) {
+      credit[hp - 1U] = unit->restart_guard.snapshot_credit_ms(now_ms);
+    }
+  }
+  const bool saved = arm_restart_handoff(credit[0], credit[1]);
+  ESP_LOGI(TAG, "Controlled restart: confirmed off-time credit HP1=%us HP2=%us (%s)",
+           static_cast<unsigned>(credit[0] / 1000U), static_cast<unsigned>(credit[1] / 1000U),
+           saved ? "saved" : "conservative fallback");
+  // Even a failed write may have changed flash. Never resume normal control
+  // here; the next boot consumes any possible record before enabling services.
+  App.safe_reboot();
 }
 
 void OpenQuattIncidentManager::dump_config() {
@@ -700,6 +752,7 @@ void OpenQuattIncidentManager::observe_transport(uint8_t hp_index, bool online, 
   unit->transport_seen = true;
   unit->transport_online = online;
   if (!online) {
+    unit->restart_guard.invalidate();
     unit->pump_context = {};
     unit->engine.observe_link_round(now_ms, false);
     unit->last_link_round_ms = now_ms;
@@ -710,16 +763,27 @@ void OpenQuattIncidentManager::observe_transport(uint8_t hp_index, bool online, 
 
 void OpenQuattIncidentManager::observe_working_mode(uint8_t hp_index, float working_mode, uint32_t now_ms) {
   UnitState* unit = this->unit_(hp_index);
-  if (unit == nullptr || !std::isfinite(working_mode)) return;
+  if (unit == nullptr) return;
+  if (!std::isfinite(working_mode)) {
+    unit->working_mode_valid = false;
+    unit->restart_guard.invalidate();
+    return;
+  }
+  if (static_cast<int>(std::lround(working_mode)) != 0) unit->restart_guard.invalidate();
   unit->working_mode = working_mode;
   unit->working_mode_valid = true;
   ++unit->working_mode_generation;
-  (void)now_ms;
+  unit->rest_mode_observed_ms = now_ms;
 }
 
 void OpenQuattIncidentManager::observe_compressor_frequency(uint8_t hp_index, float frequency_hz, uint32_t now_ms) {
   UnitState* unit = this->unit_(hp_index);
-  if (unit == nullptr || !std::isfinite(frequency_hz)) return;
+  if (unit == nullptr) return;
+  if (!std::isfinite(frequency_hz) || frequency_hz < 0.0F) {
+    unit->compressor_frequency_valid = false;
+    unit->restart_guard.invalidate();
+    return;
+  }
   unit->compressor_frequency_hz = frequency_hz;
   unit->compressor_frequency_valid = true;
   ++unit->compressor_frequency_generation;
@@ -747,6 +811,17 @@ void OpenQuattIncidentManager::observe_compressor_frequency(uint8_t hp_index, fl
   observation.stop_mode_confirmed =
       unit->working_mode_valid && post_command_mode && static_cast<uint8_t>(std::lround(unit->working_mode)) == 0U;
   unit->engine.observe_run(observation);
+  // Rest evidence requires a new mode sample as well as this frequency sample.
+  // Cached STOPPED alone is insufficient after a communication gap.
+  if (frequency_hz > 0.5F) {
+    unit->restart_guard.invalidate();
+  } else if (unit->transport_online && observation.fresh && observation.stop_mode_confirmed &&
+             unit->engine.outputs().stop_confirmed &&
+             static_cast<uint32_t>(now_ms - unit->rest_mode_observed_ms) <= LINK_ROUND_TIMEOUT_MS &&
+             feedback_generation_is_newer(unit->working_mode_generation, unit->rest_mode_generation)) {
+    unit->restart_guard.observe_stopped(now_ms);
+    unit->rest_mode_generation = unit->working_mode_generation;
+  }
   this->publish_transitions_(*unit, hp_slot_(hp_index), now_ms);
   if (unit->engine.outputs().run_state == oq_incidents::RunState::RUNNING) {
     unit->start_feedback_armed = false;
@@ -861,7 +936,10 @@ void OpenQuattIncidentManager::observe_complete_link_round_(UnitState& unit, uin
 bool OpenQuattIncidentManager::request_start(uint8_t hp_index, uint8_t expected_mode, uint32_t now_ms) {
   UnitState* unit = this->unit_(hp_index);
   const bool newly_armed = unit != nullptr && unit->engine.outputs().run_state == oq_incidents::RunState::STOPPED;
+  if (this->restarting_ || !restart_handoff_storage_ready() || (newly_armed && !unit->restart_guard.can_start(now_ms)))
+    return false;
   if (unit == nullptr || !unit->engine.request_start(now_ms)) return false;
+  if (newly_armed) unit->restart_guard.invalidate();
   unit->expected_mode = expected_mode;
   unit->active_command_mode = expected_mode;
   unit->command_mode_generation = unit->working_mode_generation;
@@ -1677,7 +1755,16 @@ oq_incidents::DerivedOutputs OpenQuattIncidentManager::outputs_for_slot_(size_t 
   const bool persistence_blocks =
       !this->manual_reset_persistence_.initialization_pending() &&
       (!this->manual_reset_persistence_.ready() || (this->manual_reset_persistence_.fault_mask() & hp_mask) != 0U);
-  return apply_persistence_safety_gate(outputs, persistence_blocks);
+  outputs = apply_persistence_safety_gate(outputs, persistence_blocks);
+  const UnitState& unit = this->units_()[slot];
+  if (outputs.run_state == oq_incidents::RunState::STOPPED || !unit.startup_released) {
+    outputs.available_for_start = outputs.available_for_start && unit.restart_guard.can_start(millis());
+  }
+  if (this->restarting_ || !restart_handoff_storage_ready()) {
+    outputs.available_for_start = false;
+    outputs.must_stop = true;
+  }
+  return outputs;
 }
 
 void OpenQuattIncidentManager::publish_snapshot_(uint32_t now_ms) {

--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
@@ -526,7 +526,10 @@ void OpenQuattIncidentManager::setup() {
     UnitState& unit = this->units_()[slot];
     unit.last_link_round_ms = now_ms;
     unit.restart_guard.configure(this->minimum_off_ms_, LINK_ROUND_TIMEOUT_MS);
-    unit.restart_guard.restore_credit(restored_off_credit_ms(static_cast<uint8_t>(slot + 1U)), true);
+    const uint32_t restored_credit_ms = restored_off_credit_ms(static_cast<uint8_t>(slot + 1U));
+    unit.restart_guard.restore_credit(restored_credit_ms, true);
+    unit.restart_credit_pending = restored_credit_ms != 0U;
+    unit.restart_credit_pending_since_ms = now_ms;
   }
   this->setup_manual_reset_persistence_(now_ms);
   for (size_t slot = 0U; slot < this->units_().size(); ++slot) {
@@ -561,8 +564,12 @@ void OpenQuattIncidentManager::loop() {
       this->process_fault_snapshot_(unit, slot, now_ms, true);
     }
 
+    const bool credit_acquisition_active = restored_credit_acquisition_active(
+        unit.restart_credit_pending, unit.transport_seen, unit.transport_online, now_ms,
+        unit.restart_credit_pending_since_ms, RESTART_CREDIT_ACQUISITION_TIMEOUT_MS);
+    if (unit.restart_credit_pending && !credit_acquisition_active) invalidate_restart_credit_(unit);
     if (link_round_timeout_elapsed(now_ms, unit.last_link_round_ms, LINK_ROUND_TIMEOUT_MS)) {
-      unit.restart_guard.invalidate();
+      if (!credit_acquisition_active) unit.restart_guard.invalidate();
       unit.engine.observe_link_round(now_ms, false);
       unit.last_link_round_ms = now_ms;
     }
@@ -586,6 +593,16 @@ uint32_t OpenQuattIncidentManager::minimum_off_remaining_ms(uint8_t hp_index, ui
   return unit == nullptr ? this->minimum_off_ms_ : unit->restart_guard.remaining_ms(now_ms);
 }
 
+void OpenQuattIncidentManager::invalidate_restart_credit(uint8_t hp_index) {
+  UnitState* unit = this->unit_(hp_index);
+  if (unit != nullptr) invalidate_restart_credit_(*unit);
+}
+
+void OpenQuattIncidentManager::invalidate_restart_credit_(UnitState& unit) {
+  unit.restart_credit_pending = false;
+  unit.restart_guard.invalidate();
+}
+
 void OpenQuattIncidentManager::perform_restart_(uint32_t now_ms) {
   // Runs synchronously on the ESPHome loop. No controller/strategy loop can
   // enqueue another start between this snapshot and safe_reboot().
@@ -594,13 +611,11 @@ void OpenQuattIncidentManager::perform_restart_(uint32_t now_ms) {
   for (uint8_t hp = 1U; hp <= this->configured_hp_count(); ++hp) {
     if (this->polling_paused_ == nullptr || !this->polling_paused_->has_state() || this->polling_paused_->state) break;
     const UnitState* unit = this->unit_(hp);
-    auto* controller = this->controllers_[hp - 1U];
-    // ESPHome 2026.8 submits one-shots directly to the hub; the controller's
-    // ownership list is not a second transmit queue. Continuous reads are safe.
-    if (unit == nullptr || controller == nullptr || controller->hub() == nullptr ||
-        !controller->hub()->tx_buffer_empty() || controller->hub()->tx_blocked())
-      continue;
+    if (unit == nullptr) continue;
     const auto outputs = this->get_outputs(hp);
+    // Telemetry reads and safe-stop writes may still be in flight. Every active
+    // mode/level write invalidates the guard before it enters the Modbus queue;
+    // start_feedback_armed additionally covers the incident start lifecycle.
     if (outputs.link_state == oq_incidents::LinkState::HEALTHY && outputs.stop_confirmed &&
         !outputs.stop_confirmation_pending && !unit->start_feedback_armed) {
       credit[hp - 1U] = unit->restart_guard.snapshot_credit_ms(now_ms);
@@ -752,7 +767,7 @@ void OpenQuattIncidentManager::observe_transport(uint8_t hp_index, bool online, 
   unit->transport_seen = true;
   unit->transport_online = online;
   if (!online) {
-    unit->restart_guard.invalidate();
+    invalidate_restart_credit_(*unit);
     unit->pump_context = {};
     unit->engine.observe_link_round(now_ms, false);
     unit->last_link_round_ms = now_ms;
@@ -766,10 +781,10 @@ void OpenQuattIncidentManager::observe_working_mode(uint8_t hp_index, float work
   if (unit == nullptr) return;
   if (!std::isfinite(working_mode)) {
     unit->working_mode_valid = false;
-    unit->restart_guard.invalidate();
+    invalidate_restart_credit_(*unit);
     return;
   }
-  if (static_cast<int>(std::lround(working_mode)) != 0) unit->restart_guard.invalidate();
+  if (static_cast<int>(std::lround(working_mode)) != 0) invalidate_restart_credit_(*unit);
   unit->working_mode = working_mode;
   unit->working_mode_valid = true;
   ++unit->working_mode_generation;
@@ -781,7 +796,7 @@ void OpenQuattIncidentManager::observe_compressor_frequency(uint8_t hp_index, fl
   if (unit == nullptr) return;
   if (!std::isfinite(frequency_hz) || frequency_hz < 0.0F) {
     unit->compressor_frequency_valid = false;
-    unit->restart_guard.invalidate();
+    invalidate_restart_credit_(*unit);
     return;
   }
   unit->compressor_frequency_hz = frequency_hz;
@@ -814,12 +829,13 @@ void OpenQuattIncidentManager::observe_compressor_frequency(uint8_t hp_index, fl
   // Rest evidence requires a new mode sample as well as this frequency sample.
   // Cached STOPPED alone is insufficient after a communication gap.
   if (frequency_hz > 0.5F) {
-    unit->restart_guard.invalidate();
+    invalidate_restart_credit_(*unit);
   } else if (unit->transport_online && observation.fresh && observation.stop_mode_confirmed &&
              unit->engine.outputs().stop_confirmed &&
              static_cast<uint32_t>(now_ms - unit->rest_mode_observed_ms) <= LINK_ROUND_TIMEOUT_MS &&
              feedback_generation_is_newer(unit->working_mode_generation, unit->rest_mode_generation)) {
     unit->restart_guard.observe_stopped(now_ms);
+    unit->restart_credit_pending = false;
     unit->rest_mode_generation = unit->working_mode_generation;
   }
   this->publish_transitions_(*unit, hp_slot_(hp_index), now_ms);
@@ -939,7 +955,7 @@ bool OpenQuattIncidentManager::request_start(uint8_t hp_index, uint8_t expected_
   if (this->restarting_ || !restart_handoff_storage_ready() || (newly_armed && !unit->restart_guard.can_start(now_ms)))
     return false;
   if (unit == nullptr || !unit->engine.request_start(now_ms)) return false;
-  if (newly_armed) unit->restart_guard.invalidate();
+  if (newly_armed) invalidate_restart_credit_(*unit);
   unit->expected_mode = expected_mode;
   unit->active_command_mode = expected_mode;
   unit->command_mode_generation = unit->working_mode_generation;

--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.h
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.h
@@ -10,13 +10,17 @@
 #include <freertos/semphr.h>
 
 #include "esphome/components/globals/globals_component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/modbus_controller/modbus_controller.h"
 #include "esphome/components/openquatt_decision_log/OpenQuattDecisionLog.h"
 #include "esphome/components/openquatt_web_auth/OpenQuattWebAuth.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "OpenQuattIncidentPolicy.h"
+#include "OpenQuattRestartHandoff.h"
 #include "PsramBuffer.h"
+#include "includes/control/oq_hp_restart_guard.h"
 #include "includes/diagnostics/oq_pump_ipwm_feedback.h"
 #include "includes/incidents/oq_hp_incident_engine.h"
 #include "includes/incidents/oq_manual_reset_latch_policy.h"
@@ -47,6 +51,14 @@ class OpenQuattIncidentManager : public Component {
   void set_control_mode_code(IntGlobal* value) { this->control_mode_code_ = value; }
   void set_decision_log(openquatt_decision_log::OpenQuattDecisionLog* value) { this->decision_log_ = value; }
   void set_web_auth(openquatt_web_auth::OpenQuattWebAuth* value) { this->web_auth_ = value; }
+  void set_minimum_off_ms(uint32_t value) { this->minimum_off_ms_ = value; }
+  void set_polling_paused(binary_sensor::BinarySensor* value) { this->polling_paused_ = value; }
+  void set_hp1_controller(modbus_controller::ModbusController* value) { this->controllers_[0] = value; }
+  void set_hp2_controller(modbus_controller::ModbusController* value) { this->controllers_[1] = value; }
+  // Button callbacks only enqueue; state and Modbus queues belong to loop().
+  void request_restart() { this->restart_requested_.store(true); }
+  bool startup_inhibited(uint8_t hp_index) const;
+  uint32_t minimum_off_remaining_ms(uint8_t hp_index, uint32_t now_ms) const;
 
   void setup() override;
   void loop() override;
@@ -129,6 +141,10 @@ class OpenQuattIncidentManager : public Component {
 
   struct UnitState {
     oq_incidents::HpIncidentEngine engine{};
+    oq_hp_restart_guard::Policy restart_guard{};
+    bool startup_released{false};
+    uint32_t rest_mode_generation{0U};
+    uint32_t rest_mode_observed_ms{0U};
     bool configured{false};
     bool transport_online{false};
     bool transport_seen{false};
@@ -234,6 +250,7 @@ class OpenQuattIncidentManager : public Component {
   UnitState* unit_(uint8_t hp_index);
   const UnitState* unit_(uint8_t hp_index) const;
   void process_fault_snapshot_(UnitState& unit, size_t slot, uint32_t now_ms, bool force_partial);
+  void perform_restart_(uint32_t now_ms);
   void observe_complete_link_round_(UnitState& unit, uint32_t now_ms);
   void publish_transitions_(UnitState& unit, size_t slot, uint32_t now_ms);
   void publish_incident_transition_(size_t slot, const oq_incidents::IncidentDefinition& definition,
@@ -261,6 +278,11 @@ class OpenQuattIncidentManager : public Component {
   IntGlobal* control_mode_code_{nullptr};
   openquatt_decision_log::OpenQuattDecisionLog* decision_log_{nullptr};
   openquatt_web_auth::OpenQuattWebAuth* web_auth_{nullptr};
+  std::array<modbus_controller::ModbusController*, 2U> controllers_{};
+  binary_sensor::BinarySensor* polling_paused_{nullptr};
+  uint32_t minimum_off_ms_{240000U};
+  std::atomic<bool> restart_requested_{false};
+  bool restarting_{false};
   bool fallback_requested_{false};
   bool fallback_active_{false};
   uint8_t fallback_block_reason_{0U};

--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.h
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.h
@@ -11,7 +11,6 @@
 
 #include "esphome/components/globals/globals_component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/modbus_controller/modbus_controller.h"
 #include "esphome/components/openquatt_decision_log/OpenQuattDecisionLog.h"
 #include "esphome/components/openquatt_web_auth/OpenQuattWebAuth.h"
 #include "esphome/components/time/real_time_clock.h"
@@ -53,10 +52,9 @@ class OpenQuattIncidentManager : public Component {
   void set_web_auth(openquatt_web_auth::OpenQuattWebAuth* value) { this->web_auth_ = value; }
   void set_minimum_off_ms(uint32_t value) { this->minimum_off_ms_ = value; }
   void set_polling_paused(binary_sensor::BinarySensor* value) { this->polling_paused_ = value; }
-  void set_hp1_controller(modbus_controller::ModbusController* value) { this->controllers_[0] = value; }
-  void set_hp2_controller(modbus_controller::ModbusController* value) { this->controllers_[1] = value; }
   // Button callbacks only enqueue; state and Modbus queues belong to loop().
   void request_restart() { this->restart_requested_.store(true); }
+  void invalidate_restart_credit(uint8_t hp_index);
   bool startup_inhibited(uint8_t hp_index) const;
   uint32_t minimum_off_remaining_ms(uint8_t hp_index, uint32_t now_ms) const;
 
@@ -103,6 +101,7 @@ class OpenQuattIncidentManager : public Component {
 
  protected:
   static constexpr uint32_t LINK_ROUND_TIMEOUT_MS = 15000U;
+  static constexpr uint32_t RESTART_CREDIT_ACQUISITION_TIMEOUT_MS = 120000U;
   static constexpr uint32_t PARTIAL_FAULT_SNAPSHOT_TIMEOUT_MS = 15000U;
   static constexpr uint32_t MANUAL_RESET_PERSIST_RETRY_MS = 60000U;
   static constexpr uint8_t INITIALIZATION_FAULT_SNAPSHOT_COUNT = 2U;
@@ -142,6 +141,8 @@ class OpenQuattIncidentManager : public Component {
   struct UnitState {
     oq_incidents::HpIncidentEngine engine{};
     oq_hp_restart_guard::Policy restart_guard{};
+    bool restart_credit_pending{false};
+    uint32_t restart_credit_pending_since_ms{0U};
     bool startup_released{false};
     uint32_t rest_mode_generation{0U};
     uint32_t rest_mode_observed_ms{0U};
@@ -249,6 +250,7 @@ class OpenQuattIncidentManager : public Component {
   PublishedSnapshot& response_snapshot_() const;
   UnitState* unit_(uint8_t hp_index);
   const UnitState* unit_(uint8_t hp_index) const;
+  static void invalidate_restart_credit_(UnitState& unit);
   void process_fault_snapshot_(UnitState& unit, size_t slot, uint32_t now_ms, bool force_partial);
   void perform_restart_(uint32_t now_ms);
   void observe_complete_link_round_(UnitState& unit, uint32_t now_ms);
@@ -278,7 +280,6 @@ class OpenQuattIncidentManager : public Component {
   IntGlobal* control_mode_code_{nullptr};
   openquatt_decision_log::OpenQuattDecisionLog* decision_log_{nullptr};
   openquatt_web_auth::OpenQuattWebAuth* web_auth_{nullptr};
-  std::array<modbus_controller::ModbusController*, 2U> controllers_{};
   binary_sensor::BinarySensor* polling_paused_{nullptr};
   uint32_t minimum_off_ms_{240000U};
   std::atomic<bool> restart_requested_{false};

--- a/components/openquatt_incident_manager/OpenQuattIncidentPolicy.h
+++ b/components/openquatt_incident_manager/OpenQuattIncidentPolicy.h
@@ -11,6 +11,13 @@ inline bool link_round_timeout_elapsed(uint32_t now_ms, uint32_t last_round_ms, 
   return static_cast<uint32_t>(now_ms - last_round_ms) >= timeout_ms;
 }
 
+inline bool restored_credit_acquisition_active(bool credit_pending, bool transport_seen, bool transport_online,
+                                               uint32_t now_ms, uint32_t pending_since_ms,
+                                               uint32_t acquisition_timeout_ms) {
+  return credit_pending && (!transport_seen || transport_online) &&
+         static_cast<uint32_t>(now_ms - pending_since_ms) < acquisition_timeout_ms;
+}
+
 inline bool feedback_generation_is_newer(uint32_t generation, uint32_t baseline) {
   return static_cast<int32_t>(generation - baseline) > 0;
 }

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -1,0 +1,183 @@
+#include "OpenQuattRestartHandoff.h"
+
+#include <cstring>
+
+#include "OpenQuattRestartHandoffPolicy.h"
+#include "esp_app_desc.h"
+#include "esp_ota_ops.h"
+#include "esp_system.h"
+#include "nvs.h"
+#include "esphome/core/log.h"
+
+namespace esphome::openquatt_incident_manager {
+namespace {
+
+using restart_handoff::BootContext;
+using restart_handoff::Record;
+
+constexpr const char* TAG = "openquatt.restart";
+constexpr const char* NVS_NAMESPACE = "openquatt";
+constexpr const char* NVS_KEY = "oq_restart_v1";
+
+bool storage_ready{false};
+uint32_t restored_credit_ms[2]{0U, 0U};
+uint32_t configured_minimum_off_ms{0U};
+
+bool open_storage(nvs_handle_t* handle) {
+  if (handle == nullptr) return false;
+  const esp_err_t result = nvs_open(NVS_NAMESPACE, NVS_READWRITE, handle);
+  if (result != ESP_OK) {
+    ESP_LOGE(TAG, "Could not open restart handoff storage: %s", esp_err_to_name(result));
+    return false;
+  }
+  return true;
+}
+
+class NvsStorage {
+ public:
+  explicit NvsStorage(nvs_handle_t handle) : handle_(handle) {}
+
+  restart_handoff::StorageReadResult read(Record* record) const {
+    if (record == nullptr) return restart_handoff::StorageReadResult::ERROR;
+    size_t size = sizeof(*record);
+    const esp_err_t result = nvs_get_blob(this->handle_, NVS_KEY, record, &size);
+    if (result == ESP_ERR_NVS_NOT_FOUND) return restart_handoff::StorageReadResult::ABSENT;
+    if (result != ESP_OK || size != sizeof(*record)) {
+      ESP_LOGW(TAG, "Restart handoff record is unreadable (result=%s, size=%u)", esp_err_to_name(result),
+               static_cast<unsigned>(size));
+      return restart_handoff::StorageReadResult::ERROR;
+    }
+    return restart_handoff::StorageReadResult::PRESENT;
+  }
+
+  bool erase_and_verify_absent() const {
+    const esp_err_t erase_result = nvs_erase_key(this->handle_, NVS_KEY);
+    if (erase_result != ESP_OK && erase_result != ESP_ERR_NVS_NOT_FOUND) {
+      ESP_LOGE(TAG, "Could not erase restart handoff: %s", esp_err_to_name(erase_result));
+      return false;
+    }
+    if (erase_result == ESP_OK && nvs_commit(this->handle_) != ESP_OK) {
+      ESP_LOGE(TAG, "Could not commit restart handoff consume");
+      return false;
+    }
+    Record verified{};
+    return this->read(&verified) == restart_handoff::StorageReadResult::ABSENT;
+  }
+
+  bool write_commit_and_verify(const Record& record) const {
+    if (nvs_set_blob(this->handle_, NVS_KEY, &record, sizeof(record)) != ESP_OK) return false;
+    if (nvs_commit(this->handle_) != ESP_OK) return false;
+    Record verified{};
+    return this->read(&verified) == restart_handoff::StorageReadResult::PRESENT &&
+           std::memcmp(&record, &verified, sizeof(record)) == 0;
+  }
+
+ private:
+  nvs_handle_t handle_;
+};
+
+bool capture_boot_context(uint32_t minimum_off_ms, BootContext* context) {
+  if (context == nullptr || !restart_handoff::valid_minimum_off_ms(minimum_off_ms)) return false;
+  const esp_partition_t* running = esp_ota_get_running_partition();
+  const esp_partition_t* boot = esp_ota_get_boot_partition();
+  const esp_app_desc_t* description = esp_app_get_description();
+  if (running == nullptr || boot == nullptr || description == nullptr) return false;
+
+  esp_ota_img_states_t image_state = ESP_OTA_IMG_UNDEFINED;
+  const esp_err_t state_result = esp_ota_get_state_partition(running, &image_state);
+  // Without otadata rollback is unavailable, so there is no unverified OTA image
+  // to accidentally credit. Otherwise accept only an explicit valid/undefined state.
+  const bool state_safe =
+      (state_result == ESP_OK && (image_state == ESP_OTA_IMG_VALID || image_state == ESP_OTA_IMG_UNDEFINED)) ||
+      state_result == ESP_ERR_NOT_FOUND;
+  if (!state_safe) {
+    ESP_LOGW(TAG, "Restart handoff rejected unverified or unavailable image state: %s", esp_err_to_name(state_result));
+    return false;
+  }
+
+  context->software_reset = esp_reset_reason() == ESP_RST_SW;
+  context->running_partition_matches_boot = running->address == boot->address;
+  context->image_valid = state_safe;
+  context->minimum_off_ms = minimum_off_ms;
+#if OQ_TOPOLOGY_DUO
+  context->config_hash = restart_handoff::configuration_hash(minimum_off_ms, true);
+#else
+  context->config_hash = restart_handoff::configuration_hash(minimum_off_ms, false);
+#endif
+  context->boot_partition_address = running->address;
+  std::memcpy(context->image_hash, description->app_elf_sha256, sizeof(context->image_hash));
+  return restart_handoff::has_image_hash(context->image_hash);
+}
+
+}  // namespace
+
+bool initialize_restart_handoff(uint32_t minimum_off_ms) {
+  storage_ready = false;
+  restored_credit_ms[0] = 0U;
+  restored_credit_ms[1] = 0U;
+  configured_minimum_off_ms = 0U;
+
+  BootContext context{};
+  const bool context_available = capture_boot_context(minimum_off_ms, &context);
+  nvs_handle_t handle{};
+  if (!open_storage(&handle)) return false;
+  NvsStorage storage(handle);
+  const bool consumed =
+      restart_handoff::consume_record(storage, context, &restored_credit_ms[0], &restored_credit_ms[1]);
+  nvs_close(handle);
+  if (!consumed) {
+    ESP_LOGE(TAG, "Restart handoff could not be durably consumed");
+    return false;
+  }
+
+  storage_ready = true;
+  configured_minimum_off_ms = minimum_off_ms;
+  if (context_available && (restored_credit_ms[0] != 0U || restored_credit_ms[1] != 0U)) {
+    ESP_LOGI(TAG, "Restored one-shot confirmed-off credit after controlled restart");
+  }
+  return true;
+}
+
+bool restart_handoff_storage_ready() { return storage_ready; }
+
+uint32_t restored_off_credit_ms(uint8_t hp_index) {
+  if (!storage_ready || hp_index < 1U || hp_index > 2U) return 0U;
+  return restored_credit_ms[hp_index - 1U];
+}
+
+bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
+  if (!storage_ready || !restart_handoff::valid_minimum_off_ms(configured_minimum_off_ms) ||
+      hp1_credit_ms > configured_minimum_off_ms || hp2_credit_ms > configured_minimum_off_ms ||
+      (hp1_credit_ms == 0U && hp2_credit_ms == 0U)) {
+    return false;
+  }
+
+  BootContext context{};
+  if (!capture_boot_context(configured_minimum_off_ms, &context) || !context.running_partition_matches_boot ||
+      !context.image_valid) {
+    ESP_LOGE(TAG, "Restart handoff arm rejected current image context");
+    return false;
+  }
+
+  Record record{};
+  record.magic = restart_handoff::kRecordMagic;
+  record.version = restart_handoff::kRecordVersion;
+  record.state = restart_handoff::kRecordArmed;
+  record.minimum_off_ms = configured_minimum_off_ms;
+  record.config_hash = context.config_hash;
+  record.boot_partition_address = context.boot_partition_address;
+  record.hp1_credit_ms = hp1_credit_ms;
+  record.hp2_credit_ms = hp2_credit_ms;
+  std::memcpy(record.image_hash, context.image_hash, sizeof(record.image_hash));
+  restart_handoff::finalize_record(&record);
+
+  nvs_handle_t handle{};
+  if (!open_storage(&handle)) return false;
+  NvsStorage storage(handle);
+  const bool persisted = restart_handoff::persist_record(storage, record);
+  nvs_close(handle);
+  if (!persisted) ESP_LOGE(TAG, "Restart handoff arm was not durably verified");
+  return persisted;
+}
+
+}  // namespace esphome::openquatt_incident_manager

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -109,6 +109,25 @@ bool capture_boot_context(uint32_t minimum_off_ms, BootContext* context) {
   return restart_handoff::has_image_hash(context->image_hash);
 }
 
+bool confirm_pending_image_for_controlled_restart() {
+  const esp_partition_t* running = esp_ota_get_running_partition();
+  const esp_partition_t* boot = esp_ota_get_boot_partition();
+  if (running == nullptr || boot == nullptr || running->address != boot->address) return false;
+
+  esp_ota_img_states_t image_state = ESP_OTA_IMG_UNDEFINED;
+  const esp_err_t state_result = esp_ota_get_state_partition(running, &image_state);
+  if (state_result != ESP_OK || image_state != ESP_OTA_IMG_PENDING_VERIFY) return true;
+
+  // SafeMode confirms this same image in App.safe_reboot(). Do it before the
+  // handoff snapshot so the first controlled restart after OTA can be armed.
+  const esp_err_t confirm_result = esp_ota_mark_app_valid_cancel_rollback();
+  if (confirm_result != ESP_OK) {
+    ESP_LOGE(TAG, "Could not confirm pending image for controlled restart: %s", esp_err_to_name(confirm_result));
+    return false;
+  }
+  return true;
+}
+
 }  // namespace
 
 bool initialize_restart_handoff(uint32_t minimum_off_ms) {
@@ -151,6 +170,8 @@ bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
       (hp1_credit_ms == 0U && hp2_credit_ms == 0U)) {
     return false;
   }
+
+  if (!confirm_pending_image_for_controlled_restart()) return false;
 
   BootContext context{};
   if (!capture_boot_context(configured_minimum_off_ms, &context) || !context.running_partition_matches_boot ||

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace esphome::openquatt_incident_manager {
+
+// Must run before ESPHome safe-mode and all component setup. A false return means
+// the caller must restart immediately: an existing record could not be consumed.
+bool initialize_restart_handoff(uint32_t minimum_off_ms);
+bool restart_handoff_storage_ready();
+uint32_t restored_off_credit_ms(uint8_t hp_index);
+bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms);
+
+}  // namespace esphome::openquatt_incident_manager

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace esphome::openquatt_incident_manager::restart_handoff {
+
+constexpr uint32_t kRecordMagic = 0x4F515248UL;  // OQRH
+constexpr uint16_t kRecordVersion = 1U;
+constexpr uint8_t kRecordArmed = 1U;
+constexpr uint32_t kMaximumMinimumOffMs = 3600UL * 1000UL;
+constexpr size_t kImageHashSize = 32U;
+
+struct Record {
+  uint32_t magic;
+  uint16_t version;
+  uint8_t state;
+  uint8_t reserved;
+  uint32_t minimum_off_ms;
+  uint32_t config_hash;
+  uint32_t boot_partition_address;
+  uint32_t hp1_credit_ms;
+  uint32_t hp2_credit_ms;
+  uint8_t image_hash[kImageHashSize];
+  uint32_t checksum;
+};
+
+static_assert(sizeof(Record) == 64U, "Restart handoff NVS record size changed");
+
+inline uint32_t checksum(const void* data, size_t length) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  uint32_t hash = 2166136261UL;
+  for (size_t index = 0U; index < length; ++index) {
+    hash ^= bytes[index];
+    hash *= 16777619UL;
+  }
+  return hash;
+}
+
+inline uint32_t configuration_hash(uint32_t minimum_off_ms, bool duo_topology) {
+  uint32_t hash = 2166136261UL;
+  const uint8_t bytes[] = {
+      static_cast<uint8_t>(minimum_off_ms),         static_cast<uint8_t>(minimum_off_ms >> 8U),
+      static_cast<uint8_t>(minimum_off_ms >> 16U),  static_cast<uint8_t>(minimum_off_ms >> 24U),
+      static_cast<uint8_t>(duo_topology ? 1U : 0U),
+  };
+  for (uint8_t byte : bytes) {
+    hash ^= byte;
+    hash *= 16777619UL;
+  }
+  return hash;
+}
+
+inline bool valid_minimum_off_ms(uint32_t minimum_off_ms) {
+  return minimum_off_ms > 0U && minimum_off_ms <= kMaximumMinimumOffMs;
+}
+
+inline bool has_image_hash(const uint8_t (&image_hash)[kImageHashSize]) {
+  for (uint8_t byte : image_hash)
+    if (byte != 0U) return true;
+  return false;
+}
+
+inline bool valid_record(const Record& record) {
+  return record.magic == kRecordMagic && record.version == kRecordVersion && record.state == kRecordArmed &&
+         record.reserved == 0U && valid_minimum_off_ms(record.minimum_off_ms) &&
+         record.hp1_credit_ms <= record.minimum_off_ms && record.hp2_credit_ms <= record.minimum_off_ms &&
+         (record.hp1_credit_ms != 0U || record.hp2_credit_ms != 0U) && has_image_hash(record.image_hash) &&
+         record.checksum == checksum(&record, offsetof(Record, checksum));
+}
+
+inline void finalize_record(Record* record) {
+  record->checksum = 0U;
+  record->checksum = checksum(record, offsetof(Record, checksum));
+}
+
+struct BootContext {
+  bool software_reset{false};
+  bool running_partition_matches_boot{false};
+  bool image_valid{false};
+  uint32_t minimum_off_ms{0U};
+  uint32_t config_hash{0U};
+  uint32_t boot_partition_address{0U};
+  uint8_t image_hash[kImageHashSize]{};
+};
+
+enum class StorageReadResult : uint8_t { ABSENT, PRESENT, ERROR };
+
+inline bool may_restore_credit(const Record& record, const BootContext& context) {
+  return valid_record(record) && context.software_reset && context.running_partition_matches_boot &&
+         context.image_valid && context.minimum_off_ms == record.minimum_off_ms &&
+         context.config_hash == record.config_hash && context.boot_partition_address == record.boot_partition_address &&
+         has_image_hash(context.image_hash) && std::memcmp(context.image_hash, record.image_hash, kImageHashSize) == 0;
+}
+
+// A matching record is still unsafe until its deletion has been committed and
+// verified. Keep this separate so failure-path tests cannot accidentally grant
+// the in-memory credit before durable consumption.
+inline bool may_grant_after_durable_consume(bool consume_persisted, const Record& record, const BootContext& context) {
+  return consume_persisted && may_restore_credit(record, context);
+}
+
+// Storage supplies only direct, durable operations. The same flow is used with
+// NVS on-device and a fault-injecting host fake, so an optimistic cache read
+// cannot accidentally turn a failed consume into a credit.
+template <typename Storage>
+inline bool consume_record(Storage& storage, const BootContext& context, uint32_t* hp1_credit_ms,
+                           uint32_t* hp2_credit_ms) {
+  if (hp1_credit_ms == nullptr || hp2_credit_ms == nullptr) return false;
+  *hp1_credit_ms = 0U;
+  *hp2_credit_ms = 0U;
+
+  Record record{};
+  const StorageReadResult read_result = storage.read(&record);
+  if (read_result == StorageReadResult::ABSENT) return true;
+
+  const bool eligible = read_result == StorageReadResult::PRESENT && may_restore_credit(record, context);
+  // Covers corrupt records and ambiguous read failures. The adapter must prove
+  // absence with a fresh direct read after its erase/commit operation.
+  if (!storage.erase_and_verify_absent()) return false;
+  if (!may_grant_after_durable_consume(eligible, record, context)) return true;
+
+  *hp1_credit_ms = record.hp1_credit_ms;
+  *hp2_credit_ms = record.hp2_credit_ms;
+  return true;
+}
+
+template <typename Storage>
+inline bool persist_record(Storage& storage, const Record& record) {
+  return valid_record(record) && storage.write_commit_and_verify(record);
+}
+
+}  // namespace esphome::openquatt_incident_manager::restart_handoff

--- a/components/openquatt_incident_manager/__init__.py
+++ b/components/openquatt_incident_manager/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, globals as globals_component, modbus_controller, time
+from esphome.components import binary_sensor, globals as globals_component, time
 from esphome.const import CONF_ID
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
 
@@ -17,8 +17,6 @@ CONF_CONTROL_MODE_CODE = "control_mode_code"
 CONF_DECISION_LOG = "decision_log"
 CONF_WEB_AUTH = "web_auth"
 CONF_MINIMUM_OFF_TIME = "minimum_off_time"
-CONF_HP1_CONTROLLER = "hp1_controller"
-CONF_HP2_CONTROLLER = "hp2_controller"
 CONF_POLLING_PAUSED = "polling_paused"
 
 openquatt_incident_manager_ns = cg.esphome_ns.namespace(
@@ -48,8 +46,6 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_DECISION_LOG): cv.use_id(OpenQuattDecisionLog),
         cv.Required(CONF_WEB_AUTH): cv.use_id(OpenQuattWebAuth),
         cv.Required(CONF_MINIMUM_OFF_TIME): cv.positive_time_period_milliseconds,
-        cv.Required(CONF_HP1_CONTROLLER): cv.use_id(modbus_controller.ModbusController),
-        cv.Optional(CONF_HP2_CONTROLLER): cv.use_id(modbus_controller.ModbusController),
         cv.Required(CONF_POLLING_PAUSED): cv.use_id(binary_sensor.BinarySensor),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -71,12 +67,6 @@ async def _runtime_to_code(config):
     cg.add(var.set_minimum_off_ms(config[CONF_MINIMUM_OFF_TIME]))
     polling_paused = await cg.get_variable(config[CONF_POLLING_PAUSED])
     cg.add(var.set_polling_paused(polling_paused))
-    hp1_controller = await cg.get_variable(config[CONF_HP1_CONTROLLER])
-    cg.add(var.set_hp1_controller(hp1_controller))
-    if CONF_HP2_CONTROLLER in config:
-        hp2_controller = await cg.get_variable(config[CONF_HP2_CONTROLLER])
-        cg.add(var.set_hp2_controller(hp2_controller))
-
     clock = await cg.get_variable(config[CONF_CLOCK])
     cg.add(var.set_clock(clock))
     control_mode_code = await cg.get_variable(config[CONF_CONTROL_MODE_CODE])

--- a/components/openquatt_incident_manager/__init__.py
+++ b/components/openquatt_incident_manager/__init__.py
@@ -1,7 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import globals as globals_component, time
+from esphome.components import binary_sensor, globals as globals_component, modbus_controller, time
 from esphome.const import CONF_ID
+from esphome.core import CORE, CoroPriority, coroutine_with_priority
 
 AUTO_LOAD = ["globals", "time", "web_server_base"]
 DEPENDENCIES = [
@@ -15,6 +16,10 @@ CONF_CLOCK = "clock"
 CONF_CONTROL_MODE_CODE = "control_mode_code"
 CONF_DECISION_LOG = "decision_log"
 CONF_WEB_AUTH = "web_auth"
+CONF_MINIMUM_OFF_TIME = "minimum_off_time"
+CONF_HP1_CONTROLLER = "hp1_controller"
+CONF_HP2_CONTROLLER = "hp2_controller"
+CONF_POLLING_PAUSED = "polling_paused"
 
 openquatt_incident_manager_ns = cg.esphome_ns.namespace(
     "openquatt_incident_manager"
@@ -42,14 +47,35 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Required(CONF_DECISION_LOG): cv.use_id(OpenQuattDecisionLog),
         cv.Required(CONF_WEB_AUTH): cv.use_id(OpenQuattWebAuth),
+        cv.Required(CONF_MINIMUM_OFF_TIME): cv.positive_time_period_milliseconds,
+        cv.Required(CONF_HP1_CONTROLLER): cv.use_id(modbus_controller.ModbusController),
+        cv.Optional(CONF_HP2_CONTROLLER): cv.use_id(modbus_controller.ModbusController),
+        cv.Required(CONF_POLLING_PAUSED): cv.use_id(binary_sensor.BinarySensor),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
 
+@coroutine_with_priority(CoroPriority.APPLICATION + 1)
 async def to_code(config):
+    # Consume before safe_mode's generated early return, not in Component::setup().
+    initialize = openquatt_incident_manager_ns.initialize_restart_handoff(config[CONF_MINIMUM_OFF_TIME])
+    cg.add(cg.RawExpression(f"if (!{initialize}) {{ esphome::arch_restart(); return; }}"))
+    CORE.add_job(_runtime_to_code, config)
+
+
+async def _runtime_to_code(config):
+    # Keep the normal component and its dependencies out of safe mode.
     cg.add_global(openquatt_incident_manager_ns.using)
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+    cg.add(var.set_minimum_off_ms(config[CONF_MINIMUM_OFF_TIME]))
+    polling_paused = await cg.get_variable(config[CONF_POLLING_PAUSED])
+    cg.add(var.set_polling_paused(polling_paused))
+    hp1_controller = await cg.get_variable(config[CONF_HP1_CONTROLLER])
+    cg.add(var.set_hp1_controller(hp1_controller))
+    if CONF_HP2_CONTROLLER in config:
+        hp2_controller = await cg.get_variable(config[CONF_HP2_CONTROLLER])
+        cg.add(var.set_hp2_controller(hp2_controller))
 
     clock = await cg.get_variable(config[CONF_CLOCK])
     cg.add(var.set_clock(clock))

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -119,6 +119,10 @@ Configured startup delays are relative to the ESPHome scheduler becoming active.
 
 These offsets spread network and bus work; they are not readiness guarantees. A successful Modbus or OpenTherm exchange can only occur once the corresponding external equipment is connected and responsive.
 
+De compressorbeveiliging telt per HP `${oq_hp_min_off_s}` (standaard 240 seconden) vanaf bevestigde stilstand: verse compressorfrequentie en standby-modus moeten de stop bevestigen. Via **Restart** kan reeds bewezen uit-tijd eenmalig worden meegenomen bij een gecontroleerde herstart van dezelfde firmware. Na de herstart zijn opnieuw verse stopmetingen nodig; de tijd zonder metingen wordt niet meegerekend. Een HP die draaide, verouderde metingen, een crash, stroomuitval of een firmwarewissel geven geen verkorting. De afzonderlijke minimale koel-uit-tijd blijft gelden.
+
+Het herstartrecord wordt vóór safe mode en OTA-toegang uit NVS verbruikt. Als dat niet aantoonbaar lukt, herstart de controller zonder HP-starts of OTA-toegang vrij te geven; alleen extra wachten zou hergebruik van oude uit-tijd niet voorkomen. Deze opslagfout vereist herstel voordat normaal bedrijf kan hervatten.
+
 ## 4. Data Pipeline
 
 ### 4.1 Input layer

--- a/openquatt/includes/control/oq_hp_restart_guard.h
+++ b/openquatt/includes/control/oq_hp_restart_guard.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <cstdint>
+
+namespace oq_hp_restart_guard {
+
+class Policy {
+ public:
+  bool configure(uint32_t minimum_off_ms, uint32_t freshness_ms) {
+    minimum_off_ms_ = minimum_off_ms;
+    freshness_ms_ = freshness_ms;
+    configured_ = minimum_off_ms <= MAX_INTERVAL_MS && valid_interval_(freshness_ms);
+    reset_();
+    restore_open_ = configured_;
+    return configured_;
+  }
+
+  bool configured() const { return configured_; }
+
+  bool restore_credit(uint32_t credit_ms, bool valid) {
+    if (!configured_ || !restore_open_) return false;
+    pending_credit_ms_ = valid ? clamp_credit_(credit_ms) : 0;
+    restore_open_ = false;
+    return true;
+  }
+
+  void observe_stopped(uint32_t now_ms) {
+    restore_open_ = false;
+    if (!configured_) {
+      reset_();
+      return;
+    }
+
+    if (!stop_confirmed_) {
+      credit_at_observation_ms_ = pending_credit_ms_;
+      stop_confirmed_ = true;
+    } else {
+      const uint32_t elapsed_ms = static_cast<uint32_t>(now_ms - last_observation_ms_);
+      if (elapsed_ms > freshness_ms_) {
+        credit_at_observation_ms_ = 0;
+      } else {
+        credit_at_observation_ms_ = add_credit_(credit_at_observation_ms_, elapsed_ms);
+      }
+    }
+
+    pending_credit_ms_ = 0;
+    last_observation_ms_ = now_ms;
+  }
+
+  void invalidate() {
+    restore_open_ = false;
+    reset_();
+  }
+
+  bool can_start(uint32_t now_ms) const {
+    return configured_ && fresh_(now_ms) && credit_at_(now_ms) >= minimum_off_ms_;
+  }
+
+  uint32_t remaining_ms(uint32_t now_ms) const {
+    if (!configured_) return UINT32_MAX;
+    if (!fresh_(now_ms)) return minimum_off_ms_;
+    const uint32_t credit_ms = credit_at_(now_ms);
+    return credit_ms >= minimum_off_ms_ ? 0 : minimum_off_ms_ - credit_ms;
+  }
+
+  uint32_t snapshot_credit_ms(uint32_t now_ms) const {
+    if (!configured_ || !fresh_(now_ms)) return 0;
+    return credit_at_observation_ms_;
+  }
+
+ private:
+  static constexpr uint32_t MAX_INTERVAL_MS = 0x7FFFFFFFU;
+
+  static bool valid_interval_(uint32_t interval_ms) { return interval_ms > 0 && interval_ms <= MAX_INTERVAL_MS; }
+
+  void reset_() {
+    stop_confirmed_ = false;
+    pending_credit_ms_ = 0;
+    credit_at_observation_ms_ = 0;
+    last_observation_ms_ = 0;
+  }
+
+  uint32_t clamp_credit_(uint32_t credit_ms) const {
+    return credit_ms >= minimum_off_ms_ ? minimum_off_ms_ : credit_ms;
+  }
+
+  uint32_t add_credit_(uint32_t credit_ms, uint32_t elapsed_ms) const {
+    const uint32_t remaining_ms = minimum_off_ms_ - credit_ms;
+    return elapsed_ms >= remaining_ms ? minimum_off_ms_ : credit_ms + elapsed_ms;
+  }
+
+  bool fresh_(uint32_t now_ms) const {
+    return stop_confirmed_ && static_cast<uint32_t>(now_ms - last_observation_ms_) <= freshness_ms_;
+  }
+
+  uint32_t credit_at_(uint32_t now_ms) const {
+    return add_credit_(credit_at_observation_ms_, static_cast<uint32_t>(now_ms - last_observation_ms_));
+  }
+
+  uint32_t minimum_off_ms_{0};
+  uint32_t freshness_ms_{0};
+  uint32_t pending_credit_ms_{0};
+  uint32_t credit_at_observation_ms_{0};
+  uint32_t last_observation_ms_{0};
+  bool configured_{false};
+  bool restore_open_{false};
+  bool stop_confirmed_{false};
+};
+
+}  // namespace oq_hp_restart_guard

--- a/openquatt/includes/control/oq_thermal_actuator_logic.h
+++ b/openquatt/includes/control/oq_thermal_actuator_logic.h
@@ -20,9 +20,7 @@ constexpr bool valid_level_command(int control_level, int physical_level) {
 struct ManualGuardInputs {
   int requested_level;
   int mode_code;
-  uint32_t now_ms;
-  uint32_t last_stop_ms;
-  uint32_t minimum_off_ms;
+  uint32_t minimum_off_remaining_ms;
   uint32_t startup_inhibit_remaining_s;
   bool stop_requested;
   bool water_temperature_trip;
@@ -42,9 +40,8 @@ inline std::string manual_guard(const ManualGuardInputs& in, const std::string& 
   }
   if (in.mode_code != 1 && in.mode_code != 2) return "kies eerst verwarmen of koelen";
   if (in.mode_conflict) return "conflicterende werkmodus tussen HP1 en HP2";
-  const uint32_t remaining_ms = minimum_off_remaining_ms(in.now_ms, in.last_stop_ms, in.minimum_off_ms);
-  if (remaining_ms > 0) {
-    const uint32_t remaining_s = (remaining_ms + 999UL) / 1000UL;
+  if (in.minimum_off_remaining_ms > 0) {
+    const uint32_t remaining_s = (in.minimum_off_remaining_ms + 999UL) / 1000UL;
     return "minimale uit-tijd: nog " + std::to_string(remaining_s) + " s";
   }
   return current_guard;

--- a/openquatt/includes/control/oq_thermal_actuator_runtime.h
+++ b/openquatt/includes/control/oq_thermal_actuator_runtime.h
@@ -117,7 +117,6 @@ class Runtime {
       this->publish_manual_guard(static_cast<int>(roundf(id(oq_manual_hp1_level).state)),
                                  static_cast<int>(roundf(id(oq_manual_hp2_level).state)), hp1_applied, hp2_applied,
                                  cycle.service_guards[0], cycle.service_guards[1], config.now_ms,
-                                 static_cast<uint32_t>(std::max(0, config.minimum_off_s)) * 1000UL,
                                  config.minimum_flow_lph);
     }
     this->record_transition(true, hp1_applied, config.now_ms, config.dt_ms);
@@ -234,6 +233,7 @@ class Runtime {
 
   int requested_mode_code(bool is_hp1, bool active, int request_mode_code, bool request_thermal_active,
                           bool manual_service_active) const {
+    if (id(oq_incident_manager).startup_inhibited(is_hp1 ? 1U : 2U)) return 0;
     int mode_code = active && request_thermal_active ? request_mode_code : 0;
     if (manual_service_active && id(oq_manual_hp_mode_allowed)) {
       const int manual_mode = is_hp1 ? id(oq_manual_hp1_mode_code) : id(oq_manual_hp2_mode_code);
@@ -317,26 +317,27 @@ class Runtime {
   }
 
   void publish_manual_guard(int hp1_manual_level, int hp2_manual_level, int hp1_applied, int hp2_applied,
-                            std::string hp1_guard, std::string hp2_guard, uint32_t now_ms, uint32_t minimum_off_ms,
-                            float minimum_flow_lph) {
-    const uint32_t startup_remaining_s =
-        id(oq_boot_startup_inhibit_active) && id(oq_boot_startup_inhibit_until_ms) > now_ms
-            ? (id(oq_boot_startup_inhibit_until_ms) - now_ms + 999UL) / 1000UL
-            : 0;
+                            std::string hp1_guard, std::string hp2_guard, uint32_t now_ms, float minimum_flow_lph) {
     const bool flow_valid = id(flow_rate_selected).has_state() && !isnan(id(flow_rate_selected).state) &&
                             id(flow_rate_selected).state >= minimum_flow_lph;
-    const bool mode_conflict = id(oq_manual_hp1_mode_code) > 0 && id(oq_manual_hp2_mode_code) > 0 &&
+    const bool mode_conflict = !id(oq_incident_manager).startup_inhibited(1U) &&
+                               !id(oq_incident_manager).startup_inhibited(2U) && id(oq_manual_hp1_mode_code) > 0 &&
+                               id(oq_manual_hp2_mode_code) > 0 &&
                                id(oq_manual_hp1_mode_code) != id(oq_manual_hp2_mode_code);
-    const auto guard = [&](int level, int mode_code, uint32_t last_stop_ms, const std::string& current) {
+    const auto guard = [&](uint8_t hp, int level, int mode_code, int applied_level, const std::string& current) {
+      const uint32_t remaining_ms =
+          applied_level > 0 ? 0U : id(oq_incident_manager).minimum_off_remaining_ms(hp, now_ms);
+      const uint32_t startup_remaining_s =
+          id(oq_incident_manager).startup_inhibited(hp) ? (remaining_ms + 999U) / 1000U : 0U;
       return oq_thermal_actuator::manual_guard(
-          {level, mode_code, now_ms, last_stop_ms, minimum_off_ms, startup_remaining_s, id(oq_manual_hp_stop_requested),
+          {level, mode_code, remaining_ms, startup_remaining_s, id(oq_manual_hp_stop_requested),
            id(oq_water_temp_hard_trip_active), id(oq_lowflow_fault_active), flow_valid, mode_conflict},
           current);
     };
-    hp1_guard = guard(hp1_manual_level, id(oq_manual_hp1_mode_code), id(hp1_last_stop_ms), hp1_guard);
+    hp1_guard = guard(1U, hp1_manual_level, id(oq_manual_hp1_mode_code), hp1_applied, hp1_guard);
     this->finish_manual_guard_(hp1_manual_level, hp1_applied, hp1_guard);
 #if OQ_TOPOLOGY_DUO
-    hp2_guard = guard(hp2_manual_level, id(oq_manual_hp2_mode_code), id(hp2_last_stop_ms), hp2_guard);
+    hp2_guard = guard(2U, hp2_manual_level, id(oq_manual_hp2_mode_code), hp2_applied, hp2_guard);
     this->finish_manual_guard_(hp2_manual_level, hp2_applied, hp2_guard);
 #else
     (void)hp2_manual_level;
@@ -404,7 +405,8 @@ class Runtime {
     // Contract order: incident stop -> defrost hold -> cooling rest -> per-HP rest
     // -> valid mode -> frequency policy -> start/stop registration -> physical write.
     const auto incident_guard =
-        oq_incident_actuator::decide({level, previous, incident.available_for_start, incident.must_stop});
+        oq_incident_actuator::decide({level, previous, incident.available_for_start,
+                                      incident.must_stop || id(oq_incident_manager).startup_inhibited(hp_index)});
     if (incident_guard.bypass_runtime_and_defrost_holds) this->clear_retained_level(is_hp1);
     const auto retained = incident_guard.bypass_runtime_and_defrost_holds
                               ? oq_odu::RetainedLevel{}
@@ -417,9 +419,8 @@ class Runtime {
                                         oq_cooling::global_minimum_off_time_blocks_start(
                                             cycle.cooling.remaining_ms, false,
                                             cycle.restart_by_minimum_off_time && cycle.cooling_stop_planned, previous));
-    const uint32_t hp_rest_remaining_ms = oq_thermal_actuator::minimum_off_remaining_ms(
-        cycle.config.now_ms, this->last_stop_ms_(is_hp1),
-        static_cast<uint32_t>(std::max(0, cycle.config.minimum_off_s)) * 1000UL);
+    const uint32_t hp_rest_remaining_ms =
+        id(oq_incident_manager).minimum_off_remaining_ms(hp_index, cycle.config.now_ms);
     const bool defrost_hold = oq_odu::retained_level_should_override_request(retained, incident_guard.guarded_level,
                                                                              cycle.manual_service_active);
     const auto preflight = oq_thermal_actuator::decide_preflight(
@@ -590,10 +591,6 @@ class Runtime {
 
   int previous_applied_(bool is_hp1) const {
     return is_hp1 ? id(hp1_last_applied_level) : OQ_ACTUATOR_SECONDARY_ID(last_applied_level);
-  }
-
-  uint32_t last_stop_ms_(bool is_hp1) const {
-    return is_hp1 ? id(hp1_last_stop_ms) : OQ_ACTUATOR_SECONDARY_ID(last_stop_ms);
   }
 
   bool& cooling_confirmation_pending_(bool is_hp1) {

--- a/openquatt/includes/control/oq_thermal_actuator_runtime.h
+++ b/openquatt/includes/control/oq_thermal_actuator_runtime.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #include <algorithm>
+#include <cstring>
 #include <string>
 
 #include "oq_compressor_frequency_runtime.h"
@@ -259,6 +260,7 @@ class Runtime {
       if (current != physical_level || (physical_level == 0 && force_write)) {
         auto call = id(hp1_compressor_level).make_call();
         call.set_option(level_options[physical_level]);
+        if (physical_level > 0) id(oq_incident_manager).invalidate_restart_credit(1U);
         call.perform();
       }
       id(hp1_last_commanded_physical_level) = physical_level;
@@ -270,6 +272,7 @@ class Runtime {
     if (current != physical_level || (physical_level == 0 && force_write)) {
       auto call = id(hp2_compressor_level).make_call();
       call.set_option(level_options[physical_level]);
+      if (physical_level > 0) id(oq_incident_manager).invalidate_restart_credit(2U);
       call.perform();
     }
     id(hp2_last_commanded_physical_level) = physical_level;
@@ -686,10 +689,12 @@ class Runtime {
   }
 
   void write_mode_option_(bool is_hp1, const char* option, bool force_write) {
+    const bool active_mode = std::strcmp(option, "Cooling") == 0 || std::strcmp(option, "Heating") == 0;
     if (is_hp1) {
       if (force_write || id(hp1_set_working_mode).current_option() != option) {
         auto call = id(hp1_set_working_mode).make_call();
         call.set_option(option);
+        if (active_mode) id(oq_incident_manager).invalidate_restart_credit(1U);
         call.perform();
       }
       return;
@@ -698,6 +703,7 @@ class Runtime {
     if (force_write || id(hp2_set_working_mode).current_option() != option) {
       auto call = id(hp2_set_working_mode).make_call();
       call.set_option(option);
+      if (active_mode) id(oq_incident_manager).invalidate_restart_credit(2U);
       call.perform();
     }
 #else

--- a/openquatt/includes/control/oq_thermal_request_logic.h
+++ b/openquatt/includes/control/oq_thermal_request_logic.h
@@ -70,6 +70,8 @@ struct ManualRequestInput {
   bool stop_requested;
   bool safety_stop;
   bool startup_inhibit;
+  bool hp1_startup_inhibit{false};
+  bool hp2_startup_inhibit{false};
 };
 
 struct ManualRequest {
@@ -238,31 +240,40 @@ inline int hold_request_mode_code(int hold1, int hold2, bool hp1_cooling_hold, b
 }
 
 inline ManualRequest arbitrate_manual_request(const ManualRequestInput& input) {
-  const int hp1_mode = clamp_level(input.hp1_mode_code, 0, 2);
-  const int hp2_mode = input.duo ? clamp_level(input.hp2_mode_code, 0, 2) : 0;
-  int hp1_level = hp1_mode > 0 ? clamp_level(input.hp1_requested_level, 0, std::max(0, input.hp1_max_level)) : 0;
-  int hp2_level = hp2_mode > 0 ? clamp_level(input.hp2_requested_level, 0, std::max(0, input.hp2_max_level)) : 0;
+  const int hp1_requested_mode = clamp_level(input.hp1_mode_code, 0, 2);
+  const int hp2_requested_mode = input.duo ? clamp_level(input.hp2_mode_code, 0, 2) : 0;
+  const int hp1_requested_level =
+      hp1_requested_mode > 0 ? clamp_level(input.hp1_requested_level, 0, std::max(0, input.hp1_max_level)) : 0;
+  const int hp2_requested_level =
+      hp2_requested_mode > 0 ? clamp_level(input.hp2_requested_level, 0, std::max(0, input.hp2_max_level)) : 0;
+  const int hp1_mode = input.hp1_startup_inhibit ? 0 : hp1_requested_mode;
+  const int hp2_mode = input.hp2_startup_inhibit ? 0 : hp2_requested_mode;
+  int hp1_level = input.hp1_startup_inhibit ? 0 : hp1_requested_level;
+  int hp2_level = input.hp2_startup_inhibit ? 0 : hp2_requested_level;
+  const int hp1_hold_level = input.hp1_startup_inhibit ? 0 : input.hp1_hold_level;
+  const int hp2_hold_level = input.hp2_startup_inhibit ? 0 : input.hp2_hold_level;
   const bool conflict = hp1_mode > 0 && hp2_mode > 0 && hp1_mode != hp2_mode;
-  const int desired_hp1 = (!input.stop_requested && !input.safety_stop && !conflict) ? hp1_level : 0;
-  const int desired_hp2 = (!input.stop_requested && !input.safety_stop && !conflict) ? hp2_level : 0;
+  const int desired_hp1 = (!input.stop_requested && !input.safety_stop && !conflict) ? hp1_requested_level : 0;
+  const int desired_hp2 = (!input.stop_requested && !input.safety_stop && !conflict) ? hp2_requested_level : 0;
 
   if (input.stop_requested) {
-    hp1_level = input.hp1_hold_level;
-    hp2_level = input.duo ? input.hp2_hold_level : 0;
+    hp1_level = hp1_hold_level;
+    hp2_level = input.duo ? hp2_hold_level : 0;
   }
   if (input.safety_stop || input.startup_inhibit || conflict) {
     hp1_level = 0;
     hp2_level = 0;
   } else if (!input.stop_requested) {
-    if (hp1_level == 0) hp1_level = input.hp1_hold_level;
-    if (input.duo && hp2_level == 0) hp2_level = input.hp2_hold_level;
+    if (hp1_level == 0) hp1_level = hp1_hold_level;
+    if (input.duo && hp2_level == 0) hp2_level = hp2_hold_level;
   }
 
   int mode_code = 0;
   if (hp1_level > 0 && hp1_mode > 0) mode_code = hp1_mode;
   if (hp2_level > 0 && hp2_mode > 0) mode_code = hp2_mode;
   if (mode_code == 0 && (hp1_level > 0 || hp2_level > 0)) {
-    mode_code = hold_request_mode_code(hp1_level, hp2_level, input.hp1_cooling_hold, input.hp2_cooling_hold);
+    mode_code = hold_request_mode_code(hp1_level, hp2_level, input.hp1_cooling_hold && !input.hp1_startup_inhibit,
+                                       input.hp2_cooling_hold && !input.hp2_startup_inhibit);
   }
   const ManualReason reason = input.safety_stop       ? MANUAL_SAFETY_STOP
                               : input.startup_inhibit ? MANUAL_STARTUP_INHIBIT

--- a/openquatt/includes/control/oq_thermal_request_runtime.h
+++ b/openquatt/includes/control/oq_thermal_request_runtime.h
@@ -44,9 +44,9 @@ class Runtime {
 
     const bool startup_inhibit_active = this->update_startup_inhibit_(config.now_ms, config.minimum_off_s);
     const bool startup_inhibit_changed =
-        !this->startup_snapshot_initialized_ || startup_inhibit_active != this->last_startup_inhibit_active_;
+        !this->startup_snapshot_initialized_ || this->startup_mask_ != this->last_startup_mask_;
     this->startup_snapshot_initialized_ = true;
-    this->last_startup_inhibit_active_ = startup_inhibit_active;
+    this->last_startup_mask_ = this->startup_mask_;
     if (id(oq_heat_last_mode_code) != mode.control_flavor_code) {
       id(oq_heat_last_mode_code) = mode.control_flavor_code;
       id(oq_heat_last_loop_ms) = 0;
@@ -99,32 +99,38 @@ class Runtime {
  private:
   bool strategy_snapshot_initialized_{false};
   bool startup_snapshot_initialized_{false};
-  bool last_startup_inhibit_active_{false};
+  uint8_t startup_mask_{0};
+  uint8_t last_startup_mask_{0};
   int last_cm_code_{-1};
   int last_strategy_hp1_{0};
   int last_strategy_hp2_{0};
 
   bool update_startup_inhibit_(uint32_t now_ms, uint32_t minimum_off_s) {
-    if (id(oq_boot_startup_inhibit_until_ms) == 0) {
-      const uint32_t inhibit_ms = minimum_off_s * 1000UL;
-      id(oq_boot_startup_inhibit_until_ms) = now_ms + inhibit_ms;
-      id(oq_boot_startup_inhibit_active) = inhibit_ms > 0;
-      if (!id(oq_boot_startup_inhibit_logged) && inhibit_ms > 0) {
-        ESP_LOGI("quatt", "Startup inhibit armed for %us after reboot; compressors remain blocked.",
-                 static_cast<unsigned int>(minimum_off_s));
-        id(oq_boot_startup_inhibit_logged) = true;
-        id(oq_boot_startup_inhibit_cleared_logged) = false;
-      }
+    this->startup_mask_ = id(oq_incident_manager).startup_inhibited(1U) ? 1U : 0U;
+    uint32_t remaining_ms = this->startup_mask_ ? id(oq_incident_manager).minimum_off_remaining_ms(1U, now_ms) : 0U;
+#if OQ_TOPOLOGY_DUO
+    if (id(oq_incident_manager).startup_inhibited(2U)) {
+      this->startup_mask_ |= 2U;
+      remaining_ms = std::max(remaining_ms, id(oq_incident_manager).minimum_off_remaining_ms(2U, now_ms));
     }
-    const bool active = oq_request::deadline_pending(now_ms, id(oq_boot_startup_inhibit_until_ms));
+#endif
+    const bool active = this->startup_mask_ != 0U;
+    // Diagnostic deadline only; the manager's per-HP confirmed-stop guards own release.
+    id(oq_boot_startup_inhibit_until_ms) = active ? now_ms + remaining_ms : 0U;
     id(oq_boot_startup_inhibit_active) = active;
-    if (!active && id(oq_boot_startup_inhibit_until_ms) > 0 && id(oq_boot_startup_inhibit_logged) &&
-        !id(oq_boot_startup_inhibit_cleared_logged)) {
-      ESP_LOGI("quatt", "Startup inhibit cleared after reboot; compressors may resume.");
+    if (active && !id(oq_boot_startup_inhibit_logged)) {
+      ESP_LOGI("quatt", "Startup guard: up to %us per HP, measured from confirmed compressor stop.",
+               static_cast<unsigned>(minimum_off_s));
+      id(oq_boot_startup_inhibit_logged) = true;
+    }
+    if (!active && id(oq_boot_startup_inhibit_logged) && !id(oq_boot_startup_inhibit_cleared_logged)) {
+      ESP_LOGI("quatt", "Startup minimum off-time confirmed for all HPs.");
       id(oq_boot_startup_inhibit_cleared_logged) = true;
     }
     return active;
   }
+
+  bool startup_blocked_(bool is_hp1) const { return (this->startup_mask_ & (is_hp1 ? 1U : 2U)) != 0U; }
 
   void track_measured_start_(bool is_hp1, uint32_t now_ms) {
     const float raw = is_hp1 ? id(hp1_working_mode).state : OQ_REQUEST_SECONDARY_ID(working_mode).state;
@@ -249,6 +255,8 @@ class Runtime {
 
   void update_startup_event_(uint32_t now_ms, uint32_t minimum_off_s, int cm_code, bool startup_inhibit,
                              int target_mode_code, int desired_hp1, int desired_hp2) {
+    if (!this->startup_blocked_(true)) desired_hp1 = 0;
+    if (!this->startup_blocked_(false)) desired_hp2 = 0;
     const bool has_request = desired_hp1 > 0 || desired_hp2 > 0;
     const bool blocked = startup_inhibit && has_request;
     const uint8_t subject = desired_hp1 > 0 && desired_hp2 > 0 ? openquatt_decision_log::SUBJECT_BOTH
@@ -326,9 +334,11 @@ class Runtime {
     const bool flow_ok =
         oq_request::finite_value_at_least(id(flow_rate_selected).has_state(), flow, config.minimum_flow_lph);
     const bool safety_stop = id(oq_water_temp_hard_trip_active) || id(oq_lowflow_fault_active) || !flow_ok;
-    const int hp1_hold = this->minimum_runtime_hold_(true, config.now_ms, minimum_runtime_ms, startup_inhibit);
+    const int hp1_hold =
+        this->minimum_runtime_hold_(true, config.now_ms, minimum_runtime_ms, this->startup_blocked_(true));
 #if OQ_TOPOLOGY_DUO
-    const int hp2_hold = this->minimum_runtime_hold_(false, config.now_ms, minimum_runtime_ms, startup_inhibit);
+    const int hp2_hold =
+        this->minimum_runtime_hold_(false, config.now_ms, minimum_runtime_ms, this->startup_blocked_(false));
 #else
     const int hp2_hold = 0;
 #endif
@@ -350,9 +360,14 @@ class Runtime {
 #endif
         id(oq_manual_hp_stop_requested),
         safety_stop,
-        startup_inhibit,
+        false,
+        this->startup_blocked_(true),
+        this->startup_blocked_(false),
     };
-    const auto request = oq_request::arbitrate_manual_request(input);
+    auto request = oq_request::arbitrate_manual_request(input);
+    if (startup_inhibit && request.hp1_level == 0 && request.hp2_level == 0 && !safety_stop) {
+      request.reason = oq_request::MANUAL_STARTUP_INHIBIT;
+    }
     id(oq_manual_hp_mode_allowed) = request.mode_allowed;
     this->update_startup_event_(config.now_ms, config.minimum_off_s, id(oq_control_mode_code), startup_inhibit,
                                 hp1_mode > 0 ? hp1_mode : hp2_mode, request.desired_hp1_level,
@@ -368,10 +383,12 @@ class Runtime {
   void run_inactive_(const TickConfig& config, const oq_request::ModeContext& mode, bool startup_inhibit,
                      uint32_t minimum_runtime_ms, const oq_frequency_runtime::Context& frequency, int raw, int post_cap,
                      int cap) {
-    const int hp1_runtime = this->minimum_runtime_hold_(true, config.now_ms, minimum_runtime_ms, startup_inhibit);
+    const int hp1_runtime =
+        this->minimum_runtime_hold_(true, config.now_ms, minimum_runtime_ms, this->startup_blocked_(true));
     const int hp1_level = hp1_runtime > 0 ? hp1_runtime : this->defrost_hold_(true, frequency);
 #if OQ_TOPOLOGY_DUO
-    const int hp2_runtime = this->minimum_runtime_hold_(false, config.now_ms, minimum_runtime_ms, startup_inhibit);
+    const int hp2_runtime =
+        this->minimum_runtime_hold_(false, config.now_ms, minimum_runtime_ms, this->startup_blocked_(false));
     const int hp2_level = hp2_runtime > 0 ? hp2_runtime : this->defrost_hold_(false, frequency);
 #else
     const int hp2_level = 0;
@@ -458,13 +475,13 @@ class Runtime {
     if (hard_stop) hp1_level = hp2_level = 0;
     this->update_startup_event_(config.now_ms, config.minimum_off_s, id(oq_control_mode_code), startup_inhibit,
                                 mode.thermal_mode_code, hp1_level, hp2_level);
-    if (startup_inhibit) hp1_level = hp2_level = 0;
-    const bool hold_blocked = hard_stop || startup_inhibit;
-    this->apply_minimum_runtime_(true, hp1_level, hold_blocked, mode.cooling, config.now_ms, minimum_runtime_ms,
-                                 mode.thermal_mode_code, frequency);
+    if (this->startup_blocked_(true)) hp1_level = 0;
+    if (this->startup_blocked_(false)) hp2_level = 0;
+    this->apply_minimum_runtime_(true, hp1_level, hard_stop || this->startup_blocked_(true), mode.cooling,
+                                 config.now_ms, minimum_runtime_ms, mode.thermal_mode_code, frequency);
 #if OQ_TOPOLOGY_DUO
-    this->apply_minimum_runtime_(false, hp2_level, hold_blocked, mode.cooling, config.now_ms, minimum_runtime_ms,
-                                 mode.thermal_mode_code, frequency);
+    this->apply_minimum_runtime_(false, hp2_level, hard_stop || this->startup_blocked_(false), mode.cooling,
+                                 config.now_ms, minimum_runtime_ms, mode.thermal_mode_code, frequency);
 #else
     hp2_level = 0;
 #endif

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -102,6 +102,9 @@ modbus_controller:
             ESP_LOGI("quatt", "%sModbus ONLINE", "${prefix}");
         - script.execute: ${hp_id}_detect_odu_generation_once
 
+openquatt_incident_manager:
+  ${hp_id}_controller: ${hp_id}
+
 openquatt_odu_eeprom_dump:
   - id: ${hp_id}_odu_eeprom_dump
     controller: ${hp_id}

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -102,9 +102,6 @@ modbus_controller:
             ESP_LOGI("quatt", "%sModbus ONLINE", "${prefix}");
         - script.execute: ${hp_id}_detect_odu_generation_once
 
-openquatt_incident_manager:
-  ${hp_id}_controller: ${hp_id}
-
 openquatt_odu_eeprom_dump:
   - id: ${hp_id}_odu_eeprom_dump
     controller: ${hp_id}

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -1221,10 +1221,19 @@ button:
             then:
               - script.execute: oq_install_firmware_test_manifest_deferred
 
-  - platform: restart
+  - platform: template
     name: Restart
     icon: mdi:restart
     id: restart_switch
+    device_class: restart
+    entity_category: config
+    on_press:
+      - lambda: |-
+          if (id(oq_incident_manager).is_failed()) {
+            App.safe_reboot();
+          } else {
+            id(oq_incident_manager).request_restart();
+          }
 
   - platform: safe_mode
     name: Safe mode

--- a/openquatt/oq_web_access.yaml
+++ b/openquatt/oq_web_access.yaml
@@ -39,6 +39,8 @@ openquatt_decision_log:
 
 openquatt_incident_manager:
   id: oq_incident_manager
+  minimum_off_time: ${oq_hp_min_off_s}s
+  polling_paused: oq_runtime_polling_paused
   clock: oq_time
   control_mode_code: oq_control_mode_code
   decision_log: oq_decision_log

--- a/scripts/tests/test_thermal_actuator_runtime_contract.py
+++ b/scripts/tests/test_thermal_actuator_runtime_contract.py
@@ -27,13 +27,24 @@ class ThermalActuatorRuntimeContractTest(unittest.TestCase):
             self.assertIn(state, RUNTIME)
             self.assertNotIn(state, YAML)
 
+    def test_every_active_modbus_write_invalidates_restart_credit_first(self) -> None:
+        level_write = RUNTIME.index("call.perform();", RUNTIME.index("void write_level"))
+        self.assertLess(RUNTIME.index("invalidate_restart_credit(1U)", RUNTIME.index("void write_level")), level_write)
+        hp2_level_write = RUNTIME.index("call.perform();", level_write + 1)
+        self.assertLess(RUNTIME.index("invalidate_restart_credit(2U)", level_write), hp2_level_write)
+        mode_helper = RUNTIME.index("void write_mode_option_")
+        hp1_mode_write = RUNTIME.index("call.perform();", mode_helper)
+        self.assertLess(RUNTIME.index("invalidate_restart_credit(1U)", mode_helper), hp1_mode_write)
+        hp2_mode_write = RUNTIME.index("call.perform();", hp1_mode_write + 1)
+        self.assertLess(RUNTIME.index("invalidate_restart_credit(2U)", hp1_mode_write), hp2_mode_write)
+
     def test_complete_runtime_stack_stays_bounded(self) -> None:
         paths = ("openquatt/oq_thermal_actuator.yaml", "openquatt/includes/control/oq_thermal_actuator_logic.h",
                  "openquatt/includes/control/oq_thermal_actuator_runtime.h", "tests/host/thermal_actuator_logic_test.cpp",
                  "scripts/tests/test_thermal_actuator_runtime_contract.py", "scripts/tests/test_v2_compressor_level_contract.py",
                  "scripts/tests/test_compressor_frequency_policy_contract.py")
         # Includes the confirmed-rest reporting and its new communication-gap regression cases.
-        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1320)
+        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1340)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_thermal_actuator_runtime_contract.py
+++ b/scripts/tests/test_thermal_actuator_runtime_contract.py
@@ -14,7 +14,7 @@ class ThermalActuatorRuntimeContractTest(unittest.TestCase):
             self.assertNotIn(detail, YAML)
 
     def test_runtime_delegates_ordered_safety_gates_to_the_tested_core(self) -> None:
-        markers = ("const auto incident_guard", "const auto retained", "oq_thermal_actuator::minimum_off_remaining_ms(",
+        markers = ("const auto incident_guard", "const auto retained", "const uint32_t hp_rest_remaining_ms =",
                    "oq_thermal_actuator::decide_preflight(", "cycle.frequency.pick_allowed_level(",
                    "oq_thermal_actuator::valid_level_command(", "apply_start_gate_before_active_write(",
                    "apply_stop_notification_before_safe_write(", "this->write_level(is_hp1, command.physical_level")
@@ -27,12 +27,13 @@ class ThermalActuatorRuntimeContractTest(unittest.TestCase):
             self.assertIn(state, RUNTIME)
             self.assertNotIn(state, YAML)
 
-    def test_complete_runtime_stack_stays_net_smaller(self) -> None:
+    def test_complete_runtime_stack_stays_bounded(self) -> None:
         paths = ("openquatt/oq_thermal_actuator.yaml", "openquatt/includes/control/oq_thermal_actuator_logic.h",
                  "openquatt/includes/control/oq_thermal_actuator_runtime.h", "tests/host/thermal_actuator_logic_test.cpp",
                  "scripts/tests/test_thermal_actuator_runtime_contract.py", "scripts/tests/test_v2_compressor_level_contract.py",
                  "scripts/tests/test_compressor_frequency_policy_contract.py")
-        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1291)
+        # Includes the confirmed-rest reporting and its new communication-gap regression cases.
+        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1320)
 
 
 if __name__ == "__main__":

--- a/tests/host/hp_restart_guard_test.cpp
+++ b/tests/host/hp_restart_guard_test.cpp
@@ -1,0 +1,170 @@
+#include <assert.h>
+
+#include <cstdint>
+
+#include "../../openquatt/includes/control/oq_hp_restart_guard.h"
+
+namespace {
+
+constexpr uint32_t MINIMUM_OFF_MS = 240000;
+constexpr uint32_t FRESHNESS_MS = 10000;
+
+oq_hp_restart_guard::Policy make_policy() {
+  oq_hp_restart_guard::Policy policy;
+  assert(policy.configure(MINIMUM_OFF_MS, FRESHNESS_MS));
+  return policy;
+}
+
+void test_requires_fresh_stopped_evidence() {
+  auto policy = make_policy();
+  assert(!policy.can_start(0));
+  assert(policy.remaining_ms(0) == MINIMUM_OFF_MS);
+  assert(policy.snapshot_credit_ms(0) == 0);
+
+  assert(policy.restore_credit(MINIMUM_OFF_MS, true));
+  assert(!policy.can_start(5000));
+  assert(policy.remaining_ms(5000) == MINIMUM_OFF_MS);
+
+  policy.observe_stopped(5000);
+  assert(policy.can_start(5000));
+}
+
+void test_restored_credit_is_clamped_and_reboot_time_is_not_counted() {
+  auto partial = make_policy();
+  assert(partial.restore_credit(150000, true));
+  assert(!partial.can_start(90000));
+  partial.observe_stopped(90000);
+  assert(partial.remaining_ms(90000) == 90000);
+  for (uint32_t now_ms = 100000; now_ms <= 170000; now_ms += FRESHNESS_MS) partial.observe_stopped(now_ms);
+  assert(!partial.can_start(179999));
+  assert(partial.can_start(180000));
+
+  auto full = make_policy();
+  assert(full.restore_credit(MINIMUM_OFF_MS + 1, true));
+  full.observe_stopped(1000);
+  assert(full.remaining_ms(1000) == 0);
+  assert(full.can_start(1000));
+
+  auto invalid = make_policy();
+  assert(invalid.restore_credit(MINIMUM_OFF_MS, false));
+  invalid.observe_stopped(1000);
+  assert(invalid.remaining_ms(1000) == MINIMUM_OFF_MS);
+}
+
+void test_repeated_stopped_observations_do_not_restart_timer() {
+  auto policy = make_policy();
+  policy.observe_stopped(1000);
+  policy.observe_stopped(6000);
+  policy.observe_stopped(11000);
+  assert(policy.remaining_ms(11000) == 230000);
+  assert(policy.remaining_ms(16000) == 225000);
+  assert(policy.snapshot_credit_ms(16000) == 10000);
+}
+
+void test_gap_and_active_observation_invalidate_evidence() {
+  auto gap = make_policy();
+  assert(gap.restore_credit(150000, true));
+  gap.observe_stopped(1000);
+  assert(gap.remaining_ms(11000) == 80000);
+  assert(!gap.can_start(11001));
+  assert(gap.remaining_ms(11001) == MINIMUM_OFF_MS);
+  assert(gap.snapshot_credit_ms(11001) == 0);
+  gap.observe_stopped(11001);
+  assert(gap.remaining_ms(11001) == MINIMUM_OFF_MS);
+  assert(gap.snapshot_credit_ms(11001) == 0);
+
+  auto active = make_policy();
+  assert(active.restore_credit(MINIMUM_OFF_MS, true));
+  active.observe_stopped(1000);
+  assert(active.can_start(1000));
+  active.invalidate();
+  assert(!active.can_start(1000));
+  assert(active.remaining_ms(1000) == MINIMUM_OFF_MS);
+  assert(!active.restore_credit(MINIMUM_OFF_MS, true));
+}
+
+void test_policies_are_independent_per_heat_pump() {
+  auto hp1 = make_policy();
+  auto hp2 = make_policy();
+  assert(hp1.restore_credit(MINIMUM_OFF_MS, true));
+  assert(hp2.restore_credit(60000, true));
+  hp1.observe_stopped(1000);
+  hp2.observe_stopped(1000);
+  assert(hp1.can_start(1000));
+  assert(!hp2.can_start(1000));
+  assert(hp2.remaining_ms(1000) == 180000);
+
+  hp1.invalidate();
+  assert(!hp1.can_start(1000));
+  assert(hp2.remaining_ms(1000) == 180000);
+}
+
+void test_snapshot_only_contains_observed_safe_time_across_restarts() {
+  auto first_boot = make_policy();
+  assert(first_boot.restore_credit(150000, true));
+  first_boot.observe_stopped(1000);
+  assert(first_boot.snapshot_credit_ms(9000) == 150000);
+  first_boot.observe_stopped(9000);
+  assert(first_boot.snapshot_credit_ms(9000) == 158000);
+
+  auto second_boot = make_policy();
+  assert(second_boot.restore_credit(first_boot.snapshot_credit_ms(9000), true));
+  assert(second_boot.snapshot_credit_ms(50000) == 0);
+  second_boot.observe_stopped(50000);
+  assert(second_boot.remaining_ms(50000) == 82000);
+  assert(second_boot.snapshot_credit_ms(55000) == 158000);
+  second_boot.observe_stopped(55000);
+  assert(second_boot.snapshot_credit_ms(55000) == 163000);
+}
+
+void test_millis_zero_and_wraparound() {
+  auto at_zero = make_policy();
+  at_zero.observe_stopped(0);
+  assert(!at_zero.can_start(0));
+  at_zero.observe_stopped(10000);
+  assert(at_zero.remaining_ms(10000) == 230000);
+
+  oq_hp_restart_guard::Policy wrapping;
+  assert(wrapping.configure(3000, 2000));
+  constexpr uint32_t before_wrap = UINT32_MAX - 1000;
+  wrapping.observe_stopped(before_wrap);
+  wrapping.observe_stopped(500);
+  assert(wrapping.remaining_ms(500) == 1499);
+  assert(!wrapping.can_start(1998));
+  assert(wrapping.can_start(1999));
+}
+
+void test_configuration_boundaries() {
+  oq_hp_restart_guard::Policy policy;
+  assert(policy.configure(0, FRESHNESS_MS));
+  assert(!policy.can_start(0));
+  assert(policy.remaining_ms(0) == 0);
+  policy.observe_stopped(0);
+  assert(policy.can_start(0));
+  assert(policy.remaining_ms(0) == 0);
+
+  assert(!policy.configure(MINIMUM_OFF_MS, 0));
+  assert(!policy.restore_credit(MINIMUM_OFF_MS, true));
+  assert(!policy.can_start(0));
+
+  assert(!policy.configure(0x80000000U, FRESHNESS_MS));
+  assert(!policy.can_start(0));
+  assert(policy.remaining_ms(0) == UINT32_MAX);
+
+  assert(!policy.configure(MINIMUM_OFF_MS, 0x80000000U));
+  assert(!policy.can_start(0));
+}
+
+}  // namespace
+
+int main() {
+  test_requires_fresh_stopped_evidence();
+  test_restored_credit_is_clamped_and_reboot_time_is_not_counted();
+  test_repeated_stopped_observations_do_not_restart_timer();
+  test_gap_and_active_observation_invalidate_evidence();
+  test_policies_are_independent_per_heat_pump();
+  test_snapshot_only_contains_observed_safe_time_across_restarts();
+  test_millis_zero_and_wraparound();
+  test_configuration_boundaries();
+  return 0;
+}

--- a/tests/host/openquatt_incident_runtime_policy_test.cpp
+++ b/tests/host/openquatt_incident_runtime_policy_test.cpp
@@ -19,6 +19,7 @@ using esphome::openquatt_incident_manager::incident_storage_failure_outputs;
 using esphome::openquatt_incident_manager::link_round_timeout_elapsed;
 using esphome::openquatt_incident_manager::perform_start_failure_retry;
 using esphome::openquatt_incident_manager::post_command_feedback_complete;
+using esphome::openquatt_incident_manager::restored_credit_acquisition_active;
 using esphome::openquatt_incident_manager::run_observation_is_fresh;
 using esphome::openquatt_incident_manager::should_emit_operator_stop_confirmation;
 using esphome::openquatt_incident_manager::should_emit_start_confirmation;
@@ -128,6 +129,16 @@ void test_link_round_timeout_tolerates_scan_jitter() {
   assert(engine.outputs().link_state == oq_incidents::LinkState::SUSPECT);
   engine.observe_link_round(last_round_ms + 45000U, false);
   assert(engine.outputs().link_state == oq_incidents::LinkState::LOST);
+}
+
+void test_restored_credit_survives_only_bounded_online_acquisition() {
+  constexpr uint32_t kTimeoutMs = 120000U;
+  assert(restored_credit_acquisition_active(true, false, false, 119999U, 0U, kTimeoutMs));
+  assert(restored_credit_acquisition_active(true, true, true, 119999U, 0U, kTimeoutMs));
+  assert(!restored_credit_acquisition_active(true, true, false, 1000U, 0U, kTimeoutMs));
+  assert(!restored_credit_acquisition_active(true, false, false, 120000U, 0U, kTimeoutMs));
+  assert(!restored_credit_acquisition_active(false, false, false, 1U, 0U, kTimeoutMs));
+  assert(restored_credit_acquisition_active(true, false, false, 50U, UINT32_MAX - 49U, kTimeoutMs));
 }
 
 void test_duo_fallback_coverage_fails_closed() {
@@ -441,6 +452,7 @@ int main() {
   test_confirmation_audit_policy();
   test_start_failure_retry_production_policy();
   test_link_round_timeout_tolerates_scan_jitter();
+  test_restored_credit_survives_only_bounded_online_acquisition();
   test_duo_fallback_coverage_fails_closed();
   test_incident_storage_failure_forces_safe_outputs();
   test_fallback_output_confirmation();

--- a/tests/host/restart_handoff_test.cpp
+++ b/tests/host/restart_handoff_test.cpp
@@ -1,0 +1,316 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h"
+
+namespace {
+
+using esphome::openquatt_incident_manager::restart_handoff::BootContext;
+using esphome::openquatt_incident_manager::restart_handoff::configuration_hash;
+using esphome::openquatt_incident_manager::restart_handoff::consume_record;
+using esphome::openquatt_incident_manager::restart_handoff::finalize_record;
+using esphome::openquatt_incident_manager::restart_handoff::may_grant_after_durable_consume;
+using esphome::openquatt_incident_manager::restart_handoff::may_restore_credit;
+using esphome::openquatt_incident_manager::restart_handoff::persist_record;
+using esphome::openquatt_incident_manager::restart_handoff::Record;
+using esphome::openquatt_incident_manager::restart_handoff::StorageReadResult;
+using esphome::openquatt_incident_manager::restart_handoff::valid_record;
+
+constexpr uint32_t MINIMUM_OFF_MS = 240000U;
+
+struct FakeStorage {
+  bool present{false};
+  Record record{};
+  bool load_error{false};
+  mutable uint8_t transient_read_errors{0U};
+  bool erase_error{false};
+  bool erase_commit_ok{true};
+  bool erase_not_found{false};
+  bool erase_readback_stale{false};
+  bool write_ok{true};
+  bool write_commit_ok{true};
+  bool write_readback_stale{false};
+  uint32_t erase_calls{0U};
+
+  StorageReadResult read(Record* target) const {
+    if (load_error || target == nullptr) return StorageReadResult::ERROR;
+    if (transient_read_errors > 0U) {
+      --transient_read_errors;
+      return StorageReadResult::ERROR;
+    }
+    if (!present) return StorageReadResult::ABSENT;
+    *target = record;
+    return StorageReadResult::PRESENT;
+  }
+
+  bool erase_and_verify_absent() {
+    ++erase_calls;
+    if (erase_error || !erase_commit_ok) return false;
+    if (!erase_not_found && !erase_readback_stale) present = false;
+    Record verified{};
+    return this->read(&verified) == StorageReadResult::ABSENT;
+  }
+
+  bool write_commit_and_verify(const Record& next) {
+    if (!write_ok) return false;
+    record = next;
+    present = true;
+    if (!write_commit_ok) return false;
+    if (write_readback_stale) record.hp1_credit_ms--;
+    Record verified{};
+    return this->read(&verified) == StorageReadResult::PRESENT && std::memcmp(&next, &verified, sizeof(next)) == 0;
+  }
+};
+
+Record make_record() {
+  Record record{};
+  record.magic = esphome::openquatt_incident_manager::restart_handoff::kRecordMagic;
+  record.version = esphome::openquatt_incident_manager::restart_handoff::kRecordVersion;
+  record.state = esphome::openquatt_incident_manager::restart_handoff::kRecordArmed;
+  record.minimum_off_ms = MINIMUM_OFF_MS;
+  record.config_hash = configuration_hash(MINIMUM_OFF_MS, true);
+  record.boot_partition_address = 0x210000U;
+  record.hp1_credit_ms = MINIMUM_OFF_MS;
+  record.hp2_credit_ms = 120000U;
+  for (size_t index = 0U; index < sizeof(record.image_hash); ++index)
+    record.image_hash[index] = static_cast<uint8_t>(index);
+  finalize_record(&record);
+  return record;
+}
+
+BootContext matching_context(const Record& record) {
+  BootContext context{};
+  context.software_reset = true;
+  context.running_partition_matches_boot = true;
+  context.image_valid = true;
+  context.minimum_off_ms = record.minimum_off_ms;
+  context.config_hash = record.config_hash;
+  context.boot_partition_address = record.boot_partition_address;
+  std::memcpy(context.image_hash, record.image_hash, sizeof(context.image_hash));
+  return context;
+}
+
+void test_only_exact_controlled_restart_restores_credit() {
+  const Record record = make_record();
+  assert(valid_record(record));
+  const BootContext context = matching_context(record);
+  assert(may_restore_credit(record, context));
+}
+
+void test_corrupt_or_partial_arm_never_restores_credit() {
+  Record corrupt = make_record();
+  corrupt.hp1_credit_ms++;
+  assert(!valid_record(corrupt));
+  assert(!may_restore_credit(corrupt, matching_context(corrupt)));
+
+  Record partial = make_record();
+  partial.state = 0U;
+  finalize_record(&partial);
+  assert(!valid_record(partial));
+
+  const Record valid = make_record();
+  Record partially_consumed{};
+  assert(!valid_record(partially_consumed));
+  assert(!may_grant_after_durable_consume(true, partially_consumed, matching_context(valid)));
+}
+
+void test_replay_and_non_restart_paths_are_rejected() {
+  const Record record = make_record();
+  auto context = matching_context(record);
+  context.software_reset = false;
+  assert(!may_restore_credit(record, context));
+  context = matching_context(record);
+  context.running_partition_matches_boot = false;
+  assert(!may_restore_credit(record, context));
+  context = matching_context(record);
+  context.boot_partition_address++;
+  assert(!may_restore_credit(record, context));
+  context = matching_context(record);
+  context.image_valid = false;
+  assert(!may_restore_credit(record, context));
+}
+
+void test_consume_failure_never_grants_in_memory_credit() {
+  const Record record = make_record();
+  const BootContext context = matching_context(record);
+  assert(may_restore_credit(record, context));
+  assert(!may_grant_after_durable_consume(false, record, context));
+  assert(may_grant_after_durable_consume(true, record, context));
+}
+
+void test_storage_consume_clears_before_credit_and_cannot_replay() {
+  FakeStorage storage{};
+  storage.present = true;
+  storage.record = make_record();
+  const BootContext context = matching_context(storage.record);
+  uint32_t hp1_credit = 0U;
+  uint32_t hp2_credit = 0U;
+  assert(consume_record(storage, context, &hp1_credit, &hp2_credit));
+  assert(hp1_credit == MINIMUM_OFF_MS);
+  assert(hp2_credit == 120000U);
+  assert(storage.erase_calls == 1U);
+  assert(!storage.present);
+
+  hp1_credit = 1U;
+  hp2_credit = 1U;
+  assert(consume_record(storage, context, &hp1_credit, &hp2_credit));
+  assert(hp1_credit == 0U && hp2_credit == 0U);
+}
+
+void test_storage_consume_failure_injection_fails_closed() {
+  const Record record = make_record();
+  const BootContext context = matching_context(record);
+  uint32_t hp1_credit = 123U;
+  uint32_t hp2_credit = 456U;
+
+  FakeStorage corrupt{};
+  corrupt.present = true;
+  corrupt.record = record;
+  corrupt.record.checksum++;
+  assert(consume_record(corrupt, context, &hp1_credit, &hp2_credit));
+  assert(corrupt.erase_calls == 1U && hp1_credit == 0U && hp2_credit == 0U);
+
+  FakeStorage unreadable{};
+  unreadable.load_error = true;
+  unreadable.erase_readback_stale = true;
+  assert(!consume_record(unreadable, context, &hp1_credit, &hp2_credit));
+  assert(unreadable.erase_calls == 1U && hp1_credit == 0U && hp2_credit == 0U);
+
+  // An initially ambiguous direct read is only accepted when the post-erase
+  // direct read proves that no record exists; an erase-not-found alone is not
+  // considered proof.
+  FakeStorage ambiguous_then_absent{};
+  ambiguous_then_absent.transient_read_errors = 1U;
+  ambiguous_then_absent.erase_not_found = true;
+  assert(consume_record(ambiguous_then_absent, context, &hp1_credit, &hp2_credit));
+  assert(ambiguous_then_absent.erase_calls == 1U && hp1_credit == 0U && hp2_credit == 0U);
+
+  FakeStorage erase_not_found_but_present{};
+  erase_not_found_but_present.present = true;
+  erase_not_found_but_present.record = record;
+  erase_not_found_but_present.erase_not_found = true;
+  assert(!consume_record(erase_not_found_but_present, context, &hp1_credit, &hp2_credit));
+  assert(hp1_credit == 0U && hp2_credit == 0U);
+
+  FakeStorage erase_commit_failed{};
+  erase_commit_failed.present = true;
+  erase_commit_failed.record = record;
+  erase_commit_failed.erase_commit_ok = false;
+  assert(!consume_record(erase_commit_failed, context, &hp1_credit, &hp2_credit));
+  assert(hp1_credit == 0U && hp2_credit == 0U);
+}
+
+void test_storage_arm_failure_injection_requires_commit_and_readback() {
+  const Record record = make_record();
+  FakeStorage commit_failed{};
+  commit_failed.write_commit_ok = false;
+  assert(!persist_record(commit_failed, record));
+
+  FakeStorage stale_readback{};
+  stale_readback.write_readback_stale = true;
+  assert(!persist_record(stale_readback, record));
+
+  FakeStorage saved{};
+  assert(persist_record(saved, record));
+  assert(saved.present && std::memcmp(&saved.record, &record, sizeof(record)) == 0);
+}
+
+void test_failed_arm_with_visible_record_is_consumed_once_before_replay() {
+  const Record record = make_record();
+  const BootContext context = matching_context(record);
+  FakeStorage storage{};
+  storage.write_commit_ok = false;
+  assert(!persist_record(storage, record));
+  assert(storage.present);
+
+  uint32_t hp1_credit = 0U;
+  uint32_t hp2_credit = 0U;
+  // Even if a failed commit left bytes visible, boot must erase and verify the
+  // one-shot record before exposing its credit.
+  assert(consume_record(storage, context, &hp1_credit, &hp2_credit));
+  assert(!storage.present && hp1_credit == MINIMUM_OFF_MS && hp2_credit == 120000U);
+
+  hp1_credit = 1U;
+  hp2_credit = 1U;
+  assert(consume_record(storage, context, &hp1_credit, &hp2_credit));
+  assert(hp1_credit == 0U && hp2_credit == 0U);
+}
+
+void test_uncontrolled_reset_consumes_without_credit() {
+  FakeStorage storage{};
+  storage.present = true;
+  storage.record = make_record();
+  auto context = matching_context(storage.record);
+  context.software_reset = false;
+  uint32_t hp1_credit = 1U;
+  uint32_t hp2_credit = 1U;
+  assert(consume_record(storage, context, &hp1_credit, &hp2_credit));
+  assert(!storage.present && hp1_credit == 0U && hp2_credit == 0U);
+}
+
+void test_consume_commit_failure_blocks_then_recovers_once() {
+  FakeStorage storage{};
+  storage.present = true;
+  storage.record = make_record();
+  const BootContext context = matching_context(storage.record);
+  uint32_t hp1_credit = 1U;
+  uint32_t hp2_credit = 1U;
+  storage.erase_commit_ok = false;
+  assert(!consume_record(storage, context, &hp1_credit, &hp2_credit));
+  assert(storage.present && hp1_credit == 0U && hp2_credit == 0U);
+
+  storage.erase_commit_ok = true;
+  assert(consume_record(storage, context, &hp1_credit, &hp2_credit));
+  assert(!storage.present && hp1_credit == MINIMUM_OFF_MS && hp2_credit == 120000U);
+
+  assert(consume_record(storage, context, &hp1_credit, &hp2_credit));
+  assert(hp1_credit == 0U && hp2_credit == 0U);
+}
+
+void test_image_and_configuration_mismatch_are_rejected() {
+  const Record record = make_record();
+  auto context = matching_context(record);
+  context.image_hash[0] ^= 0xFFU;
+  assert(!may_restore_credit(record, context));
+  context = matching_context(record);
+  context.config_hash = configuration_hash(MINIMUM_OFF_MS, false);
+  assert(!may_restore_credit(record, context));
+  context = matching_context(record);
+  context.minimum_off_ms = MINIMUM_OFF_MS - 1U;
+  assert(!may_restore_credit(record, context));
+  context = matching_context(record);
+  std::memset(context.image_hash, 0, sizeof(context.image_hash));
+  assert(!may_restore_credit(record, context));
+}
+
+void test_invalid_credit_bounds_fail_closed() {
+  Record record = make_record();
+  record.hp1_credit_ms = MINIMUM_OFF_MS + 1U;
+  finalize_record(&record);
+  assert(!valid_record(record));
+  record = make_record();
+  record.hp1_credit_ms = 0U;
+  record.hp2_credit_ms = 0U;
+  finalize_record(&record);
+  assert(!valid_record(record));
+}
+
+}  // namespace
+
+int main() {
+  test_only_exact_controlled_restart_restores_credit();
+  test_corrupt_or_partial_arm_never_restores_credit();
+  test_replay_and_non_restart_paths_are_rejected();
+  test_consume_failure_never_grants_in_memory_credit();
+  test_storage_consume_clears_before_credit_and_cannot_replay();
+  test_storage_consume_failure_injection_fails_closed();
+  test_storage_arm_failure_injection_requires_commit_and_readback();
+  test_failed_arm_with_visible_record_is_consumed_once_before_replay();
+  test_uncontrolled_reset_consumes_without_credit();
+  test_consume_commit_failure_blocks_then_recovers_once();
+  test_image_and_configuration_mismatch_are_rejected();
+  test_invalid_credit_bounds_fail_closed();
+  return 0;
+}

--- a/tests/host/thermal_actuator_logic_test.cpp
+++ b/tests/host/thermal_actuator_logic_test.cpp
@@ -1,11 +1,13 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include "../../openquatt/includes/control/oq_hp_restart_guard.h"
 #include "../../openquatt/includes/control/oq_thermal_actuator_logic.h"
 int main() {
   using namespace oq_thermal_actuator;
-  ManualGuardInputs input{5, 2, 10000U, 0U, 300000U, 0U, false, false, false, true, false};
+  ManualGuardInputs input{5, 2, 0U, 0U, false, false, false, true, false};
   assert(manual_guard(input, "Vrijgegeven") == "Vrijgegeven");
+  input.minimum_off_remaining_ms = 30000U;
   input.stop_requested = true;
   input.water_temperature_trip = true;
   assert(manual_guard(input, "Vrijgegeven") == "stopverzoek wordt veilig afgerond");
@@ -29,10 +31,28 @@ int main() {
   input.mode_conflict = true;
   assert(manual_guard(input, "Vrijgegeven") == "conflicterende werkmodus tussen HP1 en HP2");
   input.mode_conflict = false;
-  input.now_ms = 25U;
-  input.last_stop_ms = UINT32_MAX - 50U;
-  input.minimum_off_ms = 1000U;
-  assert(manual_guard(input, "Vrijgegeven") == "minimale uit-tijd: nog 1 s");
+
+  oq_hp_restart_guard::Policy restart_guard;
+  assert(restart_guard.configure(240000U, 10000U));
+  restart_guard.observe_stopped(1000U);
+  for (uint32_t now_ms = 11000U; now_ms <= 221000U; now_ms += 10000U) restart_guard.observe_stopped(now_ms);
+  input.minimum_off_remaining_ms = restart_guard.remaining_ms(226000U);
+  assert(input.minimum_off_remaining_ms == 15000U);
+  assert(manual_guard(input, "Vrijgegeven") == "minimale uit-tijd: nog 15 s");
+
+  restart_guard.observe_stopped(231001U);
+  input.minimum_off_remaining_ms = restart_guard.remaining_ms(231001U);
+  assert(input.minimum_off_remaining_ms == 240000U);
+  assert(manual_guard(input, "Vrijgegeven") == "minimale uit-tijd: nog 240 s");
+
+  oq_hp_restart_guard::Policy released_guard;
+  assert(released_guard.configure(240000U, 10000U));
+  assert(released_guard.restore_credit(240000U, true));
+  released_guard.observe_stopped(0U);
+  input.minimum_off_remaining_ms = released_guard.remaining_ms(0U);
+  assert(input.minimum_off_remaining_ms == 0U);
+  assert(manual_guard(input, "Vrijgegeven") == "Vrijgegeven");
+
   assert(manual_guard(input, "Bestaande blokkering") == "Bestaande blokkering");
   input.requested_level = 0;
   assert(manual_guard(input, "Vrijgegeven") == "Vrijgegeven");

--- a/tests/host/thermal_request_logic_test.cpp
+++ b/tests/host/thermal_request_logic_test.cpp
@@ -83,6 +83,27 @@ int main() {
   assert(!manual_result.mode_allowed && manual_result.reason == oq_request::MANUAL_STARTUP_INHIBIT);
   assert(manual_result.desired_hp1_level == 4 && manual_result.hp1_level == 0);
 
+  // An inhibited HP1 cooling request must not conflict with or select the mode for HP2's heating runtime hold.
+  manual = {true, 1, 0, 4, 0, 10, 10, 5, 3, true, false, false, false, false, true, false};
+  manual_result = oq_request::arbitrate_manual_request(manual);
+  assert(manual_result.mode_allowed && !manual_result.mode_conflict);
+  assert(manual_result.mode_code == 2 && manual_result.hp1_level == 0 && manual_result.hp2_level == 3);
+  assert(manual_result.desired_hp1_level == 4 && manual_result.desired_hp2_level == 0);
+
+  // The mirrored case keeps HP1's cooling runtime hold independent of an inhibited HP2 heating request and hold.
+  manual = {true, 0, 2, 0, 4, 10, 10, 3, 5, true, false, false, false, false, false, true};
+  manual_result = oq_request::arbitrate_manual_request(manual);
+  assert(manual_result.mode_allowed && !manual_result.mode_conflict);
+  assert(manual_result.mode_code == 1 && manual_result.hp1_level == 3 && manual_result.hp2_level == 0);
+  assert(manual_result.desired_hp1_level == 0 && manual_result.desired_hp2_level == 4);
+
+  // An inhibited opposite-mode request also cannot conflict with an active request on the released HP.
+  manual = {true, 1, 2, 4, 3, 10, 10, 0, 0, false, false, false, false, false, true, false};
+  manual_result = oq_request::arbitrate_manual_request(manual);
+  assert(manual_result.mode_allowed && !manual_result.mode_conflict);
+  assert(manual_result.mode_code == 2 && manual_result.hp1_level == 0 && manual_result.hp2_level == 3);
+  assert(manual_result.desired_hp1_level == 4 && manual_result.desired_hp2_level == 3);
+
   assert(!oq_request::thermal_mode_matches(std::numeric_limits<float>::infinity(), 1));
   assert(!oq_request::thermal_mode_matches(std::numeric_limits<float>::quiet_NaN(), 1));
   assert(oq_request::thermal_mode_matches(1.0f, 1));


### PR DESCRIPTION
# Wat verandert deze PR?

- De bestaande **Restart**-knop neemt per HP eenmalig reeds bevestigde compressorstilstand mee naar een gecontroleerde controllerherstart.
- Na de boot wordt pas na een verse stopwaarneming vrijgegeven; rebootduur en tijd zonder geldige communicatie tellen niet mee.
- Onzekere toestand, actieve feedback/opdracht, communicatieverlies, verlopen acquisitie, stroomuitval, crash, OTA/rollback of een afwijkende firmware/configuratie vallen terug op de volledige minimale uit-tijd.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting: naam, ID en `device_class` van de bestaande Restart-entiteit blijven gelijk. Er komen geen HA-entiteiten of instellingen bij. Alleen gecontroleerde Restart krijgt deze optimalisatie; de minimale koel-uit-tijd blijft ongewijzigd.

## Achtergrond

Een controllerreboot onderbreekt de communicatie met de buitenunit. De implementatie neemt daarom nooit een draaiende compressor over, maar bewaart vlak vóór Restart uitsluitend aantoonbare stilstand. HP1 en HP2 houden elk hun eigen krediet en vrijgavetijd.

Het 64-byte NVS-record is one-shot en vereist dezelfde firmwarehash, configuratie, partitie en software-reset. Het record wordt vóór safe mode/OTA-toegang duurzaam verbruikt; bij een lees-, wis- of commitfout start de normale regeling niet. Na boot vervalt pending krediet bij expliciet communicatieverlies, actieve mode/frequentie, een actieve Modbus-write of uiterlijk na 120 seconden zonder bruikbare verse waarneming. De beveiliging gebruikt monotone `millis()`-duurmeting; timesync/RTC heeft geen rol in de vrijgave.

De complete diff is gecontroleerd op control-paden, lifecycle, callbacks, retries, fresh install, OTA/rollback, ontbrekende/corrupte NVS-state, wrap-around en beide HP's. Een afzonderlijke koude adversariële review van `origin/dev...HEAD` vond geen blocker.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie: `docs/system-overview.md` beschrijft bevestigde uit-tijd, de uitsluitingen en de conservatieve terugval.

## Validatie

- `CXX=g++-15 bash scripts/run_host_regression_tests.sh`: 65 hostregressies geslaagd, inclusief deadline/offline/actieve toestand, NVS-fouten, corrupte context en timer-wrap.
- `npm run check:python-contracts`: 221 tests geslaagd; alle actieve mode/level-writes zijn contractueel afgedekt.
- `npm run check:cpp-format`, `npm run check:docs:contracts` en `git diff --check`: geslaagd.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`: geslaagd met ESPHome 2026.8.2; image `0x215bf0`, DIRAM 203807/341760 bytes (59,63%).
- GitHub CI run 2009: alle contract-, format-, docs-, web- en firmwareprofieljobs geslaagd.
- HIL op Q Duo WiFi met de exact gerebaseerde firmware: bij opgeslagen krediet HP1=98 s en HP2=79 s waren beide na circa 115 s nog geblokkeerd; HP1 kwam na 172 s vrij en HP2 na 193 s. Beide bleven CM0, working mode 0 en compressorfrequentie 0 Hz. Een eerdere volledige-kredietproef kwam bij de eerste gezonde meetronde rond 90 s vrij; een normale OTA-boot zonder record bleef langer dan 240 s conservatief geblokkeerd.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` blijft blokkeren op drie vooraf bestaande `origin/dev`-stylemeldingen: `configs/hil/input_sources_fast_duo_wifi.yaml:26`, `openquatt/oq_common.yaml:723` en `openquatt/oq_common.yaml:840`. Directe ESPHome-configuratie en compile slagen.

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact: kandidaat na de HIL-cycli: 108383 B vrije interne heap, 39828 B minimum-sinds-boot, 61440 B grootste blok en 43,3% fragmentatie. Oudere live baseline: 104679 B / 39828 B / 61440 B / 41,3%. De wijziging voegt kleine vaste guard-state en een tijdelijk 64-byte NVS-record toe, zonder nieuwe task of langdurige buffer. Deze snapshots zijn geen identieke worst-case netwerk/OTA/Modbus-belastingstest.

Nog niet fysiek verstoord: RS485 losnemen vóór de eerste stopbevestiging, stroomuitval/crash, draaiende HP en echte NVS-fouten. De bijbehorende fail-closed paden zijn met host/failure-injection-tests en code-audit afgedekt.