### PR TITLE
Geen fictieve OpenTherm-telemetrie meer naar thermostaat

### DIFF
--- a/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
+++ b/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
@@ -697,13 +697,19 @@ unsigned long OpenQuattOTSlave::build_slave_response_(OpenThermMessageType type,
         responseData = 0x0000;
         break;
       case OpenThermMessageID::TdhwSetUBTdhwSetLB:
-        // Some thermostats keep probing this DHW bounds ID even when the slave
-        // does not advertise DHW support. Return conservative bounds as a
-        // compatibility response instead of DATA_INVALID.
-        responseData = 0x3C0A;
+        // OpenQuatt has no DHW setpoint bounds: no R1 DHW and no
+        // OTB polling for DHW bounds. Answer DATA_INVALID instead
+        // of invented 10-60 C.
+        responseType = OpenThermMessageType::DATA_INVALID;
+        responseData = 0x0000;
         break;
       case OpenThermMessageID::TdhwSet:
-        responseData = message_data::encode_f88(m_slave_state.t_dhw_set);
+        if (!m_slave_state.t_dhw_set_valid) {
+          responseType = OpenThermMessageType::DATA_INVALID;
+          responseData = 0x0000;
+        } else {
+          responseData = message_data::encode_f88(m_slave_state.t_dhw_set);
+        }
         break;
       case OpenThermMessageID::RemoteOverrideFunction:
         // OpenQuatt does not actively drive thermostat-side remote override
@@ -721,7 +727,16 @@ unsigned long OpenQuattOTSlave::build_slave_response_(OpenThermMessageType type,
         responseData = 0x0000;
         break;
       case OpenThermMessageID::MaxCapacityMinModLevel:
-        responseData = 0x1400;
+        if (!m_slave_state.max_capacity_valid || !m_slave_state.min_modulation_valid) {
+          responseType = OpenThermMessageType::DATA_INVALID;
+          responseData = 0x0000;
+        } else {
+          const long max_cap = lroundf(m_slave_state.max_capacity);
+          const long min_mod = lroundf(m_slave_state.min_modulation);
+          const uint8_t max_cap_u8 = static_cast<uint8_t>(max_cap < 0 ? 0 : (max_cap > 255 ? 255 : max_cap));
+          const uint8_t min_mod_u8 = static_cast<uint8_t>(min_mod < 0 ? 0 : (min_mod > 255 ? 255 : min_mod));
+          responseData = (static_cast<uint16_t>(max_cap_u8) << 8) | min_mod_u8;
+        }
         break;
       case OpenThermMessageID::CHPressure:
         if (!m_slave_state.ch_pressure_valid) {
@@ -756,10 +771,16 @@ unsigned long OpenQuattOTSlave::build_slave_response_(OpenThermMessageType type,
         }
         break;
       case OpenThermMessageID::MaxTSetUBMaxTSetLB:
-        responseData = 0x500A;
+        // Align with max_water_temp_limit_c (25-75 C). UB=75 (0x4B), LB=25 (0x19).
+        responseData = 0x4B19;
         break;
       case OpenThermMessageID::MaxTSet:
-        responseData = message_data::encode_f88(m_slave_state.max_t_set);
+        if (!m_slave_state.max_t_set_valid) {
+          responseType = OpenThermMessageType::DATA_INVALID;
+          responseData = 0x0000;
+        } else {
+          responseData = message_data::encode_f88(m_slave_state.max_t_set);
+        }
         break;
       case OpenThermMessageID::OpenThermVersionSlave:
         responseData = message_data::encode_f88(SUPPORTED_OPENTHERM_VERSION);

--- a/components/openquatt_ot_slave/OpenQuattOTSlave.h
+++ b/components/openquatt_ot_slave/OpenQuattOTSlave.h
@@ -65,7 +65,10 @@ class OpenQuattOTSlave : public PollingComponent
     m_slave_state.t_ret_valid = !std::isnan(value);
   }
   void set_slave_t_outside(float value) { m_slave_state.t_outside = value; }
-  void set_slave_max_t_set(float value) { m_slave_state.max_t_set = value; }
+  void set_slave_max_t_set(float value) {
+    m_slave_state.max_t_set = value;
+    m_slave_state.max_t_set_valid = !std::isnan(value);
+  }
   void set_slave_rel_mod_level(float value) {
     m_slave_state.rel_mod_level = value;
     m_slave_state.rel_mod_level_valid = !std::isnan(value);
@@ -78,7 +81,18 @@ class OpenQuattOTSlave : public PollingComponent
     m_slave_state.t_dhw = value;
     m_slave_state.t_dhw_valid = !std::isnan(value);
   }
-  void set_slave_t_dhw_set(float value) { m_slave_state.t_dhw_set = value; }
+  void set_slave_t_dhw_set(float value) {
+    m_slave_state.t_dhw_set = value;
+    m_slave_state.t_dhw_set_valid = !std::isnan(value);
+  }
+  void set_slave_max_capacity(float value) {
+    m_slave_state.max_capacity = value;
+    m_slave_state.max_capacity_valid = !std::isnan(value);
+  }
+  void set_slave_min_modulation(float value) {
+    m_slave_state.min_modulation = value;
+    m_slave_state.min_modulation_valid = !std::isnan(value);
+  }
   void prepare_for_firmware_update();
   bool master_room_temperature_fresh() const;
   bool master_room_setpoint_fresh() const;
@@ -150,16 +164,22 @@ class OpenQuattOTSlave : public PollingComponent
     float t_boiler = NAN;
     float t_ret = NAN;
     float t_outside = NAN;
-    float max_t_set = 60.0f;
+    float max_t_set = NAN;
     float rel_mod_level = NAN;
     float ch_pressure = NAN;
     float t_dhw = NAN;
-    float t_dhw_set = 40.0f;
+    float t_dhw_set = NAN;
+    float max_capacity = NAN;
+    float min_modulation = NAN;
     bool t_boiler_valid = false;
     bool t_ret_valid = false;
     bool rel_mod_level_valid = false;
     bool ch_pressure_valid = false;
     bool t_dhw_valid = false;
+    bool t_dhw_set_valid = false;
+    bool max_t_set_valid = false;
+    bool max_capacity_valid = false;
+    bool min_modulation_valid = false;
   };
 
   uint8_t m_pinThermostatIn = 0;

--- a/openquatt/includes/boiler/oq_boiler_otb_runtime.h
+++ b/openquatt/includes/boiler/oq_boiler_otb_runtime.h
@@ -112,6 +112,13 @@ inline void link_watch(uint32_t link_timeout_ms, uint32_t field_timeout_ms) {
       call.set_value(0.0f);
       call.perform();
     }
+    if (available) {
+      // Session-scoped init-only fields (e.g. ID15 max capacity/min modulation)
+      // are cleared on a real link timeout but never re-polled by the repeating
+      // sequence. Re-run the initial message sequence on recovery so they come
+      // back without requiring a reboot or new session.
+      id(oq_otb_hub).resume_polling();
+    }
   }
   if (!available) id(oq_otb_invalidate_telemetry).execute();
 }

