### PR TITLE
odu_runtime: maak logniveaus en statusteksten duidelijker

### DIFF
--- a/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
+++ b/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
@@ -328,7 +328,8 @@ OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::reques
 OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::request_arm(bool enabled) {
   if (!this->available_.load(std::memory_order_acquire)) return RequestResult::UNAVAILABLE;
   RequestResult result = RequestResult::ACCEPTED;
-  const char* status = enabled ? "ODU frequency table writes enabled" : "ODU frequency table writes disabled";
+  const char* status =
+      enabled ? "Compressor frequency table writes enabled" : "Compressor frequency table writes disabled";
   portENTER_CRITICAL(&this->state_mux_);
   if (this->busy_.load(std::memory_order_acquire)) {
     result = RequestResult::BUSY;
@@ -413,10 +414,14 @@ void OpenQuattOduRuntimeFrequency::reset_runtime_state(const char* failure_messa
   const char* status = this->reset_runtime_state_locked_(failure_message);
   reserved_token = this->bus_reservation_token_.exchange(0U, std::memory_order_acq_rel);
   portEXIT_CRITICAL(&this->state_mux_);
-  if (status != nullptr && std::strncmp(status, "Ready", 5) == 0) {
-    ESP_LOGD(TAG, "HP%u %s", this->hp_index_, status);
-  } else {
+  // The locked helper returns the caller-provided failure pointer verbatim only
+  // when a write had started; pointer equality (not the user-facing text)
+  // decides between WARNING and DEBUG.
+  const bool failure = failure_message != nullptr && status == failure_message;
+  if (failure) {
     ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status);
+  } else {
+    ESP_LOGD(TAG, "HP%u %s", this->hp_index_, status);
   }
   if (reserved_token != 0U) this->eeprom_dump_->end_external_operation();
 }
@@ -755,7 +760,7 @@ void OpenQuattOduRuntimeFrequency::finish_apply_(const oq_odu_runtime_frequency:
   this->write_tainted_.store(false, std::memory_order_release);
   this->set_status_locked_("Frequency table written and verified successfully");
   portEXIT_CRITICAL(&this->state_mux_);
-  ESP_LOGW(TAG, "HP%u Frequency table written and verified successfully", this->hp_index_);
+  ESP_LOGI(TAG, "HP%u Frequency table written and verified successfully", this->hp_index_);
   this->release_bus_(operation_token);
   this->write_applied_callbacks_.call();
 }

--- a/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
+++ b/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
@@ -311,7 +311,7 @@ OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::reques
       this->operation_token_.load(std::memory_order_acquire) == request_token) {
     this->loaded_.store(false, std::memory_order_release);
     this->armed_.store(false, std::memory_order_release);
-    this->set_status_locked_("LOAD_REQUESTED");
+    this->set_status_locked_("Reading compressor frequency table from ODU");
     this->pending_action_ = PendingAction::LOAD;
     this->pending_request_token_ = request_token;
     accepted = true;
@@ -321,14 +321,14 @@ OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::reques
     this->release_bus_(request_token);
     return RequestResult::BUSY;
   }
-  ESP_LOGI(TAG, "HP%u LOAD_REQUESTED", this->hp_index_);
+  ESP_LOGI(TAG, "HP%u Reading compressor frequency table from ODU", this->hp_index_);
   return RequestResult::ACCEPTED;
 }
 
 OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::request_arm(bool enabled) {
   if (!this->available_.load(std::memory_order_acquire)) return RequestResult::UNAVAILABLE;
   RequestResult result = RequestResult::ACCEPTED;
-  const char* status = enabled ? "ARMED: runtime writes enabled" : "LOCKED: runtime writes disabled";
+  const char* status = enabled ? "ODU frequency table writes enabled" : "ODU frequency table writes disabled";
   portENTER_CRITICAL(&this->state_mux_);
   if (this->busy_.load(std::memory_order_acquire)) {
     result = RequestResult::BUSY;
@@ -372,7 +372,7 @@ OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::reques
       result = RequestResult::INVALID_TABLE;
     } else {
       this->operation_tables_ = tables;
-      this->set_status_locked_("GUARD_READ_REQUESTED: checking ODU state");
+      this->set_status_locked_("Checking whether ODU is safe to modify");
       this->pending_action_ = PendingAction::APPLY;
       this->pending_request_token_ = request_token;
     }
@@ -386,7 +386,7 @@ OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::reques
     this->release_bus_(request_token);
     return result;
   }
-  ESP_LOGI(TAG, "HP%u GUARD_READ_REQUESTED: checking ODU state", this->hp_index_);
+  ESP_LOGI(TAG, "HP%u Checking whether ODU is safe to modify", this->hp_index_);
   return result;
 }
 
@@ -402,7 +402,8 @@ void OpenQuattOduRuntimeFrequency::set_extended_layout(bool extended_layout) {
   }
   portEXIT_CRITICAL(&this->state_mux_);
   if (!changed) return;
-  ESP_LOGI(TAG, "HP%u runtime frequency editor ready; load the ODU table before editing", this->hp_index_);
+  ESP_LOGI(TAG, "HP%u compressor frequency table editor ready; load the current table from the ODU before editing",
+           this->hp_index_);
   if (reserved_token != 0U) this->eeprom_dump_->end_external_operation();
 }
 
