### PR TITLE
Neem bevestigde HP-uit-tijd mee over gecontroleerde OTA

### DIFF
--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -2,11 +2,14 @@
 
 #include <cstring>
 
+#include "OpenQuattIncidentManager.h"
 #include "OpenQuattRestartHandoffPolicy.h"
 #include "esp_app_desc.h"
 #include "esp_ota_ops.h"
 #include "esp_system.h"
 #include "nvs.h"
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
 namespace esphome::openquatt_incident_manager {
@@ -85,19 +88,21 @@ bool capture_boot_context(uint32_t minimum_off_ms, BootContext* context) {
 
   esp_ota_img_states_t image_state = ESP_OTA_IMG_UNDEFINED;
   const esp_err_t state_result = esp_ota_get_state_partition(running, &image_state);
-  // Without otadata rollback is unavailable, so there is no unverified OTA image
-  // to accidentally credit. Otherwise accept only an explicit valid/undefined state.
-  const bool state_safe =
+  // A normal controlled restart requires a valid image. A controlled OTA
+  // handoff may additionally be consumed on the first PENDING_VERIFY boot.
+  const bool image_valid =
       (state_result == ESP_OK && (image_state == ESP_OTA_IMG_VALID || image_state == ESP_OTA_IMG_UNDEFINED)) ||
       state_result == ESP_ERR_NOT_FOUND;
-  if (!state_safe) {
-    ESP_LOGW(TAG, "Restart handoff rejected unverified or unavailable image state: %s", esp_err_to_name(state_result));
+  const bool image_pending_verify = state_result == ESP_OK && image_state == ESP_OTA_IMG_PENDING_VERIFY;
+  if (!image_valid && !image_pending_verify) {
+    ESP_LOGW(TAG, "Restart handoff rejected unavailable image state: %s", esp_err_to_name(state_result));
     return false;
   }
 
   context->software_reset = esp_reset_reason() == ESP_RST_SW;
   context->running_partition_matches_boot = running->address == boot->address;
-  context->image_valid = state_safe;
+  context->image_valid = image_valid;
+  context->image_pending_verify = image_pending_verify;
   context->minimum_off_ms = minimum_off_ms;
 #if OQ_TOPOLOGY_DUO
   context->config_hash = restart_handoff::configuration_hash(minimum_off_ms, true);
@@ -128,6 +133,15 @@ bool confirm_pending_image_for_controlled_restart() {
   return true;
 }
 
+bool persist_handoff_record(const Record& record) {
+  nvs_handle_t handle{};
+  if (!open_storage(&handle)) return false;
+  NvsStorage storage(handle);
+  const bool persisted = restart_handoff::persist_record(storage, record);
+  nvs_close(handle);
+  return persisted;
+}
+
 }  // namespace
 
 bool initialize_restart_handoff(uint32_t minimum_off_ms) {
@@ -152,7 +166,7 @@ bool initialize_restart_handoff(uint32_t minimum_off_ms) {
   storage_ready = true;
   configured_minimum_off_ms = minimum_off_ms;
   if (context_available && (restored_credit_ms[0] != 0U || restored_credit_ms[1] != 0U)) {
-    ESP_LOGI(TAG, "Restored one-shot confirmed-off credit after controlled restart");
+    ESP_LOGI(TAG, "Restored one-shot confirmed-off credit after controlled restart or OTA");
   }
   return true;
 }
@@ -183,7 +197,7 @@ bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
   Record record{};
   record.magic = restart_handoff::kRecordMagic;
   record.version = restart_handoff::kRecordVersion;
-  record.state = restart_handoff::kRecordArmed;
+  record.state = restart_handoff::kRecordRestartArmed;
   record.minimum_off_ms = configured_minimum_off_ms;
   record.config_hash = context.config_hash;
   record.boot_partition_address = context.boot_partition_address;
@@ -192,13 +206,135 @@ bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
   std::memcpy(record.image_hash, context.image_hash, sizeof(record.image_hash));
   restart_handoff::finalize_record(&record);
 
-  nvs_handle_t handle{};
-  if (!open_storage(&handle)) return false;
-  NvsStorage storage(handle);
-  const bool persisted = restart_handoff::persist_record(storage, record);
-  nvs_close(handle);
+  const bool persisted = persist_handoff_record(record);
   if (!persisted) ESP_LOGE(TAG, "Restart handoff arm was not durably verified");
   return persisted;
 }
+
+bool arm_ota_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
+  if (!storage_ready || !restart_handoff::valid_minimum_off_ms(configured_minimum_off_ms) ||
+      hp1_credit_ms > configured_minimum_off_ms || hp2_credit_ms > configured_minimum_off_ms ||
+      (hp1_credit_ms == 0U && hp2_credit_ms == 0U)) {
+    return false;
+  }
+
+  BootContext context{};
+  if (!capture_boot_context(configured_minimum_off_ms, &context) || !context.running_partition_matches_boot ||
+      !context.image_valid) {
+    ESP_LOGE(TAG, "OTA handoff arm rejected current image context");
+    return false;
+  }
+
+  const esp_partition_t* running = esp_ota_get_running_partition();
+  const esp_partition_t* target = running != nullptr ? esp_ota_get_next_update_partition(running) : nullptr;
+  if (target == nullptr) {
+    ESP_LOGE(TAG, "OTA handoff arm could not resolve the target partition");
+    return false;
+  }
+
+  Record record{};
+  record.magic = restart_handoff::kRecordMagic;
+  record.version = restart_handoff::kRecordVersion;
+  record.state = restart_handoff::kRecordOtaArmed;
+  record.minimum_off_ms = configured_minimum_off_ms;
+  record.config_hash = context.config_hash;
+  record.boot_partition_address = target->address;
+  record.hp1_credit_ms = hp1_credit_ms;
+  record.hp2_credit_ms = hp2_credit_ms;
+  // OTA does not know the target ELF hash before flashing. Store the source
+  // hash so rollback-disabled boots can still prove that the image changed.
+  std::memcpy(record.image_hash, context.image_hash, sizeof(record.image_hash));
+  restart_handoff::finalize_record(&record);
+
+  const bool persisted = persist_handoff_record(record);
+  if (!persisted) ESP_LOGE(TAG, "OTA handoff arm was not durably verified");
+  return persisted;
+}
+
+bool clear_restart_handoff() {
+  if (!storage_ready) return false;
+  nvs_handle_t handle{};
+  if (!open_storage(&handle)) return false;
+  NvsStorage storage(handle);
+  const bool cleared = storage.erase_and_verify_absent();
+  nvs_close(handle);
+  if (!cleared) ESP_LOGE(TAG, "Restart handoff could not be durably cleared");
+  return cleared;
+}
+
+void OpenQuattOtaHandoff::setup() {
+#ifdef USE_OTA_STATE_LISTENER
+  ota::get_global_ota_callback()->add_global_state_listener(this);
+#endif
+}
+
+void OpenQuattOtaHandoff::loop() {
+  const uint32_t now_ms = millis();
+  if (static_cast<uint32_t>(now_ms - this->last_sample_ms_) < SAMPLE_INTERVAL_MS) return;
+  this->last_sample_ms_ = now_ms;
+  this->sample_(now_ms);
+}
+
+bool OpenQuattOtaHandoff::hp_eligible_for_full_credit_(uint8_t hp_index, uint32_t now_ms) const {
+  if (this->incident_manager_ == nullptr || this->incident_manager_->is_failed() ||
+      !this->incident_manager_->storage_ready() || !this->incident_manager_->hp_configured(hp_index)) {
+    return false;
+  }
+
+  const auto outputs = this->incident_manager_->get_outputs(hp_index);
+  return outputs.link_state == oq_incidents::LinkState::HEALTHY && outputs.run_state == oq_incidents::RunState::STOPPED &&
+         outputs.stop_confirmed && !outputs.stop_confirmation_pending &&
+         this->incident_manager_->minimum_off_remaining_ms(hp_index, now_ms) == 0U;
+}
+
+void OpenQuattOtaHandoff::sample_(uint32_t now_ms) {
+  for (uint8_t hp = 1U; hp <= 2U; ++hp) {
+    this->full_credit_latches_[hp - 1U].observe(this->hp_eligible_for_full_credit_(hp, now_ms), now_ms,
+                                                FULL_CREDIT_STABLE_MS);
+  }
+}
+
+#ifdef USE_OTA_STATE_LISTENER
+void OpenQuattOtaHandoff::on_ota_global_state(ota::OTAState state, float progress, uint8_t error,
+                                              ota::OTAComponent* component) {
+  (void) progress;
+  (void) error;
+  (void) component;
+
+  if (state == ota::OTA_STARTED) {
+    const uint32_t now_ms = millis();
+    this->sample_(now_ms);
+
+    uint32_t credit[2]{0U, 0U};
+    for (uint8_t hp = 1U; hp <= 2U; ++hp) {
+      if (this->full_credit_latches_[hp - 1U].confirmed() && this->hp_eligible_for_full_credit_(hp, now_ms)) {
+        credit[hp - 1U] = this->minimum_off_ms_;
+      }
+    }
+
+    this->ota_handoff_attempted_ = credit[0] != 0U || credit[1] != 0U;
+    this->ota_handoff_saved_ = this->ota_handoff_attempted_ && arm_ota_handoff(credit[0], credit[1]);
+    ESP_LOGI(TAG, "Controlled OTA: confirmed full off-time credit HP1=%us HP2=%us (%s)",
+             static_cast<unsigned>(credit[0] / 1000U), static_cast<unsigned>(credit[1] / 1000U),
+             this->ota_handoff_saved_ ? "saved" : "conservative fallback");
+    return;
+  }
+
+  if (state == ota::OTA_ABORT || state == ota::OTA_ERROR) {
+    if (this->ota_handoff_attempted_ && !clear_restart_handoff()) {
+      ESP_LOGE(TAG, "Could not clear OTA handoff after failed OTA; rebooting fail-closed");
+      App.safe_reboot();
+      return;
+    }
+    this->ota_handoff_attempted_ = false;
+    this->ota_handoff_saved_ = false;
+    return;
+  }
+
+  if (state == ota::OTA_COMPLETED && this->ota_handoff_saved_) {
+    ESP_LOGI(TAG, "Controlled OTA completed with confirmed off-time handoff armed");
+  }
+}
+#endif
 
 }  // namespace esphome::openquatt_incident_manager

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -268,30 +268,19 @@ void OpenQuattOtaHandoff::setup() {
 #endif
 }
 
