### PR TITLE
Add raw Modbus UART capture test firmware

### DIFF
--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -5,10 +5,11 @@
 # be correlated with ESPHome's Modbus parser warnings. Also hooks the ESP-IDF UART
 # select callback to count parity/frame errors that ESPHome normally does not log.
 #
-# The active heat-pump UART RX pin gets an internal pull-up. The diagnostic build
-# also moves DE/RE control out of ESP-IDF UART_MODE_RS485_HALF_DUPLEX and into the
-# ESPHome Modbus component. This isolates the ESP-IDF RTS turnaround path while
-# keeping the same physical M1 port, baud rate, framing and OpenQuatt polling.
+# The active heat-pump UART RX pin gets an internal pull-up. This test variant
+# keeps the normal ESP-IDF UART_MODE_RS485_HALF_DUPLEX direction control and sets
+# UART_ERR_WR_MASK so characters that fail parity/framing are discarded before
+# entering the RX FIFO. The error probe remains active to verify whether hardware
+# parity events still occur even when the corrupt byte no longer reaches Modbus.
 #
 # Intentionally avoids UARTDebug::log_hex(), which adds a 10 ms delay after every
 # emitted log line and could influence the timing being investigated.
@@ -20,14 +21,15 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          oq_modbus_uart_diag::install(id(uart_bus).get_hw_serial_number());
+          const uint8_t uart_num = id(uart_bus).get_hw_serial_number();
+          oq_modbus_uart_diag::set_discard_bad_bytes(uart_num, true);
+          oq_modbus_uart_diag::install(uart_num);
 
 logger:
   initial_level: DEBUG
 
 uart:
   - id: !extend uart_bus
-    flow_control_pin: !remove
     rx_pin:
       number: ${uart_rx_pin}
       mode:
@@ -58,10 +60,6 @@ uart:
               static_cast<unsigned>(bytes.size()),
               hex_buf
             );
-
-modbus:
-  - id: !extend mod_bus
-    flow_control_pin: ${uart_rts_pin}
 
 interval:
   - interval: 1s

--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -7,9 +7,10 @@
 #
 # The active heat-pump UART RX pin gets an internal pull-up. This test variant
 # keeps the normal ESP-IDF UART_MODE_RS485_HALF_DUPLEX direction control and sets
-# UART_ERR_WR_MASK so characters that fail parity/framing are discarded before
-# entering the RX FIFO. The error probe remains active to verify whether hardware
-# parity events still occur even when the corrupt byte no longer reaches Modbus.
+# UART_ERR_WR_MASK on every hardware UART so characters that fail parity/framing
+# should be discarded before entering an RX FIFO. The error probe remains active
+# on the actual Modbus UART to verify whether hardware parity events still occur
+# even when the corrupt byte should no longer reach Modbus.
 #
 # Intentionally avoids UARTDebug::log_hex(), which adds a 10 ms delay after every
 # emitted log line and could influence the timing being investigated.
@@ -21,13 +22,19 @@ esphome:
     priority: 600
     then:
       - lambda: |-
-          const uint8_t uart_num = id(uart_bus).get_hw_serial_number();
-          oq_modbus_uart_diag::set_discard_bad_bytes(uart_num, true);
-          oq_modbus_uart_diag::install(uart_num);
+          // Diagnostic only: set the hardware discard bit on every UART to rule
+          // out an unexpected peripheral/driver mapping. Keep the error callback
+          // attached only to the UART ESPHome actually assigned to Modbus.
+          for (uint8_t uart_num = 0; uart_num < UART_NUM_MAX; uart_num++) {
+            oq_modbus_uart_diag::set_discard_bad_bytes(uart_num, true);
+          }
+          oq_modbus_uart_diag::install(id(uart_bus).get_hw_serial_number());
       - delay: 1s
       - lambda: |-
-          // Read only: prove whether later startup activity changed the filter state.
-          oq_modbus_uart_diag::report_startup_filter_state(id(uart_bus).get_hw_serial_number());
+          // Read only: prove whether later startup activity changed any filter state.
+          for (uint8_t uart_num = 0; uart_num < UART_NUM_MAX; uart_num++) {
+            oq_modbus_uart_diag::report_startup_filter_state(uart_num);
+          }
 
 logger:
   initial_level: DEBUG

