### PR TITLE
Voorkom meldingen en blokkades door R2121.b13

### DIFF
--- a/docs/instellingen-en-meetwaarden.md
+++ b/docs/instellingen-en-meetwaarden.md
@@ -136,6 +136,8 @@ Raak deze groep pas aan nadat de strategie zelf logisch voelt.
 
 Deze groep bepaalt hoe de circulatiepomp wordt aangestuurd.
 
+Het ODU-bit `R2121.b13` (`DC water pump failure`) is uitsluitend technische diagnostiek. Sommige pomp-/ODU-combinaties melden dit bit ook bij normale stilstand; de ODU-generatie identificeert het pomptype niet betrouwbaar. Daarom veroorzaakt dit bit op zichzelf geen storingsmelding, startblokkade, compressorstop, ketelfallback of herstelwachttijd. De bestaande flowbeveiliging en overige beveiligingen blijven gelden.
+
 Belangrijke instellingen:
 
 - `Flow Setpoint`

--- a/openquatt/includes/incidents/oq_hp_incident_catalog.h
+++ b/openquatt/includes/incidents/oq_hp_incident_catalog.h
@@ -44,6 +44,14 @@ constexpr IncidentDefinition make_limit(uint16_t register_address, uint8_t bit, 
           RecoveryCondition::AFTER_STABLE_READS};
 }
 
+constexpr IncidentDefinition make_diagnostic(uint16_t register_address, uint8_t bit, const char* key,
+                                             const char* presentation_key) {
+  IncidentDefinition definition = make_status(register_address, bit, key, presentation_key);
+  definition.effects = effect_mask(IncidentEffect::NONE);
+  definition.documentation_confidence = DocumentationConfidence::NAME_ONLY;
+  return definition;
+}
+
 constexpr IncidentDefinition make_start_block(uint16_t register_address, uint8_t bit, const char* key,
                                               const char* presentation_key) {
   return {incident_id(register_address, bit),
@@ -148,8 +156,10 @@ static constexpr std::array<IncidentDefinition, 41U> kHpIncidentCatalog{{
                     DocumentationConfidence::NAME_ONLY),
     make_hard_fault(2121U, 11U, "inner_coil_temperature_sensor", "hp.inner_coil_temperature_sensor_fault",
                     DocumentationConfidence::NAME_ONLY),
-    make_hard_fault(2121U, 13U, "dc_water_pump", "hp.dc_water_pump_fault", DocumentationConfidence::NAME_ONLY,
-                    effect_mask(IncidentEffect::PUMP_UNAVAILABLE)),
+    // Some ODU/pump combinations assert this bit during normal pump standby.
+    // The pump type cannot be inferred from the ODU generation. Keep the raw
+    // diagnostic, but never turn this bit alone into an alarm or control gate.
+    make_diagnostic(2121U, 13U, "dc_water_pump", "hp.dc_water_pump_fault"),
 }};
 
 inline const IncidentDefinition* catalog_definition(uint16_t register_address, uint8_t bit) {

--- a/openquatt/includes/incidents/oq_hp_incident_engine.h
+++ b/openquatt/includes/incidents/oq_hp_incident_engine.h
@@ -486,6 +486,13 @@ class HpIncidentEngine {
     }
     IncidentRuntime& runtime = incidents_[incident_slot(definition.register_address, definition.bit)];
 
+    if (definition.effects == effect_mask(IncidentEffect::NONE)) {
+      // Raw-only diagnostics must not confirm, latch, count, or start recovery.
+      runtime = {};
+      runtime.raw_active = raw_active;
+      return;
+    }
+
     if (raw_active) {
       if (!runtime.raw_active && !runtime.confirmed_active) {
         runtime.first_seen_ms = now_ms;

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -1492,6 +1492,7 @@ binary_sensor:
     internal: true
     lambda: |-
       // OT fault should only reflect explicit failure bits, not protection or cycle states.
+      // R2121.b13 is raw-only diagnostics: some pumps assert it in standby.
       auto has_bit = [](float raw, uint16_t bitmask) -> bool {
         return !isnan(raw) && ((static_cast<uint16_t>(lroundf(raw)) & bitmask) != 0);
       };
@@ -1526,8 +1527,7 @@ binary_sensor:
           has_bit(status_2121, 0x0200u) ||
           has_bit(status_2121, 0x0400u) ||
           has_bit(status_2121, 0x0800u) ||
-          has_bit(status_2121, 0x1000u) ||
-          has_bit(status_2121, 0x2000u);
+          has_bit(status_2121, 0x1000u);
 
   # ----------------------------
   # TEXT SENSOR
@@ -1691,7 +1691,7 @@ text_sensor:
       if (has_bit(status_2121, 0x0400u)) add("Outlet water temp sensor failure");
       if (has_bit(status_2121, 0x0800u)) add("Inner coil temp sensor failure");
       if (has_bit(status_2121, 0x1000u)) add("Reserved temp sensor failure");
-      if (has_bit(status_2121, 0x2000u)) add("DC water pump failure");
+      // R2121.b13 remains available in the raw register, not as a failure message.
 
       return std::string(used == 0 ? "None" : s);
 

--- a/openquatt/web/js/mock-incident-scenarios.js
+++ b/openquatt/web/js/mock-incident-scenarios.js
@@ -166,20 +166,6 @@
       registerAddress: 2120,
       bit: 4,
     }, runtimeOverrides),
-    dcWaterPump: (runtimeOverrides = {}) => incident({
-      id: 46,
-      key: "dc_water_pump",
-      presentationKey: "hp.dc_water_pump_fault",
-      category: "fault",
-      severity: "fault",
-      effects: ["display", "block_start", "stop_compressor", "mark_hp_unavailable", "pump_unavailable", "allow_cm4"],
-      effectMask: 125,
-      userAction: "contact_installer",
-      recoveryCondition: "stable_reads_and_recovery_window",
-      registerAddress: 2121,
-      bit: 13,
-      sourceDescription: "DC water pump failure",
-    }, runtimeOverrides),
     linkLoss: (runtimeOverrides = {}) => incident({
       id: 1001,
       key: "hp_link_loss",
@@ -743,16 +729,17 @@
       }),
     ]),
 
