### PR TITLE
Rapporteer actieve netwerkverbinding bij crashes

### DIFF
--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
@@ -14,6 +14,7 @@
 #include "OpenQuattFlashLayout.h"
 #include "PsramBuffer.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/select/select.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/time/real_time_clock.h"
@@ -46,6 +47,8 @@ class OpenQuattCrashTelemetry : public Component {
   void set_hardware_profile(const std::string& value) { this->hardware_profile_ = value; }
   void set_topology(const std::string& value) { this->topology_ = value; }
   void set_connection(const std::string& value) { this->connection_ = value; }
+  void set_active_connection_sensor(text_sensor::TextSensor* value) { this->active_connection_sensor_ = value; }
+  void set_connection_preference_select(select::Select* value) { this->connection_preference_select_ = value; }
 
   void setup() override;
   void loop() override;
@@ -157,6 +160,8 @@ class OpenQuattCrashTelemetry : public Component {
   switch_::Switch* usage_switch_{nullptr};
   text_sensor::TextSensor* installation_id_sensor_{nullptr};
   binary_sensor::BinarySensor* setup_complete_sensor_{nullptr};
+  text_sensor::TextSensor* active_connection_sensor_{nullptr};
+  select::Select* connection_preference_select_{nullptr};
   time::RealTimeClock* clock_{nullptr};
 
   StaticSemaphore_t gate_mutex_storage_{};

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
@@ -117,10 +117,12 @@ bool OpenQuattCrashTelemetry::build_crash_payload_() {
   append_json_key(writer, "connection_preference");
   const bool connection_preference_available =
       this->connection_preference_select_ != nullptr && this->connection_preference_select_->has_state();
+  const auto connection_preference_option =
+      connection_preference_available ? this->connection_preference_select_->current_option() : StringRef{};
   const char* connection_preference =
-      connection_preference_available
-          ? connection_preference_wire_value(this->connection_preference_select_->current_option())
-          : nullptr;
+      connection_preference_available ? connection_preference_wire_value(std::string_view(
+                                            connection_preference_option.c_str(), connection_preference_option.size()))
+                                      : nullptr;
   writer.append_json_string(connection_preference == nullptr ? record.connection : connection_preference);
   append_json_key(writer, "captured_by_reporting_build");
   writer.append(record.captured_by_reporting_build != 0U ? "true" : "false");

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryMqtt.cpp
@@ -109,7 +109,19 @@ bool OpenQuattCrashTelemetry::build_crash_payload_() {
   append_json_key(writer, "topology");
   writer.append_json_string(record.topology);
   append_json_key(writer, "connection");
-  writer.append_json_string(record.connection);
+  const bool active_connection_available =
+      this->active_connection_sensor_ != nullptr && this->active_connection_sensor_->has_state();
+  const char* active_connection =
+      active_connection_available ? active_connection_wire_value(this->active_connection_sensor_->state) : nullptr;
+  writer.append_json_string(active_connection == nullptr ? record.connection : active_connection);
+  append_json_key(writer, "connection_preference");
+  const bool connection_preference_available =
+      this->connection_preference_select_ != nullptr && this->connection_preference_select_->has_state();
+  const char* connection_preference =
+      connection_preference_available
+          ? connection_preference_wire_value(this->connection_preference_select_->current_option())
+          : nullptr;
+  writer.append_json_string(connection_preference == nullptr ? record.connection : connection_preference);
   append_json_key(writer, "captured_by_reporting_build");
   writer.append(record.captured_by_reporting_build != 0U ? "true" : "false");
   append_json_key(writer, "report_truncated");

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 namespace esphome::openquatt_crash_telemetry {
 
@@ -9,6 +10,20 @@ enum class CrashPublishKind : uint8_t {
   CRASH = 1U,
   TOMBSTONE = 2U,
 };
+
+inline constexpr const char* active_connection_wire_value(std::string_view connection) {
+  if (connection == "WiFi") return "wifi";
+  if (connection == "Ethernet") return "eth";
+  if (connection == "Not connected") return "none";
+  return nullptr;
+}
+
+inline constexpr const char* connection_preference_wire_value(std::string_view preference) {
+  if (preference == "Automatic") return "auto";
+  if (preference == "WiFi") return "wifi";
+  if (preference == "Ethernet") return "eth";
+  return nullptr;
+}
 
 inline constexpr CrashPublishKind select_crash_publish_kind(bool tombstone_pending, bool consent_enabled,
                                                             bool setup_complete, bool crash_pending) {

--- a/components/openquatt_crash_telemetry/__init__.py
+++ b/components/openquatt_crash_telemetry/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, psram, socket, switch, text_sensor, time
+from esphome.components import binary_sensor, psram, select, socket, switch, text_sensor, time
 from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
 from esphome.components.esp32.const import VARIANT_ESP32S3
 from esphome.const import CONF_ID
@@ -32,6 +32,8 @@ CONF_RELEASE_CHANNEL = "release_channel"
 CONF_HARDWARE_PROFILE = "hardware_profile"
 CONF_TOPOLOGY = "topology"
 CONF_CONNECTION = "connection"
+CONF_ACTIVE_CONNECTION_SENSOR = "active_connection_sensor"
+CONF_CONNECTION_PREFERENCE_SELECT = "connection_preference_select"
 
 openquatt_crash_telemetry_ns = cg.esphome_ns.namespace("openquatt_crash_telemetry")
 OpenQuattCrashTelemetry = openquatt_crash_telemetry_ns.class_("OpenQuattCrashTelemetry", cg.Component)
@@ -90,6 +92,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_CONNECTION): cv.All(
                 cv.string_strict, cv.Length(max=16)
             ),
+            cv.Optional(CONF_ACTIVE_CONNECTION_SENSOR): cv.use_id(text_sensor.TextSensor),
+            cv.Optional(CONF_CONNECTION_PREFERENCE_SELECT): cv.use_id(select.Select),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     validate_config,
@@ -129,3 +133,9 @@ async def to_code(config):
     cg.add(var.set_hardware_profile(config[CONF_HARDWARE_PROFILE]))
     cg.add(var.set_topology(config[CONF_TOPOLOGY]))
     cg.add(var.set_connection(config[CONF_CONNECTION]))
+    if active_connection_sensor_id := config.get(CONF_ACTIVE_CONNECTION_SENSOR):
+        active_connection_sensor = await cg.get_variable(active_connection_sensor_id)
+        cg.add(var.set_active_connection_sensor(active_connection_sensor))
+    if connection_preference_select_id := config.get(CONF_CONNECTION_PREFERENCE_SELECT):
+        connection_preference_select = await cg.get_variable(connection_preference_select_id)
+        cg.add(var.set_connection_preference_select(connection_preference_select))

--- a/docs/crash-telemetry.md
+++ b/docs/crash-telemetry.md
@@ -25,8 +25,10 @@ De payload bevat geen gewone runtime-logs, metingen of regelwaarden. Wel bevat
 hij de regels uit het ESPHome-crashrapport, het resettype, firmwareversie,
 releasekanaal, ESPHome-versie, bronrepository, volledige commit-SHA, exact
 buildtarget, release-manifest-URL indien van toepassing, hardwareprofiel,
-topologie, verbinding, buildtijd en de volledige ELF-SHA256 van de firmware die
-het rapport verstuurt.
+topologie, verbinding, verbindingsvoorkeur, buildtijd en de volledige ELF-SHA256
+van de firmware die het rapport verstuurt. Bij een gecombineerde WiFi- en
+Ethernetfirmware is `connection` de actuele verbinding (`wifi`, `eth` of `none`)
+en `connection_preference` de ingestelde voorkeur (`auto`, `wifi` of `eth`).
 
 De tijdvelden hebben bewust verschillende betekenissen:
 

--- a/openquatt/connection/wifi_eth.yaml
+++ b/openquatt/connection/wifi_eth.yaml
@@ -63,6 +63,10 @@ openquatt_usage_telemetry:
   connection_preference_select: oq_preferred_connection
   wifi_signal_sensor: oq_wifi_signal
 
+openquatt_crash_telemetry:
+  active_connection_sensor: oq_connection_text
+  connection_preference_select: oq_preferred_connection
+
 text_sensor:
   - platform: template
     id: oq_network_ip_address

--- a/scripts/tests/test_openquatt_network_contract.py
+++ b/scripts/tests/test_openquatt_network_contract.py
@@ -16,6 +16,9 @@ NETWORK_PACKAGE = (ROOT / "openquatt" / "connection" / "wifi_eth.yaml").read_tex
 USAGE_TELEMETRY_CPP = (
     ROOT / "components" / "openquatt_usage_telemetry" / "OpenQuattUsageTelemetry.cpp"
 ).read_text()
+CRASH_TELEMETRY_CPP = (
+    ROOT / "components" / "openquatt_crash_telemetry" / "OpenQuattCrashTelemetryMqtt.cpp"
+).read_text()
 INSTALLER = (ROOT / "docs" / "install" / "install.js").read_text()
 INSTALLER_PAGE = (ROOT / "docs" / "install" / "index.html").read_text()
 
@@ -73,6 +76,17 @@ class OpenQuattNetworkContractTest(unittest.TestCase):
         self.assertIn('active_connection == "WiFi"', USAGE_TELEMETRY_CPP)
         self.assertIn('active_connection == "Ethernet"', USAGE_TELEMETRY_CPP)
         self.assertIn('connection_preference == "Automatic"', USAGE_TELEMETRY_CPP)
+
+    def test_crash_telemetry_reports_active_connection_and_preference(self) -> None:
+        self.assertIn(
+            "openquatt_crash_telemetry:\n"
+            "  active_connection_sensor: oq_connection_text\n"
+            "  connection_preference_select: oq_preferred_connection",
+            NETWORK_PACKAGE,
+        )
+        self.assertIn("active_connection_wire_value(this->active_connection_sensor_->state)", CRASH_TELEMETRY_CPP)
+        self.assertIn("connection_preference_wire_value", CRASH_TELEMETRY_CPP)
+        self.assertIn('append_json_key(writer, "connection_preference")', CRASH_TELEMETRY_CPP)
 
     def test_preference_change_is_published_only_after_nvs_readback(self) -> None:
         save = function_body("save_preference_(Preference preference)", "publish_preference_()")

--- a/tests/host/openquatt_crash_telemetry_policy_test.cpp
+++ b/tests/host/openquatt_crash_telemetry_policy_test.cpp
@@ -1,7 +1,10 @@
 #include <cassert>
+#include <string_view>
 
 #include "components/openquatt_crash_telemetry/OpenQuattCrashTelemetryPolicy.h"
 
+using esphome::openquatt_crash_telemetry::active_connection_wire_value;
+using esphome::openquatt_crash_telemetry::connection_preference_wire_value;
 using esphome::openquatt_crash_telemetry::crash_data_may_be_published;
 using esphome::openquatt_crash_telemetry::crash_publication_is_retained;
 using esphome::openquatt_crash_telemetry::CrashCleanupDecision;
@@ -18,6 +21,15 @@ using esphome::openquatt_crash_telemetry::should_request_tombstone;
 using esphome::openquatt_crash_telemetry::should_wait_for_time_sync;
 
 int main() {
+  assert(std::string_view(active_connection_wire_value("WiFi")) == "wifi");
+  assert(std::string_view(active_connection_wire_value("Ethernet")) == "eth");
+  assert(std::string_view(active_connection_wire_value("Not connected")) == "none");
+  assert(active_connection_wire_value("Unknown") == nullptr);
+  assert(std::string_view(connection_preference_wire_value("Automatic")) == "auto");
+  assert(std::string_view(connection_preference_wire_value("WiFi")) == "wifi");
+  assert(std::string_view(connection_preference_wire_value("Ethernet")) == "eth");
+  assert(connection_preference_wire_value("Unknown") == nullptr);
+
   assert(select_crash_publish_kind(true, false, false, false) == CrashPublishKind::TOMBSTONE);
   assert(select_crash_publish_kind(false, true, true, true) == CrashPublishKind::CRASH);
   assert(select_crash_publish_kind(false, true, false, true) == CrashPublishKind::NONE);


### PR DESCRIPTION
# Wat verandert deze PR?

- Crashtelemetrie gebruikt nu, net als usage telemetry, de actuele WiFi/Ethernet-status.
- `connection` rapporteert `wifi`, `eth` of `none`; `connection_preference` rapporteert `auto`, `wifi` of `eth`.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De retained crashpayload krijgt het kleine extra veld `connection_preference` en leest bestaande runtime-entiteitsstatus in de hoofdloop. Er zijn geen nieuwe taken, netwerkverbindingen of dynamische allocaties.

## Achtergrond

Q-firmware heeft een gecombineerde WiFi/Ethernet-netwerkmanager. De crashpayload volgde alleen de statische buildverbinding; daardoor was de werkelijk actieve interface bij een crash niet zichtbaar. De mappings en fallbacks zijn gelijk aan usage telemetry. Bij niet-gecombineerde builds of een nog onbeschikbare status blijft de bestaande statische verbindingswaarde behouden.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De crashtelemetriedocumentatie beschrijft de nieuwe velden en waarden.

## Validatie

Volledige diff tegen `dev` apart beoordeeld op payloadcompatibiliteit, runtimevolgorde, fallbacks, geheugenbezit en configuratiepaden.

- `npm run check:cpp-format`
- `python3 -m unittest scripts.tests.test_openquatt_network_contract`
- `npm run check:python-contracts`
- `npm run check:docs`
- `git diff --check`
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml` — geslaagd met ESPHome 2026.8.2.
- `./scripts/run_host_regression_tests.sh` stopte lokaal vóór deze test bij de C++-toolchain: standaardheader `<cstdint>` ontbreekt.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Twee extra pointervelden in het componentobject; geen extra heap-, PSRAM-, task-stack- of MQTT-bufferallocaties. De Q-duo-compile rapporteert 204071 bytes DIRAM (59,7%); er is geen identieke baseline voor een delta.