--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -5,9 +5,10 @@
 # be correlated with ESPHome's Modbus parser warnings. Also hooks the ESP-IDF UART
 # select callback to count parity/frame errors that ESPHome normally does not log.
 #
-# The active heat-pump UART RX pin also gets an internal pull-up. This tests the
-# hypothesis that the RS485 receiver output briefly floats during DE/RE turnaround,
-# creating the observed stray 0xFF + parity error before an otherwise valid frame.
+# The active heat-pump UART RX pin gets an internal pull-up. The diagnostic build
+# also moves DE/RE control out of ESP-IDF UART_MODE_RS485_HALF_DUPLEX and into the
+# ESPHome Modbus component. This isolates the ESP-IDF RTS turnaround path while
+# keeping the same physical M1 port, baud rate, framing and OpenQuatt polling.
 #
 # Intentionally avoids UARTDebug::log_hex(), which adds a 10 ms delay after every
 # emitted log line and could influence the timing being investigated.
@@ -26,6 +27,7 @@ logger:
 
 uart:
   - id: !extend uart_bus
+    flow_control_pin: !remove
     rx_pin:
       number: ${uart_rx_pin}
       mode:
@@ -56,6 +58,10 @@ uart:
               static_cast<unsigned>(bytes.size()),
               hex_buf
             );
+
+modbus:
+  - id: !extend mod_bus
+    flow_control_pin: ${uart_rts_pin}
 
 interval:
   - interval: 1s

--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -1,9 +1,21 @@
 # ==============================================================================
-# Temporary diagnostic package: raw Modbus UART capture
+# Temporary diagnostic package: raw Modbus UART capture + UART error flags
 # ==============================================================================
 # Captures TX and RX as hex after 4 ms of silence so malformed/partial frames can
-# be correlated with ESPHome's Modbus parser warnings. Intentionally avoids
-# UARTDebug::log_hex(), which adds a 10 ms delay after every emitted log line.
+# be correlated with ESPHome's Modbus parser warnings. Also hooks the ESP-IDF UART
+# select callback to count parity/frame errors that ESPHome normally does not log.
+#
+# Intentionally avoids UARTDebug::log_hex(), which adds a 10 ms delay after every
+# emitted log line and could influence the timing being investigated.
+
+esphome:
+  includes:
+    - modbus_uart_error_probe.h
+  on_boot:
+    priority: 600
+    then:
+      - lambda: |-
+          oq_modbus_uart_diag::install(id(uart_bus).get_hw_serial_number());
 
 logger:
   initial_level: DEBUG
@@ -17,6 +29,9 @@ uart:
         timeout: 4ms
       sequence:
         - lambda: |-
+            // Report a parity/frame error immediately next to the raw capture when possible.
+            oq_modbus_uart_diag::report_if_changed();
+
             char hex_buf[512];
             esphome::format_hex_pretty_to(
               hex_buf,
@@ -32,3 +47,10 @@ uart:
               static_cast<unsigned>(bytes.size()),
               hex_buf
             );
+
+interval:
+  - interval: 1s
+    then:
+      - lambda: |-
+          // Fallback report if an error occurs without a UART debug trigger immediately after it.
+          oq_modbus_uart_diag::report_if_changed();

--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -5,6 +5,10 @@
 # be correlated with ESPHome's Modbus parser warnings. Also hooks the ESP-IDF UART
 # select callback to count parity/frame errors that ESPHome normally does not log.
 #
+# The active heat-pump UART RX pin also gets an internal pull-up. This tests the
+# hypothesis that the RS485 receiver output briefly floats during DE/RE turnaround,
+# creating the observed stray 0xFF + parity error before an otherwise valid frame.
+#
 # Intentionally avoids UARTDebug::log_hex(), which adds a 10 ms delay after every
 # emitted log line and could influence the timing being investigated.
 
@@ -22,6 +26,11 @@ logger:
 
 uart:
   - id: !extend uart_bus
+    rx_pin:
+      number: ${uart_rx_pin}
+      mode:
+        input: true
+        pullup: true
     debug:
       direction: BOTH
       dummy_receiver: false

