### PR TITLE
Stel een zevende compressorstart binnen een uur uit

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -251,6 +251,10 @@ Alleen als het probleem daar lijkt te zitten:
 
 ### Voor compressorpendelen
 
+OpenQuatt geeft per compressor maximaal zes startopdrachten per voortschrijdend uur vrij. Een zevende start wacht totdat de oudste van die zes starts een uur geleden is, én alle bestaande startvoorwaarden zijn vrijgegeven. De minimale draaitijd (standaard 300 s) en minimale uit-tijd (standaard 240 s) blijven gelden. Verdwijnt de vraag tijdens het wachten, dan volgt geen start. De begrenzer geldt ook bij handmatige HP-bediening; stops blijven mogelijk.
+
+De begrenzer telt vrijgegeven opdrachten van stand 0 naar een actieve stand. Een mislukte start telt conservatief mee; modulatie en herhaalde actieve opdrachten tellen niet opnieuw. De beslislog meldt een geblokkeerde start met de reden `start_stop_rate_high`; handmatige HP-bediening toont de resterende wachttijd. De uurhistorie wordt bij een controllerherstart gewist. De bestaande stilstandbeveiliging blijft gelden, maar er is geen uurgrens over reboots heen of voor autonome herstarts binnen de ODU.
+
 De diagnostische pendelwaarschuwingen zijn in Home Assistant standaard
 uitgeschakeld. Schakel `Compressor cycling warning` in om één samengesteld
 signaal te krijgen zodra minimaal één actuele pendelwaarschuwing actief is. De

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -123,6 +123,8 @@ De compressorbeveiliging telt per HP `${oq_hp_min_off_s}` (standaard 240 seconde
 
 Het herstartrecord wordt vóór safe mode en OTA-toegang uit NVS verbruikt. Als dat niet aantoonbaar lukt, herstart de controller zonder HP-starts of OTA-toegang vrij te geven; alleen extra wachten zou hergebruik van oude uit-tijd niet voorkomen. Deze opslagfout vereist herstel voordat normaal bedrijf kan hervatten.
 
+Daarnaast houdt de thermal actuator per compressor de laatste zes vrijgegeven startopdrachten bij in een vaste RAM-ringbuffer. Bij zes starts in de laatste 60 minuten wordt alleen een nieuwe start uitgesteld tot de oudste start verloopt. Doorlopen, moduleren en stoppen blijven mogelijk. Dit geldt voor verwarmen, koelen en handmatige HP-bediening. De startgeschiedenis vervalt bij iedere reboot en telt OQ-opdrachten, niet autonome ODU-herstarts; de bestaande gemeten startdiagnostiek blijft afzonderlijk beschikbaar.
+
 ## 4. Data Pipeline
 
 ### 4.1 Input layer

--- a/openquatt/includes/control/oq_compressor_start_limit.h
+++ b/openquatt/includes/control/oq_compressor_start_limit.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace oq_thermal_actuator {
+
+// Command history, not measured ODU starts. Owned by the actuator's main-loop
+// runtime; deliberately not persisted. Expire on every tick, including idle
+// ticks, so old timestamps cannot reappear after a complete millis() wrap.
+class CompressorStartLimit {
+ public:
+  static constexpr uint32_t WINDOW_MS = 60U * 60U * 1000U;
+  static constexpr uint8_t MAX_STARTS = 6U;
+
+  void expire(uint32_t now_ms) {
+    while (count_ > 0 && static_cast<uint32_t>(now_ms - starts_[oldest_]) >= WINDOW_MS) {
+      oldest_ = (oldest_ + 1U) % MAX_STARTS;
+      --count_;
+    }
+  }
+
+  uint32_t remaining_ms(uint32_t now_ms) {
+    expire(now_ms);
+    return count_ == MAX_STARTS ? WINDOW_MS - static_cast<uint32_t>(now_ms - starts_[oldest_]) : 0U;
+  }
+
+  // Call once for the final applied transition. Rejected requests, stop writes,
+  // level changes and retries of an already active command consume no slots.
+  void record_transition(int previous_level, int applied_level, uint32_t now_ms) {
+    expire(now_ms);
+    if (previous_level != 0 || applied_level <= 0) return;
+    // Defensive saturation: an unexpected extra start must not open the gate.
+    if (count_ == MAX_STARTS) {
+      oldest_ = (oldest_ + 1U) % MAX_STARTS;
+      --count_;
+    }
+    starts_[(oldest_ + count_) % MAX_STARTS] = now_ms;
+    ++count_;
+  }
+
+ private:
+  std::array<uint32_t, MAX_STARTS> starts_{};
+  uint8_t oldest_{0};
+  uint8_t count_{0};
+};
+
+}  // namespace oq_thermal_actuator

--- a/openquatt/includes/control/oq_thermal_actuator_logic.h
+++ b/openquatt/includes/control/oq_thermal_actuator_logic.h
@@ -17,6 +17,10 @@ constexpr bool valid_level_command(int control_level, int physical_level) {
   return control_level > 0 && control_level <= 10 && physical_level > 0 && physical_level <= 20;
 }
 
+// Retained defrost writes continue an active command. A zero command must go
+// through normal start authorization, even if the ODU readback still is active.
+constexpr bool may_retain_command(int previous_level, bool safety_stop) { return previous_level > 0 && !safety_stop; }
+
 struct ManualGuardInputs {
   int requested_level;
   int mode_code;
@@ -47,14 +51,16 @@ inline std::string manual_guard(const ManualGuardInputs& in, const std::string& 
   return current_guard;
 }
 
-enum class PreflightBlock : uint8_t { NONE, SAFE_ZERO, DEFROST, COOLING_REST, HP_REST, MODE };
+enum class PreflightBlock : uint8_t { NONE, SAFE_ZERO, DEFROST, COOLING_REST, HP_REST, MODE, START_LIMIT };
 
 inline PreflightBlock decide_preflight(int guarded_level, int previous_level, bool retained_hold, int expected_mode,
-                                       uint32_t hp_rest_remaining_ms, bool bypass_holds, bool cooling_start_blocked) {
+                                       uint32_t hp_rest_remaining_ms, bool bypass_holds, bool cooling_start_blocked,
+                                       uint32_t start_limit_remaining_ms = 0U) {
   if (bypass_holds) return PreflightBlock::SAFE_ZERO;
   if (retained_hold) return PreflightBlock::DEFROST;
   if (guarded_level > 0 && cooling_start_blocked) return PreflightBlock::COOLING_REST;
   if (guarded_level > 0 && previous_level == 0 && hp_rest_remaining_ms > 0) return PreflightBlock::HP_REST;
+  if (guarded_level > 0 && previous_level == 0 && start_limit_remaining_ms > 0) return PreflightBlock::START_LIMIT;
   if (guarded_level > 0 && expected_mode != 1 && expected_mode != 2) return PreflightBlock::MODE;
   return guarded_level > 0 ? PreflightBlock::NONE : PreflightBlock::SAFE_ZERO;
 }

--- a/openquatt/includes/control/oq_thermal_actuator_runtime.h
+++ b/openquatt/includes/control/oq_thermal_actuator_runtime.h
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "oq_compressor_frequency_runtime.h"
+#include "oq_compressor_start_limit.h"
 #include "oq_cooling_limiter_logic.h"
 #include "oq_incident_actuator_logic.h"
 #include "oq_thermal_actuator_logic.h"
@@ -55,6 +56,7 @@ class Runtime {
 
  public:
   void tick(const TickConfig& config) {
+    for (auto& limit : this->start_limits_) limit.expire(config.now_ms);
     const float cooling_off_state = id(cooling_minimum_off_time).state;
     int cooling_off_s = !isfinite(cooling_off_state) ? 600 : static_cast<int>(lroundf(cooling_off_state));
     const int cooling_off_floor_s = oq_cooling::cooling_minimum_off_floor_s(config.cooling_minimum_off_min_s);
@@ -371,6 +373,7 @@ class Runtime {
 
   void record_transition(bool is_hp1, int new_level, uint32_t now_ms, uint32_t dt_ms) {
     int& previous = is_hp1 ? id(hp1_last_applied_level) : OQ_ACTUATOR_SECONDARY_ID(last_applied_level);
+    this->start_limits_[is_hp1 ? 0 : 1].record_transition(previous, new_level, now_ms);
     if (previous != new_level) {
       (is_hp1 ? id(hp1_last_level_change_ms) : id(hp2_last_level_change_ms)) = now_ms;
     }
@@ -437,15 +440,18 @@ class Runtime {
     const bool force_safe_write =
         oq_incident_actuator::safe_stop_write_retry_due(stop_pending, cycle.config.now_ms, last_safe_write_ms, 10000U);
 
-    // Contract order: incident stop -> defrost hold -> cooling rest -> per-HP rest
+    // Contract order: incident stop -> defrost hold -> cooling rest -> per-HP rest -> start quota
     // -> valid mode -> frequency policy -> start/stop registration -> physical write.
     const auto incident_guard =
         oq_incident_actuator::decide({level, previous, incident.available_for_start,
                                       incident.must_stop || id(oq_incident_manager).startup_inhibited(hp_index)});
-    if (incident_guard.bypass_runtime_and_defrost_holds) this->clear_retained_level(is_hp1);
-    const auto retained = incident_guard.bypass_runtime_and_defrost_holds
-                              ? oq_odu::RetainedLevel{}
-                              : this->retained_level(is_hp1, cycle.frequency);
+    const bool may_retain =
+        oq_thermal_actuator::may_retain_command(previous, incident_guard.bypass_runtime_and_defrost_holds);
+    if (!may_retain) this->clear_retained_level(is_hp1);
+    const uint32_t start_limit_remaining_ms = this->start_limits_[is_hp1 ? 0 : 1].remaining_ms(cycle.config.now_ms);
+    // Neither retained-level early return may re-arm a zero command, including
+    // after quota expiry when demand has disappeared but ODU readback is stale.
+    const auto retained = may_retain ? this->retained_level(is_hp1, cycle.frequency) : oq_odu::RetainedLevel{};
     const int expected_mode = this->requested_mode_code(is_hp1, true, cycle.request_mode_code,
                                                         cycle.request_thermal_active, cycle.manual_service_active);
     const bool cooling_start_blocked = oq_cooling::cooling_stop_confirmation_blocks_start(
@@ -460,7 +466,7 @@ class Runtime {
                                                                              cycle.manual_service_active);
     const auto preflight = oq_thermal_actuator::decide_preflight(
         incident_guard.guarded_level, previous, defrost_hold, expected_mode, hp_rest_remaining_ms,
-        incident_guard.bypass_runtime_and_defrost_holds, cooling_start_blocked);
+        incident_guard.bypass_runtime_and_defrost_holds, cooling_start_blocked, start_limit_remaining_ms);
     level = preflight == oq_thermal_actuator::PreflightBlock::NONE ? incident_guard.guarded_level : 0;
     std::string block_reason;
     uint8_t candidate_reason = openquatt_decision_log::REASON_UNKNOWN;
@@ -515,6 +521,17 @@ class Runtime {
       candidate_aux_s = this->cap_seconds_(remaining_s);
       this->service_guard_(cycle, is_hp1) = "minimale uit-tijd: nog " + std::to_string(remaining_s) + " s";
       this->log_block_change(is_hp1, reason);
+    }
+
+    if (preflight == oq_thermal_actuator::PreflightBlock::START_LIMIT) {
+      const uint32_t remaining_s = (start_limit_remaining_ms + 999U) / 1000U;
+      block_reason = "compressor start limit reached (6/60 min)";
+      candidate_reason = openquatt_decision_log::REASON_START_STOP_RATE_HIGH;
+      candidate_aux_s = this->cap_seconds_(remaining_s);
+      this->service_guard_(cycle, is_hp1) = "startlimiet 6/uur bereikt: nog " + std::to_string(remaining_s) + " s";
+      // Keep the log reason stable: the countdown belongs in service status
+      // and the existing candidate event, not a new log line every five seconds.
+      this->log_block_change(is_hp1, block_reason);
     }
 
     int applied = level;
@@ -815,6 +832,7 @@ class Runtime {
   }
 
   std::string last_optimizer_reason_;
+  oq_thermal_actuator::CompressorStartLimit start_limits_[OQ_TOPOLOGY_DUO ? 2 : 1]{};
   std::string last_block_reasons_[2];
   std::string last_manual_guard_status_;
   bool last_defrost_seen_[2]{false, false};

--- a/scripts/tests/test_thermal_actuator_runtime_contract.py
+++ b/scripts/tests/test_thermal_actuator_runtime_contract.py
@@ -48,10 +48,29 @@ class ThermalActuatorRuntimeContractTest(unittest.TestCase):
     def test_complete_runtime_stack_stays_bounded(self) -> None:
         paths = ("openquatt/oq_thermal_actuator.yaml", "openquatt/includes/control/oq_thermal_actuator_logic.h",
                  "openquatt/includes/control/oq_thermal_actuator_runtime.h", "tests/host/thermal_actuator_logic_test.cpp",
+                 "openquatt/includes/control/oq_compressor_start_limit.h", "tests/host/compressor_start_limit_test.cpp",
                  "scripts/tests/test_thermal_actuator_runtime_contract.py", "scripts/tests/test_v2_compressor_level_contract.py",
                  "scripts/tests/test_compressor_frequency_policy_contract.py")
-        # Includes restart-credit invalidation and the read-only frequency-limit diagnosis.
-        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1370)
+        # Includes restart credit, frequency diagnosis and the bounded start quota with regression coverage.
+        self.assertLessEqual(sum(len((ROOT / path).read_text().splitlines()) for path in paths), 1600)
+
+    def test_start_quota_covers_retained_writes_and_final_transitions(self) -> None:
+        actuator = RUNTIME[RUNTIME.index("int apply_level_"):RUNTIME.index("int previous_applied_")]
+        remaining = actuator.index("start_limits_[is_hp1 ? 0 : 1].remaining_ms")
+        retained = actuator.index("const auto retained")
+        preflight = actuator.index("oq_thermal_actuator::decide_preflight(")
+        self.assertLess(remaining, retained)
+        self.assertLess(retained, preflight)
+        self.assertIn("oq_thermal_actuator::may_retain_command(previous, incident_guard.bypass_runtime_and_defrost_holds)", actuator)
+        self.assertIn("if (!may_retain) this->clear_retained_level(is_hp1);", actuator)
+        self.assertIn("may_retain ? this->retained_level(is_hp1, cycle.frequency) : oq_odu::RetainedLevel{}", actuator[retained:preflight])
+        self.assertIn("cooling_start_blocked, start_limit_remaining_ms)", actuator)
+        self.assertLess(preflight, actuator.index("apply_active_mode_hold("))
+        self.assertLess(preflight, actuator.index("apply_start_gate_before_active_write("))
+        self.assertIn("for (auto& limit : this->start_limits_) limit.expire(config.now_ms);", RUNTIME)
+        self.assertEqual(RUNTIME.count(".record_transition(previous, new_level, now_ms)"), 1)
+        transition = RUNTIME[RUNTIME.index("void record_transition("):RUNTIME.index("private:")]
+        self.assertLess(transition.index(".record_transition("), transition.index("previous = new_level;"))
 
 
 if __name__ == "__main__":

--- a/tests/host/compressor_start_limit_test.cpp
+++ b/tests/host/compressor_start_limit_test.cpp
@@ -1,0 +1,106 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "../../openquatt/includes/control/oq_compressor_start_limit.h"
+#include "../../openquatt/includes/control/oq_thermal_actuator_logic.h"
+#include "../../openquatt/includes/odu/oq_odu_compressor_levels.h"
+
+int main() {
+  using oq_thermal_actuator::CompressorStartLimit;
+  using oq_thermal_actuator::decide_preflight;
+  using oq_thermal_actuator::PreflightBlock;
+  constexpr uint32_t minute = 60000U;
+  constexpr uint32_t hour = CompressorStartLimit::WINDOW_MS;
+  CompressorStartLimit hp1;
+  CompressorStartLimit hp2;
+  static_assert(sizeof(CompressorStartLimit) <= 28U, "Start history must remain fixed and small");
+
+  // Six admitted starts nine minutes apart, including a valid timestamp zero.
+  for (uint32_t n = 0; n < 6; ++n) {
+    const uint32_t now = n * 9 * minute;
+    assert(hp1.remaining_ms(now) == 0);
+    hp1.record_transition(0, 1, now);
+    hp1.record_transition(1, 1, now + 1000);  // repeated active command / retry
+    hp1.record_transition(1, 3, now + 2000);  // modulation
+    hp1.record_transition(3, 0, now + 5 * minute);
+  }
+  const uint32_t seventh = 54 * minute;
+  assert(hp1.remaining_ms(seventh) == 6 * minute);
+  assert(hp2.remaining_ms(seventh) == 0);  // Independent Duo quota.
+  const auto block = [&](int requested, int previous, uint32_t rest, bool safety) {
+    return decide_preflight(requested, previous, false, 2, rest, safety, false, hp1.remaining_ms(seventh));
+  };
+  assert(block(1, 0, 0, false) == PreflightBlock::START_LIMIT);
+  assert(block(1, 0, minute, false) == PreflightBlock::HP_REST);
+  assert(block(1, 1, 0, false) == PreflightBlock::NONE);
+  assert(block(0, 1, 0, false) == PreflightBlock::SAFE_ZERO);
+  assert(block(1, 1, 0, true) == PreflightBlock::SAFE_ZERO);
+  for (uint32_t now = seventh; now < hour; now += 5000) {
+    hp1.record_transition(0, 0, now);  // Blocked or cancelled demand never consumes a slot.
+    assert(hp1.remaining_ms(now) == hour - now);
+  }
+  assert(hp1.remaining_ms(hour - 1) == 1);
+  // Positive/stale ODU readback must not resurrect a stopped command after
+  // quota expiry, especially when the demand disappeared during the wait.
+  const auto stale_retained =
+      oq_odu::update_retained_level_snapshot({}, true, false, 3, 0, 0, false, oq_odu::RuntimeFrequencySnapshot{});
+  assert(stale_retained.control_level > 0);
+  for (uint32_t now : {hour - 1, hour}) {
+    for (int previous : {0, 1}) {
+      for (int demand : {0, 1}) {
+        for (bool safety_stop : {false, true}) {
+          const bool may_retain = oq_thermal_actuator::may_retain_command(previous, safety_stop);
+          const bool retained = may_retain && stale_retained.control_level > 0;
+          const auto decision =
+              decide_preflight(demand, previous, retained, 2, 0, safety_stop, false, hp1.remaining_ms(now));
+          if (safety_stop || (previous == 0 && demand == 0)) {
+            assert(decision == PreflightBlock::SAFE_ZERO);
+          } else if (previous > 0) {
+            assert(decision == PreflightBlock::DEFROST);
+          } else {
+            assert(decision == (now < hour ? PreflightBlock::START_LIMIT : PreflightBlock::NONE));
+          }
+        }
+      }
+    }
+  }
+  assert(hp1.remaining_ms(hour) == 0);
+  hp1.record_transition(0, 1, hour);
+  assert(hp1.remaining_ms(hour) == 9 * minute);
+  assert(hp1.remaining_ms(hour + 9 * minute) == 0);
+
+  // A long idle period is expired on ticks, before any complete millis wrap.
+  hp1.expire(2 * hour);
+  assert(hp1.remaining_ms(seventh) == 0);
+  // No persistence by design: a new runtime starts a fresh history.
+  CompressorStartLimit rebooted;
+  assert(rebooted.remaining_ms(0) == 0);
+
+  CompressorStartLimit wrapping;
+  const uint32_t first = UINT32_MAX - 30 * minute;
+  for (uint32_t n = 0; n < 6; ++n) wrapping.record_transition(0, 1, first + n * 9 * minute);
+  assert(wrapping.remaining_ms(first + seventh) == 6 * minute);
+  assert(wrapping.remaining_ms(first + hour - 1) == 1);
+  assert(wrapping.remaining_ms(first + hour) == 0);
+  wrapping.record_transition(0, 1, first + hour);
+  assert(wrapping.remaining_ms(first + hour) == 9 * minute);
+
+  // Simulate recurring demand across many ring-buffer turns: no rolling hour
+  // admits a seventh command. Test a second run across clock wrap as well.
+  for (uint32_t origin : {0U, UINT32_MAX - hour}) {
+    CompressorStartLimit limit;
+    uint32_t admitted[100]{};
+    unsigned count = 0;
+    for (uint32_t elapsed = 0; elapsed < 12 * hour; elapsed += 9 * minute) {
+      const uint32_t now = origin + elapsed;
+      if (limit.remaining_ms(now) != 0) continue;
+      limit.record_transition(0, 1, now);
+      admitted[count++] = now;
+      unsigned in_window = 0;
+      for (unsigned n = 0; n < count; ++n) {
+        if (static_cast<uint32_t>(now - admitted[n]) < hour) ++in_window;
+      }
+      assert(in_window <= 6);
+    }
+  }
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Iedere compressor krijgt een vaste ringbuffer met de laatste zes vrijgegeven OQ-startopdrachten. Een zevende start wacht tot de oudste start 60 minuten geleden is, naast de bestaande uit-tijd- en incidentbeveiligingen.
- Stops en modulatie blijven mogelijk. Een ontdooihold mag uitsluitend een al actieve opdracht voortzetten; stale ODU-readback kan na het wachten geen gestopte opdracht zonder vraag opnieuw activeren.
- Blokkering verschijnt in de bestaande beslislog; handmatige HP-bediening toont de resterende wachttijd. Documentatie en gerichte regressietests toegevoegd.

## Type

- [x] Bugfix
- [x] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De begrenzer geldt onafhankelijk per HP, voor verwarmen, koelen en handmatige bediening. Bij starts op minuut 0, 9, 18, 27, 36 en 45 wordt de aanvraag op minuut 54 pas vanaf minuut 60 vrijgegeven, mits er nog vraag is en de overige startvoorwaarden toestaan. De bestaande defaults van 300 s runtime en 240 s uit-tijd wijzigen niet.

## Achtergrond

Refs #632. Dit implementeert de afgesproken compacte variant: telling van vrijgegeven `0 → >0`-opdrachten, zonder flashopslag. Mislukte startopdrachten tellen conservatief mee; geblokkeerde aanvragen, actieve retries en niveauwijzigingen niet. Geen aparte safety-uitzonderingslogica: stoppen blijft vrij, een volgende start doorloopt dezelfde guard.

De historie begint na iedere reboot opnieuw. Bestaande gemeten stilstandbeveiliging/herstartcredit blijft gelden; dit is bewust geen absolute uurgrens over reboots of autonome ODU-herstarts heen. Geen nieuwe instellingen, NVS-velden of backup-/migratievereisten.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

Werking, opdrachtmeting, onafhankelijke Duo-limiet, handmatige status en rebootbeperking beschreven in `docs/instellingen-en-meetwaarden.md` en `docs/system-overview.md`.

## Validatie

- `bash scripts/run_host_regression_tests.sh`: 66 tests geslaagd. Nieuwe dekking: zesde/zevende start, exacte uurgrens, twaalf uur herhaalde aanvragen, HP-isolatie, retries/modulatie/stops, ingetrokken vraag, lege historie na reboot, idle-expiry en `millis()`-wrap.
- Gedragsregressie met echte retained-level-resolver: positieve stale readback, actieve/gestopte opdracht, vraag aan/uit, volle/verlopen quota en incidentstop.
- `python3 -B -m unittest discover -s scripts/tests -p 'test_*.py'`: 226 tests geslaagd, inclusief aansluiting op de centrale actuator en beide retained-write-paden.
- `npm run check:cpp-format`, `python3 scripts/check_docs_consistency.py`, `node scripts/check_web_docs_sync.mjs`: geslaagd.
- `npm run build:web`: geslaagd; gegenereerde assets niet gecommit.
- `esphome -q config configs/heatpump_controller_q/duo_wifi.yaml` en `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`: geslaagd, ESPHome 2026.8.2. Geen upload uitgevoerd.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` stopt vóór configvalidatie op bestaande, ongewijzigde style-fouten: `configs/hil/input_sources_fast_duo_wifi.yaml:26` en `openquatt/oq_common.yaml:723,840`. Daarom config en compile rechtstreeks uitgevoerd.
- Complete diff tegen `dev` inhoudelijk geaudit op start-/stopvolgorde, manual/verwarmen/koelen, mislukte writes, callback-eigenaarschap, rollover, verse installatie, upgrade/reboot, backup/restore en privacy. Aparte cold adversarial review uitgevoerd; gevonden retained-herstartpad opgelost en opnieuw beoordeeld, geen resterende codeblockers.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Vaste extra historie: 28 bytes per HP (56 bytes Duo), zonder dynamische history-allocaties, nieuwe tasks of flashwrites. Bestaande stringpaden tonen de diagnose/wachttijd. Candidate Q Duo compile rapporteert 204231 bytes RAM en 2195207 bytes image; dit is geen runtime-heapmeting of baselinevergelijking.

**Concept-PR:** HIL-validatie van startuitstel, verdwijnen van vraag en actief ontdooien, plus baseline/candidate internal-heap-, largest-block- en stackmetingen zijn nog niet uitgevoerd. Die staan open vóór hardware-/releasevrijgave.