### PR TITLE
Test: diagnose Modbus RX-glitch met ODU uit

### DIFF
--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -1,0 +1,52 @@
+# ==============================================================================
+# Temporary PR #671 diagnostic: raw Modbus RX + UART parity/frame error probe
+# ==============================================================================
+# Used for the ODU-off field test on the problematic Controller Q installation.
+# Keep the controller powered and the RS485 wiring/termination connected while
+# switching the ODU off. Any RX bytes or parity/frame errors then help determine
+# whether the glitch still exists without an active ODU transceiver.
+#
+# Important: this test intentionally does NOT use UART_ERR_WR_MASK. The active
+# test settings are rx_full_threshold: 120, rx_timeout: 1 and the existing RX
+# pull-up from single.yaml.
+
+esphome:
+  includes:
+    - modbus_uart_error_probe.h
+  on_boot:
+    priority: 600
+    then:
+      - lambda: |-
+          oq_modbus_uart_diag::install(id(uart_bus).get_hw_serial_number());
+
+uart:
+  - id: !extend uart_bus
+    debug:
+      direction: RX
+      dummy_receiver: false
+      after:
+        timeout: 4ms
+      sequence:
+        - lambda: |-
+            oq_modbus_uart_diag::report_if_changed();
+
+            char hex_buf[512];
+            esphome::format_hex_pretty_to(
+              hex_buf,
+              sizeof(hex_buf),
+              bytes.data(),
+              bytes.size(),
+              ' '
+            );
+            ESP_LOGW(
+              "oq.modbus_raw",
+              "RX %u bytes: %s",
+              static_cast<unsigned>(bytes.size()),
+              hex_buf
+            );
+
+interval:
+  - interval: 1s
+    then:
+      - lambda: |-
+          oq_modbus_uart_diag::report_if_changed();

--- a/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
+++ b/configs/heatpump_controller_q/modbus_uart_diagnostics.yaml
@@ -1,10 +1,10 @@
 # ==============================================================================
-# Temporary PR #671 diagnostic: raw Modbus RX + UART parity/frame error probe
+# Temporary PR #671 diagnostic: suspicious raw Modbus RX + UART error probe
 # ==============================================================================
 # Used for the ODU-off field test on the problematic Controller Q installation.
 # Keep the controller powered and the RS485 wiring/termination connected while
-# switching the ODU off. Any RX bytes or parity/frame errors then help determine
-# whether the glitch still exists without an active ODU transceiver.
+# switching the ODU off. Any short RX fragment or parity/frame error then helps
+# determine whether the glitch still exists without an active ODU transceiver.
 #
 # Important: this test intentionally does NOT use UART_ERR_WR_MASK. The active
 # test settings are rx_full_threshold: 120, rx_timeout: 1 and the existing RX
@@ -28,7 +28,13 @@ uart:
         timeout: 4ms
       sequence:
         - lambda: |-