@@ -412,7 +413,7 @@ void OpenQuattOduRuntimeFrequency::reset_runtime_state(const char* failure_messa
   const char* status = this->reset_runtime_state_locked_(failure_message);
   reserved_token = this->bus_reservation_token_.exchange(0U, std::memory_order_acq_rel);
   portEXIT_CRITICAL(&this->state_mux_);
-  if (status != nullptr && std::strncmp(status, "READY", 5) == 0) {
+  if (status != nullptr && std::strncmp(status, "Ready", 5) == 0) {
     ESP_LOGD(TAG, "HP%u %s", this->hp_index_, status);
   } else {
     ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status);
@@ -431,8 +432,9 @@ const char* OpenQuattOduRuntimeFrequency::reset_runtime_state_locked_(const char
   this->loaded_.store(false, std::memory_order_release);
   this->armed_.store(false, std::memory_order_release);
   if (had_write_started) this->write_tainted_.store(true, std::memory_order_release);
-  const char* status =
-      had_write_started && failure_message != nullptr ? failure_message : "READY: load ODU runtime table";
+  const char* status = had_write_started && failure_message != nullptr
+                           ? failure_message
+                           : "Ready: load the current compressor frequency table from the ODU";
   this->set_status_locked_(status);
   return status;
 }
@@ -495,16 +497,16 @@ void OpenQuattOduRuntimeFrequency::loop() {
   if (this->operation_ != Operation::NONE && millis() - this->operation_started_ms_ >= this->operation_timeout_ms_) {
     const uint32_t operation_token = this->operation_token_.load(std::memory_order_acquire);
     if (this->operation_ == Operation::LOAD) {
-      this->fail_operation_("LOAD_FAILED: Modbus response timeout", operation_token);
+      this->fail_operation_("Loading failed: ODU did not respond in time", operation_token);
     } else if (this->write_started_) {
-      this->fail_operation_("VERIFY_FAILED: write acknowledgement timeout", operation_token);
+      this->fail_operation_("Verification failed: ODU did not acknowledge the write in time", operation_token);
     } else {
-      this->finish_without_write_("BLOCKED: ODU guard response timeout", operation_token);
+      this->finish_without_write_("Write blocked: ODU safety check timed out", operation_token, true);
     }
   }
 }
 
-void OpenQuattOduRuntimeFrequency::finish_without_write_(const char* status, uint32_t operation_token) {
+void OpenQuattOduRuntimeFrequency::finish_without_write_(const char* status, uint32_t operation_token, bool warn) {
   portENTER_CRITICAL(&this->state_mux_);
   if (!this->busy_.load(std::memory_order_acquire) ||
       this->operation_token_.load(std::memory_order_acquire) != operation_token) {
@@ -516,7 +518,11 @@ void OpenQuattOduRuntimeFrequency::finish_without_write_(const char* status, uin
   this->busy_.store(false, std::memory_order_release);
   this->set_status_locked_(status);
   portEXIT_CRITICAL(&this->state_mux_);
-  ESP_LOGI(TAG, "HP%u %s", this->hp_index_, status != nullptr ? status : "");
+  if (warn) {
+    ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status != nullptr ? status : "");
+  } else {
+    ESP_LOGI(TAG, "HP%u %s", this->hp_index_, status != nullptr ? status : "");
+  }
   this->release_bus_(operation_token);
 }
 
@@ -550,7 +556,7 @@ void OpenQuattOduRuntimeFrequency::queue_load_base_(uint32_t operation_token) {
         oq_odu_runtime_frequency::RuntimeFrequencyTables tables;
         size_t loaded = 0U;
         if (!oq_odu_runtime_frequency::parse_base_runtime_table(data.data(), data.size(), tables, loaded)) {
-          this->fail_operation_("LOAD_FAILED: incomplete base runtime table", operation_token);
+          this->fail_operation_("Loading failed: incomplete compressor frequency table received", operation_token);
           return;
         }
         if (this->extended_layout_.load(std::memory_order_acquire)) {
@@ -575,7 +581,8 @@ void OpenQuattOduRuntimeFrequency::queue_load_extension_(oq_odu_runtime_frequenc
         }
         size_t loaded = 0U;
         if (!oq_odu_runtime_frequency::parse_extended_runtime_table(data.data(), data.size(), tables, loaded)) {
-          this->fail_operation_("LOAD_FAILED: incomplete extended runtime table", operation_token);
+          this->fail_operation_("Loading failed: incomplete compressor frequency table extension received",
+                                operation_token);
           return;
         }
         this->finish_load_(tables, operation_token);
@@ -587,9 +594,8 @@ void OpenQuattOduRuntimeFrequency::finish_load_(const oq_odu_runtime_frequency::
                                                 uint32_t operation_token) {
   if (!this->token_matches_(operation_token)) return;
   char status[64];
-  std::snprintf(status, sizeof(status), "LOADED: %u/%u runtime registers",
-                static_cast<unsigned>(oq_odu_runtime_frequency::runtime_register_count(tables.level_count)),
-                static_cast<unsigned>(oq_odu_runtime_frequency::runtime_register_count(tables.level_count)));
+  std::snprintf(status, sizeof(status), "Compressor frequency table loaded (%u levels)",
+                static_cast<unsigned>(tables.level_count));
   portENTER_CRITICAL(&this->state_mux_);
   if (!this->busy_.load(std::memory_order_acquire) ||
       this->operation_token_.load(std::memory_order_acquire) != operation_token) {
@@ -615,20 +621,20 @@ void OpenQuattOduRuntimeFrequency::queue_guard_(uint32_t operation_token) {
         uint16_t compressor_hz = 0U;
         if (!oq_odu_runtime_frequency::read_u16_word(data.data(), data.size(), GUARD_WORKING_MODE_INDEX,
                                                      working_mode)) {
-          this->finish_without_write_("BLOCKED: ODU mode unknown", operation_token);
+          this->finish_without_write_("Write blocked: ODU operating mode unknown", operation_token, true);
           return;
         }
         if (!oq_odu_runtime_frequency::read_u16_word(data.data(), data.size(), GUARD_COMPRESSOR_FREQUENCY_INDEX,
                                                      compressor_hz)) {
-          this->finish_without_write_("BLOCKED: compressor frequency unknown", operation_token);
+          this->finish_without_write_("Write blocked: compressor frequency unknown", operation_token, true);
           return;
         }
         if (working_mode != 0U) {
-          this->finish_without_write_("BLOCKED: ODU is not in standby", operation_token);
+          this->finish_without_write_("Write blocked: ODU is not in standby", operation_token, false);
           return;
         }
         if (compressor_hz > 0U) {
-          this->finish_without_write_("BLOCKED: compressor is running", operation_token);
+          this->finish_without_write_("Write blocked: compressor is running", operation_token, false);
           return;
         }
         this->begin_write_(operation_token);
@@ -646,9 +652,9 @@ void OpenQuattOduRuntimeFrequency::begin_write_(uint32_t operation_token) {
   this->armed_.store(false, std::memory_order_release);
   this->write_started_ = true;
   this->write_tainted_.store(true, std::memory_order_release);
-  this->set_status_locked_("WRITE_QUEUED: runtime table write requested");
+  this->set_status_locked_("Writing compressor frequency table to ODU");
   portEXIT_CRITICAL(&this->state_mux_);
-  ESP_LOGW(TAG, "HP%u WRITE_QUEUED: runtime table write requested", this->hp_index_);
+  ESP_LOGW(TAG, "HP%u Writing compressor frequency table to ODU", this->hp_index_);
   this->write_started_callbacks_.call();
   this->queue_write_register_(0U, operation_token);
 }
@@ -663,16 +669,16 @@ void OpenQuattOduRuntimeFrequency::queue_write_register_(size_t write_index, uin
       portEXIT_CRITICAL(&this->state_mux_);
       return;
     }
-    this->set_status_locked_("WRITE_CONFIRMED: runtime writes acknowledged");
+    this->set_status_locked_("Frequency table written; verifying readback");
     portEXIT_CRITICAL(&this->state_mux_);
-    ESP_LOGW(TAG, "HP%u WRITE_CONFIRMED: runtime writes acknowledged", this->hp_index_);
+    ESP_LOGW(TAG, "HP%u Frequency table written; verifying readback", this->hp_index_);
     this->queue_readback_base_(operation_token);
     return;
   }
 
   const auto target = oq_odu_runtime_frequency::runtime_write_register(this->operation_tables_, write_index);
   if (!target.valid) {
-    this->fail_operation_("VERIFY_FAILED: invalid runtime register mapping", operation_token);
+    this->fail_operation_("Verification failed: internal register mapping error", operation_token);
     return;
   }
   auto command = modbus_controller::ModbusCommandItem::create_write_single_command(this->controller_, target.address,
@@ -695,7 +701,7 @@ void OpenQuattOduRuntimeFrequency::queue_readback_base_(uint32_t operation_token
         oq_odu_runtime_frequency::RuntimeFrequencyTables actual;
         size_t loaded = 0U;
         if (!oq_odu_runtime_frequency::parse_base_runtime_table(data.data(), data.size(), actual, loaded)) {
-          this->fail_operation_("VERIFY_FAILED: incomplete base readback", operation_token);
+          this->fail_operation_("Verification failed: incomplete readback from ODU", operation_token);
           return;
         }
         if (this->operation_tables_.level_count == oq_odu_runtime_frequency::EXTENDED_LEVEL_COUNT) {
@@ -720,7 +726,7 @@ void OpenQuattOduRuntimeFrequency::queue_readback_extension_(oq_odu_runtime_freq
         }
         size_t loaded = 0U;
         if (!oq_odu_runtime_frequency::parse_extended_runtime_table(data.data(), data.size(), actual, loaded)) {
-          this->fail_operation_("VERIFY_FAILED: incomplete extended readback", operation_token);
+          this->fail_operation_("Verification failed: incomplete extended readback from ODU", operation_token);
           return;
         }
         this->finish_apply_(actual, operation_token);
@@ -738,7 +744,7 @@ void OpenQuattOduRuntimeFrequency::finish_apply_(const oq_odu_runtime_frequency:
   }
   if (!oq_odu_runtime_frequency::tables_match(actual, this->operation_tables_)) {
     portEXIT_CRITICAL(&this->state_mux_);
-    this->fail_operation_("VERIFY_FAILED: readback mismatch", operation_token);
+    this->fail_operation_("Verification failed: ODU values differ from requested table", operation_token);
     return;
   }
   this->tables_ = actual;
@@ -747,9 +753,9 @@ void OpenQuattOduRuntimeFrequency::finish_apply_(const oq_odu_runtime_frequency:
   this->busy_.store(false, std::memory_order_release);
   this->loaded_.store(true, std::memory_order_release);
   this->write_tainted_.store(false, std::memory_order_release);
-  this->set_status_locked_("APPLIED: runtime table written and read back");
+  this->set_status_locked_("Frequency table written and verified successfully");
   portEXIT_CRITICAL(&this->state_mux_);
-  ESP_LOGW(TAG, "HP%u APPLIED: runtime table written and read back", this->hp_index_);
+  ESP_LOGW(TAG, "HP%u Frequency table written and verified successfully", this->hp_index_);
   this->release_bus_(operation_token);
   this->write_applied_callbacks_.call();
 }

--- a/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
+++ b/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.cpp
@@ -321,7 +321,7 @@ OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::reques
     this->release_bus_(request_token);
     return RequestResult::BUSY;
   }
-  ESP_LOGW(TAG, "HP%u LOAD_REQUESTED", this->hp_index_);
+  ESP_LOGI(TAG, "HP%u LOAD_REQUESTED", this->hp_index_);
   return RequestResult::ACCEPTED;
 }
 
@@ -339,7 +339,13 @@ OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::reques
     this->set_status_locked_(status);
   }
   portEXIT_CRITICAL(&this->state_mux_);
-  if (result == RequestResult::ACCEPTED) ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status);
+  if (result == RequestResult::ACCEPTED) {
+    if (enabled) {
+      ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status);
+    } else {
+      ESP_LOGI(TAG, "HP%u %s", this->hp_index_, status);
+    }
+  }
   return result;
 }
 
@@ -380,7 +386,7 @@ OpenQuattOduRuntimeFrequency::RequestResult OpenQuattOduRuntimeFrequency::reques
     this->release_bus_(request_token);
     return result;
   }
-  ESP_LOGW(TAG, "HP%u GUARD_READ_REQUESTED: checking ODU state", this->hp_index_);
+  ESP_LOGI(TAG, "HP%u GUARD_READ_REQUESTED: checking ODU state", this->hp_index_);
   return result;
 }
 
@@ -406,7 +412,11 @@ void OpenQuattOduRuntimeFrequency::reset_runtime_state(const char* failure_messa
   const char* status = this->reset_runtime_state_locked_(failure_message);
   reserved_token = this->bus_reservation_token_.exchange(0U, std::memory_order_acq_rel);
   portEXIT_CRITICAL(&this->state_mux_);
-  ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status);
+  if (status != nullptr && std::strncmp(status, "READY", 5) == 0) {
+    ESP_LOGD(TAG, "HP%u %s", this->hp_index_, status);
+  } else {
+    ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status);
+  }
   if (reserved_token != 0U) this->eeprom_dump_->end_external_operation();
 }
 
@@ -506,7 +516,7 @@ void OpenQuattOduRuntimeFrequency::finish_without_write_(const char* status, uin
   this->busy_.store(false, std::memory_order_release);
   this->set_status_locked_(status);
   portEXIT_CRITICAL(&this->state_mux_);
-  ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status != nullptr ? status : "");
+  ESP_LOGI(TAG, "HP%u %s", this->hp_index_, status != nullptr ? status : "");
   this->release_bus_(operation_token);
 }
 
