### PR TITLE
Herstel main → dev-kanaalwissel bij dezelfde basisversie

### DIFF
--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -324,6 +324,8 @@ Een backup is vooral handig bij:
 
 De web-app toont update-informatie via de firmware-updatefunctie. Normaal volg je het stabiele kanaal.
 
+Na het kiezen van `dev` kun je de aangeboden dev-build ook installeren wanneer deze dezelfde basisversie heeft als de draaiende main-release (bijvoorbeeld `v0.49.1` → `v0.49.1-dev.780`). De web-app bevestigt de kanaalwissel pas wanneer het device de bedoelde dev-build en het dev-kanaal meldt.
+
 Gebruik een dev-kanaal alleen als je bewust test en weet dat de firmware nog kan veranderen. Voor releasegebruik is het stabiele kanaal de route.
 
 Draait het device op een nieuwere dev-versie dan de laatste main-release, dan biedt de OTA-modal na het kiezen van `main` een expliciete downgrade aan. Controleer de getoonde doelversie en bevestig bewust dat je teruggaat naar oudere firmware. Maak zo nodig eerst een instellingenbackup: instellingen blijven lokaal opgeslagen, maar functies en instellingen die alleen in de dev-build bestaan, zijn na de downgrade mogelijk niet meer beschikbaar.

--- a/openquatt/web/js/src/features/firmware-actions.js
+++ b/openquatt/web/js/src/features/firmware-actions.js
@@ -8,7 +8,7 @@ import { isLikelyDeviceConnectionError, refreshEntities } from "../core/entity-s
 import { armOtaRefresh, awaitOtaEvidence, beginDeviceReconnect, clearOtaRefresh } from "../core/device-reconnect.js";
 import { clearQuickStartSetupInstall, state, storeQuickStartSetupInstall } from "../core/state.js";
 import { getFirmwareConnectionLabel, getFirmwareTopologyLabel, getInstallationTopology } from "./device-context.js";
