### PR TITLE
Behoud ODU-metadata bij korte Modbus-uitval

### DIFF
--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.cpp
@@ -776,6 +776,23 @@ void OpenQuattIncidentManager::observe_transport(uint8_t hp_index, bool online, 
   }
 }
 
+void OpenQuattIncidentManager::observe_runtime_frequency_mapping(uint8_t hp_index, bool valid, uint32_t now_ms) {
+  UnitState* unit = this->unit_(hp_index);
+  if (unit == nullptr || (unit->runtime_frequency_mapping_observed && unit->runtime_frequency_mapping_valid == valid)) {
+    return;
+  }
+  unit->runtime_frequency_mapping_valid = valid;
+  unit->runtime_frequency_mapping_observed = true;
+  if (!valid) invalidate_restart_credit_(*unit);
+  if (valid) {
+    ESP_LOGI(TAG, "HP%u runtime frequency mapping validated", hp_index);
+  } else {
+    ESP_LOGW(TAG, "HP%u runtime frequency mapping unusable", hp_index);
+  }
+  this->publish_transitions_(*unit, hp_slot_(hp_index), now_ms);
+  this->publish_snapshot_(now_ms);
+}
+
 void OpenQuattIncidentManager::observe_working_mode(uint8_t hp_index, float working_mode, uint32_t now_ms) {
   UnitState* unit = this->unit_(hp_index);
   if (unit == nullptr) return;
@@ -1236,6 +1253,8 @@ size_t OpenQuattIncidentManager::synthetic_slot_(oq_incidents::IncidentId incide
       return 2U;
     case PERSISTENCE_FAILURE_INCIDENT_ID:
       return 3U;
+    case RUNTIME_FREQUENCY_MAPPING_INCIDENT_ID:
+      return 4U;
     default:
       return SYNTHETIC_INCIDENT_COUNT;
   }
@@ -1322,6 +1341,22 @@ oq_incidents::IncidentDefinition OpenQuattIncidentManager::synthetic_definition_
               DocumentationConfidence::DESCRIBED,
               UserAction::CONTACT_INSTALLER,
               RecoveryCondition::REVIEW_REQUIRED};
+    case 4U:
+      return {RUNTIME_FREQUENCY_MAPPING_INCIDENT_ID,
+              0U,
+              0U,
+              "hp_runtime_frequency_mapping",
+              "hp.runtime_frequency_mapping",
+              IncidentCategory::FAULT,
+              IncidentSeverity::FAULT,
+              fallback_fault_effects,
+              1U,
+              1U,
+              ClearPolicy::AFTER_STABLE_READS,
+              FallbackPolicy::AFTER_SYSTEM_GUARDS,
+              DocumentationConfidence::DESCRIBED,
+              UserAction::CHECK_INSTALLATION,
+              RecoveryCondition::STABLE_TELEMETRY};
     default:
       return {};
   }
@@ -1337,6 +1372,8 @@ uint8_t OpenQuattIncidentManager::reason_for_incident_id_(oq_incidents::Incident
       return openquatt_decision_log::REASON_HP_STOP_UNCONFIRMED;
     case PERSISTENCE_FAILURE_INCIDENT_ID:
       return openquatt_decision_log::REASON_HP_PERSISTENCE_FAILURE;
+    case RUNTIME_FREQUENCY_MAPPING_INCIDENT_ID:
+      return openquatt_decision_log::REASON_HP_FAULT;
     default:
       return openquatt_decision_log::REASON_UNKNOWN;
   }
