### PR TITLE
Maak lokale historie in Quick Start beheersbaar

### DIFF
--- a/openquatt/web/css/src/05-layout-controls.css
+++ b/openquatt/web/css/src/05-layout-controls.css
@@ -420,6 +420,42 @@
   align-items: center;
 }
 
+.oq-quickstart-history {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px 20px;
+  margin-top: 18px;
+  padding: 16px 18px;
+  border: 1px solid var(--oq-helper-line);
+  border-radius: var(--oq-helper-radius-lg);
+  background: var(--oq-settings-subpanel-background);
+}
+
+.oq-quickstart-history > div {
+  flex: 1 1 360px;
+  min-width: 0;
+}
+
+.oq-quickstart-history-label,
+.oq-quickstart-history-copy {
+  margin: 0;
+}
+
+.oq-quickstart-history-label {
+  color: var(--oq-helper-ink);
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.oq-quickstart-history-copy {
+  margin-top: 4px;
+  color: var(--oq-helper-soft);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
 .oq-helper-fields {
   display: grid;
   gap: 12px;

--- a/openquatt/web/js/src/features/quickstart.js
+++ b/openquatt/web/js/src/features/quickstart.js
@@ -785,9 +785,14 @@ import { renderUsageTelemetryConsent, renderUsageTelemetryDisclosure } from "./u
         <h2 class="oq-helper-section-title">Bevestigen en afronden</h2>
         <p class="oq-helper-section-copy">Controleer nog één keer je keuzes. Met afronden markeer je Quick Start als voltooid.</p>
         ${renderConfirmReviewCards()}
-        <section class="oq-helper-surface oq-helper-surface--muted" aria-label="Lokale historie">
-          <h3>Lokale historie</h3>
-          <p>Energiegegevens en belangrijke regelgebeurtenissen worden lokaal bewaard zodat Resultaten en diagnose ook na een herstart beschikbaar blijven. Dit kan later worden aangepast onder Instellingen → Gegevens bewaren.</p>
+        <section class="oq-quickstart-history" aria-label="Lokale historie">
+          <div>
+            <p class="oq-quickstart-history-label">Lokale historie</p>
+            <p class="oq-quickstart-history-copy">Energiegegevens en belangrijke regelgebeurtenissen blijven ook na een herstart beschikbaar in Resultaten en Diagnose.</p>
+          </div>
+          <button class="oq-helper-button oq-helper-button--ghost" type="button" data-oq-action="open-history-storage-modal">
+            Gegevens bewaren
+          </button>
         </section>
         ${state.controlNotice ? `<p class="oq-helper-notice">${escapeHtml(state.controlNotice)}</p>` : ""}
         ${state.controlError ? `<p class="oq-helper-error">${escapeHtml(state.controlError)}</p>` : ""}

--- a/openquatt/web/tests/quickstart-history.test.mjs
+++ b/openquatt/web/tests/quickstart-history.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const quickStartSource = await readFile(new URL("../js/src/features/quickstart.js", import.meta.url), "utf8");
+
+test("Quick Start verwijst naar beheer van lokale historie", () => {
+  assert.match(quickStartSource, /class="oq-quickstart-history"/);
+  assert.match(quickStartSource, /data-oq-action="open-history-storage-modal"/);
+});


### PR DESCRIPTION
# Wat verandert deze PR?

- Maakt de lokale-historiekaart in de laatste Quick Start-stap compact en consistent met de overige UI.
- Voegt een knop **Gegevens bewaren** toe die de bestaande opslagbeheerweergave opent.
- Voegt een gerichte regressietest toe voor deze doorgang.

## Type

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [x] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de webinterface verandert; de bestaande opslagbeheeractie wordt hergebruikt.

## Achtergrond

De Quick Start verwees alleen tekstueel naar gegevens bewaren. De nieuwe knop opent de bestaande beheerweergave; firmware- en setupwisselwijzigingen vallen expliciet buiten deze PR.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De bestaande opslagfunctie verandert niet; alleen de Quick Start-doorgang ernaartoe.

## Validatie

- `npm run build:web`
- `npm run check:web`
- `node --test openquatt/web/tests/quickstart-history.test.mjs`
- `git diff --check`

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing: alleen webbron en een gerichte webtest wijzigen.