### PR TITLE
Reduce expected boiler and telemetry log noise

### DIFF
--- a/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
+++ b/components/openquatt_usage_telemetry/OpenQuattUsageTelemetry.cpp
@@ -303,9 +303,6 @@ void OpenQuattUsageTelemetry::dump_config() {
   ESP_LOGCONFIG(TAG, "  Broker configured: %s", YESNO(this->is_configured()));
   ESP_LOGCONFIG(TAG, "  Transport: %s", this->tls_ ? "MQTT/TLS" : "MQTT");
   ESP_LOGCONFIG(TAG, "  Port: %u", this->port_);
-  if (!this->tls_ && this->is_configured()) {
-    ESP_LOGW(TAG, "Usage statistics transport is not encrypted");
-  }
   ESP_LOGCONFIG(TAG, "  Choice configured: %s", YESNO(this->choice_configured_.load()));
   ESP_LOGCONFIG(TAG, "  Quick Start complete: %s", YESNO(this->is_setup_complete_()));
   ESP_LOGCONFIG(TAG, "  Publish interval: %" PRIu32 " seconds", this->interval_ms_ / 1000U);

--- a/openquatt/includes/control/oq_boiler_runtime.h
+++ b/openquatt/includes/control/oq_boiler_runtime.h
@@ -239,8 +239,10 @@ class Runtime {
   void publish_controller_log_(int control_mode, float supply_c, bool supply_valid,
                                const oq_boiler::ControllerDecision& decision, oq_boiler::BoilerRole role,
                                const oq_boiler::BoilerLogDecision& controller_log) {
+    const bool blocked = decision.demand_present && !decision.output_active;
+    const bool blocked_changed = !have_controller_state_ || blocked != last_blocked_;
     const bool reason_changed = !have_controller_state_ || decision.block_reason != last_block_reason_;
-    if (!have_controller_state_ || decision.output_active != last_allowed_ || reason_changed) {
+    if (!have_controller_state_ || decision.output_active != last_allowed_ || reason_changed || blocked_changed) {
       const char* reason = oq_boiler::block_reason_text(decision.block_reason);
       if (decision.output_active) {
         const char* context = role == oq_boiler::BoilerRole::COMMISSIONING_CM100 ? "CM100 commissioning task"
@@ -249,14 +251,13 @@ class Runtime {
         ESP_LOGI("quatt.boiler", "Boiler enabled: %s and safety guards clear", context);
       } else if (id(oq_water_temp_hard_trip_active)) {
         ESP_LOGW("quatt.boiler", "Boiler blocked: %s", reason);
-      } else if (decision.block_reason == oq_boiler::BLOCK_COMMISSIONING_WAITING) {
+      } else if (blocked && decision.block_reason == oq_boiler::BLOCK_COMMISSIONING_WAITING) {
         ESP_LOGI("quatt.boiler", "Boiler commissioning: waiting for flow to settle");
-      } else {
+      } else if (blocked) {
         ESP_LOGI("quatt.boiler", "Boiler blocked: %s", reason);
       }
     }
 
-    const bool blocked = decision.demand_present && !decision.output_active;
     if (blocked && (!last_blocked_ || reason_changed)) {
       id(oq_decision_log)
           .emit(openquatt_decision_log::EVENT_DECISION_BLOCKED, openquatt_decision_log::SUBJECT_CV,

--- a/openquatt/includes/control/oq_boiler_runtime.h
+++ b/openquatt/includes/control/oq_boiler_runtime.h
@@ -240,9 +240,9 @@ class Runtime {
                                const oq_boiler::ControllerDecision& decision, oq_boiler::BoilerRole role,
                                const oq_boiler::BoilerLogDecision& controller_log) {
     const bool blocked = decision.demand_present && !decision.output_active;
-    const bool blocked_changed = !have_controller_state_ || blocked != last_blocked_;
+    const bool became_blocked = blocked && !last_blocked_;
     const bool reason_changed = !have_controller_state_ || decision.block_reason != last_block_reason_;
-    if (!have_controller_state_ || decision.output_active != last_allowed_ || reason_changed || blocked_changed) {
+    if (!have_controller_state_ || decision.output_active != last_allowed_ || reason_changed || became_blocked) {
       const char* reason = oq_boiler::block_reason_text(decision.block_reason);
       if (decision.output_active) {
         const char* context = role == oq_boiler::BoilerRole::COMMISSIONING_CM100 ? "CM100 commissioning task"


### PR DESCRIPTION
# Wat verandert deze PR?

- Log `Boiler blocked: ...` alleen wanneer er daadwerkelijk boiler demand wordt geblokkeerd; idle/startup `flow unavailable` veroorzaakt daarmee geen misleidende logregel meer.
- Behoud de hard-trip warning en log een nieuwe blokkering ook wanneer de block reason tijdens idle al hetzelfde was.
- Verwijder de verwachte `Usage statistics transport is not encrypted` warning; transport en poort blijven zichtbaar in de config-log.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de voorwaarden voor operator-facing logging zijn aangepast. Boiler decisions, outputs, safety guards en telemetry-transport/configuratie wijzigen niet. De bestaande structured decision log blijft ongewijzigd.

## Achtergrond

`oq_boiler::evaluate()` kan tijdens idle al `BLOCK_FLOW_UNAVAILABLE` opleveren, omdat de flow-validatie vóór de demand-check plaatsvindt. De runtime-log presenteerde dat vervolgens als `Boiler blocked`, ook zonder boiler demand. Deze PR koppelt de normale block-log daarom aan dezelfde semantiek die de structured decision log al gebruikt: `demand_present && !output_active`.

De centrale usage telemetry gebruikt momenteel bewust plain MQTT. `dump_config()` meldt transport en poort al expliciet, waardoor een extra warning bij iedere boot vooral logruis veroorzaakt.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen user-facing instellingen, API's of functioneel gedrag wijzigen; alleen verwachte/misleidende runtime-logregels worden opgeschoond.

## Validatie

- Diff gecontroleerd tegen `dev`: alleen boiler-log gating en het verwijderen van de redundante telemetry-warning.
- Geen lokale firmware-build uitgevoerd; PR-CI kan de relevante builds/tests bevestigen.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen allocaties, buffers, tasks of stackgroottes gewijzigd.