-import { beginFirmwareOtaQuietWindow, clearFirmwareOtaQuietWindow, getFirmwareBuildSwitchModel, getFirmwareConnectionSwitchModel, getFirmwareCurrentVersion, getFirmwareLatestVersion, getFirmwareRunningChannelLabel, getFirmwareTestAssetUrls, getFirmwareTestPrNumber, getFirmwareTestTargetModel, getFirmwareTopologySwitchModel, getFirmwareUpdateEntity, hasFirmwareTestLegacyCapability, hasFirmwareTestManifestCapability, hasKnownFirmwareTargetVersion, isFirmwareDowngradeAvailable, isFirmwareEntityAlignedWithChannel, isFirmwareUpdateEntityForBuild, isQuickStartSetupFirmwareCurrent, pollFirmwareInstallState, pollFirmwareUpdateState, primeFirmwareInstallProgressHints, primeFirmwareUpdateState, resetFirmwareInstallUiState, resetFirmwareManualUploadSelection, resetFirmwareTestSelection, wait } from "./firmware-update.js";
+import { beginFirmwareOtaQuietWindow, clearFirmwareOtaQuietWindow, getFirmwareBuildSwitchModel, getFirmwareConnectionSwitchModel, getFirmwareCurrentVersion, getFirmwareLatestVersion, getFirmwareRunningChannelLabel, getFirmwareTestAssetUrls, getFirmwareTestPrNumber, getFirmwareTestTargetModel, getFirmwareTopologySwitchModel, getFirmwareUpdateEntity, hasFirmwareTestLegacyCapability, hasFirmwareTestManifestCapability, hasKnownFirmwareTargetVersion, isFirmwareChannelTransition, isFirmwareDowngradeAvailable, isFirmwareEntityAlignedWithChannel, isFirmwareUpdateEntityForBuild, isQuickStartSetupFirmwareCurrent, pollFirmwareInstallState, pollFirmwareUpdateState, primeFirmwareInstallProgressHints, primeFirmwareUpdateState, resetFirmwareInstallUiState, resetFirmwareManualUploadSelection, resetFirmwareTestSelection, wait } from "./firmware-update.js";
 import { render } from "../core/render-scheduler.js";
 
   export async function requestFirmwareOta(path, options) {
@@ -164,6 +164,7 @@ import { render } from "../core/render-scheduler.js";
 
     const targetVersion = getFirmwareLatestVersion(entity);
     const downgrade = isFirmwareDowngradeAvailable(entity);
+    const channelSwitch = isFirmwareChannelTransition(entity);
     if (downgrade && state.firmwareDowngradeConfirmedVersion !== targetVersion) {
       state.controlError = "Bevestig opnieuw dat je naar de oudere main-firmware wilt teruggaan.";
       render();
@@ -184,7 +185,7 @@ import { render } from "../core/render-scheduler.js";
     state.updateInstallBusy = true;
     state.updateInstallTargetVersion = targetVersion;
     primeFirmwareInstallProgressHints();
-    state.updateInstallMode = downgrade ? "downgrade" : "normal";
+    state.updateInstallMode = downgrade ? "downgrade" : channelSwitch ? "channel-switch" : "normal";
     state.updateInstallTargetConnection = "";
     state.updateInstallTargetTopology = "";
     state.controlError = "";
@@ -206,7 +207,13 @@ import { render } from "../core/render-scheduler.js";
         state.updateInstallTargetVersion = refreshedTargetVersion;
       } else {
         await setFirmwareUpdateTarget("current build", { poll: false, force: true });
-        state.updateInstallTargetVersion = getFirmwareLatestVersion(getFirmwareUpdateEntity() || {}) || state.updateInstallTargetVersion;
+        if (channelSwitch) {
+          if (!isFirmwareChannelTransition() || getFirmwareLatestVersion() !== targetVersion) {
+            throw new Error("De dev-doelversie is gewijzigd of niet meer beschikbaar. Controleer de getoonde versie opnieuw.");
+          }
+        } else {
+          state.updateInstallTargetVersion = getFirmwareLatestVersion(getFirmwareUpdateEntity() || {}) || state.updateInstallTargetVersion;
+        }
       }
       beginFirmwareOtaQuietWindow();
       const installButtonEntity = ENTITY_DEFS.installFirmwareUpdateTarget;

--- a/openquatt/web/js/src/features/firmware-update.js
+++ b/openquatt/web/js/src/features/firmware-update.js
@@ -355,6 +355,11 @@ import { render } from "../core/render-scheduler.js";
     if (!target || !current || !parseFirmwareVersion(target) || !parseFirmwareVersion(current)) {
       return false;
     }
+    if (state.updateInstallMode === "channel-switch") {
+      return getFirmwareRunningChannelLabel().toLowerCase() === "dev"
+        && parseFirmwareVersion(current).prereleaseTag.toLowerCase() === "dev"
+        && current.replace(/^v/, "") === target.replace(/^v/, "");
+    }
     const relation = compareFirmwareVersions(current, target);
     return state.updateInstallMode === "downgrade" ? relation === 0 : relation >= 0;
   }
@@ -365,7 +370,10 @@ import { render } from "../core/render-scheduler.js";
     if (!latest || !current) {
       return false;
     }
-    if (isFirmwareDowngradeAvailable(entity)) {
+    if (state.updateInstallMode === "channel-switch") {
+      return hasInstalledFirmwareTargetVersion();
+    }
+    if (isFirmwareDowngradeAvailable(entity) || isFirmwareChannelTransition(entity)) {
       return false;
     }
     return compareFirmwareVersions(current, latest) >= 0;
@@ -806,7 +814,7 @@ import { render } from "../core/render-scheduler.js";
     if (!isFirmwareEntityAlignedWithChannel()) {
       return false;
     }
-    if (isFirmwarePrToDevTransition()) {
+    if (isFirmwareChannelTransition()) {
       return true;
     }
     const relation = getFirmwareVersionRelation();
@@ -850,7 +858,7 @@ import { render } from "../core/render-scheduler.js";
       && relation !== null
       && relation <= 0
       && !isFirmwareDowngradeAvailable(entity)
-      && !isFirmwarePrToDevTransition(entity)
+      && !isFirmwareChannelTransition(entity)
     ) {
       latest = "";
     }
@@ -869,12 +877,13 @@ import { render } from "../core/render-scheduler.js";
     return compareFirmwareVersions(latest, current);
   }
 