@@ -592,7 +602,7 @@ void OpenQuattOduRuntimeFrequency::finish_load_(const oq_odu_runtime_frequency::
   this->loaded_.store(true, std::memory_order_release);
   this->set_status_locked_(status);
   portEXIT_CRITICAL(&this->state_mux_);
-  ESP_LOGW(TAG, "HP%u %s", this->hp_index_, status);
+  ESP_LOGI(TAG, "HP%u %s", this->hp_index_, status);
   this->release_bus_(operation_token);
 }
 

--- a/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.h
+++ b/components/openquatt_odu_runtime_frequency/OpenQuattOduRuntimeFrequency.h
@@ -90,7 +90,7 @@ class OpenQuattOduRuntimeFrequency : public Component {
   bool write_started_{false};
   uint32_t operation_started_ms_{0U};
   uint32_t operation_timeout_ms_{BASE_OPERATION_TIMEOUT_MS};
-  char status_[96]{"READY: load ODU runtime table"};
+  char status_[96]{"Ready: load the current compressor frequency table from the ODU"};
 
   CallbackManager<void()> write_started_callbacks_{};
   CallbackManager<void()> write_applied_callbacks_{};
@@ -99,7 +99,7 @@ class OpenQuattOduRuntimeFrequency : public Component {
   void release_bus_(uint32_t request_token = 0U);
   void set_status_locked_(const char* status);
   const char* reset_runtime_state_locked_(const char* failure_message);
-  void finish_without_write_(const char* status, uint32_t operation_token);
+  void finish_without_write_(const char* status, uint32_t operation_token, bool warn);
   void fail_operation_(const char* status, uint32_t operation_token);
   void finish_apply_(const oq_odu_runtime_frequency::RuntimeFrequencyTables& actual, uint32_t operation_token);
   bool token_matches_(uint32_t operation_token) const;

--- a/openquatt/oq_HP_io.yaml
+++ b/openquatt/oq_HP_io.yaml
@@ -77,7 +77,7 @@ modbus_controller:
             id(${hp_id}_odu_generation_request_pending) = false;
             id(${hp_id}_odu_generation_revalidation_required) = true;
             id(${hp_id}_odu_runtime_frequency)->reset_runtime_state(
-                "VERIFY_FAILED: ODU disconnected during write");
+                "Verification failed: ODU disconnected during write");
             if (id(${hp_id}_odu_runtime_frequency)
                     ->runtime_reload_blocked_after_write()) {
               id(oq_incident_manager).observe_runtime_frequency_mapping(

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -4142,7 +4142,7 @@
       const enabled = params.get("enabled") === "true";
       if (enabled && !service.loaded) return mockResponse(409, { ok: false, error: "load_required" });
       service.armed = enabled;
-      service.status = enabled ? "ODU frequency table writes enabled" : "ODU frequency table writes disabled";
+      service.status = enabled ? "Compressor frequency table writes enabled" : "Compressor frequency table writes disabled";
       return mockResponse(200, getOduRuntimeServicePayload(hp));
     }
     if (action === "load") {

--- a/openquatt/web/js/mock-device.js
+++ b/openquatt/web/js/mock-device.js
@@ -217,8 +217,8 @@
       },
     },
     oduRuntimeFrequencyService: {
-      1: { loaded: false, armed: false, busy: false, status: "READY: load ODU runtime table", extendedLayout: false },
-      2: { loaded: false, armed: false, busy: false, status: "READY: load ODU runtime table", extendedLayout: false },
+      1: { loaded: false, armed: false, busy: false, status: "Ready: load the current compressor frequency table from the ODU", extendedLayout: false },
+      2: { loaded: false, armed: false, busy: false, status: "Ready: load the current compressor frequency table from the ODU", extendedLayout: false },
     },
     oduSettingsService: {
       1: { loaded: false, busy: false, status: "READY", profileAvailable: false, autoReapply: false, actual: { mode: 1, startTemperatureC: 4, stopDeltaC: 3 } },
@@ -297,7 +297,7 @@
       loaded: false,
       armed: false,
       busy: false,
-      status: "READY: load ODU runtime table",
+      status: "Ready: load the current compressor frequency table from the ODU",
       extendedLayout: profile.variant === "V2 new model",
     };
     const settings = state.oduSettingsService[hp === 2 ? 2 : 1];
@@ -4142,19 +4142,19 @@
       const enabled = params.get("enabled") === "true";
       if (enabled && !service.loaded) return mockResponse(409, { ok: false, error: "load_required" });
       service.armed = enabled;
-      service.status = enabled ? "ARMED: runtime writes enabled" : "LOCKED: runtime writes disabled";
+      service.status = enabled ? "ODU frequency table writes enabled" : "ODU frequency table writes disabled";
       return mockResponse(200, getOduRuntimeServicePayload(hp));
     }
     if (action === "load") {
       service.busy = true;
       service.loaded = false;
       service.armed = false;
-      service.status = "LOAD_REQUESTED";
+      service.status = "Reading compressor frequency table from ODU";
       window.setTimeout(() => {
         service.busy = false;
         service.loaded = true;
-        const registerCount = service.extendedLayout ? 42 : 22;
-        service.status = `LOADED: ${registerCount}/${registerCount} runtime registers`;
+        const levelCount = service.extendedLayout ? 21 : 11;
+        service.status = `Compressor frequency table loaded (${levelCount} levels)`;
         notifyMockUpdated();
       }, 320);
       return mockResponse(200, getOduRuntimeServicePayload(hp));
@@ -4169,24 +4169,24 @@
       return mockResponse(409, { ok: false, error: "invalid_table" });
     }
     service.busy = true;
