### PR TITLE
Bewaar abort- en assertdetails in crashrapporten

### DIFF
--- a/components/openquatt_crash_telemetry/OpenQuattAbortDetails.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattAbortDetails.cpp
@@ -1,0 +1,65 @@
+#include "OpenQuattAbortDetails.h"
+
+#include "esp_attr.h"
+#include "esp_system.h"
+#include "esp_memory_utils.h"
+#include "esphome/core/build_info_data.h"
+#include "esphome/core/log.h"
+#include "freertos/FreeRTOS.h"
+#include "soc/soc_caps.h"
+
+namespace {
+using esphome::openquatt_crash_telemetry::detail::AbortDetails;
+
+static volatile AbortDetails s_abort_details[SOC_CPU_CORES_NUM] __attribute__((section(".noinit")));
+// A core writes only its own slot. The latch rejects nested aborts on that
+// core without relying on atomics, which can take locks on some ESP32 targets.
+static volatile bool s_capture_started[SOC_CPU_CORES_NUM];
+static uint32_t s_build_time = static_cast<uint32_t>(esphome::ESPHOME_BUILD_TIME);
+static_assert(SOC_CPU_CORES_NUM <= 2, "Abort capture supports one or two cores");
+struct BootDetails {
+  AbortDetails records[SOC_CPU_CORES_NUM];
+  bool valid[SOC_CPU_CORES_NUM];
+
+  BootDetails() {
+    // C++ startup runs before normal component/task setup. This snapshot is
+    // immutable afterwards: another core can panic during report replay without
+    // racing the normal-runtime reader of the previous boot's text.
+    for (size_t core = 0; core < SOC_CPU_CORES_NUM; ++core) {
+      this->valid[core] = esphome::openquatt_crash_telemetry::detail::snapshot_abort_details(
+          s_abort_details[core], s_build_time, this->records[core]);
+    }
+  }
+};
+static const BootDetails s_boot_details;
+}  // namespace
+
+extern "C" void __attribute__((noreturn)) __real_panic_abort(const char* details);
+
+// Called by ESP-IDF's esp_system_abort, including __assert_func. Keep the
+// original panic handler and ESPHome's backtrace capture intact.
+extern "C" void IRAM_ATTR __attribute__((noreturn)) __wrap_panic_abort(const char* details) {
+  const uint32_t core = static_cast<uint32_t>(xPortGetCoreID());
+  if (core < SOC_CPU_CORES_NUM && !s_capture_started[core]) {
+    s_capture_started[core] = true;
+    esphome::openquatt_crash_telemetry::detail::capture_abort_details(
+        s_abort_details[core], details, s_build_time, core, [](uintptr_t address) __attribute__((always_inline)) {
+          return esp_ptr_in_dram(reinterpret_cast<const void*>(address));
+        });
+  }
+  __real_panic_abort(details);
+}
+
+namespace esphome::openquatt_crash_telemetry {
+void log_abort_details(uint8_t crashed_core) {
+  // Called only for an ESPHome Abort replay from this build. Core matching
+  // prevents attaching the other core's details if two aborts race.
+  if (crashed_core >= SOC_CPU_CORES_NUM || !s_boot_details.valid[crashed_core] || esp_reset_reason() != ESP_RST_PANIC ||
+      s_boot_details.records[crashed_core].core != crashed_core) {
+    return;
+  }
+  // Read only at normal runtime, after the panic-time writer has rebooted.
+  const auto& record = s_boot_details.records[crashed_core];
+  ESP_LOGE("esp32.crash", "  Abort details: %s%s", record.text, record.truncated != 0U ? " [truncated]" : "");
+}
+}  // namespace esphome::openquatt_crash_telemetry