-            oq_modbus_uart_diag::report_if_changed();
+            // Keep normal ODU traffic quiet. Log short fragments (the field
+            // symptom is normally one byte) and any RX batch associated with a
+            // newly observed hardware UART error.
+            const bool uart_error = oq_modbus_uart_diag::report_if_changed();
+            if (!uart_error && bytes.size() > 2) {
+              return;
+            }
 
             char hex_buf[512];
             esphome::format_hex_pretty_to(

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -49,7 +49,7 @@ inline void install(uint8_t uart_num) {
   ESP_LOGI("oq.modbus_uart_err", "UART%u parity/frame error probe installed (ERR_WR_MASK not used)", uart_num);
 }
 
-inline void report_if_changed() {
+inline bool report_if_changed() {
   static uint32_t reported_parity = 0;
   static uint32_t reported_frame = 0;
   static uint32_t reported_other = 0;
@@ -58,7 +58,7 @@ inline void report_if_changed() {
   const uint32_t frame = frame_error_count;
   const uint32_t other = other_error_count;
   if (parity == reported_parity && frame == reported_frame && other == reported_other) {
-    return;
+    return false;
   }
 
   ESP_LOGW("oq.modbus_uart_err", "UART RX errors: parity=%u frame=%u other=%u", parity, frame, other);
@@ -67,6 +67,7 @@ inline void report_if_changed() {
   reported_parity = parity;
   reported_frame = frame;
   reported_other = other;
+  return true;
 }
 
 }  // namespace oq_modbus_uart_diag

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "driver/uart.h"
+#include "driver/uart_select.h"
+#include "hal/uart_ll.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+
+namespace oq_modbus_uart_diag {
+
+static volatile uint32_t parity_error_count = 0;
+static volatile uint32_t frame_error_count = 0;
+static volatile uint32_t other_error_count = 0;
+static volatile uint32_t last_error_status = 0;
+
+static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t *task_woken) {
+  if (notification == UART_SELECT_READ_NOTIF) {
+    esphome::Application::wake_loop_isrsafe(task_woken);
+    return;
+  }
+
+  if (notification != UART_SELECT_ERROR_NOTIF) {
+    return;
+  }
+
+  const uint32_t status = uart_ll_get_intsts_mask(UART_LL_GET_HW(uart_num));
+  last_error_status = status;
+
+  bool classified = false;
+  if ((status & UART_INTR_PARITY_ERR) != 0) {
+    parity_error_count++;
+    classified = true;
+  }
+  if ((status & UART_INTR_FRAM_ERR) != 0) {
+    frame_error_count++;
+    classified = true;
+  }
+  if (!classified) {
+    other_error_count++;
+  }
+
+  esphome::Application::wake_loop_isrsafe(task_woken);
+}
+
+inline void install(uint8_t uart_num) {
+  uart_set_select_notif_callback(static_cast<uart_port_t>(uart_num), uart_cb);
+  ESP_LOGI("oq.modbus_uart_err", "UART%u parity/frame error probe installed (ERR_WR_MASK not used)", uart_num);
+}
+
+inline void report_if_changed() {
+  static uint32_t reported_parity = 0;
+  static uint32_t reported_frame = 0;
+  static uint32_t reported_other = 0;
+
+  const uint32_t parity = parity_error_count;
+  const uint32_t frame = frame_error_count;
+  const uint32_t other = other_error_count;
+  if (parity == reported_parity && frame == reported_frame && other == reported_other) {
+    return;
+  }
+
+  ESP_LOGW("oq.modbus_uart_err", "UART RX errors: parity=%u frame=%u other=%u", parity, frame, other);
+  ESP_LOGW("oq.modbus_uart_err", "Last UART status=0x%08X", static_cast<unsigned>(last_error_status));
+
+  reported_parity = parity;
+  reported_frame = frame;
+  reported_other = other;
+}
+
+}  // namespace oq_modbus_uart_diag
+
+#endif  // USE_ESP32

--- a/configs/heatpump_controller_q/modbus_uart_error_probe.h
+++ b/configs/heatpump_controller_q/modbus_uart_error_probe.h
@@ -15,7 +15,7 @@ static volatile uint32_t frame_error_count = 0;
 static volatile uint32_t other_error_count = 0;
 static volatile uint32_t last_error_status = 0;
 
-static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t *task_woken) {
+static void IRAM_ATTR uart_cb(uart_port_t uart_num, uart_select_notif_t notification, BaseType_t* task_woken) {
   if (notification == UART_SELECT_READ_NOTIF) {
     esphome::Application::wake_loop_isrsafe(task_woken);
     return;

--- a/configs/heatpump_controller_q/single.yaml
+++ b/configs/heatpump_controller_q/single.yaml
@@ -31,6 +31,7 @@ packages:
   openquatt_base_common: !include ../../openquatt/base/common.yaml
   openquatt_connection_wifi_eth: !include ../../openquatt/connection/wifi_eth.yaml
   openquatt_packages_common: !include ../../openquatt/oq_packages_common.yaml
+  oq_modbus_uart_diagnostics: !include modbus_uart_diagnostics.yaml
 
 # Keep the UART RX input at idle HIGH during brief RS485 receiver turn-off gaps.
 uart:

--- a/openquatt/oq_common.yaml
+++ b/openquatt/oq_common.yaml
@@ -257,7 +257,7 @@ uart:
     data_bits: 8
     stop_bits: 1
     parity: EVEN
-    rx_full_threshold: 1
+    rx_full_threshold: 120
     rx_timeout: 1
 
 modbus:


### PR DESCRIPTION
# Wat verandert deze PR?

Deze PR blijft **test-firmware** voor onderzoek naar de Modbus RX-glitch op één probleeminstallatie.

- Houdt `uart_bus.rx_full_threshold` op `120`.
- Houdt `rx_timeout: 1`, 19200 8E1, RS485 DE/RE en overige Modbus-instellingen ongewijzigd.
- Houdt de bestaande interne RX pull-up op Controller Q Single actief.
- Voegt tijdelijke diagnose toe:
  - hardware UART parity-/frame-error counter;
  - raw RX logging van korte fragmenten;
  - raw RX logging wanneer daarbij een nieuwe UART-error is gezien.
- Gebruikt bewust **geen `UART_ERR_WR_MASK`**.

## Status

**Niet mergen.** Deze PR is uitsluitend voor gecontroleerde diagnose.

## Resultaat test 1: `rx_full_threshold: 120`

De eerste fieldtest draaide als `v0.50.0-pr.671.1813+e5146a8` op de probleeminstallatie.

In ongeveer negen minuten traden opnieuw zes `1 byte - timeout after partial response` events op:

```text
15:57:31  1 byte - timeout after partial response
15:58:20  1 byte - timeout after partial response
16:01:00  1 byte - timeout after partial response
16:03:30  1 byte - timeout after partial response
16:06:10  1 byte - timeout after partial response
16:06:33  1 byte - timeout after partial response
```

**Conclusie:** `rx_full_threshold: 1` was niet de oorzaak van de stray-byte/glitch. Threshold `120` elimineert het probleem niet.

## Resultaat test 2: ODU spanningsloos, bus aangesloten

De tweede fieldtest draaide als `v0.50.0-pr.671.1828+59e2813` met raw RX en hardware parity/frame monitoring.

Bij boot, terwijl de ODU actief was, werd direct het bekende patroon gevangen:

```text
Clearing buffer of 1 bytes - timeout after partial response
UART RX errors: parity=1 frame=0 other=0
RX 9 bytes: 01 06 07 DA 00 00 A9 45 FF
```

De eerste 8 bytes vormen een volledig geldig FC06-responseframe; de extra `FF` staat erachter en valt samen met precies één hardware parity-error.

Daarna is alleen de ODU spanningsloos gemaakt. Controller Q bleef ingeschakeld, RS485 A/B/GND en terminatie bleven aangesloten en OpenQuatt bleef normaal pollen. In dit ODU-off deel ontstonden de verwachte Modbus timeouts/offline-statussen, maar de parity-teller liep niet verder op en er verschenen geen nieuwe stray RX-bytes.

Na het opnieuw inschakelen van de ODU kwam hetzelfde patroon terug:

```text
RX 34 bytes: 01 03 1C ... E9 E6 FF   (parity=2)
RX 8 bytes:  01 03 02 00 00 B8 44 FF  (parity=3)
RX 8 bytes:  01 03 02 00 00 B8 44 FF  (parity=4)
```

### Conclusie test 2

De glitch vereist in deze test een **actieve ODU**. De sterkste huidige verklaring is daarom:

```text
ODU verstuurt een geldig Modbus-responseframe
-> ODU/transceiver laat de RS485-bus los
-> elektrische overgang / onvoldoende noise margin / common-mode/transceiver-effect
-> receiver decodeert een extra 0xFF
-> ESP32 UART meldt parity error
```

Dit wijst veel sterker naar de **ODU-side bus-release / fysieke RS485-overgang** dan naar de Modbus-parser, `rx_full_threshold`, of Controller Q DE/RE-aansturing.

Dat betekent nog niet dat de ODU zelf defect is; de oorzaak kan ook zitten in de combinatie ODU-transceiver, bekabeling, bias/termination, common-mode of receiver-noise-margin.

## Softwarematige impact van main-loop latency

Tijdens het ODU-off deel liep de main-loop latency op meerdere momenten sterk op, met component-operaties van honderden milliseconden en onder andere:

```text
network took ... 528 ms
modbus took ... 377 ms
template.binary_sensor took ... 488 ms
OpenTherm request cadence delayed to 1161 ms ... main-loop processing latency 294 ms
api took ... 665 ms
```

Deze stalls kunnen de **hardware parity-glitch niet veroorzaken**. Ze kunnen wel beïnvloeden hoe lang de stray `FF` in de softwarebuffer blijft staan en daarmee of hij:

- als losse `1 byte - timeout after partial response` wordt opgeruimd; of
- lang genoeg blijft liggen om met een volgend frame te interfereren en `parse failed` te veroorzaken.

De theorie dat eerder waargenomen leading `FF`-bytes restbytes van het vorige responseframe waren is daarmee plausibel, maar nog niet rechtstreeks bewezen met één doorlopende transactiecapture.

## `UART_ERR_WR_MASK`

PR #665 blijft terecht gesloten zonder merge. In die HIL-test stond `UART_ERR_WR_MASK=1` aantoonbaar actief, terwijl parity-foutieve bytes alsnog in de RX-buffer konden worden gelezen. Daarom wordt `ERR_WR_MASK` niet als betrouwbare oplossing beschouwd en is het in deze diagnosebuild bewust uitgeschakeld.

## Huidige werkhypothese

**Fysieke oorzaak:** zeer waarschijnlijk een glitch tijdens/na het vrijgeven van de RS485-bus door de actieve ODU/transceiver.

**Softwarematige escalatie:** main-loop-/buffer-timing bepaalt waarschijnlijk of de corrupte byte alleen als losse partial eindigt of een volgend frame kan verstoren.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [x] Control/platform
- [x] Anders - tijdelijke diagnose/testfirmware

## Impact

- [ ] Geen runtime/control gedragswijziging bedoeld
- [x] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt

## Documentatie

- [x] Geen documentatiewijziging nodig

Docs-impact motivatie: tijdelijke diagnosebuild; geen gebruikersfeature.

## Validatie

- [x] Fieldtest `rx_full_threshold: 120`: probleem blijft optreden
- [x] ODU-off fieldtest: geen nieuwe parity/raw-RX glitches waargenomen terwijl polling doorging
- [x] ODU opnieuw aan: `valid response + FF + parity error` opnieuw gereproduceerd
- [x] `UART_ERR_WR_MASK` bewust niet gebruikt

Heap/stack-impact: tijdelijke diagnosecode; raw logging gebruikt een lokale 512-byte buffer alleen wanneer een verdacht RX-fragment wordt gelogd.