@@ -1492,6 +1529,8 @@ void OpenQuattIncidentManager::publish_transitions_(UnitState& unit, size_t slot
       !this->manual_reset_persistence_.initialization_pending() &&
       (!this->manual_reset_persistence_.ready() || (this->manual_reset_persistence_.fault_mask() & hp_mask) != 0U);
   this->publish_synthetic_incident_(unit, slot, 3U, persistence_failure, now_ms);
+  this->publish_synthetic_incident_(
+      unit, slot, 4U, unit.runtime_frequency_mapping_observed && !unit.runtime_frequency_mapping_valid, now_ms);
 
   const bool stop_confirmation_edge = should_emit_stop_confirmation(
       unit.stop_feedback_armed, unit.previous_outputs.stop_confirmed, current_outputs.stop_confirmed);
@@ -1775,6 +1814,30 @@ oq_incidents::DerivedOutputs OpenQuattIncidentManager::outputs_for_slot_(size_t 
   const UnitState& unit = this->units_()[slot];
   if (outputs.run_state == oq_incidents::RunState::STOPPED || !unit.startup_released) {
     outputs.available_for_start = outputs.available_for_start && unit.restart_guard.can_start(millis());
+  }
+  if (!unit.runtime_frequency_mapping_valid) {
+    // A missing or interrupted mapping is a control-safety condition. The
+    // actuator receives this only through the incident-manager outputs, so a
+    // policy lookup never becomes an untracked compressor stop.
+    outputs.available_for_start = false;
+    outputs.must_stop = true;
+    outputs.fault_active = true;
+    outputs.protection_active = true;
+    outputs.fallback_cause_present = true;
+    outputs.fallback_eligible = outputs.stop_confirmed && !outputs.stop_unconfirmed;
+    outputs.active_effects |= oq_incidents::IncidentEffect::DISPLAY | oq_incidents::IncidentEffect::BLOCK_START |
+                              oq_incidents::IncidentEffect::STOP_COMPRESSOR |
+                              oq_incidents::IncidentEffect::MARK_HP_UNAVAILABLE;
+    outputs.active_incident_count = outputs.active_incident_count == UINT8_MAX
+                                        ? outputs.active_incident_count
+                                        : static_cast<uint8_t>(outputs.active_incident_count + 1U);
+    if (outputs.primary_incident_id == oq_incidents::kNoIncident) {
+      outputs.primary_incident_id = oq_incidents::kRuntimeFrequencyMappingIncidentId;
+    }
+    if (outputs.protection_state == oq_incidents::ProtectionState::CLEAR ||
+        outputs.protection_state == oq_incidents::ProtectionState::LIMITED) {
+      outputs.protection_state = oq_incidents::ProtectionState::FAULT_ACTIVE;
+    }
   }
   if (this->restarting_ || !restart_handoff_storage_ready()) {
     outputs.available_for_start = false;

--- a/components/openquatt_incident_manager/OpenQuattIncidentManager.h
+++ b/components/openquatt_incident_manager/OpenQuattIncidentManager.h
@@ -64,6 +64,9 @@ class OpenQuattIncidentManager : public Component {
   float get_setup_priority() const override;
 
   void observe_transport(uint8_t hp_index, bool online, uint32_t now_ms);
+  // A table that may have changed during a write is an explicit incident
+  // input, rather than an implicit frequency-policy stop.
+  void observe_runtime_frequency_mapping(uint8_t hp_index, bool valid, uint32_t now_ms);
   void observe_working_mode(uint8_t hp_index, float working_mode, uint32_t now_ms);
   void observe_compressor_frequency(uint8_t hp_index, float frequency_hz, uint32_t now_ms);
   void observe_fault_word(uint8_t hp_index, uint16_t register_address, uint16_t word, uint32_t now_ms);
@@ -105,13 +108,15 @@ class OpenQuattIncidentManager : public Component {
   static constexpr uint32_t PARTIAL_FAULT_SNAPSHOT_TIMEOUT_MS = 15000U;
   static constexpr uint32_t MANUAL_RESET_PERSIST_RETRY_MS = 60000U;
   static constexpr uint8_t INITIALIZATION_FAULT_SNAPSHOT_COUNT = 2U;
-  static constexpr size_t SYNTHETIC_INCIDENT_COUNT = 4U;
+  static constexpr size_t SYNTHETIC_INCIDENT_COUNT = 5U;
   static constexpr size_t ACTION_RESULT_HISTORY_SIZE = 4U;
   static constexpr oq_incidents::IncidentId LINK_LOSS_INCIDENT_ID = oq_incidents::kLinkLossIncidentId;
   static constexpr oq_incidents::IncidentId START_FAILED_INCIDENT_ID = oq_incidents::kStartFailedIncidentId;
   static constexpr oq_incidents::IncidentId STOP_UNCONFIRMED_INCIDENT_ID = oq_incidents::kStopUnconfirmedIncidentId;
   static constexpr oq_incidents::IncidentId PERSISTENCE_FAILURE_INCIDENT_ID =
       oq_incidents::kPersistenceFailureIncidentId;
+  static constexpr oq_incidents::IncidentId RUNTIME_FREQUENCY_MAPPING_INCIDENT_ID =
+      oq_incidents::kRuntimeFrequencyMappingIncidentId;
 
   struct ActionResultRecord {
     const char* action{"none"};
@@ -149,6 +154,8 @@ class OpenQuattIncidentManager : public Component {
     bool configured{false};
     bool transport_online{false};
     bool transport_seen{false};
+    bool runtime_frequency_mapping_valid{false};
+    bool runtime_frequency_mapping_observed{false};
     float working_mode{0.0F};
     bool working_mode_valid{false};
     uint32_t working_mode_generation{0U};

--- a/openquatt/experimental/oq_odu_runtime_frequency_service_hp.yaml
+++ b/openquatt/experimental/oq_odu_runtime_frequency_service_hp.yaml
@@ -53,15 +53,14 @@ openquatt_odu_runtime_frequency:
     hp_index: ${hp_index}
     on_write_started:
       - lambda: |-
-          // A write makes the control snapshot stale until verified.
+          // Keep the last validated snapshot for diagnostics, but block control
+          // through the incident manager until the write is read back fully.
           id(${hp_id}_compressor_level_profile_request_token) =
               oq_odu::next_request_token(
                   id(${hp_id}_compressor_level_profile_request_token));
           id(${hp_id}_compressor_level_profile_request_pending) = false;
-          id(${hp_id}_runtime_frequency_snapshot_storage) =
-              oq_odu::RuntimeFrequencySnapshotStorage{};
-          id(${hp_id}_compressor_level_profile).publish_state(
-              oq_odu::compressor_level_profile_label(
-                  oq_odu::CompressorLevelProfile::UNKNOWN));
+          id(${hp_id}_runtime_frequency_revalidation_required) = true;
+          id(oq_incident_manager).observe_runtime_frequency_mapping(
+              ${hp_index}, false, millis());
     on_write_applied:
       - script.execute: ${hp_id}_load_runtime_frequency_table_once

--- a/openquatt/includes/control/oq_incident_actuator_logic.h
+++ b/openquatt/includes/control/oq_incident_actuator_logic.h
@@ -27,8 +27,15 @@ inline Decision decide(const Inputs& inputs) {
   if (inputs.must_stop) {
     return Decision{Action::FORCE_STOP, 0, true};
   }
-  if (inputs.requested_level > 0 && inputs.previous_applied_level <= 0 && !inputs.available_for_start) {
-    return Decision{Action::BLOCK_NEW_START, 0, false};
+  if (inputs.requested_level > 0 && !inputs.available_for_start) {
+    if (inputs.previous_applied_level <= 0) {
+      return Decision{Action::BLOCK_NEW_START, 0, false};
+    }
+    // During a bounded continuation window, reductions remain safe but a
+    // stale/unavailable unit must not receive a higher compressor request.
+    const int guarded_level =
+        inputs.requested_level > inputs.previous_applied_level ? inputs.previous_applied_level : inputs.requested_level;
+    return Decision{Action::FOLLOW_REQUEST, guarded_level, false};
   }
   return Decision{Action::FOLLOW_REQUEST, inputs.requested_level, false};
 }

--- a/openquatt/includes/incidents/oq_hp_incident_types.h
+++ b/openquatt/includes/incidents/oq_hp_incident_types.h
@@ -14,6 +14,7 @@ static constexpr IncidentId kLinkLossIncidentId = 1001U;
 static constexpr IncidentId kStartFailedIncidentId = 1002U;
 static constexpr IncidentId kStopUnconfirmedIncidentId = 1003U;
 static constexpr IncidentId kPersistenceFailureIncidentId = 1004U;
+static constexpr IncidentId kRuntimeFrequencyMappingIncidentId = 1005U;
 static constexpr uint16_t kFirstFaultRegister = 2119U;
 static constexpr uint16_t kLastFaultRegister = 2121U;
 static constexpr size_t kFaultRegisterCount = 3U;

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -35,6 +35,9 @@ esphome:
           id(${hp_id}_odu_generation_detection_complete) = false;
           id(${hp_id}_odu_generation_request_pending) = false;
           id(${hp_id}_odu_generation_request_token) = 0U;
+          id(${hp_id}_odu_generation_revalidation_required) = true;
+          id(${hp_id}_runtime_frequency_revalidation_required) = true;
+          id(${hp_id}_validated_control_board_item) = 0U;
           id(${hp_id}_generation).publish_state("Unknown");
           id(${hp_id}_generation_variant_code) =
               static_cast<int>(oq_odu::Variant::UNKNOWN);
@@ -66,28 +69,27 @@ modbus_controller:
       then:
         - lambda: |-
             id(${hp_id}_is_online) = false;
-            // A reconnected controller may belong to different ODU hardware.
+            // Preserve validated control metadata; the incident manager decides
+            // whether a transport interruption requires a stop.
             id(${hp_id}_odu_generation_request_token) =
                 oq_odu::next_request_token(
                     id(${hp_id}_odu_generation_request_token));
             id(${hp_id}_odu_generation_request_pending) = false;
-            id(${hp_id}_odu_generation_detection_complete) = false;
-            id(${hp_id}_generation_variant_code) =
-                static_cast<int>(oq_odu::Variant::UNKNOWN);
-            id(${hp_id}_runtime_frequency_snapshot_storage) = {};
+            id(${hp_id}_odu_generation_revalidation_required) = true;
             id(${hp_id}_odu_runtime_frequency)->reset_runtime_state(
                 "VERIFY_FAILED: ODU disconnected during write");
+            if (id(${hp_id}_odu_runtime_frequency)
+                    ->runtime_reload_blocked_after_write()) {
+              id(oq_incident_manager).observe_runtime_frequency_mapping(
+                  ${hp_index}, false, millis());
+            }
             id(${hp_id}_odu_settings)->notify_odu_offline();
             id(${hp_id}_compressor_level_profile_request_token) =
                 oq_odu::next_request_token(
                     id(${hp_id}_compressor_level_profile_request_token));
             id(${hp_id}_compressor_level_profile_request_pending) = false;
+            id(${hp_id}_runtime_frequency_revalidation_required) = true;
             id(${hp_id}_runtime_frequency_retry_ms) = 0U;
-            id(${hp_id}_compressor_level_profile).publish_state(
-                oq_odu::compressor_level_profile_label(
-                    oq_odu::CompressorLevelProfile::UNKNOWN));
-            id(${hp_id}_generation).publish_state("Unknown");
-            id(${hp_id}_generation_variant).publish_state("Unknown");
             id(${hp_id}_pump_relay).invalidate_state();
             id(${hp_id}_status_2108_raw).publish_state(NAN);
             id(${hp_id}_status_2115_raw).publish_state(NAN);
@@ -205,17 +207,34 @@ globals:
     restore_value: no
     initial_value: '0'
 
+  # Re-read identity after a transport interruption without withdrawing metadata.
+  - id: ${hp_id}_odu_generation_revalidation_required
+    type: bool
+    restore_value: no
+    initial_value: 'true'
+
+  - id: ${hp_id}_validated_control_board_item
+    type: uint16_t
+    restore_value: no
+    initial_value: '0'
+
   - id: ${hp_id}_generation_variant_code
     type: int
     restore_value: no
     initial_value: '0'
 
   # Immutable control snapshot built from the read-only runtime frequency
-  # table. It is never restored across boots or reconnects.
+  # table. It is never restored across boots, but survives transport flaps.
   - id: ${hp_id}_runtime_frequency_snapshot_storage
     type: std::array<uint8_t, 46>
     restore_value: no
     initial_value: 'std::array<uint8_t, 46>{}'
+
+  # Replace the active snapshot only after every required table is valid.
+  - id: ${hp_id}_runtime_frequency_revalidation_required
+    type: bool
+    restore_value: no
+    initial_value: 'true'
 
   - id: ${hp_id}_compressor_level_profile_request_pending
     type: bool
@@ -245,25 +264,12 @@ script:
           id(${hp_id}_odu_generation_request_token) = request_token;
           id(${hp_id}_runtime_frequency_retry_ms) =
               millis() == 0U ? 1U : millis();
-          id(${hp_id}_odu_generation_detection_complete) = false;
           id(${hp_id}_odu_generation_request_pending) = true;
-          id(${hp_id}_odu_runtime_frequency)->reset_runtime_state();
-          id(${hp_id}_odu_settings)->notify_odu_offline();
-          id(${hp_id}_generation).publish_state("Unknown");
-          id(${hp_id}_generation_variant_code) =
-              static_cast<int>(oq_odu::Variant::UNKNOWN);
-          id(${hp_id}_compressor_level_profile_request_token) =
-              oq_odu::next_request_token(
-                  id(${hp_id}_compressor_level_profile_request_token));
-          id(${hp_id}_compressor_level_profile_request_pending) = false;
-          id(${hp_id}_generation_variant).publish_state("Unknown");
-          id(${hp_id}_customer_model_code).publish_state("Unknown");
 
           // Do not interleave an identity request with an operation that owns the Modbus bus.
           if (id(${hp_id}_odu_eeprom_dump).is_active() || id(oq_runtime_polling_paused).state) {
             id(${hp_id}_odu_generation_request_pending) = false;
-            id(${hp_id}_odu_generation_detection_complete) = false;
-            ESP_LOGW("quatt.odu", "%sODU generation detection blocked while runtime polling is paused", "${prefix}");
+            ESP_LOGW("quatt.odu", "%sODU generation revalidation blocked while runtime polling is paused; keeping last validated metadata", "${prefix}");
             return;
           }
 
@@ -282,48 +288,68 @@ script:
                 const auto core = oq_odu::parse_core_identity_response(
                     data.data(), data.size());
                 if (!core.available) {
-                  id(${hp_id}_odu_generation_detection_complete) = false;
                   id(${hp_id}_odu_generation_request_pending) = false;
-                  ESP_LOGW("quatt.odu", "%sODU core identity response incomplete", "${prefix}");
+                  ESP_LOGW("quatt.odu", "%sODU core identity response incomplete; keeping last validated metadata", "${prefix}");
                   return;
                 }
 
-                // Keep the periodic raw diagnostic entities coherent with this
-                // explicit atomic identity snapshot.
-                id(${hp_id}_pcb_firmware_raw).publish_state(core.pcb_program);
-                id(${hp_id}_control_board_item).publish_state(core.control_board_item);
+                auto apply_validated_identity = [=](const oq_odu::Detection& detection) {
+                  auto invalidate_runtime_frequency_reload = [=]() {
+                    id(${hp_id}_compressor_level_profile_request_token) =
+                        oq_odu::next_request_token(
+                            id(${hp_id}_compressor_level_profile_request_token));
+                    id(${hp_id}_compressor_level_profile_request_pending) = false;
+                    id(${hp_id}_runtime_frequency_revalidation_required) = true;
+                  };
+                  if (detection.variant == oq_odu::Variant::UNKNOWN) {
+                    invalidate_runtime_frequency_reload();
+                    id(${hp_id}_odu_generation_detection_complete) = false;
+                    id(oq_incident_manager).observe_runtime_frequency_mapping(
+                        ${hp_index}, false, millis());
+                    ESP_LOGW("quatt.odu", "%sODU identity is unsupported; keeping last validated metadata", "${prefix}");
+                    return false;
+                  }
 
-                auto apply_detected_variant = [=](oq_odu::Variant detected_variant) {
+                  // Publish only validated identity; keep the frequency snapshot
+                  // active until its separate complete reload succeeds.
+                  const auto previous_variant = static_cast<oq_odu::Variant>(
+                      id(${hp_id}_generation_variant_code));
+                  const bool identity_changed =
+                      id(${hp_id}_validated_control_board_item) != 0U &&
+                      (id(${hp_id}_validated_control_board_item) != core.control_board_item ||
+                       previous_variant != detection.variant);
+                  if (identity_changed) {
+                    invalidate_runtime_frequency_reload();
+                    id(oq_incident_manager).observe_runtime_frequency_mapping(
+                        ${hp_index}, false, millis());
+                    ESP_LOGW("quatt.odu", "%sODU identity changed; incident manager requires mapping revalidation", "${prefix}");
+                  }
+                  id(${hp_id}_pcb_firmware_raw).publish_state(core.pcb_program);
+                  id(${hp_id}_control_board_item).publish_state(core.control_board_item);
                   id(${hp_id}_odu_runtime_frequency)->set_extended_layout(
-                      detected_variant == oq_odu::Variant::V2_NEW_MODEL);
+                      detection.variant == oq_odu::Variant::V2_NEW_MODEL);
                   id(${hp_id}_odu_settings)->set_odu_identity(
-                      core.control_board_item, detected_variant);
-                  const auto active_snapshot =
-                      oq_odu::decode_runtime_frequency_snapshot(
-                          id(${hp_id}_runtime_frequency_snapshot_storage));
-                  if (active_snapshot.variant == detected_variant) return;
-
-                  oq_odu::RuntimeFrequencySnapshot pending_snapshot;
-                  pending_snapshot.variant = detected_variant;
-                  id(${hp_id}_runtime_frequency_snapshot_storage) =
-                      oq_odu::encode_runtime_frequency_snapshot(
-                          pending_snapshot);
-                  id(${hp_id}_compressor_level_profile).publish_state(
-                      oq_odu::compressor_level_profile_label(
-                          oq_odu::CompressorLevelProfile::UNKNOWN));
-                };
-
-                if (!oq_odu::requires_customer_model(core)) {
-                  const auto detection = oq_odu::detect_generation(core);
-                  apply_detected_variant(detection.variant);
-                  id(${hp_id}_customer_model_code).publish_state("Not read");
+                      core.control_board_item, detection.variant);
                   id(${hp_id}_generation_variant_code) =
                       static_cast<int>(detection.variant);
+                  id(${hp_id}_validated_control_board_item) = core.control_board_item;
                   id(${hp_id}_generation_variant).publish_state(
                       oq_odu::variant_label(detection.variant));
                   id(${hp_id}_generation).publish_state(
                       oq_odu::generation_label(detection.generation));
                   id(${hp_id}_odu_generation_detection_complete) = true;
+                  id(${hp_id}_odu_generation_revalidation_required) = false;
+                  id(${hp_id}_runtime_frequency_revalidation_required) = true;
+                  return true;
+                };
+
+                if (!oq_odu::requires_customer_model(core)) {
+                  const auto detection = oq_odu::detect_generation(core);
+                  if (!apply_validated_identity(detection)) {
+                    id(${hp_id}_odu_generation_request_pending) = false;
+                    return;
+                  }
+                  id(${hp_id}_customer_model_code).publish_state("Not read");
                   id(${hp_id}_odu_generation_request_pending) = false;
                   id(${hp_id}_load_runtime_frequency_table_once).execute();
                   return;
@@ -349,30 +375,19 @@ script:
                               oq_odu::parse_customer_model_response(
                                   customer_model_data.data(),
                                   customer_model_data.size());
-                          id(${hp_id}_customer_model_code).publish_state(
-                              oq_odu::customer_model_label(customer_model));
                           const auto detection =
                               oq_odu::detect_generation(core, customer_model);
-                          if (customer_model.available) {
-                            apply_detected_variant(detection.variant);
-                          }
-                          id(${hp_id}_generation_variant_code) =
-                              static_cast<int>(detection.variant);
-                          id(${hp_id}_generation_variant).publish_state(
-                              oq_odu::variant_label(detection.variant));
-                          id(${hp_id}_generation).publish_state(
-                              oq_odu::generation_label(detection.generation));
-                          id(${hp_id}_odu_generation_detection_complete) =
-                              customer_model.available;
                           id(${hp_id}_odu_generation_request_pending) = false;
-                          if (!customer_model.available) {
+                          if (!customer_model.available ||
+                              !apply_validated_identity(detection)) {
                             ESP_LOGW("quatt.odu",
-                                     "%sODU customer model response incomplete",
+                                     "%sODU customer model response incomplete or unsupported; keeping last validated metadata",
                                      "${prefix}");
+                            return;
                           }
-                          if (customer_model.available) {
-                            id(${hp_id}_load_runtime_frequency_table_once).execute();
-                          }
+                          id(${hp_id}_customer_model_code).publish_state(
+                              oq_odu::customer_model_label(customer_model));
+                          id(${hp_id}_load_runtime_frequency_table_once).execute();
                         });
                 id(${hp_id}).queue_command(std::move(customer_model_command));
               });
@@ -385,8 +400,7 @@ script:
           id(${hp_id}_odu_generation_request_token) =
               oq_odu::next_request_token(id(${hp_id}_odu_generation_request_token));
           id(${hp_id}_odu_generation_request_pending) = false;
-          id(${hp_id}_odu_generation_detection_complete) = false;
-          ESP_LOGW("quatt.odu", "%sODU generation detection timed out", "${prefix}");
+          ESP_LOGW("quatt.odu", "%sODU generation revalidation timed out; keeping last validated metadata", "${prefix}");
 
   - id: ${hp_id}_load_runtime_frequency_table_once
     mode: restart
@@ -430,35 +444,24 @@ script:
                       return;
                     }
 
-                    const auto previous_snapshot =
-                        oq_odu::decode_runtime_frequency_snapshot(
-                            id(${hp_id}_runtime_frequency_snapshot_storage));
                     auto snapshot = oq_odu::parse_base_frequency_table_response(
                         data.data(), data.size(), variant);
-                    if (!snapshot.heating.valid && !snapshot.cooling.valid) {
+                    if (!snapshot.heating.valid || !snapshot.cooling.valid) {
                       id(${hp_id}_compressor_level_profile_request_pending) = false;
-                      ESP_LOGW("quatt.odu", "%sRuntime frequency base table invalid; keeping previous snapshot", "${prefix}");
+                      ESP_LOGW("quatt.odu", "%sRuntime frequency base table incomplete; keeping previous snapshot", "${prefix}");
                       return;
                     }
 
-                    const bool defer_base_publish =
-                        variant == oq_odu::Variant::V2_NEW_MODEL &&
-                        previous_snapshot.variant == variant &&
-                        (previous_snapshot.heating.valid ||
-                         previous_snapshot.cooling.valid);
-                    if (!defer_base_publish) {
+                    if (variant != oq_odu::Variant::V2_NEW_MODEL) {
                       id(${hp_id}_runtime_frequency_snapshot_storage) =
                           oq_odu::encode_runtime_frequency_snapshot(snapshot);
                       const auto profile =
                           oq_odu::compressor_level_profile(snapshot);
                       id(${hp_id}_compressor_level_profile).publish_state(
                           oq_odu::compressor_level_profile_label(profile));
-                    }
-                    if (!snapshot.heating.valid || !snapshot.cooling.valid) {
-                      ESP_LOGW("quatt.odu", "%sRuntime frequency base table partially invalid", "${prefix}");
-                    }
-
-                    if (variant != oq_odu::Variant::V2_NEW_MODEL) {
+                      id(${hp_id}_runtime_frequency_revalidation_required) = false;
+                      id(oq_incident_manager).observe_runtime_frequency_mapping(
+                          ${hp_index}, true, millis());
                       id(${hp_id}_compressor_level_profile_request_pending) = false;
                       return;
                     }
@@ -491,6 +494,13 @@ script:
                                 ESP_LOGW("quatt.odu", "%sV2 runtime frequency extension response incomplete; keeping previous snapshot", "${prefix}");
                                 return;
                               }
+                              if (!extension_result.heating_valid ||
+                                  !extension_result.cooling_valid) {
+                                id(${hp_id}_compressor_level_profile_request_pending) =
+                                    false;
+                                ESP_LOGW("quatt.odu", "%sV2 runtime frequency extension invalid; keeping previous snapshot", "${prefix}");
+                                return;
+                              }
                               id(${hp_id}_runtime_frequency_snapshot_storage) =
                                   oq_odu::encode_runtime_frequency_snapshot(
                                       extended_snapshot);
@@ -500,12 +510,11 @@ script:
                               id(${hp_id}_compressor_level_profile).publish_state(
                                   oq_odu::compressor_level_profile_label(
                                       extended_profile));
+                              id(${hp_id}_runtime_frequency_revalidation_required) = false;
+                              id(oq_incident_manager).observe_runtime_frequency_mapping(
+                                  ${hp_index}, true, millis());
                               id(${hp_id}_compressor_level_profile_request_pending) =
                                   false;
-                              if (!extension_result.heating_valid ||
-                                  !extension_result.cooling_valid) {
-                                ESP_LOGW("quatt.odu", "%sV2 runtime frequency extension partially invalid; affected mode limited to F10", "${prefix}");
-                              }
                             });
                     id(${hp_id}).queue_command(std::move(extension_command));
                   });
@@ -1724,7 +1733,7 @@ interval:
             const bool retry_due = last_retry == 0U ||
                 now - last_retry >= 60000UL;
             if (retry_due &&
-                !id(${hp_id}_odu_generation_detection_complete) &&
+                id(${hp_id}_odu_generation_revalidation_required) &&
                 !id(${hp_id}_odu_generation_request_pending)) {
               id(${hp_id}_runtime_frequency_retry_ms) = now == 0U ? 1U : now;
               id(${hp_id}_detect_odu_generation_once).execute();
@@ -1738,7 +1747,8 @@ interval:
                 (snapshot.variant == oq_odu::Variant::V2_NEW_MODEL &&
                  (!oq_odu::has_extended_frequency_table(snapshot, 1) ||
                   !oq_odu::has_extended_frequency_table(snapshot, 2)));
-            if (retry_due && table_incomplete &&
+            if (retry_due &&
+                (table_incomplete || id(${hp_id}_runtime_frequency_revalidation_required)) &&
                 id(${hp_id}_odu_generation_detection_complete) &&
                 !id(${hp_id}_odu_generation_request_pending) &&
                 !id(${hp_id}_compressor_level_profile_request_pending) &&
@@ -1772,5 +1782,8 @@ interval:
                 id(${hp_id}_is_online) = true;
                 id(oq_incident_manager).observe_transport(
                     ${hp_index}, true, millis());
+                if (!id(${hp_id}_odu_generation_request_pending)) {
+                  id(${hp_id}_detect_odu_generation_once).execute();
+                }
               });
           id(${hp_id}).queue_command(std::move(probe));

--- a/openquatt/web/js/src/core/incident-monitoring.js
+++ b/openquatt/web/js/src/core/incident-monitoring.js
@@ -73,6 +73,7 @@ const INCIDENT_CATALOG = [
   [1002, "hp_start_failed", "Warmtepompstart niet bevestigd"],
   [1003, "hp_stop_unconfirmed", "Warmtepompstop niet bevestigd"],
   [1004, "hp_manual_reset_persistence_failure", "Opslag van handmatige resetstatus mislukt"],
+  [1005, "hp_runtime_frequency_mapping", "ODU-frequentietabel moet opnieuw worden gevalideerd"],
 ];
 const INCIDENT_LABEL_BY_ID = new Map(INCIDENT_CATALOG.map(([id, , label]) => [id, label]));
 const INCIDENT_LABEL_BY_KEY = Object.freeze(Object.fromEntries(

--- a/openquatt/web/tests/incident-monitoring.test.mjs
+++ b/openquatt/web/tests/incident-monitoring.test.mjs
@@ -386,6 +386,10 @@ test("catalog and synthetic incident fallbacks never expose a bare incident id",
     "Opslag van handmatige resetstatus mislukt",
   );
   assert.equal(
+    getIncidentDisplayLabel({ id: 1005 }),
+    "ODU-frequentietabel moet opnieuw worden gevalideerd",
+  );
+  assert.equal(
     getIncidentDisplayLabel({ id: 26 }),
     "Niet-geclassificeerde ODU-melding (R2120.b9)",
   );

--- a/scripts/run_host_regression_tests.sh
+++ b/scripts/run_host_regression_tests.sh
@@ -13,15 +13,21 @@ if (( ${#sources[@]} == 0 )); then
   exit 1
 fi
 
+compiler_args=(-std=c++17 -Wall -Wextra -Werror)
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  sdk_root="${SDKROOT:-$(xcrun --sdk macosx --show-sdk-path)}"
+  libcxx_headers="${sdk_root}/usr/include/c++/v1"
+  if [[ -f "${libcxx_headers}/cstdint" ]]; then
+    compiler_args+=(-isystem "${libcxx_headers}")
+  fi
+fi
+
 for source in "${sources[@]}"; do
   test_name="$(basename "${source}" .cpp)"
   binary="${build_root}/${test_name}"
   echo "[build] ${test_name}"
   "${CXX:-c++}" \
-    -std=c++17 \
-    -Wall \
-    -Wextra \
-    -Werror \
+    "${compiler_args[@]}" \
     -I"${repo_root}" \
     -I"${repo_root}/openquatt" \
     "${source}" \

--- a/scripts/tests/test_modbus_metadata_continuity_contract.py
+++ b/scripts/tests/test_modbus_metadata_continuity_contract.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HP_IO = (ROOT / "openquatt/oq_HP_io.yaml").read_text()
+INCIDENT_MANAGER_HEADER = (
+    ROOT / "components/openquatt_incident_manager/OpenQuattIncidentManager.h"
+).read_text()
+INCIDENT_MANAGER_SOURCE = (
+    ROOT / "components/openquatt_incident_manager/OpenQuattIncidentManager.cpp"
+).read_text()
+
+
+def yaml_block(source: str, start: str, end: str) -> str:
+    return source[source.index(start):source.index(end, source.index(start))]
+
+
+class ModbusMetadataContinuityContractTest(unittest.TestCase):
+    def test_runtime_snapshot_replaces_only_after_complete_validation(self) -> None:
+        loader = yaml_block(
+            HP_IO,
+            "id: ${hp_id}_load_runtime_frequency_table_once",
+            "id: ${hp_id}_detect_odu_generation",
+        )
+        self.assertIn("if (!snapshot.heating.valid || !snapshot.cooling.valid)", loader)
+        self.assertIn("extension invalid; keeping previous snapshot", loader)
+        self.assertIn("runtime_frequency_revalidation_required) = false", loader)
+        self.assertNotIn("partially invalid; affected mode limited to F10", loader)
+
+    def test_transport_flap_preserves_control_metadata_and_rechecks_it(self) -> None:
+        offline = yaml_block(HP_IO, "on_offline:", "on_online:")
+        online = yaml_block(HP_IO, "on_online:", "openquatt_odu_eeprom_dump:")
+        detection = yaml_block(
+            HP_IO,
+            "id: ${hp_id}_detect_odu_generation_once",
+            "id: ${hp_id}_load_runtime_frequency_table_once",
+        )
+        for value in (
+            "CompressorLevelProfile::UNKNOWN",
+            "runtime_frequency_snapshot_storage) = {}",
+            'generation).publish_state("Unknown")',
+        ):
+            self.assertNotIn(value, offline)
+        for value in (
+            "compressor_level_profile_request_token",
+            "odu_generation_revalidation_required",
+            "runtime_frequency_revalidation_required",
+            "odu_runtime_frequency)->reset_runtime_state",
+            "VERIFY_FAILED: ODU disconnected during write",
+        ):
+            self.assertIn(value, offline)
+        self.assertIn("detect_odu_generation_once", online)
+        for value in (
+            "reset_runtime_state",
+            "notify_odu_offline",
+            "runtime_frequency_snapshot_storage) =",
+        ):
+            self.assertNotIn(value, detection)
+
+    def test_interrupted_write_is_an_explicit_incident_manager_stop(self) -> None:
+        offline = yaml_block(HP_IO, "on_offline:", "on_online:")
+        detection = yaml_block(
+            HP_IO,
+            "id: ${hp_id}_detect_odu_generation_once",
+            "id: ${hp_id}_load_runtime_frequency_table_once",
+        )
+        self.assertIn("runtime_reload_blocked_after_write()", offline)
+        self.assertIn("observe_runtime_frequency_mapping(", offline)
+        self.assertIn("invalidate_runtime_frequency_reload", detection)
+        self.assertIn("odu_generation_detection_complete) = false", detection)
+        self.assertIn("observe_runtime_frequency_mapping", INCIDENT_MANAGER_HEADER)
+        self.assertIn("runtime_frequency_mapping_valid", INCIDENT_MANAGER_SOURCE)
+        self.assertIn("outputs.must_stop = true", INCIDENT_MANAGER_SOURCE)
+        self.assertIn("kRuntimeFrequencyMappingIncidentId", INCIDENT_MANAGER_SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_v2_compressor_level_contract.py
+++ b/scripts/tests/test_v2_compressor_level_contract.py
@@ -83,8 +83,8 @@ class V2CompressorLevelContractTest(unittest.TestCase):
         self.assertIn("variant != oq_odu::Variant::V2_NEW_MODEL", HP_IO)
         self.assertIn("create_read_command(", HP_IO)
         self.assertNotIn("create_write_multiple_command(", HP_IO)
-        self.assertIn("affected mode limited to F10", HP_IO)
-        self.assertIn("defer_base_publish", HP_IO)
+        self.assertIn("extension invalid; keeping previous snapshot", HP_IO)
+        self.assertNotIn("defer_base_publish", HP_IO)
         extension_guard = HP_IO.index("if (!extension_result.response_complete)")
         extension_publish = HP_IO.index("runtime_frequency_snapshot_storage) =", extension_guard)
         self.assertLess(extension_guard, extension_publish)
@@ -100,7 +100,10 @@ class V2CompressorLevelContractTest(unittest.TestCase):
 
     def test_experimental_write_invalidates_and_then_reloads_control_snapshot(self) -> None:
         self.assertIn("on_write_started:", RUNTIME_EDITOR)
-        self.assertIn("oq_odu::RuntimeFrequencySnapshotStorage{}", RUNTIME_EDITOR)
+        self.assertIn("runtime_frequency_revalidation_required", RUNTIME_EDITOR)
+        self.assertIn("observe_runtime_frequency_mapping(", RUNTIME_EDITOR)
+        self.assertNotIn("RuntimeFrequencySnapshotStorage{}", RUNTIME_EDITOR)
+        self.assertNotIn("CompressorLevelProfile::UNKNOWN", RUNTIME_EDITOR)
         self.assertIn("write_tainted_.store(true", RUNTIME_EDITOR_SOURCE)
         self.assertIn("VERIFY_FAILED: readback mismatch", RUNTIME_EDITOR_SOURCE)
         self.assertIn("write_tainted_.store(false", RUNTIME_EDITOR_SOURCE)
@@ -138,20 +141,11 @@ class V2CompressorLevelContractTest(unittest.TestCase):
         self.assertIn("write_tainted_", RUNTIME_EDITOR_HEADER)
         self.assertIn("if (this->write_started_)", RUNTIME_EDITOR_SOURCE)
 
-    def test_offline_transition_invalidates_and_rechecks_profile(self) -> None:
-        offline_block = yaml_block(HP_IO, "on_offline:", "on_online:")
-        online_block = yaml_block(HP_IO, "on_online:", "openquatt_odu_eeprom_dump:")
-        self.assertIn("CompressorLevelProfile::UNKNOWN", offline_block)
-        self.assertIn("runtime_frequency_snapshot_storage) = {}", offline_block)
-        self.assertIn("compressor_level_profile_request_token", offline_block)
-        self.assertIn("odu_runtime_frequency)->reset_runtime_state", offline_block)
-        self.assertIn("VERIFY_FAILED: ODU disconnected during write", offline_block)
-        self.assertIn("detect_odu_generation_once", online_block)
-
     def test_blocked_or_incomplete_detection_is_retried_without_opening_extension(self) -> None:
         self.assertIn("runtime_frequency_retry_ms", HP_IO)
         self.assertIn("now - last_retry >= 60000UL", HP_IO)
-        self.assertIn("!id(${hp_id}_odu_generation_detection_complete)", HP_IO)
+        self.assertIn("id(${hp_id}_odu_generation_revalidation_required)", HP_IO)
+        self.assertIn("id(${hp_id}_runtime_frequency_revalidation_required)", HP_IO)
         self.assertIn("table_incomplete", HP_IO)
         self.assertIn("!id(${hp_id}_compressor_level_profile_request_pending)", HP_IO)
 

--- a/tests/host/incident_actuator_logic_test.cpp
+++ b/tests/host/incident_actuator_logic_test.cpp
@@ -26,6 +26,14 @@ int main() {
   assert(decision.action == Action::FOLLOW_REQUEST);
   assert(decision.guarded_level == 5);
 
+  decision = decide(Inputs{7, 5, false, false});
+  assert(decision.action == Action::FOLLOW_REQUEST);
+  assert(decision.guarded_level == 5);
+
+  decision = decide(Inputs{3, 5, false, false});
+  assert(decision.action == Action::FOLLOW_REQUEST);
+  assert(decision.guarded_level == 3);
+
   decision = decide(Inputs{0, 5, false, true});
   assert(decision.action == Action::FORCE_STOP);
   assert(decision.guarded_level == 0);


### PR DESCRIPTION
# Wat verandert deze PR?

- Behoudt de laatst volledig gevalideerde ODU-identiteit en runtime-frequentiesnapshot tijdens korte Modbus-uitval; herlezing vervangt de actieve snapshot pas na volledige validatie.
- Laat start/stop/herstel via de incidentmanager lopen, inclusief expliciet incident 1005 voor een werkelijk onbruikbare mapping en een continuation-clamp die tijdens `suspect` geen hogere compressorstand toestaat.
- Dekt late callbacks, gewijzigde hardware, onvolledige V1/V2-tabellen en onderbroken runtimewrites af; herstelt daarnaast de macOS-hosttestcompilatie via de geselecteerde Apple SDK-headers.

Closes #638

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Een korte transporthapering trekt de gevalideerde metadata niet meer in. Een draaiende HP mag begrensd doorgaan zonder impliciete F0-stop; nieuwe starts en verhogingen blijven geblokkeerd zolang de incidentmanager geen startvrijgave geeft. Bevestigd linkverlies en werkelijk onbruikbare of mogelijk halfgeschreven mappings blijven fail-closed. De web-UI krijgt alleen een label voor het nieuwe synthetische incident; er komen geen nieuwe instelbare entities bij.

## Achtergrond

De volledige diff is na implementatie opnieuw adversarieel beoordeeld op transportflapping, late callbacks, gedeeltelijke reads, identity change, runtimewrite/readback, start/stopvolgorde, retries, cold boot en Duo-interleaving. Daarbij is aanvullend afgedwongen dat een al draaiende HP tijdens `suspect` wel mag verlagen of stoppen, maar niet mag verhogen. Requesttokens maken oude identity- en tabelcallbacks ongeldig; een oude snapshot blijft atomair intact totdat alle voor de variant vereiste tabellen geldig zijn.

HIL met OpenQuatt Simulator v0.1.0 (`openquatt-modbus-opentherm-v1`) dekte:

- korte Duo-busflap voor beide adressen zonder metadatareset, `must_stop` of incident 1005;
- een incomplete basistabelresponse op register 3000, met ongewijzigde V1.5-snapshot (30/30 Hz) en succesvolle herstelread;
- een lopende CM5-koelcyclus op beide lead-units over opeenvolgende runs; de definitieve run miste op HP1 exact twee responses, bleef fysiek F1/30 Hz zonder verhoging of stop, herstelde naar `healthy` en eindigde gecontroleerd op F0/0 Hz;
- automatische restore van alle gewijzigde simulator- en controllerinstellingen.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Dit herstelt intern fout- en herstelgedrag zonder nieuwe gebruikersworkflow of configuratie. Het enige nieuwe zichtbare element is de zelfverklarende incidenttekst in de bestaande diagnoseweergave.

## Validatie

- [x] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- Geen nieuwe dynamische buffers, taken of allocatiepaden; twee booleans worden toegevoegd aan de bestaande vaste incidentstate in PSRAM.
- Q-edition Duo-build: DIRAM 204167/341760 bytes (59,74%), app-partitie 58% vrij.
- HIL-smoke na OTA: heap free 112191, minimum free 46028, largest block 63488, fragmentatie 43,41%, PSRAM free 6834724.

Checks:

- `bash scripts/run_host_regression_tests.sh` — 65/65 geslaagd op macOS.
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 225/225 geslaagd.
- `npm run check:cpp-format` — geslaagd.
- `npm run check:web` — build, 450/450 tests en qualitycheck geslaagd.
- `esphome run --device openquatt.local --ota-platform esphome --no-logs configs/heatpump_controller_q/duo_wifi.yaml` — compile en OTA geslaagd; exacte PR-head draait als config hash `0xee06711c`.
- `node scripts/hil/run-input-sources.mjs --controller http://192.168.2.92 --simulator http://192.168.2.63 --stage smoke` — geslaagd na de definitieve OTA.
- `git diff --check origin/dev...HEAD` — geslaagd.

`python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` bereikt de configvalidatie niet door reeds bestaande stijlmeldingen in `configs/hil/input_sources_fast_duo_wifi.yaml:26`, `openquatt/oq_common.yaml:723` en `openquatt/oq_common.yaml:840`; de directe ESPHome-compile van het doelconfiguratiebestand is wel geslaagd.
