### PR TITLE
Filter UART-foutbytes op Controller Q RS485

### DIFF
--- a/openquatt/profiles/heatpump_controller_q.yaml
+++ b/openquatt/profiles/heatpump_controller_q.yaml
@@ -49,6 +49,7 @@ packages:
   oq_hardware_revision: !include heatpump_controller_q_hardware_revision.yaml
   oq_status_leds: !include heatpump_controller_q_status_leds.yaml
   oq_cic_compatibility: !include heatpump_controller_q_cic_compatibility.yaml
+  oq_uart_error_filter: !include heatpump_controller_q_uart_error_filter.yaml
   oq_aux_relay_control: !include ../oq_aux_relay_control.yaml
   oq_sensor_source_selects_opentherm: !include ../oq_sensor_source_selects_opentherm.yaml
   oq_ot_slave: !include

--- a/openquatt/profiles/heatpump_controller_q_uart_error_filter.h
+++ b/openquatt/profiles/heatpump_controller_q_uart_error_filter.h
@@ -2,31 +2,23 @@
 
 #ifdef USE_ESP_IDF
 
-#include "driver/uart.h"
 #include "soc/uart_reg.h"
 #include "esphome/components/uart/uart_component_esp_idf.h"
 #include "esphome/core/log.h"
 
 namespace oq_controller_q_uart {
 
-inline bool error_character_discard_enabled(uint8_t uart_num) {
-  return (REG_READ(UART_CONF0_REG(uart_num)) & UART_ERR_WR_MASK) != 0;
-}
+inline void enable_error_character_discard(esphome::uart::IDFUARTComponent* uart, const char* port_name) {
+  const uint8_t uart_num = uart->get_hw_serial_number();
+  REG_SET_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
 
-inline bool error_character_discard_enabled(esphome::uart::IDFUARTComponent* uart) {
-  return error_character_discard_enabled(uart->get_hw_serial_number());
-}
-
-inline void enable_error_character_discard_all() {
-  for (uint8_t uart_num = 0; uart_num < UART_NUM_MAX; uart_num++) {
-    REG_SET_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
-    if (!error_character_discard_enabled(uart_num)) {
-      ESP_LOGW("oq.uart_filter", "Controller Q UART%u: parity/framing error discard did not enable", uart_num);
-      continue;
-    }
-
-    ESP_LOGI("oq.uart_filter", "Controller Q UART%u: parity/framing error discard enabled", uart_num);
+  if ((REG_READ(UART_CONF0_REG(uart_num)) & UART_ERR_WR_MASK) == 0) {
+    ESP_LOGW("oq.uart_filter", "Controller Q %s UART%u: parity/framing error discard did not enable", port_name,
+             uart_num);
+    return;
   }
+
+  ESP_LOGI("oq.uart_filter", "Controller Q %s UART%u: parity/framing error discard enabled", port_name, uart_num);
 }
 
 }  // namespace oq_controller_q_uart

--- a/openquatt/profiles/heatpump_controller_q_uart_error_filter.h
+++ b/openquatt/profiles/heatpump_controller_q_uart_error_filter.h
@@ -2,24 +2,24 @@
 
 #ifdef USE_ESP_IDF
 
+#include "driver/uart.h"
 #include "soc/uart_reg.h"
-#include "esphome/components/uart/uart_component_esp_idf.h"
 #include "esphome/core/log.h"
 
 namespace oq_controller_q_uart {
 
-inline void enable_error_character_discard(esphome::uart::IDFUARTComponent* uart, const char* port_name) {
-  const uint8_t uart_num = uart->get_hw_serial_number();
-  REG_SET_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
+inline void enable_error_character_discard_all() {
+  for (uint8_t uart_num = 0; uart_num < UART_NUM_MAX; uart_num++) {
+    REG_SET_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
 
-  const uint32_t conf0 = REG_READ(UART_CONF0_REG(uart_num));
-  if ((conf0 & UART_ERR_WR_MASK) == 0) {
-    ESP_LOGW("oq.uart_filter", "Controller Q %s UART%u: parity/framing error discard did not enable", port_name,
-             uart_num);
-    return;
+    const uint32_t conf0 = REG_READ(UART_CONF0_REG(uart_num));
+    if ((conf0 & UART_ERR_WR_MASK) == 0) {
+      ESP_LOGW("oq.uart_filter", "Controller Q UART%u: parity/framing error discard did not enable", uart_num);
+      continue;
+    }
+
+    ESP_LOGI("oq.uart_filter", "Controller Q UART%u: parity/framing error discard enabled", uart_num);
   }
-
-  ESP_LOGI("oq.uart_filter", "Controller Q %s UART%u: parity/framing error discard enabled", port_name, uart_num);
 }
 
 }  // namespace oq_controller_q_uart

--- a/openquatt/profiles/heatpump_controller_q_uart_error_filter.h
+++ b/openquatt/profiles/heatpump_controller_q_uart_error_filter.h
@@ -4,16 +4,23 @@
 
 #include "driver/uart.h"
 #include "soc/uart_reg.h"
+#include "esphome/components/uart/uart_component_esp_idf.h"
 #include "esphome/core/log.h"
 
 namespace oq_controller_q_uart {
 
+inline bool error_character_discard_enabled(uint8_t uart_num) {
+  return (REG_READ(UART_CONF0_REG(uart_num)) & UART_ERR_WR_MASK) != 0;
+}
+
+inline bool error_character_discard_enabled(esphome::uart::IDFUARTComponent* uart) {
+  return error_character_discard_enabled(uart->get_hw_serial_number());
+}
+
 inline void enable_error_character_discard_all() {
   for (uint8_t uart_num = 0; uart_num < UART_NUM_MAX; uart_num++) {
     REG_SET_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
-
-    const uint32_t conf0 = REG_READ(UART_CONF0_REG(uart_num));
-    if ((conf0 & UART_ERR_WR_MASK) == 0) {
+    if (!error_character_discard_enabled(uart_num)) {
       ESP_LOGW("oq.uart_filter", "Controller Q UART%u: parity/framing error discard did not enable", uart_num);
       continue;
     }

--- a/openquatt/profiles/heatpump_controller_q_uart_error_filter.h
+++ b/openquatt/profiles/heatpump_controller_q_uart_error_filter.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef USE_ESP_IDF
+
+#include "soc/uart_reg.h"
+#include "esphome/components/uart/uart_component_esp_idf.h"
+#include "esphome/core/log.h"
+
+namespace oq_controller_q_uart {
+
+inline void enable_error_character_discard(esphome::uart::IDFUARTComponent* uart, const char* port_name) {
+  const uint8_t uart_num = uart->get_hw_serial_number();
+  REG_SET_BIT(UART_CONF0_REG(uart_num), UART_ERR_WR_MASK);
+
+  const uint32_t conf0 = REG_READ(UART_CONF0_REG(uart_num));
+  if ((conf0 & UART_ERR_WR_MASK) == 0) {
+    ESP_LOGW("oq.uart_filter", "Controller Q %s UART%u: parity/framing error discard did not enable", port_name,
+             uart_num);
+    return;
+  }
+
+  ESP_LOGI("oq.uart_filter", "Controller Q %s UART%u: parity/framing error discard enabled", port_name, uart_num);
+}
+
+}  // namespace oq_controller_q_uart
+
+#endif  // USE_ESP_IDF

--- a/openquatt/profiles/heatpump_controller_q_uart_error_filter.yaml
+++ b/openquatt/profiles/heatpump_controller_q_uart_error_filter.yaml
@@ -18,3 +18,17 @@ esphome:
     then:
       - lambda: |-
           oq_controller_q_uart::enable_error_character_discard_all();
+
+binary_sensor:
+  - platform: template
+    id: oq_m1_uart_error_character_discard
+    name: "M1 UART error character discard"
+    entity_category: diagnostic
+    lambda: |-
+      return oq_controller_q_uart::error_character_discard_enabled(id(uart_bus));
+  - platform: template
+    id: oq_m2_uart_error_character_discard
+    name: "M2 UART error character discard"
+    entity_category: diagnostic
+    lambda: |-
+      return oq_controller_q_uart::error_character_discard_enabled(id(cic_compat_uart_bus));

--- a/openquatt/profiles/heatpump_controller_q_uart_error_filter.yaml
+++ b/openquatt/profiles/heatpump_controller_q_uart_error_filter.yaml
@@ -1,10 +1,14 @@
 # ==============================================================================
 # OpenQuatt - Heatpump Controller Q UART parity/framing error filter
 # ==============================================================================
-# IDFUARTComponent configures the peripheral at BUS priority (1000). This hook
+# IDFUARTComponent configures the peripherals at BUS priority (1000). This hook
 # joins the Q profile's final on_boot trigger at -100, after all UART setup, so
 # uart_driver_install(), uart_param_config(), thresholds and
 # UART_MODE_RS485_HALF_DUPLEX cannot overwrite UART_ERR_WR_MASK during startup.
+#
+# Apply the hardware discard bit to every UART peripheral on Controller Q. This
+# follows ESPHome maintainer guidance while the ESP32-S3 ERR_WR_MASK behaviour is
+# being investigated; it also rules out an unexpected UART-peripheral mapping.
 
 esphome:
   includes:
@@ -13,5 +17,4 @@ esphome:
     priority: -100
     then:
       - lambda: |-
-          oq_controller_q_uart::enable_error_character_discard(id(uart_bus), "M1");
-          oq_controller_q_uart::enable_error_character_discard(id(cic_compat_uart_bus), "M2");
+          oq_controller_q_uart::enable_error_character_discard_all();

--- a/openquatt/profiles/heatpump_controller_q_uart_error_filter.yaml
+++ b/openquatt/profiles/heatpump_controller_q_uart_error_filter.yaml
@@ -1,0 +1,17 @@
+# ==============================================================================
+# OpenQuatt - Heatpump Controller Q UART parity/framing error filter
+# ==============================================================================
+# IDFUARTComponent configures the peripheral at BUS priority (1000). This hook
+# joins the Q profile's final on_boot trigger at -100, after all UART setup, so
+# uart_driver_install(), uart_param_config(), thresholds and
+# UART_MODE_RS485_HALF_DUPLEX cannot overwrite UART_ERR_WR_MASK during startup.
+
+esphome:
+  includes:
+    - ${openquatt_root}/profiles/heatpump_controller_q_uart_error_filter.h
+  on_boot:
+    priority: -100
+    then:
+      - lambda: |-
+          oq_controller_q_uart::enable_error_character_discard(id(uart_bus), "M1");
+          oq_controller_q_uart::enable_error_character_discard(id(cic_compat_uart_bus), "M2");

--- a/openquatt/profiles/heatpump_controller_q_uart_error_filter.yaml
+++ b/openquatt/profiles/heatpump_controller_q_uart_error_filter.yaml
@@ -1,34 +1,15 @@
 # ==============================================================================
 # OpenQuatt - Heatpump Controller Q UART parity/framing error filter
 # ==============================================================================
-# IDFUARTComponent configures the peripherals at BUS priority (1000). This hook
-# joins the Q profile's final on_boot trigger at -100, after all UART setup, so
-# uart_driver_install(), uart_param_config(), thresholds and
-# UART_MODE_RS485_HALF_DUPLEX cannot overwrite UART_ERR_WR_MASK during startup.
-#
-# Apply the hardware discard bit to every UART peripheral on Controller Q. This
-# follows ESPHome maintainer guidance while the ESP32-S3 ERR_WR_MASK behaviour is
-# being investigated; it also rules out an unexpected UART-peripheral mapping.
+# IDFUARTComponent configures UARTs at BUS priority (1000). This hook runs at
+# 600, after the peripheral exists and before OpenQuatt logic starts Modbus I/O.
 
 esphome:
   includes:
     - ${openquatt_root}/profiles/heatpump_controller_q_uart_error_filter.h
   on_boot:
-    priority: -100
+    priority: 600
     then:
       - lambda: |-
-          oq_controller_q_uart::enable_error_character_discard_all();
-
-binary_sensor:
-  - platform: template
-    id: oq_m1_uart_error_character_discard
-    name: "M1 UART error character discard"
-    entity_category: diagnostic
-    lambda: |-
-      return oq_controller_q_uart::error_character_discard_enabled(id(uart_bus));
-  - platform: template
-    id: oq_m2_uart_error_character_discard
-    name: "M2 UART error character discard"
-    entity_category: diagnostic
-    lambda: |-
-      return oq_controller_q_uart::error_character_discard_enabled(id(cic_compat_uart_bus));
+          oq_controller_q_uart::enable_error_character_discard(id(uart_bus), "M1");
+          oq_controller_q_uart::enable_error_character_discard(id(cic_compat_uart_bus), "M2");


### PR DESCRIPTION
# Wat verandert deze PR?

- Schakelt op Controller Q (ESP32-S3) `UART_ERR_WR_MASK` in voor de twee gebruikte Modbus-UARTs: M1 en M2.
- De hook draait op bootprioriteit `600`, na ESPHome's UART-initialisatie (`1000`) en vóór OpenQuatt Modbus-verkeer start.

## Status

**Niet mergen.** De fysieke HIL-proef hieronder toont dat de registerwrite wel beklijft, maar op de beschikbare ESP32-S3/M1-opstelling niet betrouwbaar voorkomt dat parity-foutieve responsbytes de UART-RX-buffer bereiken. De PR is daarom onderzoeksresultaat, geen gevalideerde bugfix.

## Type

- [x] Bugfix
- [x] Control/platform

## Impact

- [x] Runtime/control gedrag gewijzigd
- [x] Geen user-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus geraakt

Alleen de ontvangst op de twee bestaande Controller Q Modbus-UARTs wordt geraakt. Baudrate, parity, time-outs, buffers, RS485 DE/RE en retries blijven ongewijzigd.

## Achtergrond

ESPHome geeft parity- en framingfoutbytes standaard door aan componenten. De voorgestelde ESP-IDF-oplossing uit esphome/esphome#19070 zet de niet via de driver-API beschikbare `UART_CONF0.err_wr_mask` rechtstreeks voor de betrokken UART.

## Validatie

- [x] `npm run check:cpp-format`
- [x] `esphome compile configs/heatpump_controller_q/duo_wifi.yaml`
- [x] OTA naar de HIL-testcontroller en afsluitende read-only HIL-smoke: PASS
- [x] Simulator en controller hersteld naar normale teststatus
- [x] Controller-side tijdelijke ESP-IDF-eventqueue zag fysieke `UART_PARITY_ERR`-events
- [x] `UART_ERR_WR_MASK` readback op de fysiek aangesloten M1-UART was `1`
- [x] Simulator zond een volledige parity-foutieve 19200 8O1 Modbus-respons met unieke `A5 5A` marker
- [ ] Hardware-discard van parity-foutieve bytes bewezen

Bij ingeschakeld mask registreerde de controller 99 parity-events, maar drie unieke markers uit parity-foutieve responsen werden alsnog uit de RX-buffer gelezen. Een testvariant met het mask bewust uit registreerde dezelfde foutklasse en liet eveneens markerbytes door. Door het variabele aantal geaccepteerde one-shots is dit geen prestatievergelijking, maar de positieve observatie met mask=1 is al voldoende: deze PR kan geen betrouwbare byte-discard claimen.

M2 is niet fysiek aangesloten op deze desktopopstelling; de fysieke proef betreft M1. Tijdelijke controllerinstrumentatie, testconfiguraties en simulatorwijzigingen zijn verwijderd en niet onderdeel van deze PR.

## Audit

Volledige diff tegen `dev` beoordeeld op scope, ESP-IDF-registerbeschikbaarheid, bootvolgorde, UART-lifecycle en foutpad. De helper is ESP-IDF-afgeschermd, schrijft éénmaal tijdens boot uitsluitend naar de twee Modbus-UARTs en controleert de registerwrite via readback. De HIL-uitkomst blokkeert merge totdat een werkzame, fysiek geverifieerde oplossing beschikbaar is.