-    service.status = "GUARD_READ_REQUESTED: checking ODU state";
+    service.status = "Checking whether ODU is safe to modify";
     window.setTimeout(() => {
       const hpName = `HP${hp}`;
       const mode = String(getEntity("text_sensor", `${hpName} - Working Mode Label`)?.value || "").trim();
       const compressorHz = Number(getEntity("sensor", `${hpName} - Compressor frequency`)?.value);
       if (!mode || /unknown|onbekend/i.test(mode)) {
-        service.status = "BLOCKED: ODU mode unknown";
+        service.status = "Write blocked: ODU operating mode unknown";
       } else if (!/standby|stand-by/i.test(mode)) {
-        service.status = "BLOCKED: ODU is not in standby";
+        service.status = "Write blocked: ODU is not in standby";
       } else if (!Number.isFinite(compressorHz)) {
-        service.status = "BLOCKED: compressor frequency unknown";
+        service.status = "Write blocked: compressor frequency unknown";
       } else if (compressorHz > 0.5) {
-        service.status = "BLOCKED: compressor is running";
+        service.status = "Write blocked: compressor is running";
       } else {
         service.armed = false;
         state.oduRuntimeFrequency[hpName] = { cooling, heating };
         syncMockOduIdentityEntities(hp);
-        service.status = "APPLIED: runtime table written and read back";
+        service.status = "Frequency table written and verified successfully";
       }
       service.busy = false;
       notifyMockUpdated();

--- a/openquatt/web/js/src/features/odu-runtime-frequency.js
+++ b/openquatt/web/js/src/features/odu-runtime-frequency.js
@@ -37,7 +37,7 @@ export function normalizeOduRuntimeFrequencyStatus(payload = {}, hp = 1) {
     armed: payload.armed === true,
     extendedLayout: payload.extended_layout === true,
     levelCount,
-    status: String(payload.status || "READY: load ODU runtime table"),
+    status: String(payload.status || "Ready: load the current compressor frequency table from the ODU"),
     csrfToken: String(payload.csrf_token || ""),
     cooling: normalizeValues(payload.cooling),
     heating: normalizeValues(payload.heating),
@@ -320,11 +320,12 @@ function getTableValidation(hp) {
 
 function getStatusPresentation(status) {
   const code = String(status || "").toUpperCase();
-  if (code.includes("APPLIED")) return ["De gekozen waarden zijn actief", "success"];
+  if (code.includes("VERIFIED SUCCESSFULLY")) return ["De gekozen waarden zijn actief", "success"];
   if (code.includes("LOADED")) return ["Waarden uit de buitenunit geladen", "success"];
   if (code.includes("BLOCKED")) return ["Wacht tot de buitenunit stilstaat", "warning"];
   if (code.includes("FAILED")) return ["Toepassen kon niet worden bevestigd", "warning"];
-  if (code.includes("WRITE") || code.includes("GUARD") || code.includes("REQUESTED")) return ["Bezig met controleren", ""];
+  if (code.includes("WRITING") || code.includes("READING") || code.includes("CHECKING")
+    || code.includes("VERIFYING") || code.includes("WRITES")) return ["Bezig met controleren", ""];
   return ["Laad eerst de actuele waarden", ""];
 }
 

--- a/openquatt/web/js/src/features/odu-runtime-frequency.js
+++ b/openquatt/web/js/src/features/odu-runtime-frequency.js
@@ -318,14 +318,20 @@ function getTableValidation(hp) {
   return { valid: invalid.length === 0, invalid };
 }
 
-function getStatusPresentation(status) {
+export function getStatusPresentation(status) {
   const code = String(status || "").toUpperCase();
   if (code.includes("VERIFIED SUCCESSFULLY")) return ["De gekozen waarden zijn actief", "success"];
   if (code.includes("LOADED")) return ["Waarden uit de buitenunit geladen", "success"];
+  if (code.includes("OPERATING MODE UNKNOWN") || code.includes("FREQUENCY UNKNOWN")
+    || code.includes("SAFETY CHECK TIMED OUT")) {
+    return ["Veilige toestand van de buitenunit kon niet worden vastgesteld", "warning"];
+  }
   if (code.includes("BLOCKED")) return ["Wacht tot de buitenunit stilstaat", "warning"];
   if (code.includes("FAILED")) return ["Toepassen kon niet worden bevestigd", "warning"];
+  if (code.includes("WRITES ENABLED")) return ["Wijzigingen vrijgegeven", ""];
+  if (code.includes("WRITES DISABLED")) return ["Wijzigingen vergrendeld", ""];
   if (code.includes("WRITING") || code.includes("READING") || code.includes("CHECKING")
-    || code.includes("VERIFYING") || code.includes("WRITES")) return ["Bezig met controleren", ""];
+    || code.includes("VERIFYING")) return ["Bezig met controleren", ""];
   return ["Laad eerst de actuele waarden", ""];
 }
 

--- a/openquatt/web/tests/odu-runtime-frequency-editor.test.mjs
+++ b/openquatt/web/tests/odu-runtime-frequency-editor.test.mjs
@@ -82,7 +82,7 @@ test("runtime-editor hydrateert F0-F20 maar toont de uitbreiding alleen na nativ
   assert.match(mockSource, /status\|load\|arm\|apply/);
   assert.match(mockSource, /pathname\.match\(\/\\\/openquatt\\\/odu-runtime/);
   assert.match(mockSource, /Number\.isInteger\(value\)/);
-  assert.match(mockSource, /service\.extendedLayout \? 42 : 22/);
+  assert.match(mockSource, /service\.extendedLayout \? 21 : 11/);
 });
 
 test("dev-preview onderscheidt direct toepasbare bodemplaatinstellingen van de geblokkeerde frequentietabel", () => {
@@ -94,7 +94,7 @@ test("dev-preview onderscheidt direct toepasbare bodemplaatinstellingen van de g
   assert.match(mockSource, /window\.__OQ_DEV_ODU_WRITE_STATE__ = state\.oduWriteState/);
   assert.doesNotMatch(mockSource, /service\.status = "PENDING_SAFE"/);
   assert.match(mockSource, /service\.status = "IN_SYNC"/);
-  assert.match(mockSource, /BLOCKED: ODU is not in standby/);
+  assert.match(mockSource, /Write blocked: ODU is not in standby/);
   assert.match(featureSource, /__OQ_PREVIEW__ && typeof window !== "undefined"/);
   assert.match(featureSource, /window\.__OQ_DEV_ODU_WRITE_STATE__/);
   assert.match(devSource, /mock-fixtures\.js\?v=odu-settings-v3/);

--- a/openquatt/web/tests/odu-runtime-frequency-status.test.mjs
+++ b/openquatt/web/tests/odu-runtime-frequency-status.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+globalThis.__OQ_PREVIEW__ = false;
+globalThis.window = {
+  location: { pathname: "/dev.html" },
+  setTimeout,
+  clearTimeout,
+  localStorage: { getItem: () => null },
+};
+
+const { getStatusPresentation } = await import("../js/src/features/odu-runtime-frequency.js");
+
+const CASES = [
+  // [firmware status, expected Dutch label, expected tone]
+  ["Ready: load the current compressor frequency table from the ODU", "Laad eerst de actuele waarden", ""],
+  ["Reading compressor frequency table from ODU", "Bezig met controleren", ""],
+  ["Compressor frequency table loaded (11 levels)", "Waarden uit de buitenunit geladen", "success"],
+  ["Compressor frequency table loaded (21 levels)", "Waarden uit de buitenunit geladen", "success"],
+  ["Compressor frequency table writes enabled", "Wijzigingen vrijgegeven", ""],
+  ["Compressor frequency table writes disabled", "Wijzigingen vergrendeld", ""],
+  ["Checking whether ODU is safe to modify", "Bezig met controleren", ""],
+  ["Write blocked: ODU is not in standby", "Wacht tot de buitenunit stilstaat", "warning"],
+  ["Write blocked: compressor is running", "Wacht tot de buitenunit stilstaat", "warning"],
+  ["Write blocked: ODU operating mode unknown", "Veilige toestand van de buitenunit kon niet worden vastgesteld", "warning"],
+  ["Write blocked: compressor frequency unknown", "Veilige toestand van de buitenunit kon niet worden vastgesteld", "warning"],
+  ["Write blocked: ODU safety check timed out", "Veilige toestand van de buitenunit kon niet worden vastgesteld", "warning"],
+  ["Writing compressor frequency table to ODU", "Bezig met controleren", ""],
+  ["Frequency table written; verifying readback", "Bezig met controleren", ""],
+  ["Frequency table written and verified successfully", "De gekozen waarden zijn actief", "success"],
+  ["Loading failed: ODU did not respond in time", "Toepassen kon niet worden bevestigd", "warning"],
+  ["Loading failed: incomplete compressor frequency table received", "Toepassen kon niet worden bevestigd", "warning"],
+  ["Loading failed: incomplete compressor frequency table extension received", "Toepassen kon niet worden bevestigd", "warning"],
+  ["Verification failed: ODU did not acknowledge the write in time", "Toepassen kon niet worden bevestigd", "warning"],
+  ["Verification failed: internal register mapping error", "Toepassen kon niet worden bevestigd", "warning"],
+  ["Verification failed: incomplete readback from ODU", "Toepassen kon niet worden bevestigd", "warning"],
+  ["Verification failed: incomplete extended readback from ODU", "Toepassen kon niet worden bevestigd", "warning"],
+  ["Verification failed: ODU values differ from requested table", "Toepassen kon niet worden bevestigd", "warning"],
+  ["Verification failed: ODU disconnected during write", "Toepassen kon niet worden bevestigd", "warning"],
+  ["", "Laad eerst de actuele waarden", ""],
+];
+
+test("elke odu-runtime-firmwarestatus krijgt de bedoelde Nederlandse uitleg", () => {
+  for (const [status, label, tone] of CASES) {
+    assert.deepEqual(getStatusPresentation(status), [label, tone], `status: ${status || "<leeg>"}`);
+  }
+});

--- a/openquatt/web/tests/odu-write-mock.test.mjs
+++ b/openquatt/web/tests/odu-write-mock.test.mjs
@@ -76,13 +76,13 @@ test("frequentietabelmock blijft geblokkeerd tot standby met stilstaande compres
     const initialTable = mock.state.oduRuntimeFrequency.HP1;
     assert.equal(mock.request("odu-runtime", 1, "apply", values).status, 200);
     mock.finish();
-    assert.match(mock.request("odu-runtime", 1, "status").payload.status, /^BLOCKED:/);
+    assert.match(mock.request("odu-runtime", 1, "status").payload.status, /^Write blocked:/);
     assert.equal(mock.state.oduRuntimeFrequency.HP1, initialTable);
     mock.telemetry.mode = "Standby";
     mock.telemetry.frequency = 0;
     assert.equal(mock.request("odu-runtime", 1, "apply", values).status, 200);
     mock.finish();
-    assert.match(mock.request("odu-runtime", 1, "status").payload.status, /^APPLIED:/);
+    assert.match(mock.request("odu-runtime", 1, "status").payload.status, /^Frequency table written and verified/);
   }
 });
 

--- a/scripts/tests/test_esphome_compatibility_contract.py
+++ b/scripts/tests/test_esphome_compatibility_contract.py
@@ -122,7 +122,7 @@ class ESPHomeCompatibilityContractTest(unittest.TestCase):
         self.assertIn("token_matches_(operation_token)", ODU_RUNTIME_SOURCE)
         self.assertIn("BASE_OPERATION_TIMEOUT_MS = 30000U", ODU_RUNTIME_HEADER)
         self.assertIn("EXTENDED_OPERATION_TIMEOUT_MS = 60000U", ODU_RUNTIME_HEADER)
-        self.assertIn("VERIFY_FAILED: write acknowledgement timeout", ODU_RUNTIME_SOURCE)
+        self.assertIn("Verification failed: ODU did not acknowledge the write in time", ODU_RUNTIME_SOURCE)
         self.assertNotIn("create_write_multiple_command", ODU_RUNTIME_SOURCE)
 
     def test_bottom_plate_writes_allow_running_compressor_and_remain_verified(self) -> None:
@@ -138,8 +138,8 @@ class ESPHomeCompatibilityContractTest(unittest.TestCase):
         self.assertIn("try_begin_external_operation()", ODU_SETTINGS_SOURCE)
         self.assertIn("end_external_operation()", ODU_SETTINGS_SOURCE)
         self.assertIn("queue_guard_", ODU_RUNTIME_SOURCE)
-        self.assertIn("BLOCKED: ODU is not in standby", ODU_RUNTIME_SOURCE)
-        self.assertIn("BLOCKED: compressor is running", ODU_RUNTIME_SOURCE)
+        self.assertIn("Write blocked: ODU is not in standby", ODU_RUNTIME_SOURCE)
+        self.assertIn("Write blocked: compressor is running", ODU_RUNTIME_SOURCE)
 
     def test_runtime_table_and_eeprom_dump_exclude_each_other(self) -> None:
         self.assertIn("try_begin_external_operation", ODU_EEPROM_HEADER)
@@ -158,7 +158,7 @@ class ESPHomeCompatibilityContractTest(unittest.TestCase):
             ODU_RUNTIME_SOURCE,
         )
         self.assertIn(
-            "finish_without_write_(const char* status, uint32_t operation_token)",
+            "finish_without_write_(const char* status, uint32_t operation_token, bool warn)",
             ODU_RUNTIME_SOURCE,
         )
 

--- a/scripts/tests/test_modbus_metadata_continuity_contract.py
+++ b/scripts/tests/test_modbus_metadata_continuity_contract.py
@@ -47,7 +47,7 @@ class ModbusMetadataContinuityContractTest(unittest.TestCase):
             "odu_generation_revalidation_required",
             "runtime_frequency_revalidation_required",
             "odu_runtime_frequency)->reset_runtime_state",
-            "VERIFY_FAILED: ODU disconnected during write",
+            "Verification failed: ODU disconnected during write",
         ):
             self.assertIn(value, offline)
         self.assertIn("detect_odu_generation_once", online)

--- a/scripts/tests/test_v2_compressor_level_contract.py
+++ b/scripts/tests/test_v2_compressor_level_contract.py
@@ -105,9 +105,9 @@ class V2CompressorLevelContractTest(unittest.TestCase):
         self.assertNotIn("RuntimeFrequencySnapshotStorage{}", RUNTIME_EDITOR)
         self.assertNotIn("CompressorLevelProfile::UNKNOWN", RUNTIME_EDITOR)
         self.assertIn("write_tainted_.store(true", RUNTIME_EDITOR_SOURCE)
-        self.assertIn("VERIFY_FAILED: readback mismatch", RUNTIME_EDITOR_SOURCE)
+        self.assertIn("Verification failed: ODU values differ from requested table", RUNTIME_EDITOR_SOURCE)
         self.assertIn("write_tainted_.store(false", RUNTIME_EDITOR_SOURCE)
-        self.assertIn("APPLIED: runtime table written and read back", RUNTIME_EDITOR_SOURCE)
+        self.assertIn("Frequency table written and verified successfully", RUNTIME_EDITOR_SOURCE)
         self.assertIn("on_write_applied:", RUNTIME_EDITOR)
         self.assertIn("script.execute: ${hp_id}_load_runtime_frequency_table_once", RUNTIME_EDITOR)
 


### PR DESCRIPTION
# Wat verandert deze PR?

- Schoont de logging van `openquatt.odu_runtime` op zodat normale statusovergangen niet langer als WARNING verschijnen.
- Maakt de status- en logteksten begrijpelijker voor gebruikers en beheerders; interne termen als `LOAD_REQUESTED`, `GUARD_READ_REQUESTED` en `VERIFY_FAILED` zijn vervangen door duidelijke omschrijvingen.
- Gebruikt consequent `compressor frequency table` in plaats van `runtime table`.
- Verbetert de webpresentatie van statussen, met aparte meldingen voor normale safety-refusals, onbekende/timeout-situaties en het vrijgeven/vergrendelen van wijzigingen.
- Voegt een gerichte webtest toe die alle relevante firmwarestatussen aan de juiste Nederlandse uitleg en tone koppelt.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [x] Anders (logging-classificatie + statusteksten)

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Deze PR wijzigt alleen log-levels, statusstrings en de presentatie daarvan. De state machine, guard-logica, Modbus-writes, readback-verificatie en control/runtime-logica blijven functioneel ongewijzigd.

De logindeling is nu bewust:
- `DEBUG`: normale `Ready`/boot-resetstatus.
- `INFO`: lezen/laden, safety-checks, normale refusals (ODU niet in standby of compressor draait), vergrendelen en succesvolle verificatie.
- `WARNING`: writes vrijgeven, daadwerkelijke write/verificatiefase, situaties waarin de veilige toestand niet kan worden vastgesteld, load/verify-fouten en disconnect tijdens write.

## Achtergrond

De bestaande logging gebruikte meerdere WARNINGs voor normale of verwachte toestanden, waardoor echte afwijkingen minder opvielen. Tegelijk waren veel statusstrings vooral begrijpelijk als je de interne state machine kende.

Deze PR maakt de logging semantisch consistenter en de meldingen leesbaar zonder de onderliggende logica te veranderen. `reset_runtime_state()` bepaalt WARNING/DEBUG op basis van de echte failure-conditie en niet meer op basis van de tekstinhoud.

De webapp onderscheidt nu onder meer:
- veilige toestand niet vast te stellen → `Veilige toestand van de buitenunit kon niet worden vastgesteld`;
- ODU niet in standby / compressor draait → `Wacht tot de buitenunit stilstaat`;
- writes vrijgegeven/vergrendeld → `Wijzigingen vrijgegeven` / `Wijzigingen vergrendeld`.

Een toekomstige opsplitsing naar aparte `status_code` en leesbare `message` kan de resterende tekstkoppeling verder verminderen, maar valt buiten de scope van deze PR.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen documentatie verwijst naar deze interne statusstrings; configuratie, API en functioneel gedrag wijzigen niet.

## Validatie

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen nieuwe buffers, taken of allocaties; alleen log-macro's, stringliteralen en presentatie-logica zijn aangepast.

Getest:

- `npm run check:cpp-format` — passed
- `python3 -m unittest discover -s scripts/tests -p "test_*.py"` — 230 tests OK
- `node openquatt/web/run-web-tests.mjs` — 457 tests OK, inclusief de nieuwe status-mappingtest
- `node openquatt/web/check-web-quality.mjs` — bekende pre-existing bundelgrootte-overtreding op de ongewijzigde `dev`-bundle; buiten scope van deze PR
