### PR TITLE
Maak de R1-startprobe stil en onderscheid OpenTherm-logtags

### DIFF
--- a/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
+++ b/components/openquatt_ot_slave/OpenQuattOTSlave.cpp
@@ -99,7 +99,7 @@ unsigned int write_f88(const float value, const unsigned int data) { return (uns
 
 namespace esphome {
 namespace OpenQuattOTSlave {
-static const char* TAG = "OpenQuattOTSlave";
+static const char* TAG = "oq.ot.thermostat";
 // The T6 can go several seconds without polling ID 0 while it cycles through
 // other IDs. Keep the last known master status long enough to avoid a spurious
 // CH-enable "blinking" effect in Home Assistant.

--- a/components/openquatt_ot_slave/OpenTherm.cpp
+++ b/components/openquatt_ot_slave/OpenTherm.cpp
@@ -9,7 +9,7 @@ Copyright 2018, Ihor Melnyk
 #include "esp_err.h"
 #include "esp_private/esp_clk.h"
 #include "esp_timer.h"
-static const char* TAG = "OpenThermV2";
+static const char* TAG = "oq.ot.thermostat.transport";
 using namespace esphome;
 
 namespace {

--- a/components/openquatt_ot_slave/switch.cpp
+++ b/components/openquatt_ot_slave/switch.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome {
 namespace OpenQuattOTSlave {
-static const char* const TAG = "OpenQuattOTSlave.switch";
+static const char* const TAG = "oq.ot.thermostat.switch";
 
 void OpenQuattOTSlaveSwitch::write_state(bool state) {
   if (this->write_callback_) {

--- a/components/opentherm/hub.cpp
+++ b/components/opentherm/hub.cpp
@@ -6,7 +6,7 @@
 
 namespace esphome::opentherm {
 
-static const char* const TAG = "opentherm";
+static const char* const TAG = "oq.ot.boiler";
 static constexpr uint32_t MIN_CONVERSATION_GAP_US = 100000;
 static constexpr uint32_t MAX_CONVERSATION_CADENCE_US = 1150000;
 static constexpr uint32_t SLOW_PHASE_US = 50000;
@@ -212,6 +212,7 @@ void OpenthermHub::start_priority_polling(MessageId first, MessageId second) {
 
 void OpenthermHub::resume_polling() {
   this->polling_enabled_ = true;
+  this->no_response_expected_ = false;
   this->urgent_priority_pending_ = false;
   this->deferred_priority_pending_ = false;
   this->deferred_priority_activated_ = false;
@@ -228,6 +229,7 @@ void OpenthermHub::resume_polling() {
 
 void OpenthermHub::suspend_polling() {
   this->polling_enabled_ = false;
+  this->no_response_expected_ = false;
   this->urgent_priority_pending_ = false;
   this->deferred_priority_pending_ = false;
   this->deferred_priority_activated_ = false;
@@ -668,7 +670,16 @@ void OpenthermHub::handle_timeout_error_() {
   } else if (has_wire_timing && conversation_timing.response_captured) {
     ESP_LOGW(TAG, "Timeout while waiting for response from device: frame was captured after the receive deadline");
   } else if (has_wire_timing) {
-    ESP_LOGW(TAG, "Timeout while waiting for response from device: no frame captured before the receive deadline");
+    // TX succeeded but no boiler responded. During the controlled R1 startup
+    // verification probe this is expected (no boiler on the bus) and stays
+    // below WARN; transport counters in stop_opentherm_() are unaffected.
+    if (!this->no_response_expected_) {
+      ESP_LOGW(TAG, "Timeout while waiting for response from device: no frame captured before the receive deadline");
+    } else {
+      ESP_LOGD(TAG,
+               "Timeout while waiting for response from device: no frame captured before the receive deadline "
+               "(expected during startup verification)");
+    }
   } else {
     ESP_LOGW(TAG, "Timeout while waiting for response from device");
   }
@@ -679,6 +690,7 @@ void OpenthermHub::handle_timer_error_() {
   this->urgent_priority_pending_ = false;
   this->deferred_priority_pending_ = false;
   this->deferred_priority_activated_ = false;
+  this->no_response_expected_ = false;
   this->opentherm_->report_and_reset_timer_error();
   this->stop_opentherm_();
   // Timer error is critical, there is no point in retrying.

--- a/components/opentherm/hub.h
+++ b/components/opentherm/hub.h
@@ -73,6 +73,10 @@ class OpenthermHub final : public Component {
   MessageId deferred_priority_second_ = MessageId::STATUS;
   // The OpenQuatt transport owner explicitly starts polling after restore.
   bool polling_enabled_ = false;
+  // Controlled startup probe (R1 verification): the absence of a boiler
+  // response is expected and must not warn. All other timeout classes
+  // (TX failure, late frame, unclassifiable) always warn.
+  bool no_response_expected_ = false;
   std::unordered_map<MessageId, uint8_t> configured_messages_;
   std::vector<MessageId> messages_;
   std::vector<MessageId>::const_iterator message_iterator_;
@@ -202,6 +206,8 @@ class OpenthermHub final : public Component {
   void resume_polling();
   void suspend_polling();
   bool is_polling_enabled() const { return this->polling_enabled_; }
+  void set_no_response_expected(bool expected) { this->no_response_expected_ = expected; }
+  bool no_response_expected() const { return this->no_response_expected_; }
 
   template <typename F>
   void add_on_before_send_callback(F&& callback) {

--- a/components/opentherm/number/opentherm_number.cpp
+++ b/components/opentherm/number/opentherm_number.cpp
@@ -2,7 +2,7 @@
 
 namespace esphome::opentherm {
 
-static const char* const TAG = "opentherm.number";
+static const char* const TAG = "oq.ot.boiler.number";
 
 void OpenthermNumber::control(float value) {
   this->publish_state(value);

--- a/components/opentherm/opentherm.cpp
+++ b/components/opentherm/opentherm.cpp
@@ -21,7 +21,7 @@ namespace esphome::opentherm {
 
 using std::string;
 
-static const char* const TAG = "opentherm";
+static const char* const TAG = "oq.ot.boiler";
 
 #ifdef ESP8266
 OpenTherm* OpenTherm::instance = nullptr;

--- a/components/opentherm/output/opentherm_output.cpp
+++ b/components/opentherm/output/opentherm_output.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome::opentherm {
 
-static const char* const TAG = "opentherm.output";
+static const char* const TAG = "oq.ot.boiler.output";
 
 void opentherm::OpenthermOutput::write_state(float state) {
   ESP_LOGD(TAG, "Received state: %.2f. Min value: %.2f, max value: %.2f", state, min_value_, max_value_);

--- a/components/opentherm/switch/opentherm_switch.cpp
+++ b/components/opentherm/switch/opentherm_switch.cpp
@@ -2,7 +2,7 @@
 
 namespace esphome::opentherm {
 
-static const char* const TAG = "opentherm.switch";
+static const char* const TAG = "oq.ot.boiler.switch";
 
 void OpenthermSwitch::write_state(bool state) { this->publish_state(state); }
 

--- a/openquatt/includes/boiler/oq_boiler_otb_runtime.h
+++ b/openquatt/includes/boiler/oq_boiler_otb_runtime.h
@@ -20,6 +20,7 @@ inline void connection_changed(bool opentherm_selected) {
       id(oq_otb_startup_probe_active) = false;
       id(oq_boiler_connection_mismatch_state) = false;
       id(oq_boiler_connection_mismatch).publish_state(false);
+      id(oq_otb_hub).set_no_response_expected(false);
       id(oq_otb_hub).resume_polling();
     } else {
       id(oq_otb_withdraw_and_flush).execute();
@@ -28,6 +29,8 @@ inline void connection_changed(bool opentherm_selected) {
       id(oq_boiler_connection_mismatch_state) = false;
       id(oq_boiler_connection_mismatch).publish_state(false);
       id(boiler_relay).turn_off();
+      id(oq_otb_hub).set_no_response_expected(true);
+      ESP_LOGI("quatt.boiler", "Verifying boiler OpenTherm connection before enabling R1");
       id(oq_otb_hub)
           .start_priority_polling(esphome::opentherm::MessageId::STATUS, esphome::opentherm::MessageId::CH_SETPOINT);
     }

--- a/openquatt/includes/boiler/oq_otb_telemetry.h
+++ b/openquatt/includes/boiler/oq_otb_telemetry.h
@@ -211,7 +211,10 @@ class TelemetryState {
   }
 
   void record_log_message(uint32_t now_ms, const char* tag, const char* message) {
-    if (tag == nullptr || message == nullptr || strcmp(tag, "opentherm") != 0) return;
+    // Boiler-side OpenTherm master logs under "oq.ot.boiler". Thermostat-side
+    // tags ("oq.ot.thermostat*") and unrelated components must not count as
+    // boiler transport errors.
+    if (tag == nullptr || message == nullptr || strcmp(tag, "oq.ot.boiler") != 0) return;
 
     TransportError error = TRANSPORT_ERROR_NONE;
     if (strstr(message, "NO_TRANSITION") != nullptr) {

--- a/openquatt/oq_boiler_opentherm.yaml
+++ b/openquatt/oq_boiler_opentherm.yaml
@@ -42,17 +42,22 @@ esphome:
             id(oq_otb_startup_probe_active) = false;
             id(oq_boiler_connection_mismatch_state) = false;
             id(oq_boiler_connection_mismatch).publish_state(false);
+            id(oq_otb_hub).set_no_response_expected(false);
             id(oq_otb_hub).resume_polling();
           } else {
             // Before R1 can become available, actively check whether an
             // OpenTherm boiler is physically responding. STATUS(CH=off) and
             // TSet=0 are prioritized; a matching complete STATUS response
             // latches the connection, including a valid negative acknowledgement.
+            // Missing boiler responses are expected during this bounded probe and
+            // stay below WARN; TX failures and late frames still warn.
             oq_otb::startup_probe_state.begin(millis());
             id(oq_otb_startup_probe_active) = true;
             id(oq_boiler_connection_mismatch_state) = false;
             id(oq_boiler_connection_mismatch).publish_state(false);
             id(boiler_relay).turn_off();
+            id(oq_otb_hub).set_no_response_expected(true);
+            ESP_LOGI("quatt.boiler", "Verifying boiler OpenTherm connection before enabling R1");
             id(oq_otb_hub).start_priority_polling(
                 esphome::opentherm::MessageId::STATUS,
                 esphome::opentherm::MessageId::CH_SETPOINT);
@@ -64,9 +69,12 @@ esphome:
           // A normal shutdown gets one bounded opportunity to deliver and
           // acknowledge STATUS(CH=off) plus TSet=0 before the hub is stopped.
           // Hard power loss remains inherently fail-silent.
+          // Clear probe suppression first so the off-handshake timeouts warn normally.
+          id(oq_otb_hub).set_no_response_expected(false);
           id(oq_otb_withdraw_and_flush).execute();
           oq_otb::startup_probe_state.end();
           id(oq_otb_startup_probe_active) = false;
+          id(oq_otb_hub).set_no_response_expected(false);
           id(oq_boiler_transport_active) = false;
 
 logger:
@@ -740,6 +748,9 @@ interval:
 
           oq_otb::startup_probe_state.end();
           id(oq_otb_startup_probe_active) = false;
+          // Probe over (any outcome): missing responses are no longer expected.
+          // Clear before normal polling continues so real timeouts warn again.
+          id(oq_otb_hub).set_no_response_expected(false);
           id(boiler_relay).turn_off();
           id(oq_boiler_output_request) = false;
           id(oq_boiler_output_target_temperature_c) = NAN;

--- a/scripts/tests/test_otb_startup_logging_contract.py
+++ b/scripts/tests/test_otb_startup_logging_contract.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HUB_HEADER = (ROOT / "components" / "opentherm" / "hub.h").read_text()
+HUB_CPP = (ROOT / "components" / "opentherm" / "hub.cpp").read_text()
+OT_MASTER_CPP = (ROOT / "components" / "opentherm" / "opentherm.cpp").read_text()
+OT_NUMBER_CPP = (ROOT / "components" / "opentherm" / "number" / "opentherm_number.cpp").read_text()
+OT_SWITCH_CPP = (ROOT / "components" / "opentherm" / "switch" / "opentherm_switch.cpp").read_text()
+OT_OUTPUT_CPP = (ROOT / "components" / "opentherm" / "output" / "opentherm_output.cpp").read_text()
+OT_SLAVE_CPP = (ROOT / "components" / "openquatt_ot_slave" / "OpenQuattOTSlave.cpp").read_text()
+OT_SLAVE_SWITCH_CPP = (ROOT / "components" / "openquatt_ot_slave" / "switch.cpp").read_text()
+OT_SLAVE_TRANSPORT_CPP = (ROOT / "components" / "openquatt_ot_slave" / "OpenTherm.cpp").read_text()
+OTB_PACKAGE = (ROOT / "openquatt" / "oq_boiler_opentherm.yaml").read_text()
+OTB_RUNTIME = (ROOT / "openquatt" / "includes" / "boiler" / "oq_boiler_otb_runtime.h").read_text()
+OTB_TELEMETRY = (ROOT / "openquatt" / "includes" / "boiler" / "oq_otb_telemetry.h").read_text()
+
+
+class OtbStartupLoggingContractTest(unittest.TestCase):
+    def test_suppression_state_exists_and_is_scoped(self) -> None:
+        self.assertIn("bool no_response_expected_ = false;", HUB_HEADER)
+        self.assertIn("void set_no_response_expected(bool expected)", HUB_HEADER)
+        self.assertIn("bool no_response_expected() const", HUB_HEADER)
+
+    def test_timeout_suppresses_only_expected_no_frame(self) -> None:
+        start = HUB_CPP.index("void OpenthermHub::handle_timeout_error_()")
+        end = HUB_CPP.index("void OpenthermHub::handle_timer_error_()", start)
+        method = HUB_CPP[start:end]
+        # All three transport/timing deviations must keep a WARN path.
+        self.assertIn("RMT TX did not complete", method)
+        self.assertIn("frame was captured after the receive deadline", method)
+        self.assertIn("Timeout while waiting for response from device", method)
+        self.assertGreaterEqual(method.count("ESP_LOGW"), 3)
+        # Only the expected no-response case is gated on the probe flag.
+        self.assertIn("if (!this->no_response_expected_)", method)
+        # Suppressed probe timeout stays visible below WARN for diagnostics.
+        self.assertIn("ESP_LOGD", method)
+        # No early return: transport reset and counters must still run.
+        self.assertIn("this->stop_opentherm_();", method)
+        self.assertNotIn("return;", method.split("this->stop_opentherm_();")[0].split("handle_timeout_error_")[1])
+
+    def test_suppression_is_never_sticky(self) -> None:
+        resume_start = HUB_CPP.index("void OpenthermHub::resume_polling()")
+        suspend_start = HUB_CPP.index("void OpenthermHub::suspend_polling()", resume_start)
+        write_initial = HUB_CPP.index("void OpenthermHub::write_initial_messages_", suspend_start)
+        resume_method = HUB_CPP[resume_start:suspend_start]
+        suspend_method = HUB_CPP[suspend_start:write_initial]
+        self.assertIn("this->no_response_expected_ = false;", resume_method)
+        self.assertIn("this->no_response_expected_ = false;", suspend_method)
+        # Priority polling is also used outside the probe and must not imply suppression.
+        poll_start = HUB_CPP.index("void OpenthermHub::start_priority_polling(")
+        poll_end = HUB_CPP.index("void OpenthermHub::resume_polling()", poll_start)
+        poll_method = HUB_CPP[poll_start:poll_end]
+        self.assertNotIn("no_response_expected_", poll_method)
+
+    def test_boiler_log_tags(self) -> None:
+        self.assertIn('"oq.ot.boiler"', HUB_CPP)
+        self.assertIn('"oq.ot.boiler"', OT_MASTER_CPP)
+        self.assertIn('"oq.ot.boiler.number"', OT_NUMBER_CPP)
+        self.assertIn('"oq.ot.boiler.switch"', OT_SWITCH_CPP)
+        self.assertIn('"oq.ot.boiler.output"', OT_OUTPUT_CPP)
+        for source in (HUB_CPP, OT_MASTER_CPP):
+            self.assertNotIn('TAG = "opentherm"', source)
+        self.assertNotIn('"opentherm.number"', OT_NUMBER_CPP)
+        self.assertNotIn('"opentherm.switch"', OT_SWITCH_CPP)
+        self.assertNotIn('"opentherm.output"', OT_OUTPUT_CPP)
+
+    def test_thermostat_log_tags(self) -> None:
+        self.assertIn('"oq.ot.thermostat"', OT_SLAVE_CPP)
+        self.assertIn('"oq.ot.thermostat.switch"', OT_SLAVE_SWITCH_CPP)
+        self.assertIn('"oq.ot.thermostat.transport"', OT_SLAVE_TRANSPORT_CPP)
+        self.assertNotIn('"OpenQuattOTSlave"', OT_SLAVE_CPP)
+        self.assertNotIn('"OpenQuattOTSlave.switch"', OT_SLAVE_SWITCH_CPP)
+        self.assertNotIn('"OpenThermV2"', OT_SLAVE_TRANSPORT_CPP)
+
+    def test_no_component_namespace_rename(self) -> None:
+        self.assertIn("namespace esphome::opentherm", HUB_CPP)
+        self.assertIn("namespace OpenQuattOTSlave", OT_SLAVE_CPP)
+
+    def test_telemetry_follows_boiler_tag(self) -> None:
+        self.assertIn('strcmp(tag, "oq.ot.boiler")', OTB_TELEMETRY)
+        self.assertNotIn('strcmp(tag, "opentherm")', OTB_TELEMETRY)
+
+    def test_boot_probe_sets_and_clears_suppression(self) -> None:
+        boot_start = OTB_PACKAGE.index("on_boot:")
+        shutdown_start = OTB_PACKAGE.index("on_shutdown:", boot_start)
+        boot_block = OTB_PACKAGE[boot_start:shutdown_start]
+        self.assertIn("id(oq_otb_hub).set_no_response_expected(true);", boot_block)
+        self.assertIn("id(oq_otb_hub).set_no_response_expected(false);", boot_block)
+        self.assertIn("id(oq_otb_hub).start_priority_polling(", boot_block)
+        self.assertLess(
+            boot_block.index("set_no_response_expected(true);"),
+            boot_block.index("start_priority_polling("),
+        )
+        self.assertLess(
+            boot_block.index("set_no_response_expected(false);"),
+            boot_block.index("resume_polling();"),
+        )
+
+    def test_probe_exit_clears_before_normal_polling(self) -> None:
+        self.assertIn(
+            "id(oq_otb_hub).set_no_response_expected(false);",
+            OTB_PACKAGE[OTB_PACKAGE.index("startup_probe_state.end();\n          id(oq_otb_startup_probe_active) = false;"):],
+        )
+        end_marker = "oq_otb::startup_probe_state.end();\n          id(oq_otb_startup_probe_active) = false;"
+        end_pos = OTB_PACKAGE.index(end_marker, OTB_PACKAGE.index("STARTUP_PROBE_RUNNING) return;"))
+        window = OTB_PACKAGE[end_pos : end_pos + 600]
+        self.assertIn("set_no_response_expected(false);", window)
+
+    def test_connection_change_covers_both_directions(self) -> None:
+        self.assertEqual(OTB_RUNTIME.count("set_no_response_expected(true);"), 1)
+        self.assertEqual(OTB_RUNTIME.count("set_no_response_expected(false);"), 1)
+        ot_branch = OTB_RUNTIME.index("if (opentherm_selected) {")
+        r1_branch = OTB_RUNTIME.index("} else {", ot_branch)
+        self.assertLess(
+            OTB_RUNTIME.index("set_no_response_expected(false);", ot_branch),
+            OTB_RUNTIME.index("resume_polling();", ot_branch),
+        )
+        self.assertLess(
+            OTB_RUNTIME.index("set_no_response_expected(true);", r1_branch),
+            OTB_RUNTIME.index("start_priority_polling(", r1_branch),
+        )
+
+    def test_shutdown_clears_suppression(self) -> None:
+        shutdown_start = OTB_PACKAGE.index("on_shutdown:")
+        logger_start = OTB_PACKAGE.index("logger:", shutdown_start)
+        shutdown_block = OTB_PACKAGE[shutdown_start:logger_start]
+        self.assertIn("set_no_response_expected(false);", shutdown_block)
+
+    def test_probe_start_logs_single_info(self) -> None:
+        probe_log = 'ESP_LOGI("quatt.boiler", "Verifying boiler OpenTherm connection before enabling R1");'
+        boot_start = OTB_PACKAGE.index("on_boot:")
+        shutdown_start = OTB_PACKAGE.index("on_shutdown:", boot_start)
+        boot_block = OTB_PACKAGE[boot_start:shutdown_start]
+        self.assertIn(probe_log, boot_block)
+        self.assertEqual(boot_block.count(probe_log), 1)
+        self.assertLess(
+            boot_block.index("set_no_response_expected(true);"),
+            boot_block.index(probe_log),
+        )
+        self.assertLess(
+            boot_block.index(probe_log),
+            boot_block.index("start_priority_polling("),
+        )
+        self.assertIn(probe_log, OTB_RUNTIME)
+        self.assertEqual(OTB_RUNTIME.count(probe_log), 1)
+        r1_branch = OTB_RUNTIME.index("} else {", OTB_RUNTIME.index("if (opentherm_selected) {"))
+        self.assertLess(
+            OTB_RUNTIME.index("set_no_response_expected(true);", r1_branch),
+            OTB_RUNTIME.index(probe_log, r1_branch),
+        )
+        self.assertLess(
+            OTB_RUNTIME.index(probe_log, r1_branch),
+            OTB_RUNTIME.index("start_priority_polling(", r1_branch),
+        )
+
+    def test_new_text_prefers_boiler_thermostat_terms(self) -> None:
+        probe_log = "Verifying boiler OpenTherm connection before enabling R1"
+        self.assertIn(probe_log, OTB_PACKAGE)
+        self.assertIn(probe_log, OTB_RUNTIME)
+        for forbidden in ("OTB", "OTT", "master", "slave", "Master", "Slave"):
+            self.assertNotIn(forbidden, probe_log)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/host/ot_boiler_telemetry_test.cpp
+++ b/tests/host/ot_boiler_telemetry_test.cpp
@@ -103,21 +103,30 @@ int main() {
   assert(state.field_is_fresh(oq_otb::FIELD_BOILER_WATER_TEMPERATURE, 4, 10));
   assert(!state.field_is_fresh(oq_otb::FIELD_BOILER_WATER_TEMPERATURE, 5, 10));
 
-  // Only warnings emitted by the ESPHome OpenTherm component are counted.
+  // Only warnings emitted by the boiler-side OpenTherm master are counted.
   state.record_log_message(1000, "wifi", "NO_TRANSITION");
-  state.record_log_message(1001, "opentherm", "Unrelated warning");
+  state.record_log_message(1001, "oq.ot.boiler", "Unrelated warning");
   assert(state.transport_error_count() == 0);
 
-  state.record_log_message(1010, "opentherm", "Protocol error occured while receiving response: NO_TRANSITION");
-  state.record_log_message(1020, "opentherm", "Protocol error occured while receiving response: NO_CHANGE_TOO_LONG");
-  state.record_log_message(1030, "opentherm", "Protocol error occured while receiving response: INVALID_STOP_BIT");
-  state.record_log_message(1040, "opentherm", "Protocol error occured while receiving response: PARITY_ERROR");
-  state.record_log_message(1050, "opentherm",
+  // Legacy and thermostat-side tags must not count as boiler transport errors.
+  state.record_log_message(1002, "opentherm", "Protocol error occured while receiving response: NO_TRANSITION");
+  state.record_log_message(1003, "oq.ot.thermostat", "Timeout while waiting for response from device");
+  state.record_log_message(1004, "oq.ot.thermostat.transport", "Timeout while waiting for response from device");
+  state.record_log_message(1005, "oq.ot.boiler.number", "Timeout while waiting for response from device");
+  state.record_log_message(1006, "oq.ot.boiler.switch", "Timeout while waiting for response from device");
+  assert(state.transport_error_count() == 0);
+
+  state.record_log_message(1010, "oq.ot.boiler", "Protocol error occured while receiving response: NO_TRANSITION");
+  state.record_log_message(1020, "oq.ot.boiler", "Protocol error occured while receiving response: NO_CHANGE_TOO_LONG");
+  state.record_log_message(1030, "oq.ot.boiler", "Protocol error occured while receiving response: INVALID_STOP_BIT");
+  state.record_log_message(1040, "oq.ot.boiler", "Protocol error occured while receiving response: PARITY_ERROR");
+  state.record_log_message(1050, "oq.ot.boiler",
                            "Timeout while waiting for response from device: no frame captured before the receive "
                            "deadline");
-  state.record_log_message(1060, "opentherm", "Hub timeout triggered during send");
-  state.record_log_message(1070, "opentherm", "Hub timeout triggered during receive");
-  state.record_log_message(1080, "opentherm", "Error occured while manipulating timer (TIMER_START_ERROR): ESP_FAIL");
+  state.record_log_message(1060, "oq.ot.boiler", "Hub timeout triggered during send");
+  state.record_log_message(1070, "oq.ot.boiler", "Hub timeout triggered during receive");
+  state.record_log_message(1080, "oq.ot.boiler",
+                           "Error occured while manipulating timer (TIMER_START_ERROR): ESP_FAIL");
 
   assert(state.transport_error_count() == 8);
   assert(state.protocol_error_count() == 4);


### PR DESCRIPTION
# Wat verandert deze PR?

- Houdt verwachte ontbrekende boilerresponses tijdens de begrensde R1-startprobe onder WARN, zonder transportfouten of counters te verbergen.
- Geeft boiler- en thermostaatzijde afzonderlijke, herkenbare OpenTherm-logtags.
- Behoudt bestaande detectie, mismatch/safety, off-flush en link-recovery.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [x] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen de verwachte `no frame captured`-melding tijdens een actieve R1-startprobe wordt DEBUG. TX-fouten, late frames, timerfouten en normale OpenTherm-runtime-timeouts blijven WARN. De transportadministratie en foutcounters lopen altijd door. Suppressie wordt fail-safe gewist bij probe-einde, resume, suspend, shutdown en timerfout.

## Achtergrond

De oorspronkelijke branch was per ongeluk vanaf `main` gemaakt. Deze PR is herschreven naar één functionele commit bovenop actuele `dev`. De complete diff bevat uitsluitend de startup-probe-, logtag- en bijbehorende testwijzigingen. De recente `resume_polling()`-link-recovery uit `dev` is behouden.

Nieuwe tags:

- boiler: `oq.ot.boiler`, `oq.ot.boiler.number`, `oq.ot.boiler.switch`, `oq.ot.boiler.output`
- thermostaat: `oq.ot.thermostat`, `oq.ot.thermostat.switch`, `oq.ot.thermostat.transport`

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

De wijziging raakt uitsluitend interne diagnostische logtags en het logniveau van een verwachte startup-probe-timeout; er wijzigen geen gebruikersinstellingen, entities of bedieningsflows.

## Validatie

Actuele head: `2aecec4a1a8817ca2b31ed48eb6d8572a2755ad4`, gebaseerd op `dev` `a8f39bd7e7eb4aa689e473edfaaa00d04815f1ec`.

- `npm run check:cpp-format` — PASS
- `npm run check:python-contracts` — PASS (262 tests)
- `python3 -m unittest scripts.tests.test_otb_startup_logging_contract scripts.tests.test_otb_polling_lifecycle_contract` — PASS (23 tests)
- `bash scripts/run_host_regression_tests.sh` — PASS in CI (69 tests op de voorafgaande functioneel identieke head)
- alle zes firmwareprofielen — PASS in CI op de voorafgaande functioneel identieke head
- volledige diff-audit en aparte onafhankelijke cold review — PASS; patch-id ongewijzigd na de laatste docs-only `dev`-rebase

### HCQ HIL-testverslag

Opstelling: `openquatt-test`, Heatpump Controller Q hardware 1.2 batch 1, Duo, WiFi; HCQ simulatorcontract `openquatt-modbus-opentherm-v2` v0.4.0. Kandidaatconfig-hash `0x9ba0bbfd`. De laatste rebase voegde uitsluitend documentatie uit `dev` toe; de geteste firmware-inhoud en functionele patch zijn identiek aan de actuele head.

- read-only smoke — PASS
- R1 + boiler-OT los — PASS: één duidelijke probe-INFO; na circa 8 s de correcte no-boiler-INFO; geen `oq.ot.boiler` timeout-WARNs tijdens of na de probe; R1 bleef geselecteerd en mismatch bleef uit
- OpenTherm + boiler-OT los — PASS: normale `oq.ot.boiler` no-response-WARNs zichtbaar; suppressie is niet sticky
- thermostaatzijde — PASS: effectieve room- en setpointbron `OT thermostat`, beide 20,0 °C; nieuwe thermostaat-tags zichtbaar; oude componenttags afwezig
- R1 + aangesloten simulator — PASS: boiler gedetecteerd, R1 geblokkeerd, mismatch aan en OT-link actief met CH uit
- OpenTherm → R1 — PASS: off-handshake bevestigd in 320 ms vóór suppressie/startprobe; daarna correcte detectie- en mismatchroute
- eindstatus — hersteld naar OpenTherm, mismatch uit, OT-link actief

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Eén `bool` en twee inline accessors; geen nieuwe buffers, taken of dynamische allocaties. HIL-smoke na OTA: internal heap free 108.483 B, minimum 43.684 B, grootste block 63.488 B, fragmentatie 41,48%, PSRAM free 6.822.428 B.