--- a/components/openquatt_crash_telemetry/OpenQuattAbortDetails.h
+++ b/components/openquatt_crash_telemetry/OpenQuattAbortDetails.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace esphome::openquatt_crash_telemetry::detail {
+
+static constexpr uint32_t ABORT_DETAILS_MAGIC = 0x4F514144U;
+static constexpr uint32_t ABORT_DETAILS_VERSION = 1U;
+static constexpr size_t ABORT_DETAILS_CAPACITY = 256U;
+
+struct AbortReplayContext {
+  bool is_abort{false};
+  uint8_t core{0xFFU};
+
+  // Consume the ANSI-stripped, newline-terminated report lines, not logger
+  // messages that may still contain terminal color sequences.
+  void observe(const char* line) {
+    if (std::strcmp(line, "  Reason: Abort\n") == 0) is_abort = true;
+    if (std::strcmp(line, "  Crashed core: 0\n") == 0) core = 0U;
+    if (std::strcmp(line, "  Crashed core: 1\n") == 0) core = 1U;
+  }
+};
+
+// Separate from the ESPHome record and the persisted MQTT record. Only this
+// small panic-time buffer requires internal RAM; no PSRAM/flash access here.
+struct AbortDetails {
+  uint32_t magic;
+  uint32_t version;
+  uint32_t build_time;
+  uint32_t core;
+  uint32_t length;
+  uint32_t truncated;
+  char text[ABORT_DETAILS_CAPACITY];
+  uint32_t checksum;
+};
+static_assert(sizeof(AbortDetails) == 284U, "Keep the internal panic buffer budget explicit");
+
+// Inline these routines into the IRAM wrapper. Do not introduce libc calls,
+// allocation or flash-resident lookup tables in this path.
+__attribute__((always_inline)) inline uint32_t abort_details_checksum(const volatile AbortDetails& record) {
+  uint32_t hash = 2166136261U;
+  const auto* bytes = reinterpret_cast<const volatile uint8_t*>(&record);
+  for (size_t i = offsetof(AbortDetails, version); i < offsetof(AbortDetails, checksum); ++i) {
+    hash = (hash ^ bytes[i]) * 16777619U;
+  }
+  return hash;
+}
+
+template <typename Readable>
+__attribute__((always_inline)) inline void capture_abort_details(volatile AbortDetails& record, const char* text,
+                                                                 uint32_t build_time, uint32_t core,
+                                                                 Readable readable) {
+  record.magic = 0U;
+  record.version = ABORT_DETAILS_VERSION;
+  record.build_time = build_time;
+  record.core = core;
+  record.length = 0U;
+  record.truncated = 0U;
+  for (size_t i = 0; i < ABORT_DETAILS_CAPACITY; ++i) record.text[i] = '\0';
+  if (text == nullptr) return;
+  const uintptr_t start = reinterpret_cast<uintptr_t>(text);
+  for (size_t i = 0; i < ABORT_DETAILS_CAPACITY; ++i) {
+    // Validate every byte, including the final byte used to detect truncation.
+    // An unreadable source invalidates the entire detail instead of risking a
+    // second panic or attaching a misleading partial diagnostic.
+    if (start > UINTPTR_MAX - i || !readable(start + i)) return;
+    const char c = *reinterpret_cast<const volatile char*>(start + i);
+    if (c == '\0') break;
+    if (i == ABORT_DETAILS_CAPACITY - 1U) {
+      record.truncated = 1U;
+      break;
+    }
+    record.text[i] = c >= 0x20 && c <= 0x7E ? c : '?';
+    record.length = static_cast<uint32_t>(i + 1U);
+  }
+  if (record.length == 0U) return;
+  record.checksum = abort_details_checksum(record);
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+  record.magic = ABORT_DETAILS_MAGIC;  // Commit last; interrupted copies fail closed.
+}
+
+inline bool valid_abort_details(const volatile AbortDetails& record, uint32_t build_time) {
+  return record.magic == ABORT_DETAILS_MAGIC && record.version == ABORT_DETAILS_VERSION && build_time != 0U &&
+         record.build_time == build_time && record.core < 2U && record.length > 0U &&
+         record.length < ABORT_DETAILS_CAPACITY && record.truncated <= 1U && record.text[record.length] == '\0' &&
+         record.checksum == abort_details_checksum(record);
+}
+
+// Take ownership once at boot, before any new crash. Never carry a stale valid
+// marker through a later watchdog/fault/normal restart, even if setup fails.
+inline bool take_abort_details(volatile AbortDetails& record, uint32_t build_time) {
+  const bool valid = valid_abort_details(record, build_time);
+  record.magic = 0U;
+  return valid;
+}
+
+inline bool snapshot_abort_details(volatile AbortDetails& record, uint32_t build_time, AbortDetails& snapshot) {
+  const bool valid = take_abort_details(record, build_time);
+  if (valid) {
+    const auto* source = reinterpret_cast<const volatile uint8_t*>(&record);
+    auto* destination = reinterpret_cast<uint8_t*>(&snapshot);
+    for (size_t i = 0; i < sizeof(AbortDetails); ++i) destination[i] = source[i];
+  }
+  return valid;
+}
+
+}  // namespace esphome::openquatt_crash_telemetry::detail
+
+namespace esphome::openquatt_crash_telemetry {
+void log_abort_details(uint8_t crashed_core);
+}

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.cpp
@@ -1,4 +1,5 @@
 #include "OpenQuattCrashTelemetry.h"