-  function isFirmwarePrToDevTransition(entity = getFirmwareUpdateEntity() || {}) {
+  export function isFirmwareChannelTransition(entity = getFirmwareUpdateEntity() || {}) {
     const current = parseFirmwareVersion(getFirmwareCurrentVersion(entity));
     const latest = parseFirmwareVersion(getFirmwareLatestVersion(entity));
     return getFirmwareChannelLabel().toLowerCase() === "dev"
       && isFirmwareEntityAlignedWithChannel(entity, "dev")
-      && current?.prereleaseTag.toLowerCase() === "pr"
+      && (current?.prereleaseTag.toLowerCase() === "pr"
+        || (current?.prereleaseTag === "" && getFirmwareRunningChannelLabel().toLowerCase() === "main"))
       && latest?.prereleaseTag.toLowerCase() === "dev";
   }
 
@@ -1164,8 +1173,10 @@ import { render } from "../core/render-scheduler.js";
       const { current, latest } = getFirmwareUpdateVersions();
       return `De stabiele main-release ${latest} is ouder dan de draaiende dev-build ${current}. Je kunt bewust teruggaan naar main.`;
     }
-    if (isFirmwarePrToDevTransition()) {
-      return "Dev-firmware kan de PR-testfirmware vervangen.";
+    if (isFirmwareChannelTransition()) {
+      return parseFirmwareVersion(getFirmwareCurrentVersion())?.prereleaseTag.toLowerCase() === "pr"
+        ? "Dev-firmware kan de PR-testfirmware vervangen."
+        : "Dev-firmware kan de huidige main-firmware vervangen.";
     }
     if (isFirmwareUpdateAvailable()) {
       return "Er staat een nieuwere firmware klaar.";

--- a/openquatt/web/tests/firmware-update.test.mjs
+++ b/openquatt/web/tests/firmware-update.test.mjs
@@ -12,9 +12,14 @@ globalThis.window = {
 
 const { state } = await import("../js/src/core/state.js");
 const { setRenderCallback } = await import("../js/src/core/render-scheduler.js");
-const { installFirmwareTestUpdate } = await import("../js/src/features/firmware-actions.js");
+const { installFirmwareTestUpdate, installFirmwareUpdate } = await import("../js/src/features/firmware-actions.js");
 const {
   getFirmwareModalCopy,
+  compareFirmwareVersions,
+  hasInstalledFirmwareLatestVersion,
+  hasInstalledFirmwareTargetVersion,
+  isFirmwareChannelTransition,
+  isFirmwareInstallSettled,
   getFirmwareProgressModel,
   getFirmwareTestAssetUrls,
   getFirmwareUpdateVersions,
@@ -115,6 +120,148 @@ test("PR test firmware can return to the dev channel", () => {
   const modal = renderUpdateModal();
   const installButton = modal.match(/<button class="oq-helper-button[^"]*" type="button" data-oq-action="install-firmware-update"[^>]*>/)?.[0] || "";
   assert.doesNotMatch(installButton, /disabled/);
+});
+
+function setMainToDevState(target = "v0.49.1-dev.780+abcdef0") {
+  setPrToDevState();
+  state.entities.projectVersionText = { state: "v0.49.1" };
+  state.entities.releaseChannelText = { state: "main" };
+  Object.assign(state.entities.firmwareUpdate, {
+    state: "NO UPDATE",
+    current_version: "v0.49.1",
+    latest_version: target,
+    value: target,
+  });
+}
+
+test("main to dev remains available regardless of semantic version ordering", () => {
+  for (const target of ["v0.49.1-dev.780+abcdef0", "v0.50.0-dev.1+abcdef0", "v0.48.0-dev.1+abcdef0"]) {
+    setMainToDevState(target);
+    assert.equal(isFirmwareChannelTransition(), true);
+    assert.equal(isFirmwareUpdateAvailable(), true);
+    assert.equal(getUpdateStatus(), "Beschikbaar");
+    assert.equal(getFirmwareUpdateVersions().latest, target);
+    assert.equal(hasInstalledFirmwareLatestVersion(), false);
+    assert.match(getFirmwareModalCopy(), /Dev-firmware kan de huidige main-firmware vervangen/);
+    const button = renderUpdateModal().match(/<button[^>]*data-oq-action="install-firmware-update"[^>]*>/)?.[0];
+    assert.ok(button);
+    assert.doesNotMatch(button, /disabled/);
+  }
+  assert.equal(compareFirmwareVersions("v0.49.1", "v0.49.1-dev.780"), 1);
+});
+
+test("channel transition requires the selected dev channel and a known dev target", () => {
+  for (const target of ["", "onbekend", "v0.49.1"]) {
+    setMainToDevState(target);
+    assert.equal(isFirmwareChannelTransition(), false);
+    assert.equal(isFirmwareUpdateAvailable(), false);
+  }
+  setMainToDevState();
+  state.entities.firmwareUpdateChannel = { state: "main" };
+  assert.equal(isFirmwareChannelTransition(), false);
+  assert.equal(isFirmwareUpdateAvailable(), false);
+
+  setMainToDevState();
+  delete state.entities.releaseChannelText;
+  assert.equal(isFirmwareChannelTransition(), false);
+  assert.equal(isFirmwareUpdateAvailable(), false);
+
+  setMainToDevState();
+  state.entities.projectVersionText = { state: "onbekend" };
+  assert.equal(isFirmwareChannelTransition(), false);
+});
+
+test("same-channel updates retain ordinary version ordering", () => {
+  setMainToDevState();
+  state.entities.projectVersionText = { state: "v0.49.1-dev.779" };
+  state.entities.releaseChannelText = { state: "dev" };
+  assert.equal(isFirmwareChannelTransition(), false);
+  assert.equal(isFirmwareUpdateAvailable(), true);
+
+  setMainToDevState("v0.49.1");
+  state.entities.firmwareUpdateChannel = { state: "main" };
+  state.entities.firmwareUpdate.release_url = "https://github.com/OpenQuatt/OpenQuatt/releases/tag/v0.49.1";
+  assert.equal(isFirmwareUpdateAvailable(), false);
+  assert.equal(getUpdateStatus(), "Actueel");
+  assert.equal(getFirmwareUpdateVersions().latest, "—");
+});
+
+test("channel-switch completion fails closed until the exact dev build and channel are reported", () => {
+  for (const setup of [setMainToDevState, setPrToDevState]) {
+    setup();
+    const target = state.entities.firmwareUpdate.latest_version;
+    state.updateInstallMode = "channel-switch";
+    state.updateInstallBusy = true;
+    state.updateInstallTargetVersion = target;
+    assert.equal(hasInstalledFirmwareTargetVersion(), false);
+    assert.equal(hasInstalledFirmwareLatestVersion(), false);
+    assert.equal(isFirmwareInstallSettled(), false);
+    assert.equal(isFirmwareInstallCompletionConfirmed(), false);
+
+    // New channel alone, stale/wrong version, or a different build hash is not success.
+    state.entities.releaseChannelText = { state: "dev" };
+    for (const version of ["onbekend", "v0.50.0", "v0.50.0-dev.999", target.replace(/\+.*$/, "+other")]) {
+      state.entities.projectVersionText = { state: version };
+      assert.equal(isFirmwareInstallCompletionConfirmed(), false);
+    }
+    state.entities.projectVersionText = { state: target };
+    for (const channel of ["main", "onbekend", ""]) {
+      state.entities.releaseChannelText = { state: channel };
+      assert.equal(isFirmwareInstallCompletionConfirmed(), false);
+    }
+    state.entities.releaseChannelText = { state: "dev" };
+    // Cached pre-reboot update entity must not override live build evidence.
+    assert.equal(isFirmwareInstallCompletionConfirmed(), true);
+    state.entities.firmwareUpdateStatus = { state: "Uploading" };
+    assert.equal(isFirmwareInstallCompletionConfirmed(), false);
+    delete state.entities.firmwareUpdateStatus;
+  }
+});
+
+test("channel-switch action captures its target and never completes on a failed request", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalLocation = window.location;
+  t.after(() => { globalThis.fetch = originalFetch; window.location = originalLocation; setRenderCallback(null); });
+  window.location = { pathname: "/" };
+  setMainToDevState();
+  const observed = [];
+  setRenderCallback(() => {});
+  globalThis.fetch = async () => {
+    observed.push([state.updateInstallMode, state.updateInstallTargetVersion]);
+    assert.equal(isFirmwareInstallCompletionConfirmed(), false);
+    return { ok: false, status: 503 };
+  };
+  await installFirmwareUpdate();
+  assert.deepEqual(observed, [["channel-switch", "v0.49.1-dev.780+abcdef0"]]);
+  assert.equal(state.updateInstallCompleted, false);
+  assert.equal(state.updateInstallBusy, false);
+  assert.match(state.controlError, /503/);
+});
+
+test("channel-switch aborts if target or channel changes while the target write is pending", async (t) => {
+  const originalFetch = globalThis.fetch;
+  const originalLocation = window.location;
+  t.after(() => { globalThis.fetch = originalFetch; window.location = originalLocation; setRenderCallback(null); });
+  window.location = { pathname: "/" };
+  setRenderCallback(() => {});
+  for (const change of [
+    () => { state.entities.firmwareUpdate.latest_version = "v0.49.1-dev.781+changed"; },
+    () => { state.entities.firmwareUpdateChannel = { state: "main" }; },
+  ]) {
+    setMainToDevState();
+    state.entities.firmwareUpdateTarget = { state: "current build" };
+    let requests = 0;
+    globalThis.fetch = async () => {
+      requests += 1;
+      change();
+      return { ok: true };
+    };
+    await installFirmwareUpdate();
+    assert.equal(requests, 1, "no install request after target/channel changes");
+    assert.equal(state.updateInstallCompleted, false);
+    assert.equal(state.updateInstallBusy, false);
+    assert.match(state.controlError, /dev-doelversie is gewijzigd/);
+  }
 });
 
 test("PR firmware starts with one complete render before the first device write", async (t) => {


### PR DESCRIPTION
# Wat verandert deze PR?

- Een expliciete main → dev-kanaalwissel blijft beschikbaar bij dezelfde of een lagere basisversie; de doelversie blijft zichtbaar en `Nu bijwerken` wordt beschikbaar. PR → dev gebruikt dezelfde overgangscontrole.
- Installaties in modus `channel-switch` worden pas bevestigd zodra het device het dev-kanaal en de exacte doelversie inclusief buildmetadata meldt. Een gewijzigde UI-doelversie of kanaal tijdens de target-write stopt de actie vóór het installrequest.
- Voeg regressietests en gebruikersuitleg toe; normale SemVer-vergelijking en de bestaande dev → main-downgradeflow blijven behouden.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting: uitsluitend browserlogica voor updatebeschikbaarheid en voltooiingsbevestiging; geen firmware-control-, entity-, configuratie- of persistentiewijzigingen.

## Achtergrond

Fixes #643.

Voorbeeld: draaiend `v0.49.1`, geselecteerd `dev`, doel `v0.49.1-dev.780+abcdef0`. De SemVer-volgorde blijft correct, maar bepaalt niet langer of deze expliciete overgang beschikbaar is of al voltooid is.

De complete diff tegen de actuele `dev` is beoordeeld op correctheid, beveiliging/privacy, entry paths, lifecycle/timing, foutafhandeling en compatibiliteit, gevolgd door een onafhankelijke koude adversariële review (Astra high). Geen blockers. Fresh install, upgrades en backup/restore vereisen geen migratie: er verandert geen opgeslagen schema. De bestaande firmware-installatieroute met `force_update: true` blijft intact.

Resterende beperking: de firmware haalt het manifest bij installatie opnieuw op. Als `dev-latest` intussen verschuift, kan een andere build worden geïnstalleerd; de web-app bevestigt die terecht niet als de oorspronkelijk gekozen doelbuild.

## Documentatie

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie: `docs/web-app.md` beschrijft de main → dev-overgang en de vereiste bevestiging.

## Validatie

- `npm run check:web`: geslaagd, 455 tests en kwaliteits-/bundelbudgetcontroles. Daarna één aanvullende interleavingtest toegevoegd; `node --test openquatt/web/tests/firmware-update.test.mjs`: alle 20 tests geslaagd.
- `npm run smoke:web`, `node openquatt/web/build-assets.mjs --check`, `npm run check:docs` en `git diff --check`: geslaagd.
- Regressies: main → gelijke/hogere/lagere dev, PR → dev, gewone dev-update, main actueel, bestaande downgrade, onbekende data, stale update-entity, verkeerd kanaal/hash/versie, actieve OTA, HTTP 503 en kanaal-/doelwijzigingen tijdens target-write.
- Chrome met lokale mock: preview desktop licht; productie-JS én -CSS desktop 1633×952 en mobiel 390×844, licht/donker. Doelversie, beschikbare knop, main actueel, expliciet main → dev kiezen, sluiten/heropenen en geavanceerde bediening gecontroleerd. Geen console-errors. In-app browser geblokkeerd door een lokale plugin-ondertekeningsfout; Chrome gebruikt als fallback. Geen Safari/iOS of echte OTA/HIL uitgevoerd.
- Productiebundels vergeleken met opnieuw gebouwde `dev`: JS raw 917621 → 918163 B (+542), gzip 262720 → 262847 B (+127); CSS raw 195013 B / gzip 38221 B ongewijzigd. Binnen relatief groeibudget. Geen gegenereerde bundles gecommit.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact: geen wijzigingen aan firmwareallocaties, interne heap, PSRAM of task-stacks. Alleen de hierboven vermelde webassetgroei; geen firmwarecompile nodig voor deze JS/docs-fix.