### PR TITLE
Waarschuw voor te lage compressorfrequentie

### DIFF
--- a/components/openquatt_decision_log/OpenQuattDecisionLog.cpp
+++ b/components/openquatt_decision_log/OpenQuattDecisionLog.cpp
@@ -1195,6 +1195,8 @@ const char* OpenQuattDecisionLog::subject_to_string_(uint8_t value) {
 
 const char* OpenQuattDecisionLog::reason_to_string_(uint8_t value) {
   switch (value) {
+    case REASON_FREQUENCY_CAP_BELOW_MINIMUM:
+      return "frequency_cap_below_minimum";
     case REASON_KEEP_CURRENT:
       return "keep_current";
     case REASON_HOLD_ACTIVE:

--- a/components/openquatt_decision_log/OpenQuattDecisionLog.h
+++ b/components/openquatt_decision_log/OpenQuattDecisionLog.h
@@ -123,6 +123,7 @@ enum ReasonCode : uint8_t {
   REASON_HP_RECOVERED = 71,
   REASON_ROOM_DEMAND = 72,
   REASON_SETPOINT_RAISE = 73,
+  REASON_FREQUENCY_CAP_BELOW_MINIMUM = 74,
 };
 
 enum Severity : uint8_t {

--- a/openquatt/includes/control/oq_compressor_frequency_policy.h
+++ b/openquatt/includes/control/oq_compressor_frequency_policy.h
@@ -35,6 +35,22 @@ inline int automatic_frequency_hz(bool configured_v2, const oq_odu::RuntimeFrequ
   return frequency_hz > 0 ? frequency_hz : -1;
 }
 
+// Read-only diagnostic: the lowest frequency the automatic level mapping can
+// request, before applying the user cap or an excluded frequency range.
+inline int minimum_automatic_frequency_hz(bool configured_v2, const oq_odu::RuntimeFrequencySnapshot& snapshot,
+                                          int mode_code) {
+  int minimum = MAX_POLICY_FREQUENCY_HZ + 1;
+  for (int level = 1; level <= oq_odu::MODEL_LEVEL_MAX; ++level) {
+    const int hz = automatic_frequency_hz(configured_v2, snapshot, mode_code, level);
+    if (hz > 0) minimum = std::min(minimum, hz);
+  }
+  return minimum <= MAX_POLICY_FREQUENCY_HZ ? minimum : -1;
+}
+
+inline bool cap_below_minimum(int cap_hz, int minimum_hz) {
+  return cap_hz >= 0 && cap_hz <= MAX_POLICY_FREQUENCY_HZ && minimum_hz > 0 && cap_hz < minimum_hz;
+}
+
 inline bool frequency_allowed(int frequency_hz, int cap_hz, const FrequencyRange& excluded) {
   if (frequency_hz <= 0 || cap_hz < 0 || cap_hz > MAX_POLICY_FREQUENCY_HZ) return false;
   if (!valid_frequency_range(excluded)) return false;

--- a/openquatt/includes/control/oq_thermal_actuator_runtime.h
+++ b/openquatt/includes/control/oq_thermal_actuator_runtime.h
@@ -76,6 +76,10 @@ class Runtime {
                                     restart_by_minimum_off_time),
     };
     this->publish_defrost_events(config.now_ms);
+    this->publish_frequency_limit_block_(true, cycle);
+#if OQ_TOPOLOGY_DUO
+    this->publish_frequency_limit_block_(false, cycle);
+#endif
     const bool hp1_was_cooling = this->applied_cooling_[0] || this->applied_mode_is_cooling_(true, request_mode_code);
 #if OQ_TOPOLOGY_DUO
     const bool hp2_was_cooling = this->applied_cooling_[1] || this->applied_mode_is_cooling_(false, request_mode_code);
@@ -388,6 +392,34 @@ class Runtime {
   }
 
  private:
+  void publish_frequency_limit_block_(bool is_hp1, const Cycle& cycle) {
+    const int cm = id(oq_control_mode_code);
+    const int requested = is_hp1 ? id(oq_request_hp1_level) : id(oq_request_hp2_level);
+    const auto incident = id(oq_incident_manager).get_outputs(is_hp1 ? 1U : 2U);
+    const int minimum = oq_frequency_policy::minimum_automatic_frequency_hz(
+        cycle.frequency.configured_v2, cycle.frequency.snapshot(is_hp1), cm == 5 ? 1 : 2);
+    const bool blocked = !cycle.manual_service_active && (cm == 2 || cm == 3 || cm == 5) && requested > 0 &&
+                         this->previous_applied_(is_hp1) == 0 && !incident.running_confirmed &&
+                         oq_frequency_policy::cap_below_minimum(cycle.frequency.cap_hz, minimum);
+    uint32_t& previous = this->last_frequency_limit_blocks_[is_hp1 ? 0 : 1];
+    const bool silent = id(oq_silent_active).state;
+    const uint32_t signature = blocked ? (static_cast<uint32_t>(cm) << 24) | (silent ? 1U << 23 : 0U) |
+                                             (static_cast<uint32_t>(cycle.frequency.cap_hz) << 8) |
+                                             static_cast<uint32_t>(minimum)
+                                       : 0U;
+    if (signature == previous) return;
+    previous = signature;
+    if (!blocked) return;
+    // Keep the pre-policy request: the final actuator request can already be
+    // zero because this frequency limit rejected every allowed level.
+    id(oq_decision_log)
+        .emit(openquatt_decision_log::EVENT_CANDIDATE_BLOCKED,
+              is_hp1 ? openquatt_decision_log::SUBJECT_HP1 : openquatt_decision_log::SUBJECT_HP2,
+              openquatt_decision_log::REASON_FREQUENCY_CAP_BELOW_MINIMUM, openquatt_decision_log::SEVERITY_LIMITED,
+              static_cast<uint8_t>(cm), openquatt_decision_log::STATE_STANDBY, openquatt_decision_log::STATE_BLOCKED,
+              static_cast<int16_t>(cycle.frequency.cap_hz), static_cast<int16_t>(minimum), 0, 0, silent ? 1U : 0U);
+  }
+
   int apply_level_(bool is_hp1, int requested, bool was_cooling, Cycle& cycle) {
     constexpr int MAX_LEVEL = 10;
     const int maximum = cycle.manual_service_active
@@ -792,6 +824,7 @@ class Runtime {
   uint32_t last_safe_stop_write_ms_[2]{0, 0};
   oq_odu::RetainedLevel retained_levels_[2]{};
   uint8_t last_candidate_reasons_[2]{openquatt_decision_log::REASON_UNKNOWN, openquatt_decision_log::REASON_UNKNOWN};
+  uint32_t last_frequency_limit_blocks_[2]{};
 };
 
 inline Runtime& runtime() {

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -737,6 +737,38 @@ sensor:
         - lambda: |-
             id(${hp_id}_current_last_update_ms) = millis();
 
+  - platform: template
+    id: ${hp_id}_minimum_heating_frequency
+    name: "${prefix}Minimum heating frequency"
+    unit_of_measurement: "Hz"
+    accuracy_decimals: 0
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    lambda: |-
+      // Report the actual automatic mapping; an unavailable table stays unknown.
+      if (!id(hp_generation).has_state()) return NAN;
+      const auto snapshot = oq_odu::decode_runtime_frequency_snapshot(id(${hp_id}_runtime_frequency_snapshot_storage));
+      const int hz = oq_frequency_policy::minimum_automatic_frequency_hz(
+          id(hp_generation).current_option() == "V2", snapshot, 2);
+      return hz > 0 ? static_cast<float>(hz) : NAN;
+
+  - platform: template
+    id: ${hp_id}_minimum_cooling_frequency
+    name: "${prefix}Minimum cooling frequency"
+    unit_of_measurement: "Hz"
+    accuracy_decimals: 0
+    entity_category: diagnostic
+    disabled_by_default: true
+    update_interval: 5s
+    lambda: |-
+      // Cooling can have a different minimum from heating on the same unit.
+      if (!id(hp_generation).has_state()) return NAN;
+      const auto snapshot = oq_odu::decode_runtime_frequency_snapshot(id(${hp_id}_runtime_frequency_snapshot_storage));
+      const int hz = oq_frequency_policy::minimum_automatic_frequency_hz(
+          id(hp_generation).current_option() == "V2", snapshot, 1);
+      return hz > 0 ? static_cast<float>(hz) : NAN;
+
   - platform: modbus_controller
     modbus_controller_id: ${hp_id}
     id: ${hp_id}_compressor_frequency_demand

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -257,6 +257,11 @@
       return;
     }
     const profile = getMockOduProfile(hp);
+    const frequencyTable = state.oduRuntimeFrequency[`HP${hp}`];
+    for (const mode of ["heating", "cooling"]) {
+      const minimum = profile.generation === "Unknown" ? NaN : Math.min(...frequencyTable[mode].slice(1));
+      setEntity("sensor", `HP${hp} - Minimum ${mode} frequency`, { value: minimum, uom: "Hz" });
+    }
     setEntity("sensor", `HP${hp} - Control board item number`, { value: profile.controlBoardItem });
     setEntity("text_sensor", `HP${hp} - ODU generation`, {
       state: profile.generation,
@@ -4180,6 +4185,7 @@
       } else {
         service.armed = false;
         state.oduRuntimeFrequency[hpName] = { cooling, heating };
+        syncMockOduIdentityEntities(hp);
         service.status = "APPLIED: runtime table written and read back";
       }
       service.busy = false;

--- a/openquatt/web/js/src/core/config.js
+++ b/openquatt/web/js/src/core/config.js
@@ -551,6 +551,8 @@
     ["hp1Cop", DOMAIN_SENSOR, "HP1 - COP", false],
     ["hp1Compressor", DOMAIN_SENSOR, "HP1 compressor level"],
     ["hp1Freq", DOMAIN_SENSOR, "HP1 - Compressor frequency", false],
+    ["hp1MinimumHeatingHz", DOMAIN_SENSOR, "HP1 - Minimum heating frequency"],
+    ["hp1MinimumCoolingHz", DOMAIN_SENSOR, "HP1 - Minimum cooling frequency"],
     ["hp1FanSpeed", DOMAIN_SENSOR, "HP1 - Fan speed", false],
     ["hp1Flow", DOMAIN_SENSOR, "HP1 - Flow", false],
     ["hp1EvaporatorCoilTemp", DOMAIN_SENSOR, "HP1 - Evaporator coil temperature", false],
@@ -579,6 +581,8 @@
     ["hp2Cop", DOMAIN_SENSOR, "HP2 - COP"],
     ["hp2Compressor", DOMAIN_SENSOR, "HP2 compressor level"],
     ["hp2Freq", DOMAIN_SENSOR, "HP2 - Compressor frequency"],
+    ["hp2MinimumHeatingHz", DOMAIN_SENSOR, "HP2 - Minimum heating frequency"],
+    ["hp2MinimumCoolingHz", DOMAIN_SENSOR, "HP2 - Minimum cooling frequency"],
     ["hp2FanSpeed", DOMAIN_SENSOR, "HP2 - Fan speed"],
     ["hp2Flow", DOMAIN_SENSOR, "HP2 - Flow"],
     ["hp2EvaporatorCoilTemp", DOMAIN_SENSOR, "HP2 - Evaporator coil temperature"],
@@ -760,6 +764,7 @@
     "phDemandFallTime",
   ];
   export const FREQUENCY_CAP_KEYS = ["dayMaxHz", "silentMaxHz"];
+  export const FREQUENCY_MINIMUM_KEYS = ["hp1MinimumHeatingHz", "hp1MinimumCoolingHz", "hp2MinimumHeatingHz", "hp2MinimumCoolingHz"];
   export const LIMIT_KEYS = [...FREQUENCY_CAP_KEYS, "maxWater"];
   export const FLOW_SETTING_KEYS = ["flowControlMode", "flowSetpoint", "coolingFlowSetpoint", "manualIpwm"];
   export const FLOW_TUNING_KEYS = ["flowKp", "flowKi"];
@@ -1652,6 +1657,7 @@
     ...INSTALLATION_MONITORING_OVERVIEW_KEYS,
   ];
   export const OVERVIEW_METADATA_KEYS = [
+    ...FREQUENCY_MINIMUM_KEYS,
     "hpGeneration",
     "boilerCvAssistEnabled",
     "boilerRatedHeatPower",

--- a/openquatt/web/js/src/core/entity-actions.js
+++ b/openquatt/web/js/src/core/entity-actions.js
@@ -1,3 +1,4 @@
+import { patchFrequencyLimitWarnings } from "../features/frequency-limits.js";
 import { hasEntity } from "./app-shared.js";
 import { ENTITY_DEFS } from "./config.js";
 import { getInputDraftValue } from "./control-drafts.js";
@@ -325,6 +326,7 @@ function updateFrequencyRangeControl(input) {
       if (!Number.isNaN(numeric)) {
         const normalized = normalizeNumber(field, event.target.value);
         state.drafts[field] = normalized;
+        if (field === "silentMaxHz" || field === "dayMaxHz") patchFrequencyLimitWarnings();
         if (event.target.type === "range") {
           if (field === "electricalCurrentLimit") {
             const sliderValue = event.target.closest("[data-oq-settings-field]")?.querySelector(".oq-helper-slider-meta strong");

--- a/openquatt/web/js/src/core/entity-sync.js
+++ b/openquatt/web/js/src/core/entity-sync.js
@@ -1,3 +1,5 @@
+import { FREQUENCY_MINIMUM_KEYS } from "./config.js";
+import { patchFrequencyLimitWarnings } from "../features/frequency-limits.js";
 import { getSetupCompleteState, isTrendHistoryEnabled, renderAppSummary } from "./app-shared.js";
 import { AUX_RELAY_SETTING_KEYS, AUX_RELAY_STATE_KEYS, BOILER_DIAGNOSTIC_KEYS, BOILER_SETTING_KEYS, BOILER_SUPPORT_SWITCHING_KEYS, BULK_POLL_INTERVAL_MS, CIC_COMPATIBILITY_KEYS, CIC_POLLING_DIAGNOSTIC_KEYS, CIC_POLLING_SETTING_KEYS, COMMISSIONING_STATE_KEYS, COMPRESSOR_SETTING_KEYS, CONNECTIVITY_PROBE_SUCCESS_TTL_MS, CONNECTIVITY_PROBE_TIMEOUT_MS, CONTROL_REPLAY_STATE_KEYS, COOLING_SCHEDULE_EFFECTIVE_SOURCE_KEY, COOLING_SCHEDULE_SOURCE_KEY, COOLING_SCHEDULE_TIME_KEYS, COOLING_SCHEDULE_VALID_KEY, COOLING_SETTING_KEYS, CURVE_POINTS, CURVE_SETTING_KEYS, ENTITY_DEFS, ENTITY_REFRESH_CONCURRENCY, FAST_OVERVIEW_KEYS, FAST_VIEW_ENTITY_REFRESH_CONCURRENCY, FIRMWARE_ENTITY_KEYS, FIRMWARE_MODAL_KEYS, FLOW_SETTING_KEYS, FLOW_TUNING_KEYS, FREQUENCY_CAP_KEYS, HEADER_ENTITY_KEYS, HIDDEN_POLL_INTERVAL_MS, INSTALLATION_MONITORING_STATE_KEYS, LIMIT_KEYS, OPENTHERM_DIAGNOSTIC_KEYS, OPENTHERM_SETTING_KEYS, OTB_DIAGNOSTIC_KEYS, OVERVIEW_ENERGY_COLUMN_CONFIGS, OVERVIEW_KEYS, OVERVIEW_METADATA_KEYS, POWER_HOUSE_KEYS, QUICK_START_FLOW_SOURCE_KEYS, QUICK_START_THERMOSTAT_SOURCE_KEYS, SENSOR_CALIBRATION_KEYS, SENSOR_CALIBRATION_STATE_KEYS, SENSOR_SELECTION_KEYS, SENSOR_SELECTION_STATE_KEYS, SERVICE_CONTROL_KEYS, SERVICE_STATUS_ENTITY_KEYS, SETTINGS_GROUP_IDS, SETTINGS_GROUPS, SETTINGS_KEYS, SILENT_SETTING_KEYS, STATIC_POLL_INTERVAL_MS } from "./config.js";
 import { buildEntityPath, isCurveMode } from "./domain-helpers.js";
@@ -240,6 +242,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
       ...FLOW_TUNING_KEYS,
       ...SILENT_SETTING_KEYS,
       ...COMPRESSOR_SETTING_KEYS,
+      ...FREQUENCY_MINIMUM_KEYS,
       ...SENSOR_CALIBRATION_KEYS,
       ...SENSOR_CALIBRATION_STATE_KEYS,
       "maxWater",
@@ -264,6 +267,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
       ...POWER_HOUSE_KEYS,
       ...CURVE_SETTING_KEYS,
       ...FREQUENCY_CAP_KEYS,
+      ...FREQUENCY_MINIMUM_KEYS,
     ],
     cooling: [
       "manualCoolingEnable",
@@ -279,6 +283,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
       "silentActive",
       ...FREQUENCY_CAP_KEYS,
       ...COOLING_SETTING_KEYS,
+      ...FREQUENCY_MINIMUM_KEYS,
     ],
     integrations: [
       ...OPENTHERM_SETTING_KEYS,
@@ -1248,6 +1253,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
             ]
           : ["setupComplete", ...HEADER_ENTITY_KEYS, "strategy", ...staticKeys];
     const generationBefore = ODU_GENERATION_KEYS.map(getEntityValue).join();
+    if (state.systemModal === "silent-settings") keys.push(...FREQUENCY_CAP_KEYS, ...FREQUENCY_MINIMUM_KEYS);
 
     state.entitySyncInFlight = true;
     state.lastEntitySyncAttemptAt = now;
@@ -1268,6 +1274,7 @@ import { fetchWithTimeout } from "./browser-utils.js";
         concurrency: forceFast && isOverviewLike ? FAST_VIEW_ENTITY_REFRESH_CONCURRENCY : ENTITY_REFRESH_CONCURRENCY,
       });
       state.lastFastEntitySyncAt = Date.now();
+      patchFrequencyLimitWarnings();
       if (isBulkDue && (syncView === "overview" || syncView === "control" || syncView === "diagnosis") && !isPrefetchOverview) {
         state.lastBulkEntitySyncAt = state.lastFastEntitySyncAt;
       }
@@ -1415,6 +1422,10 @@ import { fetchWithTimeout } from "./browser-utils.js";
         return;
       }
       if (hasOpenOverlay) {
+        if (state.systemModal === "silent-settings" && !state.focusedField
+          && FREQUENCY_CAP_KEYS.some((key) => state.entities[key] && !state.root?.querySelector(`[data-oq-field="${key}"]`))) {
+          render();
+        }
         return;
       }
       if (state.appView === "settings") {

--- a/openquatt/web/js/src/features/control-replay-view.js
+++ b/openquatt/web/js/src/features/control-replay-view.js
@@ -1,3 +1,4 @@
+import { describeFrequencyLimit } from "./frequency-limits.js";
 import { getEntityNumericValue, getEntityStateText, hasEntity, isEntityActive } from "../core/app-shared.js";
 import { renderOqIcon } from "../core/config.js";
 import { getEntityValue } from "../core/entity-store.js";
@@ -379,6 +380,7 @@ import { replaceOuterHtmlIfSignatureChanged } from "../views/view-utils.js";
   }
 
   const CONTROL_WORKING_REASON_METAS = createControlWorkingReasonMetas([
+    ["frequency_cap_below_minimum", "Frequentielimiet te laag", "De ingestelde maximumfrequentie ligt onder de laagste compressorfrequentie. Hierdoor kan de warmtepomp niet starten.", "Controleer de limiet bij Stille uren", "Vergelijk met het minimum van de buitenunit"],
     ["keep_current", "Huidige keuze blijft logisch", "De huidige stand past bij de vraag in huis. Wisselen zou nu weinig voordeel geven.", "Vraag blijft binnen de band", "Geen betere keuze nodig", "Rustig door laten lopen"],
     ["hold_active", "Wissel bewust uitgesteld", "Het systeem wacht bewust even, zodat warmtepompen niet onnodig vaak starten en stoppen.", "Vraag is nog niet duidelijk anders", "Minimale looptijd telt mee", "Actieve bron werkt nog goed"],
     ["defrost_hold", "Ontdooien rustig laten verlopen", "Een warmtepomp ontdooit kort. Dat is normaal wintergedrag en herstelt vanzelf.", "Ontdooien actief of net klaar", "Warmte kan kort lager zijn", "Herstart gebeurt automatisch"],
@@ -757,7 +759,6 @@ import { replaceOuterHtmlIfSignatureChanged } from "../views/view-utils.js";
     const stickyActive = hasEntity("stickyActive") && isEntityActive("stickyActive");
     const boilerActive = modeModel.boilerActive;
     const startupInhibit = getControlWorkingActiveStartupInhibit();
-
     let title = "Eén warmtepomp actief";
     let copy = "De actuele vraag past binnen één warmtepomp. De andere warmtepomp blijft beschikbaar als extra capaciteit nodig is.";
     let expectation = "Een extra warmtepomp schakelt bij zodra de vraag lang genoeg hoog blijft en alle wachttijden vrij zijn.";
@@ -1110,6 +1111,19 @@ import { replaceOuterHtmlIfSignatureChanged } from "../views/view-utils.js";
     const incidentCopy = getControlReplayIncidentEventCopy(event, subject);
     if (incidentCopy) {
       return incidentCopy;
+    }
+    if (reasonCode === "frequency_cap_below_minimum") {
+      const silent = (Number(event?.flags) & 1) !== 0;
+      return {
+        title: `${subject} kan niet starten: frequentielimiet`,
+        summary: describeFrequencyLimit(Number(event.value_a), {
+          unit: event.subject === "HP2" ? "hp2" : "hp1",
+          mode: Number(event.cm) === 5 ? "cooling" : "heating",
+          minimum: Number(event.value_b),
+        }),
+        detail: `De maximale compressorfrequentie ${silent ? "tijdens stille uren" : "overdag"} sloot alle compressorstanden voor deze bedrijfsmodus uit.`,
+        next: `Controleer bij Stille uren de maximale compressorfrequentie ${silent ? "tijdens stille uren" : "overdag"}. Deze moet minstens gelijk zijn aan het genoemde minimum.`,
+      };
     }
     const fallback = {
       title: "Keuze van het systeem",
@@ -3229,6 +3243,10 @@ import { replaceOuterHtmlIfSignatureChanged } from "../views/view-utils.js";
       graphMinute: getControlWorkingGraphMinute(),
       mode: current.modeLabel,
       title: current.title,
+      copy: current.copy,
+      expectation: current.expectation,
+      hp1Status: current.hp1Status,
+      hp2Status: current.hp2Status,
       reason: current.primaryReason,
       hp1Running: current.hp1Running,
       hp2Running: current.hp2Running,

--- a/openquatt/web/js/src/features/frequency-limits.js
+++ b/openquatt/web/js/src/features/frequency-limits.js
@@ -1,0 +1,59 @@
+import { formatValue, getEntityValue, parseLooseNumber } from "../core/entity-store.js";
+import { state } from "../core/state.js";
+import { getInstallationTopology } from "./device-context.js";
+
+function readFrequency(key, useDrafts = false) {
+  const entity = state.entities[key];
+  const value = parseLooseNumber(useDrafts ? getEntityValue(key) : entity?.value ?? entity?.state);
+  return Number.isFinite(value) && value >= 0 && value <= 120 ? Math.round(value) : null;
+}
+
+export function getFrequencyLimitModel(key, { useDrafts = false, mode = "" } = {}) {
+  const cap = readFrequency(key, useDrafts);
+  const units = getInstallationTopology() === "duo" ? ["hp1", "hp2"] : ["hp1"];
+  const modes = mode ? [mode] : ["heating", "cooling"];
+  const limits = units.flatMap((unit) => modes.map((operation) => {
+    const minimum = readFrequency(`${unit}Minimum${operation === "cooling" ? "Cooling" : "Heating"}Hz`);
+    return { unit, mode: operation, minimum, blocked: cap !== null && minimum > 0 && cap < minimum };
+  }));
+  return { cap, limits, blocked: limits.filter((limit) => limit.blocked), unknown: limits.some((limit) => !(limit.minimum > 0)) };
+}
+
+export function describeFrequencyLimit(cap, { unit, mode, minimum }) {
+  return `${cap} Hz is lager dan het minimum van ${unit.toUpperCase()} bij ${mode === "cooling" ? "koelen" : "verwarmen"}: ${minimum} Hz. ${unit.toUpperCase()} kan hierdoor niet starten.`;
+}
+
+export function getFrequencyLimitWarning(key) {
+  const model = getFrequencyLimitModel(key, { useDrafts: true });
+  const groups = new Map();
+  for (const limit of model.blocked) {
+    const groupKey = `${limit.mode}:${limit.minimum}`;
+    if (!groups.has(groupKey)) groups.set(groupKey, { ...limit, units: [] });
+    groups.get(groupKey).units.push(limit.unit.toUpperCase());
+  }
+  const minima = [...groups.values()].map(({ units, mode, minimum }) =>
+    `${units.join(" en ")} bij ${mode === "cooling" ? "koelen" : "verwarmen"}: ${minimum} Hz`);
+  const messages = minima.length
+    ? [`${model.cap} Hz is te laag. Minimum: ${minima.join("; ")}. Deze buitenunits kunnen in die bedrijfsmodi niet starten.`]
+    : [];
+  if (model.unknown) messages.push("Minimumfrequentie nog niet beschikbaar voor alle bedrijfsmodi en buitenunits. Een te lage limiet kan starten verhinderen.");
+  return { text: messages.join(" "), warning: model.blocked.length > 0 };
+}
+
+export function patchFrequencyLimitWarnings(root = state.root) {
+  root?.querySelectorAll("[data-oq-frequency-limit-warning]").forEach((node) => {
+    const key = node.dataset.oqFrequencyLimitWarning;
+    const warning = getFrequencyLimitWarning(key);
+    // Keep the visible slider and its warning on the same draft/live value,
+    // including remote changes while the overview modal is open.
+    const cap = readFrequency(key, true);
+    const card = node.closest("[data-oq-settings-field]");
+    const input = card?.querySelector('input[type="range"]');
+    const label = card?.querySelector(".oq-helper-slider-meta strong");
+    if (cap !== null && input && input.value !== String(cap)) input.value = String(cap);
+    if (cap !== null && label) label.textContent = formatValue(key, cap);
+    if (node.textContent !== warning.text) node.textContent = warning.text;
+    node.hidden = !warning.text;
+    node.classList.toggle("oq-settings-action-note--warning", warning.warning);
+  });
+}

--- a/openquatt/web/js/src/features/header-status.js
+++ b/openquatt/web/js/src/features/header-status.js
@@ -680,7 +680,7 @@ import { render } from "../core/render-scheduler.js";
         titleId: "oq-silent-settings-modal-title",
         kicker: "Stille uren",
         title: "Stille uren instellen",
-        modalClass: "oq-helper-modal--wide",
+        modalClass: "oq-helper-modal--wide oq-helper-modal--scrollable",
         closeAction: "close-system-modal",
         closeLabel: "Sluit stille-uren-popup",
         bodyMarkup: `

--- a/openquatt/web/js/src/settings/silent.js
+++ b/openquatt/web/js/src/settings/silent.js
@@ -1,13 +1,19 @@
 import { renderSettingsSection, renderSettingsSliderField, renderSettingsTimeField } from "./controls.js";
 import { escapeHtml } from "../core/html.js";
+import { getFrequencyLimitWarning } from "../features/frequency-limits.js";
+
+  function renderFrequencyLimitWarning(key) {
+    const warning = getFrequencyLimitWarning(key);
+    return `<p class="oq-settings-action-note${warning.warning ? " oq-settings-action-note--warning" : ""}" data-oq-frequency-limit-warning="${escapeHtml(key)}" role="status" aria-live="polite" ${warning.text ? "" : "hidden"}>${escapeHtml(warning.text)}</p>`;
+  }
 
   export function renderSilentSettingsGrid(className = "oq-settings-grid") {
     return `
       <div class="${escapeHtml(className)}">
         ${renderSettingsTimeField("silentStartTime", "Start stille uren", "Vanaf dit tijdstip werkt het systeem in stille modus.")}
         ${renderSettingsTimeField("silentEndTime", "Einde stille uren", "Vanaf dit tijdstip stopt de stille modus weer.")}
-        ${renderSettingsSliderField("silentMaxHz", "Maximale compressorfrequentie tijdens stille uren", "Bepaalt hoe snel de compressor maximaal mag draaien tijdens stille uren.")}
-        ${renderSettingsSliderField("dayMaxHz", "Maximale compressorfrequentie overdag", "Bepaalt hoe snel de compressor overdag maximaal mag draaien.")}
+        ${renderSettingsSliderField("silentMaxHz", "Maximale compressorfrequentie tijdens stille uren", "Bepaalt hoe snel de compressor maximaal mag draaien tijdens stille uren.", "", { footerMarkup: renderFrequencyLimitWarning("silentMaxHz") })}
+        ${renderSettingsSliderField("dayMaxHz", "Maximale compressorfrequentie overdag", "Bepaalt hoe snel de compressor overdag maximaal mag draaien.", "", { footerMarkup: renderFrequencyLimitWarning("dayMaxHz") })}
       </div>
     `;
   }

--- a/openquatt/web/smoke-web.mjs
+++ b/openquatt/web/smoke-web.mjs
@@ -40,6 +40,8 @@ const boundaryAllowedEdges = new Set([
   "core/entity-sync.js -> features/odu-runtime-frequency.js",
   "core/entity-sync.js -> features/odu-settings.js",
   "core/entity-sync.js -> features/security-actions.js",
+  "core/entity-sync.js -> features/frequency-limits.js",
+  "core/entity-actions.js -> features/frequency-limits.js",
   "core/entity-write-actions.js -> features/firmware-update.js",
   "core/entity-write-actions.js -> features/security-actions.js",
   "core/entity-write-actions.js -> features/storage-history.js",

--- a/openquatt/web/tests/frequency-limit-warning.test.mjs
+++ b/openquatt/web/tests/frequency-limit-warning.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { loadReplayHarness } from "./helpers/replay-render-harness.mjs";
+
+globalThis.__OQ_PREVIEW__ = false;
+globalThis.window = { location: { pathname: "/" }, localStorage: { getItem: () => null } };
+const { state } = await import("../js/src/core/state.js");
+const { getFrequencyLimitModel, getFrequencyLimitWarning, patchFrequencyLimitWarnings } = await import("../js/src/features/frequency-limits.js");
+const { renderSilentSettingsGrid } = await import("../js/src/settings/silent.js");
+const { renderSystemModal } = await import("../js/src/features/header-status.js");
+const source = await readFile(new URL("../js/src/features/control-replay-view.js", import.meta.url), "utf8");
+const { getDecisionEventCopy, getControlWorkingCurrent } = await loadReplayHarness(`${source}\nexport { getControlWorkingCurrent };`);
+
+function setup(topology = "single") {
+  state.entities = Object.fromEntries(Object.entries({
+    installationTopology: topology,
+    controlModeLabel: "CM2",
+    silentActive: true,
+    silentMaxHz: 20,
+    dayMaxHz: 90,
+    hp1MinimumHeatingHz: 30,
+    hp1MinimumCoolingHz: 26,
+    hp2MinimumHeatingHz: 20,
+    hp2MinimumCoolingHz: 30,
+  }).map(([key, value]) => [key, { value, state: String(value), min_value: 20, max_value: 120, step: 1, uom: "Hz" }]));
+  state.drafts = {};
+  state.inputDrafts = {};
+  state.decisionLog = { ok: true, events: [] };
+  state.loadingEntities = false;
+}
+
+test("silent/day sliders warn below the actual minimum and keep equality/defaults valid", () => {
+  setup();
+  const warning = getFrequencyLimitWarning("silentMaxHz");
+  assert.equal(warning.warning, true);
+  assert.match(warning.text, /20 Hz.*HP1 bij verwarmen: 30 Hz/);
+  assert.match(warning.text, /HP1 bij koelen: 26 Hz/);
+  assert.doesNotMatch(warning.text, /HP2/);
+  const markup = renderSilentSettingsGrid();
+  assert.match(markup, /data-oq-frequency-limit-warning="silentMaxHz" role="status" aria-live="polite"/);
+  assert.match(markup, /Deze buitenunits kunnen in die bedrijfsmodi niet starten/);
+  state.systemModal = "silent-settings";
+  assert.match(renderSystemModal(), /oq-helper-modal--wide oq-helper-modal--scrollable/);
+  assert.equal(getFrequencyLimitWarning("dayMaxHz").text, "");
+  for (const cap of [30, 67, 90]) {
+    state.drafts.silentMaxHz = cap;
+    assert.equal(getFrequencyLimitWarning("silentMaxHz").text, "");
+  }
+});
+
+test("Duo compares each unit and mode independently, including a valid 20 Hz minimum", () => {
+  setup("duo");
+  const model = getFrequencyLimitModel("silentMaxHz", { mode: "heating" });
+  assert.deepEqual(model.blocked.map(({ unit }) => unit), ["hp1"]);
+  assert.equal(model.limits[1].blocked, false);
+  state.entities.hp1MinimumHeatingHz.value = 20;
+  assert.equal(getFrequencyLimitModel("silentMaxHz", { mode: "heating" }).blocked.length, 0);
+  assert.equal(getFrequencyLimitModel("silentMaxHz", { mode: "cooling" }).blocked.length, 2);
+});
+
+test("missing or invalid minimum data stays unknown; polling repairs the existing warning node", () => {
+  setup();
+  for (const value of [undefined, null, "", "NAN", 0, -1, 121]) {
+    state.entities.hp1MinimumHeatingHz = { value };
+    state.entities.hp1MinimumCoolingHz = { value };
+    assert.equal(getFrequencyLimitWarning("silentMaxHz").warning, false);
+    assert.match(getFrequencyLimitWarning("silentMaxHz").text, /nog niet beschikbaar/);
+  }
+  const node = { dataset: { oqFrequencyLimitWarning: "silentMaxHz" }, textContent: "", hidden: false,
+    classList: { toggle: (_name, active) => { node.warning = active; } }, closest: () => card };
+  const input = { value: "20" };
+  const label = { textContent: "20 Hz" };
+  const card = { querySelector: (selector) => selector.startsWith("input") ? input : label };
+  const root = { querySelectorAll: () => [node] };
+  patchFrequencyLimitWarnings(root);
+  assert.match(node.textContent, /nog niet beschikbaar/);
+  state.entities.hp1MinimumHeatingHz = { value: 30 };
+  state.entities.hp1MinimumCoolingHz = { value: 30 };
+  patchFrequencyLimitWarnings(root);
+  assert.equal(node.warning, true);
+  state.drafts.silentMaxHz = 30;
+  patchFrequencyLimitWarnings(root);
+  assert.equal(node.hidden, true);
+  assert.equal(node.warning, false);
+  assert.equal(input.value, "30");
+  assert.equal(label.textContent, "30 Hz");
+  state.entities.silentMaxHz.value = 20;
+  patchFrequencyLimitWarnings(root);
+  assert.equal(input.value, "30", "polling must preserve the unsaved draft");
+  state.drafts = {};
+  patchFrequencyLimitWarnings(root);
+  assert.equal(input.value, "20");
+  assert.equal(label.textContent, "20 Hz");
+  assert.equal(node.warning, true);
+});
+
+test("current control status does not infer a blocked start from a low cap", () => {
+  setup();
+  const panels = [{ title: "HP1", keys: { mode: "hp1Mode", freq: "hp1Freq", defrost: "hp1Defrost" } }];
+  state.drafts.silentMaxHz = 67;
+  assert.equal(getFrequencyLimitWarning("silentMaxHz").warning, false);
+  assert.notEqual(getControlWorkingCurrent(panels).primaryReason, "frequency_cap_below_minimum");
+  assert.equal(getControlWorkingCurrent(panels).hp1Status, "Beschikbaar");
+  state.drafts.silentMaxHz = 20;
+  assert.equal(getFrequencyLimitWarning("silentMaxHz").warning, true);
+  assert.notEqual(getControlWorkingCurrent(panels).primaryReason, "frequency_cap_below_minimum");
+});
+
+test("decision log preserves historical cap, minimum, mode and day/silent selection", () => {
+  setup();
+  state.entities.silentMaxHz.value = 67;
+  state.entities.hp1MinimumHeatingHz.value = 26;
+  const event = { event_type: "candidate_blocked", reason: "frequency_cap_below_minimum", subject: "HP1", cm: 2, value_a: 20, value_b: 30, flags: 1 };
+  const copy = getDecisionEventCopy(event);
+  assert.match(copy.summary, /20 Hz.*verwarmen: 30 Hz/);
+  assert.match(copy.detail, /tijdens stille uren/);
+  const cooling = getDecisionEventCopy({ ...event, subject: "HP2", cm: 5, flags: 0, _oq_context_cm: 2 });
+  assert.match(cooling.summary, /HP2 bij koelen: 30 Hz/);
+  assert.match(cooling.detail, /overdag/);
+});

--- a/openquatt/web/tests/odu-write-mock.test.mjs
+++ b/openquatt/web/tests/odu-write-mock.test.mjs
@@ -31,6 +31,7 @@ function createOduMock(mode, frequency) {
     getEntity: (_type, name) => ({ value: name.endsWith("Working Mode Label") ? telemetry.mode : telemetry.frequency }),
     mockResponse: (status, payload) => ({ status, payload: JSON.parse(JSON.stringify(payload)) }),
     notifyMockUpdated: () => {},
+    syncMockOduIdentityEntities: () => {},
   };
   runInNewContext(mockSource.slice(start, end), context);
   return {

--- a/scripts/tests/test_thermal_actuator_runtime_contract.py
+++ b/scripts/tests/test_thermal_actuator_runtime_contract.py
@@ -38,13 +38,20 @@ class ThermalActuatorRuntimeContractTest(unittest.TestCase):
         hp2_mode_write = RUNTIME.index("call.perform();", hp1_mode_write + 1)
         self.assertLess(RUNTIME.index("invalidate_restart_credit(2U)", hp1_mode_write), hp2_mode_write)
 
+    def test_frequency_limit_event_requires_a_pre_policy_request(self) -> None:
+        start = RUNTIME.index("void publish_frequency_limit_block_")
+        end = RUNTIME.index("int apply_level_", start)
+        diagnostic = RUNTIME[start:end]
+        self.assertIn("const int requested = is_hp1 ? id(oq_request_hp1_level) : id(oq_request_hp2_level);", diagnostic)
+        self.assertIn("requested > 0", diagnostic)
+
     def test_complete_runtime_stack_stays_bounded(self) -> None:
         paths = ("openquatt/oq_thermal_actuator.yaml", "openquatt/includes/control/oq_thermal_actuator_logic.h",
                  "openquatt/includes/control/oq_thermal_actuator_runtime.h", "tests/host/thermal_actuator_logic_test.cpp",
                  "scripts/tests/test_thermal_actuator_runtime_contract.py", "scripts/tests/test_v2_compressor_level_contract.py",
                  "scripts/tests/test_compressor_frequency_policy_contract.py")
-        # Includes the confirmed-rest reporting and its new communication-gap regression cases.
-        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1340)
+        # Includes restart-credit invalidation and the read-only frequency-limit diagnosis.
+        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1370)
 
 
 if __name__ == "__main__":

--- a/tests/host/oq_compressor_frequency_policy_test.cpp
+++ b/tests/host/oq_compressor_frequency_policy_test.cpp
@@ -50,6 +50,15 @@ int main() {
   using namespace oq_frequency_policy;
 
   const auto v1 = make_v1_snapshot();
+  assert(minimum_automatic_frequency_hz(false, v1, 2) == 30);
+  assert(minimum_automatic_frequency_hz(false, v1, 1) == 30);
+  assert(cap_below_minimum(20, minimum_automatic_frequency_hz(false, v1, 2)));
+  assert(!cap_below_minimum(30, minimum_automatic_frequency_hz(false, v1, 2)));
+  assert(!cap_below_minimum(67, 30));
+  assert(!cap_below_minimum(90, 30));
+  assert(!cap_below_minimum(-1, 30));
+  assert(!cap_below_minimum(20, -1));
+  assert(!cap_below_minimum(20, 0));
   assert(automatic_frequency_hz(false, v1, 2, 6) == 67);
   assert(automatic_frequency_hz(false, v1, 1, 6) == 56);
   assert(automatic_frequency_hz(false, v1, 2, 0) == 0);
@@ -63,6 +72,9 @@ int main() {
   v2_old.heating = make_table({0, 20, 26, 30, 48, 55, 61, 72, 80, 85, 90});
   assert(automatic_frequency_hz(true, v2_old, 2, 8) == 80);
   assert(automatic_frequency_hz(true, v2_old, 1, 10) == 71);
+  assert(minimum_automatic_frequency_hz(true, v2_old, 2) == 20);
+  assert(minimum_automatic_frequency_hz(true, v2_old, 1) == 30);
+  assert(!cap_below_minimum(20, minimum_automatic_frequency_hz(true, v2_old, 2)));
 
   auto v2 = v1;
   v2.variant = oq_odu::Variant::V2_NEW_MODEL;
@@ -72,6 +84,8 @@ int main() {
   assert(automatic_frequency_hz(true, v2, 2, 8) == 82);
   assert(automatic_frequency_hz(true, v2, 2, 10) == 90);
   assert(automatic_frequency_hz(true, v2, 1, 10) == 46);
+  assert(minimum_automatic_frequency_hz(true, v2, 2) == automatic_frequency_hz(true, v2, 2, 1));
+  assert(minimum_automatic_frequency_hz(true, v2, 1) == automatic_frequency_hz(true, v2, 1, 1));
 
   auto runtime_edited = v1;
   runtime_edited.heating.hz[6] = 65;
@@ -97,6 +111,16 @@ int main() {
   auto unknown = v1;
   unknown.heating.valid = false;
   assert(automatic_frequency_hz(false, unknown, 2, 6) == -1);
+  assert(minimum_automatic_frequency_hz(false, unknown, 2) == -1);
+  assert(minimum_automatic_frequency_hz(false, {}, 2) == -1);
+  auto lowered_minimum = v1;
+  lowered_minimum.heating.hz[1] = 26;
+  assert(minimum_automatic_frequency_hz(false, lowered_minimum, 2) == 26);
+  assert(minimum_automatic_frequency_hz(false, lowered_minimum, 1) == 30);
+  assert(cap_below_minimum(25, 26));
+  assert(!cap_below_minimum(26, 26));
+  assert(pick_allowed_level(false, lowered_minimum, 2, 1, 1, 10, 25, {}) == 0);
+  assert(pick_allowed_level(false, lowered_minimum, 2, 1, 1, 10, 26, {}) == 1);
 
   const FrequencyRange none{};
   assert(frequency_allowed(67, 67, none));


### PR DESCRIPTION
# Wat verandert deze PR?

- Toont onder de dag- en stille-frequenties een waarschuwing wanneer de ingestelde limiet onder de werkelijke minimumfrequentie van een buitenunit en modus ligt.
- Legt een vraag-gebonden beslisevent vast met de historische cap, het minimum en de dag/stille-keuze, zodat de tijdlijn de blokkade verklaart.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De bestaande frequentiepolicy en de standaarden van 67/90 Hz blijven gelijk. De firmware publiceert alleen diagnostische minimumwaarden en een gededupliceerd beslisevent bij een concrete pre-policy aanvraag; de compressorbesturing zelf verandert niet.

## Achtergrond

Een frequentielimiet onder de laagste waarde van de actuele tabel kan alle automatische compressorstanden uitsluiten. Het event gebruikt de runtimefrequentietabel en de pre-policy per-HP aanvraag, zodat een lage limiet zonder warmtevraag geen blokkade meldt. Ontbrekende minimumwaarden krijgen in de webapp een voorzichtige uitleg zonder verzonnen drempel.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De uitleg staat bij de instelling en in de beslislog; er is geen nieuw instelcontract of migratiestap.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

De wijziging gebruikt twee `uint32_t`-signaturen als statische runtime-state en voegt geen heap-, PSRAM-, taak- of netwerkallocaties toe. Q Duo WiFi compileert met DIRAM 204063/341760 B (59,7%).

Uitgevoerd:

- `npm run check:web`
- `npm run smoke:web`
- `node openquatt/web/build-assets.mjs --check`
- `npm run check:cpp-format`
- `python3 -m unittest scripts.tests.test_compressor_frequency_policy_contract scripts.tests.test_thermal_actuator_runtime_contract`
- Hosttest `oq_compressor_frequency_policy_test.cpp`
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`

Geen HIL-, OTA- of browsercheck op fysiek apparaat uitgevoerd.

## Audit

De complete diff tegen `dev` is gecontroleerd op policygedrag, legacy/fresh-installgedrag, eventdeduplicatie, lifecycle en webcompatibiliteit. Er is geen configuratiemigratie: bestaande en nieuwe installaties behouden hun ingestelde waarden; nieuwe installaties starten met 67/90 Hz. Het event wist zijn deduplicatiesignatuur zodra de concrete aanvraag of blokkade verdwijnt en kan daarna opnieuw worden vastgelegd.
