### PR TITLE
Documenteer live logstream voor diagnose

### DIFF
--- a/docs/problemen-oplossen.md
+++ b/docs/problemen-oplossen.md
@@ -222,6 +222,7 @@ Vermeld bij een hulpvraag of bugmelding:
 - wat je verwachtte en wat er daadwerkelijk gebeurde;
 - het tijdstip en de stappen om het probleem te herhalen;
 - relevante screenshots uit `Diagnose` of `Beslislog` en recente wijzigingen;
+- houd bij een reproduceerbaar probleem het `Logboek` open en vermeld het tijdstip waarop de relevante regels verschenen;
 - bij een reproduceerbaar probleem: een [debugopname uit de web-app](web-app.md#debugopname-voor-support);
 - bij een ontbrekende warmtepompverbinding met de HCQ: een scherpe foto van `M1` en de Modbusverbinding met de warmtepomp.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -206,6 +206,9 @@ occurrence, recovery condition, user action and affected HP.
 - firmware update entities, runtime update-channel select, and manual check trigger
 - runtime logger level controls
 - runtime balancing service entities from thermal request control (`Runtime lead HP`, runtime counter reset)
+- a bounded, two-client SSE log stream for the local web UI
+
+The log stream is a local UI diagnostic interface, not a public API contract. It sends only new records after a cursor (`since` or `Last-Event-ID`); `/openquatt/logs/recent` remains the bounded backfill source after reconnect. Each client has a preallocated PSRAM frame buffer. Slow clients never create an unbounded queue and are closed after sustained send backpressure.
 
 ## 5. Heating Strategy Mechanics
 

--- a/docs/web-app.md
+++ b/docs/web-app.md
@@ -141,6 +141,8 @@ Zie je hier al vreemde waarden, ga dan niet meteen tunen. Controleer eerst de br
 - schakelt het systeem vaak;
 - reageert de regeling logisch op setpoint en kamertemperatuur.
 
+Gebruik bij een probleem dat je opnieuw kunt veroorzaken ook het **Logboek**. Nieuwe regels verschijnen daar live; valt de verbinding kort weg, dan vult OpenQuatt de gemiste recente regels weer aan. Het logboek is vluchtige diagnose-informatie: bewaar voor support daarnaast altijd een debugopname.
+
 Via `Instellingen → Systeem → Gegevens bewaren` beheer je welke historie OpenQuatt bewaart. OpenQuatt maakt daarbij onderscheid tussen twee soorten geheugen:
 
 - **PSRAM (tijdelijk, vluchtig)** — snelle opslag voor recente diagnosegegevens en RAM-logs. Deze historie is direct beschikbaar zolang de controller online is en verdwijnt na een herstart.


### PR DESCRIPTION
# Wat verandert deze PR?

- Legt in de web-app-documentatie uit dat het Logboek live regels toont en na een korte onderbreking recente regels aanvult.
- Voegt supportinstructies en het begrensde technische SSE-contract toe.

## Type

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] UI/config
- [ ] Control/platform
- [ ] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen documentatie; geen firmware- of web-app-code gewijzigd.

## Achtergrond

De live logstream is bedoeld voor lokale diagnose. Het technische contract benoemt de twee-clientgrens, cursor/backfill en bounded PSRAM-buffer, zonder hiervan een publieke API-belofte te maken.

## Documentatie

Kies exact één optie:

- [x] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [ ] Geen documentatiewijziging nodig

Docs-impact motivatie:

De gebruikers-, support- en technische documentatie zijn afgestemd op de live logstream.

## Validatie

- `npm run check:docs`

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Niet van toepassing; alleen Markdown-documentatie gewijzigd.