+#include "OpenQuattAbortDetails.h"
 #include "OpenQuattCrashTelemetryAnsi.h"
 #include "OpenQuattCrashTelemetryHelpers.h"
 
@@ -328,7 +329,11 @@ void OpenQuattCrashTelemetry::capture_pending_crash_() {
   copy_text_(record->connection, sizeof(record->connection), this->connection_);
 
   this->capture_active_ = true;
+  this->capture_context_ = {};
   esp32::crash_handler_log();
+  if (this->capture_context_.is_abort && record->captured_by_reporting_build != 0U) {
+    log_abort_details(this->capture_context_.core);
+  }
   this->capture_active_ = false;
 
   if (record->report_length == 0U) {
@@ -361,6 +366,7 @@ void OpenQuattCrashTelemetry::on_log_(const char* tag, const char* message, size
     record->captured_by_reporting_build = 0U;
   }
 
+  const size_t line_start = record->report_length;
   detail::AnsiSequenceFilter ansi_filter;
   for (const char* cursor = body; *cursor != '\0'; ++cursor) {
     const unsigned char c = static_cast<unsigned char>(*cursor);
@@ -375,6 +381,7 @@ void OpenQuattCrashTelemetry::on_log_(const char* tag, const char* message, size
   if (record->report_length + 2U < CRASH_REPORT_CAPACITY) {
     record->report[record->report_length++] = '\n';
     record->report[record->report_length] = '\0';
+    this->capture_context_.observe(record->report + line_start);
   } else {
     record->truncated = 1U;
   }

--- a/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
+++ b/components/openquatt_crash_telemetry/OpenQuattCrashTelemetry.h
@@ -9,6 +9,7 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
+#include "OpenQuattAbortDetails.h"
 #include "OpenQuattCrashTelemetryPolicy.h"
 #include "OpenQuattCrashTelemetryRecord.h"
 #include "OpenQuattFlashLayout.h"
@@ -189,6 +190,7 @@ class OpenQuattCrashTelemetry : public Component {
   size_t payload_size_{0U};
 
   bool capture_active_{false};
+  detail::AbortReplayContext capture_context_{};
   std::atomic<bool> setup_complete_{false};
   std::atomic<bool> consent_enabled_{false};
   std::atomic<bool> time_synchronized_{false};

--- a/components/openquatt_crash_telemetry/__init__.py
+++ b/components/openquatt_crash_telemetry/__init__.py
@@ -102,6 +102,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    cg.add_build_flag("-Wl,--wrap=panic_abort")
     add_idf_sdkconfig_option("CONFIG_APP_RETRIEVE_LEN_ELF_SHA", 64)
     if CORE.is_esp32 and get_esp32_variant() == VARIANT_ESP32S3:
         psram.request_external_task_stack()

--- a/docs/crash-telemetry.md
+++ b/docs/crash-telemetry.md
@@ -30,6 +30,36 @@ van de firmware die het rapport verstuurt. Bij een gecombineerde WiFi- en
 Ethernetfirmware is `connection` de actuele verbinding (`wifi`, `eth` of `none`)
 en `connection_preference` de ingestelde voorkeur (`auto`, `wifi` of `eth`).
 
+Bij een abort/assert bevat het rapport ook `Abort details`, wanneer de tekst
+veilig beschikbaar was. Een assert is een interne controle die de firmware
+stopt wanneer een verwachte toestand niet klopt. De detailregel kan de functie,
+het bronbestand, de regel en de gefaalde controle bevatten. Dit helpt wanneer
+meerdere controles hetzelfde backtrace-adres delen; het bewijst niet vanzelf
+de onderliggende oorzaak.
+
+OpenQuatt bewaart daarvoor maximaal 255 tekens per core in vaste buffers in
+intern RAM die een softwareherstart overleven (284 bytes per core inclusief
+metadata; 568 bytes op de dual-core ESP32-S3). Iedere core schrijft zijn eigen
+buffer, zodat gelijktijdige aborts geen gedeelde schrijfbuffer nodig hebben.
+Bij de volgende boot wordt hiervan een onveranderlijke kopie gemaakt voor het
+rapport; een nieuwe crash kan de tekst van het vorige rapport zo niet wijzigen.
+Die kopie kost nogmaals 568 bytes op de ESP32-S3, plus enkele statusbytes.
+Langere teksten krijgen `[truncated]`;
+onleesbare, lege of niet bij deze build/core passende details worden weggelaten.
+Tijdens de abort worden alleen bytes uit intern DRAM gelezen, zonder
+geheugenallocatie, locks of flashschrijfacties. Tekst in flash of PSRAM wordt
+overgeslagen. Na de herstart loopt de detailregel mee in hetzelfde begrensde
+crashrecord, met dezelfde toestemming, publicatie- en retryregels. Er wordt
+geen gewone logbuffer meegestuurd; abortteksten kunnen wel door de betreffende
+software ingevulde technische waarden bevatten.
+
+Deze uitbreiding helpt alleen bij toekomstige aborts/asserts. Oude rapporten,
+een stroomonderbreking en crashes zonder beschikbare aborttekst krijgen geen
+extra detailregel. De firmware verwijdert de RAM-geldigheidsmarkering vroeg bij
+de volgende boot om details van een eerdere crash niet opnieuw te gebruiken.
+Bij falende flashopslag gevolgd door nog een herstart kan de detailregel daarom
+verloren gaan; het bestaande ESPHome-crashrecord houdt zijn eigen levenscyclus.
+
 De tijdvelden hebben bewust verschillende betekenissen:
 
 - `crash_timestamp` is de laatste geldige UTC Unix-tijd die vóór de reset in een

--- a/tests/host/openquatt_abort_details_test.cpp
+++ b/tests/host/openquatt_abort_details_test.cpp
@@ -1,0 +1,104 @@
+#include <cassert>
+#include <cstring>
+#include <string>
+
+#include "../../components/openquatt_crash_telemetry/OpenQuattAbortDetails.h"
+#include "../../components/openquatt_crash_telemetry/OpenQuattCrashTelemetryAnsi.h"
+
+using namespace esphome::openquatt_crash_telemetry::detail;
+
+int main() {
+  AbortReplayContext context{};
+  assert(!context.is_abort && context.core == 0xFFU);
+  context.observe("  Reason: Task watchdog\n");
+  assert(!context.is_abort);
+  context.observe("  Crashed core: 0\n");
+  assert(context.core == 0U);
+  context.observe("  Crashed core: 1\n");
+  assert(context.core == 1U);
+  std::string clean_line;
+  AnsiSequenceFilter filter;
+  for (char c : std::string("  Reason: Abort\033[0m")) {
+    if (!filter.should_skip(static_cast<uint8_t>(c))) clean_line += c;
+  }
+  clean_line += '\n';
+  context.observe(clean_line.c_str());
+  assert(context.is_abort);
+  context = {};
+  context.observe("  Reason: Abort");  // Incomplete replay line.
+  assert(!context.is_abort && context.core == 0xFFU);
+
+  AbortDetails record{};
+  constexpr uint32_t build = 123456U;
+  const auto readable = [](uintptr_t) { return true; };
+  const char* text = "assert failed: recv_tcp api_msg.c:322 (recv_tcp: recv for wrong pcb!)";
+  capture_abort_details(record, text, build, 1U, readable);
+  assert(valid_abort_details(record, build));
+  assert(std::strcmp(record.text, text) == 0);
+  assert(record.truncated == 0U);
+  assert(!valid_abort_details(record, build + 1U));
+  assert(!valid_abort_details(record, 0U));
+  auto corrupt = record;
+  corrupt.text[3] ^= 1;
+  assert(!valid_abort_details(corrupt, build));
+  corrupt = record;
+  corrupt.version++;
+  assert(!valid_abort_details(corrupt, build));
+  corrupt = record;
+  corrupt.length = UINT32_MAX;
+  assert(!valid_abort_details(corrupt, build));
+  corrupt = record;
+  corrupt.magic = 0U;  // Interrupted write, otherwise complete.
+  assert(!valid_abort_details(corrupt, build));
+  assert(take_abort_details(record, build));
+  assert(!take_abort_details(record, build));  // No stale details on later boots.
+
+  for (size_t size : {254U, 255U, 256U, 600U}) {
+    const std::string long_text(size, 'a');
+    capture_abort_details(record, long_text.c_str(), build, 0U, readable);
+    assert(valid_abort_details(record, build));
+    assert(record.length == (size < 256U ? size : 255U));
+    assert(record.truncated == (size >= 256U ? 1U : 0U));
+    assert(record.text[record.length] == '\0');
+  }
+
+  // Every partial read must fail closed, including a missing terminator byte.
+  for (size_t readable_bytes = 0; readable_bytes <= std::strlen(text); ++readable_bytes) {
+    capture_abort_details(record, text, build, 0U, [&](uintptr_t address) {
+      return address < reinterpret_cast<uintptr_t>(text) + readable_bytes;
+    });
+    assert(!valid_abort_details(record, build));
+  }
+  capture_abort_details(record, reinterpret_cast<const char*>(1U), build, 0U, [](uintptr_t) { return false; });
+  assert(!valid_abort_details(record, build));
+  capture_abort_details(record, nullptr, build, 0U, readable);
+  assert(!valid_abort_details(record, build));
+  capture_abort_details(record, "", build, 0U, readable);
+  assert(!valid_abort_details(record, build));
+  capture_abort_details(record, "test\n\033\t%%", build, 0U, readable);
+  assert(valid_abort_details(record, build));
+  assert(std::strcmp(record.text, "test???%%") == 0);
+  capture_abort_details(record, text, build, 2U, readable);
+  assert(!valid_abort_details(record, build));
+  capture_abort_details(record, text, 0U, 0U, readable);
+  assert(!valid_abort_details(record, build));
+
+  AbortDetails cores[2]{};
+  capture_abort_details(cores[0], "core zero", build, 0U, readable);
+  capture_abort_details(cores[1], "core one", build, 1U, readable);
+  assert(take_abort_details(cores[0], build));
+  assert(take_abort_details(cores[1], build));
+  assert(std::strcmp(cores[0].text, "core zero") == 0);
+  assert(std::strcmp(cores[1].text, "core one") == 0);
+  assert(cores[0].core == 0U && cores[1].core == 1U);
+
+  AbortDetails snapshot{};
+  capture_abort_details(record, "previous crash", build, 1U, readable);
+  assert(snapshot_abort_details(record, build, snapshot));
+  // New panic on the same core while normal runtime replays the old report.
+  capture_abort_details(record, "new crash", build, 1U, readable);
+  assert(std::strcmp(snapshot.text, "previous crash") == 0);
+  assert(valid_abort_details(record, build));
+  assert(take_abort_details(record, build));
+  assert(!snapshot_abort_details(record, build, snapshot));
+}


### PR DESCRIPTION
# Wat verandert deze PR?

- Bewaart bij een abort maximaal 255 tekens diagnostische tekst per core en voegt die na de herstart als `Abort details` toe aan het bestaande crashrapport. Hiermee zijn assertions te onderscheiden die hetzelfde backtrace-adres delen, zoals onderzocht in #631.
- Gebruikt een IRAM-hook op `panic_abort`, met begrensde DRAM-reads en aparte `.noinit`-slots per core. Geen lokale ESPHome-patch nodig; de oorspronkelijke panichandler blijft actief.
- Maakt bij boot een onveranderlijke kopie voor replay, valideert versie/checksum/buildtijd/core en verwijdert de RAM-geldigheidsmarkering. Nieuwe crashes kunnen het oude rapport niet overschrijven. MQTT-schema en flashrecordlayout blijven gelijk.

## Type

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting: uitsluitend de abort-/rapportageroute verandert; geen regeling of actuatoren aangepast. De vaste buffers gebruiken bewust intern RAM omdat PSRAM bij een panic niet veilig beschikbaar hoeft te zijn. Bestaande opt-in, PUBACK, persistence en retryregels blijven gelden. De normale rapportcapaciteit blijft begrensd.

## Achtergrond

Diagnostische uitbreiding, geen bewezen fix voor de oorspronkelijke TCP-crash. Lege of niet in intern DRAM leesbare tekst wordt overgeslagen; afkappen wordt gemarkeerd. Flash-/PSRAM-teksten, oude crashes en watchdogs zonder Abort-replay krijgen geen aanvullende tekst. Abortteksten kunnen technische runtimewaarden bevatten; gewone logs worden niet toegevoegd.

Na falende flashopslag en nog een reboot kan de aanvullende tekst verloren gaan: het vroeg verwijderen van de RAM-marker voorkomt dat oude details aan een latere crash worden gekoppeld. ESPHome behoudt zijn eigen bestaande crashrecordlevenscyclus.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie: `docs/crash-telemetry.md` beschrijft de aanvullende regel, grenzen, privacy, geheugenbudget en gedrag bij herstart/opslagfalen.

## Validatie

- `./scripts/run_host_regression_tests.sh`: alle 66 tests opnieuw geslaagd op de uiteindelijke PR-commit, inclusief de abortdetailtest.
- `npm run check:cpp-format`: geslaagd.
- `python3 -m unittest scripts.tests.test_internal_heap_contract scripts.tests.test_nvs_persistence_contract scripts.tests.test_openquatt_network_contract`: 25 tests geslaagd.
- `python3 scripts/check_docs_consistency.py`: geslaagd.
- `npm run build:web`: geslaagd, geen gewijzigde gegenereerde bundles.
- `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`: geslaagd met ESPHome 2026.8.2 / ESP-IDF 5.5.5.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml`: stopt op drie bestaande style-consistency-fouten in ongewijzigde `configs/hil/input_sources_fast_duo_wifi.yaml:26` en `openquatt/oq_common.yaml:723,840`. De rechtstreekse ESPHome-compile valideert en bouwt het target wel.
- Gelinkte Q Duo-ELF gecontroleerd: `esp_system_abort` roept `__wrap_panic_abort` aan. De wrapper staat in IRAM; objectcode/relocaties bevatten alleen interne data/literals en de aanroep naar de oorspronkelijke `panic_abort`, zonder libc-, malloc-, lock- of flashfuncties. Het extra stackframe is 32 bytes in deze build.

Afzonderlijke adversariële review van de volledige diff tegenover `dev`: panic-context, nested/concurrent aborts, immutable replay, ANSI-filtering, onderbroken kopieën, beschadigde/lange/onleesbare records, versies/buildtijd, fresh boot/upgrade, flashfalen en opt-in/retrygrenzen beoordeeld. De gevonden replay-race is opgelost met de bootsnapshot en een regressietest. Geen wijzigingen aan recordlayout, backup/restore of configuratie nodig.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Q Duo ELF-symbolen: 568 bytes `.noinit`-buffers, 572 bytes bootsnapshot inclusief flags/padding, 4 bytes buildtijdmirror en 2 bytes capture-latches; samen 1146 bytes statische data, exclusief eventuele linkerpadding en instance-layout. Wrapper: 283 bytes IRAM-code plus literals. Geen nieuwe dynamische allocaties of worker/task. Dit is een statische inventaris, geen gemeten baseline/candidate-heapmarge.

### Hardwaretest Q Duo WiFi

- Tijdelijke lokale testfirmware via OTA geïnstalleerd. Een tokenbeveiligd HTTP-verzoek activeerde een gecontroleerde assert; een ongeldig token werd geweigerd.
- Assert → softwareherstart → opgeslagen crashrecord → ontvangen MQTT-crashrapport end-to-end bevestigd. Het ontvangen rapport bevat `Abort details` met `OpenQuattHilAbortTest::loop()`, bronbestand/regel en `OpenQuatt controlled HTTP abort test`.
- Daarna de normale PR-firmware zonder testcomponent opnieuw gecompileerd en via OTA geïnstalleerd. De service-API reageert met HTTP 200 en status `IDLE`.
- De tijdelijke HTTP-crashroute en testconfiguratie maken geen deel uit van deze PR; de lokale testbronnen zijn opgeruimd.
- Afzonderlijke review van de volledige PR-diff vond geen concrete codebugs. C++-formatcontrole opnieuw geslaagd; alle 14 CI-checks geslaagd vóór merge.

### Openstaande validatie

Baseline/candidate-metingen van current/minimum internal heap, largest block/fragmentatie en task-stack-watermarks onder representatieve gelijktijdige netwerkbelasting zijn nog niet uitgevoerd. De geslaagde assert-test en statische geheugeninventaris bewijzen deze runtime-marges niet. Ontbrekende/te lange teksten zijn met hosttests afgedekt, niet als volledige hardwaretestmatrix. Deze beperkingen blijven open voor releasevalidatie; de merge naar `dev` is geen bewijs van afgeronde geheugenvalidatie.
