### PR TITLE
Voeg dedicated SSE-logstream toe voor diagnose en support

### DIFF
--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -10,7 +10,6 @@
 #include <cstdlib>
 
 #include <cerrno>
-#include <freertos/task.h>
 #include <sys/socket.h>
 
 #include "esp_random.h"
@@ -838,26 +837,11 @@ void OpenQuattLogHistory::setup() {
 }
 
 void OpenQuattLogHistory::loop() {
-  this->note_loop_stack_watermark_();
   this->sync_time_state_();
 #ifdef USE_ESP32_CRASH_HANDLER
   this->maybe_log_pending_crash_report_();
 #endif
   this->loop_streams_();
-}
-
-void OpenQuattLogHistory::note_loop_stack_watermark_() {
-  const uint32_t now_ms = millis();
-  if (this->last_stack_watermark_ms_ != 0 && (now_ms - this->last_stack_watermark_ms_) < 1000U) {
-    return;
-  }
-  this->last_stack_watermark_ms_ = now_ms;
-  // ESP-IDF returns the remaining high-watermark directly in bytes.
-  const uint32_t free_bytes = static_cast<uint32_t>(uxTaskGetStackHighWaterMark(nullptr));
-  uint32_t observed = this->loop_stack_min_free_bytes_.load(std::memory_order_relaxed);
-  while ((observed == 0 || free_bytes < observed) &&
-         !this->loop_stack_min_free_bytes_.compare_exchange_weak(observed, free_bytes, std::memory_order_relaxed)) {
-  }
 }
 
 void OpenQuattLogHistory::dump_config() {
@@ -927,17 +911,7 @@ void OpenQuattLogHistory::write_recent_logs(httpd_req_t* req) const {
   ChunkedJsonWriter writer(req);
   if (!writer.write_literal("{\"enabled\":true") || !writer.write_literal(",\"csrf_token\":") ||
       !writer.write_json_string(this->csrf_token_.c_str(), this->csrf_token_.size()) ||
-      !writer.write_literal(",\"stream\":{\"eagain\":") ||
-      !writer.write_uint32(this->stream_eagain_count_.load(std::memory_order_relaxed)) ||
-      !writer.write_literal(",\"partial_sends\":") ||
-      !writer.write_uint32(this->stream_partial_send_count_.load(std::memory_order_relaxed)) ||
-      !writer.write_literal(",\"send_timeout_closes\":") ||
-      !writer.write_uint32(this->stream_send_timeout_close_count_.load(std::memory_order_relaxed)) ||
-      !writer.write_literal(",\"send_error_closes\":") ||
-      !writer.write_uint32(this->stream_send_error_close_count_.load(std::memory_order_relaxed)) ||
-      !writer.write_literal(",\"loop_stack_min_free_bytes\":") ||
-      !writer.write_uint32(this->loop_stack_min_free_bytes_.load(std::memory_order_relaxed)) ||
-      !writer.write_literal("}") || !writer.write_literal(",\"entries\":[")) {
+      !writer.write_literal(",\"entries\":[")) {
     ESP_LOGW(TAG, "Failed to start recent log response");
     return;
   }
@@ -1311,17 +1285,17 @@ bool OpenQuattLogHistory::build_stream_heartbeat_(char* out, size_t out_size, si
   return true;
 }
 
-bool OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason) {
+void OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason) {
   // Main-loop only. Terminal: once closing is set, pump_stream_session_()
   // attempts no further socket sends and only drives the async close below.
   // Performs no HTTPD calls itself, so repeated requests are harmless: the
   // single choke point for queueing is maybe_queue_stream_close_().
   if (index >= this->streams_.size()) {
-    return false;
+    return;
   }
   auto& session = this->streams_[index];
   if (session.closing) {
-    return false;
+    return;
   }
   session.closing = true;
   ESP_LOGW(TAG, "Closing log stream client %u (%s)", static_cast<unsigned>(index), reason != nullptr ? reason : "slow");
@@ -1329,7 +1303,6 @@ bool OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason
   // (see loop_streams_()). Never clear fd here: a late free_ctx must still find
   // this session's fd, otherwise it could wipe a replacement connection that
   // reused the same static slot.
-  return true;
 }
 
 void OpenQuattLogHistory::stream_close_work_(void* arg) {
@@ -1402,7 +1375,6 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
   const size_t remaining = session.pend_len - session.pend_sent;
   const int sent = httpd_socket_send(session.hd, sockfd, base + session.pend_sent, remaining, 0);
   if (sent == HTTPD_SOCK_ERR_TIMEOUT) {
-    this->stream_eagain_count_.fetch_add(1, std::memory_order_relaxed);
     if (session.first_fail_ms == 0) {
       session.first_fail_ms = now_ms;
     }
@@ -1410,9 +1382,7 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
       ++session.fail_count;
     }
     if ((now_ms - session.first_fail_ms) >= STREAM_SEND_TIMEOUT_MS) {
-      if (this->request_stream_close_(index, "send-timeout")) {
-        this->stream_send_timeout_close_count_.fetch_add(1, std::memory_order_relaxed);
-      }
+      this->request_stream_close_(index, "send-timeout");
     }
     return false;
   }
@@ -1421,13 +1391,10 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
     // backpressure signal (that is HTTPD_SOCK_ERR_TIMEOUT above); it indicates
     // a broken peer. Fail closed so the client resyncs via /recent instead of
     // spinning forever on zero-progress partial sends.
-    if (this->request_stream_close_(index, "send-error")) {
-      this->stream_send_error_close_count_.fetch_add(1, std::memory_order_relaxed);
-    }
+    this->request_stream_close_(index, "send-error");
     return false;
   }
   if (static_cast<size_t>(sent) < remaining) {
-    this->stream_partial_send_count_.fetch_add(1, std::memory_order_relaxed);
     session.pend_sent += static_cast<size_t>(sent);
     session.fail_count = 0;
     session.first_fail_ms = 0;

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -1006,40 +1006,57 @@ bool OpenQuattLogHistory::parse_stream_since_(httpd_req_t* req, bool* has_since,
   }
 
   const size_t query_len = httpd_req_get_url_query_len(req);
-  if (query_len > 0 && query_len < 256) {
-    char query[256];
-    if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
-      char value[32];
-      static constexpr const char* KEYS[] = {"since", "last_seq", "lastEventId", "last_event_id"};
-      for (const char* key : KEYS) {
-        const esp_err_t found = httpd_query_key_value(query, key, value, sizeof(value));
-        if (found == ESP_OK) {
-          uint16_t seq = 0;
-          if (!log_stream_logic::parse_seq_strict(value, &seq)) {
-            *invalid = true;
-            return true;
-          }
-          *has_since = true;
-          *since = seq;
+  const size_t header_len = httpd_req_get_hdr_value_len(req, "Last-Event-ID");
+  if (log_stream_logic::cursor_carrier_oversized(query_len, header_len)) {
+    // Fail closed: an oversized query string or cursor header can neither be
+    // parsed nor safely truncated, so reject it instead of ignoring a cursor
+    // that may hide inside the unreadable tail.
+    *invalid = true;
+    return true;
+  }
+
+  if (query_len > 0) {
+    char query[log_stream_logic::CURSOR_QUERY_BUF_SIZE];
+    if (httpd_req_get_url_query_str(req, query, sizeof(query)) != ESP_OK) {
+      *invalid = true;
+      return true;
+    }
+    char value[log_stream_logic::CURSOR_VALUE_BUF_SIZE];
+    static constexpr const char* KEYS[] = {"since", "last_seq", "lastEventId", "last_event_id"};
+    for (const char* key : KEYS) {
+      const esp_err_t found = httpd_query_key_value(query, key, value, sizeof(value));
+      if (found == ESP_ERR_HTTPD_RESULT_TRUNC) {
+        // Cursor key present but value does not fit: reject, do not mask.
+        *invalid = true;
+        return true;
+      }
+      if (found == ESP_OK) {
+        uint16_t seq = 0;
+        if (!log_stream_logic::parse_seq_strict(value, &seq)) {
+          *invalid = true;
           return true;
         }
+        *has_since = true;
+        *since = seq;
+        return true;
       }
     }
   }
 
-  const size_t header_len = httpd_req_get_hdr_value_len(req, "Last-Event-ID");
-  if (header_len > 0 && header_len < 32) {
-    char value[32];
-    if (httpd_req_get_hdr_value_str(req, "Last-Event-ID", value, sizeof(value)) == ESP_OK) {
-      uint16_t seq = 0;
-      if (!log_stream_logic::parse_seq_strict(value, &seq)) {
-        *invalid = true;
-        return true;
-      }
-      *has_since = true;
-      *since = seq;
+  if (header_len > 0) {
+    char value[log_stream_logic::CURSOR_HEADER_BUF_SIZE];
+    if (httpd_req_get_hdr_value_str(req, "Last-Event-ID", value, sizeof(value)) != ESP_OK) {
+      *invalid = true;
       return true;
     }
+    uint16_t seq = 0;
+    if (!log_stream_logic::parse_seq_strict(value, &seq)) {
+      *invalid = true;
+      return true;
+    }
+    *has_since = true;
+    *since = seq;
+    return true;
   }
 
   return true;
@@ -1269,27 +1286,73 @@ bool OpenQuattLogHistory::build_stream_heartbeat_(char* out, size_t out_size, si
 }
 
 void OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason) {
+  // Main-loop only. Terminal: once closing is set, pump_stream_session_()
+  // attempts no further socket sends and only drives the async close below.
+  // Performs no HTTPD calls itself, so repeated requests are harmless: the
+  // single choke point for queueing is maybe_queue_stream_close_().
   if (index >= this->streams_.size()) {
     return;
   }
   auto& session = this->streams_[index];
-  const bool first_request = !session.closing;
-  session.closing = true;
-  if (first_request) {
-    session.close_request_ms = millis();
-    ESP_LOGW(TAG, "Closing log stream client %u (%s)", static_cast<unsigned>(index),
-             reason != nullptr ? reason : "slow");
+  if (session.closing) {
+    return;
   }
+  session.closing = true;
+  ESP_LOGW(TAG, "Closing log stream client %u (%s)", static_cast<unsigned>(index), reason != nullptr ? reason : "slow");
   // The slot is only recycled after free_ctx confirms the real socket close
   // (see loop_streams_()). Never clear fd here: a late free_ctx must still find
   // this session's fd, otherwise it could wipe a replacement connection that
   // reused the same static slot.
-  const int sockfd = session.fd.load();
-  if (session.hd != nullptr && sockfd > 0) {
-    const esp_err_t err = httpd_sess_trigger_close(session.hd, sockfd);
-    if (err != ESP_OK && first_request) {
-      ESP_LOGW(TAG, "Log stream trigger-close failed (%d), retrying", static_cast<int>(err));
-    }
+}
+
+void OpenQuattLogHistory::stream_close_work_(void* arg) {
+  // Runs on the HTTPD task via httpd_queue_work(). Shuts the socket down only
+  // when this exact session still owns it: httpd_sess_get_ctx() is evaluated
+  // here, at execution time, so a recycled fd number or a reused session slot
+  // can never cause a replacement connection to be closed (the flaw that rules
+  // out httpd_sess_trigger_close(), which queues a bare sock_db pointer).
+  auto* session = static_cast<LogStreamSession*>(arg);
+  if (session == nullptr) {
+    return;
+  }
+  const httpd_handle_t hd = session->close_hd;
+  const int fd = session->close_fd;
+  void* const expected = session->close_expected;
+  if (hd != nullptr && fd > 0 && expected != nullptr && httpd_sess_get_ctx(hd, fd) == expected) {
+    (void)shutdown(fd, SHUT_RDWR);
+  }
+  session->close_work_queued.store(false, std::memory_order_release);
+}
+
+void OpenQuattLogHistory::maybe_queue_stream_close_(size_t index, uint32_t now_ms) {
+  // Main-loop only. Queues at most one identity-checked close work item per
+  // session: re-queue only when queueing previously failed (flag was released)
+  // or the previous callback finished (flag released by stream_close_work_())
+  // while the session demonstrably still exists (fd still set, no free_ctx).
+  if (index >= this->streams_.size()) {
+    return;
+  }
+  auto& session = this->streams_[index];
+  if (!session.closing) {
+    return;
+  }
+  const int sockfd = session.fd.load(std::memory_order_acquire);
+  if (session.hd == nullptr || sockfd <= 0) {
+    return;
+  }
+  if (session.close_request_ms != 0 && (now_ms - session.close_request_ms) < STREAM_CLOSE_RETRY_INTERVAL_MS) {
+    return;
+  }
+  bool expected_queued = false;
+  if (!session.close_work_queued.compare_exchange_strong(expected_queued, true, std::memory_order_acq_rel)) {
+    return;
+  }
+  session.close_hd = session.hd;
+  session.close_fd = sockfd;
+  session.close_expected = &session;
+  session.close_request_ms = now_ms;
+  if (httpd_queue_work(session.close_hd, &OpenQuattLogHistory::stream_close_work_, &session) != ESP_OK) {
+    session.close_work_queued.store(false, std::memory_order_release);
   }
 }
 
@@ -1343,47 +1406,21 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
   return true;
 }
 
-bool OpenQuattLogHistory::send_stream_buffered_(size_t index, const char* data, size_t len, uint32_t now_ms) {
-  if (index >= this->streams_.size() || data == nullptr) {
-    return false;
-  }
-  auto& session = this->streams_[index];
-  if (!session.pend_buf || len > STREAM_EVENT_BUFFER_SIZE) {
-    return false;
-  }
-  if (session.pend_len != 0) {
-    return false;
-  }
-  std::memcpy(session.pend_buf.data(), data, len);
-  session.pend_len = len;
-  session.pend_sent = 0;
-  return this->flush_stream_pending_(index, now_ms);
-}
-
 void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
   if (index >= this->streams_.size()) {
     return;
   }
   auto& session = this->streams_[index];
 
-  if (!this->flush_stream_pending_(index, now_ms)) {
+  if (session.closing) {
+    // Terminal: never attempt socket sends for a closing session, not even to
+    // drain a stuck pending frame. Just drive the identity-checked async close
+    // and wait for free_ctx to confirm the real socket close, which is the only
+    // path that recycles the slot.
+    this->maybe_queue_stream_close_(index, now_ms);
     return;
   }
-  if (session.closing) {
-    // Wait for free_ctx to confirm the real socket close before recycling the
-    // slot. Retry the async trigger periodically (e.g. work queue was full);
-    // the slot stays reserved meanwhile so a late free_ctx can never wipe a
-    // replacement connection.
-    if (session.fd.load() > 0 && (now_ms - session.close_request_ms) >= STREAM_CLOSE_RETRY_INTERVAL_MS) {
-      session.close_request_ms = now_ms;
-      const int sockfd = session.fd.load();
-      if (session.hd != nullptr && sockfd > 0) {
-        const esp_err_t err = httpd_sess_trigger_close(session.hd, sockfd);
-        if (err != ESP_OK) {
-          ESP_LOGD(TAG, "Log stream trigger-close retry failed (%d)", static_cast<int>(err));
-        }
-      }
-    }
+  if (!this->flush_stream_pending_(index, now_ms)) {
     return;
   }
 
@@ -1527,25 +1564,55 @@ void OpenQuattLogHistory::loop_streams_() {
     return;
   }
   const uint32_t now_ms = millis();
+  httpd_handle_t current_hd = nullptr;
+  if (web_server_base::global_web_server_base != nullptr &&
+      web_server_base::global_web_server_base->get_server() != nullptr) {
+    current_hd = web_server_base::global_web_server_base->get_server()->get_server();
+  }
   for (size_t index = 0; index < this->streams_.size(); ++index) {
-    const int sockfd = this->streams_[index].fd.load();
+    const int sockfd = this->streams_[index].fd.load(std::memory_order_acquire);
+    const bool work_queued = this->streams_[index].close_work_queued.load(std::memory_order_acquire);
     bool active = false;
     bool ready = false;
     if (this->lock_history_()) {
-      active = this->streams_[index].active;
-      ready = this->streams_[index].ready;
-      // Reclaim sessions whose socket died (free_ctx cleared fd). Slots are only
-      // recycled here, after the real close confirmation, so a late free_ctx can
-      // never wipe a replacement connection reusing this static slot.
-      if (active && ready && sockfd <= 0) {
-        this->streams_[index].active = false;
-        this->streams_[index].ready = false;
-        this->streams_[index].closing = false;
-        this->streams_[index].need_gap = false;
-        this->streams_[index].pending_kind = StreamPendingKind::NONE;
-        this->streams_[index].pending_seq = 0;
-        this->streams_[index].pend_len = 0;
-        this->streams_[index].pend_sent = 0;
+      auto& session = this->streams_[index];
+      active = session.active;
+      ready = session.ready;
+      if (active && session.hd != nullptr && session.hd != current_hd) {
+        // The HTTPD server instance is gone (stop/restart): its sockets died
+        // with it and its work queue will never run again, so outstanding
+        // close work for it can neither execute nor alias a new server.
+        session.active = false;
+        session.ready = false;
+        session.closing = false;
+        session.need_gap = false;
+        session.close_work_queued.store(false, std::memory_order_release);
+        session.hd = nullptr;
+        session.close_hd = nullptr;
+        session.close_fd = -1;
+        session.close_expected = nullptr;
+        session.close_request_ms = 0;
+        session.pending_kind = StreamPendingKind::NONE;
+        session.pending_seq = 0;
+        session.pend_len = 0;
+        session.pend_sent = 0;
+        active = false;
+      } else if (active && ready && sockfd <= 0 && !work_queued) {
+        // Reclaim exclusively after the real close confirmation (free_ctx
+        // cleared fd) with no close work outstanding, so a late close callback
+        // can never wipe a replacement connection reusing this static slot.
+        session.active = false;
+        session.ready = false;
+        session.closing = false;
+        session.need_gap = false;
+        session.close_hd = nullptr;
+        session.close_fd = -1;
+        session.close_expected = nullptr;
+        session.close_request_ms = 0;
+        session.pending_kind = StreamPendingKind::NONE;
+        session.pending_seq = 0;
+        session.pend_len = 0;
+        session.pend_sent = 0;
         active = false;
       }
       this->unlock_history_();
@@ -1642,6 +1709,12 @@ esp_err_t OpenQuattLogHistory::handle_log_stream(httpd_req_t* req) {
       session.fail_count = 0;
       session.first_fail_ms = 0;
       session.close_request_ms = 0;
+      // Reclaim gate guarantees no close work is outstanding for this slot
+      // (loop_streams_() only recycles with fd==0 and !close_work_queued).
+      session.close_work_queued.store(false, std::memory_order_release);
+      session.close_hd = nullptr;
+      session.close_fd = -1;
+      session.close_expected = nullptr;
       session.pending_kind = StreamPendingKind::NONE;
       session.pending_seq = 0;
       session.pend_len = 0;

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -1386,7 +1386,11 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
     }
     return false;
   }
-  if (sent == HTTPD_SOCK_ERR_FAIL || sent == HTTPD_SOCK_ERR_INVALID || sent < 0) {
+  if (sent == HTTPD_SOCK_ERR_FAIL || sent == HTTPD_SOCK_ERR_INVALID || sent <= 0) {
+    // Note: sent==0 for a non-empty non-blocking send is not the normal
+    // backpressure signal (that is HTTPD_SOCK_ERR_TIMEOUT above); it indicates
+    // a broken peer. Fail closed so the client resyncs via /recent instead of
+    // spinning forever on zero-progress partial sends.
     this->request_stream_close_(index, "send-error");
     return false;
   }

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -979,8 +979,7 @@ bool OpenQuattLogHistory::stream_storage_available() const {
 }
 
 bool OpenQuattLogHistory::seq_is_newer_(uint16_t seq, uint16_t base) {
-  const uint16_t diff = static_cast<uint16_t>(seq - base);
-  return diff != 0 && diff < 0x8000U;
+  return log_stream_logic::seq_is_newer(seq, base);
 }
 
 void OpenQuattLogHistory::stream_free_ctx_(void* ctx) {
@@ -992,29 +991,19 @@ void OpenQuattLogHistory::stream_free_ctx_(void* ctx) {
   ESP_LOGD(TAG, "Log stream closed (fd: %d)", fd);
 }
 
-bool OpenQuattLogHistory::parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since) const {
+bool OpenQuattLogHistory::parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since, bool* invalid) const {
   if (has_since != nullptr) {
     *has_since = false;
   }
   if (since != nullptr) {
     *since = 0;
   }
-  if (req == nullptr || has_since == nullptr || since == nullptr) {
+  if (invalid != nullptr) {
+    *invalid = false;
+  }
+  if (req == nullptr || has_since == nullptr || since == nullptr || invalid == nullptr) {
     return false;
   }
-
-  auto parse_to_seq = [](const char* text, uint16_t* out) -> bool {
-    if (text == nullptr || out == nullptr || text[0] == '\0') {
-      return false;
-    }
-    char* end = nullptr;
-    const unsigned long value = std::strtoul(text, &end, 10);
-    if (end == text) {
-      return false;
-    }
-    *out = static_cast<uint16_t>(value & 0xFFFFUL);
-    return true;
-  };
 
   const size_t query_len = httpd_req_get_url_query_len(req);
   if (query_len > 0 && query_len < 256) {
@@ -1023,13 +1012,16 @@ bool OpenQuattLogHistory::parse_stream_since_(httpd_req_t* req, bool* has_since,
       char value[32];
       static constexpr const char* KEYS[] = {"since", "last_seq", "lastEventId", "last_event_id"};
       for (const char* key : KEYS) {
-        if (httpd_query_key_value(query, key, value, sizeof(value)) == ESP_OK) {
+        const esp_err_t found = httpd_query_key_value(query, key, value, sizeof(value));
+        if (found == ESP_OK) {
           uint16_t seq = 0;
-          if (parse_to_seq(value, &seq)) {
-            *has_since = true;
-            *since = seq;
+          if (!log_stream_logic::parse_seq_strict(value, &seq)) {
+            *invalid = true;
             return true;
           }
+          *has_since = true;
+          *since = seq;
+          return true;
         }
       }
     }
@@ -1040,11 +1032,13 @@ bool OpenQuattLogHistory::parse_stream_since_(httpd_req_t* req, bool* has_since,
     char value[32];
     if (httpd_req_get_hdr_value_str(req, "Last-Event-ID", value, sizeof(value)) == ESP_OK) {
       uint16_t seq = 0;
-      if (parse_to_seq(value, &seq)) {
-        *has_since = true;
-        *since = seq;
+      if (!log_stream_logic::parse_seq_strict(value, &seq)) {
+        *invalid = true;
         return true;
       }
+      *has_since = true;
+      *since = seq;
+      return true;
     }
   }
 
@@ -1114,6 +1108,75 @@ bool OpenQuattLogHistory::build_stream_log_event_(const LogEntry& entry, char* o
     return false;
   }
   if (!sse_buffer_append_json_string_(out, out_size, &pos, entry.raw, entry.raw_len)) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "}\n\n")) {
+    return false;
+  }
+
+  const size_t payload_len = pos - CHUNK_HEADER_LEN;
+  if (payload_len + CHUNK_HEADER_LEN + 2 > out_size) {
+    return false;
+  }
+  char header[CHUNK_HEADER_LEN + 1];
+  std::snprintf(header, sizeof(header), "%08X\r\n", static_cast<unsigned>(payload_len));
+  std::memcpy(out, header, CHUNK_HEADER_LEN);
+  out[pos++] = '\r';
+  out[pos++] = '\n';
+  *out_len = pos;
+  return true;
+}
+
+bool OpenQuattLogHistory::build_stream_log_event_truncated_(const LogEntry& entry, char* out, size_t out_size,
+                                                            size_t* out_len) const {
+  // Fallback for pathological records that do not fit even the enlarged event
+  // buffer (raw + tag/message with worst-case JSON escaping). Never skip a
+  // sequence: deliver seq/ts/level plus a bounded raw prefix with an explicit
+  // truncated flag so diagnostics stay gap-free.
+  if (out == nullptr || out_len == nullptr || out_size < 256) {
+    return false;
+  }
+  static constexpr size_t CHUNK_HEADER_LEN = 10;
+  static constexpr size_t RAW_PREFIX_MAX = 64;
+  size_t pos = CHUNK_HEADER_LEN;
+
+  char num[32];
+  int written = std::snprintf(num, sizeof(num), "id: %u\n", static_cast<unsigned>(entry.seq));
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "event: log\n")) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "data: ")) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "{\"seq\":")) {
+    return false;
+  }
+  written = std::snprintf(num, sizeof(num), "%u", static_cast<unsigned>(entry.seq));
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"ts\":")) {
+    return false;
+  }
+  written = std::snprintf(num, sizeof(num), "%" PRIu64, static_cast<uint64_t>(entry.timestamp_s) * 1000ULL);
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"level\":")) {
+    return false;
+  }
+  const char* level = level_to_string_(entry.level);
+  if (!sse_buffer_append_json_string_(out, out_size, &pos, level, std::strlen(level))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"truncated\":true,\"raw\":")) {
+    return false;
+  }
+  const size_t prefix_len = entry.raw_len < RAW_PREFIX_MAX ? entry.raw_len : RAW_PREFIX_MAX;
+  if (!sse_buffer_append_json_string_(out, out_size, &pos, entry.raw, prefix_len)) {
     return false;
   }
   if (!sse_buffer_append_literal_(out, out_size, &pos, "}\n\n")) {
@@ -1210,16 +1273,23 @@ void OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason
     return;
   }
   auto& session = this->streams_[index];
-  if (session.closing) {
-    return;
-  }
+  const bool first_request = !session.closing;
   session.closing = true;
-  session.close_request_ms = millis();
-  const int sockfd = session.fd.load();
-  if (session.hd != nullptr && sockfd > 0) {
+  if (first_request) {
+    session.close_request_ms = millis();
     ESP_LOGW(TAG, "Closing log stream client %u (%s)", static_cast<unsigned>(index),
              reason != nullptr ? reason : "slow");
-    (void)httpd_sess_trigger_close(session.hd, sockfd);
+  }
+  // The slot is only recycled after free_ctx confirms the real socket close
+  // (see loop_streams_()). Never clear fd here: a late free_ctx must still find
+  // this session's fd, otherwise it could wipe a replacement connection that
+  // reused the same static slot.
+  const int sockfd = session.fd.load();
+  if (session.hd != nullptr && sockfd > 0) {
+    const esp_err_t err = httpd_sess_trigger_close(session.hd, sockfd);
+    if (err != ESP_OK && first_request) {
+      ESP_LOGW(TAG, "Log stream trigger-close failed (%d), retrying", static_cast<int>(err));
+    }
   }
 }
 
@@ -1265,6 +1335,8 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
   }
   session.pend_len = 0;
   session.pend_sent = 0;
+  session.pending_kind = StreamPendingKind::NONE;
+  session.pending_seq = 0;
   session.fail_count = 0;
   session.first_fail_ms = 0;
   session.last_activity_ms = now_ms;
@@ -1298,10 +1370,19 @@ void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
     return;
   }
   if (session.closing) {
-    if ((now_ms - session.close_request_ms) > 10000UL) {
-      // httpd did not confirm the close; reclaim defensively. A late free_ctx
-      // may drop one replacement event at most; the client resyncs via /recent.
-      session.fd.store(0);
+    // Wait for free_ctx to confirm the real socket close before recycling the
+    // slot. Retry the async trigger periodically (e.g. work queue was full);
+    // the slot stays reserved meanwhile so a late free_ctx can never wipe a
+    // replacement connection.
+    if (session.fd.load() > 0 && (now_ms - session.close_request_ms) >= STREAM_CLOSE_RETRY_INTERVAL_MS) {
+      session.close_request_ms = now_ms;
+      const int sockfd = session.fd.load();
+      if (session.hd != nullptr && sockfd > 0) {
+        const esp_err_t err = httpd_sess_trigger_close(session.hd, sockfd);
+        if (err != ESP_OK) {
+          ESP_LOGD(TAG, "Log stream trigger-close retry failed (%d)", static_cast<int>(err));
+        }
+      }
     }
     return;
   }
@@ -1318,12 +1399,17 @@ void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
       this->request_stream_close_(index, "gap-too-large");
       return;
     }
+    // Commit at queue time: even if the socket only accepts part of this frame
+    // now, the remainder stays pending and need_gap stays cleared, so the gap
+    // is never queued twice.
+    session.pending_kind = StreamPendingKind::GAP;
+    session.pending_seq = session.gap_newest;
+    session.need_gap = false;
     session.pend_len = frame_len;
     session.pend_sent = 0;
     if (!this->flush_stream_pending_(index, now_ms)) {
       return;
     }
-    session.need_gap = false;
   }
 
   // Snapshot one entry at a time under the history lock so socket I/O never
@@ -1333,8 +1419,6 @@ void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
     LogEntry entry{};
     bool history_empty = false;
     bool lagged = false;
-    uint16_t oldest = 0;
-    uint16_t newest = 0;
     uint32_t next_seq = 0;
 
     if (!this->lock_history_()) {
@@ -1346,12 +1430,9 @@ void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
     } else {
       const size_t oldest_index = this->head_ % ENTRY_CAPACITY;
       const size_t newest_index = (this->head_ + this->count_ - 1) % ENTRY_CAPACITY;
-      oldest = this->entries_[oldest_index].seq;
-      newest = this->entries_[newest_index].seq;
-      const bool at_oldest_minus_one = session.last_seq == static_cast<uint16_t>(oldest - 1U);
-      const uint16_t dist_to_last = static_cast<uint16_t>(session.last_seq - oldest);
-      const uint16_t dist_to_newest = static_cast<uint16_t>(newest - oldest);
-      if (!at_oldest_minus_one && dist_to_last > dist_to_newest) {
+      const uint16_t oldest = this->entries_[oldest_index].seq;
+      const uint16_t newest = this->entries_[newest_index].seq;
+      if (!log_stream_logic::cursor_in_window(session.last_seq, oldest, newest)) {
         lagged = true;
       } else {
         // Find the oldest entry newer than last_seq.
@@ -1393,16 +1474,24 @@ void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
     }
     size_t frame_len = 0;
     if (!this->build_stream_log_event_(entry, buf, STREAM_EVENT_BUFFER_SIZE, &frame_len)) {
-      ESP_LOGW(TAG, "Log stream event too large (seq %u)", static_cast<unsigned>(entry.seq));
-      session.last_seq = entry.seq;
-      continue;
+      // Pathological record: fall back to a bounded truncated frame so the
+      // sequence is still delivered instead of skipped.
+      ESP_LOGW(TAG, "Log stream event truncated (seq %u)", static_cast<unsigned>(entry.seq));
+      if (!this->build_stream_log_event_truncated_(entry, buf, STREAM_EVENT_BUFFER_SIZE, &frame_len)) {
+        this->request_stream_close_(index, "event-too-large");
+        return;
+      }
     }
+    // Commit at queue time: last_seq advances now, so a later EAGAIN/partial
+    // send resumes with the remainder of this frame and never re-queues it.
+    session.pending_kind = StreamPendingKind::LOG;
+    session.pending_seq = entry.seq;
+    session.last_seq = entry.seq;
     session.pend_len = frame_len;
     session.pend_sent = 0;
     if (!this->flush_stream_pending_(index, now_ms)) {
       return;
     }
-    session.last_seq = entry.seq;
   }
 
   if (!session.closing && session.pend_len == 0 &&
@@ -1415,6 +1504,8 @@ void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
     if (!this->build_stream_heartbeat_(buf, STREAM_EVENT_BUFFER_SIZE, &frame_len)) {
       return;
     }
+    session.pending_kind = StreamPendingKind::HEARTBEAT;
+    session.pending_seq = 0;
     session.pend_len = frame_len;
     session.pend_sent = 0;
     (void)this->flush_stream_pending_(index, now_ms);
@@ -1443,12 +1534,16 @@ void OpenQuattLogHistory::loop_streams_() {
     if (this->lock_history_()) {
       active = this->streams_[index].active;
       ready = this->streams_[index].ready;
-      // Reclaim sessions whose socket died (free_ctx cleared fd).
+      // Reclaim sessions whose socket died (free_ctx cleared fd). Slots are only
+      // recycled here, after the real close confirmation, so a late free_ctx can
+      // never wipe a replacement connection reusing this static slot.
       if (active && ready && sockfd <= 0) {
         this->streams_[index].active = false;
         this->streams_[index].ready = false;
         this->streams_[index].closing = false;
         this->streams_[index].need_gap = false;
+        this->streams_[index].pending_kind = StreamPendingKind::NONE;
+        this->streams_[index].pending_seq = 0;
         this->streams_[index].pend_len = 0;
         this->streams_[index].pend_sent = 0;
         active = false;
@@ -1479,7 +1574,15 @@ esp_err_t OpenQuattLogHistory::handle_log_stream(httpd_req_t* req) {
 
   bool has_since = false;
   uint16_t since = 0;
-  this->parse_stream_since_(req, &has_since, &since);
+  bool cursor_invalid = false;
+  this->parse_stream_since_(req, &has_since, &since, &cursor_invalid);
+  if (cursor_invalid) {
+    httpd_resp_set_status(req, HTTPD_400);
+    httpd_resp_set_type(req, "application/json; charset=utf-8");
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+    httpd_resp_sendstr(req, R"({"ok":false,"error":"bad_since"})");
+    return ESP_OK;
+  }
 
   size_t slot = STREAM_MAX_CLIENTS;
   uint16_t initial_seq = 0;
@@ -1504,29 +1607,23 @@ esp_err_t OpenQuattLogHistory::handle_log_stream(httpd_req_t* req) {
     return ESP_OK;
   }
 
-  if (this->count_ == 0) {
-    initial_seq = static_cast<uint16_t>((this->next_seq_ - 1U) & 0xFFFFUL);
-  } else {
-    const size_t oldest_index = this->head_ % ENTRY_CAPACITY;
-    const size_t newest_index = (this->head_ + this->count_ - 1) % ENTRY_CAPACITY;
-    const uint16_t oldest = this->entries_[oldest_index].seq;
-    const uint16_t newest = this->entries_[newest_index].seq;
-    gap_oldest = oldest;
-    gap_newest = newest;
-    if (!has_since) {
-      initial_seq = newest;
-    } else {
-      const bool at_oldest_minus_one = since == static_cast<uint16_t>(oldest - 1U);
-      const uint16_t dist_to_since = static_cast<uint16_t>(since - oldest);
-      const uint16_t dist_to_newest = static_cast<uint16_t>(newest - oldest);
-      if (at_oldest_minus_one || dist_to_since <= dist_to_newest) {
-        initial_seq = since;
-      } else {
-        // Stale or future cursor: start live and tell the client to backfill via /recent.
-        initial_seq = newest;
-        need_gap = true;
-      }
+  {
+    const bool history_empty = this->count_ == 0;
+    uint16_t oldest = 0;
+    uint16_t newest = 0;
+    if (!history_empty) {
+      const size_t oldest_index = this->head_ % ENTRY_CAPACITY;
+      const size_t newest_index = (this->head_ + this->count_ - 1) % ENTRY_CAPACITY;
+      oldest = this->entries_[oldest_index].seq;
+      newest = this->entries_[newest_index].seq;
+      gap_oldest = oldest;
+      gap_newest = newest;
     }
+    const uint16_t next_minus_one = static_cast<uint16_t>((this->next_seq_ - 1U) & 0xFFFFUL);
+    const log_stream_logic::CursorResolution resolved =
+        log_stream_logic::resolve_initial_seq(has_since, since, history_empty, oldest, newest, next_minus_one);
+    initial_seq = resolved.initial_seq;
+    need_gap = resolved.need_gap;
   }
 
   for (size_t index = 0; index < this->streams_.size(); ++index) {
@@ -1545,6 +1642,8 @@ esp_err_t OpenQuattLogHistory::handle_log_stream(httpd_req_t* req) {
       session.fail_count = 0;
       session.first_fail_ms = 0;
       session.close_request_ms = 0;
+      session.pending_kind = StreamPendingKind::NONE;
+      session.pending_seq = 0;
       session.pend_len = 0;
       session.pend_sent = 0;
       break;

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 
 #include <cerrno>
+#include <freertos/task.h>
 #include <sys/socket.h>
 
 #include "esp_random.h"
@@ -837,11 +838,26 @@ void OpenQuattLogHistory::setup() {
 }
 
 void OpenQuattLogHistory::loop() {
+  this->note_loop_stack_watermark_();
   this->sync_time_state_();
 #ifdef USE_ESP32_CRASH_HANDLER
   this->maybe_log_pending_crash_report_();
 #endif
   this->loop_streams_();
+}
+
+void OpenQuattLogHistory::note_loop_stack_watermark_() {
+  const uint32_t now_ms = millis();
+  if (this->last_stack_watermark_ms_ != 0 && (now_ms - this->last_stack_watermark_ms_) < 1000U) {
+    return;
+  }
+  this->last_stack_watermark_ms_ = now_ms;
+  // ESP-IDF returns the remaining high-watermark directly in bytes.
+  const uint32_t free_bytes = static_cast<uint32_t>(uxTaskGetStackHighWaterMark(nullptr));
+  uint32_t observed = this->loop_stack_min_free_bytes_.load(std::memory_order_relaxed);
+  while ((observed == 0 || free_bytes < observed) &&
+         !this->loop_stack_min_free_bytes_.compare_exchange_weak(observed, free_bytes, std::memory_order_relaxed)) {
+  }
 }
 
 void OpenQuattLogHistory::dump_config() {
@@ -911,7 +927,17 @@ void OpenQuattLogHistory::write_recent_logs(httpd_req_t* req) const {
   ChunkedJsonWriter writer(req);
   if (!writer.write_literal("{\"enabled\":true") || !writer.write_literal(",\"csrf_token\":") ||
       !writer.write_json_string(this->csrf_token_.c_str(), this->csrf_token_.size()) ||
-      !writer.write_literal(",\"entries\":[")) {
+      !writer.write_literal(",\"stream\":{\"eagain\":") ||
+      !writer.write_uint32(this->stream_eagain_count_.load(std::memory_order_relaxed)) ||
+      !writer.write_literal(",\"partial_sends\":") ||
+      !writer.write_uint32(this->stream_partial_send_count_.load(std::memory_order_relaxed)) ||
+      !writer.write_literal(",\"send_timeout_closes\":") ||
+      !writer.write_uint32(this->stream_send_timeout_close_count_.load(std::memory_order_relaxed)) ||
+      !writer.write_literal(",\"send_error_closes\":") ||
+      !writer.write_uint32(this->stream_send_error_close_count_.load(std::memory_order_relaxed)) ||
+      !writer.write_literal(",\"loop_stack_min_free_bytes\":") ||
+      !writer.write_uint32(this->loop_stack_min_free_bytes_.load(std::memory_order_relaxed)) ||
+      !writer.write_literal("}") || !writer.write_literal(",\"entries\":[")) {
     ESP_LOGW(TAG, "Failed to start recent log response");
     return;
   }
@@ -1285,17 +1311,17 @@ bool OpenQuattLogHistory::build_stream_heartbeat_(char* out, size_t out_size, si
   return true;
 }
 
-void OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason) {
+bool OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason) {
   // Main-loop only. Terminal: once closing is set, pump_stream_session_()
   // attempts no further socket sends and only drives the async close below.
   // Performs no HTTPD calls itself, so repeated requests are harmless: the
   // single choke point for queueing is maybe_queue_stream_close_().
   if (index >= this->streams_.size()) {
-    return;
+    return false;
   }
   auto& session = this->streams_[index];
   if (session.closing) {
-    return;
+    return false;
   }
   session.closing = true;
   ESP_LOGW(TAG, "Closing log stream client %u (%s)", static_cast<unsigned>(index), reason != nullptr ? reason : "slow");
@@ -1303,6 +1329,7 @@ void OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason
   // (see loop_streams_()). Never clear fd here: a late free_ctx must still find
   // this session's fd, otherwise it could wipe a replacement connection that
   // reused the same static slot.
+  return true;
 }
 
 void OpenQuattLogHistory::stream_close_work_(void* arg) {
@@ -1375,6 +1402,7 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
   const size_t remaining = session.pend_len - session.pend_sent;
   const int sent = httpd_socket_send(session.hd, sockfd, base + session.pend_sent, remaining, 0);
   if (sent == HTTPD_SOCK_ERR_TIMEOUT) {
+    this->stream_eagain_count_.fetch_add(1, std::memory_order_relaxed);
     if (session.first_fail_ms == 0) {
       session.first_fail_ms = now_ms;
     }
@@ -1382,7 +1410,9 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
       ++session.fail_count;
     }
     if ((now_ms - session.first_fail_ms) >= STREAM_SEND_TIMEOUT_MS) {
-      this->request_stream_close_(index, "send-timeout");
+      if (this->request_stream_close_(index, "send-timeout")) {
+        this->stream_send_timeout_close_count_.fetch_add(1, std::memory_order_relaxed);
+      }
     }
     return false;
   }
@@ -1391,10 +1421,13 @@ bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
     // backpressure signal (that is HTTPD_SOCK_ERR_TIMEOUT above); it indicates
     // a broken peer. Fail closed so the client resyncs via /recent instead of
     // spinning forever on zero-progress partial sends.
-    this->request_stream_close_(index, "send-error");
+    if (this->request_stream_close_(index, "send-error")) {
+      this->stream_send_error_close_count_.fetch_add(1, std::memory_order_relaxed);
+    }
     return false;
   }
   if (static_cast<size_t>(sent) < remaining) {
+    this->stream_partial_send_count_.fetch_add(1, std::memory_order_relaxed);
     session.pend_sent += static_cast<size_t>(sent);
     session.fail_count = 0;
     session.first_fail_ms = 0;
@@ -1555,11 +1588,16 @@ void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
 
 void OpenQuattLogHistory::loop_streams_() {
   bool any_active = false;
-  for (const auto& session : this->streams_) {
-    if (session.active && session.ready) {
-      any_active = true;
-      break;
+  if (this->lock_history_()) {
+    for (const auto& session : this->streams_) {
+      if (session.active) {
+        any_active = true;
+        break;
+      }
     }
+    this->unlock_history_();
+  } else {
+    return;
   }
   if (!any_active) {
     return;
@@ -1583,24 +1621,29 @@ void OpenQuattLogHistory::loop_streams_() {
       active = session.active;
       ready = session.ready;
       if (active && session.hd != nullptr && session.hd != current_hd) {
-        // The HTTPD server instance is gone (stop/restart): its sockets died
-        // with it and its work queue will never run again, so outstanding
-        // close work for it can neither execute nor alias a new server.
-        session.active = false;
+        // A restarted HTTPD instance must not recycle this static slot before
+        // the old session's free_ctx has cleared fd. Otherwise that late
+        // callback could exchange the fd of a replacement session to zero.
         session.ready = false;
-        session.closing = false;
-        session.need_gap = false;
-        session.close_work_queued.store(false, std::memory_order_release);
-        session.hd = nullptr;
-        session.close_hd = nullptr;
-        session.close_fd = -1;
-        session.close_expected = nullptr;
-        session.close_request_ms = 0;
-        session.pending_kind = StreamPendingKind::NONE;
-        session.pending_seq = 0;
-        session.pend_len = 0;
-        session.pend_sent = 0;
-        active = false;
+        ready = false;
+        if (sockfd <= 0) {
+          // free_ctx confirms the old socket is gone. Its work queue is gone
+          // too, so any stale queued-close marker can now be discarded.
+          session.active = false;
+          session.closing = false;
+          session.need_gap = false;
+          session.close_work_queued.store(false, std::memory_order_release);
+          session.hd = nullptr;
+          session.close_hd = nullptr;
+          session.close_fd = -1;
+          session.close_expected = nullptr;
+          session.close_request_ms = 0;
+          session.pending_kind = StreamPendingKind::NONE;
+          session.pending_seq = 0;
+          session.pend_len = 0;
+          session.pend_sent = 0;
+          active = false;
+        }
       } else if (active && ready && sockfd <= 0 && !work_queued) {
         // Reclaim exclusively after the real close confirmation (free_ctx
         // cleared fd) with no close work outstanding, so a late close callback

--- a/components/openquatt_log_history/OpenQuattLogHistory.cpp
+++ b/components/openquatt_log_history/OpenQuattLogHistory.cpp
@@ -3,9 +3,14 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
+#include <cstdlib>
+
+#include <cerrno>
+#include <sys/socket.h>
 
 #include "esp_random.h"
 #include "esphome/core/defines.h"
@@ -120,6 +125,108 @@ static bool url_path_matches(const char* url, const char* path) {
   }
   const size_t path_len = std::strlen(path);
   return std::strncmp(url, path, path_len) == 0 && (url[path_len] == '\0' || url[path_len] == '?');
+}
+
+// Non-blocking socket send for SSE sessions. Prevents the main loop from blocking
+// on a slow client; EAGAIN is reported as HTTPD_SOCK_ERR_TIMEOUT so the caller can
+// retry later without growing an unbounded per-client queue.
+static int log_stream_nonblocking_send_(httpd_handle_t hd, int sockfd, const char* buf, size_t buf_len, int flags) {
+  (void)hd;
+  if (buf == nullptr) {
+    return HTTPD_SOCK_ERR_INVALID;
+  }
+  const int ret = send(sockfd, buf, buf_len, flags | MSG_DONTWAIT);
+  if (ret < 0) {
+    const int err = errno;
+    if (err == EAGAIN || err == EWOULDBLOCK) {
+      return HTTPD_SOCK_ERR_TIMEOUT;
+    }
+    return HTTPD_SOCK_ERR_FAIL;
+  }
+  return ret;
+}
+
+static bool sse_buffer_append_(char* out, size_t out_size, size_t* pos, const char* data, size_t len) {
+  if (out == nullptr || pos == nullptr || (data == nullptr && len != 0)) {
+    return false;
+  }
+  if (len == 0) {
+    return true;
+  }
+  if (*pos >= out_size || len > out_size - *pos) {
+    return false;
+  }
+  std::memcpy(out + *pos, data, len);
+  *pos += len;
+  return true;
+}
+
+static bool sse_buffer_append_literal_(char* out, size_t out_size, size_t* pos, const char* text) {
+  if (text == nullptr) {
+    return true;
+  }
+  return sse_buffer_append_(out, out_size, pos, text, std::strlen(text));
+}
+
+static bool sse_buffer_append_json_string_(char* out, size_t out_size, size_t* pos, const char* value, size_t len) {
+  if (!sse_buffer_append_(out, out_size, pos, "\"", 1)) {
+    return false;
+  }
+  for (size_t index = 0; index < len; ++index) {
+    const unsigned char c = static_cast<unsigned char>(value[index]);
+    switch (c) {
+      case '\\':
+        if (!sse_buffer_append_literal_(out, out_size, pos, "\\\\")) {
+          return false;
+        }
+        break;
+      case '"':
+        if (!sse_buffer_append_literal_(out, out_size, pos, "\\\"")) {
+          return false;
+        }
+        break;
+      case '\b':
+        if (!sse_buffer_append_literal_(out, out_size, pos, "\\b")) {
+          return false;
+        }
+        break;
+      case '\f':
+        if (!sse_buffer_append_literal_(out, out_size, pos, "\\f")) {
+          return false;
+        }
+        break;
+      case '\n':
+        if (!sse_buffer_append_literal_(out, out_size, pos, "\\n")) {
+          return false;
+        }
+        break;
+      case '\r':
+        if (!sse_buffer_append_literal_(out, out_size, pos, "\\r")) {
+          return false;
+        }
+        break;
+      case '\t':
+        if (!sse_buffer_append_literal_(out, out_size, pos, "\\t")) {
+          return false;
+        }
+        break;
+      default:
+        if (c < 0x20) {
+          char buffer[7];
+          const int written = std::snprintf(buffer, sizeof(buffer), "\\u%04X", c);
+          if (written < 0 || !sse_buffer_append_(out, out_size, pos, buffer, static_cast<size_t>(written))) {
+            return false;
+          }
+        } else {
+          const char ch = static_cast<char>(c);
+          if (!sse_buffer_append_(out, out_size, pos, &ch, 1)) {
+            return false;
+          }
+        }
+        break;
+    }
+  }
+  return sse_buffer_append_(out, out_size, pos, "\"", 1);
 }
 
 class ChunkedJsonWriter {
@@ -284,7 +391,7 @@ class OpenQuattLogHistoryRequestHandler : public AsyncWebHandler {
   bool canHandle(AsyncWebServerRequest* request) const override {
     char url_buf[AsyncWebServerRequest::URL_BUF_SIZE];
     request->url_to(url_buf);
-    if (url_path_matches(url_buf, "/openquatt/logs/recent")) {
+    if (url_path_matches(url_buf, "/openquatt/logs/recent") || url_path_matches(url_buf, "/openquatt/logs/stream")) {
       return request->method() == HTTP_GET;
     }
     return url_path_matches(url_buf, "/openquatt/logs/clear") && request->method() == HTTP_POST;
@@ -304,6 +411,11 @@ class OpenQuattLogHistoryRequestHandler : public AsyncWebHandler {
       }
       this->parent_->clear_history();
       request->send(200, "application/json", R"({"ok":true})");
+      return;
+    }
+    if (url_path_matches(url_buf, "/openquatt/logs/stream")) {
+      httpd_req_t* stream_req = *request;
+      this->parent_->handle_log_stream(stream_req);
       return;
     }
 
@@ -701,6 +813,15 @@ void OpenQuattLogHistory::setup() {
   if (!this->entries_.allocate_external(ENTRY_CAPACITY)) {
     ESP_LOGE(TAG, "Failed to allocate log history buffer in PSRAM");
   }
+  bool streams_ready = true;
+  for (auto& session : this->streams_) {
+    if (!session.pend_buf.allocate_external(STREAM_EVENT_BUFFER_SIZE)) {
+      streams_ready = false;
+    }
+  }
+  if (!streams_ready) {
+    ESP_LOGE(TAG, "Failed to allocate log stream buffers in PSRAM; /openquatt/logs/stream unavailable");
+  }
   this->rotate_csrf_token_();
 
   logger::global_logger->add_log_callback(
@@ -720,12 +841,19 @@ void OpenQuattLogHistory::loop() {
 #ifdef USE_ESP32_CRASH_HANDLER
   this->maybe_log_pending_crash_report_();
 #endif
+  this->loop_streams_();
 }
 
 void OpenQuattLogHistory::dump_config() {
   size_t entry_count = 0;
+  size_t stream_count = 0;
   if (this->lock_history_()) {
     entry_count = this->count_;
+    for (const auto& session : this->streams_) {
+      if (session.active && session.ready) {
+        ++stream_count;
+      }
+    }
     this->unlock_history_();
   }
 
@@ -734,6 +862,8 @@ void OpenQuattLogHistory::dump_config() {
   ESP_LOGCONFIG(TAG, "  Entries: %u / %u", static_cast<unsigned>(entry_count), static_cast<unsigned>(ENTRY_CAPACITY));
   ESP_LOGCONFIG(TAG, "  History buffer: %s",
                 !this->entries_ ? "missing" : (this->entries_.is_external() ? "PSRAM" : "internal"));
+  ESP_LOGCONFIG(TAG, "  Log stream: %u / %u clients", static_cast<unsigned>(stream_count),
+                static_cast<unsigned>(STREAM_MAX_CLIENTS));
 #ifdef USE_ESP32_CRASH_HANDLER
   ESP_LOGCONFIG(TAG, "  Pending crash report: %s", YESNO(this->pending_crash_report_));
 #endif
@@ -837,6 +967,638 @@ void OpenQuattLogHistory::write_recent_logs(httpd_req_t* req) const {
   if (httpd_resp_send_chunk(req, nullptr, 0) != ESP_OK) {
     ESP_LOGW(TAG, "Failed to terminate recent log response");
   }
+}
+
+bool OpenQuattLogHistory::stream_storage_available() const {
+  for (const auto& session : this->streams_) {
+    if (!session.pend_buf) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool OpenQuattLogHistory::seq_is_newer_(uint16_t seq, uint16_t base) {
+  const uint16_t diff = static_cast<uint16_t>(seq - base);
+  return diff != 0 && diff < 0x8000U;
+}
+
+void OpenQuattLogHistory::stream_free_ctx_(void* ctx) {
+  auto* session = static_cast<LogStreamSession*>(ctx);
+  if (session == nullptr) {
+    return;
+  }
+  const int fd = session->fd.exchange(0);
+  ESP_LOGD(TAG, "Log stream closed (fd: %d)", fd);
+}
+
+bool OpenQuattLogHistory::parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since) const {
+  if (has_since != nullptr) {
+    *has_since = false;
+  }
+  if (since != nullptr) {
+    *since = 0;
+  }
+  if (req == nullptr || has_since == nullptr || since == nullptr) {
+    return false;
+  }
+
+  auto parse_to_seq = [](const char* text, uint16_t* out) -> bool {
+    if (text == nullptr || out == nullptr || text[0] == '\0') {
+      return false;
+    }
+    char* end = nullptr;
+    const unsigned long value = std::strtoul(text, &end, 10);
+    if (end == text) {
+      return false;
+    }
+    *out = static_cast<uint16_t>(value & 0xFFFFUL);
+    return true;
+  };
+
+  const size_t query_len = httpd_req_get_url_query_len(req);
+  if (query_len > 0 && query_len < 256) {
+    char query[256];
+    if (httpd_req_get_url_query_str(req, query, sizeof(query)) == ESP_OK) {
+      char value[32];
+      static constexpr const char* KEYS[] = {"since", "last_seq", "lastEventId", "last_event_id"};
+      for (const char* key : KEYS) {
+        if (httpd_query_key_value(query, key, value, sizeof(value)) == ESP_OK) {
+          uint16_t seq = 0;
+          if (parse_to_seq(value, &seq)) {
+            *has_since = true;
+            *since = seq;
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  const size_t header_len = httpd_req_get_hdr_value_len(req, "Last-Event-ID");
+  if (header_len > 0 && header_len < 32) {
+    char value[32];
+    if (httpd_req_get_hdr_value_str(req, "Last-Event-ID", value, sizeof(value)) == ESP_OK) {
+      uint16_t seq = 0;
+      if (parse_to_seq(value, &seq)) {
+        *has_since = true;
+        *since = seq;
+        return true;
+      }
+    }
+  }
+
+  return true;
+}
+
+bool OpenQuattLogHistory::build_stream_log_event_(const LogEntry& entry, char* out, size_t out_size,
+                                                  size_t* out_len) const {
+  if (out == nullptr || out_len == nullptr || out_size < 128) {
+    return false;
+  }
+  static constexpr size_t CHUNK_HEADER_LEN = 10;
+  size_t pos = CHUNK_HEADER_LEN;
+
+  char num[32];
+  int written = std::snprintf(num, sizeof(num), "id: %u\n", static_cast<unsigned>(entry.seq));
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "event: log\n")) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "data: ")) {
+    return false;
+  }
+
+  const char* tag_start = "";
+  size_t tag_len = 0;
+  const char* message_start = entry.raw;
+  size_t message_len = entry.raw_len;
+  split_log_fields_(entry.raw, &tag_start, &tag_len, &message_start, &message_len);
+  const char* level = level_to_string_(entry.level);
+
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "{\"seq\":")) {
+    return false;
+  }
+  written = std::snprintf(num, sizeof(num), "%u", static_cast<unsigned>(entry.seq));
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"ts\":")) {
+    return false;
+  }
+  written = std::snprintf(num, sizeof(num), "%" PRIu64, static_cast<uint64_t>(entry.timestamp_s) * 1000ULL);
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"level\":")) {
+    return false;
+  }
+  if (!sse_buffer_append_json_string_(out, out_size, &pos, level, std::strlen(level))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"tag\":")) {
+    return false;
+  }
+  if (!sse_buffer_append_json_string_(out, out_size, &pos, tag_start, tag_len)) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"message\":")) {
+    return false;
+  }
+  if (!sse_buffer_append_json_string_(out, out_size, &pos, message_start, message_len)) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"raw\":")) {
+    return false;
+  }
+  if (!sse_buffer_append_json_string_(out, out_size, &pos, entry.raw, entry.raw_len)) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "}\n\n")) {
+    return false;
+  }
+
+  const size_t payload_len = pos - CHUNK_HEADER_LEN;
+  if (payload_len + CHUNK_HEADER_LEN + 2 > out_size) {
+    return false;
+  }
+  char header[CHUNK_HEADER_LEN + 1];
+  std::snprintf(header, sizeof(header), "%08X\r\n", static_cast<unsigned>(payload_len));
+  std::memcpy(out, header, CHUNK_HEADER_LEN);
+  out[pos++] = '\r';
+  out[pos++] = '\n';
+  *out_len = pos;
+  return true;
+}
+
+bool OpenQuattLogHistory::build_stream_gap_event_(uint16_t oldest, uint16_t newest, const char* reason, char* out,
+                                                  size_t out_size, size_t* out_len) const {
+  if (out == nullptr || out_len == nullptr || out_size < 128) {
+    return false;
+  }
+  static constexpr size_t CHUNK_HEADER_LEN = 10;
+  size_t pos = CHUNK_HEADER_LEN;
+
+  char num[32];
+  int written = std::snprintf(num, sizeof(num), "id: %u\n", static_cast<unsigned>(newest));
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "event: gap\n")) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "data: {\"resync\":true")) {
+    return false;
+  }
+  if (reason != nullptr && reason[0] != '\0') {
+    if (!sse_buffer_append_literal_(out, out_size, &pos, ",\"reason\":")) {
+      return false;
+    }
+    if (!sse_buffer_append_json_string_(out, out_size, &pos, reason, std::strlen(reason))) {
+      return false;
+    }
+  }
+  written = std::snprintf(num, sizeof(num), ",\"oldest\":%u", static_cast<unsigned>(oldest));
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  written = std::snprintf(num, sizeof(num), ",\"newest\":%u", static_cast<unsigned>(newest));
+  if (written <= 0 || !sse_buffer_append_(out, out_size, &pos, num, static_cast<size_t>(written))) {
+    return false;
+  }
+  if (!sse_buffer_append_literal_(out, out_size, &pos, "}\n\n")) {
+    return false;
+  }
+
+  const size_t payload_len = pos - CHUNK_HEADER_LEN;
+  if (payload_len + CHUNK_HEADER_LEN + 2 > out_size) {
+    return false;
+  }
+  char header[CHUNK_HEADER_LEN + 1];
+  std::snprintf(header, sizeof(header), "%08X\r\n", static_cast<unsigned>(payload_len));
+  std::memcpy(out, header, CHUNK_HEADER_LEN);
+  out[pos++] = '\r';
+  out[pos++] = '\n';
+  *out_len = pos;
+  return true;
+}
+
+bool OpenQuattLogHistory::build_stream_heartbeat_(char* out, size_t out_size, size_t* out_len) const {
+  if (out == nullptr || out_len == nullptr || out_size < 64) {
+    return false;
+  }
+  static constexpr size_t CHUNK_HEADER_LEN = 10;
+  static constexpr const char* PAYLOAD = ": heartbeat\n\n";
+  static constexpr size_t PAYLOAD_LEN = 13;
+  if (CHUNK_HEADER_LEN + PAYLOAD_LEN + 2 > out_size) {
+    return false;
+  }
+  char header[CHUNK_HEADER_LEN + 1];
+  std::snprintf(header, sizeof(header), "%08X\r\n", static_cast<unsigned>(PAYLOAD_LEN));
+  std::memcpy(out, header, CHUNK_HEADER_LEN);
+  std::memcpy(out + CHUNK_HEADER_LEN, PAYLOAD, PAYLOAD_LEN);
+  out[CHUNK_HEADER_LEN + PAYLOAD_LEN] = '\r';
+  out[CHUNK_HEADER_LEN + PAYLOAD_LEN + 1] = '\n';
+  *out_len = CHUNK_HEADER_LEN + PAYLOAD_LEN + 2;
+  return true;
+}
+
+void OpenQuattLogHistory::request_stream_close_(size_t index, const char* reason) {
+  if (index >= this->streams_.size()) {
+    return;
+  }
+  auto& session = this->streams_[index];
+  if (session.closing) {
+    return;
+  }
+  session.closing = true;
+  session.close_request_ms = millis();
+  const int sockfd = session.fd.load();
+  if (session.hd != nullptr && sockfd > 0) {
+    ESP_LOGW(TAG, "Closing log stream client %u (%s)", static_cast<unsigned>(index),
+             reason != nullptr ? reason : "slow");
+    (void)httpd_sess_trigger_close(session.hd, sockfd);
+  }
+}
+
+bool OpenQuattLogHistory::flush_stream_pending_(size_t index, uint32_t now_ms) {
+  if (index >= this->streams_.size()) {
+    return false;
+  }
+  auto& session = this->streams_[index];
+  if (!session.pend_buf || session.pend_len <= session.pend_sent) {
+    return true;
+  }
+  const int sockfd = session.fd.load();
+  if (session.hd == nullptr || sockfd <= 0) {
+    return false;
+  }
+  const char* base = session.pend_buf.data();
+  if (base == nullptr) {
+    return false;
+  }
+  const size_t remaining = session.pend_len - session.pend_sent;
+  const int sent = httpd_socket_send(session.hd, sockfd, base + session.pend_sent, remaining, 0);
+  if (sent == HTTPD_SOCK_ERR_TIMEOUT) {
+    if (session.first_fail_ms == 0) {
+      session.first_fail_ms = now_ms;
+    }
+    if (session.fail_count < 0xFFFFU) {
+      ++session.fail_count;
+    }
+    if ((now_ms - session.first_fail_ms) >= STREAM_SEND_TIMEOUT_MS) {
+      this->request_stream_close_(index, "send-timeout");
+    }
+    return false;
+  }
+  if (sent == HTTPD_SOCK_ERR_FAIL || sent == HTTPD_SOCK_ERR_INVALID || sent < 0) {
+    this->request_stream_close_(index, "send-error");
+    return false;
+  }
+  if (static_cast<size_t>(sent) < remaining) {
+    session.pend_sent += static_cast<size_t>(sent);
+    session.fail_count = 0;
+    session.first_fail_ms = 0;
+    return false;
+  }
+  session.pend_len = 0;
+  session.pend_sent = 0;
+  session.fail_count = 0;
+  session.first_fail_ms = 0;
+  session.last_activity_ms = now_ms;
+  return true;
+}
+
+bool OpenQuattLogHistory::send_stream_buffered_(size_t index, const char* data, size_t len, uint32_t now_ms) {
+  if (index >= this->streams_.size() || data == nullptr) {
+    return false;
+  }
+  auto& session = this->streams_[index];
+  if (!session.pend_buf || len > STREAM_EVENT_BUFFER_SIZE) {
+    return false;
+  }
+  if (session.pend_len != 0) {
+    return false;
+  }
+  std::memcpy(session.pend_buf.data(), data, len);
+  session.pend_len = len;
+  session.pend_sent = 0;
+  return this->flush_stream_pending_(index, now_ms);
+}
+
+void OpenQuattLogHistory::pump_stream_session_(size_t index, uint32_t now_ms) {
+  if (index >= this->streams_.size()) {
+    return;
+  }
+  auto& session = this->streams_[index];
+
+  if (!this->flush_stream_pending_(index, now_ms)) {
+    return;
+  }
+  if (session.closing) {
+    if ((now_ms - session.close_request_ms) > 10000UL) {
+      // httpd did not confirm the close; reclaim defensively. A late free_ctx
+      // may drop one replacement event at most; the client resyncs via /recent.
+      session.fd.store(0);
+    }
+    return;
+  }
+
+  if (session.need_gap) {
+    char* buf = session.pend_buf.data();
+    if (buf == nullptr) {
+      this->request_stream_close_(index, "no-buffer");
+      return;
+    }
+    size_t frame_len = 0;
+    if (!this->build_stream_gap_event_(session.gap_oldest, session.gap_newest, "resync", buf, STREAM_EVENT_BUFFER_SIZE,
+                                       &frame_len)) {
+      this->request_stream_close_(index, "gap-too-large");
+      return;
+    }
+    session.pend_len = frame_len;
+    session.pend_sent = 0;
+    if (!this->flush_stream_pending_(index, now_ms)) {
+      return;
+    }
+    session.need_gap = false;
+  }
+
+  // Snapshot one entry at a time under the history lock so socket I/O never
+  // blocks the logger callback. Bounded per-loop batch keeps control latency safe.
+  for (uint8_t sent = 0; sent < STREAM_MAX_EVENTS_PER_LOOP; ++sent) {
+    bool have_entry = false;
+    LogEntry entry{};
+    bool history_empty = false;
+    bool lagged = false;
+    uint16_t oldest = 0;
+    uint16_t newest = 0;
+    uint32_t next_seq = 0;
+
+    if (!this->lock_history_()) {
+      return;
+    }
+    if (this->count_ == 0) {
+      history_empty = true;
+      next_seq = this->next_seq_;
+    } else {
+      const size_t oldest_index = this->head_ % ENTRY_CAPACITY;
+      const size_t newest_index = (this->head_ + this->count_ - 1) % ENTRY_CAPACITY;
+      oldest = this->entries_[oldest_index].seq;
+      newest = this->entries_[newest_index].seq;
+      const bool at_oldest_minus_one = session.last_seq == static_cast<uint16_t>(oldest - 1U);
+      const uint16_t dist_to_last = static_cast<uint16_t>(session.last_seq - oldest);
+      const uint16_t dist_to_newest = static_cast<uint16_t>(newest - oldest);
+      if (!at_oldest_minus_one && dist_to_last > dist_to_newest) {
+        lagged = true;
+      } else {
+        // Find the oldest entry newer than last_seq.
+        for (size_t offset = 0; offset < this->count_; ++offset) {
+          const size_t entry_index = (this->head_ + offset) % ENTRY_CAPACITY;
+          const LogEntry& candidate = this->entries_[entry_index];
+          if (seq_is_newer_(candidate.seq, session.last_seq)) {
+            entry = candidate;
+            have_entry = true;
+            break;
+          }
+        }
+      }
+    }
+    this->unlock_history_();
+
+    if (lagged) {
+      this->request_stream_close_(index, "behind-history");
+      return;
+    }
+    if (history_empty) {
+      const uint16_t current = static_cast<uint16_t>((next_seq - 1U) & 0xFFFFUL);
+      if (session.last_seq != current) {
+        session.last_seq = current;
+        session.need_gap = true;
+        session.gap_oldest = current;
+        session.gap_newest = current;
+      }
+      break;
+    }
+    if (!have_entry) {
+      break;
+    }
+
+    char* buf = session.pend_buf.data();
+    if (buf == nullptr) {
+      this->request_stream_close_(index, "no-buffer");
+      return;
+    }
+    size_t frame_len = 0;
+    if (!this->build_stream_log_event_(entry, buf, STREAM_EVENT_BUFFER_SIZE, &frame_len)) {
+      ESP_LOGW(TAG, "Log stream event too large (seq %u)", static_cast<unsigned>(entry.seq));
+      session.last_seq = entry.seq;
+      continue;
+    }
+    session.pend_len = frame_len;
+    session.pend_sent = 0;
+    if (!this->flush_stream_pending_(index, now_ms)) {
+      return;
+    }
+    session.last_seq = entry.seq;
+  }
+
+  if (!session.closing && session.pend_len == 0 &&
+      (now_ms - session.last_activity_ms) >= STREAM_HEARTBEAT_INTERVAL_MS) {
+    char* buf = session.pend_buf.data();
+    if (buf == nullptr) {
+      return;
+    }
+    size_t frame_len = 0;
+    if (!this->build_stream_heartbeat_(buf, STREAM_EVENT_BUFFER_SIZE, &frame_len)) {
+      return;
+    }
+    session.pend_len = frame_len;
+    session.pend_sent = 0;
+    (void)this->flush_stream_pending_(index, now_ms);
+  }
+}
+
+void OpenQuattLogHistory::loop_streams_() {
+  bool any_active = false;
+  for (const auto& session : this->streams_) {
+    if (session.active && session.ready) {
+      any_active = true;
+      break;
+    }
+  }
+  if (!any_active) {
+    return;
+  }
+  if (!this->storage_available() || !this->stream_storage_available()) {
+    return;
+  }
+  const uint32_t now_ms = millis();
+  for (size_t index = 0; index < this->streams_.size(); ++index) {
+    const int sockfd = this->streams_[index].fd.load();
+    bool active = false;
+    bool ready = false;
+    if (this->lock_history_()) {
+      active = this->streams_[index].active;
+      ready = this->streams_[index].ready;
+      // Reclaim sessions whose socket died (free_ctx cleared fd).
+      if (active && ready && sockfd <= 0) {
+        this->streams_[index].active = false;
+        this->streams_[index].ready = false;
+        this->streams_[index].closing = false;
+        this->streams_[index].need_gap = false;
+        this->streams_[index].pend_len = 0;
+        this->streams_[index].pend_sent = 0;
+        active = false;
+      }
+      this->unlock_history_();
+    }
+    if (!active || !ready || sockfd <= 0) {
+      continue;
+    }
+    this->pump_stream_session_(index, now_ms);
+  }
+}
+
+esp_err_t OpenQuattLogHistory::handle_log_stream(httpd_req_t* req) {
+  if (req == nullptr) {
+    return ESP_FAIL;
+  }
+  if (!this->storage_available()) {
+    httpd_resp_set_status(req, "503 Service Unavailable");
+    httpd_resp_sendstr(req, R"({"ok":false,"available":false,"error":"psram_unavailable"})");
+    return ESP_OK;
+  }
+  if (!this->stream_storage_available()) {
+    httpd_resp_set_status(req, "503 Service Unavailable");
+    httpd_resp_sendstr(req, R"({"ok":false,"available":false,"error":"stream_unavailable"})");
+    return ESP_OK;
+  }
+
+  bool has_since = false;
+  uint16_t since = 0;
+  this->parse_stream_since_(req, &has_since, &since);
+
+  size_t slot = STREAM_MAX_CLIENTS;
+  uint16_t initial_seq = 0;
+  bool need_gap = false;
+  uint16_t gap_oldest = 0;
+  uint16_t gap_newest = 0;
+
+  if (!this->lock_history_()) {
+    httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Unable to lock log history");
+    return ESP_OK;
+  }
+  size_t active_count = 0;
+  for (const auto& session : this->streams_) {
+    if (session.active) {
+      ++active_count;
+    }
+  }
+  if (active_count >= STREAM_MAX_CLIENTS) {
+    this->unlock_history_();
+    httpd_resp_set_status(req, "503 Service Unavailable");
+    httpd_resp_sendstr(req, R"({"ok":false,"error":"busy"})");
+    return ESP_OK;
+  }
+
+  if (this->count_ == 0) {
+    initial_seq = static_cast<uint16_t>((this->next_seq_ - 1U) & 0xFFFFUL);
+  } else {
+    const size_t oldest_index = this->head_ % ENTRY_CAPACITY;
+    const size_t newest_index = (this->head_ + this->count_ - 1) % ENTRY_CAPACITY;
+    const uint16_t oldest = this->entries_[oldest_index].seq;
+    const uint16_t newest = this->entries_[newest_index].seq;
+    gap_oldest = oldest;
+    gap_newest = newest;
+    if (!has_since) {
+      initial_seq = newest;
+    } else {
+      const bool at_oldest_minus_one = since == static_cast<uint16_t>(oldest - 1U);
+      const uint16_t dist_to_since = static_cast<uint16_t>(since - oldest);
+      const uint16_t dist_to_newest = static_cast<uint16_t>(newest - oldest);
+      if (at_oldest_minus_one || dist_to_since <= dist_to_newest) {
+        initial_seq = since;
+      } else {
+        // Stale or future cursor: start live and tell the client to backfill via /recent.
+        initial_seq = newest;
+        need_gap = true;
+      }
+    }
+  }
+
+  for (size_t index = 0; index < this->streams_.size(); ++index) {
+    if (!this->streams_[index].active) {
+      slot = index;
+      auto& session = this->streams_[index];
+      session.active = true;
+      session.ready = false;
+      session.closing = false;
+      session.need_gap = need_gap;
+      session.gap_oldest = gap_oldest;
+      session.gap_newest = gap_newest;
+      session.hd = nullptr;
+      session.fd.store(0);
+      session.last_seq = initial_seq;
+      session.fail_count = 0;
+      session.first_fail_ms = 0;
+      session.close_request_ms = 0;
+      session.pend_len = 0;
+      session.pend_sent = 0;
+      break;
+    }
+  }
+  this->unlock_history_();
+
+  if (slot >= STREAM_MAX_CLIENTS) {
+    httpd_resp_set_status(req, "503 Service Unavailable");
+    httpd_resp_sendstr(req, R"({"ok":false,"error":"busy"})");
+    return ESP_OK;
+  }
+
+  httpd_resp_set_status(req, HTTPD_200);
+  httpd_resp_set_type(req, "text/event-stream");
+  httpd_resp_set_hdr(req, "Cache-Control", "no-cache");
+  httpd_resp_set_hdr(req, "Connection", "keep-alive");
+  httpd_resp_set_hdr(req, "X-Accel-Buffering", "no");
+  if (httpd_resp_send_chunk(req, "retry: 3000\n\n", 13) != ESP_OK) {
+    if (this->lock_history_()) {
+      this->streams_[slot].active = false;
+      this->streams_[slot].ready = false;
+      this->unlock_history_();
+    }
+    return ESP_OK;
+  }
+
+  const int sockfd = httpd_req_to_sockfd(req);
+  if (sockfd < 0) {
+    if (this->lock_history_()) {
+      this->streams_[slot].active = false;
+      this->streams_[slot].ready = false;
+      this->unlock_history_();
+    }
+    httpd_resp_send_chunk(req, nullptr, 0);
+    return ESP_OK;
+  }
+  httpd_sess_set_send_override(req->handle, sockfd, log_stream_nonblocking_send_);
+  req->sess_ctx = &this->streams_[slot];
+  req->free_ctx = stream_free_ctx_;
+
+  if (this->lock_history_()) {
+    auto& session = this->streams_[slot];
+    session.hd = req->handle;
+    session.fd.store(sockfd);
+    session.last_activity_ms = millis();
+    session.ready = true;
+    this->unlock_history_();
+  }
+  ESP_LOGI(TAG, "Log stream client connected (%u/%u)", static_cast<unsigned>(active_count + 1),
+           static_cast<unsigned>(STREAM_MAX_CLIENTS));
+  // Intentionally no terminating zero chunk: the connection stays open and
+  // loop_streams_() forwards new history entries via raw socket sends.
+  return ESP_OK;
 }
 
 }  // namespace openquatt_log_history

--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -10,6 +10,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
+#include "OpenQuattLogStreamLogic.h"
 #include "PsramBuffer.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/components/web_server_base/web_server_base.h"
@@ -43,10 +44,13 @@ class OpenQuattLogHistory : public Component {
   // cause unbounded RAM growth or block logging/control. History stays the
   // backfill source; the stream only forwards entries newer than last_seq.
   static constexpr size_t STREAM_MAX_CLIENTS = 2;
-  static constexpr size_t STREAM_EVENT_BUFFER_SIZE = 2048;
+  static constexpr size_t STREAM_EVENT_BUFFER_SIZE = 4096;
   static constexpr uint32_t STREAM_HEARTBEAT_INTERVAL_MS = 15000UL;
   static constexpr uint32_t STREAM_SEND_TIMEOUT_MS = 30000UL;
+  static constexpr uint32_t STREAM_CLOSE_RETRY_INTERVAL_MS = 1000UL;
   static constexpr uint8_t STREAM_MAX_EVENTS_PER_LOOP = 8;
+
+  enum class StreamPendingKind : uint8_t { NONE, LOG, GAP, HEARTBEAT };
 
   struct LogEntry {
     uint16_t seq{0};
@@ -70,6 +74,13 @@ class OpenQuattLogHistory : public Component {
     uint32_t close_request_ms{0};
     uint16_t gap_oldest{0};
     uint16_t gap_newest{0};
+    // Pending-frame state: committed exactly once at queue time so a later
+    // EAGAIN/partial send can never cause the same frame to be queued twice.
+    // last_seq (for LOG) is advanced and need_gap (for GAP) is cleared when
+    // the frame is queued, not when its last byte hits the socket. On socket
+    // failure this is safe: reconnects resume from the client Last-Event-ID.
+    StreamPendingKind pending_kind{StreamPendingKind::NONE};
+    uint16_t pending_seq{0};
     size_t pend_len{0};
     size_t pend_sent{0};
     PsramBuffer<char> pend_buf{};
@@ -124,10 +135,11 @@ class OpenQuattLogHistory : public Component {
                                 size_t* message_len);
   static bool seq_is_newer_(uint16_t seq, uint16_t base);
   static void stream_free_ctx_(void* ctx);
-  bool parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since) const;
+  bool parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since, bool* invalid) const;
   void loop_streams_();
   void request_stream_close_(size_t index, const char* reason);
   bool build_stream_log_event_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;
+  bool build_stream_log_event_truncated_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;
   bool build_stream_gap_event_(uint16_t oldest, uint16_t newest, const char* reason, char* out, size_t out_size,
                                size_t* out_len) const;
   bool build_stream_heartbeat_(char* out, size_t out_size, size_t* out_len) const;

--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -114,14 +114,6 @@ class OpenQuattLogHistory : public Component {
   std::string csrf_token_;
   SemaphoreHandle_t history_mutex_{nullptr};
   std::array<LogStreamSession, STREAM_MAX_CLIENTS> streams_{};
-  // Read-only HIL diagnostics. These atomics avoid coupling HTTPD/free_ctx
-  // observations to the history mutex or adding per-client allocations.
-  std::atomic<uint32_t> stream_eagain_count_{0};
-  std::atomic<uint32_t> stream_partial_send_count_{0};
-  std::atomic<uint32_t> stream_send_timeout_close_count_{0};
-  std::atomic<uint32_t> stream_send_error_close_count_{0};
-  std::atomic<uint32_t> loop_stack_min_free_bytes_{0};
-  uint32_t last_stack_watermark_ms_{0};
 
 #ifdef USE_ESP32_CRASH_HANDLER
   bool pending_crash_report_{false};
@@ -139,7 +131,6 @@ class OpenQuattLogHistory : public Component {
   void sync_time_state_();
   void rebase_history_(uint32_t offset_s);
   void rotate_csrf_token_();
-  void note_loop_stack_watermark_();
   bool lock_history_() const;
   void unlock_history_() const;
 
@@ -162,7 +153,7 @@ class OpenQuattLogHistory : public Component {
   static void stream_close_work_(void* arg);
   bool parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since, bool* invalid) const;
   void loop_streams_();
-  bool request_stream_close_(size_t index, const char* reason);
+  void request_stream_close_(size_t index, const char* reason);
   void maybe_queue_stream_close_(size_t index, uint32_t now_ms);
   bool build_stream_log_event_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;
   bool build_stream_log_event_truncated_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;

--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -63,6 +63,8 @@ class OpenQuattLogHistory : public Component {
   struct LogStreamSession {
     bool active{false};
     bool ready{false};
+    // Terminal: once closing is set, pump_stream_session_() attempts no further
+    // socket sends and only drives the async close below.
     bool closing{false};
     bool need_gap{false};
     httpd_handle_t hd{nullptr};
@@ -71,7 +73,20 @@ class OpenQuattLogHistory : public Component {
     uint16_t fail_count{0};
     uint32_t last_activity_ms{0};
     uint32_t first_fail_ms{0};
+    // Last async-close queue attempt (0 = none yet, so the first attempt is
+    // immediate). Bounds re-queue cadence, never reclaims anything.
     uint32_t close_request_ms{0};
+    // True while an identity-checked close work item is queued or running on
+    // the HTTPD task. Slots are recycled exclusively after free_ctx confirmed
+    // fd==0 with no work outstanding, so a late callback can never alias a
+    // replacement connection.
+    std::atomic<bool> close_work_queued{false};
+    // Identity snapshot for the queued async close, read by stream_close_work_()
+    // on the HTTPD task. Written by the main loop exclusively while
+    // close_work_queued==false, hence stable for the queued callback.
+    httpd_handle_t close_hd{nullptr};
+    int close_fd{-1};
+    void* close_expected{nullptr};
     uint16_t gap_oldest{0};
     uint16_t gap_newest{0};
     // Pending-frame state: committed exactly once at queue time so a later
@@ -135,16 +150,17 @@ class OpenQuattLogHistory : public Component {
                                 size_t* message_len);
   static bool seq_is_newer_(uint16_t seq, uint16_t base);
   static void stream_free_ctx_(void* ctx);
+  static void stream_close_work_(void* arg);
   bool parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since, bool* invalid) const;
   void loop_streams_();
   void request_stream_close_(size_t index, const char* reason);
+  void maybe_queue_stream_close_(size_t index, uint32_t now_ms);
   bool build_stream_log_event_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;
   bool build_stream_log_event_truncated_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;
   bool build_stream_gap_event_(uint16_t oldest, uint16_t newest, const char* reason, char* out, size_t out_size,
                                size_t* out_len) const;
   bool build_stream_heartbeat_(char* out, size_t out_size, size_t* out_len) const;
   bool flush_stream_pending_(size_t index, uint32_t now_ms);
-  bool send_stream_buffered_(size_t index, const char* data, size_t len, uint32_t now_ms);
   void pump_stream_session_(size_t index, uint32_t now_ms);
 };
 

--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -114,6 +114,14 @@ class OpenQuattLogHistory : public Component {
   std::string csrf_token_;
   SemaphoreHandle_t history_mutex_{nullptr};
   std::array<LogStreamSession, STREAM_MAX_CLIENTS> streams_{};
+  // Read-only HIL diagnostics. These atomics avoid coupling HTTPD/free_ctx
+  // observations to the history mutex or adding per-client allocations.
+  std::atomic<uint32_t> stream_eagain_count_{0};
+  std::atomic<uint32_t> stream_partial_send_count_{0};
+  std::atomic<uint32_t> stream_send_timeout_close_count_{0};
+  std::atomic<uint32_t> stream_send_error_close_count_{0};
+  std::atomic<uint32_t> loop_stack_min_free_bytes_{0};
+  uint32_t last_stack_watermark_ms_{0};
 
 #ifdef USE_ESP32_CRASH_HANDLER
   bool pending_crash_report_{false};
@@ -131,6 +139,7 @@ class OpenQuattLogHistory : public Component {
   void sync_time_state_();
   void rebase_history_(uint32_t offset_s);
   void rotate_csrf_token_();
+  void note_loop_stack_watermark_();
   bool lock_history_() const;
   void unlock_history_() const;
 
@@ -153,7 +162,7 @@ class OpenQuattLogHistory : public Component {
   static void stream_close_work_(void* arg);
   bool parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since, bool* invalid) const;
   void loop_streams_();
-  void request_stream_close_(size_t index, const char* reason);
+  bool request_stream_close_(size_t index, const char* reason);
   void maybe_queue_stream_close_(size_t index, uint32_t now_ms);
   bool build_stream_log_event_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;
   bool build_stream_log_event_truncated_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;

--- a/components/openquatt_log_history/OpenQuattLogHistory.h
+++ b/components/openquatt_log_history/OpenQuattLogHistory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -31,11 +32,21 @@ class OpenQuattLogHistory : public Component {
   void clear_history();
   const std::string& get_csrf_token() const { return this->csrf_token_; }
   bool storage_available() const { return static_cast<bool>(this->entries_); }
+  bool stream_storage_available() const;
   void write_recent_logs(httpd_req_t* req) const;
+  esp_err_t handle_log_stream(httpd_req_t* req);
 
  protected:
   static constexpr size_t ENTRY_CAPACITY = 250;
   static constexpr size_t RAW_MAX_LEN = 224;
+  // Dedicated SSE log stream bounds: a slow or disconnected client must never
+  // cause unbounded RAM growth or block logging/control. History stays the
+  // backfill source; the stream only forwards entries newer than last_seq.
+  static constexpr size_t STREAM_MAX_CLIENTS = 2;
+  static constexpr size_t STREAM_EVENT_BUFFER_SIZE = 2048;
+  static constexpr uint32_t STREAM_HEARTBEAT_INTERVAL_MS = 15000UL;
+  static constexpr uint32_t STREAM_SEND_TIMEOUT_MS = 30000UL;
+  static constexpr uint8_t STREAM_MAX_EVENTS_PER_LOOP = 8;
 
   struct LogEntry {
     uint16_t seq{0};
@@ -43,6 +54,29 @@ class OpenQuattLogHistory : public Component {
     uint8_t raw_len{0};
     uint8_t level{0};
     char raw[RAW_MAX_LEN]{};
+  };
+
+  struct LogStreamSession {
+    bool active{false};
+    bool ready{false};
+    bool closing{false};
+    bool need_gap{false};
+    httpd_handle_t hd{nullptr};
+    std::atomic<int> fd{0};
+    uint16_t last_seq{0};
+    uint16_t fail_count{0};
+    uint32_t last_activity_ms{0};
+    uint32_t first_fail_ms{0};
+    uint32_t close_request_ms{0};
+    uint16_t gap_oldest{0};
+    uint16_t gap_newest{0};
+    size_t pend_len{0};
+    size_t pend_sent{0};
+    PsramBuffer<char> pend_buf{};
+
+    LogStreamSession() = default;
+    LogStreamSession(const LogStreamSession&) = delete;
+    LogStreamSession& operator=(const LogStreamSession&) = delete;
   };
 
   bool time_rebased_{false};
@@ -53,6 +87,7 @@ class OpenQuattLogHistory : public Component {
   uint32_t next_seq_{1};
   std::string csrf_token_;
   SemaphoreHandle_t history_mutex_{nullptr};
+  std::array<LogStreamSession, STREAM_MAX_CLIENTS> streams_{};
 
 #ifdef USE_ESP32_CRASH_HANDLER
   bool pending_crash_report_{false};
@@ -87,6 +122,18 @@ class OpenQuattLogHistory : public Component {
   static void copy_sanitized_log_line_(const char* message, size_t message_len, char* out, size_t out_size);
   static void split_log_fields_(const char* raw, const char** tag_start, size_t* tag_len, const char** message_start,
                                 size_t* message_len);
+  static bool seq_is_newer_(uint16_t seq, uint16_t base);
+  static void stream_free_ctx_(void* ctx);
+  bool parse_stream_since_(httpd_req_t* req, bool* has_since, uint16_t* since) const;
+  void loop_streams_();
+  void request_stream_close_(size_t index, const char* reason);
+  bool build_stream_log_event_(const LogEntry& entry, char* out, size_t out_size, size_t* out_len) const;
+  bool build_stream_gap_event_(uint16_t oldest, uint16_t newest, const char* reason, char* out, size_t out_size,
+                               size_t* out_len) const;
+  bool build_stream_heartbeat_(char* out, size_t out_size, size_t* out_len) const;
+  bool flush_stream_pending_(size_t index, uint32_t now_ms);
+  bool send_stream_buffered_(size_t index, const char* data, size_t len, uint32_t now_ms);
+  void pump_stream_session_(size_t index, uint32_t now_ms);
 };
 
 }  // namespace openquatt_log_history

--- a/components/openquatt_log_history/OpenQuattLogStreamLogic.h
+++ b/components/openquatt_log_history/OpenQuattLogStreamLogic.h
@@ -1,0 +1,102 @@
+#pragma once
+
+// Pure, host-testable decision logic for the dedicated SSE log stream
+// (GET /openquatt/logs/stream, issue #673).
+//
+// This header deliberately depends only on standard C++ headers so it can be
+// covered by host regression tests. It performs no I/O and owns no state:
+// the firmware component in OpenQuattLogHistory.{h,cpp} remains the only place
+// that touches sockets, PSRAM buffers and the history mutex.
+//
+// Conventions:
+// - Log sequence numbers are uint16_t and wrap. All ordering comparisons are
+//   wrap-aware and only meaningful for distances well below 32768. The stream
+//   closes a client long before that (history holds 250 entries), so wrap
+//   ambiguity cannot occur in practice.
+// - A cursor is "in window" when it equals oldest-1 (ask everything buffered)
+//   or lies in [oldest, newest] (catch up from cursor+1). Anything else means
+//   the client must backfill via GET /openquatt/logs/recent.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+
+namespace esphome {
+namespace openquatt_log_history {
+namespace log_stream_logic {
+
+inline bool seq_is_newer(uint16_t seq, uint16_t base) {
+  const auto diff = static_cast<uint16_t>(seq - base);
+  return diff != 0 && diff < 0x8000U;
+}
+
+inline bool cursor_in_window(uint16_t cursor, uint16_t oldest, uint16_t newest) {
+  if (cursor == static_cast<uint16_t>(oldest - 1U)) {
+    return true;
+  }
+  const auto dist_to_cursor = static_cast<uint16_t>(cursor - oldest);
+  const auto dist_to_newest = static_cast<uint16_t>(newest - oldest);
+  return dist_to_cursor <= dist_to_newest;
+}
+
+struct CursorResolution {
+  // Initial last_seq for the new session: entries newer than this are sent.
+  uint16_t initial_seq{0};
+  // True when the client must backfill via /recent before relying on live data.
+  bool need_gap{false};
+};
+
+inline CursorResolution resolve_initial_seq(bool has_since, uint16_t since, bool history_empty, uint16_t oldest,
+                                            uint16_t newest, uint16_t next_seq_minus_one) {
+  CursorResolution out{};
+  if (history_empty) {
+    out.initial_seq = next_seq_minus_one;
+    out.need_gap = false;
+    return out;
+  }
+  if (!has_since) {
+    out.initial_seq = newest;
+    out.need_gap = false;
+    return out;
+  }
+  if (cursor_in_window(since, oldest, newest)) {
+    out.initial_seq = since;
+    out.need_gap = false;
+    return out;
+  }
+  // Stale or future cursor: start live and tell the client to backfill.
+  out.initial_seq = newest;
+  out.need_gap = true;
+  return out;
+}
+
+// Strict decimal uint16 cursor parsing for ?since= / Last-Event-ID.
+// Accepts only [0-9]+ without sign, whitespace or trailing garbage and only
+// values <= 65535. Returns false for absent (null/empty) and invalid input;
+// callers distinguish "parameter absent" (key/header not present) from
+// "parameter present but invalid" before calling this helper.
+inline bool parse_seq_strict(const char* text, uint16_t* out) {
+  if (out != nullptr) {
+    *out = 0;
+  }
+  if (text == nullptr || out == nullptr || text[0] == '\0') {
+    return false;
+  }
+  unsigned long value = 0;
+  for (size_t i = 0; text[i] != '\0'; ++i) {
+    const char c = text[i];
+    if (c < '0' || c > '9') {
+      return false;
+    }
+    value = value * 10UL + static_cast<unsigned long>(c - '0');
+    if (value > 0xFFFFUL) {
+      return false;
+    }
+  }
+  *out = static_cast<uint16_t>(value);
+  return true;
+}
+
+}  // namespace log_stream_logic
+}  // namespace openquatt_log_history
+}  // namespace esphome

--- a/components/openquatt_log_history/OpenQuattLogStreamLogic.h
+++ b/components/openquatt_log_history/OpenQuattLogStreamLogic.h
@@ -97,6 +97,21 @@ inline bool parse_seq_strict(const char* text, uint16_t* out) {
   return true;
 }
 
+// Bounds for the cursor carriers (?since= query string, single query value and
+// Last-Event-ID header). A legitimate log-stream client only sends tiny
+// decimal cursors, so an oversized carrier is fail-closed as an invalid cursor
+// (HTTP 400 bad_since) instead of being silently truncated or ignored.
+inline constexpr size_t CURSOR_QUERY_BUF_SIZE = 256;
+inline constexpr size_t CURSOR_VALUE_BUF_SIZE = 32;
+inline constexpr size_t CURSOR_HEADER_BUF_SIZE = 32;
+
+inline bool cursor_carrier_oversized(size_t query_len, size_t header_len) {
+  if (query_len >= CURSOR_QUERY_BUF_SIZE) {
+    return true;
+  }
+  return header_len > 0 && header_len >= CURSOR_HEADER_BUF_SIZE;
+}
+
 }  // namespace log_stream_logic
 }  // namespace openquatt_log_history
 }  // namespace esphome

--- a/scripts/tests/test_internal_heap_contract.py
+++ b/scripts/tests/test_internal_heap_contract.py
@@ -254,19 +254,6 @@ class InternalHeapPlacementContractTest(unittest.TestCase):
             TRENDS_CPP,
         )
 
-    def test_log_stream_hil_observability_is_read_only_and_bounded(self) -> None:
-        for field in (
-            "stream_eagain_count_",
-            "stream_partial_send_count_",
-            "stream_send_timeout_close_count_",
-            "stream_send_error_close_count_",
-            "loop_stack_min_free_bytes_",
-        ):
-            self.assertIn(field, LOG_HISTORY_HEADER)
-            self.assertIn(field, LOG_HISTORY_CPP)
-        self.assertIn(',\\"stream\\":{\\"eagain\\":', LOG_HISTORY_CPP)
-        self.assertIn("uxTaskGetStackHighWaterMark(nullptr)", LOG_HISTORY_CPP)
-
     def test_optional_history_allocation_failures_are_explicit(self) -> None:
         self.assertIn("bool storage_available() const", LOG_HISTORY_HEADER)
         self.assertIn('"503 Service Unavailable"', LOG_HISTORY_CPP)

--- a/scripts/tests/test_internal_heap_contract.py
+++ b/scripts/tests/test_internal_heap_contract.py
@@ -213,6 +213,10 @@ class InternalHeapPlacementContractTest(unittest.TestCase):
             LOG_HISTORY_CPP,
         )
         self.assertIn(
+            "pend_buf.allocate_external(STREAM_EVENT_BUFFER_SIZE)",
+            LOG_HISTORY_CPP,
+        )
+        self.assertIn(
             "this->samples_.allocate_external(BUFFER_BYTES)",
             DEBUG_RECORDER_CPP,
         )

--- a/scripts/tests/test_internal_heap_contract.py
+++ b/scripts/tests/test_internal_heap_contract.py
@@ -216,6 +216,7 @@ class InternalHeapPlacementContractTest(unittest.TestCase):
             "pend_buf.allocate_external(STREAM_EVENT_BUFFER_SIZE)",
             LOG_HISTORY_CPP,
         )
+
         self.assertIn(
             "this->samples_.allocate_external(BUFFER_BYTES)",
             DEBUG_RECORDER_CPP,
@@ -252,6 +253,19 @@ class InternalHeapPlacementContractTest(unittest.TestCase):
             "this->flash_index_.allocate_external(FLASH_SLOT_COUNT)",
             TRENDS_CPP,
         )
+
+    def test_log_stream_hil_observability_is_read_only_and_bounded(self) -> None:
+        for field in (
+            "stream_eagain_count_",
+            "stream_partial_send_count_",
+            "stream_send_timeout_close_count_",
+            "stream_send_error_close_count_",
+            "loop_stack_min_free_bytes_",
+        ):
+            self.assertIn(field, LOG_HISTORY_HEADER)
+            self.assertIn(field, LOG_HISTORY_CPP)
+        self.assertIn(',\\"stream\\":{\\"eagain\\":', LOG_HISTORY_CPP)
+        self.assertIn("uxTaskGetStackHighWaterMark(nullptr)", LOG_HISTORY_CPP)
 
     def test_optional_history_allocation_failures_are_explicit(self) -> None:
         self.assertIn("bool storage_available() const", LOG_HISTORY_HEADER)

--- a/tests/host/openquatt_log_stream_logic_test.cpp
+++ b/tests/host/openquatt_log_stream_logic_test.cpp
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <initializer_list>
+#include <stdint.h>
+
+#include "components/openquatt_log_history/OpenQuattLogStreamLogic.h"
+
+int main() {
+  using namespace esphome::openquatt_log_history::log_stream_logic;
+
+  // --- seq_is_newer: plain ordering -------------------------------------
+  assert(seq_is_newer(101, 100));
+  assert(!seq_is_newer(100, 100));
+  assert(!seq_is_newer(100, 101));
+
+  // --- seq_is_newer: uint16 wrap -----------------------------------------
+  assert(seq_is_newer(0, 65535));
+  assert(seq_is_newer(1, 65535));
+  assert(!seq_is_newer(65535, 0));
+  assert(!seq_is_newer(65535, 1));
+  // Half-range boundary: distances < 32768 count as newer.
+  assert(seq_is_newer(32767, 0));
+  assert(!seq_is_newer(32768, 0));
+
+  // --- cursor_in_window ----------------------------------------------------
+  // Window [90, 100]: oldest-1 and every buffered seq are in window.
+  assert(cursor_in_window(89, 90, 100));
+  assert(cursor_in_window(90, 90, 100));
+  assert(cursor_in_window(95, 90, 100));
+  assert(cursor_in_window(100, 90, 100));
+  // Too old (overwritten) and future cursors are out of window.
+  assert(!cursor_in_window(88, 90, 100));
+  assert(!cursor_in_window(101, 90, 100));
+  assert(!cursor_in_window(0, 90, 100));
+  // Wrapped window [65530, 5]: members on both sides of the wrap are inside.
+  assert(cursor_in_window(65529, 65530, 5));
+  assert(cursor_in_window(65530, 65530, 5));
+  assert(cursor_in_window(0, 65530, 5));
+  assert(cursor_in_window(5, 65530, 5));
+  assert(!cursor_in_window(65528, 65530, 5));
+  assert(!cursor_in_window(6, 65530, 5));
+
+  // --- resolve_initial_seq ---------------------------------------------------
+  // Empty history: start at next_seq-1, never a gap.
+  {
+    const CursorResolution r = resolve_initial_seq(false, 0, true, 0, 0, 42);
+    assert(r.initial_seq == 42);
+    assert(!r.need_gap);
+  }
+  {
+    const CursorResolution r = resolve_initial_seq(true, 41, true, 0, 0, 42);
+    assert(r.initial_seq == 42);
+    assert(!r.need_gap);
+  }
+  // Live connect without cursor: start at newest, no gap.
+  {
+    const CursorResolution r = resolve_initial_seq(false, 0, false, 90, 100, 100);
+    assert(r.initial_seq == 100);
+    assert(!r.need_gap);
+  }
+  // Valid cursors resume without a gap.
+  for (uint16_t cursor : {89, 90, 95, 100}) {
+    const CursorResolution r = resolve_initial_seq(true, cursor, false, 90, 100, 100);
+    assert(r.initial_seq == cursor);
+    assert(!r.need_gap);
+  }
+  // Stale cursor (overwritten) and future cursor: start live with a gap flag
+  // so the client backfills via GET /openquatt/logs/recent.
+  for (uint16_t cursor : {88, 0, 101, 500}) {
+    const CursorResolution r = resolve_initial_seq(true, cursor, false, 90, 100, 100);
+    assert(r.initial_seq == 100);
+    assert(r.need_gap);
+  }
+
+  // --- parse_seq_strict -------------------------------------------------------
+  uint16_t seq = 0xFFFF;
+  assert(parse_seq_strict("0", &seq) && seq == 0);
+  assert(parse_seq_strict("1", &seq) && seq == 1);
+  assert(parse_seq_strict("65535", &seq) && seq == 65535);
+  assert(parse_seq_strict("007", &seq) && seq == 7);
+  // Invalid: empty, non-numeric, trailing garbage, out of range, signs, space.
+  assert(!parse_seq_strict(nullptr, &seq));
+  assert(!parse_seq_strict("", &seq));
+  assert(!parse_seq_strict("abc", &seq));
+  assert(!parse_seq_strict("123abc", &seq));
+  assert(!parse_seq_strict("12 3", &seq));
+  assert(!parse_seq_strict("70000", &seq));
+  assert(!parse_seq_strict("65536", &seq));
+  assert(!parse_seq_strict("-1", &seq));
+  assert(!parse_seq_strict("+1", &seq));
+  assert(!parse_seq_strict(" 1", &seq));
+  assert(!parse_seq_strict("1 ", &seq));
+  assert(!parse_seq_strict("0x10", &seq));
+  assert(!parse_seq_strict("3.5", &seq));
+
+  // State-machine contracts that socket-level HIL must additionally cover
+  // (needs real httpd sockets, see PR #674 HIL plan):
+  // - EAGAIN/partial send keeps exactly one pending frame; last_seq is already
+  //   committed at queue time so the frame is never queued twice.
+  // - gap frames clear need_gap at queue time for the same reason.
+  // - closing slots are only recycled after free_ctx confirms the real close;
+  //   a late free_ctx must never wipe a replacement connection's fd.
+}

--- a/tests/host/openquatt_log_stream_logic_test.cpp
+++ b/tests/host/openquatt_log_stream_logic_test.cpp
@@ -92,11 +92,29 @@ int main() {
   assert(!parse_seq_strict("0x10", &seq));
   assert(!parse_seq_strict("3.5", &seq));
 
+  // --- cursor_carrier_oversized --------------------------------------------------
+  // Normal carriers (absent or tiny decimal cursors) are parseable in place.
+  assert(!cursor_carrier_oversized(0, 0));
+  assert(!cursor_carrier_oversized(7, 0));
+  assert(!cursor_carrier_oversized(0, 5));
+  assert(!cursor_carrier_oversized(CURSOR_QUERY_BUF_SIZE - 1, CURSOR_HEADER_BUF_SIZE - 1));
+  // Oversized carriers fail closed as invalid cursors instead of being silently
+  // truncated or ignored (a cursor may hide in the unreadable tail).
+  assert(cursor_carrier_oversized(CURSOR_QUERY_BUF_SIZE, 0));
+  assert(cursor_carrier_oversized(CURSOR_QUERY_BUF_SIZE + 100, 0));
+  assert(cursor_carrier_oversized(0, CURSOR_HEADER_BUF_SIZE));
+  assert(cursor_carrier_oversized(0, CURSOR_HEADER_BUF_SIZE + 10));
+
   // State-machine contracts that socket-level HIL must additionally cover
   // (needs real httpd sockets, see PR #674 HIL plan):
   // - EAGAIN/partial send keeps exactly one pending frame; last_seq is already
   //   committed at queue time so the frame is never queued twice.
   // - gap frames clear need_gap at queue time for the same reason.
+  // - closing is terminal: pump attempts no further sends once closing is set.
+  // - async close is identity-checked on the HTTPD task
+  //   (httpd_sess_get_ctx() == expected session) and at most one close work
+  //   item is outstanding per slot; re-queue only after queue failure or a
+  //   finished callback with the session demonstrably still alive.
   // - closing slots are only recycled after free_ctx confirms the real close;
-  //   a late free_ctx must never wipe a replacement connection's fd.
+  //   a late close callback can never wipe a replacement connection's fd.
 }


### PR DESCRIPTION
# Wat verandert deze PR?

- Voegt `GET /openquatt/logs/stream` toe als dedicated Server-Sent Events-stream voor nieuwe OpenQuatt-logregels (issue #673).
- `GET /openquatt/logs/recent` blijft ongewijzigd als history/backfill-bron; de huidige web-app polling blijft werken.
- Maakt langdurige logcapture mogelijk voor diagnose en support, bijvoorbeeld met `curl -N http://openquatt.local/openquatt/logs/stream > openquatt.log`.

**Niet mergen vóór de HIL- en geheugenvalidatie hieronder is afgerond.**

## Type

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [x] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

De wijziging raakt alleen de diagnostische webserver/logginglaag. De warmtepompregeling en bestaande entities/configuratie wijzigen niet. Voor de stream worden maximaal twee vaste sessies gebruikt met elk één begrensde PSRAM-buffer van 4096 B.

## Achtergrond

Het huidige web-logboek bewaart maximaal 250 regels in RAM. Dat is voldoende voor normaal gebruik, maar minder geschikt voor intermitterende problemen die pas na langere tijd optreden. Een dedicated SSE-route maakt continue capture mogelijk zonder de algemene `/events`-stream daarvoor te gebruiken.

PR #671 is een directe use-case: de Modbus RX-glitch moet langere tijd gevolgd kunnen worden zonder dat oudere regels uit de 250-entry history verdwijnen.

### Ontwerp

De bestaande RAM-history blijft de bron van waarheid. De logger-callback schrijft alleen naar de ringbuffer; socket-I/O gebeurt uitsluitend buiten de logger-callback en buiten de history-mutex.

De stream:

- stuurt nieuwe logregels als SSE-events;
- gebruikt de bestaande sequence als SSE `id` en in de payload;
- levert `seq`, `ts`, `level`, `tag`, `message` en `raw`;
- ondersteunt `?since=`, `?last_seq=` en `Last-Event-ID` voor reconnect;
- valideert cursors strikt en geeft HTTP 400 `bad_since` bij ongeldige invoer;
- geeft een `gap`-event wanneer history-backfill via `/recent` nodig is;
- houdt per client maximaal één pending frame aan;
- begrenst gelijktijdige stream-clients op twee;
- gebruikt PSRAM-only buffers en geen onbeperkte queue;
- gebruikt commit-at-queue zodat EAGAIN/partial sends hetzelfde LOG/GAP-frame niet opnieuw queueën;
- gebruikt een 4096 B eventbuffer met een bounded `truncated:true` fallback in plaats van een sequence over te slaan.

`/openquatt/logs/recent` blijft beschikbaar als history/backfill-bron. De web-app kan later separaat van polling naar history + SSE worden gemigreerd.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Backend-diagnose-endpoint zonder nieuwe gebruikersinstelling of gewijzigde gebruikersflow; de huidige web-app blijft pollen. Gebruik en reconnect/backfill-gedrag zijn vastgelegd in issue #673 en deze PR.

## Validatie

Softwarematig uitgevoerd op de actuele implementatie:

- [x] `npm run check:cpp-format`
- [x] `npm run check:python-contracts` — 242 tests, inclusief PSRAM-contract voor streambuffers
- [x] host-test `openquatt_log_stream_logic_test` — seq-wrap, window/gap-resolutie en strikte cursor-parsing
- [x] `node --test openquatt/web/tests/webserver-logs.test.mjs` — 27 tests; bestaande polling ongewijzigd

De laatste CI-run werd uitsluitend door de PR-documentatiecontractcheck geblokkeerd doordat de exacte template-opties niet meer volledig in de PR-tekst stonden; de codegerichte host-, Python-, web- en formatjobs waren groen. CI op head `7e14d0d` was volledig groen, inclusief host regressions, Python/contracts, docs en de firmwarecompilematrix (Q Single/Duo, Waveshare Single/Duo, Listener). Voor de nieuwe head (identity-checked close-route plus `sent <= 0`-verdediging) loopt de matrix opnieuw; daarna resteert alleen HIL.

Nog uit te voeren vóór merge:

- [ ] langdurige `curl -N` capture met 1 client;
- [ ] 2 gelijktijdige normale clients;
- [ ] bewust trage/niet-lezende client met EAGAIN/partial sends;
- [ ] herhaald connect/disconnect/reconnect en delayed-close/free_ctx-scenario's;
- [ ] gelijktijdige `/events`, web/API, HA, MQTT, Modbus, OpenTherm en representatieve overige load;
- [ ] baseline vs kandidaat: current/minimum internal heap, largest free block, fragmentatie, vrij PSRAM en relevante stack-watermarks.

- [ ] Geheugenimpact gemeten op representatieve hardware
- [ ] Geen runtime-geheugenimpact

Heap/stack-impact:

- history-buffer ongewijzigd;
- +2 x 4096 B PSRAM voor vaste pending streambuffers, fail-closed bij allocatiefout;
- kleine interne sessie-state voor twee clients;
- werkelijke runtime-/stackimpact nog te bepalen met bovenstaande HIL-meting.

Closes #673