--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -24,6 +24,10 @@ esphome:
           const uint8_t uart_num = id(uart_bus).get_hw_serial_number();
           oq_modbus_uart_diag::set_discard_bad_bytes(uart_num, true);
           oq_modbus_uart_diag::install(uart_num);
+      - delay: 1s
+      - lambda: |-
+          // Read only: prove whether later startup activity changed the filter state.
+          oq_modbus_uart_diag::report_startup_filter_state(id(uart_bus).get_hw_serial_number());
 
 logger:
   initial_level: DEBUG

--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -1,0 +1,34 @@
+# ==============================================================================
+# Temporary diagnostic package: raw Modbus UART capture
+# ==============================================================================
+# Captures TX and RX as hex after 4 ms of silence so malformed/partial frames can
+# be correlated with ESPHome's Modbus parser warnings. Intentionally avoids
+# UARTDebug::log_hex(), which adds a 10 ms delay after every emitted log line.
+
+logger:
+  initial_level: DEBUG
+
+uart:
+  - id: !extend uart_bus
+    debug:
+      direction: BOTH
+      dummy_receiver: false
+      after:
+        timeout: 4ms
+      sequence:
+        - lambda: |-
+            char hex_buf[512];
+            esphome::format_hex_pretty_to(
+              hex_buf,
+              sizeof(hex_buf),
+              bytes.data(),
+              bytes.size(),
+              ' '
+            );
+            ESP_LOGD(
+              "oq.modbus_raw",
+              "%s %u bytes: %s",
+              direction == esphome::uart::UART_DIRECTION_RX ? "RX" : "TX",
+              static_cast<unsigned>(bytes.size()),
+              hex_buf
+            );

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -15,7 +15,8 @@ static volatile uint32_t frame_error_count = 0;
 static volatile uint32_t other_error_count = 0;
 static volatile uint32_t last_error_status = 0;
 
