### PR TITLE
Voorkom pendelen na room-start

### DIFF
--- a/openquatt/includes/control/oq_heat_intent_logic.h
+++ b/openquatt/includes/control/oq_heat_intent_logic.h
@@ -9,6 +9,7 @@ enum Reason : uint8_t {
   NONE = 0,
   ROOM_DEMAND = 1,
   SETPOINT_RAISE = 2,
+  ROOM_RECOVERY = 3,
 };
 
 struct State {
@@ -17,6 +18,8 @@ struct State {
   float last_setpoint_c = NAN;
   bool setpoint_raise_active = false;
   uint32_t room_confirm_since_ms = 0;
+  bool room_start_armed = false;
+  bool room_recovery_active = false;
 };
 
 struct Input {
@@ -41,6 +44,8 @@ struct Decision {
   bool setpoint_raise_edge = false;
   bool setpoint_raise_cancelled = false;
   bool room_condition = false;
+  bool fast_start = false;
+  bool room_recovery_active = false;
   Reason reason = NONE;
 };
 
@@ -59,12 +64,14 @@ inline Decision evaluate(const Input& input, State state) {
   }
 
   if (!state.initialized || state.setpoint_source != input.setpoint_source || !std::isfinite(state.last_setpoint_c)) {
-    state = {true, input.setpoint_source, input.setpoint_c, false, 0};
+    state = {true, input.setpoint_source, input.setpoint_c, false, 0, false, false};
   } else {
     const float change_c = input.setpoint_c - state.last_setpoint_c;
     if (change_c < -0.01f) {
       out.setpoint_raise_cancelled = state.setpoint_raise_active;
       state.setpoint_raise_active = false;
+      state.room_start_armed = false;
+      state.room_recovery_active = false;
     } else if (!input.compressor_active && change_c + 0.0001f >= input.setpoint_raise_delta_c &&
                input.setpoint_c > input.room_c) {
       state.setpoint_raise_active = true;
@@ -91,14 +98,39 @@ inline Decision evaluate(const Input& input, State state) {
       (input.room_confirm_ms == 0 ||
        (state.room_confirm_since_ms != 0 &&
         static_cast<uint32_t>(input.now_ms - state.room_confirm_since_ms) >= input.room_confirm_ms));
-  out.active = state.setpoint_raise_active || room_confirmed;
-  out.reason = state.setpoint_raise_active ? SETPOINT_RAISE : (room_confirmed ? ROOM_DEMAND : NONE);
+
+  // A confirmed room-demand start is only promoted to recovery after an HP
+  // actually starts. This prevents the minimum-output floor from becoming a
+  // permanent below-setpoint mode while retaining the successful start until
+  // the room has moved clearly out of its restart band.
+  if (!state.room_recovery_active) {
+    if (state.room_start_armed && input.compressor_active) {
+      state.room_start_armed = false;
+      state.room_recovery_active = true;
+    } else if (room_confirmed && !input.compressor_active) {
+      state.room_start_armed = true;
+    } else if (!room_confirmed) {
+      state.room_start_armed = false;
+    }
+  }
+  const float recovery_release_c = input.setpoint_c - 0.5f * input.room_resume_delta_c;
+  if (state.room_recovery_active && input.room_c >= recovery_release_c) state.room_recovery_active = false;
+
+  out.fast_start =
+      !input.compressor_active && !state.room_recovery_active && (state.setpoint_raise_active || room_confirmed);
+  out.room_recovery_active = state.room_recovery_active;
+  out.active = state.setpoint_raise_active || room_confirmed || state.room_recovery_active;
+  out.reason = state.setpoint_raise_active  ? SETPOINT_RAISE
+               : state.room_recovery_active ? ROOM_RECOVERY
+               : room_confirmed             ? ROOM_DEMAND
+                                            : NONE;
   out.next = state;
   return out;
 }
 
 inline const char* reason_name(Reason reason) {
   if (reason == SETPOINT_RAISE) return "setpoint_raise";
+  if (reason == ROOM_RECOVERY) return "room_recovery";
   if (reason == ROOM_DEMAND) return "room_demand";
   return "none";
 }

--- a/openquatt/includes/control/oq_power_house_runtime.h
+++ b/openquatt/includes/control/oq_power_house_runtime.h
@@ -54,7 +54,7 @@ class Runtime {
   }
 
   void tick(const TickConfig& config) {
-    const bool active = id(oq_control_mode_code) != 5 && id(oq_heat_mode_code) != 1;
+    const bool active = id(oq_strategy_active_code) == 3 && id(oq_control_mode_code) != 5 && id(oq_heat_mode_code) != 1;
     if (!active) {
       this->reset();
       return;
@@ -117,7 +117,10 @@ class Runtime {
         now_ms, applied_total > 0, std::max(0.0f, demand_tuning.comfort_below_c), 10000UL,
         config.ot_room_temperature_fresh, config.ot_room_setpoint_fresh, this->intent_state_);
     this->intent_state_ = intent.next;
-    id(oq_ph_fast_intent_code) = static_cast<int>(intent.reason);
+    // Only a pending start bypasses Power House's normal start confirmation.
+    // A recovery which was interrupted by a protection hold must re-enter by
+    // the ordinary, confirmed path.
+    id(oq_ph_fast_intent_code) = intent.fast_start ? static_cast<int>(intent.reason) : 0;
     id(oq_phouse_last_ms) = demand.next.last_ms;
     id(oq_phouse_comfort_memory_c) = demand.next.comfort_memory_c;
     id(oq_phouse_demand_external) = demand.external;
@@ -197,7 +200,10 @@ class Runtime {
 #if OQ_TOPOLOGY_DUO
     include_minimum(dispatch_input.hp2);
 #endif
-    if (intent.active && applied_total == 0 && std::isfinite(minimum_viable_w) &&
+    // A room recovery follows a room-demand start only; it is released halfway
+    // through the restart band. It therefore cannot turn every below-setpoint
+    // interval into an implicit keep-running-at-minimum mode.
+    if ((intent.fast_start || intent.room_recovery_active) && std::isfinite(minimum_viable_w) &&
         id(oq_water_temp_limit_factor) >= 0.999f) {
       requested_w = std::max(requested_w, minimum_viable_w);
       next_last_w = std::max(next_last_w, requested_w);

--- a/tests/host/heat_intent_logic_test.cpp
+++ b/tests/host/heat_intent_logic_test.cpp
@@ -34,7 +34,7 @@ void test_thermostat_examples() {
   auto running = input(3000, 20.0f, 20.5f);
   running.compressor_active = true;
   out = evaluate(running, out.next);
-  assert(out.active && out.reason == ROOM_DEMAND && !out.next.setpoint_raise_active);
+  assert(out.active && out.reason == ROOM_RECOVERY && out.room_recovery_active && !out.next.setpoint_raise_active);
 }
 
 void test_source_freshness_and_enable_fail_closed() {
@@ -78,11 +78,88 @@ void test_power_house_room_confirmation() {
   out = evaluate(cold, out.next);
   assert(out.active && out.reason == ROOM_DEMAND);
 }
+
+void test_room_recovery_requires_a_real_room_demand_start_and_has_hysteresis() {
+  auto cold = input(1000, 19.8f, 20.0f);
+  cold.room_confirm_ms = 10000;
+  auto out = evaluate(cold, {});
+  cold.now_ms = 11000;
+  out = evaluate(cold, out.next);
+  assert(out.active && out.fast_start && out.reason == ROOM_DEMAND);
+
+  cold.now_ms = 12000;
+  cold.compressor_active = true;
+  out = evaluate(cold, out.next);
+  assert(out.active && !out.fast_start && out.room_recovery_active && out.reason == ROOM_RECOVERY);
+
+  // The recovery holds across the original restart boundary (19.9 C), then
+  // releases halfway through the 0.1 K restart band (19.95 C).
+  cold.now_ms = 13000;
+  cold.room_c = 19.92f;
+  out = evaluate(cold, out.next);
+  assert(out.room_recovery_active && out.reason == ROOM_RECOVERY);
+  cold.now_ms = 14000;
+  cold.room_c = 19.95f;
+  out = evaluate(cold, out.next);
+  assert(!out.room_recovery_active && !out.fast_start && out.reason == NONE);
+
+  // A room sample may move above the restart boundary while the compressor is
+  // starting. An already armed start must still recover until 19.95 C.
+  auto start_edge = input(1000, 19.89f, 20.0f);
+  out = evaluate(start_edge, {});
+  assert(out.next.room_start_armed);
+  start_edge.now_ms = 2000;
+  start_edge.room_c = 19.92f;
+  start_edge.compressor_active = true;
+  out = evaluate(start_edge, out.next);
+  assert(out.room_recovery_active && out.reason == ROOM_RECOVERY);
+
+  // A setpoint reduction cancels an in-flight recovery rather than preserving
+  // output against a lower comfort target.
+  cold.now_ms = 15000;
+  cold.room_c = 19.8f;
+  cold.setpoint_c = 20.1f;
+  cold.compressor_active = false;
+  out = evaluate(cold, out.next);
+  cold.now_ms = 25000;
+  out = evaluate(cold, out.next);
+  cold.compressor_active = true;
+  cold.now_ms = 26000;
+  out = evaluate(cold, out.next);
+  assert(out.room_recovery_active);
+  cold.setpoint_c = 20.0f;
+  cold.now_ms = 27000;
+  out = evaluate(cold, out.next);
+  assert(!out.room_recovery_active && !out.next.room_start_armed);
+}
+
+void test_room_recovery_does_not_attach_to_an_existing_run_and_fails_closed() {
+  auto cold = input(1000, 19.8f, 20.0f);
+  cold.compressor_active = true;
+  auto out = evaluate(cold, {});
+  assert(out.active && !out.room_recovery_active && !out.next.room_start_armed);
+  out = evaluate(cold, out.next);
+  assert(!out.room_recovery_active && !out.next.room_start_armed);
+
+  cold.compressor_active = false;
+  out = evaluate(cold, {});
+  cold.compressor_active = true;
+  cold.now_ms = 2000;
+  out = evaluate(cold, out.next);
+  assert(out.room_recovery_active);
+
+  cold.room_fresh = false;
+  cold.now_ms = 3000;
+  out = evaluate(cold, out.next);
+  assert(!out.active && !out.room_recovery_active && !out.next.initialized);
+}
 }  // namespace
 
 int main() {
   test_thermostat_examples();
   test_source_freshness_and_enable_fail_closed();
   test_power_house_room_confirmation();
+  test_room_recovery_requires_a_real_room_demand_start_and_has_hysteresis();
+  test_room_recovery_does_not_attach_to_an_existing_run_and_fails_closed();
   return 0;
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Houdt de minimale haalbare warmtevraag vast nadat een bevestigde room-demand de compressor werkelijk heeft gestart.
- Laat de room-recovery los op de helft van de restartband; veiligheids-, water- en incidentgates blijven leidend.
- Houdt fast-start beperkt tot de pending start en dekt de start-/sensorinterleaving met hosttests.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [x] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De Power House-room-intent wordt alleen na een feitelijk gestarte compressor gepromoveerd tot recovery. Daardoor valt Pmin niet direct weg en kan de low-load-OFF-grens niet dezelfde start stoppen. Minimum-off, incidentmanager en waterlimiet worden niet omzeild.

## Achtergrond

De onderzochte V2-opname toonde een room-start met tijdelijke Pmin, gevolgd door een wegvallende vraag onder de low-load-OFF-grens. De interactie is vermoedelijk een regressie sinds de snelle eerste verwarmingsstart (PR #627): die maakt de tijdelijke Pmin-start mogelijk, terwijl de bestaande low-load-logica de vraag direct daarna weer kan stoppen. Deze PR corrigeert uitsluitend die controlinteractie. De uitgebreide recorderdiagnostiek en een eventuele V2-frequentiemappinganalyse lopen apart.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen instelling of gebruikersgericht gedrag toegevoegd; dit is een interne regressiefix.

## Validatie

- `./scripts/run_host_regression_tests.sh` — 68 groen.
- `npm run check:cpp-format` — groen.
- `python3 -m unittest discover -s scripts/tests -p "test_*.py"` — 233 groen.
- `python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/duo_wifi.yaml` bereikt de style-check maar faalt op drie bestaande meldingen in `duo.yaml`, `single.yaml`, `input_sources_fast_duo_wifi.yaml` en twee bestaande commentaarmeldingen in `oq_common.yaml`; niet veroorzaakt door deze diff.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

Geen dynamische allocaties of recorderwijzigingen. Twee booleans worden toegevoegd aan bestaande room-intent-state; HIL-meting is niet gedaan.

## Resterend risico

HIL moet nog de timing tussen logisch toegepast level en werkelijk compressorstart, sensorupdates tijdens starten en recovery na water-/incidentonderbreking verifiëren.
