### PR TITLE
Enable RX pull-ups on Controller Q RS485 buses

### DIFF
--- a/configs/heatpump_controller_q/duo.yaml
+++ b/configs/heatpump_controller_q/duo.yaml
@@ -33,3 +33,11 @@ packages:
   openquatt_connection_wifi_eth: !include ../../openquatt/connection/wifi_eth.yaml
   openquatt_packages_common: !include ../../openquatt/oq_packages_common.yaml
   openquatt_topology_duo_packages: !include ../../openquatt/topology/duo_packages.yaml
+
+uart:
+  - id: !extend uart_bus
+    rx_pin:
+      number: ${uart_rx_pin}
+      mode:
+        input: true
+        pullup: true

--- a/configs/heatpump_controller_q/single.yaml
+++ b/configs/heatpump_controller_q/single.yaml
@@ -31,3 +31,11 @@ packages:
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_wifi_eth: !include ../../openquatt/connection/wifi_eth.yaml
   openquatt_packages_common: !include ../../openquatt/oq_packages_common.yaml
+
+uart:
+  - id: !extend uart_bus
+    rx_pin:
+      number: ${uart_rx_pin}
+      mode:
+        input: true
+        pullup: true

--- a/configs/heatpump_controller_q/single.yaml
+++ b/configs/heatpump_controller_q/single.yaml
@@ -32,6 +32,7 @@ packages:
   openquatt_connection_wifi_eth: !include ../../openquatt/connection/wifi_eth.yaml
   openquatt_packages_common: !include ../../openquatt/oq_packages_common.yaml
 
+# Keep the UART RX input at idle HIGH during brief RS485 receiver turn-off gaps.
 uart:
   - id: !extend uart_bus
     rx_pin:

--- a/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
+++ b/openquatt/profiles/heatpump_controller_q_cic_compatibility.yaml
@@ -16,7 +16,11 @@ substitutions:
 uart:
   - id: cic_compat_uart_bus
     tx_pin: ${cic_compat_uart_tx_pin}
-    rx_pin: ${cic_compat_uart_rx_pin}
+    rx_pin:
+      number: ${cic_compat_uart_rx_pin}
+      mode:
+        input: true
+        pullup: true
     flow_control_pin: ${cic_compat_uart_rts_pin}
     baud_rate: 19200
     data_bits: 8


### PR DESCRIPTION
# Wat verandert deze PR?

- Schakelt de interne ESP32-S3 RX pull-up in op beide RS485-poorten van de Heatpump Controller Q.
- M1 / primaire warmtepompbus: `GPIO42`; M2 / CiC-compatibiliteitsbus: `GPIO39`.
- Laat de overige Modbus-configuratie en ESP-IDF RS485 half-duplex/DE-RE-aansturing ongewijzigd.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De wijziging beperkt zich tot de elektrische idle-bias van de UART RX-pinnen op de Controller Q. Baudrate, framing (`19200 8E1`), `rx_full_threshold: 1`, `rx_timeout: 1`, polling en de bestaande ESP-IDF RS485 half-duplex/DE-RE-aansturing blijven gelijk.

Bij een probleeminstallatie zijn incidentele stray `0xFF`-bytes gevonden die vrijwel één-op-één samenvallen met hardware UART parity errors. De diagnosefirmware in #657 laat zien dat de interne RX pull-up de foutfrequentie duidelijk verlaagt, maar de onderliggende elektrische transient niet volledig wegneemt. Deze PR neemt alleen deze kleine robustness-maatregel over naar `dev`; raw UART logging, parity-error probe en overige diagnose-experimenten blijven in #657.

## Achtergrond

De ESP32-S3 interne pull-up is relatief zwak, maar bleek in de praktijk al een duidelijke verbetering te geven. Voor een volgende PCB-revisie wordt daarnaast een sterkere externe pull-up op de RX/RO-lijn overwogen.

Scope:
- alleen Heatpump Controller Q;
- M1 (`GPIO42`) en M2 (`GPIO39`);
- Single en Duo waar de betreffende bus actief is;
- geen wijziging aan control-logica, command timing of gebruikersinstellingen.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Interne hardware-robustnesswijziging zonder nieuwe gebruikersinstelling, entity, installatiehandeling of wijziging aan de firmwarematrix. Dat de CiC-profiel-YAML wordt geraakt is implementatiedetail; het gebruikersgedrag en de configuratie van de CiC-compatibiliteitsfunctie veranderen niet.

## Validatie

- M1 is op representatieve Controller Q-hardware getest via de diagnosefirmware uit #657; parity/stray-byte events werden duidelijk minder frequent, maar niet volledig geëlimineerd.
- Ook met de latere handmatige DE/RE-test bleven incidentele parity-events bestaan, waardoor de pull-up als robustness-maatregel losstaat van de DE/RE-strategie.
- M2 gebruikt dezelfde RX-pinconfiguratie maar is in deze testreeks niet afzonderlijk belast getest.
- CI valideert en compileert de relevante configuraties.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen GPIO input pull-up configuratie; geen extra runtime component, buffer, taak of heap/PSRAM-allocatie.