-static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t *task_woken) {
+static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification,
+                              BaseType_t *task_woken) {
   if (notification == UART_SELECT_READ_NOTIF) {
     esphome::Application::wake_loop_isrsafe(task_woken);
     return;

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -15,8 +15,7 @@ static volatile uint32_t frame_error_count = 0;
 static volatile uint32_t other_error_count = 0;
 static volatile uint32_t last_error_status = 0;
 
-static void IRAM_ATTR uart_select_callback(uart_port_t uart_num, uart_select_notif_t notification,
-                                           BaseType_t *task_woken) {
+static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t *task_woken) {
   if (notification == UART_SELECT_READ_NOTIF) {
     esphome::Application::wake_loop_isrsafe(task_woken);
     return;
@@ -42,12 +41,11 @@ static void IRAM_ATTR uart_select_callback(uart_port_t uart_num, uart_select_not
     other_error_count++;
   }
 
-  // Make the main loop run promptly so the diagnostic log stays close to the raw UART capture.
   esphome::Application::wake_loop_isrsafe(task_woken);
 }
 
 inline void install(uint8_t uart_num) {
-  uart_set_select_notif_callback(static_cast<uart_port_t>(uart_num), uart_select_callback);
+  uart_set_select_notif_callback(static_cast<uart_port_t>(uart_num), uart_cb);
   ESP_LOGI("oq.modbus_uart_err", "UART parity/frame error probe installed on UART%u", uart_num);
 }
 
@@ -63,10 +61,8 @@ inline void report_if_changed() {
     return;
   }
 
-  ESP_LOGW("oq.modbus_uart_err",
-           "UART RX error: parity=%u (+%u), frame=%u (+%u), other=%u (+%u), last_status=0x%08X",
-           parity, parity - reported_parity, frame, frame - reported_frame, other, other - reported_other,
-           static_cast<unsigned>(last_error_status));
+  ESP_LOGW("oq.modbus_uart_err", "UART RX errors: parity=%u frame=%u other=%u", parity, frame, other);
+  ESP_LOGW("oq.modbus_uart_err", "Last UART status=0x%08X", static_cast<unsigned>(last_error_status));
 
   reported_parity = parity;
   reported_frame = frame;

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -15,7 +15,7 @@ static volatile uint32_t frame_error_count = 0;
 static volatile uint32_t other_error_count = 0;
 static volatile uint32_t last_error_status = 0;
 
-static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t *task_woken) {
+static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t* task_woken) {
   if (notification == UART_SELECT_READ_NOTIF) {
     esphome::Application::wake_loop_isrsafe(task_woken);
     return;

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -15,8 +15,7 @@ static volatile uint32_t frame_error_count = 0;
 static volatile uint32_t other_error_count = 0;
 static volatile uint32_t last_error_status = 0;
 
-static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification,
-                              BaseType_t *task_woken) {
+static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t *task_woken) {
   if (notification == UART_SELECT_READ_NOTIF) {
     esphome::Application::wake_loop_isrsafe(task_woken);
     return;

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -57,8 +57,8 @@ inline void set_discard_bad_bytes(uint8_t uart_num, bool discard = true) {
   ESP_LOGI("oq.modbus_uart_err", "UART%u discard parity/framing-failed bytes: %s", uart_num,
            discard ? "enabled" : "disabled");
 #else
-  (void) uart_num;
-  (void) discard;
+  (void)uart_num;
+  (void)discard;
   ESP_LOGW("oq.modbus_uart_err", "UART parity/framing discard filter requires ESP-IDF");
 #endif
 }

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -5,6 +5,9 @@
 #include "driver/uart.h"
 #include "driver/uart_select.h"
 #include "hal/uart_ll.h"
+#ifdef USE_ESP_IDF
+#include "soc/uart_reg.h"
+#endif
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
@@ -42,6 +45,22 @@ static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notifica
   }
 
   esphome::Application::wake_loop_isrsafe(task_woken);
+}
+
+inline void set_discard_bad_bytes(uint8_t uart_num, bool discard = true) {
+#ifdef USE_ESP_IDF
+  if (discard) {
+    REG_SET_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
+  } else {
+    REG_CLR_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
+  }
+  ESP_LOGI("oq.modbus_uart_err", "UART%u discard parity/framing-failed bytes: %s", uart_num,
+           discard ? "enabled" : "disabled");
+#else
+  (void) uart_num;
+  (void) discard;
+  ESP_LOGW("oq.modbus_uart_err", "UART parity/framing discard filter requires ESP-IDF");
+#endif
 }
 
 inline void install(uint8_t uart_num) {

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "driver/uart.h"
+#include "driver/uart_select.h"
+#include "hal/uart_ll.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+
+namespace oq_modbus_uart_diag {
+
+static volatile uint32_t parity_error_count = 0;
+static volatile uint32_t frame_error_count = 0;
+static volatile uint32_t other_error_count = 0;
+static volatile uint32_t last_error_status = 0;
+
+static void IRAM_ATTR uart_select_callback(uart_port_t uart_num, uart_select_notif_t notification,
+                                           BaseType_t *task_woken) {
+  if (notification == UART_SELECT_READ_NOTIF) {
+    esphome::Application::wake_loop_isrsafe(task_woken);
+    return;
+  }
+
+  if (notification != UART_SELECT_ERROR_NOTIF) {
+    return;
+  }
+
+  const uint32_t status = uart_ll_get_intsts_mask(UART_LL_GET_HW(uart_num));
+  last_error_status = status;
+
+  bool classified = false;
+  if ((status & UART_INTR_PARITY_ERR) != 0) {
+    parity_error_count++;
+    classified = true;
+  }
+  if ((status & UART_INTR_FRAM_ERR) != 0) {
+    frame_error_count++;
+    classified = true;
+  }
+  if (!classified) {
+    other_error_count++;
+  }
+
+  // Make the main loop run promptly so the diagnostic log stays close to the raw UART capture.
+  esphome::Application::wake_loop_isrsafe(task_woken);
+}
+
+inline void install(uint8_t uart_num) {
+  uart_set_select_notif_callback(static_cast<uart_port_t>(uart_num), uart_select_callback);
+  ESP_LOGI("oq.modbus_uart_err", "UART parity/frame error probe installed on UART%u", uart_num);
+}
+
+inline void report_if_changed() {
+  static uint32_t reported_parity = 0;
+  static uint32_t reported_frame = 0;
+  static uint32_t reported_other = 0;
+
+  const uint32_t parity = parity_error_count;
+  const uint32_t frame = frame_error_count;
+  const uint32_t other = other_error_count;
+  if (parity == reported_parity && frame == reported_frame && other == reported_other) {
+    return;
+  }
+
+  ESP_LOGW("oq.modbus_uart_err",
+           "UART RX error: parity=%u (+%u), frame=%u (+%u), other=%u (+%u), last_status=0x%08X",
+           parity, parity - reported_parity, frame, frame - reported_frame, other, other - reported_other,
+           static_cast<unsigned>(last_error_status));
+
+  reported_parity = parity;
+  reported_frame = frame;
+  reported_other = other;
+}
+
+}  // namespace oq_modbus_uart_diag
+
+#endif  // USE_ESP32

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -17,6 +17,27 @@ static volatile uint32_t parity_error_count = 0;
 static volatile uint32_t frame_error_count = 0;
 static volatile uint32_t other_error_count = 0;
 static volatile uint32_t last_error_status = 0;
+#ifdef USE_ESP_IDF
+static volatile uint32_t last_error_conf0 = 0;
+static volatile uint8_t last_error_uart_num = 0;
+static volatile bool last_error_conf0_valid = false;
+#endif
+
+#ifdef USE_ESP_IDF
+inline uint32_t read_conf0(uint8_t uart_num) { return REG_READ(UART_CONF0_REG(uart_num)); }
+
+inline bool err_wr_mask_enabled(uint32_t conf0) { return (conf0 & UART_ERR_WR_MASK) != 0; }
+
+inline void log_conf0_info(uint8_t uart_num, const char* label, uint32_t conf0) {
+  ESP_LOGI("oq.modbus_uart_err", "UART%u %s: 0x%08X ERR_WR_MASK=%u", uart_num, label, static_cast<unsigned>(conf0),
+           err_wr_mask_enabled(conf0));
+}
+
+inline void log_conf0_warn(uint8_t uart_num, const char* label, uint32_t conf0) {
+  ESP_LOGW("oq.modbus_uart_err", "UART%u %s: 0x%08X ERR_WR_MASK=%u", uart_num, label, static_cast<unsigned>(conf0),
+           err_wr_mask_enabled(conf0));
+}
+#endif
 
 static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t* task_woken) {
   if (notification == UART_SELECT_READ_NOTIF) {
@@ -28,6 +49,12 @@ static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notifica
     return;
   }
 
+#ifdef USE_ESP_IDF
+  // Preserve the peripheral state at the error interrupt; report it later from the main loop.
+  last_error_conf0 = read_conf0(static_cast<uint8_t>(uart_num));
+  last_error_uart_num = static_cast<uint8_t>(uart_num);
+  last_error_conf0_valid = true;
+#endif
   const uint32_t status = uart_ll_get_intsts_mask(UART_LL_GET_HW(uart_num));
   last_error_status = status;
 
@@ -49,13 +76,17 @@ static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notifica
 
 inline void set_discard_bad_bytes(uint8_t uart_num, bool discard = true) {
 #ifdef USE_ESP_IDF
+  const uint32_t conf0_before = read_conf0(uart_num);
+  log_conf0_info(uart_num, "CONF0 before filter", conf0_before);
+
   if (discard) {
     REG_SET_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
   } else {
     REG_CLR_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
   }
-  ESP_LOGI("oq.modbus_uart_err", "UART%u discard parity/framing-failed bytes: %s", uart_num,
-           discard ? "enabled" : "disabled");
+
+  const uint32_t conf0_after = read_conf0(uart_num);
+  log_conf0_info(uart_num, "CONF0 after filter", conf0_after);
 #else
   (void)uart_num;
   (void)discard;
@@ -65,7 +96,16 @@ inline void set_discard_bad_bytes(uint8_t uart_num, bool discard = true) {
 
 inline void install(uint8_t uart_num) {
   uart_set_select_notif_callback(static_cast<uart_port_t>(uart_num), uart_cb);
-  ESP_LOGI("oq.modbus_uart_err", "UART parity/frame error probe installed on UART%u", uart_num);
+  ESP_LOGI("oq.modbus_uart_err", "UART%u selected for uart_bus; parity/frame error probe installed", uart_num);
+}
+
+inline void report_startup_filter_state(uint8_t uart_num) {
+#ifdef USE_ESP_IDF
+  const uint32_t conf0 = read_conf0(uart_num);
+  log_conf0_info(uart_num, "filter state after startup", conf0);
+#else
+  (void)uart_num;
+#endif
 }
 
 inline void report_if_changed() {
@@ -82,6 +122,15 @@ inline void report_if_changed() {
 
   ESP_LOGW("oq.modbus_uart_err", "UART RX errors: parity=%u frame=%u other=%u", parity, frame, other);
   ESP_LOGW("oq.modbus_uart_err", "Last UART status=0x%08X", static_cast<unsigned>(last_error_status));
+#ifdef USE_ESP_IDF
+  if (last_error_conf0_valid) {
+    const uint32_t conf0_at_error = last_error_conf0;
+    const uint8_t uart_num = last_error_uart_num;
+    const uint32_t conf0_now = read_conf0(uart_num);
+    log_conf0_warn(uart_num, "CONF0 at error", conf0_at_error);
+    log_conf0_warn(uart_num, "CONF0 now", conf0_now);
+  }
+#endif
 
   reported_parity = parity;
   reported_frame = frame;

--- a/configs/heatpump_controller_q/single.yaml
+++ b/configs/heatpump_controller_q/single.yaml
@@ -12,14 +12,6 @@ substitutions:
   oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_q_flow_source_selector_id: "oq_q_flow_source"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=0"
-  # Diagnostic PR only: swap the physical M1/M2 RS485 interfaces so the heat-pump
-  # Modbus master runs over the M2 transceiver and CiC compatibility runs over M1.
-  uart_tx_pin: "GPIO45"                                 # Heat-pump Modbus via physical M2 TX.
-  uart_rx_pin: "GPIO39"                                 # Heat-pump Modbus via physical M2 RX.
-  uart_rts_pin: "GPIO38"                                # Heat-pump Modbus via physical M2 DE/RE.
-  cic_compat_uart_tx_pin: "GPIO40"                      # CiC compatibility via physical M1 TX.
-  cic_compat_uart_rx_pin: "GPIO42"                      # CiC compatibility via physical M1 RX.
-  cic_compat_uart_rts_pin: "GPIO41"                     # CiC compatibility via physical M1 DE/RE.
   main_release_manifest_url: "https://github.com/OpenQuatt/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/OpenQuatt/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-single-ota.manifest.json"
   release_manifest_url: "https://github.com/OpenQuatt/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-ota.manifest.json"

--- a/configs/heatpump_controller_q/single.yaml
+++ b/configs/heatpump_controller_q/single.yaml
@@ -31,3 +31,4 @@ packages:
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_wifi_eth: !include ../../openquatt/connection/wifi_eth.yaml
   openquatt_packages_common: !include ../../openquatt/oq_packages_common.yaml
+  modbus_uart_diagnostics: !include modbus_uart_diagnostics.yaml

--- a/configs/heatpump_controller_q/single.yaml
+++ b/configs/heatpump_controller_q/single.yaml
@@ -12,6 +12,14 @@ substitutions:
   oq_controller_flow_sensor_id: "flow_rate_controller"
   oq_q_flow_source_selector_id: "oq_q_flow_source"
   oq_topology_build_flag: "-DOQ_TOPOLOGY_DUO=0"
+  # Diagnostic PR only: swap the physical M1/M2 RS485 interfaces so the heat-pump
+  # Modbus master runs over the M2 transceiver and CiC compatibility runs over M1.
+  uart_tx_pin: "GPIO45"                                 # Heat-pump Modbus via physical M2 TX.
+  uart_rx_pin: "GPIO39"                                 # Heat-pump Modbus via physical M2 RX.
+  uart_rts_pin: "GPIO38"                                # Heat-pump Modbus via physical M2 DE/RE.
+  cic_compat_uart_tx_pin: "GPIO40"                      # CiC compatibility via physical M1 TX.
+  cic_compat_uart_rx_pin: "GPIO42"                      # CiC compatibility via physical M1 RX.
+  cic_compat_uart_rts_pin: "GPIO41"                     # CiC compatibility via physical M1 DE/RE.
   main_release_manifest_url: "https://github.com/OpenQuatt/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-ota.manifest.json"
   dev_release_manifest_url: "https://github.com/OpenQuatt/OpenQuatt/releases/download/dev-latest/openquatt-heatpump-controller-q-single-ota.manifest.json"
   release_manifest_url: "https://github.com/OpenQuatt/OpenQuatt/releases/latest/download/openquatt-heatpump-controller-q-single-ota.manifest.json"

--- a/configs/heatpump_controller_q/single.yaml
+++ b/configs/heatpump_controller_q/single.yaml
@@ -32,3 +32,12 @@ packages:
   openquatt_connection_wifi_eth: !include ../../openquatt/connection/wifi_eth.yaml
   openquatt_packages_common: !include ../../openquatt/oq_packages_common.yaml
   modbus_uart_diagnostics: !include modbus_uart_diagnostics.yaml
+
+# Keep the UART RX input at idle HIGH during brief RS485 receiver turn-off gaps.
+uart:
+  - id: !extend uart_bus
+    rx_pin:
+      number: ${uart_rx_pin}
+      mode:
+        input: true
+        pullup: true


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt een tijdelijke diagnosepackage toe voor de **Heatpump Controller Q Single** testfirmware.
- Logt ruwe Modbus **TX en RX bytes in hex** en telt ESP32 UART **parity- en frame-errors**.
- Test nu ook hardwarematig weggooien van parity/framing-foute bytes via `UART_ERR_WR_MASK`, op basis van de analyse van @exciton in esphome/esphome#19070.
- Houdt de interne RX pull-up actief en gebruikt weer de normale ESP-IDF `UART_MODE_RS485_HALF_DUPLEX` DE/RE-aansturing.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [x] Anders — tijdelijke diagnose/testfirmware

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De basis-Modbusconfiguratie blijft `19200 8E1`, `rx_full_threshold: 1`, `rx_timeout: 1` en dezelfde polling. De huidige testvariant laat parity/framing-foute UART-characters door de ESP32-hardware weggooien voordat ze in de RX FIFO en Modbus-parser terechtkomen.

De ESP-IDF UART-driver detecteert parity/frame errors, maar standaard blijft het foutieve character in de RX FIFO staan. De probe blijft daarom actief om te controleren of hardware parity-events nog steeds optreden terwijl de corrupte byte niet meer aan Modbus wordt doorgegeven.

Context: https://github.com/esphome/esphome/issues/19070

## Achtergrond

Dezelfde gebruiker meldt dat een tweede Controller Q met dezelfde firmwareversie nagenoeg geen errors geeft. Dat maakt een algemene firmware- of Modbus-loadlimiet minder waarschijnlijk en maakt controller-/bekabeling-/ODU-/bus-specifieke verschillen extra relevant.

Deze PR is bedoeld als **test-firmware** en niet om in deze vorm permanent naar `dev` te mergen.

## Testresultaten tot nu toe

### 1. Raw UART capture

De ODU levert doorgaans een volledig geldig Modbus-responseframe. Rond sommige transacties verschijnt daarnaast één stray byte, meestal `0xFF` (één keer ook `0xFE`).

Afhankelijk van de timing:

- staat de stray byte los en wordt hij verwijderd als `1 byte - timeout after partial response`, waarna het geldige frame normaal wordt verwerkt; of
- wordt de stray byte met het geldige responseframe samengevoegd, waarna ESPHome `parse failed` meldt.

### 2. UART parity probe

De stray bytes correleren zeer sterk met **hardware UART parity errors**:

```text
UART RX errors: parity=53 frame=0 other=0
RX 8 bytes: FF 01 03 02 00 00 B8 44
```

De parity-counter liep tijdens de storingen vrijwel één-op-één op, terwijl `frame=0` en `other=0` bleven. De corrupte byte bereikt standaard ondanks de parity error gewoon de RX-buffer.

### 3. Interne ESP32-S3 RX pull-up

De interne pull-up op de actieve Modbus RX-pin (orde van grootte ~45 kΩ) maakte de foutfrequentie in de testvensters **duidelijk lager**, maar elimineerde de parity-errors niet volledig. De productievariant van deze robustness-maatregel is inmiddels via #658 naar `dev` gegaan.

### 4. ESP-IDF automatic half-duplex vs. Modbus-managed DE/RE

We hebben tijdelijk UART-level `flow_control_pin` verwijderd en DE/RE expliciet door de ESPHome Modbus-component laten schakelen (`DE on -> write -> flush -> DE off`). Ook daarmee werd de fout opnieuw gevangen:

```text
TX: 01 03 07 DF 00 01 B4 84
RX: 01 03 02 03 E8 B8 FA FF
UART RX errors: parity=10 frame=0 other=0
```

De eerste 7 RX-bytes zijn een volledig geldig antwoord; de foutieve `FF` verschijnt **daarna**. Daarmee lijkt ESP-IDF automatic RS485 half-duplex/RTS-turnaround niet de primaire oorzaak. De huidige testvariant gebruikt daarom weer de normale ESP-IDF half-duplexroute.

### 5. Hardware discard van parity-foute bytes — huidige test

@exciton wees erop dat de ESP32 UART standaard parity/framing-foute characters toch in de RX FIFO schrijft. De ESP32 heeft hiervoor `UART_CONF0.err_wr_mask`; met `UART_ERR_WR_MASK` gezet wordt zo'n fout character hardwarematig **niet** in de FIFO opgeslagen.

Deze PR zet dat bit nu tijdens boot voor de actieve Modbus UART. De raw capture en parity probe blijven actief.

Verwachte uitkomst als dit werkt:

- hardware parity-errors kunnen nog steeds worden geteld;
- de bijbehorende stray `0xFF` bereikt de RX-buffer niet meer;
- `FF + valid response` kan de Modbus-parser niet meer vergiftigen;
- `parse failed` / 1-byte partials door deze specifieke glitch zouden sterk moeten afnemen of verdwijnen.

`rx_full_threshold: 1` blijft voor deze test bewust nog ongewijzigd, zodat alleen het effect van de parity-filter wordt geïsoleerd. Een aparte test met de ESPHome-default threshold volgt eventueel daarna.

### 6. Huidige interpretatie

Het sterkste fysieke patroon blijft:

```text
ODU verstuurt geldig frame
-> ODU stopt met zenden / bus keert terug naar idle
-> korte elektrische transient / onvoldoende noise margin
-> receiver decodeert een stray character
-> ESP32 meldt parity error
```

De filter is dus bedoeld als **softwarematige bescherming tegen aantoonbaar corrupte UART-characters**, niet als bewijs dat de onderliggende elektrische oorzaak is opgelost. De root cause wordt nog gezocht in transceiver-turnoff, A/B bias/termination, kabel/common-mode of lokale gevoeligheid van de Controller Q receiver.

Ter vergelijking is op een probleemvrije Duo opnieuw gemeten: **~60 Ω over A/B met beide ODUs aangesloten en de Controller Q losgekoppeld**, en **~40 Ω met de Controller Q aangesloten**. Dat is consistent met twee ODU-terminaties van ongeveer 120 Ω plus ongeveer 120 Ω in de controller. Daarmee is 'te veel termination' op zichzelf geen sterke verklaring voor de probleeminstallatie; de probleemvrije Duo draait juist met zwaardere parallelle terminatie.

## Documentatie

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie: tijdelijke diagnosebuild; geen gebruikersfeature.

## Validatie

- [ ] `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single.yaml`
- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

CI/PR test-firmware build draait voor de laatste commit.

Heap/stack-impact: niet representatief gemeten; uitsluitend testfirmware. De raw logger gebruikt een tijdelijke 512-byte stackbuffer.

### 5a. Eerste fieldtest met `UART_ERR_WR_MASK`

De eerste fieldtest liet ondanks de beoogde hardwarefilter nog steeds een geldig responseframe gevolgd door `FF` zien, samen met een parity-error:

```text
RX 8 bytes: 01 03 02 00 00 B8 44 FF
UART RX errors: parity=4 frame=0 other=0
```

Deze revisie voegt daarom register-read-back toe: `UART_CONF0` vóór en direct na het zetten van `UART_ERR_WR_MASK`, nogmaals na 1 seconde startup, en als ISR-snapshot bij ieder UART-error-event (later buiten ISR-context gelogd). Zo wordt zichtbaar of `ERR_WR_MASK` werkelijk actief was toen de parity-foute byte werd ontvangen, zonder het bit periodiek opnieuw te zetten of de parity-errordiagnostiek te onderdrukken.