-void OpenQuattOtaHandoff::loop() {
-  const uint32_t now_ms = millis();
-  if (static_cast<uint32_t>(now_ms - this->last_sample_ms_) < SAMPLE_INTERVAL_MS) return;
-  this->last_sample_ms_ = now_ms;
-  this->sample_(now_ms);
-}
-
-bool OpenQuattOtaHandoff::hp_eligible_for_full_credit_(uint8_t hp_index, uint32_t now_ms) const {
+uint32_t OpenQuattOtaHandoff::full_credit_if_confirmed_(uint8_t hp_index, uint32_t now_ms) const {
   if (this->incident_manager_ == nullptr || this->incident_manager_->is_failed() ||
       !this->incident_manager_->storage_ready() || !this->incident_manager_->hp_configured(hp_index)) {
-    return false;
+    return 0U;
   }
 
   const auto outputs = this->incident_manager_->get_outputs(hp_index);
-  return outputs.link_state == oq_incidents::LinkState::HEALTHY && outputs.run_state == oq_incidents::RunState::STOPPED &&
-         outputs.stop_confirmed && !outputs.stop_confirmation_pending &&
-         this->incident_manager_->minimum_off_remaining_ms(hp_index, now_ms) == 0U;
-}
-
-void OpenQuattOtaHandoff::sample_(uint32_t now_ms) {
-  for (uint8_t hp = 1U; hp <= 2U; ++hp) {
-    this->full_credit_latches_[hp - 1U].observe(this->hp_eligible_for_full_credit_(hp, now_ms), now_ms,
-                                                FULL_CREDIT_STABLE_MS);
+  if (outputs.link_state != oq_incidents::LinkState::HEALTHY || outputs.run_state != oq_incidents::RunState::STOPPED ||
+      !outputs.stop_confirmed || outputs.stop_confirmation_pending ||
+      this->incident_manager_->minimum_off_remaining_ms(hp_index, now_ms) != 0U) {
+    return 0U;
   }
+  return this->minimum_off_ms_;
 }
 
 #ifdef USE_OTA_STATE_LISTENER
@@ -303,19 +292,14 @@ void OpenQuattOtaHandoff::on_ota_global_state(ota::OTAState state, float progres
 
   if (state == ota::OTA_STARTED) {
     const uint32_t now_ms = millis();
-    this->sample_(now_ms);
+    const uint32_t hp1_credit_ms = this->full_credit_if_confirmed_(1U, now_ms);
+    const uint32_t hp2_credit_ms = this->full_credit_if_confirmed_(2U, now_ms);
 
-    uint32_t credit[2]{0U, 0U};
-    for (uint8_t hp = 1U; hp <= 2U; ++hp) {
-      if (this->full_credit_latches_[hp - 1U].confirmed() && this->hp_eligible_for_full_credit_(hp, now_ms)) {
-        credit[hp - 1U] = this->minimum_off_ms_;
-      }
-    }
-
-    this->ota_handoff_attempted_ = credit[0] != 0U || credit[1] != 0U;
-    this->ota_handoff_saved_ = this->ota_handoff_attempted_ && arm_ota_handoff(credit[0], credit[1]);
+    this->ota_handoff_attempted_ = hp1_credit_ms != 0U || hp2_credit_ms != 0U;
+    this->ota_handoff_saved_ =
+        this->ota_handoff_attempted_ && arm_ota_handoff(hp1_credit_ms, hp2_credit_ms);
     ESP_LOGI(TAG, "Controlled OTA: confirmed full off-time credit HP1=%us HP2=%us (%s)",
-             static_cast<unsigned>(credit[0] / 1000U), static_cast<unsigned>(credit[1] / 1000U),
+             static_cast<unsigned>(hp1_credit_ms / 1000U), static_cast<unsigned>(hp2_credit_ms / 1000U),
              this->ota_handoff_saved_ ? "saved" : "conservative fallback");
     return;
   }

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -108,8 +108,7 @@ bool capture_boot_context(uint32_t minimum_off_ms, BootContext* context) {
   // transitioning it to PENDING_VERIFY. Exact partition+image matching still
   // makes that a safe unconfirmed state for this one-shot handoff.
   const bool image_pending_verify =
-      state_result == ESP_OK &&
-      (image_state == ESP_OTA_IMG_PENDING_VERIFY || image_state == ESP_OTA_IMG_NEW);
+      state_result == ESP_OK && (image_state == ESP_OTA_IMG_PENDING_VERIFY || image_state == ESP_OTA_IMG_NEW);
   if (!image_valid && !image_pending_verify) {
     ESP_LOGW(TAG, "Restart handoff rejected unavailable image state: %s", esp_err_to_name(state_result));
     return false;

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -286,9 +286,9 @@ uint32_t OpenQuattOtaHandoff::full_credit_if_confirmed_(uint8_t hp_index, uint32
 #ifdef USE_OTA_STATE_LISTENER
 void OpenQuattOtaHandoff::on_ota_global_state(ota::OTAState state, float progress, uint8_t error,
                                               ota::OTAComponent* component) {
-  (void) progress;
-  (void) error;
-  (void) component;
+  (void)progress;
+  (void)error;
+  (void)component;
 
   if (state == ota::OTA_STARTED) {
     const uint32_t now_ms = millis();
@@ -296,8 +296,7 @@ void OpenQuattOtaHandoff::on_ota_global_state(ota::OTAState state, float progres
     const uint32_t hp2_credit_ms = this->full_credit_if_confirmed_(2U, now_ms);
 
     this->ota_handoff_attempted_ = hp1_credit_ms != 0U || hp2_credit_ms != 0U;
-    this->ota_handoff_saved_ =
-        this->ota_handoff_attempted_ && arm_ota_handoff(hp1_credit_ms, hp2_credit_ms);
+    this->ota_handoff_saved_ = this->ota_handoff_attempted_ && arm_ota_handoff(hp1_credit_ms, hp2_credit_ms);
     ESP_LOGI(TAG, "Controlled OTA: confirmed full off-time credit HP1=%us HP2=%us (%s)",
              static_cast<unsigned>(hp1_credit_ms / 1000U), static_cast<unsigned>(hp2_credit_ms / 1000U),
              this->ota_handoff_saved_ ? "saved" : "conservative fallback");

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -104,7 +104,12 @@ bool capture_boot_context(uint32_t minimum_off_ms, BootContext* context) {
   const bool image_valid =
       (state_result == ESP_OK && (image_state == ESP_OTA_IMG_VALID || image_state == ESP_OTA_IMG_UNDEFINED)) ||
       state_result == ESP_ERR_NOT_FOUND;
-  const bool image_pending_verify = state_result == ESP_OK && image_state == ESP_OTA_IMG_PENDING_VERIFY;
+  // Older deployed bootloaders can leave the first OTA boot in NEW instead of
+  // transitioning it to PENDING_VERIFY. Exact partition+image matching still
+  // makes that a safe unconfirmed state for this one-shot handoff.
+  const bool image_pending_verify =
+      state_result == ESP_OK &&
+      (image_state == ESP_OTA_IMG_PENDING_VERIFY || image_state == ESP_OTA_IMG_NEW);
   if (!image_valid && !image_pending_verify) {
     ESP_LOGW(TAG, "Restart handoff rejected unavailable image state: %s", esp_err_to_name(state_result));
     return false;

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -8,7 +8,6 @@
 #include "esp_ota_ops.h"
 #include "esp_system.h"
 #include "nvs.h"
-#include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
@@ -25,6 +24,20 @@ constexpr const char* NVS_KEY = "oq_restart_v1";
 bool storage_ready{false};
 uint32_t restored_credit_ms[2]{0U, 0U};
 uint32_t configured_minimum_off_ms{0U};
+
+uint32_t current_configuration_hash(uint32_t minimum_off_ms) {
+#if OQ_TOPOLOGY_DUO
+  return restart_handoff::configuration_hash(minimum_off_ms, true);
+#else
+  return restart_handoff::configuration_hash(minimum_off_ms, false);
+#endif
+}
+
+bool valid_handoff_credit(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
+  return storage_ready && restart_handoff::valid_minimum_off_ms(configured_minimum_off_ms) &&
+         hp1_credit_ms <= configured_minimum_off_ms && hp2_credit_ms <= configured_minimum_off_ms &&
+         (hp1_credit_ms != 0U || hp2_credit_ms != 0U);
+}
 
 bool open_storage(nvs_handle_t* handle) {
   if (handle == nullptr) return false;
@@ -88,8 +101,6 @@ bool capture_boot_context(uint32_t minimum_off_ms, BootContext* context) {
 
   esp_ota_img_states_t image_state = ESP_OTA_IMG_UNDEFINED;
   const esp_err_t state_result = esp_ota_get_state_partition(running, &image_state);
-  // A normal controlled restart requires a valid image. A controlled OTA
-  // handoff may additionally be consumed on the first PENDING_VERIFY boot.
   const bool image_valid =
       (state_result == ESP_OK && (image_state == ESP_OTA_IMG_VALID || image_state == ESP_OTA_IMG_UNDEFINED)) ||
       state_result == ESP_ERR_NOT_FOUND;
@@ -104,11 +115,7 @@ bool capture_boot_context(uint32_t minimum_off_ms, BootContext* context) {
   context->image_valid = image_valid;
   context->image_pending_verify = image_pending_verify;
   context->minimum_off_ms = minimum_off_ms;
-#if OQ_TOPOLOGY_DUO
-  context->config_hash = restart_handoff::configuration_hash(minimum_off_ms, true);
-#else
-  context->config_hash = restart_handoff::configuration_hash(minimum_off_ms, false);
-#endif
+  context->config_hash = current_configuration_hash(minimum_off_ms);
   context->boot_partition_address = running->address;
   std::memcpy(context->image_hash, description->app_elf_sha256, sizeof(context->image_hash));
   return restart_handoff::has_image_hash(context->image_hash);
@@ -142,6 +149,24 @@ bool persist_handoff_record(const Record& record) {
   return persisted;
 }
 
+bool persist_target_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms, uint32_t boot_partition_address,
+                            const uint8_t* image_hash) {
+  if (!valid_handoff_credit(hp1_credit_ms, hp2_credit_ms) || image_hash == nullptr) return false;
+
+  Record record{};
+  record.magic = restart_handoff::kRecordMagic;
+  record.version = restart_handoff::kRecordVersion;
+  record.state = restart_handoff::kRecordArmed;
+  record.minimum_off_ms = configured_minimum_off_ms;
+  record.config_hash = current_configuration_hash(configured_minimum_off_ms);
+  record.boot_partition_address = boot_partition_address;
+  record.hp1_credit_ms = hp1_credit_ms;
+  record.hp2_credit_ms = hp2_credit_ms;
+  std::memcpy(record.image_hash, image_hash, sizeof(record.image_hash));
+  restart_handoff::finalize_record(&record);
+  return persist_handoff_record(record);
+}
+
 }  // namespace
 
 bool initialize_restart_handoff(uint32_t minimum_off_ms) {
@@ -166,7 +191,9 @@ bool initialize_restart_handoff(uint32_t minimum_off_ms) {
   storage_ready = true;
   configured_minimum_off_ms = minimum_off_ms;
   if (context_available && (restored_credit_ms[0] != 0U || restored_credit_ms[1] != 0U)) {
-    ESP_LOGI(TAG, "Restored one-shot confirmed-off credit after controlled restart or OTA");
+    ESP_LOGI(TAG, "Restored one-shot confirmed-off credit HP1=%us HP2=%us",
+             static_cast<unsigned>(restored_credit_ms[0] / 1000U),
+             static_cast<unsigned>(restored_credit_ms[1] / 1000U));
   }
   return true;
 }
@@ -179,12 +206,7 @@ uint32_t restored_off_credit_ms(uint8_t hp_index) {
 }
 
 bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
-  if (!storage_ready || !restart_handoff::valid_minimum_off_ms(configured_minimum_off_ms) ||
-      hp1_credit_ms > configured_minimum_off_ms || hp2_credit_ms > configured_minimum_off_ms ||
-      (hp1_credit_ms == 0U && hp2_credit_ms == 0U)) {
-    return false;
-  }
-
+  if (!valid_handoff_credit(hp1_credit_ms, hp2_credit_ms)) return false;
   if (!confirm_pending_image_for_controlled_restart()) return false;
 
   BootContext context{};
@@ -194,72 +216,38 @@ bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
     return false;
   }
 
-  Record record{};
-  record.magic = restart_handoff::kRecordMagic;
-  record.version = restart_handoff::kRecordVersion;
-  record.state = restart_handoff::kRecordRestartArmed;
-  record.minimum_off_ms = configured_minimum_off_ms;
-  record.config_hash = context.config_hash;
-  record.boot_partition_address = context.boot_partition_address;
-  record.hp1_credit_ms = hp1_credit_ms;
-  record.hp2_credit_ms = hp2_credit_ms;
-  std::memcpy(record.image_hash, context.image_hash, sizeof(record.image_hash));
-  restart_handoff::finalize_record(&record);
-
-  const bool persisted = persist_handoff_record(record);
+  const bool persisted =
+      persist_target_handoff(hp1_credit_ms, hp2_credit_ms, context.boot_partition_address, context.image_hash);
   if (!persisted) ESP_LOGE(TAG, "Restart handoff arm was not durably verified");
   return persisted;
 }
 
-bool arm_ota_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
-  if (!storage_ready || !restart_handoff::valid_minimum_off_ms(configured_minimum_off_ms) ||
-      hp1_credit_ms > configured_minimum_off_ms || hp2_credit_ms > configured_minimum_off_ms ||
-      (hp1_credit_ms == 0U && hp2_credit_ms == 0U)) {
-    return false;
-  }
-
-  BootContext context{};
-  if (!capture_boot_context(configured_minimum_off_ms, &context) || !context.running_partition_matches_boot ||
-      !context.image_valid) {
-    ESP_LOGE(TAG, "OTA handoff arm rejected current image context");
-    return false;
-  }
+bool arm_completed_ota_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms) {
+  if (!valid_handoff_credit(hp1_credit_ms, hp2_credit_ms)) return false;
 
   const esp_partition_t* running = esp_ota_get_running_partition();
-  const esp_partition_t* target = running != nullptr ? esp_ota_get_next_update_partition(running) : nullptr;
-  if (target == nullptr) {
-    ESP_LOGE(TAG, "OTA handoff arm could not resolve the target partition");
+  const esp_partition_t* target = esp_ota_get_boot_partition();
+  if (running == nullptr || target == nullptr || running->address == target->address) {
+    ESP_LOGE(TAG, "Completed OTA handoff has no distinct selected boot partition");
     return false;
   }
 
-  Record record{};
-  record.magic = restart_handoff::kRecordMagic;
-  record.version = restart_handoff::kRecordVersion;
-  record.state = restart_handoff::kRecordOtaArmed;
-  record.minimum_off_ms = configured_minimum_off_ms;
-  record.config_hash = context.config_hash;
-  record.boot_partition_address = target->address;
-  record.hp1_credit_ms = hp1_credit_ms;
-  record.hp2_credit_ms = hp2_credit_ms;
-  // OTA does not know the target ELF hash before flashing. Store the source
-  // hash so rollback-disabled boots can still prove that the image changed.
-  std::memcpy(record.image_hash, context.image_hash, sizeof(record.image_hash));
-  restart_handoff::finalize_record(&record);
+  esp_app_desc_t target_description{};
+  const esp_err_t description_result = esp_ota_get_partition_description(target, &target_description);
+  if (description_result != ESP_OK) {
+    ESP_LOGE(TAG, "Completed OTA handoff could not read target image: %s", esp_err_to_name(description_result));
+    return false;
+  }
 
-  const bool persisted = persist_handoff_record(record);
-  if (!persisted) ESP_LOGE(TAG, "OTA handoff arm was not durably verified");
-  return persisted;
-}
+  const bool persisted =
+      persist_target_handoff(hp1_credit_ms, hp2_credit_ms, target->address, target_description.app_elf_sha256);
+  if (!persisted) {
+    ESP_LOGE(TAG, "Completed OTA handoff was not durably verified");
+    return false;
+  }
 
-bool clear_restart_handoff() {
-  if (!storage_ready) return false;
-  nvs_handle_t handle{};
-  if (!open_storage(&handle)) return false;
-  NvsStorage storage(handle);
-  const bool cleared = storage.erase_and_verify_absent();
-  nvs_close(handle);
-  if (!cleared) ESP_LOGE(TAG, "Restart handoff could not be durably cleared");
-  return cleared;
+  ESP_LOGI(TAG, "Controlled OTA handoff armed for boot partition 0x%08X", static_cast<unsigned>(target->address));
+  return true;
 }
 
 void OpenQuattOtaHandoff::setup() {
@@ -283,6 +271,12 @@ uint32_t OpenQuattOtaHandoff::full_credit_if_confirmed_(uint8_t hp_index, uint32
   return this->minimum_off_ms_;
 }
 
+void OpenQuattOtaHandoff::clear_ota_snapshot_() {
+  this->ota_hp1_credit_ms_ = 0U;
+  this->ota_hp2_credit_ms_ = 0U;
+  this->ota_handoff_attempted_ = false;
+}
+
 #ifdef USE_OTA_STATE_LISTENER
 void OpenQuattOtaHandoff::on_ota_global_state(ota::OTAState state, float progress, uint8_t error,
                                               ota::OTAComponent* component) {
@@ -291,31 +285,36 @@ void OpenQuattOtaHandoff::on_ota_global_state(ota::OTAState state, float progres
   (void)component;
 
   if (state == ota::OTA_STARTED) {
+    this->clear_ota_snapshot_();
     const uint32_t now_ms = millis();
-    const uint32_t hp1_credit_ms = this->full_credit_if_confirmed_(1U, now_ms);
-    const uint32_t hp2_credit_ms = this->full_credit_if_confirmed_(2U, now_ms);
-
-    this->ota_handoff_attempted_ = hp1_credit_ms != 0U || hp2_credit_ms != 0U;
-    this->ota_handoff_saved_ = this->ota_handoff_attempted_ && arm_ota_handoff(hp1_credit_ms, hp2_credit_ms);
-    ESP_LOGI(TAG, "Controlled OTA: confirmed full off-time credit HP1=%us HP2=%us (%s)",
-             static_cast<unsigned>(hp1_credit_ms / 1000U), static_cast<unsigned>(hp2_credit_ms / 1000U),
-             this->ota_handoff_saved_ ? "saved" : "conservative fallback");
+    this->ota_hp1_credit_ms_ = this->full_credit_if_confirmed_(1U, now_ms);
+    this->ota_hp2_credit_ms_ = this->full_credit_if_confirmed_(2U, now_ms);
+    this->ota_handoff_attempted_ = this->ota_hp1_credit_ms_ != 0U || this->ota_hp2_credit_ms_ != 0U;
+    ESP_LOGI(TAG, "Controlled OTA: captured full off-time credit HP1=%us HP2=%us%s",
+             static_cast<unsigned>(this->ota_hp1_credit_ms_ / 1000U),
+             static_cast<unsigned>(this->ota_hp2_credit_ms_ / 1000U),
+             this->ota_handoff_attempted_ ? "" : " (none)");
     return;
   }
 
   if (state == ota::OTA_ABORT || state == ota::OTA_ERROR) {
-    if (this->ota_handoff_attempted_ && !clear_restart_handoff()) {
-      ESP_LOGE(TAG, "Could not clear OTA handoff after failed OTA; rebooting fail-closed");
-      App.safe_reboot();
-      return;
+    if (this->ota_handoff_attempted_) {
+      ESP_LOGI(TAG, "Controlled OTA failed; discarded captured off-time credit");
     }
-    this->ota_handoff_attempted_ = false;
-    this->ota_handoff_saved_ = false;
+    this->clear_ota_snapshot_();
     return;
   }
 
-  if (state == ota::OTA_COMPLETED && this->ota_handoff_saved_) {
-    ESP_LOGI(TAG, "Controlled OTA completed with confirmed off-time handoff armed");
+  if (state == ota::OTA_COMPLETED) {
+    if (!this->ota_handoff_attempted_) {
+      this->clear_ota_snapshot_();
+      return;
+    }
+    const bool saved = arm_completed_ota_handoff(this->ota_hp1_credit_ms_, this->ota_hp2_credit_ms_);
+    ESP_LOGI(TAG, "Controlled OTA completed: off-time credit HP1=%us HP2=%us (%s)",
+             static_cast<unsigned>(this->ota_hp1_credit_ms_ / 1000U),
+             static_cast<unsigned>(this->ota_hp2_credit_ms_ / 1000U), saved ? "saved" : "conservative fallback");
+    this->clear_ota_snapshot_();
   }
 }
 #endif

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.cpp
@@ -292,8 +292,7 @@ void OpenQuattOtaHandoff::on_ota_global_state(ota::OTAState state, float progres
     this->ota_handoff_attempted_ = this->ota_hp1_credit_ms_ != 0U || this->ota_hp2_credit_ms_ != 0U;
     ESP_LOGI(TAG, "Controlled OTA: captured full off-time credit HP1=%us HP2=%us%s",
              static_cast<unsigned>(this->ota_hp1_credit_ms_ / 1000U),
-             static_cast<unsigned>(this->ota_hp2_credit_ms_ / 1000U),
-             this->ota_handoff_attempted_ ? "" : " (none)");
+             static_cast<unsigned>(this->ota_hp2_credit_ms_ / 1000U), this->ota_handoff_attempted_ ? "" : " (none)");
     return;
   }
 

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
 
 #include "esphome/core/component.h"
 #ifdef USE_OTA_STATE_LISTENER
 #include "esphome/components/ota/ota_backend.h"
 #endif
-#include "OpenQuattRestartHandoffPolicy.h"
 
 namespace esphome::openquatt_incident_manager {
 
@@ -33,22 +31,15 @@ class OpenQuattOtaHandoff : public Component
   void set_minimum_off_ms(uint32_t value) { this->minimum_off_ms_ = value; }
 
   void setup() override;
-  void loop() override;
 #ifdef USE_OTA_STATE_LISTENER
   void on_ota_global_state(ota::OTAState state, float progress, uint8_t error, ota::OTAComponent* component) override;
 #endif
 
  protected:
-  static constexpr uint32_t SAMPLE_INTERVAL_MS = 1000U;
-  static constexpr uint32_t FULL_CREDIT_STABLE_MS = 15000U;
-
-  bool hp_eligible_for_full_credit_(uint8_t hp_index, uint32_t now_ms) const;
-  void sample_(uint32_t now_ms);
+  uint32_t full_credit_if_confirmed_(uint8_t hp_index, uint32_t now_ms) const;
 
   OpenQuattIncidentManager* incident_manager_{nullptr};
   uint32_t minimum_off_ms_{240000U};
-  uint32_t last_sample_ms_{0U};
-  std::array<restart_handoff::StableFullCreditLatch, 2U> full_credit_latches_{};
   bool ota_handoff_attempted_{false};
   bool ota_handoff_saved_{false};
 };

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
@@ -23,7 +23,7 @@ bool clear_restart_handoff();
 class OpenQuattOtaHandoff : public Component
 #ifdef USE_OTA_STATE_LISTENER
     ,
-                             public ota::OTAGlobalStateListener
+                            public ota::OTAGlobalStateListener
 #endif
 {
  public:

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
@@ -17,8 +17,7 @@ bool initialize_restart_handoff(uint32_t minimum_off_ms);
 bool restart_handoff_storage_ready();
 uint32_t restored_off_credit_ms(uint8_t hp_index);
 bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms);
-bool arm_ota_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms);
-bool clear_restart_handoff();
+bool arm_completed_ota_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms);
 
 class OpenQuattOtaHandoff : public Component
 #ifdef USE_OTA_STATE_LISTENER
@@ -37,11 +36,13 @@ class OpenQuattOtaHandoff : public Component
 
  protected:
   uint32_t full_credit_if_confirmed_(uint8_t hp_index, uint32_t now_ms) const;
+  void clear_ota_snapshot_();
 
   OpenQuattIncidentManager* incident_manager_{nullptr};
   uint32_t minimum_off_ms_{240000U};
+  uint32_t ota_hp1_credit_ms_{0U};
+  uint32_t ota_hp2_credit_ms_{0U};
   bool ota_handoff_attempted_{false};
-  bool ota_handoff_saved_{false};
 };
 
 }  // namespace esphome::openquatt_incident_manager

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoff.h
@@ -1,8 +1,17 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 
+#include "esphome/core/component.h"
+#ifdef USE_OTA_STATE_LISTENER
+#include "esphome/components/ota/ota_backend.h"
+#endif
+#include "OpenQuattRestartHandoffPolicy.h"
+
 namespace esphome::openquatt_incident_manager {
+
+class OpenQuattIncidentManager;
 
 // Must run before ESPHome safe-mode and all component setup. A false return means
 // the caller must restart immediately: an existing record could not be consumed.
@@ -10,5 +19,38 @@ bool initialize_restart_handoff(uint32_t minimum_off_ms);
 bool restart_handoff_storage_ready();
 uint32_t restored_off_credit_ms(uint8_t hp_index);
 bool arm_restart_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms);
+bool arm_ota_handoff(uint32_t hp1_credit_ms, uint32_t hp2_credit_ms);
+bool clear_restart_handoff();
+
+class OpenQuattOtaHandoff : public Component
+#ifdef USE_OTA_STATE_LISTENER
+    ,
+                             public ota::OTAGlobalStateListener
+#endif
+{
+ public:
+  void set_incident_manager(OpenQuattIncidentManager* value) { this->incident_manager_ = value; }
+  void set_minimum_off_ms(uint32_t value) { this->minimum_off_ms_ = value; }
+
+  void setup() override;
+  void loop() override;
+#ifdef USE_OTA_STATE_LISTENER
+  void on_ota_global_state(ota::OTAState state, float progress, uint8_t error, ota::OTAComponent* component) override;
+#endif
+
+ protected:
+  static constexpr uint32_t SAMPLE_INTERVAL_MS = 1000U;
+  static constexpr uint32_t FULL_CREDIT_STABLE_MS = 15000U;
+
+  bool hp_eligible_for_full_credit_(uint8_t hp_index, uint32_t now_ms) const;
+  void sample_(uint32_t now_ms);
+
+  OpenQuattIncidentManager* incident_manager_{nullptr};
+  uint32_t minimum_off_ms_{240000U};
+  uint32_t last_sample_ms_{0U};
+  std::array<restart_handoff::StableFullCreditLatch, 2U> full_credit_latches_{};
+  bool ota_handoff_attempted_{false};
+  bool ota_handoff_saved_{false};
+};
 
 }  // namespace esphome::openquatt_incident_manager

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
@@ -8,7 +8,10 @@ namespace esphome::openquatt_incident_manager::restart_handoff {
 
 constexpr uint32_t kRecordMagic = 0x4F515248UL;  // OQRH
 constexpr uint16_t kRecordVersion = 1U;
-constexpr uint8_t kRecordArmed = 1U;
+constexpr uint8_t kRecordRestartArmed = 1U;
+constexpr uint8_t kRecordOtaArmed = 2U;
+// Backward-compatible name used by the existing controlled-restart tests.
+constexpr uint8_t kRecordArmed = kRecordRestartArmed;
 constexpr uint32_t kMaximumMinimumOffMs = 3600UL * 1000UL;
 constexpr size_t kImageHashSize = 32U;
 
@@ -62,8 +65,10 @@ inline bool has_image_hash(const uint8_t (&image_hash)[kImageHashSize]) {
   return false;
 }
 
+inline bool valid_record_state(uint8_t state) { return state == kRecordRestartArmed || state == kRecordOtaArmed; }
+
 inline bool valid_record(const Record& record) {
-  return record.magic == kRecordMagic && record.version == kRecordVersion && record.state == kRecordArmed &&
+  return record.magic == kRecordMagic && record.version == kRecordVersion && valid_record_state(record.state) &&
          record.reserved == 0U && valid_minimum_off_ms(record.minimum_off_ms) &&
          record.hp1_credit_ms <= record.minimum_off_ms && record.hp2_credit_ms <= record.minimum_off_ms &&
          (record.hp1_credit_ms != 0U || record.hp2_credit_ms != 0U) && has_image_hash(record.image_hash) &&
@@ -79,6 +84,7 @@ struct BootContext {
   bool software_reset{false};
   bool running_partition_matches_boot{false};
   bool image_valid{false};
+  bool image_pending_verify{false};
   uint32_t minimum_off_ms{0U};
   uint32_t config_hash{0U};
   uint32_t boot_partition_address{0U};
@@ -88,10 +94,26 @@ struct BootContext {
 enum class StorageReadResult : uint8_t { ABSENT, PRESENT, ERROR };
 
 inline bool may_restore_credit(const Record& record, const BootContext& context) {
-  return valid_record(record) && context.software_reset && context.running_partition_matches_boot &&
-         context.image_valid && context.minimum_off_ms == record.minimum_off_ms &&
-         context.config_hash == record.config_hash && context.boot_partition_address == record.boot_partition_address &&
-         has_image_hash(context.image_hash) && std::memcmp(context.image_hash, record.image_hash, kImageHashSize) == 0;
+  if (!valid_record(record) || !context.software_reset || !context.running_partition_matches_boot ||
+      context.minimum_off_ms != record.minimum_off_ms || context.config_hash != record.config_hash ||
+      context.boot_partition_address != record.boot_partition_address || !has_image_hash(context.image_hash)) {
+    return false;
+  }
+
+  if (record.state == kRecordRestartArmed) {
+    return context.image_valid && std::memcmp(context.image_hash, record.image_hash, kImageHashSize) == 0;
+  }
+
+  if (record.state == kRecordOtaArmed) {
+    // With rollback enabled, the first boot of the selected OTA partition is
+    // pending verification. Without rollback, ESP-IDF reports the image as
+    // valid/undefined; require a different image hash in that case so an old
+    // partition cannot consume an OTA handoff merely through a software reboot.
+    const bool image_changed = std::memcmp(context.image_hash, record.image_hash, kImageHashSize) != 0;
+    return context.image_pending_verify || (context.image_valid && image_changed);
+  }
+
+  return false;
 }
 
 // A matching record is still unsafe until its deletion has been committed and
@@ -130,5 +152,35 @@ template <typename Storage>
 inline bool persist_record(Storage& storage, const Record& record) {
   return valid_record(record) && storage.write_commit_and_verify(record);
 }
+
+class StableFullCreditLatch {
+ public:
+  void observe(bool eligible, uint32_t now_ms, uint32_t stable_ms) {
+    if (!eligible) {
+      this->reset();
+      return;
+    }
+    if (!this->tracking_) {
+      this->tracking_ = true;
+      this->since_ms_ = now_ms;
+      this->confirmed_ = stable_ms == 0U;
+      return;
+    }
+    if (static_cast<uint32_t>(now_ms - this->since_ms_) >= stable_ms) this->confirmed_ = true;
+  }
+
+  void reset() {
+    this->tracking_ = false;
+    this->confirmed_ = false;
+    this->since_ms_ = 0U;
+  }
+
+  bool confirmed() const { return this->confirmed_; }
+
+ private:
+  bool tracking_{false};
+  bool confirmed_{false};
+  uint32_t since_ms_{0U};
+};
 
 }  // namespace esphome::openquatt_incident_manager::restart_handoff

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
@@ -8,10 +8,7 @@ namespace esphome::openquatt_incident_manager::restart_handoff {
 
 constexpr uint32_t kRecordMagic = 0x4F515248UL;  // OQRH
 constexpr uint16_t kRecordVersion = 1U;
-constexpr uint8_t kRecordRestartArmed = 1U;
-constexpr uint8_t kRecordOtaArmed = 2U;
-// Backward-compatible name used by the existing controlled-restart tests.
-constexpr uint8_t kRecordArmed = kRecordRestartArmed;
+constexpr uint8_t kRecordArmed = 1U;
 constexpr uint32_t kMaximumMinimumOffMs = 3600UL * 1000UL;
 constexpr size_t kImageHashSize = 32U;
 
@@ -65,10 +62,8 @@ inline bool has_image_hash(const uint8_t (&image_hash)[kImageHashSize]) {
   return false;
 }
 
-inline bool valid_record_state(uint8_t state) { return state == kRecordRestartArmed || state == kRecordOtaArmed; }
-
 inline bool valid_record(const Record& record) {
-  return record.magic == kRecordMagic && record.version == kRecordVersion && valid_record_state(record.state) &&
+  return record.magic == kRecordMagic && record.version == kRecordVersion && record.state == kRecordArmed &&
          record.reserved == 0U && valid_minimum_off_ms(record.minimum_off_ms) &&
          record.hp1_credit_ms <= record.minimum_off_ms && record.hp2_credit_ms <= record.minimum_off_ms &&
          (record.hp1_credit_ms != 0U || record.hp2_credit_ms != 0U) && has_image_hash(record.image_hash) &&
@@ -94,25 +89,10 @@ struct BootContext {
 enum class StorageReadResult : uint8_t { ABSENT, PRESENT, ERROR };
 
 inline bool may_restore_credit(const Record& record, const BootContext& context) {
-  if (!valid_record(record) || !context.software_reset || !context.running_partition_matches_boot ||
-      context.minimum_off_ms != record.minimum_off_ms || context.config_hash != record.config_hash ||
-      context.boot_partition_address != record.boot_partition_address || !has_image_hash(context.image_hash)) {
-    return false;
-  }
-
-  if (record.state == kRecordRestartArmed) {
-    return context.image_valid && std::memcmp(context.image_hash, record.image_hash, kImageHashSize) == 0;
-  }
-
-  if (record.state == kRecordOtaArmed) {
-    // The OTA record already names the exact inactive partition selected before
-    // flashing. A successful software reboot into that partition is sufficient,
-    // even when the same binary was reinstalled. Failed/interrupted OTA stays on
-    // the source partition and therefore cannot consume the credit.
-    return context.image_pending_verify || context.image_valid;
-  }
-
-  return false;
+  return valid_record(record) && context.software_reset && context.running_partition_matches_boot &&
+         (context.image_valid || context.image_pending_verify) && context.minimum_off_ms == record.minimum_off_ms &&
+         context.config_hash == record.config_hash && context.boot_partition_address == record.boot_partition_address &&
+         has_image_hash(context.image_hash) && std::memcmp(context.image_hash, record.image_hash, kImageHashSize) == 0;
 }
 
 // A matching record is still unsafe until its deletion has been committed and

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
@@ -106,9 +106,8 @@ inline bool may_restore_credit(const Record& record, const BootContext& context)
 
   if (record.state == kRecordOtaArmed) {
     // With rollback enabled, the first boot of the selected OTA partition is
-    // pending verification. Without rollback, ESP-IDF reports the image as
-    // valid/undefined; require a different image hash in that case so an old
-    // partition cannot consume an OTA handoff merely through a software reboot.
+    // pending verification. Without rollback, require a changed image hash so
+    // the old partition cannot consume an OTA handoff after a software reboot.
     const bool image_changed = std::memcmp(context.image_hash, record.image_hash, kImageHashSize) != 0;
     return context.image_pending_verify || (context.image_valid && image_changed);
   }
@@ -152,35 +151,5 @@ template <typename Storage>
 inline bool persist_record(Storage& storage, const Record& record) {
   return valid_record(record) && storage.write_commit_and_verify(record);
 }
-
-class StableFullCreditLatch {
- public:
-  void observe(bool eligible, uint32_t now_ms, uint32_t stable_ms) {
-    if (!eligible) {
-      this->reset();
-      return;
-    }
-    if (!this->tracking_) {
-      this->tracking_ = true;
-      this->since_ms_ = now_ms;
-      this->confirmed_ = stable_ms == 0U;
-      return;
-    }
-    if (static_cast<uint32_t>(now_ms - this->since_ms_) >= stable_ms) this->confirmed_ = true;
-  }
-
-  void reset() {
-    this->tracking_ = false;
-    this->confirmed_ = false;
-    this->since_ms_ = 0U;
-  }
-
-  bool confirmed() const { return this->confirmed_; }
-
- private:
-  bool tracking_{false};
-  bool confirmed_{false};
-  uint32_t since_ms_{0U};
-};
 
 }  // namespace esphome::openquatt_incident_manager::restart_handoff

--- a/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
+++ b/components/openquatt_incident_manager/OpenQuattRestartHandoffPolicy.h
@@ -105,11 +105,11 @@ inline bool may_restore_credit(const Record& record, const BootContext& context)
   }
 
   if (record.state == kRecordOtaArmed) {
-    // With rollback enabled, the first boot of the selected OTA partition is
-    // pending verification. Without rollback, require a changed image hash so
-    // the old partition cannot consume an OTA handoff after a software reboot.
-    const bool image_changed = std::memcmp(context.image_hash, record.image_hash, kImageHashSize) != 0;
-    return context.image_pending_verify || (context.image_valid && image_changed);
+    // The OTA record already names the exact inactive partition selected before
+    // flashing. A successful software reboot into that partition is sufficient,
+    // even when the same binary was reinstalled. Failed/interrupted OTA stays on
+    // the source partition and therefore cannot consume the credit.
+    return context.image_pending_verify || context.image_valid;
   }
 
   return false;

--- a/components/openquatt_incident_manager/__init__.py
+++ b/components/openquatt_incident_manager/__init__.py
@@ -18,12 +18,16 @@ CONF_DECISION_LOG = "decision_log"
 CONF_WEB_AUTH = "web_auth"
 CONF_MINIMUM_OFF_TIME = "minimum_off_time"
 CONF_POLLING_PAUSED = "polling_paused"
+CONF_OTA_HANDOFF_ID = "ota_handoff_id"
 
 openquatt_incident_manager_ns = cg.esphome_ns.namespace(
     "openquatt_incident_manager"
 )
 OpenQuattIncidentManager = openquatt_incident_manager_ns.class_(
     "OpenQuattIncidentManager", cg.Component
+)
+OpenQuattOtaHandoff = openquatt_incident_manager_ns.class_(
+    "OpenQuattOtaHandoff", cg.Component
 )
 
 openquatt_decision_log_ns = cg.esphome_ns.namespace("openquatt_decision_log")
@@ -39,6 +43,7 @@ OpenQuattWebAuth = openquatt_web_auth_ns.class_(
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(OpenQuattIncidentManager),
+        cv.GenerateID(CONF_OTA_HANDOFF_ID): cv.declare_id(OpenQuattOtaHandoff),
         cv.Required(CONF_CLOCK): cv.use_id(time.RealTimeClock),
         cv.Required(CONF_CONTROL_MODE_CODE): cv.use_id(
             globals_component.GlobalsComponent
@@ -75,3 +80,8 @@ async def _runtime_to_code(config):
     cg.add(var.set_decision_log(decision_log))
     web_auth = await cg.get_variable(config[CONF_WEB_AUTH])
     cg.add(var.set_web_auth(web_auth))
+
+    ota_handoff = cg.new_Pvariable(config[CONF_OTA_HANDOFF_ID])
+    await cg.register_component(ota_handoff, config)
+    cg.add(ota_handoff.set_incident_manager(var))
+    cg.add(ota_handoff.set_minimum_off_ms(config[CONF_MINIMUM_OFF_TIME]))

--- a/tests/host/restart_handoff_test.cpp
+++ b/tests/host/restart_handoff_test.cpp
@@ -68,7 +68,7 @@ Record make_record() {
   Record record{};
   record.magic = esphome::openquatt_incident_manager::restart_handoff::kRecordMagic;
   record.version = esphome::openquatt_incident_manager::restart_handoff::kRecordVersion;
-  record.state = esphome::openquatt_incident_manager::restart_handoff::kRecordRestartArmed;
+  record.state = esphome::openquatt_incident_manager::restart_handoff::kRecordArmed;
   record.minimum_off_ms = MINIMUM_OFF_MS;
   record.config_hash = configuration_hash(MINIMUM_OFF_MS, true);
   record.boot_partition_address = 0x210000U;
@@ -76,15 +76,6 @@ Record make_record() {
   record.hp2_credit_ms = 120000U;
   for (size_t index = 0U; index < sizeof(record.image_hash); ++index)
     record.image_hash[index] = static_cast<uint8_t>(index);
-  finalize_record(&record);
-  return record;
-}
-
-Record make_ota_record() {
-  Record record = make_record();
-  record.state = esphome::openquatt_incident_manager::restart_handoff::kRecordOtaArmed;
-  record.boot_partition_address = 0x410000U;
-  record.hp2_credit_ms = MINIMUM_OFF_MS;
   finalize_record(&record);
   return record;
 }
@@ -101,47 +92,29 @@ BootContext matching_context(const Record& record) {
   return context;
 }
 
-void test_only_exact_controlled_restart_restores_credit() {
+void test_only_exact_controlled_reboot_restores_credit() {
   const Record record = make_record();
   assert(valid_record(record));
   const BootContext context = matching_context(record);
   assert(may_restore_credit(record, context));
 }
 
-void test_controlled_ota_restores_on_selected_partition() {
-  const Record record = make_ota_record();
-  assert(valid_record(record));
+void test_pending_ota_boot_uses_same_exact_handoff_policy() {
+  const Record record = make_record();
 
   auto pending_context = matching_context(record);
   pending_context.image_valid = false;
   pending_context.image_pending_verify = true;
-  pending_context.image_hash[0] ^= 0x5AU;
   assert(may_restore_credit(record, pending_context));
 
-  auto changed_image_context = matching_context(record);
-  changed_image_context.image_hash[0] ^= 0xA5U;
-  assert(may_restore_credit(record, changed_image_context));
-
-  // Reinstalling the exact same binary is still a controlled OTA when the
-  // reboot lands on the inactive partition recorded before flashing.
-  const auto same_image_context = matching_context(record);
-  assert(may_restore_credit(record, same_image_context));
-}
-
-void test_ota_handoff_rejects_wrong_partition_or_uncontrolled_boot() {
-  const Record record = make_ota_record();
+  pending_context.image_hash[0] ^= 0x5AU;
+  assert(!may_restore_credit(record, pending_context));
 
   auto wrong_partition = matching_context(record);
-  wrong_partition.image_pending_verify = true;
   wrong_partition.image_valid = false;
+  wrong_partition.image_pending_verify = true;
   wrong_partition.boot_partition_address++;
   assert(!may_restore_credit(record, wrong_partition));
-
-  auto uncontrolled_reset = matching_context(record);
-  uncontrolled_reset.image_pending_verify = true;
-  uncontrolled_reset.image_valid = false;
-  uncontrolled_reset.software_reset = false;
-  assert(!may_restore_credit(record, uncontrolled_reset));
 }
 
 void test_corrupt_or_partial_arm_never_restores_credit() {
@@ -345,9 +318,8 @@ void test_invalid_credit_bounds_fail_closed() {
 }  // namespace
 
 int main() {
-  test_only_exact_controlled_restart_restores_credit();
-  test_controlled_ota_restores_on_selected_partition();
-  test_ota_handoff_rejects_wrong_partition_or_uncontrolled_boot();
+  test_only_exact_controlled_reboot_restores_credit();
+  test_pending_ota_boot_uses_same_exact_handoff_policy();
   test_corrupt_or_partial_arm_never_restores_credit();
   test_replay_and_non_restart_paths_are_rejected();
   test_consume_failure_never_grants_in_memory_credit();

--- a/tests/host/restart_handoff_test.cpp
+++ b/tests/host/restart_handoff_test.cpp
@@ -108,7 +108,7 @@ void test_only_exact_controlled_restart_restores_credit() {
   assert(may_restore_credit(record, context));
 }
 
-void test_controlled_ota_restores_on_selected_new_partition() {
+void test_controlled_ota_restores_on_selected_partition() {
   const Record record = make_ota_record();
   assert(valid_record(record));
 
@@ -118,16 +118,18 @@ void test_controlled_ota_restores_on_selected_new_partition() {
   pending_context.image_hash[0] ^= 0x5AU;
   assert(may_restore_credit(record, pending_context));
 
-  auto rollback_disabled_context = matching_context(record);
-  rollback_disabled_context.image_hash[0] ^= 0xA5U;
-  assert(may_restore_credit(record, rollback_disabled_context));
+  auto changed_image_context = matching_context(record);
+  changed_image_context.image_hash[0] ^= 0xA5U;
+  assert(may_restore_credit(record, changed_image_context));
+
+  // Reinstalling the exact same binary is still a controlled OTA when the
+  // reboot lands on the inactive partition recorded before flashing.
+  const auto same_image_context = matching_context(record);
+  assert(may_restore_credit(record, same_image_context));
 }
 
-void test_ota_handoff_rejects_old_or_uncontrolled_boot() {
+void test_ota_handoff_rejects_wrong_partition_or_uncontrolled_boot() {
   const Record record = make_ota_record();
-
-  auto same_image = matching_context(record);
-  assert(!may_restore_credit(record, same_image));
 
   auto wrong_partition = matching_context(record);
   wrong_partition.image_pending_verify = true;
@@ -344,8 +346,8 @@ void test_invalid_credit_bounds_fail_closed() {
 
 int main() {
   test_only_exact_controlled_restart_restores_credit();
-  test_controlled_ota_restores_on_selected_new_partition();
-  test_ota_handoff_rejects_old_or_uncontrolled_boot();
+  test_controlled_ota_restores_on_selected_partition();
+  test_ota_handoff_rejects_wrong_partition_or_uncontrolled_boot();
   test_corrupt_or_partial_arm_never_restores_credit();
   test_replay_and_non_restart_paths_are_rejected();
   test_consume_failure_never_grants_in_memory_credit();

--- a/tests/host/restart_handoff_test.cpp
+++ b/tests/host/restart_handoff_test.cpp
@@ -15,7 +15,6 @@ using esphome::openquatt_incident_manager::restart_handoff::may_grant_after_dura
 using esphome::openquatt_incident_manager::restart_handoff::may_restore_credit;
 using esphome::openquatt_incident_manager::restart_handoff::persist_record;
 using esphome::openquatt_incident_manager::restart_handoff::Record;
-using esphome::openquatt_incident_manager::restart_handoff::StableFullCreditLatch;
 using esphome::openquatt_incident_manager::restart_handoff::StorageReadResult;
 using esphome::openquatt_incident_manager::restart_handoff::valid_record;
 
@@ -341,33 +340,6 @@ void test_invalid_credit_bounds_fail_closed() {
   assert(!valid_record(record));
 }
 
-void test_full_credit_latch_requires_stable_eligibility() {
-  StableFullCreditLatch latch{};
-  constexpr uint32_t STABLE_MS = 15000U;
-
-  latch.observe(true, 1000U, STABLE_MS);
-  assert(!latch.confirmed());
-  latch.observe(true, 15999U, STABLE_MS);
-  assert(!latch.confirmed());
-  latch.observe(true, 16000U, STABLE_MS);
-  assert(latch.confirmed());
-
-  latch.observe(false, 17000U, STABLE_MS);
-  assert(!latch.confirmed());
-  latch.observe(true, 18000U, STABLE_MS);
-  assert(!latch.confirmed());
-}
-
-void test_full_credit_latch_handles_millis_wrap() {
-  StableFullCreditLatch latch{};
-  constexpr uint32_t STABLE_MS = 15000U;
-  constexpr uint32_t START_MS = 0xFFFFF000U;
-  latch.observe(true, START_MS, STABLE_MS);
-  assert(!latch.confirmed());
-  latch.observe(true, static_cast<uint32_t>(START_MS + STABLE_MS), STABLE_MS);
-  assert(latch.confirmed());
-}
-
 }  // namespace
 
 int main() {
@@ -385,7 +357,5 @@ int main() {
   test_consume_commit_failure_blocks_then_recovers_once();
   test_image_and_configuration_mismatch_are_rejected();
   test_invalid_credit_bounds_fail_closed();
-  test_full_credit_latch_requires_stable_eligibility();
-  test_full_credit_latch_handles_millis_wrap();
   return 0;
 }

--- a/tests/host/restart_handoff_test.cpp
+++ b/tests/host/restart_handoff_test.cpp
@@ -15,6 +15,7 @@ using esphome::openquatt_incident_manager::restart_handoff::may_grant_after_dura
 using esphome::openquatt_incident_manager::restart_handoff::may_restore_credit;
 using esphome::openquatt_incident_manager::restart_handoff::persist_record;
 using esphome::openquatt_incident_manager::restart_handoff::Record;
+using esphome::openquatt_incident_manager::restart_handoff::StableFullCreditLatch;
 using esphome::openquatt_incident_manager::restart_handoff::StorageReadResult;
 using esphome::openquatt_incident_manager::restart_handoff::valid_record;
 
@@ -68,7 +69,7 @@ Record make_record() {
   Record record{};
   record.magic = esphome::openquatt_incident_manager::restart_handoff::kRecordMagic;
   record.version = esphome::openquatt_incident_manager::restart_handoff::kRecordVersion;
-  record.state = esphome::openquatt_incident_manager::restart_handoff::kRecordArmed;
+  record.state = esphome::openquatt_incident_manager::restart_handoff::kRecordRestartArmed;
   record.minimum_off_ms = MINIMUM_OFF_MS;
   record.config_hash = configuration_hash(MINIMUM_OFF_MS, true);
   record.boot_partition_address = 0x210000U;
@@ -76,6 +77,15 @@ Record make_record() {
   record.hp2_credit_ms = 120000U;
   for (size_t index = 0U; index < sizeof(record.image_hash); ++index)
     record.image_hash[index] = static_cast<uint8_t>(index);
+  finalize_record(&record);
+  return record;
+}
+
+Record make_ota_record() {
+  Record record = make_record();
+  record.state = esphome::openquatt_incident_manager::restart_handoff::kRecordOtaArmed;
+  record.boot_partition_address = 0x410000U;
+  record.hp2_credit_ms = MINIMUM_OFF_MS;
   finalize_record(&record);
   return record;
 }
@@ -97,6 +107,40 @@ void test_only_exact_controlled_restart_restores_credit() {
   assert(valid_record(record));
   const BootContext context = matching_context(record);
   assert(may_restore_credit(record, context));
+}
+
+void test_controlled_ota_restores_on_selected_new_partition() {
+  const Record record = make_ota_record();
+  assert(valid_record(record));
+
+  auto pending_context = matching_context(record);
+  pending_context.image_valid = false;
+  pending_context.image_pending_verify = true;
+  pending_context.image_hash[0] ^= 0x5AU;
+  assert(may_restore_credit(record, pending_context));
+
+  auto rollback_disabled_context = matching_context(record);
+  rollback_disabled_context.image_hash[0] ^= 0xA5U;
+  assert(may_restore_credit(record, rollback_disabled_context));
+}
+
+void test_ota_handoff_rejects_old_or_uncontrolled_boot() {
+  const Record record = make_ota_record();
+
+  auto same_image = matching_context(record);
+  assert(!may_restore_credit(record, same_image));
+
+  auto wrong_partition = matching_context(record);
+  wrong_partition.image_pending_verify = true;
+  wrong_partition.image_valid = false;
+  wrong_partition.boot_partition_address++;
+  assert(!may_restore_credit(record, wrong_partition));
+
+  auto uncontrolled_reset = matching_context(record);
+  uncontrolled_reset.image_pending_verify = true;
+  uncontrolled_reset.image_valid = false;
+  uncontrolled_reset.software_reset = false;
+  assert(!may_restore_credit(record, uncontrolled_reset));
 }
 
 void test_corrupt_or_partial_arm_never_restores_credit() {
@@ -297,10 +341,39 @@ void test_invalid_credit_bounds_fail_closed() {
   assert(!valid_record(record));
 }
 
+void test_full_credit_latch_requires_stable_eligibility() {
+  StableFullCreditLatch latch{};
+  constexpr uint32_t STABLE_MS = 15000U;
+
+  latch.observe(true, 1000U, STABLE_MS);
+  assert(!latch.confirmed());
+  latch.observe(true, 15999U, STABLE_MS);
+  assert(!latch.confirmed());
+  latch.observe(true, 16000U, STABLE_MS);
+  assert(latch.confirmed());
+
+  latch.observe(false, 17000U, STABLE_MS);
+  assert(!latch.confirmed());
+  latch.observe(true, 18000U, STABLE_MS);
+  assert(!latch.confirmed());
+}
+
+void test_full_credit_latch_handles_millis_wrap() {
+  StableFullCreditLatch latch{};
+  constexpr uint32_t STABLE_MS = 15000U;
+  constexpr uint32_t START_MS = 0xFFFFF000U;
+  latch.observe(true, START_MS, STABLE_MS);
+  assert(!latch.confirmed());
+  latch.observe(true, static_cast<uint32_t>(START_MS + STABLE_MS), STABLE_MS);
+  assert(latch.confirmed());
+}
+
 }  // namespace
 
 int main() {
   test_only_exact_controlled_restart_restores_credit();
+  test_controlled_ota_restores_on_selected_new_partition();
+  test_ota_handoff_rejects_old_or_uncontrolled_boot();
   test_corrupt_or_partial_arm_never_restores_credit();
   test_replay_and_non_restart_paths_are_rejected();
   test_consume_failure_never_grants_in_memory_credit();
@@ -312,5 +385,7 @@ int main() {
   test_consume_commit_failure_blocks_then_recovers_once();
   test_image_and_configuration_mismatch_are_rejected();
   test_invalid_credit_bounds_fail_closed();
+  test_full_credit_latch_requires_stable_eligibility();
+  test_full_credit_latch_handles_millis_wrap();
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Neemt per HP een volledig bevestigde minimale uit-tijd eenmalig mee over een gecontroleerde OTA.
- Behandelt Restart en succesvolle OTA bij de volgende boot via dezelfde one-shot handoff-policy: software-reset, exacte bootpartitie, exacte image-hash en dezelfde topology/minimum-off configuratie.
- Na reboot blijft een verse stopwaarneming vereist; tijd zonder HP-feedback tijdens reboot/OTA telt niet mee.
- Crash, stroomuitval, verkeerde/rollback-partitie, OTA-fout/abort, config-mismatch of onzekere HP-status vallen terug op de normale volledige wachttijd.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De bestaande 240 s compressor-startbeveiliging blijft leidend. Alleen wanneer een HP vóór OTA al aantoonbaar de volledige minimale uit-tijd heeft voltooid, wordt 240 s krediet meegenomen. De nieuwe firmware moet daarna opnieuw verse STOPPED-feedback zien voordat de HP wordt vrijgegeven.

## Achtergrond

#634 neemt bevestigde uit-tijd al mee over een gewone gecontroleerde Restart. Een HP die al uren stilstaat moest na OTA echter opnieuw de volledige 240 s wachten.

De eerste #661-implementatie schreef bij `OTA_STARTED` al een apart OTA-record en probeerde vooraf de updatepartitie te voorspellen. Twee HIL-tests lieten zien dat dit onnodig complex en niet betrouwbaar genoeg was: zowel een same-image OTA als een echte image-wissel bouwden na reboot opnieuw exact 240 s op.

De implementatie is daarom vereenvoudigd naar één **controlled reboot handoff**:

1. `OTA_STARTED`: snapshot alleen het reeds volledig bevestigde krediet per HP in RAM; runtime polling/control is vanaf dit moment gepauzeerd.
2. Download/flashing: er staat nog geen OTA-handoff in NVS.
3. `OTA_COMPLETED`: ESPHome heeft de image succesvol afgerond en de nieuwe bootpartitie al geselecteerd. OpenQuatt leest nu de werkelijke `esp_ota_get_boot_partition()` plus `app_elf_sha256` van die geflashte image en schrijft daarmee hetzelfde one-shot recordtype als Restart.
4. Reboot: dezelfde restore-policy als Restart controleert software-reset + exacte partition + exacte image-hash + configuratie. Daarna is opnieuw verse STOPPED-feedback vereist.

Hierdoor laat een afgebroken/mislukte OTA geen handoff-record achter, werkt een same-image reinstall vanzelf, en worden rollback/verkeerde partitie of image-mismatch fail-closed afgewezen. De eerste boot mag zowel `PENDING_VERIFY` als legacy `NEW` zijn; oudere reeds uitgerolde bootloaders kunnen `NEW` niet naar `PENDING_VERIFY` promoveren. Omdat partition en image-hash exact moeten matchen, geeft dat geen extra replayruimte.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen nieuwe instelling of gebruikersactie; dit corrigeert alleen het startup-gedrag rond de bestaande OTA-flow. De minimale uit-tijd en vereiste verse stopbevestiging blijven ongewijzigd.

## Validatie

- Hostpolicy gebruikt nu één exact handoff-contract voor Restart en OTA; `PENDING_VERIFY`/legacy `NEW` is toegestaan, maar partition/image/config moeten exact overeenkomen.
- Failure-injection voor NVS consume/persist en one-shot replay blijft behouden.
- HIL test 1 — eerste OTA-implementatie (`760d44c` -> dezelfde image): OTA-handoff werd niet toegepast; volledige 240 s opnieuw opgebouwd.
- HIL test 2 — aangepaste OTA-implementatie (`760d44c` -> `078aba6`): idem; hiermee bleek dat de pre-flash OTA-recordaanpak fundamenteel moest worden vereenvoudigd.
- Gewone Restart op hardware: krediet wordt correct hersteld; HP1 werd ~26 s na boot vrijgegeven in plaats van +240 s.
- HIL test 3 — definitieve post-flash handoff (`61bbba4` -> dezelfde `61bbba4` image): geslaagd. Beide HP's waren vóór OTA volledig vrijgegeven (`19:30:37`). Na OTA bootte de controller om `19:31:31`; HP1 werd om `19:31:49` (+18 s), HP2 om `19:32:06` (+35 s) en beide HP's waren om `19:32:10` (+39 s) vrijgegeven. Er werd dus géén nieuwe 240 s opgebouwd; het meegenomen krediet werd toegepast zodra per HP opnieuw verse STOPPED-feedback beschikbaar was.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Kleine vaste extra OTA-listenerstate: managerpointer, minimum-off waarde, twee `uint32_t` credits en één boolean. Geen nieuwe buffers, task of runtimehistorie; niet fysiek gemeten.