--- a/openquatt/oq_ot_slave.yaml
+++ b/openquatt/oq_ot_slave.yaml
@@ -157,34 +157,45 @@ interval:
                               && !isnan(id(otb_dhw_temp).state)
                           ? id(otb_dhw_temp).state
                           : NAN);
+                  id(oq_ot_slave_hub).set_slave_max_capacity(
+                      otb_available && id(otb_max_capacity).has_state()
+                              && !isnan(id(otb_max_capacity).state)
+                          ? id(otb_max_capacity).state
+                          : NAN);
+                  id(oq_ot_slave_hub).set_slave_min_modulation(
+                      otb_available && id(otb_min_modulation).has_state()
+                              && !isnan(id(otb_min_modulation).state)
+                          ? id(otb_min_modulation).state
+                          : NAN);
                 } else {
-                  const float r1_supply_c =
+                  // R1 / on-off: only expose real measurements. Unknown
+                  // telemetry stays NAN so the slave answers DATA_INVALID.
+                  // No invented pressure, DHW, modulation or capacity.
+                  id(oq_ot_slave_hub).set_slave_t_boiler(
                       id(water_supply_temp_selected).has_state() &&
                               !isnan(id(water_supply_temp_selected).state)
                           ? id(water_supply_temp_selected).state
-                          : 20.0f;
-                  const float r1_return_c =
+                          : NAN);
+                  id(oq_ot_slave_hub).set_slave_t_ret(
                       id(hp1_water_in_temp).has_state() &&
                               !isnan(id(hp1_water_in_temp).state)
                           ? id(hp1_water_in_temp).state
-                          : 20.0f;
-                  id(oq_ot_slave_hub).set_slave_t_boiler(r1_supply_c);
-                  id(oq_ot_slave_hub).set_slave_t_ret(r1_return_c);
-
-                  float ot_rel_mod_level = id(oq_demand_filtered) * 5.0f;
-                  if (ot_rel_mod_level < 0.0f) ot_rel_mod_level = 0.0f;
-                  if (ot_rel_mod_level > 100.0f) ot_rel_mod_level = 100.0f;
-                  id(oq_ot_slave_hub).set_slave_rel_mod_level(ot_rel_mod_level);
-                  // Compatibility fallback only for a non-OT boiler path. OTB
-                  // never reports this fictive value.
-                  id(oq_ot_slave_hub).set_slave_ch_pressure(1.5f);
-                  id(oq_ot_slave_hub).set_slave_t_dhw(40.0f);
+                          : NAN);
+                  id(oq_ot_slave_hub).set_slave_rel_mod_level(NAN);
+                  id(oq_ot_slave_hub).set_slave_ch_pressure(NAN);
+                  id(oq_ot_slave_hub).set_slave_t_dhw(NAN);
+                  id(oq_ot_slave_hub).set_slave_max_capacity(NAN);
+                  id(oq_ot_slave_hub).set_slave_min_modulation(NAN);
                 }
                 if (id(max_water_temp_limit_c).has_state() && !isnan(id(max_water_temp_limit_c).state)) {
                   id(oq_ot_slave_hub).set_slave_max_t_set(id(max_water_temp_limit_c).state);
+                } else {
+                  id(oq_ot_slave_hub).set_slave_max_t_set(NAN);
                 }
                 if (id(outside_temp_selected).has_state() && !isnan(id(outside_temp_selected).state)) {
                   id(oq_ot_slave_hub).set_slave_t_outside(id(outside_temp_selected).state);
+                } else {
+                  id(oq_ot_slave_hub).set_slave_t_outside(NAN);
                 }
 
                 auto is_active_problem = [](auto *binary) -> bool {
@@ -217,11 +228,10 @@ interval:
                     id(otb_dhw_active).state;
                 const bool boiler_flame_on =
                     otb_available && id(otb_flame_on).has_state() && id(otb_flame_on).state;
-                // Preserve the established composite heat-source indication
-                // for R1 installations. With OTB selected, expose only the
-                // boiler's real flame state instead of inventing one from HP activity.
+                // Flame only on real flame state (OTB). HP/CH activity
+                // is not a flame; R1 therefore never reports flame_on.
                 const bool slave_flame_on =
-                    otb_selected ? boiler_flame_on : ch_active;
+                    otb_selected ? boiler_flame_on : false;
 
                 const bool hp1_fault = is_active_problem(id(hp1_ot_fault_active));
                 const bool hp2_fault =

--- a/openquatt/web/tests/boiler-view.test.mjs
+++ b/openquatt/web/tests/boiler-view.test.mjs
@@ -31,6 +31,14 @@ const boilerOpenThermRuntime = await readFile(
   "utf8",
 );
 const otSlaveYaml = await readFile(new URL("../../oq_ot_slave.yaml", import.meta.url), "utf8");
+const otSlaveCpp = await readFile(
+  new URL("../../../components/openquatt_ot_slave/OpenQuattOTSlave.cpp", import.meta.url),
+  "utf8",
+);
+const otSlaveHeader = await readFile(
+  new URL("../../../components/openquatt_ot_slave/OpenQuattOTSlave.h", import.meta.url),
+  "utf8",
+);
 const commonSubstitutionsYaml = await readFile(new URL("../../oq_substitutions_common.yaml", import.meta.url), "utf8");
 const quickStartSource = await readFile(new URL("../js/src/features/quickstart.js", import.meta.url), "utf8");
 const quickStartActionsSource = await readFile(new URL("../js/src/features/quickstart-actions.js", import.meta.url), "utf8");
@@ -518,10 +526,68 @@ test("DHW permission stays enabled without a user-facing setting", () => {
   assert.ok(SETTINGS_GROUP_KEY_MAP.integrations.includes("otbDhwPresent"));
 });
 
-test("thermostat slave uses real OTB flame state without changing R1 compatibility", () => {
+test("thermostat slave reports only real flame state, never HP activity as flame", () => {
   assert.match(
     otSlaveYaml,
-    /const bool slave_flame_on\s*=\s*\n\s*otb_selected \? boiler_flame_on : ch_active;/,
+    /const bool slave_flame_on\s*=\s*\n\s*otb_selected \? boiler_flame_on : false;/,
   );
   assert.match(otSlaveYaml, /set_slave_flame_on\(slave_flame_on\);/);
+  assert.doesNotMatch(otSlaveYaml, /otb_selected \? boiler_flame_on : ch_active/);
+});
+
+test("issue 668: R1 thermostat path reports no invented telemetry", () => {
+  assert.match(otSlaveYaml, /set_slave_rel_mod_level\(NAN\)/);
+  assert.match(otSlaveYaml, /set_slave_ch_pressure\(NAN\)/);
+  assert.match(otSlaveYaml, /set_slave_t_dhw\(NAN\)/);
+  assert.match(otSlaveYaml, /set_slave_max_capacity\(NAN\)/);
+  assert.match(otSlaveYaml, /set_slave_min_modulation\(NAN\)/);
+  assert.doesNotMatch(otSlaveYaml, /set_slave_ch_pressure\(1\.5f\)/);
+  assert.doesNotMatch(otSlaveYaml, /set_slave_t_dhw\(40\.0f\)/);
+  assert.doesNotMatch(otSlaveYaml, /oq_demand_filtered\) \* 5\.0f/);
+  assert.doesNotMatch(otSlaveYaml, /: 20\.0f;/);
+  assert.match(
+    otSlaveYaml,
+    /id\(water_supply_temp_selected\)\.state\s*\n?\s*: NAN/,
+  );
+  assert.match(
+    otSlaveYaml,
+    /id\(hp1_water_in_temp\)\.has_state\(\)[\s\S]*?: NAN/,
+  );
+});
+
+test("issue 668: thermostat forwards real OTB capacity and handles stale links as invalid", () => {
+  assert.match(otSlaveYaml, /id\(otb_max_capacity\)\.state\s*\n?\s*: NAN/);
+  assert.match(otSlaveYaml, /id\(otb_min_modulation\)\.state\s*\n?\s*: NAN/);
+  assert.match(otSlaveYaml, /set_slave_max_capacity\(/);
+  assert.match(otSlaveYaml, /set_slave_min_modulation\(/);
+  assert.match(otSlaveYaml, /set_slave_max_t_set\(NAN\)/);
+  assert.match(otSlaveYaml, /set_slave_t_outside\(NAN\)/);
+  assert.doesNotMatch(otSlaveCpp, /responseData = 0x1400;/);
+  assert.match(otSlaveCpp, /m_slave_state\.max_capacity_valid/);
+  assert.match(otSlaveCpp, /m_slave_state\.min_modulation_valid/);
+});
+
+test("issue 668: missing thermostat telemetry answers DATA_INVALID with real bounds", () => {
+  for (const flag of [
+    "t_boiler_valid",
+    "t_ret_valid",
+    "rel_mod_level_valid",
+    "ch_pressure_valid",
+    "t_dhw_valid",
+    "t_dhw_set_valid",
+    "max_t_set_valid",
+  ]) {
+    assert.match(otSlaveCpp, new RegExp(`!m_slave_state\\.${flag}`));
+  }
+  assert.match(otSlaveCpp, /case OpenThermMessageID::TdhwSetUBTdhwSetLB:[\s\S]*?DATA_INVALID/);
+  assert.match(otSlaveCpp, /case OpenThermMessageID::TdhwSet:[\s\S]*?DATA_INVALID/);
+  assert.match(otSlaveCpp, /case OpenThermMessageID::MaxCapacityMinModLevel:[\s\S]*?DATA_INVALID/);
+  assert.match(otSlaveCpp, /case OpenThermMessageID::MaxTSet:[\s\S]*?DATA_INVALID/);
+  assert.doesNotMatch(otSlaveCpp, /responseData = 0x3C0A;/);
+  assert.doesNotMatch(otSlaveCpp, /responseData = 0x500A;/);
+  assert.match(otSlaveCpp, /responseData = 0x4B19;/);
+  assert.match(otSlaveHeader, /float max_t_set = NAN;/);
+  assert.match(otSlaveHeader, /float t_dhw_set = NAN;/);
+  assert.match(otSlaveHeader, /bool max_t_set_valid = false;/);
+  assert.match(otSlaveHeader, /bool t_dhw_set_valid = false;/);
 });

--- a/openquatt/web/tests/boiler-view.test.mjs
+++ b/openquatt/web/tests/boiler-view.test.mjs
@@ -591,3 +591,10 @@ test("issue 668: missing thermostat telemetry answers DATA_INVALID with real bou
   assert.match(otSlaveHeader, /bool max_t_set_valid = false;/);
   assert.match(otSlaveHeader, /bool t_dhw_set_valid = false;/);
 });
+
+test("issue 668: OTB link recovery re-polls init-only capacity fields", () => {
+  assert.match(
+    boilerOpenThermRuntime,
+    /inline void link_watch[\s\S]*?if \(available\)[\s\S]*?id\(oq_otb_hub\)\.resume_polling\(\);/,
+  );
+});


### PR DESCRIPTION
# Wat verandert deze PR?

- R1/aan-uit pad naar de thermostaat stuurt geen verzonnen druk, DHW-temperatuur, DHW-setpoint, modulatie, capaciteit of 20 °C-fallbacks meer; onbekende waarden blijven NAN en worden als DATA_INVALID beantwoord.
- OTB-pad stuurt echte ketelcapaciteit/min-modulatie door en valt bij missing/stale OTB-telemetrie terug op DATA_INVALID in plaats van R1-dummywaarden; vlam alleen bij echte OTB-vlamstatus.
- MaxTSet-bounds gecorrigeerd naar 25–75 °C (0x4B19) en DHW-bounds/setpoint als DATA_INVALID zolang OpenQuatt ze niet kent.
- OTB link-recovery runt opnieuw de initial-message sequence, zodat session-scoped ID15/capaciteit na een echte link-uitval terugkomt zonder reboot.
- Closes #668.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Thermostaat (OTT) ziet nu DATA_INVALID waar OpenQuatt geen echte meting heeft. CH-active, cooling, fault/diagnostic en protocol-identiteit/capabilities zijn ongewijzigd.

## Achtergrond

Issue #668: de OT-slave rapporteerde geloofwaardige maar verzonnen telemetrie (o.a. CHPressure 1,5 bar, Tdhw 40 °C, RelMod uit demand, 0x1400, flame uit CH-active). OTB-druk/temperaturen deden al NAN bij missing link; dit trekt die werkwijze door naar alle velden.

Compatibility: TrOverride/RemoteOverride-neutrals en T6-DATA_INVALID blijven behouden. De expliciete DHW-bounds compatibility (0x3C0A) is bewust verwijderd conform “alleen rapporteren wat we weten”. Dit is op een Honeywell/Resideo T6 hardwarematig gevalideerd: boot, warmtevraag en idle werken zonder foutmelding of problematische onderhandeling; CH en setpoint blijven correct functioneren.

Recovery: ID15/capaciteit is init-only en session-scoped. Bij een echte link-timeout wist de telemetry-laag alle valid-flags, maar de repeating-polling haalde ID15 nooit opnieuw op. link_watch() doet daarom bij unavailable→available weer resume_polling().

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen gebruikersdocs beschrijven de oude dummywaarden; gedragswijziging is alleen zichtbaar als wegvallen van onjuiste thermostaatwaarden.

## Validatie

- node --test openquatt/web/tests/boiler-view.test.mjs
- node openquatt/web/run-web-tests.mjs
- ./scripts/run_host_regression_tests.sh
- npm run check:cpp-format
- python3 scripts/dev.py validate --config-only --config configs/heatpump_controller_q/single.yaml
- Hardwaretest Honeywell/Resideo T6: geslaagd (boot + warmtevraag + idle; geen OT-foutmelding/eindeloze onderhandeling; CH/setpoint OK)

Resultaat: boiler-view 30/30 pass, web-suite 478/478 pass, host-regressie 68/68 pass, cpp-format pass, python-contracts otb-polling/boiler-runtime pass. CI en PR test firmware build groen. dev.py config-only strandt op pre-existing style-fouten in oq_common.yaml/uart, geen meldingen voor gewijzigde files.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Alleen enkele floats/bools in bestaande OT-slave state, geen heap-, PSRAM-, task- of netwerkallocaties geraakt.