### PR TITLE
Voeg Home Assistant-documentatie toe aan dashboardpagina

### DIFF
--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -1,21 +1,20 @@
-# OpenQuatt voor Home Assistant
+# OpenQuatt in Home Assistant
 
-De Home Assistant-dashboards, optionele packages en bijbehorende handleidingen
-hebben een eigen releasecyclus. De primaire bron staat in de publieke companion-
-repository:
+Gebruik Home Assistant om OpenQuatt te volgen, het dashboard aan je opstelling aan te passen en optionele dynamische bronnen te koppelen.
 
-**[OpenQuatt/home-assistant-openquatt](https://github.com/OpenQuatt/home-assistant-openquatt)**
+## Begin hier
 
-Daar vind je:
+1. [Installeer het dashboard](installation.md). Kies daarna het juiste Single- of Duo-bestand.
+2. [Gebruik het dashboard](dashboard.md). Hier staat de dagelijkse route en waar je bij afwijkend gedrag eerst kijkt.
+3. Voeg alleen wanneer nodig [dynamische bronnen](dynamic-sources.md) of [dynamische koelbronnen](cooling.md) toe.
 
-- de actuele Single- en Duo-dashboards in het Nederlands en Engels;
-- de packages voor dynamische bronselectie en dynamische koelbronnen;
-- installatie-, gebruiks- en compatibiliteitsinformatie.
+## Kies je dashboard
 
-OpenQuatt zelf blijft via de ESPHome-integratie het entity/API-contract aan Home
-Assistant aanbieden. Firmware, ESPHome-configuratie en dat contract blijven in
-deze repository.
+Kies een dashboard dat past bij je opstelling en taal:
 
-Gebruik geen oude dashboard- of packagekopie uit de geschiedenis van deze
-repository: de companion-repository is vanaf de migratie voor issue
-[#424](https://github.com/OpenQuatt/OpenQuatt/issues/424) leidend.
+- [Single · Nederlands](https://github.com/OpenQuatt/home-assistant-openquatt/blob/main/dashboards/single-nl.yaml)
+- [Single · Engels](https://github.com/OpenQuatt/home-assistant-openquatt/blob/main/dashboards/single-en.yaml)
+- [Duo · Nederlands](https://github.com/OpenQuatt/home-assistant-openquatt/blob/main/dashboards/duo-nl.yaml)
+- [Duo · Engels](https://github.com/OpenQuatt/home-assistant-openquatt/blob/main/dashboards/duo-en.yaml)
+
+De dashboardbestanden en Home Assistant-packages hebben een eigen releasecyclus. De actuele bron staat in [OpenQuatt/home-assistant-openquatt](https://github.com/OpenQuatt/home-assistant-openquatt). Deze pagina helpt je kiezen en gebruiken; haal YAML en packages altijd uit die repository.

--- a/docs/dashboardoverzicht.md
+++ b/docs/dashboardoverzicht.md
@@ -1,9 +1,5 @@
 # Dashboard gebruiken
 
-De actuele dashboardhandleiding staat in de Home Assistant companion-repository:
+De dashboardhandleiding staat nu op [Dashboard gebruiken](dashboard/dashboard.md).
 
-**[Dashboard gebruiken in OpenQuatt Home Assistant](https://github.com/OpenQuatt/home-assistant-openquatt/blob/main/docs/dashboard.md)**
-
-De companion-repository is de primaire bron voor dashboards, Home Assistant-
-packages en de bijbehorende installatie- en gebruiksdocumentatie. Deze pagina
-blijft als korte doorverwijzing bestaan zodat bestaande links bruikbaar blijven.
+Deze oude link blijft beschikbaar voor bestaande bladwijzers. De dashboardbestanden en Home Assistant-packages staan in [OpenQuatt/home-assistant-openquatt](https://github.com/OpenQuatt/home-assistant-openquatt).

--- a/scripts/build_pages_docs.py
+++ b/scripts/build_pages_docs.py
@@ -9,10 +9,14 @@ import unicodedata
 import posixpath
 import re
 import sys
+from urllib.error import URLError
+from urllib.request import urlopen
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 GITHUB_REPO_URL = "https://github.com/OpenQuatt/OpenQuatt"
+COMPANION_REPO_URL = "https://github.com/OpenQuatt/home-assistant-openquatt"
+COMPANION_RAW_URL = "https://raw.githubusercontent.com/OpenQuatt/home-assistant-openquatt/main"
 SEARCH_ICON_HTML = (
     '<svg class="search-icon-svg" viewBox="0 0 24 24" focusable="false" aria-hidden="true">'
     '<circle cx="10.5" cy="10.5" r="6.5"></circle>'
@@ -28,6 +32,7 @@ class Page:
     label: str
     kind: str
     summary: str
+    remote_source: PurePosixPath | None = None
 
 
 @dataclass(frozen=True)
@@ -44,8 +49,12 @@ PAGES = [
     Page(PurePosixPath("docs/q-edition.md"), PurePosixPath("q-edition.html"), "Heatpump Controller Q-edition aansluiten", "Aan de slag", "Doorlopende route voor aansluiten, netwerk instellen en Quick Start."),
     Page(PurePosixPath("docs/installatie-en-ingebruikname.md"), PurePosixPath("installatie-en-ingebruikname.html"), "Andere modules installeren", "Andere hardware", "Een bestaande Waveshare- of Heatpump Listener-module installeren via de web installer."),
     Page(PurePosixPath("docs/web-app.md"), PurePosixPath("web-app.html"), "Web-app gebruiken", "Handleiding", "Quick Start, instellingen, updates, backup en beveiliging via openquatt.local."),
-    Page(PurePosixPath("docs/dashboard/README.md"), PurePosixPath("dashboard/index.html"), "OpenQuatt Home Assistant", "Doorverwijzing", "Dashboards, packages en handleidingen staan in de Home Assistant companion-repository."),
-    Page(PurePosixPath("docs/dashboardoverzicht.md"), PurePosixPath("dashboardoverzicht.html"), "Dashboard gebruiken", "Doorverwijzing", "Actuele dashboardhandleiding in de Home Assistant companion-repository."),
+    Page(PurePosixPath("docs/dashboard/README.md"), PurePosixPath("dashboard/index.html"), "OpenQuatt in Home Assistant", "Home Assistant", "Dashboards, packages en handleidingen voor OpenQuatt in Home Assistant."),
+    Page(PurePosixPath("docs/dashboard/installation.md"), PurePosixPath("dashboard/installeren.html"), "Dashboard installeren", "Home Assistant", "OpenQuatt toevoegen, kaarten installeren en het juiste dashboard importeren.", PurePosixPath("docs/installation.md")),
+    Page(PurePosixPath("docs/dashboard/dashboard.md"), PurePosixPath("dashboard/gebruiken.html"), "Dashboard gebruiken", "Home Assistant", "Een rustige dagelijkse route door het OpenQuatt-dashboard.", PurePosixPath("docs/dashboard.md")),
+    Page(PurePosixPath("docs/dashboard/dynamic-sources.md"), PurePosixPath("dashboard/dynamische-bronnen.html"), "Dynamische bronnen", "Home Assistant", "Home Assistant-bronnen tijdens runtime koppelen aan OpenQuatt.", PurePosixPath("docs/dynamic-sources.md")),
+    Page(PurePosixPath("docs/dashboard/cooling.md"), PurePosixPath("dashboard/koeling.html"), "Dynamische koelbronnen", "Home Assistant", "Dauwpuntbronnen uit Home Assistant gebruiken voor veilige koeling.", PurePosixPath("docs/cooling.md")),
+    Page(PurePosixPath("docs/dashboardoverzicht.md"), PurePosixPath("dashboardoverzicht.html"), "Dashboard gebruiken", "Doorverwijzing", "Actuele dashboardhandleiding voor OpenQuatt in Home Assistant."),
     Page(PurePosixPath("docs/homey.md"), PurePosixPath("homey.html"), "OpenQuatt in Homey", "Handleiding", "Homey Pro koppelen, meekijken, automatiseren en OpenQuatt voeden met je eigen sensoren."),
     Page(PurePosixPath("docs/verwarmen-en-koelen.md"), PurePosixPath("verwarmen-en-koelen.html"), "Verwarmen en koelen uitgelegd", "Uitleg", "Heldere uitleg van Power House, stooklijnregeling, koeling, Single en Duo."),
     Page(PurePosixPath("docs/mqtt.md"), PurePosixPath("mqtt.html"), "MQTT inputbronnen", "Docs", "Beperkte MQTT inputbronnen voor externe meetwaarden zoals koelingsdauwpunt."),
@@ -84,7 +93,10 @@ SIDEBAR_GROUPS = [
         "Dashboards toevoegen nadat OpenQuatt lokaal werkt.",
         [
             PurePosixPath("docs/dashboard/README.md"),
-            PurePosixPath("docs/dashboardoverzicht.md"),
+            PurePosixPath("docs/dashboard/installation.md"),
+            PurePosixPath("docs/dashboard/dashboard.md"),
+            PurePosixPath("docs/dashboard/dynamic-sources.md"),
+            PurePosixPath("docs/dashboard/cooling.md"),
         ],
     ),
     (
@@ -431,7 +443,21 @@ class MarkdownRenderer:
 
 
 def github_source_url(page: Page) -> str:
+    if page.remote_source:
+        return f"{COMPANION_REPO_URL}/blob/main/{page.remote_source.as_posix()}"
     return f"{GITHUB_REPO_URL}/blob/main/{page.source.as_posix()}"
+
+
+def read_page_source(page: Page) -> str:
+    if not page.remote_source:
+        return (REPO_ROOT / page.source).read_text(encoding="utf-8")
+
+    source_url = f"{COMPANION_RAW_URL}/{page.remote_source.as_posix()}"
+    try:
+        with urlopen(source_url, timeout=20) as response:
+            return response.read().decode("utf-8")
+    except (OSError, URLError, UnicodeDecodeError) as error:
+        raise RuntimeError(f"Kan companion-documentatie niet ophalen: {source_url}") from error
 
 
 def build_sidebar(current_page: Page) -> str:
@@ -511,6 +537,13 @@ def render_template(rendered_page: RenderedPage, rendered_pages: list[RenderedPa
           <div class="doc-actions" aria-label="Snel starten">
             <a class="doc-action doc-action-primary" href="#kies-je-route">Kies je route</a>
             <a class="doc-action" href="{q_edition_href}">Nieuwe HCQ aansluiten</a>
+          </div>
+        """
+    elif page.source == PurePosixPath("docs/dashboard/README.md"):
+        doc_actions = f"""
+          <div class="doc-actions" aria-label="Home Assistant starten">
+            <a class="doc-action doc-action-primary" href="{rel_url(page.output, PurePosixPath('dashboard/installeren.html'))}">Dashboard installeren</a>
+            <a class="doc-action" href="{rel_url(page.output, PurePosixPath('dashboard/gebruiken.html'))}">Dashboard gebruiken</a>
           </div>
         """
 
@@ -620,7 +653,7 @@ def build_site(site_dir: Path) -> None:
     rendered_pages: list[RenderedPage] = []
     for page in PAGES:
         renderer = MarkdownRenderer(page.source, page.output)
-        text = (REPO_ROOT / page.source).read_text(encoding="utf-8")
+        text = read_page_source(page)
         lead, body = renderer.render(text)
         search_text = " ".join(
             strip_markdown(line)


### PR DESCRIPTION
# Wat verandert deze PR?

- Vervangt de kale Home Assistant-doorverwijzing door een lokale documentatiesectie met installatie, dashboardgebruik, dynamische bronnen en koeling.
- Haalt die vier Markdown-handleidingen tijdens de Pages-build rechtstreeks op uit `OpenQuatt/home-assistant-openquatt`; de inhoud staat dus niet dubbel in deze repository.
- Verwijdert de prominente verwijzing naar issue #424 en houdt actuele YAML- en packagebestanden gekoppeld aan de companion-repository.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De GitHub Pages-documentatie krijgt nieuwe statische pagina's. Firmware, entiteiten en de OpenQuatt-runtime veranderen niet.

## Achtergrond

De Pages-build downloadt vier vaste Markdown-paden vanaf de publieke `main`-branch van de companion-repository. Bij een downloadfout stopt de build met de exacte bron-URL. De companion-repository blijft hierdoor de enige tekstbron; actuele YAML en packages blijven daar ook gelinkt.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De publieke Home Assistant-startpagina verwijst nu naar lokale installatie- en gebruiksinformatie, gegenereerd vanuit de companion-documentatie.

## Validatie

- [x] `npm run check:docs`
- [x] `python3 scripts/dev.py preview-pages --no-serve`
- [x] Lokale HTTP-preview op de actuele `dev`-basis: dashboard- en gebruikspagina geven HTTP 200.
- [x] `git diff --check origin/dev...HEAD`

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; uitsluitend documentatie en statische paginaregistratie.

## Audit

Volledige diff tegen `origin/dev` gecontroleerd op gegenereerde paginapaden, interne linkherschrijving, bestaande bladwijzers, foutafhandeling bij bronophaling, externe YAML/packageverwijzingen en onbedoelde firmware- of runtimewijzigingen. Geen bevindingen.