-    scenario("pump-ipwm-failure", "Waterpompstoring met iPWM-diagnose", "Incidentmodel", "single", [
-      phase("fault", "Pomp meldt failure", "ODU-code en actuele pompcontext maken de storing technisch diagnoseerbaar.", 0, {
-        heatPumps: [stoppedFaulted(1, 46, [INCIDENTS.dcWaterPump()], {
+    scenario("pump-standby-diagnostic", "Pompdiagnostiek zonder storingsmelding", "Incidentmodel", "single", [
+      phase("standby", "Pomp staat stil", "R2121.b13 veroorzaakt geen incident, startblokkade of herstelwachttijd.", 0, {
+        system: system({ control_mode: 0 }),
+        heatPumps: [heatPump(1, {
           pump_context: {
-            request_on: true,
-            relay_on: true,
+            request_on: false,
+            relay_on: false,
             flow_switch_on: false,
-            ipwm_feedback_raw: 950,
-            ipwm_status: "pump_off_failure",
-            pump_power_w: null,
+            ipwm_feedback_raw: 740,
+            ipwm_status: "running",
+            pump_power_w: 74,
             flow_lph: 0,
           },
         })],

--- a/openquatt/web/tests/mock-incident-scenarios.test.mjs
+++ b/openquatt/web/tests/mock-incident-scenarios.test.mjs
@@ -190,18 +190,20 @@ test("fault recovery matches the firmware-derived output without publishing a cl
   assert.equal(recovering.incidents.length, 0);
 });
 
-test("pump failure fixture carries ODU source metadata and coherent iPWM context", () => {
-  const pump = catalog.getScenario("pump-ipwm-failure").phases[0].heat_pumps[0];
-  const incident = pump.incidents[0];
-  assert.equal(incident.definition.id, 46);
-  assert.equal(incident.definition.register_address, 2121);
-  assert.equal(incident.definition.bit, 13);
-  assert.equal(incident.definition.source_description, "DC water pump failure");
-  assert.equal(pump.pump_context.ipwm_feedback_raw, 950);
-  assert.equal(pump.pump_context.ipwm_status, "pump_off_failure");
-  assert.equal(pump.pump_context.flow_switch_on, false);
+test("standby pump diagnostics do not publish an incident or control effects", () => {
+  const pump = catalog.getScenario("pump-standby-diagnostic").phases[0].heat_pumps[0];
+  assert.equal(pump.incidents.length, 0);
+  assert.equal(pump.primary_incident_id, 0);
+  assert.equal(pump.protection_state, "clear");
+  assert.equal(pump.available_for_start, true);
+  assert.equal(pump.must_stop, false);
+  assert.equal(pump.fault_active, false);
+  assert.equal(pump.fallback_cause_present, false);
+  assert.equal(pump.fallback_eligible, false);
+  assert.equal(pump.pump_context.ipwm_feedback_raw, 740);
+  assert.equal(pump.pump_context.request_on, false);
+  assert.equal(pump.pump_context.relay_on, false);
   assert.equal(pump.pump_context.flow_lph, 0);
-  assert.equal(pump.pump_context.pump_power_w, null);
 });
 
 test("stop confirmation block retains its confirmed fallback cause", () => {

--- a/scripts/tests/test_pump_ipwm_contract.py
+++ b/scripts/tests/test_pump_ipwm_contract.py
@@ -27,6 +27,15 @@ def yaml_block(source: str, start_marker: str, end_marker: str) -> str:
 
 
 class PumpIpwmContractTest(unittest.TestCase):
+    def test_b13_is_not_an_ot_fault_or_failure_message(self) -> None:
+        ot_fault = yaml_block(HP_IO, "id: ${hp_id}_ot_fault_active", "text_sensor:")
+        self.assertNotIn("has_bit(status_2121, 0x2000u)", ot_fault)
+        self.assertNotIn('add("DC water pump failure")', HP_IO)
+        # The raw word still reaches diagnostics and the engine unmodified.
+        self.assertIn("${hp_index}, 2121U, fault_word, now_ms", HP_IO)
+        self.assertIn("has_bit(status_2121, 0x1000u)", ot_fault)
+        self.assertIn("has_bit(status_2120, 0x2000u)", ot_fault)
+
     def test_r2137_is_preserved_raw_and_cic_passes_it_through(self) -> None:
         raw = yaml_block(
             HP_IO,

--- a/tests/host/oq_hp_incident_engine_test.cpp
+++ b/tests/host/oq_hp_incident_engine_test.cpp
@@ -64,14 +64,131 @@ void test_catalog_classification() {
   assert(lock.clear_policy == ClearPolicy::AFTER_CONFIRMED_ODU_POWER_CYCLE);
 
   const IncidentDefinition pump = definition_for(2121U, 13U);
-  assert(has_effect(pump.effects, IncidentEffect::PUMP_UNAVAILABLE));
-  assert(has_effect(pump.effects, IncidentEffect::ALLOW_CM4));
+  assert(pump.effects == effect_mask(IncidentEffect::NONE));
+  assert(pump.fallback_policy == FallbackPolicy::NEVER);
+  assert(pump.user_action == UserAction::NONE);
 
   const IncidentDefinition unknown = definition_for(2121U, 12U);
   assert(unknown.documentation_confidence == DocumentationConfidence::REVIEW_REQUIRED);
   assert(has_effect(unknown.effects, IncidentEffect::BLOCK_START));
   assert(!has_effect(unknown.effects, IncidentEffect::STOP_COMPRESSOR));
   assert(unknown.fallback_policy == FallbackPolicy::NEVER);
+}
+
+void test_pump_diagnostic_never_alarms_or_controls() {
+  for (const bool running : {false, true}) {
+    HpIncidentEngine engine;
+    // A bit already present at boot must not leave a fault or recovery latch.
+    engine.observe_fault_words(words(1U, 0U, 0U, 0x2000U));
+    engine.observe_fault_words(words(2U, 0U, 0U, 0x2000U));
+    establish_healthy_link(engine, 100U);
+    confirm_stopped(engine, 60101U);
+    if (running) {
+      assert(engine.request_start(80100U));
+      engine.observe_run(frequency(80101U, 20.0F));
+    }
+
+    uint32_t now_ms = 90000U;
+    for (const uint16_t raw : {0x2000U, 0x2000U, 0U, 0x2000U, 0U, 0U, 0U, 0x2000U}) {
+      engine.observe_fault_words(words(now_ms, 0U, 0U, raw));
+      // Missing/stale polls must neither promote nor clear diagnostic state.
+      engine.observe_fault_words(words(now_ms + 1U, 0U, 0U, 0U, false));
+      engine.tick(now_ms + 2U);
+      const IncidentRuntime& diagnostic = engine.incident(2121U, 13U);
+      assert(diagnostic.raw_active == (raw != 0U));
+      assert(!diagnostic.confirmed_active);
+      assert(!diagnostic.latched);
+      assert(diagnostic.occurrence_count == 0U);
+      const DerivedOutputs& output = engine.outputs();
+      assert(output.active_incident_count == 0U);
+      assert(output.primary_incident_id == kNoIncident);
+      assert(output.active_effects == effect_mask(IncidentEffect::NONE));
+      assert(!output.fault_active && !output.protection_active);
+      assert(output.protection_state == ProtectionState::CLEAR);
+      assert(!output.must_stop && !output.stop_confirmation_pending);
+      assert(output.available_for_start);
+      assert(!output.fallback_cause_present && !output.fallback_eligible);
+      assert(output.run_state == (running ? RunState::RUNNING : RunState::STOPPED));
+      now_ms += 10000U;
+    }
+    // No acknowledgement, clean-read streak, or recovery wait is needed.
+    assert(engine.request_start(now_ms));
+  }
+}
+
+void test_pump_diagnostic_cannot_trip_during_startup() {
+  HpIncidentEngine engine;
+  establish_healthy_link(engine, 100U);
+  confirm_stopped(engine, 60101U);
+  auto assert_diagnostic_only = [&](uint32_t now_ms, uint16_t raw) {
+    // R2121 can arrive before mode, relay, flow, or the other fault banks.
+    auto observation = words(now_ms, 0U, 0U, raw);
+    observation.fresh = {{false, false, true}};
+    engine.observe_fault_words(observation);
+    assert(engine.outputs().protection_state == ProtectionState::CLEAR);
+    assert(engine.outputs().active_incident_count == 0U);
+    assert(engine.outputs().active_effects == effect_mask(IncidentEffect::NONE));
+    assert(!engine.outputs().must_stop);
+    assert(!engine.outputs().stop_confirmation_pending);
+    assert(!engine.outputs().fallback_cause_present);
+    assert(engine.outputs().available_for_start);
+    assert(!engine.incident(2121U, 13U).confirmed_active);
+    assert(!engine.incident(2121U, 13U).latched);
+    assert(engine.incident(2121U, 13U).occurrence_count == 0U);
+  };
+  assert_diagnostic_only(80100U, 0x2000U);
+  assert_diagnostic_only(80101U, 0x2000U);
+  assert(engine.request_start(80102U));
+  assert(engine.outputs().run_state == RunState::START_REQUESTED);
+  assert_diagnostic_only(80103U, 0x2000U);
+  engine.observe_run(frequency(80104U, 0.0F, false));
+  assert(engine.outputs().run_state == RunState::WAIT_MODE);
+  assert_diagnostic_only(80105U, 0x2000U);
+  engine.observe_run(frequency(80106U, 0.0F));
+  assert(engine.outputs().run_state == RunState::WAIT_COMPRESSOR);
+  assert_diagnostic_only(80107U, 0U);
+  assert_diagnostic_only(80108U, 0x2000U);
+  engine.observe_run(frequency(80109U, 20.0F));
+  assert(engine.outputs().run_state == RunState::RUNNING);
+  assert_diagnostic_only(80110U, 0x2000U);
+  assert_diagnostic_only(80111U, 0U);
+  assert(engine.outputs().run_state == RunState::RUNNING);
+}
+
+void test_pump_diagnostic_does_not_mask_other_faults_or_extend_their_recovery() {
+  HpIncidentEngine engine;
+  establish_healthy_link(engine, 100U);
+  confirm_stopped(engine, 60101U);
+  // The other bit is deliberately in the same register as b13.
+  engine.observe_fault_words(words(80100U, 0U, 0U, 0x2001U));
+  engine.observe_fault_words(words(90100U, 0U, 0U, 0x2001U));
+  assert(engine.outputs().must_stop);
+  assert(!engine.outputs().available_for_start);
+  assert(engine.outputs().active_incident_count == 1U);
+  assert(engine.outputs().primary_incident_id == incident_id(2121U, 0U));
+  assert(engine.outputs().fallback_cause_present);
+  engine.request_stop(90101U);
+  confirm_stopped(engine, 90102U);
+  for (const uint32_t now_ms : {110100U, 120100U, 130100U}) {
+    engine.observe_fault_words(words(now_ms, 0U, 0U, 0x2000U));
+  }
+  assert(engine.outputs().protection_state == ProtectionState::FAULT_RECOVERY);
+  assert(!engine.outputs().available_for_start);
+  engine.observe_fault_words(words(160100U, 0U, 0U, 0x2000U));
+  engine.observe_fault_words(words(190100U, 0U, 0U, 0x2000U));
+  assert(engine.outputs().protection_state == ProtectionState::CLEAR);
+  assert(engine.outputs().available_for_start);
+  assert(!engine.outputs().fallback_cause_present);
+  assert(!engine.incident(2121U, 13U).latched);
+  assert(engine.incident(2121U, 0U).latched);
+
+  // Unclassified bits must still fail closed, even alongside b13.
+  engine.observe_fault_words(words(200100U, 0U, 0U, 0x3000U));
+  engine.observe_fault_words(words(210100U, 0U, 0U, 0x3000U));
+  assert(engine.outputs().protection_state == ProtectionState::START_BLOCKED);
+  assert(!engine.outputs().available_for_start);
+  assert(engine.outputs().active_incident_count == 1U);
+  assert(engine.outputs().primary_incident_id == incident_id(2121U, 12U));
 }
 
 void test_short_link_dip_and_confirmed_loss() {
@@ -650,6 +767,9 @@ void test_power_cycle_latch_requires_explicit_confirmation() {
 
 int main() {
   test_catalog_classification();
+  test_pump_diagnostic_never_alarms_or_controls();
+  test_pump_diagnostic_cannot_trip_during_startup();
+  test_pump_diagnostic_does_not_mask_other_faults_or_extend_their_recovery();
   test_short_link_dip_and_confirmed_loss();
   test_link_loss_invalidates_old_stop_confirmation();
   test_link_loss_rearms_an_inflight_stop();


### PR DESCRIPTION
# Wat verandert deze PR?

- Behandelt `R2121.b13` uitsluitend als ruwe pompdiagnostiek. Het bit veroorzaakt geen incidentkaart, fouttekst, OpenTherm-foutstatus, telling/retentie, startblokkade, compressorstop, ketelfallback of herstelwachttijd.
- Sluit ook kortstondige triggers tijdens pomp-/compressorstart uit: de uitsluiting geldt bij iedere registerverwerking, onafhankelijk van mode-, relais- of flowfeedback.
- Past documentatie en het standby-mockscenario aan; andere storingsbits en bestaande flowbeveiligingen behouden hun beleid.

## Type

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [x] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting: de bestaande failure-tekst en OT-foutstatus negeren alleen b13. Geen nieuwe instelling, pomptypeherkenning of wijziging aan Modbus-adressen. Het ruwe register en de interne raw-status blijven behouden.

## Achtergrond

Sommige pomp-/ODU-combinaties zetten b13 bij normale stilstand en laten het bij circulatie verdwijnen. De ODU-generatie identificeert de pomp niet betrouwbaar. Een zelfstandige hard-faultclassificatie van dit bit kan daarom onterechte meldingen en regelinterventies veroorzaken.

Volledige diff tegen `dev` gereviewd, gevolgd door een afzonderlijke koude adversariële review door een Astra-high specialist. Gecontroleerd: engine, incident-API, decision-log, OT/failure-list, opstartinterleavings, ontbrekende/stale registerbanken, overige/ongeclassificeerde storingsbits, herstel, reboot/upgrade en persistente restore. B13 wordt niet persistent hersteld; de bestaande powercycle-latch blijft intact. Geen nieuwe state, opslag, allocaties of asynchrone eigenaarschapspaden.

**Concept / hardwarevalidatie nog open:** daadwerkelijke pompuitval tijdens actief ontdooien en Duo met één uitgevallen pomp moet nog via HIL worden beoordeeld, inclusief wegvallende/stale flow. De bestaande lowflow-beveiliging is geen identieke vervanger van de verwijderde b13-hard-fault: tijdens actief ontdooien wordt lowflow-standby bewust onderdrukt en Duo gebruikt geselecteerde systeemflow. Deze PR wijzigt die guards niet. Niet gemerged of op hardware uitgerold.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie: `docs/instellingen-en-meetwaarden.md` beschrijft dat b13 op zichzelf geen melding of regelinterventie veroorzaakt.

## Validatie

- `bash scripts/run_host_regression_tests.sh`: 65 hosttestbinaries geslaagd; macOS SDK-headerpad expliciet ingesteld voor de lokale compiler.
- Extra startup-regressie daarna afzonderlijk gebouwd en geslaagd: verse R2121-only reads vóór start, `START_REQUESTED`, `WAIT_MODE`, `WAIT_COMPRESSOR`, `RUNNING`; b13 blijft aan of wisselt zonder incident, stop, blokkade of herstelstatus.
- `python3 -m unittest scripts.tests.test_pump_ipwm_contract scripts.tests.test_supervisory_safety_contract`: 9 tests geslaagd.
- `npm run check:cpp-format`, `npm run check:docs`, `npm run check:web` (456 tests), `npm run smoke:web`, `node openquatt/web/build-assets.mjs --check`: geslaagd.
- `esphome config configs/heatpump_controller_q/duo_wifi.yaml` met ESPHome 2026.8.2 en `python3 scripts/check_nvs_budget.py configs/heatpump_controller_q/duo_wifi.yaml` binnen die omgeving: geslaagd; bestaande GPIO45-strappingwaarschuwing.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` stopt eerder op bestaande style-fouten in `configs/hil/input_sources_fast_duo_wifi.yaml:26` en `openquatt/oq_common.yaml:723,840`. Deze bestanden en de checker zijn identiek aan de doelbranch; daarom de configuratie en het NVS-budget afzonderlijk gecontroleerd.
- Chrome desktop: standby-scenario met preview- en productie-JS/CSS toont CM0, 0 L/h, Stand-by en Systeem Normaal. In-app browser kon niet starten door een lokale plugin-signatuurfout. Geen layoutwijziging; mobiel/Safari niet getest.
- Geen productie-JS/CSS-bronnen gewijzigd; absolute bundelbudgetten slagen, geen afzonderlijke basisbundelmeting uitgevoerd. Geen gegenereerde bundles gecommit.
- Geen firmwarecompile, OTA of HIL uitgevoerd.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact: bestaande vaste incidentopslag behouden; geen nieuwe buffers, heapallocaties, taken of gewijzigde PSRAM-plaatsing.
